### PR TITLE
fix(docs): unbreak the MDX build and read trigger config from the registry

### DIFF
--- a/apps/docs/content/docs/en/integrations/a2a.mdx
+++ b/apps/docs/content/docs/en/integrations/a2a.mdx
@@ -28,7 +28,7 @@ Use the A2A (Agent-to-Agent) protocol to call external AI agents over the latest
 
 ## Tools
 
-### `a2a_send_message`
+### A2A Send Message
 
 Send a message to an external A2A agent and return its response.
 
@@ -54,7 +54,7 @@ Send a message to an external A2A agent and return its response.
 | `state` | string | Task lifecycle state: `submitted`, `working`, `input-required`, `auth-required`, `completed`, `failed`, `canceled`, or `rejected` |
 | `artifacts` | array | Structured task output artifacts |
 
-### `a2a_get_task`
+### A2A Get Task
 
 Retrieve the current state and result of an A2A task.
 
@@ -77,7 +77,7 @@ Retrieve the current state and result of an A2A task.
 | `state` | string | Task lifecycle state |
 | `artifacts` | array | Structured task output artifacts |
 
-### `a2a_cancel_task`
+### A2A Cancel Task
 
 Request cancellation of an in-progress A2A task.
 
@@ -97,7 +97,7 @@ Request cancellation of an in-progress A2A task.
 | `state` | string | Task lifecycle state after cancellation |
 | `canceled` | boolean | Whether the task reached the canceled state |
 
-### `a2a_get_agent_card`
+### A2A Get Agent Card
 
 Fetch the Agent Card (discovery document) for an external A2A agent.
 

--- a/apps/docs/content/docs/en/integrations/agentmail.mdx
+++ b/apps/docs/content/docs/en/integrations/agentmail.mdx
@@ -43,7 +43,7 @@ Integrate AgentMail into your workflow. Create and manage email inboxes, send an
 
 ## Actions
 
-### `agentmail_create_draft`
+### Create Draft
 
 Create a new email draft in AgentMail
 
@@ -82,7 +82,7 @@ Create a new email draft in AgentMail
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last updated timestamp |
 
-### `agentmail_create_inbox`
+### Create Inbox
 
 Create a new email inbox with AgentMail
 
@@ -105,7 +105,7 @@ Create a new email inbox with AgentMail
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last updated timestamp |
 
-### `agentmail_delete_draft`
+### Delete Draft
 
 Delete an email draft in AgentMail
 
@@ -123,7 +123,7 @@ Delete an email draft in AgentMail
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the draft was successfully deleted |
 
-### `agentmail_delete_inbox`
+### Delete Inbox
 
 Delete an email inbox in AgentMail
 
@@ -140,7 +140,7 @@ Delete an email inbox in AgentMail
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the inbox was successfully deleted |
 
-### `agentmail_delete_thread`
+### Delete Thread
 
 Delete an email thread in AgentMail (moves to trash, or permanently deletes if already in trash)
 
@@ -159,7 +159,7 @@ Delete an email thread in AgentMail (moves to trash, or permanently deletes if a
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the thread was successfully deleted |
 
-### `agentmail_forward_message`
+### Forward Message
 
 Forward an email message to new recipients in AgentMail
 
@@ -184,7 +184,7 @@ Forward an email message to new recipients in AgentMail
 | `messageId` | string | ID of the forwarded message |
 | `threadId` | string | ID of the thread |
 
-### `agentmail_get_draft`
+### Get Draft
 
 Get details of a specific email draft in AgentMail
 
@@ -216,7 +216,7 @@ Get details of a specific email draft in AgentMail
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last updated timestamp |
 
-### `agentmail_get_inbox`
+### Get Inbox
 
 Get details of a specific email inbox in AgentMail
 
@@ -237,7 +237,7 @@ Get details of a specific email inbox in AgentMail
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last updated timestamp |
 
-### `agentmail_get_message`
+### Get Message
 
 Get details of a specific email message in AgentMail
 
@@ -266,7 +266,7 @@ Get details of a specific email message in AgentMail
 | `timestamp` | string | Time the message was sent or drafted |
 | `createdAt` | string | Creation timestamp |
 
-### `agentmail_get_thread`
+### Get Thread
 
 Get details of a specific email thread including messages in AgentMail
 
@@ -304,7 +304,7 @@ Get details of a specific email thread including messages in AgentMail
 |   ↳ `timestamp` | string | Time the message was sent or drafted |
 |   ↳ `createdAt` | string | Creation timestamp |
 
-### `agentmail_list_drafts`
+### List Drafts
 
 List email drafts in an inbox in AgentMail
 
@@ -336,7 +336,7 @@ List email drafts in an inbox in AgentMail
 | `count` | number | Total number of drafts |
 | `nextPageToken` | string | Token for retrieving the next page |
 
-### `agentmail_list_inboxes`
+### List Inboxes
 
 List all email inboxes in AgentMail
 
@@ -361,7 +361,7 @@ List all email inboxes in AgentMail
 | `count` | number | Total number of inboxes |
 | `nextPageToken` | string | Token for retrieving the next page |
 
-### `agentmail_list_messages`
+### List Messages
 
 List messages in an inbox in AgentMail
 
@@ -389,7 +389,7 @@ List messages in an inbox in AgentMail
 | `count` | number | Total number of messages |
 | `nextPageToken` | string | Token for retrieving the next page |
 
-### `agentmail_list_threads`
+### List Threads
 
 List email threads in AgentMail
 
@@ -421,7 +421,7 @@ List email threads in AgentMail
 | `count` | number | Total number of threads |
 | `nextPageToken` | string | Token for retrieving the next page |
 
-### `agentmail_reply_message`
+### Reply to Message
 
 Reply to an existing email message in AgentMail
 
@@ -446,7 +446,7 @@ Reply to an existing email message in AgentMail
 | `messageId` | string | ID of the sent reply message |
 | `threadId` | string | ID of the thread |
 
-### `agentmail_send_draft`
+### Send Draft
 
 Send an existing email draft in AgentMail
 
@@ -465,7 +465,7 @@ Send an existing email draft in AgentMail
 | `messageId` | string | ID of the sent message |
 | `threadId` | string | ID of the thread |
 
-### `agentmail_send_message`
+### Send Message
 
 Send an email message from an AgentMail inbox
 
@@ -491,7 +491,7 @@ Send an email message from an AgentMail inbox
 | `subject` | string | Email subject line |
 | `to` | string | Recipient email address |
 
-### `agentmail_update_draft`
+### Update Draft
 
 Update an existing email draft in AgentMail
 
@@ -530,7 +530,7 @@ Update an existing email draft in AgentMail
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last updated timestamp |
 
-### `agentmail_update_inbox`
+### Update Inbox
 
 Update the display name of an email inbox in AgentMail
 
@@ -552,7 +552,7 @@ Update the display name of an email inbox in AgentMail
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last updated timestamp |
 
-### `agentmail_update_message`
+### Update Message
 
 Add or remove labels on an email message in AgentMail
 
@@ -573,7 +573,7 @@ Add or remove labels on an email message in AgentMail
 | `messageId` | string | Unique identifier for the message |
 | `labels` | array | Current labels on the message |
 
-### `agentmail_update_thread`
+### Update Thread Labels
 
 Add or remove labels on an email thread in AgentMail
 

--- a/apps/docs/content/docs/en/integrations/agentphone.mdx
+++ b/apps/docs/content/docs/en/integrations/agentphone.mdx
@@ -43,7 +43,7 @@ Give your workflow a phone. Provision SMS- and voice-enabled numbers, send messa
 
 ## Actions
 
-### `agentphone_create_call`
+### Create Outbound Call
 
 Initiate an outbound voice call from an AgentPhone agent
 
@@ -72,7 +72,7 @@ Initiate an outbound voice call from an AgentPhone agent
 | `direction` | string | Call direction \(outbound\) |
 | `startedAt` | string | ISO 8601 timestamp |
 
-### `agentphone_create_contact`
+### Create Contact
 
 Create a new contact in AgentPhone
 
@@ -98,7 +98,7 @@ Create a new contact in AgentPhone
 | `createdAt` | string | ISO 8601 creation timestamp |
 | `updatedAt` | string | ISO 8601 update timestamp |
 
-### `agentphone_create_number`
+### Create Phone Number
 
 Provision a new SMS- and voice-enabled phone number
 
@@ -123,7 +123,7 @@ Provision a new SMS- and voice-enabled phone number
 | `agentId` | string | Agent the number is attached to |
 | `createdAt` | string | ISO 8601 timestamp when the number was created |
 
-### `agentphone_delete_contact`
+### Delete Contact
 
 Delete a contact by ID
 
@@ -141,7 +141,7 @@ Delete a contact by ID
 | `id` | string | ID of the deleted contact |
 | `deleted` | boolean | Whether the contact was deleted successfully |
 
-### `agentphone_get_call`
+### Get Call
 
 Fetch a call and its full transcript
 
@@ -177,7 +177,7 @@ Fetch a call and its full transcript
 |   ↳ `response` | string | Agent response \(when available\) |
 |   ↳ `createdAt` | string | ISO 8601 timestamp |
 
-### `agentphone_get_call_transcript`
+### Get Call Transcript
 
 Get the full ordered transcript for a call
 
@@ -198,7 +198,7 @@ Get the full ordered transcript for a call
 |   ↳ `content` | string | Turn content |
 |   ↳ `createdAt` | string | ISO 8601 timestamp |
 
-### `agentphone_get_contact`
+### Get Contact
 
 Fetch a single contact by ID
 
@@ -221,7 +221,7 @@ Fetch a single contact by ID
 | `createdAt` | string | ISO 8601 creation timestamp |
 | `updatedAt` | string | ISO 8601 update timestamp |
 
-### `agentphone_get_conversation`
+### Get Conversation
 
 Get a conversation along with its recent messages
 
@@ -257,7 +257,7 @@ Get a conversation along with its recent messages
 |   ↳ `mediaUrls` | array | All attached media URLs |
 |   ↳ `receivedAt` | string | ISO 8601 timestamp |
 
-### `agentphone_get_conversation_messages`
+### Get Conversation Messages
 
 Get paginated messages for a conversation
 
@@ -287,7 +287,7 @@ Get paginated messages for a conversation
 |   ↳ `receivedAt` | string | ISO 8601 timestamp |
 | `hasMore` | boolean | Whether more messages are available |
 
-### `agentphone_get_number_messages`
+### Get Phone Number Messages
 
 Fetch messages received on a specific phone number
 
@@ -315,7 +315,7 @@ Fetch messages received on a specific phone number
 |   ↳ `receivedAt` | string | ISO 8601 timestamp |
 | `hasMore` | boolean | Whether more messages are available |
 
-### `agentphone_get_usage`
+### Get Usage
 
 Retrieve current usage statistics for the AgentPhone account
 
@@ -335,7 +335,7 @@ Retrieve current usage statistics for the AgentPhone account
 | `periodStart` | string | Billing period start |
 | `periodEnd` | string | Billing period end |
 
-### `agentphone_get_usage_daily`
+### Get Daily Usage
 
 Get a daily breakdown of usage (messages, calls, webhooks) for the last N days
 
@@ -357,7 +357,7 @@ Get a daily breakdown of usage (messages, calls, webhooks) for the last N days
 |   ↳ `webhooks` | number | Webhook deliveries that day |
 | `days` | number | Number of days returned |
 
-### `agentphone_get_usage_monthly`
+### Get Monthly Usage
 
 Get monthly usage aggregation (messages, calls, webhooks) for the last N months
 
@@ -379,7 +379,7 @@ Get monthly usage aggregation (messages, calls, webhooks) for the last N months
 |   ↳ `webhooks` | number | Webhook deliveries that month |
 | `months` | number | Number of months returned |
 
-### `agentphone_list_calls`
+### List Calls
 
 List voice calls for this AgentPhone account
 
@@ -417,7 +417,7 @@ List voice calls for this AgentPhone account
 | `hasMore` | boolean | Whether more results are available |
 | `total` | number | Total number of matching calls |
 
-### `agentphone_list_contacts`
+### List Contacts
 
 List contacts for this AgentPhone account
 
@@ -445,7 +445,7 @@ List contacts for this AgentPhone account
 | `hasMore` | boolean | Whether more results are available |
 | `total` | number | Total number of contacts |
 
-### `agentphone_list_conversations`
+### List Conversations
 
 List conversations (message threads) for this AgentPhone account
 
@@ -475,7 +475,7 @@ List conversations (message threads) for this AgentPhone account
 | `hasMore` | boolean | Whether more results are available |
 | `total` | number | Total number of conversations |
 
-### `agentphone_list_numbers`
+### List Phone Numbers
 
 List all phone numbers provisioned for this AgentPhone account
 
@@ -502,7 +502,7 @@ List all phone numbers provisioned for this AgentPhone account
 | `hasMore` | boolean | Whether more results are available |
 | `total` | number | Total number of phone numbers |
 
-### `agentphone_react_to_message`
+### React to Message
 
 Send an iMessage tapback reaction to a message (iMessage only)
 
@@ -523,7 +523,7 @@ Send an iMessage tapback reaction to a message (iMessage only)
 | `messageId` | string | ID of the message that was reacted to |
 | `channel` | string | Channel \(imessage\) |
 
-### `agentphone_release_number`
+### Release Phone Number
 
 Release (delete) a phone number. This action is irreversible.
 
@@ -541,7 +541,7 @@ Release (delete) a phone number. This action is irreversible.
 | `id` | string | ID of the released phone number |
 | `released` | boolean | Whether the number was released successfully |
 
-### `agentphone_send_message`
+### Send Message
 
 Send an outbound SMS or iMessage from an AgentPhone agent
 
@@ -566,7 +566,7 @@ Send an outbound SMS or iMessage from an AgentPhone agent
 | `fromNumber` | string | Sender phone number |
 | `toNumber` | string | Recipient phone number |
 
-### `agentphone_update_contact`
+### Update Contact
 
 Update a contact's fields
 
@@ -593,7 +593,7 @@ Update a contact's fields
 | `createdAt` | string | ISO 8601 creation timestamp |
 | `updatedAt` | string | ISO 8601 update timestamp |
 
-### `agentphone_update_conversation`
+### Update Conversation
 
 Update conversation metadata (stored state). Pass null to clear existing metadata.
 

--- a/apps/docs/content/docs/en/integrations/agiloft.mdx
+++ b/apps/docs/content/docs/en/integrations/agiloft.mdx
@@ -40,7 +40,7 @@ Integrate with Agiloft contract lifecycle management to create, read, update, de
 
 ## Actions
 
-### `agiloft_attach_file`
+### Agiloft Attach File
 
 Attach a file to a field in an Agiloft record.
 
@@ -67,7 +67,7 @@ Attach a file to a field in an Agiloft record.
 | `fileName` | string | Name of the attached file |
 | `totalAttachments` | number | Total number of files attached in the field after the operation |
 
-### `agiloft_attachment_info`
+### Agiloft Attachment Info
 
 Get information about file attachments on a record field.
 
@@ -93,7 +93,7 @@ Get information about file attachments on a record field.
 |   ↳ `size` | number | File size in bytes |
 | `totalCount` | number | Total number of attachments in the field |
 
-### `agiloft_create_record`
+### Agiloft Create Record
 
 Create a new record in an Agiloft table.
 
@@ -115,7 +115,7 @@ Create a new record in an Agiloft table.
 | `id` | string | ID of the created record |
 | `fields` | json | Field values of the created record |
 
-### `agiloft_delete_record`
+### Agiloft Delete Record
 
 Delete a record from an Agiloft table.
 
@@ -137,7 +137,7 @@ Delete a record from an Agiloft table.
 | `id` | string | ID of the deleted record |
 | `deleted` | boolean | Whether the record was successfully deleted |
 
-### `agiloft_get_choice_line_id`
+### Agiloft Get Choice Line ID
 
 Resolve the internal numeric ID of a choice-list value, for use in EWSelect WHERE clauses against choice fields.
 
@@ -159,7 +159,7 @@ Resolve the internal numeric ID of a choice-list value, for use in EWSelect WHER
 | --------- | ---- | ----------- |
 | `choiceLineId` | number | Internal numeric line ID of the choice value |
 
-### `agiloft_lock_record`
+### Agiloft Lock Record
 
 Lock, unlock, or check the lock status of an Agiloft record.
 
@@ -184,7 +184,7 @@ Lock, unlock, or check the lock status of an Agiloft record.
 | `lockedBy` | string | Username of the user who locked the record |
 | `lockExpiresInMinutes` | number | Minutes until the lock expires |
 
-### `agiloft_read_record`
+### Agiloft Read Record
 
 Read a record by ID from an Agiloft table.
 
@@ -207,7 +207,7 @@ Read a record by ID from an Agiloft table.
 | `id` | string | ID of the record |
 | `fields` | json | Field values of the record |
 
-### `agiloft_remove_attachment`
+### Agiloft Remove Attachment
 
 Remove an attached file from a field in an Agiloft record.
 
@@ -232,7 +232,7 @@ Remove an attached file from a field in an Agiloft record.
 | `fieldName` | string | Name of the attachment field |
 | `remainingAttachments` | number | Number of attachments remaining in the field after removal |
 
-### `agiloft_retrieve_attachment`
+### Agiloft Retrieve Attachment
 
 Download an attached file from an Agiloft record field.
 
@@ -255,7 +255,7 @@ Download an attached file from an Agiloft record field.
 | --------- | ---- | ----------- |
 | `file` | file | Downloaded attachment file |
 
-### `agiloft_saved_search`
+### Agiloft Saved Search
 
 List saved searches defined for an Agiloft table.
 
@@ -279,7 +279,7 @@ List saved searches defined for an Agiloft table.
 |   ↳ `id` | number | Saved search database identifier |
 |   ↳ `description` | string | Saved search description |
 
-### `agiloft_search_records`
+### Agiloft Search Records
 
 Search for records in an Agiloft table using a query.
 
@@ -306,7 +306,7 @@ Search for records in an Agiloft table using a query.
 | `page` | number | Current page number |
 | `limit` | number | Records per page |
 
-### `agiloft_select_records`
+### Agiloft Select Records
 
 Select record IDs matching a SQL WHERE clause from an Agiloft table.
 
@@ -328,7 +328,7 @@ Select record IDs matching a SQL WHERE clause from an Agiloft table.
 | `recordIds` | array | Array of record IDs matching the query |
 | `totalCount` | number | Total number of matching records |
 
-### `agiloft_update_record`
+### Agiloft Update Record
 
 Update an existing record in an Agiloft table.
 

--- a/apps/docs/content/docs/en/integrations/ahrefs.mdx
+++ b/apps/docs/content/docs/en/integrations/ahrefs.mdx
@@ -33,7 +33,7 @@ Integrate Ahrefs SEO tools into your workflow. Analyze domain ratings, backlinks
 
 ## Actions
 
-### `ahrefs_domain_rating`
+### Ahrefs Domain Rating
 
 Get the Domain Rating (DR) and Ahrefs Rank for a target domain. Domain Rating shows the strength of a website's backlink profile on a scale from 0 to 100.
 
@@ -52,7 +52,7 @@ Get the Domain Rating (DR) and Ahrefs Rank for a target domain. Domain Rating sh
 | `domainRating` | number | Domain Rating score \(0-100\) |
 | `ahrefsRank` | number | Ahrefs Rank - global ranking based on backlink profile strength |
 
-### `ahrefs_metrics`
+### Ahrefs Metrics
 
 Get a one-call organic and paid search overview for a target domain or URL: organic traffic, organic keywords, paid traffic, paid keywords, and estimated traffic cost.
 
@@ -80,7 +80,7 @@ Get a one-call organic and paid search overview for a target domain or URL: orga
 |   ↳ `paidPages` | number | Number of pages receiving paid traffic |
 |   ↳ `paidCost` | number | Estimated monthly paid search spend \(USD\) |
 
-### `ahrefs_backlinks`
+### Ahrefs Backlinks
 
 Get a list of backlinks pointing to a target domain or URL. Returns details about each backlink including source URL, anchor text, and domain rating.
 
@@ -107,7 +107,7 @@ Get a list of backlinks pointing to a target domain or URL. Returns details abou
 |   ↳ `firstSeen` | string | When the backlink was first discovered |
 |   ↳ `lastVisited` | string | When the backlink was last checked |
 
-### `ahrefs_backlinks_stats`
+### Ahrefs Backlinks Stats
 
 Get backlink and referring domain totals for a target domain or URL, both currently live and across all time.
 
@@ -130,7 +130,7 @@ Get backlink and referring domain totals for a target domain or URL, both curren
 |   ↳ `allTimeBacklinks` | number | Total backlinks ever discovered, including lost ones |
 |   ↳ `allTimeReferringDomains` | number | Total referring domains ever discovered, including lost ones |
 
-### `ahrefs_referring_domains`
+### Ahrefs Referring Domains
 
 Get a list of domains that link to a target domain or URL. Returns unique referring domains with their domain rating, backlink counts, and discovery dates.
 
@@ -156,7 +156,7 @@ Get a list of domains that link to a target domain or URL. Returns unique referr
 |   ↳ `firstSeen` | string | When the domain was first seen linking |
 |   ↳ `lastVisited` | string | When the domain was last seen linking \(null if never re-crawled\) |
 
-### `ahrefs_broken_backlinks`
+### Ahrefs Broken Backlinks
 
 Get a list of broken backlinks pointing to a target domain or URL. Useful for identifying link reclamation opportunities.
 
@@ -180,7 +180,7 @@ Get a list of broken backlinks pointing to a target domain or URL. Useful for id
 |   ↳ `anchor` | string | The anchor text of the link |
 |   ↳ `domainRatingSource` | number | Domain Rating of the linking domain |
 
-### `ahrefs_organic_keywords`
+### Ahrefs Organic Keywords
 
 Get organic keywords that a target domain or URL ranks for in Google search results. Returns keyword details including search volume, ranking position, and estimated traffic.
 
@@ -207,7 +207,7 @@ Get organic keywords that a target domain or URL ranks for in Google search resu
 |   ↳ `traffic` | number | Estimated monthly organic traffic |
 |   ↳ `keywordDifficulty` | number | Keyword difficulty score \(0-100\) |
 
-### `ahrefs_organic_competitors`
+### Ahrefs Organic Competitors
 
 Get domains that compete with a target domain or URL for the same organic keywords, ranked by keyword overlap.
 
@@ -234,7 +234,7 @@ Get domains that compete with a target domain or URL for the same organic keywor
 |   ↳ `competitorKeywords` | number | Number of keywords the competitor ranks for |
 |   ↳ `traffic` | number | Estimated monthly organic traffic for the competitor |
 
-### `ahrefs_top_pages`
+### Ahrefs Top Pages
 
 Get the top pages of a target domain sorted by organic traffic. Returns page URLs with their traffic, keyword counts, and estimated traffic value.
 
@@ -260,7 +260,7 @@ Get the top pages of a target domain sorted by organic traffic. Returns page URL
 |   ↳ `topKeyword` | string | The top keyword driving traffic to this page |
 |   ↳ `value` | number | Estimated traffic value in USD |
 
-### `ahrefs_keyword_overview`
+### Ahrefs Keyword Overview
 
 Get detailed metrics for a keyword including search volume, keyword difficulty, CPC, clicks, and traffic potential.
 
@@ -293,7 +293,7 @@ Get detailed metrics for a keyword including search volume, keyword difficulty, 
 |     ↳ `branded` | boolean | Query references a specific brand |
 |     ↳ `local` | boolean | Query seeks local results |
 
-### `ahrefs_paid_pages`
+### Ahrefs Paid Pages
 
 Get a target domain's pages that receive paid search traffic, sorted by estimated paid traffic. Returns page URLs with their paid traffic, keyword counts, and estimated spend.
 
@@ -320,7 +320,7 @@ Get a target domain's pages that receive paid search traffic, sorted by estimate
 |   ↳ `value` | number | Estimated monthly paid traffic cost in USD |
 |   ↳ `adsCount` | number | Number of unique ads shown for this page |
 
-### `ahrefs_anchors`
+### Ahrefs Anchors
 
 Get the anchor text distribution for a target domain or URL's backlinks, showing how many links and referring domains use each anchor text.
 
@@ -346,7 +346,7 @@ Get the anchor text distribution for a target domain or URL's backlinks, showing
 |   ↳ `firstSeen` | string | When a link with this anchor was first found |
 |   ↳ `lastSeen` | string | When a backlink with this anchor was last seen \(null if still live\) |
 
-### `ahrefs_related_terms`
+### Ahrefs Related Terms
 
 Get keyword ideas related to a seed keyword: terms the same top-ranking pages also rank for ("also rank for") or also discuss ("also talk about"), with volume, difficulty, and CPC.
 
@@ -375,7 +375,7 @@ Get keyword ideas related to a seed keyword: terms the same top-ranking pages al
 |   ↳ `intents` | object | Search intent flags \(informational, navigational, commercial, transactional, branded, local\) |
 |   ↳ `serpFeatures` | array | SERP features present in the results |
 
-### `ahrefs_domain_rating_history`
+### Ahrefs Domain Rating History
 
 Get the historical Domain Rating (DR) trend for a target domain or URL over a date range, grouped daily, weekly, or monthly.
 
@@ -397,7 +397,7 @@ Get the historical Domain Rating (DR) trend for a target domain or URL over a da
 |   ↳ `date` | string | The date of the measurement |
 |   ↳ `domainRating` | number | Domain Rating score \(0-100\) on this date |
 
-### `ahrefs_metrics_history`
+### Ahrefs Metrics History
 
 Get the historical organic and paid traffic trend for a target domain or URL over a date range: organic traffic/cost and paid traffic/cost at each point in time.
 
@@ -425,7 +425,7 @@ Get the historical organic and paid traffic trend for a target domain or URL ove
 |   ↳ `paidTraffic` | number | Estimated monthly paid search visits |
 |   ↳ `paidCost` | number | Estimated monthly paid search spend \(USD\) |
 
-### `ahrefs_refdomains_history`
+### Ahrefs Referring Domains History
 
 Get the historical referring domains trend for a target domain or URL over a date range, grouped daily, weekly, or monthly.
 
@@ -448,7 +448,7 @@ Get the historical referring domains trend for a target domain or URL over a dat
 |   ↳ `date` | string | The date of the data point |
 |   ↳ `referringDomains` | number | Total number of unique domains linking to the target on this date |
 
-### `ahrefs_keywords_history`
+### Ahrefs Keywords History
 
 Get the historical organic keyword ranking distribution for a target domain or URL over a date range: how many keywords rank in each position bucket at each point in time.
 
@@ -476,7 +476,7 @@ Get the historical organic keyword ranking distribution for a target domain or U
 |   ↳ `top21To50` | number | Keywords ranking in positions 21-50 |
 |   ↳ `top51Plus` | number | Keywords ranking in position 51 and beyond |
 
-### `ahrefs_batch_analysis`
+### Ahrefs Batch Analysis
 
 Get bulk SEO metrics (Domain Rating, backlinks, referring domains, organic traffic, and more) for multiple domains or URLs in a single request. Useful for comparing many competitors at once.
 
@@ -507,7 +507,7 @@ Get bulk SEO metrics (Domain Rating, backlinks, referring domains, organic traff
 |   ↳ `paidTraffic` | number | Estimated monthly paid search traffic |
 |   ↳ `error` | string | Error message if this target could not be analyzed |
 
-### `ahrefs_site_audit_page_explorer`
+### Ahrefs Site Audit Page Explorer
 
 Get crawled pages from an Ahrefs Site Audit project with health and SEO metrics: HTTP status, title, link counts, backlinks, indexability, and traffic. Optionally filter to pages affected by a specific issue.
 
@@ -536,7 +536,7 @@ Get crawled pages from an Ahrefs Site Audit project with health and SEO metrics:
 |   ↳ `compliant` | boolean | Whether the page is indexable \(200 status, no canonical/noindex\) |
 |   ↳ `traffic` | number | Estimated monthly organic traffic to the page |
 
-### `ahrefs_rank_tracker_overview`
+### Ahrefs Rank Tracker Overview
 
 Get ranking overview metrics for the keywords tracked in an Ahrefs Rank Tracker project: position, search volume, keyword difficulty, and estimated traffic. This endpoint is free and does not consume API units.
 
@@ -566,7 +566,7 @@ Get ranking overview metrics for the keywords tracked in an Ahrefs Rank Tracker 
 |   ↳ `serpFeatures` | array | SERP features present in the results |
 |   ↳ `bestPositionKind` | string | Type of the top position \(organic, paid, or SERP feature\) |
 
-### `ahrefs_rank_tracker_serp_overview`
+### Ahrefs Rank Tracker SERP Overview
 
 Get the full SERP (search engine results page) for a keyword tracked in an Ahrefs Rank Tracker project, including every ranking URL with its position, title, and authority metrics. This endpoint is free and does not consume API units.
 
@@ -603,7 +603,7 @@ Get the full SERP (search engine results page) for a keyword tracked in an Ahref
 |   ↳ `topKeywordVolume` | number | Monthly search volume for the top keyword |
 |   ↳ `updateDate` | string | Date the SERP was last checked |
 
-### `ahrefs_rank_tracker_competitors_overview`
+### Ahrefs Rank Tracker Competitors Overview
 
 Get competitor rankings for the keywords tracked in an Ahrefs Rank Tracker project: each tracked keyword's volume and difficulty alongside every competitor's position, traffic, and traffic value. This endpoint is free and does not consume API units.
 
@@ -635,7 +635,7 @@ Get competitor rankings for the keywords tracked in an Ahrefs Rank Tracker proje
 |     ↳ `traffic` | number | Estimated traffic to the competitor |
 |     ↳ `value` | number | Estimated traffic value \(USD\) |
 
-### `ahrefs_rank_tracker_competitors_stats`
+### Ahrefs Rank Tracker Competitors Stats
 
 Get aggregate competitor stats for an Ahrefs Rank Tracker project: each competitor's traffic, traffic value, average position, and share of voice across all tracked keywords. This endpoint is free and does not consume API units.
 

--- a/apps/docs/content/docs/en/integrations/airtable.mdx
+++ b/apps/docs/content/docs/en/integrations/airtable.mdx
@@ -32,7 +32,7 @@ Integrates Airtable into the workflow. Can list bases, list tables (with schema)
 
 ## Actions
 
-### `airtable_list_bases`
+### Airtable List Bases
 
 List all bases the authenticated user has access to
 
@@ -54,7 +54,7 @@ List all bases the authenticated user has access to
 |   ↳ `offset` | string | Offset for next page of results |
 |   ↳ `totalBases` | number | Number of bases returned |
 
-### `airtable_list_tables`
+### Airtable List Tables
 
 List all tables and their schema in an Airtable base
 
@@ -83,7 +83,7 @@ List all tables and their schema in an Airtable base
 |   ↳ `baseId` | string | The base ID queried |
 |   ↳ `totalTables` | number | Number of tables in the base |
 
-### `airtable_list_records`
+### Airtable List Records
 
 Read records from an Airtable table
 
@@ -108,7 +108,7 @@ Read records from an Airtable table
 |   ↳ `offset` | string | Pagination offset for next page |
 |   ↳ `totalRecords` | number | Number of records returned |
 
-### `airtable_get_record`
+### Airtable Get Record
 
 Retrieve a single record from an Airtable table by its ID
 
@@ -131,7 +131,7 @@ Retrieve a single record from an Airtable table by its ID
 | `metadata` | json | Operation metadata |
 |   ↳ `recordCount` | number | Number of records returned \(always 1\) |
 
-### `airtable_create_records`
+### Airtable Create Records
 
 Write new records to an Airtable table
 
@@ -155,7 +155,7 @@ Write new records to an Airtable table
 | `metadata` | json | Operation metadata |
 |   ↳ `recordCount` | number | Number of records created |
 
-### `airtable_update_record`
+### Airtable Update Record
 
 Update an existing record in an Airtable table by ID
 
@@ -181,7 +181,7 @@ Update an existing record in an Airtable table by ID
 |   ↳ `recordCount` | number | Number of records updated \(always 1\) |
 |   ↳ `updatedFields` | array | List of field names that were updated |
 
-### `airtable_update_multiple_records`
+### Airtable Update Multiple Records
 
 Update multiple existing records in an Airtable table
 
@@ -206,7 +206,7 @@ Update multiple existing records in an Airtable table
 |   ↳ `recordCount` | number | Number of records updated |
 |   ↳ `updatedRecordIds` | array | List of updated record IDs |
 
-### `airtable_upsert_records`
+### Airtable Upsert Records
 
 Update existing records or create new ones in an Airtable table, matching on the specified merge fields
 
@@ -235,7 +235,7 @@ Update existing records or create new ones in an Airtable table, matching on the
 |   ↳ `createdCount` | number | Number of records created |
 |   ↳ `updatedCount` | number | Number of records updated |
 
-### `airtable_delete_records`
+### Airtable Delete Records
 
 Delete one or more records from an Airtable table by ID
 
@@ -258,7 +258,7 @@ Delete one or more records from an Airtable table by ID
 |   ↳ `recordCount` | number | Number of records deleted |
 |   ↳ `deletedRecordIds` | array | List of deleted record IDs |
 
-### `airtable_get_base_schema`
+### Airtable Get Base Schema
 
 Get the schema of all tables, fields, and views in an Airtable base
 

--- a/apps/docs/content/docs/en/integrations/airweave.mdx
+++ b/apps/docs/content/docs/en/integrations/airweave.mdx
@@ -34,7 +34,7 @@ Search across your synced data sources using Airweave. Supports semantic search 
 
 ## Actions
 
-### `airweave_search`
+### Airweave Search
 
 Search your synced data collections using Airweave. Supports semantic search with hybrid, neural, or keyword retrieval strategies. Optionally generate AI-powered answers from search results.
 

--- a/apps/docs/content/docs/en/integrations/algolia.mdx
+++ b/apps/docs/content/docs/en/integrations/algolia.mdx
@@ -34,7 +34,7 @@ Integrate Algolia into your workflow. Search indices, manage records (add, updat
 
 ## Actions
 
-### `algolia_search`
+### Algolia Search
 
 Search an Algolia index
 
@@ -83,7 +83,7 @@ Search an Algolia index
 | `facets_stats` | object | Statistics \(min, max, avg, sum\) for numeric facets |
 | `exhaustive` | object | Exhaustiveness flags for facetsCount, facetValues, nbHits, rulesMatch, and typo |
 
-### `algolia_add_record`
+### Algolia Add Record
 
 Add or replace a record in an Algolia index
 
@@ -106,7 +106,7 @@ Add or replace a record in an Algolia index
 | `createdAt` | string | Timestamp when the record was created \(only present when objectID is auto-generated\) |
 | `updatedAt` | string | Timestamp when the record was updated \(only present when replacing an existing record\) |
 
-### `algolia_get_record`
+### Algolia Get Record
 
 Get a record by objectID from an Algolia index
 
@@ -127,7 +127,7 @@ Get a record by objectID from an Algolia index
 | `objectID` | string | The objectID of the retrieved record |
 | `record` | object | The record data \(all attributes\) |
 
-### `algolia_get_records`
+### Algolia Get Records
 
 Retrieve multiple records by objectID from one or more Algolia indices
 
@@ -147,7 +147,7 @@ Retrieve multiple records by objectID from one or more Algolia indices
 | `results` | array | Array of retrieved records \(null entries for records not found\) |
 |   ↳ `objectID` | string | Unique identifier of the record |
 
-### `algolia_partial_update_record`
+### Algolia Partial Update Record
 
 Partially update a record in an Algolia index without replacing it entirely
 
@@ -170,7 +170,7 @@ Partially update a record in an Algolia index without replacing it entirely
 | `objectID` | string | The objectID of the updated record |
 | `updatedAt` | string | Timestamp when the record was updated |
 
-### `algolia_delete_record`
+### Algolia Delete Record
 
 Delete a record by objectID from an Algolia index
 
@@ -190,7 +190,7 @@ Delete a record by objectID from an Algolia index
 | `taskID` | number | Algolia task ID for tracking the deletion |
 | `deletedAt` | string | Timestamp when the record was deleted |
 
-### `algolia_browse_records`
+### Algolia Browse Records
 
 Browse and iterate over all records in an Algolia index using cursor pagination
 
@@ -224,7 +224,7 @@ Browse and iterate over all records in an Algolia index using cursor pagination
 | `hitsPerPage` | number | Number of hits per page \(1-1000, default 1000 for browse\) |
 | `processingTimeMS` | number | Server-side processing time in milliseconds |
 
-### `algolia_batch_operations`
+### Algolia Batch Operations
 
 Perform batch add, update, partial update, or delete operations on records in an Algolia index
 
@@ -244,7 +244,7 @@ Perform batch add, update, partial update, or delete operations on records in an
 | `taskID` | number | Algolia task ID for tracking the batch operation |
 | `objectIDs` | array | Array of object IDs affected by the batch operation |
 
-### `algolia_list_indices`
+### Algolia List Indices
 
 List all indices in an Algolia application
 
@@ -276,7 +276,7 @@ List all indices in an Algolia application
 |   ↳ `virtual` | boolean | Whether the index is a virtual replica |
 | `nbPages` | number | Total number of pages of indices |
 
-### `algolia_get_settings`
+### Algolia Get Settings
 
 Retrieve the settings of an Algolia index
 
@@ -303,7 +303,7 @@ Retrieve the settings of an Algolia index
 | `highlightPostTag` | string | HTML tag inserted after highlighted parts |
 | `paginationLimitedTo` | number | Maximum number of hits accessible via pagination |
 
-### `algolia_update_settings`
+### Algolia Update Settings
 
 Update the settings of an Algolia index
 
@@ -324,7 +324,7 @@ Update the settings of an Algolia index
 | `taskID` | number | Algolia task ID for tracking the settings update |
 | `updatedAt` | string | Timestamp when the settings were updated |
 
-### `algolia_delete_index`
+### Algolia Delete Index
 
 Delete an entire Algolia index and all its records
 
@@ -343,7 +343,7 @@ Delete an entire Algolia index and all its records
 | `taskID` | number | Algolia task ID for tracking the index deletion |
 | `deletedAt` | string | Timestamp when the index was deleted |
 
-### `algolia_copy_move_index`
+### Algolia Copy/Move Index
 
 Copy or move an Algolia index to a new destination
 
@@ -365,7 +365,7 @@ Copy or move an Algolia index to a new destination
 | `taskID` | number | Algolia task ID for tracking the copy/move operation |
 | `updatedAt` | string | Timestamp when the operation was performed |
 
-### `algolia_clear_records`
+### Algolia Clear Records
 
 Clear all records from an Algolia index while keeping settings, synonyms, and rules
 
@@ -384,7 +384,7 @@ Clear all records from an Algolia index while keeping settings, synonyms, and ru
 | `taskID` | number | Algolia task ID for tracking the clear operation |
 | `updatedAt` | string | Timestamp when the records were cleared |
 
-### `algolia_delete_by_filter`
+### Algolia Delete By Filter
 
 Delete all records matching a filter from an Algolia index
 
@@ -411,7 +411,7 @@ Delete all records matching a filter from an Algolia index
 | `taskID` | number | Algolia task ID for tracking the delete-by-filter operation |
 | `updatedAt` | string | Timestamp when the operation was performed |
 
-### `algolia_get_task_status`
+### Algolia Get Task Status
 
 Check whether an Algolia indexing task has finished publishing
 

--- a/apps/docs/content/docs/en/integrations/amplitude.mdx
+++ b/apps/docs/content/docs/en/integrations/amplitude.mdx
@@ -37,7 +37,7 @@ Integrate Amplitude into your workflow to track events, identify users and group
 
 ## Actions
 
-### `amplitude_send_event`
+### Amplitude Send Event
 
 Track an event in Amplitude using the HTTP V2 API.
 
@@ -75,7 +75,7 @@ Track an event in Amplitude using the HTTP V2 API.
 | `payloadSizeBytes` | number | Size of the payload in bytes |
 | `serverUploadTime` | number | Server upload timestamp |
 
-### `amplitude_identify_user`
+### Amplitude Identify User
 
 Set user properties in Amplitude using the Identify API. Supports $set, $setOnce, $add, $append, $unset operations.
 
@@ -96,7 +96,7 @@ Set user properties in Amplitude using the Identify API. Supports $set, $setOnce
 | `code` | number | HTTP response status code |
 | `message` | string | Response message |
 
-### `amplitude_group_identify`
+### Amplitude Group Identify
 
 Set group-level properties in Amplitude. Supports $set, $setOnce, $add, $append, $unset operations.
 
@@ -117,7 +117,7 @@ Set group-level properties in Amplitude. Supports $set, $setOnce, $add, $append,
 | `code` | number | HTTP response status code |
 | `message` | string | Response message |
 
-### `amplitude_user_search`
+### Amplitude User Search
 
 Search for a user by User ID, Device ID, or Amplitude ID using the Dashboard REST API.
 
@@ -139,7 +139,7 @@ Search for a user by User ID, Device ID, or Amplitude ID using the Dashboard RES
 |   ↳ `userId` | string | External user ID |
 | `type` | string | Match type \(e.g., match_user_or_device_id\) |
 
-### `amplitude_user_activity`
+### Amplitude User Activity
 
 Get the event stream for a specific user by their Amplitude ID.
 
@@ -178,7 +178,7 @@ Get the event stream for a specific user by their Amplitude ID.
 |   ↳ `firstUsed` | string | Date the user first appeared |
 |   ↳ `lastUsed` | string | Date of most recent user activity |
 
-### `amplitude_user_profile`
+### Amplitude User Profile
 
 Get a user profile including properties, cohort memberships, and computed properties. Not available for EU data-residency projects.
 
@@ -203,7 +203,7 @@ Get a user profile including properties, cohort memberships, and computed proper
 | `cohortIds` | array | List of cohort IDs the user belongs to |
 | `computations` | json | Computed user properties |
 
-### `amplitude_event_segmentation`
+### Amplitude Event Segmentation
 
 Query event analytics data with segmentation. Get event counts, uniques, averages, and more.
 
@@ -235,7 +235,7 @@ Query event analytics data with segmentation. Get event counts, uniques, average
 | `seriesCollapsed` | json | Collapsed aggregate totals per series |
 | `xValues` | array | Date values for the x-axis |
 
-### `amplitude_get_active_users`
+### Amplitude Get Active Users
 
 Get active or new user counts over a date range from the Dashboard REST API.
 
@@ -261,7 +261,7 @@ Get active or new user counts over a date range from the Dashboard REST API.
 | `seriesMeta` | array | Metadata labels for each data series \(e.g., segment names\) |
 | `xValues` | array | Date values for the x-axis |
 
-### `amplitude_realtime_active_users`
+### Amplitude Real-time Active Users
 
 Get real-time active user counts at 5-minute granularity for the last 2 days.
 
@@ -281,7 +281,7 @@ Get real-time active user counts at 5-minute granularity for the last 2 days.
 | `seriesLabels` | array | Labels for each series \(e.g., "Today", "Yesterday"\) |
 | `xValues` | array | Time values for the x-axis \(e.g., "15:00", "15:05"\) |
 
-### `amplitude_list_events`
+### Amplitude List Events
 
 List all event types in the Amplitude project with their weekly totals and unique counts.
 
@@ -306,7 +306,7 @@ List all event types in the Amplitude project with their weekly totals and uniqu
 |   ↳ `nonActive` | boolean | Whether the event is excluded from active user calculations |
 |   ↳ `flowHidden` | boolean | Whether the event is hidden from user flow charts |
 
-### `amplitude_get_revenue`
+### Amplitude Get Revenue
 
 Get revenue LTV data including ARPU, ARPPU, total revenue, and paying user counts.
 
@@ -333,7 +333,7 @@ Get revenue LTV data including ARPU, ARPPU, total revenue, and paying user count
 |   ↳ `values` | json | Per-date metric values keyed by date \(r1d..r90d, count, paid, total_amount\) |
 | `seriesLabels` | array | Labels for each data series |
 
-### `amplitude_funnels`
+### Amplitude Funnels
 
 Analyze conversion rates and drop-off between a sequence of events.
 
@@ -368,7 +368,7 @@ Analyze conversion rates and drop-off between a sequence of events.
 |   ↳ `events` | json | Event names for each funnel step |
 |   ↳ `dayFunnels` | json | Daily funnel breakdown \{series, xValues\} |
 
-### `amplitude_retention`
+### Amplitude Retention
 
 Measure how many users return to perform an action after a starting action.
 

--- a/apps/docs/content/docs/en/integrations/apify.mdx
+++ b/apps/docs/content/docs/en/integrations/apify.mdx
@@ -36,7 +36,7 @@ Integrate Apify into your workflow. Run any Apify actor or saved task with custo
 
 ## Actions
 
-### `apify_run_actor_sync`
+### APIFY Run Actor (Sync)
 
 Run an APIFY actor synchronously and get results (max 5 minutes)
 
@@ -60,7 +60,7 @@ Run an APIFY actor synchronously and get results (max 5 minutes)
 | `status` | string | Run status \(SUCCEEDED, FAILED, etc.\) |
 | `items` | array | Dataset items \(if completed\) |
 
-### `apify_run_actor_async`
+### APIFY Run Actor (Async)
 
 Run an APIFY actor asynchronously with polling for long-running tasks
 
@@ -87,7 +87,7 @@ Run an APIFY actor asynchronously with polling for long-running tasks
 | `datasetId` | string | Dataset ID containing results |
 | `items` | array | Dataset items \(if completed\) |
 
-### `apify_run_task`
+### APIFY Run Task
 
 Run a saved APIFY actor task synchronously and get dataset items (max 5 minutes)
 
@@ -111,7 +111,7 @@ Run a saved APIFY actor task synchronously and get dataset items (max 5 minutes)
 | `status` | string | Run status \(SUCCEEDED, FAILED, etc.\) |
 | `items` | array | Dataset items produced by the run |
 
-### `apify_get_dataset_items`
+### APIFY Get Dataset Items
 
 Retrieve items stored in an APIFY dataset
 
@@ -134,7 +134,7 @@ Retrieve items stored in an APIFY dataset
 | `items` | array | Items stored in the dataset |
 | `count` | number | Number of items returned |
 
-### `apify_get_run`
+### APIFY Get Run
 
 Get the status and details of an APIFY actor run
 

--- a/apps/docs/content/docs/en/integrations/apollo.mdx
+++ b/apps/docs/content/docs/en/integrations/apollo.mdx
@@ -39,7 +39,7 @@ Integrates Apollo.io into the workflow. Search for people and companies, enrich 
 
 ## Actions
 
-### `apollo_people_search`
+### Apollo People Search
 
 Search Apollo's database for people using demographic filters
 
@@ -71,7 +71,7 @@ Search Apollo's database for people using demographic filters
 | `per_page` | number | Results per page |
 | `total_entries` | number | Total matching entries |
 
-### `apollo_people_enrich`
+### Apollo People Enrichment
 
 Enrich data for a single person using Apollo
 
@@ -100,7 +100,7 @@ Enrich data for a single person using Apollo
 | `person` | json | Enriched person data from Apollo |
 | `enriched` | boolean | Whether the person was successfully enriched |
 
-### `apollo_people_bulk_enrich`
+### Apollo Bulk People Enrichment
 
 Enrich data for up to 10 people at once using Apollo
 
@@ -124,7 +124,7 @@ Enrich data for up to 10 people at once using Apollo
 | `missing_records` | number | Number of records that could not be enriched |
 | `credits_consumed` | number | Number of Apollo credits consumed by this request |
 
-### `apollo_organization_search`
+### Apollo Organization Search
 
 Search Apollo's database for companies using filters
 
@@ -152,7 +152,7 @@ Search Apollo's database for companies using filters
 | `per_page` | number | Results per page |
 | `total_entries` | number | Total matching entries |
 
-### `apollo_organization_enrich`
+### Apollo Organization Enrichment
 
 Enrich data for a single organization using Apollo
 
@@ -170,7 +170,7 @@ Enrich data for a single organization using Apollo
 | `organization` | json | Enriched organization data from Apollo |
 | `enriched` | boolean | Whether the organization was successfully enriched |
 
-### `apollo_organization_bulk_enrich`
+### Apollo Bulk Organization Enrichment
 
 Enrich data for up to 10 organizations at once using Apollo
 
@@ -191,7 +191,7 @@ Enrich data for up to 10 organizations at once using Apollo
 | `missing_records` | number | Number of domains that could not be enriched |
 | `unique_domains` | number | Number of unique domains processed |
 
-### `apollo_contact_create`
+### Apollo Create Contact
 
 Create a new contact in your Apollo database
 
@@ -226,7 +226,7 @@ Create a new contact in your Apollo database
 | `contact` | json | Created contact data from Apollo |
 | `created` | boolean | Whether the contact was successfully created |
 
-### `apollo_contact_update`
+### Apollo Update Contact
 
 Update an existing contact in your Apollo database
 
@@ -261,7 +261,7 @@ Update an existing contact in your Apollo database
 | `contact` | json | Updated contact data from Apollo |
 | `updated` | boolean | Whether the contact was successfully updated |
 
-### `apollo_contact_search`
+### Apollo Search Contacts
 
 Search your team's contacts in Apollo
 
@@ -285,7 +285,7 @@ Search your team's contacts in Apollo
 | `contacts` | json | Array of contacts matching the search criteria |
 | `pagination` | json | Pagination information |
 
-### `apollo_contact_bulk_create`
+### Apollo Bulk Create Contacts
 
 Create up to 100 contacts at once in your Apollo database. Supports deduplication to prevent creating duplicate contacts. Master key required.
 
@@ -308,7 +308,7 @@ Create up to 100 contacts at once in your Apollo database. Supports deduplicatio
 | `created` | number | Number of contacts successfully created |
 | `existing` | number | Number of existing contacts found |
 
-### `apollo_contact_bulk_update`
+### Apollo Bulk Update Contacts
 
 Update up to 100 existing contacts at once in your Apollo database. Each contact must include an id field. Master key required.
 
@@ -330,7 +330,7 @@ Update up to 100 existing contacts at once in your Apollo database. Each contact
 | `job_id` | string | Async job ID extracted from entity_progress_job |
 | `message` | string | Optional confirmation message from Apollo |
 
-### `apollo_account_create`
+### Apollo Create Account
 
 Create a new account (company) in your Apollo database
 
@@ -354,7 +354,7 @@ Create a new account (company) in your Apollo database
 | `account` | json | Created account data from Apollo |
 | `created` | boolean | Whether the account was successfully created |
 
-### `apollo_account_update`
+### Apollo Update Account
 
 Update an existing account in your Apollo database
 
@@ -379,7 +379,7 @@ Update an existing account in your Apollo database
 | `account` | json | Updated account data from Apollo |
 | `updated` | boolean | Whether the account was successfully updated |
 
-### `apollo_account_search`
+### Apollo Search Accounts
 
 Search your team's accounts in Apollo. Display limit: 50,000 records (100 records per page, 500 pages max). Use filters to narrow results. Master key required.
 
@@ -403,7 +403,7 @@ Search your team's accounts in Apollo. Display limit: 50,000 records (100 record
 | `accounts` | json | Array of accounts matching the search criteria |
 | `pagination` | json | Pagination information |
 
-### `apollo_account_bulk_create`
+### Apollo Bulk Create Accounts
 
 Create up to 100 accounts at once in your Apollo database. Set run_dedupe=true to deduplicate by domain, organization_id, and name. Master key required.
 
@@ -428,7 +428,7 @@ Create up to 100 accounts at once in your Apollo database. Set run_dedupe=true t
 | `existing` | number | Number of existing accounts found |
 | `failed` | number | Number of accounts that failed to be created |
 
-### `apollo_account_bulk_update`
+### Apollo Bulk Update Accounts
 
 Update up to 1000 existing accounts at once in your Apollo database (higher limit than contacts!). Each account must include an id field. Master key required.
 
@@ -454,7 +454,7 @@ Update up to 1000 existing accounts at once in your Apollo database (higher limi
 | `job_id` | string | Async job ID extracted from entity_progress_job |
 | `message` | string | Optional confirmation message from Apollo |
 
-### `apollo_opportunity_create`
+### Apollo Create Opportunity
 
 Create a new deal for an account in your Apollo database (master key required)
 
@@ -478,7 +478,7 @@ Create a new deal for an account in your Apollo database (master key required)
 | `opportunity` | json | Created opportunity data from Apollo |
 | `created` | boolean | Whether the opportunity was successfully created |
 
-### `apollo_opportunity_search`
+### Apollo Search Opportunities
 
 Search and list all deals/opportunities in your team's Apollo account
 
@@ -500,7 +500,7 @@ Search and list all deals/opportunities in your team's Apollo account
 | `per_page` | number | Results per page |
 | `total_entries` | number | Total matching entries |
 
-### `apollo_opportunity_get`
+### Apollo Get Opportunity
 
 Retrieve complete details of a specific deal/opportunity by ID
 
@@ -518,7 +518,7 @@ Retrieve complete details of a specific deal/opportunity by ID
 | `opportunity` | json | Complete opportunity data from Apollo |
 | `found` | boolean | Whether the opportunity was found |
 
-### `apollo_opportunity_update`
+### Apollo Update Opportunity
 
 Update an existing deal/opportunity in your Apollo database
 
@@ -542,7 +542,7 @@ Update an existing deal/opportunity in your Apollo database
 | `opportunity` | json | Updated opportunity data from Apollo |
 | `updated` | boolean | Whether the opportunity was successfully updated |
 
-### `apollo_sequence_search`
+### Apollo Search Sequences
 
 Search for sequences/campaigns in your team's Apollo account (master key required)
 
@@ -564,7 +564,7 @@ Search for sequences/campaigns in your team's Apollo account (master key require
 | `per_page` | number | Results per page |
 | `total_entries` | number | Total matching entries |
 
-### `apollo_sequence_add_contacts`
+### Apollo Add Contacts to Sequence
 
 Add contacts to an Apollo sequence
 
@@ -603,7 +603,7 @@ Add contacts to an Apollo sequence
 | `total_added` | number | Total number of contacts added |
 | `total_skipped` | number | Total number of contacts skipped |
 
-### `apollo_task_create`
+### Apollo Create Task
 
 Create one or more tasks in Apollo (one task per contact_id, master key required)
 
@@ -627,7 +627,7 @@ Create one or more tasks in Apollo (one task per contact_id, master key required
 | `tasks` | json | Array of created tasks \(when returned by Apollo\) |
 | `created` | boolean | Whether the request succeeded |
 
-### `apollo_task_search`
+### Apollo Search Tasks
 
 Search for tasks in Apollo
 
@@ -648,7 +648,7 @@ Search for tasks in Apollo
 | `tasks` | json | Array of tasks matching the search criteria |
 | `pagination` | json | Pagination information |
 
-### `apollo_email_accounts`
+### Apollo Get Email Accounts
 
 Get list of team's linked email accounts in Apollo
 

--- a/apps/docs/content/docs/en/integrations/appconfig.mdx
+++ b/apps/docs/content/docs/en/integrations/appconfig.mdx
@@ -36,7 +36,7 @@ Integrate AWS AppConfig into workflows. Manage applications, environments, and c
 
 ## Actions
 
-### `appconfig_get_configuration`
+### AppConfig Get Configuration
 
 Retrieve the latest deployed configuration for an AppConfig application, environment, and profile
 
@@ -59,7 +59,7 @@ Retrieve the latest deployed configuration for an AppConfig application, environ
 | `contentType` | string | Content type of the configuration |
 | `versionLabel` | string | Label of the retrieved configuration version |
 
-### `appconfig_list_applications`
+### AppConfig List Applications
 
 List applications in AWS AppConfig
 
@@ -84,7 +84,7 @@ List applications in AWS AppConfig
 | `nextToken` | string | Pagination token for the next page |
 | `count` | number | Number of applications returned |
 
-### `appconfig_create_application`
+### AppConfig Create Application
 
 Create an application in AWS AppConfig
 
@@ -107,7 +107,7 @@ Create an application in AWS AppConfig
 | `name` | string | Name of the created application |
 | `description` | string | Description of the created application |
 
-### `appconfig_get_application`
+### AppConfig Get Application
 
 Get details about a single AWS AppConfig application
 
@@ -128,7 +128,7 @@ Get details about a single AWS AppConfig application
 | `name` | string | Application name |
 | `description` | string | Application description |
 
-### `appconfig_update_application`
+### AppConfig Update Application
 
 Update the name or description of an AWS AppConfig application
 
@@ -152,7 +152,7 @@ Update the name or description of an AWS AppConfig application
 | `name` | string | Name of the updated application |
 | `description` | string | Description of the updated application |
 
-### `appconfig_delete_application`
+### AppConfig Delete Application
 
 Delete an AWS AppConfig application
 
@@ -172,7 +172,7 @@ Delete an AWS AppConfig application
 | `message` | string | Operation status message |
 | `id` | string | ID of the deleted application |
 
-### `appconfig_list_environments`
+### AppConfig List Environments
 
 List environments for an AWS AppConfig application
 
@@ -200,7 +200,7 @@ List environments for an AWS AppConfig application
 | `nextToken` | string | Pagination token for the next page |
 | `count` | number | Number of environments returned |
 
-### `appconfig_create_environment`
+### AppConfig Create Environment
 
 Create an environment for an AWS AppConfig application
 
@@ -225,7 +225,7 @@ Create an environment for an AWS AppConfig application
 | `name` | string | Name of the created environment |
 | `state` | string | State of the created environment |
 
-### `appconfig_get_environment`
+### AppConfig Get Environment
 
 Get details about a single AWS AppConfig environment
 
@@ -252,7 +252,7 @@ Get details about a single AWS AppConfig environment
 |   ↳ `alarmArn` | string | CloudWatch alarm ARN |
 |   ↳ `alarmRoleArn` | string | IAM role ARN for the alarm |
 
-### `appconfig_update_environment`
+### AppConfig Update Environment
 
 Update the name or description of an AWS AppConfig environment
 
@@ -278,7 +278,7 @@ Update the name or description of an AWS AppConfig environment
 | `name` | string | Name of the updated environment |
 | `state` | string | State of the updated environment |
 
-### `appconfig_delete_environment`
+### AppConfig Delete Environment
 
 Delete an AWS AppConfig environment
 
@@ -300,7 +300,7 @@ Delete an AWS AppConfig environment
 | `applicationId` | string | Owning application ID |
 | `id` | string | ID of the deleted environment |
 
-### `appconfig_list_configuration_profiles`
+### AppConfig List Configuration Profiles
 
 List configuration profiles for an AWS AppConfig application
 
@@ -329,7 +329,7 @@ List configuration profiles for an AWS AppConfig application
 | `nextToken` | string | Pagination token for the next page |
 | `count` | number | Number of configuration profiles returned |
 
-### `appconfig_create_configuration_profile`
+### AppConfig Create Configuration Profile
 
 Create a configuration profile in an AWS AppConfig application
 
@@ -358,7 +358,7 @@ Create a configuration profile in an AWS AppConfig application
 | `locationUri` | string | Location URI of the config |
 | `type` | string | Profile type |
 
-### `appconfig_get_configuration_profile`
+### AppConfig Get Configuration Profile
 
 Get details about a single AWS AppConfig configuration profile
 
@@ -386,7 +386,7 @@ Get details about a single AWS AppConfig configuration profile
 | `validators` | array | Validators configured on the profile |
 |   ↳ `type` | string | Validator type \(JSON_SCHEMA or LAMBDA\) |
 
-### `appconfig_update_configuration_profile`
+### AppConfig Update Configuration Profile
 
 Update the name, description, or retrieval role of an AppConfig configuration profile
 
@@ -414,7 +414,7 @@ Update the name, description, or retrieval role of an AppConfig configuration pr
 | `description` | string | Description of the profile |
 | `type` | string | Profile type |
 
-### `appconfig_delete_configuration_profile`
+### AppConfig Delete Configuration Profile
 
 Delete an AWS AppConfig configuration profile
 
@@ -436,7 +436,7 @@ Delete an AWS AppConfig configuration profile
 | `applicationId` | string | Owning application ID |
 | `id` | string | ID of the deleted configuration profile |
 
-### `appconfig_create_hosted_configuration_version`
+### AppConfig Create Hosted Configuration Version
 
 Create a new hosted configuration version for an AppConfig configuration profile
 
@@ -466,7 +466,7 @@ Create a new hosted configuration version for an AppConfig configuration profile
 | `contentType` | string | Content type of the configuration |
 | `versionLabel` | string | Label of the configuration version |
 
-### `appconfig_get_hosted_configuration_version`
+### AppConfig Get Hosted Configuration Version
 
 Retrieve a specific hosted configuration version from an AppConfig profile
 
@@ -493,7 +493,7 @@ Retrieve a specific hosted configuration version from an AppConfig profile
 | `contentType` | string | Content type of the configuration |
 | `versionLabel` | string | Label of the configuration version |
 
-### `appconfig_list_hosted_configuration_versions`
+### AppConfig List Hosted Configuration Versions
 
 List hosted configuration versions for an AWS AppConfig configuration profile
 
@@ -523,7 +523,7 @@ List hosted configuration versions for an AWS AppConfig configuration profile
 | `nextToken` | string | Pagination token for the next page |
 | `count` | number | Number of versions returned |
 
-### `appconfig_delete_hosted_configuration_version`
+### AppConfig Delete Hosted Configuration Version
 
 Delete a specific hosted configuration version from an AppConfig profile
 
@@ -547,7 +547,7 @@ Delete a specific hosted configuration version from an AppConfig profile
 | `configurationProfileId` | string | Owning configuration profile ID |
 | `versionNumber` | number | Version number that was deleted |
 
-### `appconfig_list_deployment_strategies`
+### AppConfig List Deployment Strategies
 
 List deployment strategies available in AWS AppConfig
 
@@ -577,7 +577,7 @@ List deployment strategies available in AWS AppConfig
 | `nextToken` | string | Pagination token for the next page |
 | `count` | number | Number of deployment strategies returned |
 
-### `appconfig_start_deployment`
+### AppConfig Start Deployment
 
 Start deploying a configuration version to an AWS AppConfig environment
 
@@ -604,7 +604,7 @@ Start deploying a configuration version to an AWS AppConfig environment
 | `state` | string | Current deployment state |
 | `percentageComplete` | number | Percentage of the deployment that has completed |
 
-### `appconfig_get_deployment`
+### AppConfig Get Deployment
 
 Get details about a specific AWS AppConfig deployment
 
@@ -636,7 +636,7 @@ Get details about a specific AWS AppConfig deployment
 | `startedAt` | string | When the deployment started |
 | `completedAt` | string | When the deployment completed |
 
-### `appconfig_list_deployments`
+### AppConfig List Deployments
 
 List deployments for an AWS AppConfig environment
 
@@ -668,7 +668,7 @@ List deployments for an AWS AppConfig environment
 | `nextToken` | string | Pagination token for the next page |
 | `count` | number | Number of deployments returned |
 
-### `appconfig_stop_deployment`
+### AppConfig Stop Deployment
 
 Stop an in-progress AWS AppConfig deployment
 

--- a/apps/docs/content/docs/en/integrations/arxiv.mdx
+++ b/apps/docs/content/docs/en/integrations/arxiv.mdx
@@ -33,7 +33,7 @@ Integrates ArXiv into the workflow. Can search for papers, get paper details, an
 
 ## Actions
 
-### `arxiv_search`
+### ArXiv Search
 
 Search for academic papers on ArXiv by keywords, authors, titles, or other fields.
 
@@ -54,7 +54,7 @@ Search for academic papers on ArXiv by keywords, authors, titles, or other field
 | `papers` | json | Array of papers matching the search query |
 | `totalResults` | number | Total number of results found for the search query |
 
-### `arxiv_get_paper`
+### ArXiv Get Paper
 
 Get detailed information about a specific ArXiv paper by its ID.
 
@@ -70,7 +70,7 @@ Get detailed information about a specific ArXiv paper by its ID.
 | --------- | ---- | ----------- |
 | `paper` | json | Detailed information about the requested ArXiv paper |
 
-### `arxiv_get_author_papers`
+### ArXiv Get Author Papers
 
 Search for papers by a specific author on ArXiv.
 

--- a/apps/docs/content/docs/en/integrations/asana.mdx
+++ b/apps/docs/content/docs/en/integrations/asana.mdx
@@ -33,7 +33,7 @@ Integrate Asana into the workflow. Can read, write, and update tasks.
 
 ## Actions
 
-### `asana_get_task`
+### Asana Get Task
 
 Retrieve a single task by GID or get multiple tasks with filters
 
@@ -72,7 +72,7 @@ Retrieve a single task by GID or get multiple tasks with filters
 |   ↳ `name` | string | Task name |
 |   ↳ `completed` | boolean | Completion status |
 
-### `asana_create_task`
+### Asana Create Task
 
 Create a new task in Asana
 
@@ -99,7 +99,7 @@ Create a new task in Asana
 | `created_at` | string | Task creation timestamp |
 | `permalink_url` | string | URL to the task in Asana |
 
-### `asana_update_task`
+### Asana Update Task
 
 Update an existing task in Asana
 
@@ -126,7 +126,7 @@ Update an existing task in Asana
 | `completed` | boolean | Whether the task is completed |
 | `modified_at` | string | Task last modified timestamp |
 
-### `asana_get_projects`
+### Asana Get Projects
 
 Retrieve all projects from an Asana workspace
 
@@ -147,7 +147,7 @@ Retrieve all projects from an Asana workspace
 |   ↳ `name` | string | Project name |
 |   ↳ `resource_type` | string | Resource type \(project\) |
 
-### `asana_search_tasks`
+### Asana Search Tasks
 
 Search for tasks in an Asana workspace
 
@@ -185,7 +185,7 @@ Search for tasks in an Asana workspace
 |   ↳ `path` | string | API path |
 |   ↳ `uri` | string | Full URI |
 
-### `asana_add_comment`
+### Asana Add Comment
 
 Add a comment (story) to an Asana task
 
@@ -209,7 +209,7 @@ Add a comment (story) to an Asana task
 |   ↳ `gid` | string | Author GID |
 |   ↳ `name` | string | Author name |
 
-### `asana_create_subtask`
+### Asana Create Subtask
 
 Create a subtask under an existing Asana task
 
@@ -236,7 +236,7 @@ Create a subtask under an existing Asana task
 | `created_at` | string | Subtask creation timestamp |
 | `permalink_url` | string | URL to the subtask in Asana |
 
-### `asana_delete_task`
+### Asana Delete Task
 
 Delete an Asana task by its GID (moves it to the trash)
 
@@ -255,7 +255,7 @@ Delete an Asana task by its GID (moves it to the trash)
 | `gid` | string | GID of the deleted task |
 | `deleted` | boolean | Whether the task was deleted |
 
-### `asana_add_followers`
+### Asana Add Followers
 
 Add one or more followers to an Asana task
 
@@ -278,7 +278,7 @@ Add one or more followers to an Asana task
 |   ↳ `gid` | string | Follower GID |
 |   ↳ `name` | string | Follower name |
 
-### `asana_create_project`
+### Asana Create Project
 
 Create a new project in an Asana workspace
 
@@ -305,7 +305,7 @@ Create a new project in an Asana workspace
 | `modified_at` | string | Project last modified timestamp |
 | `permalink_url` | string | URL to the project in Asana |
 
-### `asana_get_project`
+### Asana Get Project
 
 Retrieve a single Asana project by its GID
 
@@ -330,7 +330,7 @@ Retrieve a single Asana project by its GID
 | `modified_at` | string | Project last modified timestamp |
 | `permalink_url` | string | URL to the project in Asana |
 
-### `asana_list_workspaces`
+### Asana List Workspaces
 
 List all Asana workspaces and organizations the authenticated user belongs to
 
@@ -350,7 +350,7 @@ List all Asana workspaces and organizations the authenticated user belongs to
 |   ↳ `name` | string | Workspace name |
 |   ↳ `resource_type` | string | Resource type \(workspace\) |
 
-### `asana_create_section`
+### Asana Create Section
 
 Create a new section in an Asana project
 
@@ -371,7 +371,7 @@ Create a new section in an Asana project
 | `name` | string | Section name |
 | `created_at` | string | Section creation timestamp |
 
-### `asana_list_sections`
+### Asana List Sections
 
 List all sections in an Asana project
 

--- a/apps/docs/content/docs/en/integrations/ashby.mdx
+++ b/apps/docs/content/docs/en/integrations/ashby.mdx
@@ -36,7 +36,7 @@ Integrate Ashby into the workflow. Manage candidates (list, get, create, update,
 
 ## Actions
 
-### `ashby_add_candidate_tag`
+### Ashby Add Candidate Tag
 
 Adds a tag to a candidate in Ashby and returns the updated candidate.
 
@@ -84,7 +84,7 @@ Adds a tag to a candidate in Ashby and returns the updated candidate.
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_change_application_stage`
+### Ashby Change Application Stage
 
 Moves an application to a different interview stage. Requires an archive reason when moving to an Archived stage.
 
@@ -133,7 +133,7 @@ Moves an application to a different interview stage. Requires an archive reason 
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_create_application`
+### Ashby Create Application
 
 Creates a new application for a candidate on a job. Optionally specify interview plan, stage, source, and credited user.
 
@@ -186,7 +186,7 @@ Creates a new application for a candidate on a job. Optionally specify interview
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_create_candidate`
+### Ashby Create Candidate
 
 Creates a new candidate record in Ashby.
 
@@ -242,7 +242,7 @@ Creates a new candidate record in Ashby.
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_create_note`
+### Ashby Create Note
 
 Creates a note on a candidate in Ashby. Supports plain text and HTML content (bold, italic, underline, links, lists, code).
 
@@ -272,7 +272,7 @@ Creates a note on a candidate in Ashby. Supports plain text and HTML content (bo
 |   ↳ `lastName` | string | Author last name |
 |   ↳ `email` | string | Author email |
 
-### `ashby_get_application`
+### Ashby Get Application
 
 Retrieves full details about a single application by its ID.
 
@@ -319,7 +319,7 @@ Retrieves full details about a single application by its ID.
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_get_candidate`
+### Ashby Get Candidate
 
 Retrieves full details about a single candidate by their ID.
 
@@ -366,7 +366,7 @@ Retrieves full details about a single candidate by their ID.
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_get_job`
+### Ashby Get Job
 
 Retrieves full details about a single job by its ID.
 
@@ -413,7 +413,7 @@ Retrieves full details about a single job by its ID.
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_get_job_posting`
+### Ashby Get Job Posting
 
 Retrieves full details about a single job posting by its ID.
 
@@ -484,7 +484,7 @@ Retrieves full details about a single job posting by its ID.
 | `updatedAt` | string | ISO 8601 last update timestamp |
 | `job` | object | The expanded job object, only present when the request was made with expandJob=true |
 
-### `ashby_get_offer`
+### Ashby Get Offer
 
 Retrieves full details about a single offer by its ID.
 
@@ -531,7 +531,7 @@ Retrieves full details about a single offer by its ID.
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_list_applications`
+### Ashby List Applications
 
 Lists all applications in an Ashby organization with pagination and optional filters for status, job, and creation date.
 
@@ -554,7 +554,7 @@ Lists all applications in an Ashby organization with pagination and optional fil
 | `moreDataAvailable` | boolean | Whether more pages of results exist |
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 
-### `ashby_list_archive_reasons`
+### Ashby List Archive Reasons
 
 Lists all archive reasons configured in Ashby.
 
@@ -575,7 +575,7 @@ Lists all archive reasons configured in Ashby.
 |   ↳ `reasonType` | string | Reason type \(RejectedByCandidate, RejectedByOrg, Other\) |
 |   ↳ `isArchived` | boolean | Whether the reason is archived |
 
-### `ashby_list_candidate_tags`
+### Ashby List Candidate Tags
 
 Lists all candidate tags configured in Ashby.
 
@@ -601,7 +601,7 @@ Lists all candidate tags configured in Ashby.
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 | `syncToken` | string | Sync token to use for incremental updates in future requests |
 
-### `ashby_list_candidates`
+### Ashby List Candidates
 
 Lists all candidates in an Ashby organization with cursor-based pagination.
 
@@ -622,7 +622,7 @@ Lists all candidates in an Ashby organization with cursor-based pagination.
 | `moreDataAvailable` | boolean | Whether more pages of results exist |
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 
-### `ashby_list_custom_fields`
+### Ashby List Custom Fields
 
 Lists all custom field definitions configured in Ashby.
 
@@ -656,7 +656,7 @@ Lists all custom field definitions configured in Ashby.
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 | `syncToken` | string | Opaque sync token returned after the last page; pass on next sync |
 
-### `ashby_list_departments`
+### Ashby List Departments
 
 Lists all departments in Ashby.
 
@@ -687,7 +687,7 @@ Lists all departments in Ashby.
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 | `syncToken` | string | Opaque sync token returned after the last page; pass on next sync |
 
-### `ashby_list_interviews`
+### Ashby List Interview Schedules
 
 Lists interview schedules in Ashby, optionally filtered by application or interview stage.
 
@@ -729,7 +729,7 @@ Lists interview schedules in Ashby, optionally filtered by application or interv
 | `moreDataAvailable` | boolean | Whether more pages of results exist |
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 
-### `ashby_list_job_postings`
+### Ashby List Job Postings
 
 Lists all job postings in Ashby.
 
@@ -768,7 +768,7 @@ Lists all job postings in Ashby.
 |   ↳ `shouldDisplayCompensationOnJobBoard` | boolean | Whether compensation is shown on the job board |
 |   ↳ `updatedAt` | string | ISO 8601 last update timestamp |
 
-### `ashby_list_jobs`
+### Ashby List Jobs
 
 Lists all jobs in an Ashby organization. By default returns Open, Closed, and Archived jobs. Specify status to filter.
 
@@ -794,7 +794,7 @@ Lists all jobs in an Ashby organization. By default returns Open, Closed, and Ar
 | `moreDataAvailable` | boolean | Whether more pages of results exist |
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 
-### `ashby_list_locations`
+### Ashby List Locations
 
 Lists all locations configured in Ashby.
 
@@ -833,7 +833,7 @@ Lists all locations configured in Ashby.
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 | `syncToken` | string | Opaque sync token returned after the last page; pass on next sync |
 
-### `ashby_list_notes`
+### Ashby List Notes
 
 Lists all notes on a candidate with pagination support.
 
@@ -863,7 +863,7 @@ Lists all notes on a candidate with pagination support.
 | `moreDataAvailable` | boolean | Whether more pages of results exist |
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 
-### `ashby_list_offers`
+### Ashby List Offers
 
 Lists all offers with their latest version in an Ashby organization.
 
@@ -886,7 +886,7 @@ Lists all offers with their latest version in an Ashby organization.
 | `moreDataAvailable` | boolean | Whether more pages of results exist |
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 
-### `ashby_list_openings`
+### Ashby List Openings
 
 Lists all openings in Ashby with pagination.
 
@@ -906,7 +906,7 @@ Lists all openings in Ashby with pagination.
 | `moreDataAvailable` | boolean | Whether more pages of results exist |
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 
-### `ashby_list_sources`
+### Ashby List Sources
 
 Lists all candidate sources configured in Ashby.
 
@@ -930,7 +930,7 @@ Lists all candidate sources configured in Ashby.
 |     ↳ `title` | string | Source type title |
 |     ↳ `isArchived` | boolean | Whether archived |
 
-### `ashby_list_users`
+### Ashby List Users
 
 Lists all users in Ashby with pagination.
 
@@ -951,7 +951,7 @@ Lists all users in Ashby with pagination.
 | `moreDataAvailable` | boolean | Whether more pages of results exist |
 | `nextCursor` | string | Opaque cursor for fetching the next page |
 
-### `ashby_remove_candidate_tag`
+### Ashby Remove Candidate Tag
 
 Removes a tag from a candidate in Ashby and returns the updated candidate.
 
@@ -999,7 +999,7 @@ Removes a tag from a candidate in Ashby and returns the updated candidate.
 | `nextCursor` | string | Pagination cursor for next page |
 | `syncToken` | string | Sync token for incremental updates |
 
-### `ashby_search_candidates`
+### Ashby Search Candidates
 
 Searches for candidates by name and/or email with AND logic. Results are limited to 100 matches. Use candidate.list for full pagination.
 
@@ -1017,7 +1017,7 @@ Searches for candidates by name and/or email with AND logic. Results are limited
 | --------- | ---- | ----------- |
 | `candidates` | array | Matching candidates \(max 100 results\) |
 
-### `ashby_update_candidate`
+### Ashby Update Candidate
 
 Updates an existing candidate record in Ashby. Only provided fields are changed.
 

--- a/apps/docs/content/docs/en/integrations/athena.mdx
+++ b/apps/docs/content/docs/en/integrations/athena.mdx
@@ -44,7 +44,7 @@ Integrate AWS Athena into workflows. Execute SQL queries against data in S3, che
 
 ## Actions
 
-### `athena_start_query`
+### Athena Start Query
 
 Start an SQL query execution in AWS Athena
 
@@ -67,7 +67,7 @@ Start an SQL query execution in AWS Athena
 | --------- | ---- | ----------- |
 | `queryExecutionId` | string | Unique ID of the started query execution |
 
-### `athena_get_query_execution`
+### Athena Get Query Execution
 
 Get the status and details of an Athena query execution
 
@@ -101,7 +101,7 @@ Get the status and details of an Athena query execution
 | `totalExecutionTimeInMillis` | number | Total execution time in milliseconds |
 | `outputLocation` | string | S3 location of query results |
 
-### `athena_get_query_results`
+### Athena Get Query Results
 
 Retrieve the results of a completed Athena query execution
 
@@ -125,7 +125,7 @@ Retrieve the results of a completed Athena query execution
 | `nextToken` | string | Pagination token for next page of results |
 | `updateCount` | number | Number of rows affected \(for INSERT/UPDATE statements\) |
 
-### `athena_stop_query`
+### Athena Stop Query
 
 Stop a running Athena query execution
 
@@ -144,7 +144,7 @@ Stop a running Athena query execution
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the query was successfully stopped |
 
-### `athena_list_query_executions`
+### Athena List Query Executions
 
 List recent Athena query execution IDs
 
@@ -166,7 +166,7 @@ List recent Athena query execution IDs
 | `queryExecutionIds` | array | List of query execution IDs |
 | `nextToken` | string | Pagination token for next page |
 
-### `athena_batch_get_query_execution`
+### Athena Batch Get Query Executions
 
 Get the status and details of up to 50 Athena query executions in one call
 
@@ -205,7 +205,7 @@ Get the status and details of up to 50 Athena query executions in one call
 |   ↳ `errorCode` | string | Error code |
 |   ↳ `errorMessage` | string | Error message |
 
-### `athena_create_named_query`
+### Athena Create Named Query
 
 Create a saved/named query in AWS Athena
 
@@ -228,7 +228,7 @@ Create a saved/named query in AWS Athena
 | --------- | ---- | ----------- |
 | `namedQueryId` | string | ID of the created named query |
 
-### `athena_get_named_query`
+### Athena Get Named Query
 
 Get details of a saved/named query in AWS Athena
 
@@ -252,7 +252,7 @@ Get details of a saved/named query in AWS Athena
 | `queryString` | string | SQL query string |
 | `workGroup` | string | Workgroup name |
 
-### `athena_list_named_queries`
+### Athena List Named Queries
 
 List saved/named query IDs in AWS Athena
 
@@ -274,7 +274,7 @@ List saved/named query IDs in AWS Athena
 | `namedQueryIds` | array | List of named query IDs |
 | `nextToken` | string | Pagination token for next page |
 
-### `athena_delete_named_query`
+### Athena Delete Named Query
 
 Delete a saved/named query in AWS Athena
 
@@ -293,7 +293,7 @@ Delete a saved/named query in AWS Athena
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the named query was successfully deleted |
 
-### `athena_list_databases`
+### Athena List Databases
 
 List the databases available in an Athena data catalog
 
@@ -318,7 +318,7 @@ List the databases available in an Athena data catalog
 |   ↳ `description` | string | Database description |
 | `nextToken` | string | Pagination token for next page |
 
-### `athena_list_table_metadata`
+### Athena List Table Metadata
 
 List tables and their column/partition metadata for an Athena database
 

--- a/apps/docs/content/docs/en/integrations/attio.mdx
+++ b/apps/docs/content/docs/en/integrations/attio.mdx
@@ -33,7 +33,7 @@ Connect to Attio to manage CRM records (people, companies, custom objects), note
 
 ## Actions
 
-### `attio_list_records`
+### Attio List Records
 
 Query and list records for a given object type (e.g. people, companies)
 
@@ -61,7 +61,7 @@ Query and list records for a given object type (e.g. people, companies)
 |   ↳ `values` | json | The record attribute values |
 | `count` | number | Number of records returned |
 
-### `attio_get_record`
+### Attio Get Record
 
 Get a single record by ID from Attio
 
@@ -87,7 +87,7 @@ Get a single record by ID from Attio
 | `recordId` | string | The record ID |
 | `webUrl` | string | URL to view the record in Attio |
 
-### `attio_create_record`
+### Attio Create Record
 
 Create a new record in Attio for a given object type
 
@@ -113,7 +113,7 @@ Create a new record in Attio for a given object type
 | `recordId` | string | The ID of the created record |
 | `webUrl` | string | URL to view the record in Attio |
 
-### `attio_update_record`
+### Attio Update Record
 
 Update an existing record in Attio (appends multiselect values)
 
@@ -140,7 +140,7 @@ Update an existing record in Attio (appends multiselect values)
 | `recordId` | string | The ID of the updated record |
 | `webUrl` | string | URL to view the record in Attio |
 
-### `attio_delete_record`
+### Attio Delete Record
 
 Delete a record from Attio
 
@@ -157,7 +157,7 @@ Delete a record from Attio
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the record was deleted |
 
-### `attio_search_records`
+### Attio Search Records
 
 Fuzzy search for records across object types in Attio
 
@@ -181,7 +181,7 @@ Fuzzy search for records across object types in Attio
 |   ↳ `recordImage` | string | Image URL for the record |
 | `count` | number | Number of results returned |
 
-### `attio_assert_record`
+### Attio Assert Record
 
 Upsert a record in Attio — creates it if no match is found, updates it if a match exists
 
@@ -208,7 +208,7 @@ Upsert a record in Attio — creates it if no match is found, updates it if a ma
 | `recordId` | string | The record ID |
 | `webUrl` | string | URL to view the record in Attio |
 
-### `attio_list_notes`
+### Attio List Notes
 
 List notes in Attio, optionally filtered by parent record
 
@@ -244,7 +244,7 @@ List notes in Attio, optionally filtered by parent record
 |   ↳ `createdAt` | string | When the note was created |
 | `count` | number | Number of notes returned |
 
-### `attio_get_note`
+### Attio Get Note
 
 Get a single note by ID from Attio
 
@@ -275,7 +275,7 @@ Get a single note by ID from Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the note was created |
 
-### `attio_create_note`
+### Attio Create Note
 
 Create a note on a record in Attio
 
@@ -312,7 +312,7 @@ Create a note on a record in Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the note was created |
 
-### `attio_delete_note`
+### Attio Delete Note
 
 Delete a note from Attio
 
@@ -328,7 +328,7 @@ Delete a note from Attio
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the note was deleted |
 
-### `attio_list_tasks`
+### Attio List Tasks
 
 List tasks in Attio, optionally filtered by record, assignee, or completion status
 
@@ -366,7 +366,7 @@ List tasks in Attio, optionally filtered by record, assignee, or completion stat
 |   ↳ `createdAt` | string | When the task was created |
 | `count` | number | Number of tasks returned |
 
-### `attio_get_task`
+### Attio Get Task
 
 Get a single task by ID from Attio
 
@@ -396,7 +396,7 @@ Get a single task by ID from Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the task was created |
 
-### `attio_create_task`
+### Attio Create Task
 
 Create a task in Attio
 
@@ -430,7 +430,7 @@ Create a task in Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the task was created |
 
-### `attio_update_task`
+### Attio Update Task
 
 Update a task in Attio (deadline, completion status, linked records, assignees)
 
@@ -464,7 +464,7 @@ Update a task in Attio (deadline, completion status, linked records, assignees)
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the task was created |
 
-### `attio_delete_task`
+### Attio Delete Task
 
 Delete a task from Attio
 
@@ -480,7 +480,7 @@ Delete a task from Attio
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the task was deleted |
 
-### `attio_list_objects`
+### Attio List Objects
 
 List all objects (system and custom) in the Attio workspace
 
@@ -501,7 +501,7 @@ List all objects (system and custom) in the Attio workspace
 |   ↳ `createdAt` | string | When the object was created |
 | `count` | number | Number of objects returned |
 
-### `attio_get_object`
+### Attio Get Object
 
 Get a single object by ID or slug
 
@@ -521,7 +521,7 @@ Get a single object by ID or slug
 | `pluralNoun` | string | Plural display name |
 | `createdAt` | string | When the object was created |
 
-### `attio_create_object`
+### Attio Create Object
 
 Create a custom object in Attio
 
@@ -543,7 +543,7 @@ Create a custom object in Attio
 | `pluralNoun` | string | Plural display name |
 | `createdAt` | string | When the object was created |
 
-### `attio_update_object`
+### Attio Update Object
 
 Update a custom object in Attio
 
@@ -566,7 +566,7 @@ Update a custom object in Attio
 | `pluralNoun` | string | Plural display name |
 | `createdAt` | string | When the object was created |
 
-### `attio_list_lists`
+### Attio List Lists
 
 List all lists in the Attio workspace
 
@@ -592,7 +592,7 @@ List all lists in the Attio workspace
 |   ↳ `createdAt` | string | When the list was created |
 | `count` | number | Number of lists returned |
 
-### `attio_get_list`
+### Attio Get List
 
 Get a single list by ID or slug
 
@@ -617,7 +617,7 @@ Get a single list by ID or slug
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the list was created |
 
-### `attio_create_list`
+### Attio Create List
 
 Create a new list in Attio
 
@@ -646,7 +646,7 @@ Create a new list in Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the list was created |
 
-### `attio_update_list`
+### Attio Update List
 
 Update a list in Attio
 
@@ -675,7 +675,7 @@ Update a list in Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the list was created |
 
-### `attio_query_list_entries`
+### Attio Query List Entries
 
 Query entries in an Attio list with optional filter, sort, and pagination
 
@@ -702,7 +702,7 @@ Query entries in an Attio list with optional filter, sort, and pagination
 |   ↳ `entryValues` | json | The entry attribute values \(dynamic per list\) |
 | `count` | number | Number of entries returned |
 
-### `attio_get_list_entry`
+### Attio Get List Entry
 
 Get a single list entry by ID
 
@@ -724,7 +724,7 @@ Get a single list entry by ID
 | `createdAt` | string | When the entry was created |
 | `entryValues` | json | The entry attribute values \(dynamic per list\) |
 
-### `attio_create_list_entry`
+### Attio Create List Entry
 
 Add a record to an Attio list as a new entry
 
@@ -748,7 +748,7 @@ Add a record to an Attio list as a new entry
 | `createdAt` | string | When the entry was created |
 | `entryValues` | json | The entry attribute values \(dynamic per list\) |
 
-### `attio_update_list_entry`
+### Attio Update List Entry
 
 Update entry attribute values on an Attio list entry (appends multiselect values)
 
@@ -771,7 +771,7 @@ Update entry attribute values on an Attio list entry (appends multiselect values
 | `createdAt` | string | When the entry was created |
 | `entryValues` | json | The entry attribute values \(dynamic per list\) |
 
-### `attio_delete_list_entry`
+### Attio Delete List Entry
 
 Remove an entry from an Attio list
 
@@ -788,7 +788,7 @@ Remove an entry from an Attio list
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the entry was deleted |
 
-### `attio_list_members`
+### Attio List Members
 
 List all workspace members in Attio
 
@@ -811,7 +811,7 @@ List all workspace members in Attio
 |   ↳ `createdAt` | string | When the member was added |
 | `count` | number | Number of members returned |
 
-### `attio_get_member`
+### Attio Get Member
 
 Get a single workspace member by ID
 
@@ -833,7 +833,7 @@ Get a single workspace member by ID
 | `accessLevel` | string | Access level \(admin, member, suspended\) |
 | `createdAt` | string | When the member was added |
 
-### `attio_create_comment`
+### Attio Create Comment
 
 Create a comment on a list entry in Attio
 
@@ -874,7 +874,7 @@ Create a comment on a list entry in Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the comment was created |
 
-### `attio_get_comment`
+### Attio Get Comment
 
 Get a single comment by ID from Attio
 
@@ -906,7 +906,7 @@ Get a single comment by ID from Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the comment was created |
 
-### `attio_delete_comment`
+### Attio Delete Comment
 
 Delete a comment in Attio (if head of thread, deletes entire thread)
 
@@ -922,7 +922,7 @@ Delete a comment in Attio (if head of thread, deletes entire thread)
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the comment was deleted |
 
-### `attio_list_threads`
+### Attio List Threads
 
 List comment threads in Attio, optionally filtered by record or list entry
 
@@ -953,7 +953,7 @@ List comment threads in Attio, optionally filtered by record or list entry
 |   ↳ `createdAt` | string | When the thread was created |
 | `count` | number | Number of threads returned |
 
-### `attio_get_thread`
+### Attio Get Thread
 
 Get a single comment thread by ID from Attio
 
@@ -973,7 +973,7 @@ Get a single comment thread by ID from Attio
 |   ↳ `id` | string | The actor ID |
 | `createdAt` | string | When the thread was created |
 
-### `attio_list_webhooks`
+### Attio List Webhooks
 
 List all webhooks in the Attio workspace
 
@@ -998,7 +998,7 @@ List all webhooks in the Attio workspace
 |   ↳ `createdAt` | string | When the webhook was created |
 | `count` | number | Number of webhooks returned |
 
-### `attio_get_webhook`
+### Attio Get Webhook
 
 Get a single webhook by ID from Attio
 
@@ -1020,7 +1020,7 @@ Get a single webhook by ID from Attio
 | `status` | string | Webhook status \(active, degraded, inactive\) |
 | `createdAt` | string | When the webhook was created |
 
-### `attio_create_webhook`
+### Attio Create Webhook
 
 Create a webhook in Attio to receive event notifications
 
@@ -1044,7 +1044,7 @@ Create a webhook in Attio to receive event notifications
 | `createdAt` | string | When the webhook was created |
 | `secret` | string | The webhook signing secret \(only returned on creation\) |
 
-### `attio_update_webhook`
+### Attio Update Webhook
 
 Update a webhook in Attio (target URL and/or subscriptions)
 
@@ -1068,7 +1068,7 @@ Update a webhook in Attio (target URL and/or subscriptions)
 | `status` | string | Webhook status \(active, degraded, inactive\) |
 | `createdAt` | string | When the webhook was created |
 
-### `attio_delete_webhook`
+### Attio Delete Webhook
 
 Delete a webhook from Attio
 
@@ -1084,7 +1084,7 @@ Delete a webhook from Attio
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the webhook was deleted |
 
-### `attio_list_attributes`
+### Attio List Attributes
 
 List the attributes (schema fields) defined on an Attio object or list
 
@@ -1121,7 +1121,7 @@ List the attributes (schema fields) defined on an Attio object or list
 |   ↳ `createdAt` | string | When the attribute was created |
 | `count` | number | Number of attributes returned |
 
-### `attio_get_attribute`
+### Attio Get Attribute
 
 Get a single attribute (schema field) on an Attio object or list
 
@@ -1154,7 +1154,7 @@ Get a single attribute (schema field) on an Attio object or list
 | `config` | json | Type-dependent attribute configuration |
 | `createdAt` | string | When the attribute was created |
 
-### `attio_create_attribute`
+### Attio Create Attribute
 
 Create a new attribute (schema field) on an Attio object or list
 
@@ -1194,7 +1194,7 @@ Create a new attribute (schema field) on an Attio object or list
 | `config` | json | Type-dependent attribute configuration |
 | `createdAt` | string | When the attribute was created |
 
-### `attio_update_attribute`
+### Attio Update Attribute
 
 Update an attribute (schema field) on an Attio object or list
 

--- a/apps/docs/content/docs/en/integrations/azure_devops.mdx
+++ b/apps/docs/content/docs/en/integrations/azure_devops.mdx
@@ -35,7 +35,7 @@ Integrate Azure DevOps into your workflow. List and inspect pipelines and builds
 
 ## Actions
 
-### `azure_devops_list_pipelines`
+### Azure DevOps List Pipelines
 
 List all pipelines in an Azure DevOps project. Returns pipeline ID, name, folder, revision, and URL.
 
@@ -63,7 +63,7 @@ List all pipelines in an Azure DevOps project. Returns pipeline ID, name, folder
 |     ↳ `revision` | number | Pipeline revision number |
 |     ↳ `url` | string | Pipeline API URL |
 
-### `azure_devops_get_pipeline`
+### Azure DevOps Get Pipeline
 
 Get details for a specific pipeline in an Azure DevOps project, including configuration and repository info.
 
@@ -98,7 +98,7 @@ Get details for a specific pipeline in an Azure DevOps project, including config
 |       ↳ `self` | string | API self-link |
 |       ↳ `web` | string | Browser URL for the pipeline |
 
-### `azure_devops_list_pipeline_runs`
+### Azure DevOps List Pipeline Runs
 
 List runs for a specific pipeline in an Azure DevOps project. Returns run ID, name, state, result, and timestamps.
 
@@ -127,7 +127,7 @@ List runs for a specific pipeline in an Azure DevOps project. Returns run ID, na
 |     ↳ `url` | string | Run API URL |
 |     ↳ `webUrl` | string | Browser URL for the run |
 
-### `azure_devops_get_pipeline_run`
+### Azure DevOps Get Pipeline Run
 
 Get details for a specific pipeline run in an Azure DevOps project. Returns run state, result, timestamps, and the pipeline reference.
 
@@ -162,7 +162,7 @@ Get details for a specific pipeline run in an Azure DevOps project. Returns run 
 |       ↳ `revision` | number | Pipeline revision number |
 |       ↳ `url` | string | Pipeline API URL |
 
-### `azure_devops_list_builds`
+### Azure DevOps List Builds
 
 List builds in an Azure DevOps project. Optionally filter by pipeline definition, status, result, or branch.
 
@@ -200,7 +200,7 @@ List builds in an Azure DevOps project. Optionally filter by pipeline definition
 |       ↳ `name` | string | Definition name |
 |     ↳ `webUrl` | string | Browser URL for the build |
 
-### `azure_devops_list_build_logs`
+### Azure DevOps List Build Logs
 
 List all log entries for a specific build in Azure DevOps. Returns log IDs, types, and line counts — use the log ID with the Get Build Log tool to fetch actual log text.
 
@@ -227,7 +227,7 @@ List all log entries for a specific build in Azure DevOps. Returns log IDs, type
 |     ↳ `createdOn` | string | ISO 8601 creation timestamp |
 |     ↳ `lastChangedOn` | string | ISO 8601 last-changed timestamp |
 
-### `azure_devops_get_build_log`
+### Azure DevOps Get Build Log
 
 Fetch the text content of a specific build log in Azure DevOps. Use List Build Logs first to get the log ID. Optionally retrieve only a line range with startLine/endLine.
 
@@ -250,7 +250,7 @@ Fetch the text content of a specific build log in Azure DevOps. Use List Build L
 | `metadata` | object | Log metadata |
 |   ↳ `lineCount` | number | Number of lines in the returned log text |
 
-### `azure_devops_get_build_timeline`
+### Azure DevOps Get Build Timeline
 
 Get the execution timeline for an Azure DevOps build — every stage, job, and task with its result and log ID. Use this to identify which steps failed before fetching their logs with Get Build Log.
 
@@ -291,7 +291,7 @@ Get the execution timeline for an Azure DevOps build — every stage, job, and t
 |     ↳ `startTime` | string | ISO 8601 start timestamp |
 |     ↳ `finishTime` | string | ISO 8601 finish timestamp |
 
-### `azure_devops_get_work_items_between_builds`
+### Azure DevOps Get Work Items Between Builds
 
 Get work item references associated with commits between two builds in Azure DevOps. Returns work item IDs and URLs — use Get Work Items Batch for full field details.
 
@@ -315,7 +315,7 @@ Get work item references associated with commits between two builds in Azure Dev
 |     ↳ `id` | string | Work item ID |
 |     ↳ `url` | string | API URL for the work item |
 
-### `azure_devops_query_work_items`
+### Azure DevOps Query Work Items
 
 Execute a WIQL query to search for work items in Azure DevOps and return full field details. Use TOP N in your query to limit results (Azure enforces a 200-item maximum per batch fetch).
 
@@ -344,7 +344,7 @@ Execute a WIQL query to search for work items in Azure DevOps and return full fi
 |     ↳ `areaPath` | string | Area path of the work item |
 |     ↳ `url` | string | API URL for the work item |
 
-### `azure_devops_get_work_item`
+### Azure DevOps Get Work Item
 
 Fetch full details of a single work item by ID from Azure DevOps, including title, state, type, assignee, and area path.
 
@@ -371,7 +371,7 @@ Fetch full details of a single work item by ID from Azure DevOps, including titl
 |     ↳ `areaPath` | string | Area path of the work item |
 |     ↳ `url` | string | API URL for the work item |
 
-### `azure_devops_get_work_items_batch`
+### Azure DevOps Get Work Items Batch
 
 Fetch full details for multiple work items by ID from Azure DevOps. Pass comma-separated IDs (e.g. "123,456,789"). Requests with more than 200 IDs are automatically split into chunks.
 
@@ -400,7 +400,7 @@ Fetch full details for multiple work items by ID from Azure DevOps. Pass comma-s
 |     ↳ `areaPath` | string | Area path of the work item |
 |     ↳ `url` | string | API URL for the work item |
 
-### `azure_devops_create_work_item`
+### Azure DevOps Create Work Item
 
 Create a new Basic-process work item (Issue, Task, or Epic) in Azure DevOps. Returns the created work item with its assigned ID.
 
@@ -440,7 +440,7 @@ Create a new Basic-process work item (Issue, Task, or Epic) in Azure DevOps. Ret
 |     ↳ `areaPath` | string | Area path of the work item |
 |     ↳ `url` | string | API URL for the created work item |
 
-### `azure_devops_update_work_item`
+### Azure DevOps Update Work Item
 
 Update one or more fields on an existing work item in Azure DevOps. Provide only the fields you want to change.
 
@@ -480,7 +480,7 @@ Update one or more fields on an existing work item in Azure DevOps. Provide only
 |     ↳ `areaPath` | string | Area path of the work item |
 |     ↳ `url` | string | API URL for the work item |
 
-### `azure_devops_add_comment`
+### Azure DevOps Add Comment
 
 Add a comment to a work item in Azure DevOps.
 
@@ -512,7 +512,7 @@ Add a comment to a work item in Azure DevOps.
 |     ↳ `isDeleted` | boolean | Whether the comment is deleted |
 |     ↳ `url` | string | API URL for the comment |
 
-### `azure_devops_get_comments`
+### Azure DevOps Get Comments
 
 List comments for an Azure DevOps work item.
 

--- a/apps/docs/content/docs/en/integrations/box.mdx
+++ b/apps/docs/content/docs/en/integrations/box.mdx
@@ -42,7 +42,7 @@ Integrate Box into your workflow to manage files, folders, and e-signatures. Upl
 
 ## Actions
 
-### `box_upload_file`
+### Box Upload File
 
 Upload a file to a Box folder
 
@@ -68,7 +68,7 @@ Upload a file to a Box folder
 | `parentId` | string | Parent folder ID |
 | `parentName` | string | Parent folder name |
 
-### `box_download_file`
+### Box Download File
 
 Download a file from Box
 
@@ -85,7 +85,7 @@ Download a file from Box
 | `file` | file | Downloaded file stored in execution files |
 | `content` | string | Base64 encoded file content |
 
-### `box_get_file_info`
+### Box Get File Info
 
 Get detailed information about a file in Box
 
@@ -115,7 +115,7 @@ Get detailed information about a file in Box
 | `tags` | array | File tags |
 | `commentCount` | number | Number of comments |
 
-### `box_list_folder_items`
+### Box List Folder Items
 
 List files and folders in a Box folder
 
@@ -144,7 +144,7 @@ List files and folders in a Box folder
 | `offset` | number | Current pagination offset |
 | `limit` | number | Current pagination limit |
 
-### `box_create_folder`
+### Box Create Folder
 
 Create a new folder in Box
 
@@ -166,7 +166,7 @@ Create a new folder in Box
 | `parentId` | string | Parent folder ID |
 | `parentName` | string | Parent folder name |
 
-### `box_delete_file`
+### Box Delete File
 
 Delete a file from Box
 
@@ -183,7 +183,7 @@ Delete a file from Box
 | `deleted` | boolean | Whether the file was successfully deleted |
 | `message` | string | Success confirmation message |
 
-### `box_delete_folder`
+### Box Delete Folder
 
 Delete a folder from Box
 
@@ -201,7 +201,7 @@ Delete a folder from Box
 | `deleted` | boolean | Whether the folder was successfully deleted |
 | `message` | string | Success confirmation message |
 
-### `box_copy_file`
+### Box Copy File
 
 Copy a file to another folder in Box
 
@@ -226,7 +226,7 @@ Copy a file to another folder in Box
 | `parentId` | string | Parent folder ID |
 | `parentName` | string | Parent folder name |
 
-### `box_search`
+### Box Search
 
 Search for files and folders in Box
 
@@ -256,7 +256,7 @@ Search for files and folders in Box
 |   ↳ `parentName` | string | Parent folder name |
 | `totalCount` | number | Total number of matching results |
 
-### `box_update_file`
+### Box Update File
 
 Update file info in Box (rename, move, change description, add tags)
 
@@ -290,7 +290,7 @@ Update file info in Box (rename, move, change description, add tags)
 | `tags` | array | File tags |
 | `commentCount` | number | Number of comments |
 
-### `box_sign_create_request`
+### Box Sign Create Request
 
 Create a new Box Sign request to send documents for e-signature
 
@@ -333,7 +333,7 @@ Create a new Box Sign request to send documents for e-signature
 | `prepareUrl` | string | URL for document preparation \(if preparation is needed\) |
 | `senderEmail` | string | Email of the sender |
 
-### `box_sign_get_request`
+### Box Sign Get Request
 
 Get the details and status of a Box Sign request
 
@@ -361,7 +361,7 @@ Get the details and status of a Box Sign request
 | `prepareUrl` | string | URL for document preparation \(if preparation is needed\) |
 | `senderEmail` | string | Email of the sender |
 
-### `box_sign_list_requests`
+### Box Sign List Requests
 
 List all Box Sign requests
 
@@ -393,7 +393,7 @@ List all Box Sign requests
 | `count` | number | Number of sign requests returned in this page |
 | `nextMarker` | string | Marker for next page of results |
 
-### `box_sign_cancel_request`
+### Box Sign Cancel Request
 
 Cancel a pending Box Sign request
 
@@ -421,7 +421,7 @@ Cancel a pending Box Sign request
 | `prepareUrl` | string | URL for document preparation \(if preparation is needed\) |
 | `senderEmail` | string | Email of the sender |
 
-### `box_sign_resend_request`
+### Box Sign Resend Request
 
 Resend a Box Sign request to signers who have not yet signed
 

--- a/apps/docs/content/docs/en/integrations/brandfetch.mdx
+++ b/apps/docs/content/docs/en/integrations/brandfetch.mdx
@@ -32,7 +32,7 @@ Integrate Brandfetch into your workflow. Retrieve brand logos, colors, fonts, an
 
 ## Actions
 
-### `brandfetch_get_brand`
+### Brandfetch Get Brand
 
 Retrieve brand assets including logos, colors, fonts, and company info by domain, ticker, ISIN, or crypto symbol
 
@@ -72,7 +72,7 @@ Retrieve brand assets including logos, colors, fonts, and company info by domain
 | `qualityScore` | number | Data quality score from 0 to 1 |
 | `isNsfw` | boolean | Whether the brand contains adult content |
 
-### `brandfetch_search`
+### Brandfetch Search
 
 Search for brands by name and find their domains and logos
 

--- a/apps/docs/content/docs/en/integrations/brex.mdx
+++ b/apps/docs/content/docs/en/integrations/brex.mdx
@@ -34,7 +34,7 @@ Integrates Brex into the workflow. List and update expenses, upload and match re
 
 ## Actions
 
-### `brex_list_expenses`
+### Brex List Expenses
 
 List expenses in the Brex account with optional filters for user, status, payment status, and purchase date range
 
@@ -96,7 +96,7 @@ List expenses in the Brex account with optional filters for user, status, paymen
 |   ↳ `dashboard_url` | string | Link to the expense in the Brex dashboard |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_get_expense`
+### Brex Get Expense
 
 Get a single Brex expense by its ID, including merchant, user, and receipt details
 
@@ -159,7 +159,7 @@ Get a single Brex expense by its ID, including merchant, user, and receipt detai
 |   ↳ `download_uris` | array | Pre-signed receipt download URLs |
 | `dashboardUrl` | string | Link to the expense in the Brex dashboard |
 
-### `brex_update_expense`
+### Brex Update Expense
 
 Update the memo of a Brex card expense
 
@@ -191,7 +191,7 @@ Update the memo of a Brex card expense
 | `purchasedAt` | string | Purchase timestamp \(ISO 8601\) |
 | `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 
-### `brex_upload_receipt`
+### Brex Upload Receipt
 
 Upload a receipt file and attach it to a specific Brex card expense
 
@@ -212,7 +212,7 @@ Upload a receipt file and attach it to a specific Brex card expense
 | `receiptName` | string | Name the receipt was uploaded with |
 | `expenseId` | string | ID of the expense the receipt was attached to |
 
-### `brex_match_receipt`
+### Brex Match Receipt
 
 Upload a receipt file and let Brex automatically match it with existing expenses
 
@@ -232,7 +232,7 @@ Upload a receipt file and let Brex automatically match it with existing expenses
 | `receiptName` | string | Name the receipt was uploaded with |
 | `expenseId` | string | Always null for receipt match \(Brex matches the receipt asynchronously\) |
 
-### `brex_list_card_transactions`
+### Brex List Card Transactions
 
 List settled card transactions for all Brex card accounts
 
@@ -267,7 +267,7 @@ List settled card transactions for all Brex card accounts
 |   ↳ `expense_id` | string | Associated expense ID |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_list_cash_transactions`
+### Brex List Cash Transactions
 
 List transactions for a Brex cash account
 
@@ -297,7 +297,7 @@ List transactions for a Brex cash account
 |   ↳ `transfer_id` | string | Associated transfer ID |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_list_card_accounts`
+### Brex List Card Accounts
 
 List all Brex card accounts with balances and limits
 
@@ -325,7 +325,7 @@ List all Brex card accounts with balances and limits
 |     ↳ `currency` | string | ISO 4217 currency code \(e.g., USD\) |
 |   ↳ `current_statement_period` | json | Current statement period \(start_date, end_date\) |
 
-### `brex_list_cash_accounts`
+### Brex List Cash Accounts
 
 List all Brex cash accounts with balances and account details
 
@@ -356,7 +356,7 @@ List all Brex cash accounts with balances and account details
 |   ↳ `primary` | boolean | Whether this is the primary cash account |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_get_cash_account`
+### Brex Get Cash Account
 
 Get a Brex cash account by ID, or the primary cash account when no ID is provided
 
@@ -384,7 +384,7 @@ Get a Brex cash account by ID, or the primary cash account when no ID is provide
 | `routingNumber` | string | Bank routing number |
 | `primary` | boolean | Whether this is the primary cash account |
 
-### `brex_list_card_statements`
+### Brex List Card Statements
 
 List finalized statements for the primary Brex card account
 
@@ -411,7 +411,7 @@ List finalized statements for the primary Brex card account
 |   ↳ `period` | json | Statement period \(start_date, end_date\) |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_list_cash_statements`
+### Brex List Cash Statements
 
 List finalized statements for a Brex cash account
 
@@ -439,7 +439,7 @@ List finalized statements for a Brex cash account
 |   ↳ `period` | json | Statement period \(start_date, end_date\) |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_list_users`
+### Brex List Users
 
 List users in the Brex account, optionally filtered by email
 
@@ -468,7 +468,7 @@ List users in the Brex account, optionally filtered by email
 |   ↳ `title_id` | string | Title ID |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_get_user`
+### Brex Get User
 
 Get a Brex user by their ID
 
@@ -493,7 +493,7 @@ Get a Brex user by their ID
 | `locationId` | string | Location ID |
 | `titleId` | string | Title ID |
 
-### `brex_get_current_user`
+### Brex Get Current User
 
 Get the Brex user associated with the API token
 
@@ -517,7 +517,7 @@ Get the Brex user associated with the API token
 | `locationId` | string | Location ID |
 | `titleId` | string | Title ID |
 
-### `brex_list_departments`
+### Brex List Departments
 
 List departments in the Brex account, optionally filtered by name
 
@@ -540,7 +540,7 @@ List departments in the Brex account, optionally filtered by name
 |   ↳ `description` | string | Department description |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_list_locations`
+### Brex List Locations
 
 List locations in the Brex account, optionally filtered by name
 
@@ -563,7 +563,7 @@ List locations in the Brex account, optionally filtered by name
 |   ↳ `description` | string | Location description |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_list_titles`
+### Brex List Titles
 
 List job titles in the Brex account, optionally filtered by name
 
@@ -585,7 +585,7 @@ List job titles in the Brex account, optionally filtered by name
 |   ↳ `name` | string | Title name |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_list_cards`
+### Brex List Cards
 
 List cards in the Brex account, optionally filtered by card owner
 
@@ -616,7 +616,7 @@ List cards in the Brex account, optionally filtered by card owner
 |   ↳ `budget_id` | string | Associated budget ID |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_get_company`
+### Brex Get Company
 
 Get the Brex company associated with the API token
 
@@ -635,7 +635,7 @@ Get the Brex company associated with the API token
 | `mailingAddress` | json | Company mailing address \(line1, line2, city, state, country, postal_code\) |
 | `accountType` | string | Brex account type \(BREX_CLASSIC or BREX_EMPOWER\) |
 
-### `brex_list_budgets`
+### Brex List Budgets
 
 List budgets in the Brex account
 
@@ -668,7 +668,7 @@ List budgets in the Brex account
 |   ↳ `limit_type` | string | Budget limit type |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_get_budget`
+### Brex Get Budget
 
 Get a Brex budget by its ID
 
@@ -698,7 +698,7 @@ Get a Brex budget by its ID
 | `spendBudgetStatus` | string | Budget status \(ACTIVE, ARCHIVED, DELETED\) |
 | `limitType` | string | Budget limit type \(HARD or SOFT\) |
 
-### `brex_create_budget`
+### Brex Create Budget
 
 Create a new budget in the Brex account
 
@@ -736,7 +736,7 @@ Create a new budget in the Brex account
 | `spendBudgetStatus` | string | Status of the created budget |
 | `limitType` | string | Budget limit type |
 
-### `brex_archive_budget`
+### Brex Archive Budget
 
 Archive a Brex budget, making any spend limits beneath it unusable for future expenses and removing it from the UI
 
@@ -754,7 +754,7 @@ Archive a Brex budget, making any spend limits beneath it unusable for future ex
 | `budgetId` | string | ID of the archived budget |
 | `spendBudgetStatus` | string | Status of the budget after archiving |
 
-### `brex_list_spend_limits`
+### Brex List Spend Limits
 
 List spend limits in the Brex account, optionally filtered by member user
 
@@ -798,7 +798,7 @@ List spend limits in the Brex account, optionally filtered by member user
 |   ↳ `authorization_settings` | json | Authorization settings \(base limit, authorization type, rollover refresh\) |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_get_spend_limit`
+### Brex Get Spend Limit
 
 Get a Brex spend limit by its ID
 
@@ -838,7 +838,7 @@ Get a Brex spend limit by its ID
 |     ↳ `currency` | string | ISO 4217 currency code \(e.g., USD\) |
 | `authorizationSettings` | json | Authorization settings \(base limit, authorization type, rollover refresh\) |
 
-### `brex_create_spend_limit`
+### Brex Create Spend Limit
 
 Create a new spend limit (hard-authorization card program) in the Brex account
 
@@ -898,7 +898,7 @@ Create a new spend limit (hard-authorization card program) in the Brex account
 |     ↳ `currency` | string | ISO 4217 currency code \(e.g., USD\) |
 | `authorizationSettings` | json | Authorization settings \(base limit, authorization type, rollover refresh\) |
 
-### `brex_list_vendors`
+### Brex List Vendors
 
 List vendors in the Brex account, optionally filtered by name
 
@@ -923,7 +923,7 @@ List vendors in the Brex account, optionally filtered by name
 |   ↳ `payment_accounts` | array | Payment accounts associated with the vendor |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_get_vendor`
+### Brex Get Vendor
 
 Get a Brex vendor by its ID
 
@@ -944,7 +944,7 @@ Get a Brex vendor by its ID
 | `phone` | string | Vendor phone number |
 | `paymentAccounts` | array | Payment accounts associated with the vendor |
 
-### `brex_create_vendor`
+### Brex Create Vendor
 
 Create a new vendor in the Brex account
 
@@ -967,7 +967,7 @@ Create a new vendor in the Brex account
 | `phone` | string | Vendor phone number |
 | `paymentAccounts` | array | Payment accounts associated with the vendor |
 
-### `brex_update_vendor`
+### Brex Update Vendor
 
 Update an existing vendor in the Brex account
 
@@ -991,7 +991,7 @@ Update an existing vendor in the Brex account
 | `phone` | string | Vendor phone number |
 | `paymentAccounts` | array | Payment accounts associated with the vendor |
 
-### `brex_list_transfers`
+### Brex List Transfers
 
 List money transfers in the Brex account
 
@@ -1027,7 +1027,7 @@ List money transfers in the Brex account
 |   ↳ `is_ppro_enabled` | boolean | Whether Principal Protection \(PPRO\) is enabled |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `brex_get_transfer`
+### Brex Get Transfer
 
 Get a Brex money transfer by its ID
 
@@ -1060,7 +1060,7 @@ Get a Brex money transfer by its ID
 | `externalMemo` | string | External memo |
 | `isPproEnabled` | boolean | Whether Principal Protection \(PPRO\) is enabled |
 
-### `brex_create_transfer`
+### Brex Create Transfer
 
 Create a money transfer from a Brex cash account to a vendor
 

--- a/apps/docs/content/docs/en/integrations/brightdata.mdx
+++ b/apps/docs/content/docs/en/integrations/brightdata.mdx
@@ -32,7 +32,7 @@ Integrate Bright Data into the workflow. Scrape any URL with Web Unlocker, searc
 
 ## Actions
 
-### `brightdata_scrape_url`
+### Bright Data Scrape URL
 
 Fetch content from any URL using Bright Data Web Unlocker. Bypasses anti-bot protections, CAPTCHAs, and IP blocks automatically.
 
@@ -55,7 +55,7 @@ Fetch content from any URL using Bright Data Web Unlocker. Bypasses anti-bot pro
 | `url` | string | The URL that was scraped |
 | `statusCode` | number | HTTP status code of the response |
 
-### `brightdata_serp_search`
+### Bright Data SERP Search
 
 Search Google, Bing, DuckDuckGo, or Yandex and get structured search results using Bright Data SERP API.
 
@@ -83,7 +83,7 @@ Search Google, Bing, DuckDuckGo, or Yandex and get structured search results usi
 | `query` | string | The search query that was executed |
 | `searchEngine` | string | The search engine that was used |
 
-### `brightdata_discover`
+### Bright Data Discover
 
 AI-powered web discovery that finds and ranks results by intent. Returns up to 20 results with optional cleaned page content for RAG and verification.
 
@@ -114,7 +114,7 @@ AI-powered web discovery that finds and ranks results by intent. Returns up to 2
 | `query` | string | The search query that was executed |
 | `totalResults` | number | Total number of results returned |
 
-### `brightdata_sync_scrape`
+### Bright Data Sync Scrape
 
 Scrape URLs synchronously using a Bright Data pre-built scraper and get structured results directly. Supports up to 20 URLs with a 1-minute timeout.
 
@@ -136,7 +136,7 @@ Scrape URLs synchronously using a Bright Data pre-built scraper and get structur
 | `snapshotId` | string | Snapshot ID returned if the request exceeded the 1-minute timeout and switched to async processing |
 | `isAsync` | boolean | Whether the request fell back to async mode \(true means use snapshot ID to retrieve results\) |
 
-### `brightdata_scrape_dataset`
+### Bright Data Scrape Dataset
 
 Trigger a Bright Data pre-built scraper to extract structured data from URLs. Supports 660+ scrapers for platforms like Amazon, LinkedIn, Instagram, and more.
 
@@ -157,7 +157,7 @@ Trigger a Bright Data pre-built scraper to extract structured data from URLs. Su
 | `snapshotId` | string | The snapshot ID to retrieve results later |
 | `status` | string | Status of the scraping job \(e.g., "triggered", "running"\) |
 
-### `brightdata_snapshot_status`
+### Bright Data Snapshot Status
 
 Check the progress of an async Bright Data scraping job. Returns status: starting, running, ready, or failed.
 
@@ -176,7 +176,7 @@ Check the progress of an async Bright Data scraping job. Returns status: startin
 | `datasetId` | string | The dataset ID associated with this snapshot |
 | `status` | string | Current status of the snapshot: "starting", "running", "ready", or "failed" |
 
-### `brightdata_download_snapshot`
+### Bright Data Download Snapshot
 
 Download the results of a completed Bright Data scraping job using its snapshot ID. The snapshot must have ready status.
 
@@ -197,7 +197,7 @@ Download the results of a completed Bright Data scraping job using its snapshot 
 | `format` | string | The content type of the downloaded data |
 | `snapshotId` | string | The snapshot ID that was downloaded |
 
-### `brightdata_cancel_snapshot`
+### Bright Data Cancel Snapshot
 
 Cancel an active Bright Data scraping job using its snapshot ID. Terminates data collection in progress.
 

--- a/apps/docs/content/docs/en/integrations/browser_use.mdx
+++ b/apps/docs/content/docs/en/integrations/browser_use.mdx
@@ -33,7 +33,7 @@ Integrate Browser Use into the workflow. Can navigate the web and perform action
 
 ## Actions
 
-### `browser_use_run_task`
+### Browser Use
 
 Runs a browser automation task using BrowserUse
 

--- a/apps/docs/content/docs/en/integrations/buffer.mdx
+++ b/apps/docs/content/docs/en/integrations/buffer.mdx
@@ -18,7 +18,7 @@ Integrate Buffer into your workflow. Create, schedule, edit, and delete posts ac
 
 ## Actions
 
-### `buffer_create_post`
+### Buffer Create Post
 
 Create a post in Buffer for a channel — add it to the queue, share it immediately, schedule it for a specific time, or save it as a draft, optionally with an image or video attachment
 
@@ -68,7 +68,7 @@ Create a post in Buffer for a channel — add it to the queue, share it immediat
 |     ↳ `source` | string | Source URL of the asset |
 |     ↳ `thumbnail` | string | Thumbnail URL of the asset |
 
-### `buffer_edit_post`
+### Buffer Edit Post
 
 Edit an existing Buffer post — update its text, schedule, or media. Attaching new media replaces the existing attachments
 
@@ -118,7 +118,7 @@ Edit an existing Buffer post — update its text, schedule, or media. Attaching 
 |     ↳ `source` | string | Source URL of the asset |
 |     ↳ `thumbnail` | string | Thumbnail URL of the asset |
 
-### `buffer_get_posts`
+### Buffer Get Posts
 
 List posts in a Buffer organization, optionally filtered by channel and status (draft, needs_approval, scheduled, sending, sent, error)
 
@@ -169,7 +169,7 @@ List posts in a Buffer organization, optionally filtered by channel and status (
 |   ↳ `hasNextPage` | boolean | Whether more results are available |
 |   ↳ `endCursor` | string | Cursor to pass as "after" for the next page |
 
-### `buffer_get_post`
+### Buffer Get Post
 
 Get a single Buffer post by ID, including its status, schedule, and media
 
@@ -211,7 +211,7 @@ Get a single Buffer post by ID, including its status, schedule, and media
 |     ↳ `source` | string | Source URL of the asset |
 |     ↳ `thumbnail` | string | Thumbnail URL of the asset |
 
-### `buffer_delete_post`
+### Buffer Delete Post
 
 Delete a Buffer post by ID
 
@@ -229,7 +229,7 @@ Delete a Buffer post by ID
 | `deleted` | boolean | Whether the post was deleted |
 | `id` | string | ID of the deleted post |
 
-### `buffer_get_channels`
+### Buffer Get Channels
 
 List the social media channels connected to a Buffer organization, including their channel IDs (needed to create posts)
 
@@ -257,7 +257,7 @@ List the social media channels connected to a Buffer organization, including the
 |   ↳ `isDisconnected` | boolean | Whether the channel needs reconnection |
 |   ↳ `organizationId` | string | Organization the channel belongs to |
 
-### `buffer_create_idea`
+### Buffer Create Idea
 
 Save a content idea to a Buffer organization for later drafting and scheduling
 
@@ -282,7 +282,7 @@ Save a content idea to a Buffer organization for later drafting and scheduling
 |   ↳ `title` | string | Idea title |
 |   ↳ `text` | string | Idea text content |
 
-### `buffer_get_ideas`
+### Buffer Get Ideas
 
 List content ideas saved in a Buffer organization
 
@@ -309,7 +309,7 @@ List content ideas saved in a Buffer organization
 |   ↳ `hasNextPage` | boolean | Whether more results are available |
 |   ↳ `endCursor` | string | Cursor to pass as "after" for the next page |
 
-### `buffer_get_idea_groups`
+### Buffer Get Idea Groups
 
 List idea groups (board columns) in a Buffer organization, including the group IDs used when creating ideas
 
@@ -329,7 +329,7 @@ List idea groups (board columns) in a Buffer organization, including the group I
 |   ↳ `name` | string | Idea group name |
 |   ↳ `isLocked` | boolean | Whether the group is locked |
 
-### `buffer_get_account`
+### Buffer Get Account
 
 Get the authenticated Buffer account, including its organizations and their IDs (needed for channel and post operations)
 

--- a/apps/docs/content/docs/en/integrations/calcom.mdx
+++ b/apps/docs/content/docs/en/integrations/calcom.mdx
@@ -34,7 +34,7 @@ Integrate Cal.com into your workflow. Create and manage bookings, event types, s
 
 ## Actions
 
-### `calcom_create_booking`
+### Cal.com Create Booking
 
 Create a new booking on Cal.com
 
@@ -90,7 +90,7 @@ Create a new booking on Cal.com
 |   ↳ `icsUid` | string | ICS calendar UID |
 |   ↳ `createdAt` | string | When the booking was created |
 
-### `calcom_get_booking`
+### Cal.com Get Booking
 
 Get details of a specific booking by its UID
 
@@ -150,7 +150,7 @@ Get details of a specific booking by its UID
 |   ↳ `createdAt` | string | When the booking was created |
 |   ↳ `updatedAt` | string | When the booking was last updated |
 
-### `calcom_list_bookings`
+### Cal.com List Bookings
 
 List all bookings with optional status filter
 
@@ -221,7 +221,7 @@ List all bookings with optional status filter
 |   ↳ `hasNextPage` | boolean | Whether there is a next page |
 |   ↳ `hasPreviousPage` | boolean | Whether there is a previous page |
 
-### `calcom_cancel_booking`
+### Cal.com Cancel Booking
 
 Cancel an existing booking
 
@@ -270,7 +270,7 @@ Cancel an existing booking
 |   ↳ `createdAt` | string | When the booking was created |
 |   ↳ `status` | string | Booking status \(should be cancelled\) |
 
-### `calcom_reschedule_booking`
+### Cal.com Reschedule Booking
 
 Reschedule an existing booking to a new time
 
@@ -324,7 +324,7 @@ Reschedule an existing booking to a new time
 |   ↳ `start` | string | New start time in ISO 8601 format |
 |   ↳ `end` | string | New end time in ISO 8601 format |
 
-### `calcom_confirm_booking`
+### Cal.com Confirm Booking
 
 Confirm a pending booking that requires confirmation
 
@@ -373,7 +373,7 @@ Confirm a pending booking that requires confirmation
 |   ↳ `createdAt` | string | When the booking was created |
 |   ↳ `status` | string | Booking status \(should be accepted/confirmed\) |
 
-### `calcom_decline_booking`
+### Cal.com Decline Booking
 
 Decline a pending booking request
 
@@ -421,7 +421,7 @@ Decline a pending booking request
 |   ↳ `createdAt` | string | When the booking was created |
 |   ↳ `status` | string | Booking status \(should be cancelled/rejected\) |
 
-### `calcom_create_event_type`
+### Cal.com Create Event Type
 
 Create a new event type in Cal.com
 
@@ -460,7 +460,7 @@ Create a new event type in Cal.com
 |   ↳ `createdAt` | string | ISO timestamp of creation |
 |   ↳ `updatedAt` | string | ISO timestamp of last update |
 
-### `calcom_get_event_type`
+### Cal.com Get Event Type
 
 Get detailed information about a specific event type
 
@@ -490,7 +490,7 @@ Get detailed information about a specific event type
 |   ↳ `createdAt` | string | ISO timestamp of creation |
 |   ↳ `updatedAt` | string | ISO timestamp of last update |
 
-### `calcom_list_event_types`
+### Cal.com List Event Types
 
 Retrieve a list of all event types
 
@@ -520,7 +520,7 @@ Retrieve a list of all event types
 |   ↳ `createdAt` | string | ISO timestamp of creation |
 |   ↳ `updatedAt` | string | ISO timestamp of last update |
 
-### `calcom_update_event_type`
+### Cal.com Update Event Type
 
 Update an existing event type in Cal.com
 
@@ -560,7 +560,7 @@ Update an existing event type in Cal.com
 |   ↳ `createdAt` | string | ISO timestamp of creation |
 |   ↳ `updatedAt` | string | ISO timestamp of last update |
 
-### `calcom_delete_event_type`
+### Cal.com Delete Event Type
 
 Delete an event type from Cal.com
 
@@ -581,7 +581,7 @@ Delete an event type from Cal.com
 |   ↳ `title` | string | Event type title |
 |   ↳ `slug` | string | Event type slug |
 
-### `calcom_create_schedule`
+### Cal.com Create Schedule
 
 Create a new availability schedule in Cal.com
 
@@ -614,7 +614,7 @@ Create a new availability schedule in Cal.com
 |     ↳ `startTime` | string | Start time in HH:MM format |
 |     ↳ `endTime` | string | End time in HH:MM format |
 
-### `calcom_get_schedule`
+### Cal.com Get Schedule
 
 Get a specific schedule by ID from Cal.com
 
@@ -644,7 +644,7 @@ Get a specific schedule by ID from Cal.com
 |     ↳ `startTime` | string | Start time in HH:MM format |
 |     ↳ `endTime` | string | End time in HH:MM format |
 
-### `calcom_list_schedules`
+### Cal.com List Schedules
 
 List all availability schedules from Cal.com
 
@@ -673,7 +673,7 @@ List all availability schedules from Cal.com
 |     ↳ `startTime` | string | Start time in HH:MM format |
 |     ↳ `endTime` | string | End time in HH:MM format |
 
-### `calcom_update_schedule`
+### Cal.com Update Schedule
 
 Update an existing schedule in Cal.com
 
@@ -707,7 +707,7 @@ Update an existing schedule in Cal.com
 |     ↳ `startTime` | string | Start time in HH:MM format |
 |     ↳ `endTime` | string | End time in HH:MM format |
 
-### `calcom_delete_schedule`
+### Cal.com Delete Schedule
 
 Delete a schedule from Cal.com
 
@@ -723,7 +723,7 @@ Delete a schedule from Cal.com
 | --------- | ---- | ----------- |
 | `status` | string | Response status \(success or error\) |
 
-### `calcom_get_default_schedule`
+### Cal.com Get Default Schedule
 
 Get the default availability schedule from Cal.com
 
@@ -752,7 +752,7 @@ Get the default availability schedule from Cal.com
 |     ↳ `startTime` | string | Start time in HH:MM format |
 |     ↳ `endTime` | string | End time in HH:MM format |
 
-### `calcom_get_slots`
+### Cal.com Get Slots
 
 Get available booking slots for a Cal.com event type within a time range
 

--- a/apps/docs/content/docs/en/integrations/calendly.mdx
+++ b/apps/docs/content/docs/en/integrations/calendly.mdx
@@ -32,7 +32,7 @@ Integrate Calendly into your workflow. Manage event types, scheduled events, inv
 
 ## Actions
 
-### `calendly_get_current_user`
+### Calendly Get Current User
 
 Get information about the currently authenticated Calendly user
 
@@ -58,7 +58,7 @@ Get information about the currently authenticated Calendly user
 |   ↳ `updated_at` | string | ISO timestamp when user was last updated |
 |   ↳ `current_organization` | string | URI of current organization |
 
-### `calendly_list_event_types`
+### Calendly List Event Types
 
 Retrieve a list of all event types for a user or organization
 
@@ -99,7 +99,7 @@ Retrieve a list of all event types for a user or organization
 |   ↳ `next_page_token` | string | Token for next page |
 |   ↳ `previous_page_token` | string | Token for previous page |
 
-### `calendly_get_event_type`
+### Calendly Get Event Type
 
 Get detailed information about a specific event type
 
@@ -136,7 +136,7 @@ Get detailed information about a specific event type
 |   ↳ `type` | string | Event type classification |
 |   ↳ `updated_at` | string | ISO timestamp of last update |
 
-### `calendly_list_scheduled_events`
+### Calendly List Scheduled Events
 
 Retrieve a list of scheduled events for a user or organization
 
@@ -183,7 +183,7 @@ Retrieve a list of scheduled events for a user or organization
 |   ↳ `next_page_token` | string | Token for next page |
 |   ↳ `previous_page_token` | string | Token for previous page |
 
-### `calendly_get_scheduled_event`
+### Calendly Get Scheduled Event
 
 Get detailed information about a specific scheduled event
 
@@ -224,7 +224,7 @@ Get detailed information about a specific scheduled event
 |   ↳ `created_at` | string | ISO timestamp of event creation |
 |   ↳ `updated_at` | string | ISO timestamp of last update |
 
-### `calendly_list_event_invitees`
+### Calendly List Event Invitees
 
 Retrieve a list of invitees for a scheduled event
 
@@ -269,7 +269,7 @@ Retrieve a list of invitees for a scheduled event
 |   ↳ `next_page_token` | string | Token for next page |
 |   ↳ `previous_page_token` | string | Token for previous page |
 
-### `calendly_cancel_event`
+### Calendly Cancel Event
 
 Cancel a scheduled event
 

--- a/apps/docs/content/docs/en/integrations/clay.mdx
+++ b/apps/docs/content/docs/en/integrations/clay.mdx
@@ -33,7 +33,7 @@ Integrate Clay into the workflow. Can populate a table with data.
 
 ## Actions
 
-### `clay_populate`
+### Clay Populate
 
 Populate Clay with data from a JSON file. Enables direct communication and notifications with timestamp tracking and channel confirmation.
 

--- a/apps/docs/content/docs/en/integrations/clerk.mdx
+++ b/apps/docs/content/docs/en/integrations/clerk.mdx
@@ -34,7 +34,7 @@ Integrate Clerk authentication and user management into your workflow. Create, u
 
 ## Actions
 
-### `clerk_list_users`
+### List Users from Clerk
 
 List all users in your Clerk application with optional filtering and pagination
 
@@ -85,7 +85,7 @@ List all users in your Clerk application with optional filtering and pagination
 | `totalCount` | number | Total number of users matching the query |
 | `success` | boolean | Operation success status |
 
-### `clerk_get_user`
+### Get User from Clerk
 
 Retrieve a single user by their ID from Clerk
 
@@ -135,7 +135,7 @@ Retrieve a single user by their ID from Clerk
 | `unsafeMetadata` | json | Unsafe metadata \(modifiable from frontend\) |
 | `success` | boolean | Operation success status |
 
-### `clerk_create_user`
+### Create User in Clerk
 
 Create a new user in your Clerk application
 
@@ -182,7 +182,7 @@ Create a new user in your Clerk application
 | `publicMetadata` | json | Public metadata |
 | `success` | boolean | Operation success status |
 
-### `clerk_update_user`
+### Update User in Clerk
 
 Update an existing user in your Clerk application
 
@@ -231,7 +231,7 @@ Update an existing user in your Clerk application
 | `publicMetadata` | json | Public metadata |
 | `success` | boolean | Operation success status |
 
-### `clerk_delete_user`
+### Delete User from Clerk
 
 Delete a user from your Clerk application
 
@@ -251,7 +251,7 @@ Delete a user from your Clerk application
 | `deleted` | boolean | Whether the user was deleted |
 | `success` | boolean | Operation success status |
 
-### `clerk_ban_user`
+### Ban User in Clerk
 
 Ban a user, preventing them from signing in
 
@@ -276,7 +276,7 @@ Ban a user, preventing them from signing in
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_unban_user`
+### Unban User in Clerk
 
 Remove a ban from a user, allowing them to sign in again
 
@@ -301,7 +301,7 @@ Remove a ban from a user, allowing them to sign in again
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_lock_user`
+### Lock User in Clerk
 
 Lock a user account, blocking sign-in attempts
 
@@ -326,7 +326,7 @@ Lock a user account, blocking sign-in attempts
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_unlock_user`
+### Unlock User in Clerk
 
 Unlock a previously locked user account
 
@@ -351,7 +351,7 @@ Unlock a previously locked user account
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_get_user_oauth_token`
+### Get User OAuth Access Token from Clerk
 
 Retrieve a user's OAuth access token for a connected external provider (e.g. Google, GitHub, Microsoft) obtained via Clerk SSO
 
@@ -377,7 +377,7 @@ Retrieve a user's OAuth access token for a connected external provider (e.g. Goo
 |   ↳ `publicMetadata` | json | Public metadata associated with the token |
 | `success` | boolean | Operation success status |
 
-### `clerk_list_organizations`
+### List Organizations from Clerk
 
 List all organizations in your Clerk application with optional filtering
 
@@ -413,7 +413,7 @@ List all organizations in your Clerk application with optional filtering
 | `totalCount` | number | Total number of organizations |
 | `success` | boolean | Operation success status |
 
-### `clerk_get_organization`
+### Get Organization from Clerk
 
 Retrieve a single organization by ID or slug from Clerk
 
@@ -443,7 +443,7 @@ Retrieve a single organization by ID or slug from Clerk
 | `publicMetadata` | json | Public metadata |
 | `success` | boolean | Operation success status |
 
-### `clerk_create_organization`
+### Create Organization in Clerk
 
 Create a new organization in your Clerk application
 
@@ -478,7 +478,7 @@ Create a new organization in your Clerk application
 | `publicMetadata` | json | Public metadata |
 | `success` | boolean | Operation success status |
 
-### `clerk_update_organization`
+### Update Organization in Clerk
 
 Update an existing organization in your Clerk application
 
@@ -512,7 +512,7 @@ Update an existing organization in your Clerk application
 | `publicMetadata` | json | Public metadata |
 | `success` | boolean | Operation success status |
 
-### `clerk_delete_organization`
+### Delete Organization from Clerk
 
 Delete an organization from your Clerk application
 
@@ -532,7 +532,7 @@ Delete an organization from your Clerk application
 | `deleted` | boolean | Whether the organization was deleted |
 | `success` | boolean | Operation success status |
 
-### `clerk_list_organization_memberships`
+### List Organization Memberships from Clerk
 
 List members of a Clerk organization with optional filtering and pagination
 
@@ -570,7 +570,7 @@ List members of a Clerk organization with optional filtering and pagination
 | `totalCount` | number | Total number of memberships |
 | `success` | boolean | Operation success status |
 
-### `clerk_add_organization_member`
+### Add Organization Member in Clerk
 
 Add a user as a member of a Clerk organization with a given role
 
@@ -604,7 +604,7 @@ Add a user as a member of a Clerk organization with a given role
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_update_organization_membership`
+### Update Organization Membership in Clerk
 
 Change a member's role within a Clerk organization
 
@@ -638,7 +638,7 @@ Change a member's role within a Clerk organization
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_remove_organization_member`
+### Remove Organization Member from Clerk
 
 Remove a member from a Clerk organization
 
@@ -671,7 +671,7 @@ Remove a member from a Clerk organization
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_create_organization_invitation`
+### Create Organization Invitation in Clerk
 
 Invite a user by email to join a Clerk organization with a given role
 
@@ -711,7 +711,7 @@ Invite a user by email to join a Clerk organization with a given role
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_list_organization_invitations`
+### List Organization Invitations from Clerk
 
 List pending and past invitations for a Clerk organization
 
@@ -750,7 +750,7 @@ List pending and past invitations for a Clerk organization
 | `totalCount` | number | Total number of invitations |
 | `success` | boolean | Operation success status |
 
-### `clerk_list_sessions`
+### List Sessions from Clerk
 
 List sessions for a user or client in your Clerk application
 
@@ -783,7 +783,7 @@ List sessions for a user or client in your Clerk application
 | `totalCount` | number | Total number of sessions |
 | `success` | boolean | Operation success status |
 
-### `clerk_get_session`
+### Get Session from Clerk
 
 Retrieve a single session by ID from Clerk
 
@@ -810,7 +810,7 @@ Retrieve a single session by ID from Clerk
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_revoke_session`
+### Revoke Session in Clerk
 
 Revoke a session to immediately invalidate it
 
@@ -837,7 +837,7 @@ Revoke a session to immediately invalidate it
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_list_allowlist_identifiers`
+### List Allowlist Identifiers from Clerk
 
 List email/phone/web3-wallet identifiers on your Clerk instance allowlist
 
@@ -863,7 +863,7 @@ List email/phone/web3-wallet identifiers on your Clerk instance allowlist
 | `totalCount` | number | Total number of allowlist identifiers |
 | `success` | boolean | Operation success status |
 
-### `clerk_create_allowlist_identifier`
+### Create Allowlist Identifier in Clerk
 
 Add an email, phone number, or web3 wallet to your Clerk instance allowlist
 
@@ -887,7 +887,7 @@ Add an email, phone number, or web3 wallet to your Clerk instance allowlist
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_delete_allowlist_identifier`
+### Delete Allowlist Identifier from Clerk
 
 Remove an identifier from your Clerk instance allowlist
 
@@ -907,7 +907,7 @@ Remove an identifier from your Clerk instance allowlist
 | `deleted` | boolean | Whether the identifier was deleted |
 | `success` | boolean | Operation success status |
 
-### `clerk_list_blocklist_identifiers`
+### List Blocklist Identifiers from Clerk
 
 List email/phone/web3-wallet identifiers on your Clerk instance blocklist
 
@@ -930,7 +930,7 @@ List email/phone/web3-wallet identifiers on your Clerk instance blocklist
 | `totalCount` | number | Total number of blocklist identifiers |
 | `success` | boolean | Operation success status |
 
-### `clerk_create_blocklist_identifier`
+### Create Blocklist Identifier in Clerk
 
 Add an email, phone number, or web3 wallet to your Clerk instance blocklist to prevent sign-ups
 
@@ -952,7 +952,7 @@ Add an email, phone number, or web3 wallet to your Clerk instance blocklist to p
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_delete_blocklist_identifier`
+### Delete Blocklist Identifier from Clerk
 
 Remove an identifier from your Clerk instance blocklist
 
@@ -972,7 +972,7 @@ Remove an identifier from your Clerk instance blocklist
 | `deleted` | boolean | Whether the identifier was deleted |
 | `success` | boolean | Operation success status |
 
-### `clerk_list_jwt_templates`
+### List JWT Templates from Clerk
 
 List custom JWT templates configured on your Clerk instance
 
@@ -999,7 +999,7 @@ List custom JWT templates configured on your Clerk instance
 | `totalCount` | number | Total number of JWT templates |
 | `success` | boolean | Operation success status |
 
-### `clerk_get_jwt_template`
+### Get JWT Template from Clerk
 
 Retrieve a single custom JWT template by ID from Clerk
 
@@ -1025,7 +1025,7 @@ Retrieve a single custom JWT template by ID from Clerk
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_create_actor_token`
+### Create Actor Token in Clerk
 
 Create an actor token to impersonate a user (God Mode / act-as-user), e.g. for support tooling
 
@@ -1053,7 +1053,7 @@ Create an actor token to impersonate a user (God Mode / act-as-user), e.g. for s
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `clerk_revoke_actor_token`
+### Revoke Actor Token in Clerk
 
 Revoke an actor token before it is used or expires
 

--- a/apps/docs/content/docs/en/integrations/clickhouse.mdx
+++ b/apps/docs/content/docs/en/integrations/clickhouse.mdx
@@ -39,7 +39,7 @@ Integrate ClickHouse into the workflow. Query and insert data, manage databases 
 
 ## Actions
 
-### `clickhouse_query`
+### ClickHouse Query
 
 Execute a SELECT query on a ClickHouse database
 
@@ -63,7 +63,7 @@ Execute a SELECT query on a ClickHouse database
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_execute`
+### ClickHouse Execute
 
 Execute raw SQL (DDL, mutations, or queries) on a ClickHouse database
 
@@ -87,7 +87,7 @@ Execute raw SQL (DDL, mutations, or queries) on a ClickHouse database
 | `rows` | array | Array of rows returned from the statement |
 | `rowCount` | number | Number of rows returned or affected |
 
-### `clickhouse_insert`
+### ClickHouse Insert
 
 Insert a row into a ClickHouse table
 
@@ -112,7 +112,7 @@ Insert a row into a ClickHouse table
 | `rows` | array | Inserted rows \(empty for ClickHouse inserts\) |
 | `rowCount` | number | Number of rows inserted |
 
-### `clickhouse_insert_rows`
+### ClickHouse Insert Rows
 
 Insert multiple rows into a ClickHouse table
 
@@ -137,7 +137,7 @@ Insert multiple rows into a ClickHouse table
 | `rows` | array | Inserted rows \(empty for ClickHouse inserts\) |
 | `rowCount` | number | Number of rows inserted |
 
-### `clickhouse_update`
+### ClickHouse Update
 
 Update rows in a ClickHouse table via an ALTER TABLE ... UPDATE mutation
 
@@ -163,7 +163,7 @@ Update rows in a ClickHouse table via an ALTER TABLE ... UPDATE mutation
 | `rows` | array | Updated rows \(empty for ClickHouse mutations\) |
 | `rowCount` | number | Number of rows written by the mutation |
 
-### `clickhouse_delete`
+### ClickHouse Delete
 
 Delete rows from a ClickHouse table via an ALTER TABLE ... DELETE mutation
 
@@ -188,7 +188,7 @@ Delete rows from a ClickHouse table via an ALTER TABLE ... DELETE mutation
 | `rows` | array | Deleted rows \(empty for ClickHouse mutations\) |
 | `rowCount` | number | Number of rows affected by the mutation |
 
-### `clickhouse_list_databases`
+### ClickHouse List Databases
 
 List all databases on a ClickHouse server
 
@@ -211,7 +211,7 @@ List all databases on a ClickHouse server
 | `rows` | array | List of databases with engine and comment |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_list_tables`
+### ClickHouse List Tables
 
 List tables in the connected ClickHouse database
 
@@ -234,7 +234,7 @@ List tables in the connected ClickHouse database
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_describe_table`
+### ClickHouse Describe Table
 
 Describe the columns of a ClickHouse table
 
@@ -258,7 +258,7 @@ Describe the columns of a ClickHouse table
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_show_create_table`
+### ClickHouse Show Create Table
 
 Get the CREATE TABLE statement (DDL) for a ClickHouse table
 
@@ -281,7 +281,7 @@ Get the CREATE TABLE statement (DDL) for a ClickHouse table
 | `message` | string | Operation status message |
 | `ddl` | string | The CREATE TABLE statement |
 
-### `clickhouse_count_rows`
+### ClickHouse Count Rows
 
 Count rows in a ClickHouse table, optionally filtered
 
@@ -305,7 +305,7 @@ Count rows in a ClickHouse table, optionally filtered
 | `message` | string | Operation status message |
 | `count` | number | Number of rows |
 
-### `clickhouse_introspect`
+### ClickHouse Introspect
 
 Introspect a ClickHouse database to retrieve table structures, columns, and engines
 
@@ -338,7 +338,7 @@ Introspect a ClickHouse database to retrieve table structures, columns, and engi
 |     ↳ `isInPrimaryKey` | boolean | Whether the column is part of the primary key |
 |     ↳ `isInSortingKey` | boolean | Whether the column is part of the sorting key |
 
-### `clickhouse_create_database`
+### ClickHouse Create Database
 
 Create a new database on a ClickHouse server
 
@@ -360,7 +360,7 @@ Create a new database on a ClickHouse server
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `clickhouse_drop_database`
+### ClickHouse Drop Database
 
 Drop a database from a ClickHouse server
 
@@ -382,7 +382,7 @@ Drop a database from a ClickHouse server
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `clickhouse_create_table`
+### ClickHouse Create Table
 
 Create a new MergeTree-family table in ClickHouse
 
@@ -408,7 +408,7 @@ Create a new MergeTree-family table in ClickHouse
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `clickhouse_drop_table`
+### ClickHouse Drop Table
 
 Drop a table from a ClickHouse database
 
@@ -430,7 +430,7 @@ Drop a table from a ClickHouse database
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `clickhouse_truncate_table`
+### ClickHouse Truncate Table
 
 Remove all rows from a ClickHouse table
 
@@ -452,7 +452,7 @@ Remove all rows from a ClickHouse table
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `clickhouse_rename_table`
+### ClickHouse Rename Table
 
 Rename a ClickHouse table
 
@@ -475,7 +475,7 @@ Rename a ClickHouse table
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `clickhouse_optimize_table`
+### ClickHouse Optimize Table
 
 Trigger a merge of table parts via OPTIMIZE TABLE
 
@@ -498,7 +498,7 @@ Trigger a merge of table parts via OPTIMIZE TABLE
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `clickhouse_list_partitions`
+### ClickHouse List Partitions
 
 List active partitions for a ClickHouse table
 
@@ -522,7 +522,7 @@ List active partitions for a ClickHouse table
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_drop_partition`
+### ClickHouse Drop Partition
 
 Drop a partition from a ClickHouse table
 
@@ -545,7 +545,7 @@ Drop a partition from a ClickHouse table
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `clickhouse_list_mutations`
+### ClickHouse List Mutations
 
 List mutations (async ALTER UPDATE/DELETE) for the connected database
 
@@ -570,7 +570,7 @@ List mutations (async ALTER UPDATE/DELETE) for the connected database
 | `rows` | array | Array of mutation rows |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_list_running_queries`
+### ClickHouse List Running Queries
 
 List currently running queries on a ClickHouse server
 
@@ -593,7 +593,7 @@ List currently running queries on a ClickHouse server
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_kill_query`
+### ClickHouse Kill Query
 
 Kill a running query by its query ID
 
@@ -617,7 +617,7 @@ Kill a running query by its query ID
 | `rows` | array | Kill status rows |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_table_stats`
+### ClickHouse Table Stats
 
 Get row counts and on-disk size for tables in the connected database
 
@@ -641,7 +641,7 @@ Get row counts and on-disk size for tables in the connected database
 | `rows` | array | Array of table stats rows |
 | `rowCount` | number | Number of rows returned |
 
-### `clickhouse_list_clusters`
+### ClickHouse List Clusters
 
 List configured clusters, shards, and replicas
 

--- a/apps/docs/content/docs/en/integrations/clickup.mdx
+++ b/apps/docs/content/docs/en/integrations/clickup.mdx
@@ -18,7 +18,7 @@ Integrate ClickUp into the workflow. Create, read, update, and delete tasks, man
 
 ## Actions
 
-### `clickup_create_task`
+### ClickUp Create Task
 
 Create a new task in a ClickUp list
 
@@ -49,7 +49,7 @@ Create a new task in a ClickUp list
 | --------- | ---- | ----------- |
 | `task` | json | The created task |
 
-### `clickup_get_task`
+### ClickUp Get Task
 
 Retrieve a task from ClickUp by ID
 
@@ -67,7 +67,7 @@ Retrieve a task from ClickUp by ID
 | --------- | ---- | ----------- |
 | `task` | json | The requested task |
 
-### `clickup_update_task`
+### ClickUp Update Task
 
 Update an existing task in ClickUp
 
@@ -98,7 +98,7 @@ Update an existing task in ClickUp
 | --------- | ---- | ----------- |
 | `task` | json | The updated task |
 
-### `clickup_delete_task`
+### ClickUp Delete Task
 
 Delete a task from ClickUp
 
@@ -115,7 +115,7 @@ Delete a task from ClickUp
 | `id` | string | ID of the deleted task |
 | `deleted` | boolean | Whether the task was deleted |
 
-### `clickup_get_tasks`
+### ClickUp Get Tasks
 
 List the tasks in a ClickUp list (100 tasks per page; increment page until an empty result to paginate)
 
@@ -143,7 +143,7 @@ List the tasks in a ClickUp list (100 tasks per page; increment page until an em
 | --------- | ---- | ----------- |
 | `tasks` | array | Tasks in the list |
 
-### `clickup_search_tasks`
+### ClickUp Search Tasks
 
 Search tasks across a ClickUp workspace with filters for lists, folders, spaces, statuses, assignees, tags, and due dates (100 tasks per page; increment page until an empty result to paginate)
 
@@ -173,7 +173,7 @@ Search tasks across a ClickUp workspace with filters for lists, folders, spaces,
 | --------- | ---- | ----------- |
 | `tasks` | array | Tasks matching the filters |
 
-### `clickup_create_comment`
+### ClickUp Create Comment
 
 Add a comment to a ClickUp task
 
@@ -194,7 +194,7 @@ Add a comment to a ClickUp task
 | `histId` | string | History ID of the created comment |
 | `date` | number | Creation timestamp of the comment \(Unix ms\) |
 
-### `clickup_get_comments`
+### ClickUp Get Comments
 
 Retrieve comments on a ClickUp task, newest first (25 per page; paginate with start and startId)
 
@@ -212,7 +212,7 @@ Retrieve comments on a ClickUp task, newest first (25 per page; paginate with st
 | --------- | ---- | ----------- |
 | `comments` | array | Comments on the task, newest first |
 
-### `clickup_update_comment`
+### ClickUp Update Comment
 
 Update the content, assignee, or resolved state of a ClickUp task comment
 
@@ -232,7 +232,7 @@ Update the content, assignee, or resolved state of a ClickUp task comment
 | `id` | string | ID of the updated comment |
 | `updated` | boolean | Whether the comment was updated |
 
-### `clickup_delete_comment`
+### ClickUp Delete Comment
 
 Delete a comment from a ClickUp task
 
@@ -249,7 +249,7 @@ Delete a comment from a ClickUp task
 | `id` | string | ID of the deleted comment |
 | `deleted` | boolean | Whether the comment was deleted |
 
-### `clickup_upload_attachment`
+### ClickUp Upload Attachment
 
 Upload a file to a ClickUp task as an attachment
 
@@ -275,7 +275,7 @@ Upload a file to a ClickUp task as an attachment
 |   ↳ `thumbnailLarge` | string | Large thumbnail URL |
 | `files` | file[] | The uploaded attachment file |
 
-### `clickup_add_tag_to_task`
+### ClickUp Add Tag To Task
 
 Add an existing space tag to a ClickUp task
 
@@ -293,7 +293,7 @@ Add an existing space tag to a ClickUp task
 | `taskId` | string | ID of the tagged task |
 | `tagName` | string | Name of the tag that was added |
 
-### `clickup_remove_tag_from_task`
+### ClickUp Remove Tag From Task
 
 Remove a tag from a ClickUp task
 
@@ -311,7 +311,7 @@ Remove a tag from a ClickUp task
 | `taskId` | string | ID of the task |
 | `tagName` | string | Name of the tag that was removed |
 
-### `clickup_get_space_tags`
+### ClickUp Get Space Tags
 
 List the task tags available in a ClickUp space
 
@@ -327,7 +327,7 @@ List the task tags available in a ClickUp space
 | --------- | ---- | ----------- |
 | `tags` | array | Tags available in the space |
 
-### `clickup_get_task_members`
+### ClickUp Get Task Members
 
 List the workspace members who have explicit access to a ClickUp task
 
@@ -343,7 +343,7 @@ List the workspace members who have explicit access to a ClickUp task
 | --------- | ---- | ----------- |
 | `members` | array | Members with explicit access to the task |
 
-### `clickup_get_list_members`
+### ClickUp Get List Members
 
 List the workspace members who have explicit access to a ClickUp list
 
@@ -359,7 +359,7 @@ List the workspace members who have explicit access to a ClickUp list
 | --------- | ---- | ----------- |
 | `members` | array | Members with explicit access to the list |
 
-### `clickup_get_custom_fields`
+### ClickUp Get Custom Fields
 
 List the custom fields accessible in a ClickUp list
 
@@ -381,7 +381,7 @@ List the custom fields accessible in a ClickUp list
 |   ↳ `dateCreated` | string | Creation timestamp \(Unix ms\) |
 |   ↳ `hideFromGuests` | boolean | Whether the field is hidden from guests |
 
-### `clickup_get_workspaces`
+### ClickUp Get Workspaces
 
 List the ClickUp workspaces (teams) available to the connected account
 
@@ -400,7 +400,7 @@ List the ClickUp workspaces (teams) available to the connected account
 |   ↳ `color` | string | Workspace color |
 |   ↳ `avatar` | string | Workspace avatar URL |
 
-### `clickup_get_spaces`
+### ClickUp Get Spaces
 
 List the spaces in a ClickUp workspace
 
@@ -425,7 +425,7 @@ List the spaces in a ClickUp workspace
 |     ↳ `color` | string | Status color |
 |     ↳ `type` | string | Status type |
 
-### `clickup_get_folders`
+### ClickUp Get Folders
 
 List the folders in a ClickUp space
 
@@ -442,7 +442,7 @@ List the folders in a ClickUp space
 | --------- | ---- | ----------- |
 | `folders` | array | Folders in the space |
 
-### `clickup_get_lists`
+### ClickUp Get Lists
 
 List the lists in a ClickUp folder, or the folderless lists in a space when a space ID is provided instead
 
@@ -460,7 +460,7 @@ List the lists in a ClickUp folder, or the folderless lists in a space when a sp
 | --------- | ---- | ----------- |
 | `lists` | array | Lists in the folder or space |
 
-### `clickup_create_folder`
+### ClickUp Create Folder
 
 Create a new folder in a ClickUp space
 
@@ -477,7 +477,7 @@ Create a new folder in a ClickUp space
 | --------- | ---- | ----------- |
 | `folder` | json | The created folder |
 
-### `clickup_create_list`
+### ClickUp Create List
 
 Create a new list in a ClickUp folder, or a folderless list in a space when a space ID is provided instead
 
@@ -497,7 +497,7 @@ Create a new list in a ClickUp folder, or a folderless list in a space when a sp
 | --------- | ---- | ----------- |
 | `list` | json | The created list |
 
-### `clickup_set_custom_field_value`
+### ClickUp Set Custom Field Value
 
 Set the value of a custom field on a ClickUp task (the value shape depends on the field type)
 
@@ -516,7 +516,7 @@ Set the value of a custom field on a ClickUp task (the value shape depends on th
 | `taskId` | string | ID of the updated task |
 | `fieldId` | string | ID of the custom field that was set |
 
-### `clickup_remove_custom_field_value`
+### ClickUp Remove Custom Field Value
 
 Remove the value of a custom field from a ClickUp task (does not delete the field itself)
 
@@ -534,7 +534,7 @@ Remove the value of a custom field from a ClickUp task (does not delete the fiel
 | `taskId` | string | ID of the updated task |
 | `fieldId` | string | ID of the custom field that was cleared |
 
-### `clickup_create_checklist`
+### ClickUp Create Checklist
 
 Add a new checklist to a ClickUp task
 
@@ -551,7 +551,7 @@ Add a new checklist to a ClickUp task
 | --------- | ---- | ----------- |
 | `checklist` | json | The created checklist |
 
-### `clickup_update_checklist`
+### ClickUp Update Checklist
 
 Rename or reorder a checklist on a ClickUp task
 
@@ -570,7 +570,7 @@ Rename or reorder a checklist on a ClickUp task
 | `id` | string | ID of the updated checklist |
 | `updated` | boolean | Whether the checklist was updated |
 
-### `clickup_delete_checklist`
+### ClickUp Delete Checklist
 
 Delete a checklist from a ClickUp task
 
@@ -587,7 +587,7 @@ Delete a checklist from a ClickUp task
 | `id` | string | ID of the deleted checklist |
 | `deleted` | boolean | Whether the checklist was deleted |
 
-### `clickup_create_checklist_item`
+### ClickUp Create Checklist Item
 
 Add an item to a checklist on a ClickUp task
 
@@ -605,7 +605,7 @@ Add an item to a checklist on a ClickUp task
 | --------- | ---- | ----------- |
 | `checklist` | json | The updated checklist including its items |
 
-### `clickup_update_checklist_item`
+### ClickUp Update Checklist Item
 
 Update a checklist item on a ClickUp task — rename, assign, resolve, or nest it
 
@@ -626,7 +626,7 @@ Update a checklist item on a ClickUp task — rename, assign, resolve, or nest i
 | --------- | ---- | ----------- |
 | `checklist` | json | The updated checklist including its items |
 
-### `clickup_delete_checklist_item`
+### ClickUp Delete Checklist Item
 
 Delete an item from a checklist on a ClickUp task
 
@@ -644,7 +644,7 @@ Delete an item from a checklist on a ClickUp task
 | `id` | string | ID of the deleted checklist item |
 | `deleted` | boolean | Whether the item was deleted |
 
-### `clickup_get_time_entries`
+### ClickUp Get Time Entries
 
 List time entries in a ClickUp workspace within a date range (defaults to the last 30 days for the authenticated user)
 
@@ -669,7 +669,7 @@ List time entries in a ClickUp workspace within a date range (defaults to the la
 | --------- | ---- | ----------- |
 | `timeEntries` | array | Time entries in the date range |
 
-### `clickup_create_time_entry`
+### ClickUp Create Time Entry
 
 Create a manual time entry in a ClickUp workspace, optionally linked to a task
 
@@ -691,7 +691,7 @@ Create a manual time entry in a ClickUp workspace, optionally linked to a task
 | --------- | ---- | ----------- |
 | `timeEntry` | json | The created time entry |
 
-### `clickup_update_time_entry`
+### ClickUp Update Time Entry
 
 Update a time entry in a ClickUp workspace — description, start/end times, task, or billable state
 
@@ -715,7 +715,7 @@ Update a time entry in a ClickUp workspace — description, start/end times, tas
 | `id` | string | ID of the updated time entry |
 | `updated` | boolean | Whether the entry was updated |
 
-### `clickup_delete_time_entry`
+### ClickUp Delete Time Entry
 
 Delete a time entry from a ClickUp workspace
 
@@ -732,7 +732,7 @@ Delete a time entry from a ClickUp workspace
 | --------- | ---- | ----------- |
 | `timeEntry` | json | The deleted time entry |
 
-### `clickup_start_timer`
+### ClickUp Start Timer
 
 Start a timer for the authenticated user in a ClickUp workspace
 
@@ -752,7 +752,7 @@ Start a timer for the authenticated user in a ClickUp workspace
 | --------- | ---- | ----------- |
 | `timeEntry` | json | The started time entry \(duration is negative while running\) |
 
-### `clickup_stop_timer`
+### ClickUp Stop Timer
 
 Stop the authenticated user's currently running timer in a ClickUp workspace
 
@@ -768,7 +768,7 @@ Stop the authenticated user's currently running timer in a ClickUp workspace
 | --------- | ---- | ----------- |
 | `timeEntry` | json | The stopped time entry |
 
-### `clickup_get_running_timer`
+### ClickUp Get Running Timer
 
 Get the currently running time entry in a ClickUp workspace (null when no timer is running)
 

--- a/apps/docs/content/docs/en/integrations/cloudflare.mdx
+++ b/apps/docs/content/docs/en/integrations/cloudflare.mdx
@@ -34,7 +34,7 @@ Integrate Cloudflare into the workflow. Manage zones (domains), DNS records, SSL
 
 ## Actions
 
-### `cloudflare_list_zones`
+### Cloudflare List Zones
 
 Lists all zones (domains) in the Cloudflare account.
 
@@ -95,7 +95,7 @@ Lists all zones (domains) in the Cloudflare account.
 |   ↳ `permissions` | array | User permissions for the zone |
 | `total_count` | number | Total number of zones matching the query |
 
-### `cloudflare_get_zone`
+### Cloudflare Get Zone
 
 Gets details for a specific zone (domain) by its ID.
 
@@ -147,7 +147,7 @@ Gets details for a specific zone (domain) by its ID.
 | `vanity_name_servers` | array | Custom vanity name servers |
 | `permissions` | array | User permissions for the zone |
 
-### `cloudflare_create_zone`
+### Cloudflare Create Zone
 
 Adds a new zone (domain) to the Cloudflare account.
 
@@ -201,7 +201,7 @@ Adds a new zone (domain) to the Cloudflare account.
 | `vanity_name_servers` | array | Custom vanity name servers |
 | `permissions` | array | User permissions for the zone |
 
-### `cloudflare_delete_zone`
+### Cloudflare Delete Zone
 
 Deletes a zone (domain) from the Cloudflare account.
 
@@ -218,7 +218,7 @@ Deletes a zone (domain) from the Cloudflare account.
 | --------- | ---- | ----------- |
 | `id` | string | Deleted zone ID |
 
-### `cloudflare_list_dns_records`
+### Cloudflare List DNS Records
 
 Lists DNS records for a specific zone.
 
@@ -268,7 +268,7 @@ Lists DNS records for a specific zone.
 |   ↳ `modified_on` | string | ISO 8601 timestamp when the record was last modified |
 | `total_count` | number | Total number of DNS records matching the query |
 
-### `cloudflare_create_dns_record`
+### Cloudflare Create DNS Record
 
 Creates a new DNS record for a zone.
 
@@ -311,7 +311,7 @@ Creates a new DNS record for a zone.
 | `created_on` | string | ISO 8601 timestamp when the record was created |
 | `modified_on` | string | ISO 8601 timestamp when the record was last modified |
 
-### `cloudflare_update_dns_record`
+### Cloudflare Update DNS Record
 
 Updates an existing DNS record for a zone.
 
@@ -355,7 +355,7 @@ Updates an existing DNS record for a zone.
 | `created_on` | string | ISO 8601 timestamp when the record was created |
 | `modified_on` | string | ISO 8601 timestamp when the record was last modified |
 
-### `cloudflare_delete_dns_record`
+### Cloudflare Delete DNS Record
 
 Deletes a DNS record from a zone.
 
@@ -373,7 +373,7 @@ Deletes a DNS record from a zone.
 | --------- | ---- | ----------- |
 | `id` | string | Deleted record ID |
 
-### `cloudflare_list_certificates`
+### Cloudflare List Certificates
 
 Lists SSL/TLS certificate packs for a zone.
 
@@ -438,7 +438,7 @@ Lists SSL/TLS certificate packs for a zone.
 |     ↳ `txt_value` | string | TXT record value |
 | `total_count` | number | Total number of certificate packs |
 
-### `cloudflare_get_zone_settings`
+### Cloudflare Get Zone Settings
 
 Gets all settings for a zone including SSL mode, caching level, and security settings.
 
@@ -460,7 +460,7 @@ Gets all settings for a zone including SSL mode, caching level, and security set
 |   ↳ `modified_on` | string | ISO 8601 timestamp when the setting was last modified |
 |   ↳ `time_remaining` | number | Seconds remaining until the setting can be modified again \(only present for rate-limited settings\) |
 
-### `cloudflare_update_zone_setting`
+### Cloudflare Update Zone Setting
 
 Updates a specific zone setting such as SSL mode, security level, cache level, or other configuration.
 
@@ -483,7 +483,7 @@ Updates a specific zone setting such as SSL mode, security level, cache level, o
 | `modified_on` | string | ISO 8601 timestamp when the setting was last modified |
 | `time_remaining` | number | Seconds remaining until the setting can be modified again \(only present for rate-limited settings\) |
 
-### `cloudflare_dns_analytics`
+### Cloudflare DNS Analytics
 
 Gets DNS analytics report for a zone including query counts and trends.
 
@@ -543,7 +543,7 @@ Gets DNS analytics report for a zone including query counts and trends.
 |   ↳ `sort` | array | Sort order applied to the query |
 |   ↳ `limit` | number | Maximum number of results requested |
 
-### `cloudflare_purge_cache`
+### Cloudflare Purge Cache
 
 Purges cached content for a zone. Can purge everything or specific files/tags/hosts/prefixes.
 

--- a/apps/docs/content/docs/en/integrations/cloudformation.mdx
+++ b/apps/docs/content/docs/en/integrations/cloudformation.mdx
@@ -35,7 +35,7 @@ Integrate AWS CloudFormation into workflows. Create, update, and delete stacks, 
 
 ## Actions
 
-### `cloudformation_describe_stacks`
+### CloudFormation Describe Stacks
 
 List and describe CloudFormation stacks
 
@@ -54,7 +54,7 @@ List and describe CloudFormation stacks
 | --------- | ---- | ----------- |
 | `stacks` | array | List of CloudFormation stacks with status, outputs, and tags |
 
-### `cloudformation_create_stack`
+### CloudFormation Create Stack
 
 Create a new CloudFormation stack from a template
 
@@ -79,7 +79,7 @@ Create a new CloudFormation stack from a template
 | --------- | ---- | ----------- |
 | `stackId` | string | The unique ID of the created stack |
 
-### `cloudformation_update_stack`
+### CloudFormation Update Stack
 
 Update an existing CloudFormation stack with a new or previous template
 
@@ -103,7 +103,7 @@ Update an existing CloudFormation stack with a new or previous template
 | --------- | ---- | ----------- |
 | `stackId` | string | The unique ID of the updated stack |
 
-### `cloudformation_delete_stack`
+### CloudFormation Delete Stack
 
 Delete a CloudFormation stack and its resources
 
@@ -123,7 +123,7 @@ Delete a CloudFormation stack and its resources
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `cloudformation_cancel_update_stack`
+### CloudFormation Cancel Update Stack
 
 Cancel an in-progress stack update and roll back to the last known stable state
 
@@ -142,7 +142,7 @@ Cancel an in-progress stack update and roll back to the last known stable state
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `cloudformation_create_change_set`
+### CloudFormation Create Change Set
 
 Preview the changes a stack create or update would make before applying them
 
@@ -169,7 +169,7 @@ Preview the changes a stack create or update would make before applying them
 | `changeSetId` | string | The unique ID of the created change set |
 | `stackId` | string | The unique ID of the target stack |
 
-### `cloudformation_describe_change_set`
+### CloudFormation Describe Change Set
 
 View the resource changes a change set would make and its execution status
 
@@ -199,7 +199,7 @@ View the resource changes a change set would make and its execution status
 | `capabilities` | array | Capabilities required to execute the change set |
 | `changes` | array | List of resource changes \(action, logical/physical resource ID, resource type, replacement\) |
 
-### `cloudformation_execute_change_set`
+### CloudFormation Execute Change Set
 
 Apply a previously created and reviewed change set to its stack
 
@@ -219,7 +219,7 @@ Apply a previously created and reviewed change set to its stack
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `cloudformation_list_stack_resources`
+### CloudFormation List Stack Resources
 
 List all resources in a CloudFormation stack
 
@@ -238,7 +238,7 @@ List all resources in a CloudFormation stack
 | --------- | ---- | ----------- |
 | `resources` | array | List of stack resources with type, status, and drift information |
 
-### `cloudformation_detect_stack_drift`
+### CloudFormation Detect Stack Drift
 
 Initiate drift detection on a CloudFormation stack
 
@@ -257,7 +257,7 @@ Initiate drift detection on a CloudFormation stack
 | --------- | ---- | ----------- |
 | `stackDriftDetectionId` | string | ID to use with Describe Stack Drift Detection Status to check results |
 
-### `cloudformation_describe_stack_drift_detection_status`
+### CloudFormation Describe Stack Drift Detection Status
 
 Check the status of a stack drift detection operation
 
@@ -282,7 +282,7 @@ Check the status of a stack drift detection operation
 | `driftedStackResourceCount` | number | Number of resources that have drifted |
 | `timestamp` | number | Timestamp of the detection |
 
-### `cloudformation_describe_stack_events`
+### CloudFormation Describe Stack Events
 
 Get the event history for a CloudFormation stack
 
@@ -302,7 +302,7 @@ Get the event history for a CloudFormation stack
 | --------- | ---- | ----------- |
 | `events` | array | List of stack events with resource status and timestamps |
 
-### `cloudformation_get_template`
+### CloudFormation Get Template
 
 Retrieve the template body for a CloudFormation stack
 
@@ -323,7 +323,7 @@ Retrieve the template body for a CloudFormation stack
 | `templateBody` | string | The template body as a JSON or YAML string |
 | `stagesAvailable` | array | Available template stages |
 
-### `cloudformation_get_template_summary`
+### CloudFormation Get Template Summary
 
 Get a summary of a template or deployed stack: resource types, required capabilities, and parameters, without full validation
 
@@ -349,7 +349,7 @@ Get a summary of a template or deployed stack: resource types, required capabili
 | `version` | string | Template format version |
 | `declaredTransforms` | array | Transforms used in the template \(e.g., AWS::Serverless-2016-10-31\) |
 
-### `cloudformation_validate_template`
+### CloudFormation Validate Template
 
 Validate a CloudFormation template for syntax and structural correctness
 

--- a/apps/docs/content/docs/en/integrations/cloudwatch.mdx
+++ b/apps/docs/content/docs/en/integrations/cloudwatch.mdx
@@ -36,7 +36,7 @@ Integrate AWS CloudWatch into workflows. Run Log Insights queries, list log grou
 
 ## Actions
 
-### `cloudwatch_query_logs`
+### CloudWatch Query Logs
 
 Run a CloudWatch Log Insights query against one or more log groups
 
@@ -64,7 +64,7 @@ Run a CloudWatch Log Insights query against one or more log groups
 |   ↳ `recordsScanned` | number | Total log records scanned |
 | `status` | string | Query completion status \(Complete, Failed, Cancelled, or Timeout\) |
 
-### `cloudwatch_filter_log_events`
+### CloudWatch Filter Log Events
 
 Search log events across all streams in a log group by filter pattern and time range, without writing a Log Insights query
 
@@ -93,7 +93,7 @@ Search log events across all streams in a log group by filter pattern and time r
 |   ↳ `message` | string | Log event message |
 |   ↳ `ingestionTime` | number | Ingestion time in epoch milliseconds |
 
-### `cloudwatch_describe_log_groups`
+### CloudWatch Describe Log Groups
 
 List available CloudWatch log groups
 
@@ -118,7 +118,7 @@ List available CloudWatch log groups
 |   ↳ `retentionInDays` | number | Retention period in days \(if set\) |
 |   ↳ `creationTime` | number | Creation time in epoch milliseconds |
 
-### `cloudwatch_get_log_events`
+### CloudWatch Get Log Events
 
 Retrieve log events from a specific CloudWatch log stream
 
@@ -144,7 +144,7 @@ Retrieve log events from a specific CloudWatch log stream
 |   ↳ `message` | string | Log event message |
 |   ↳ `ingestionTime` | number | Ingestion time in epoch milliseconds |
 
-### `cloudwatch_describe_log_streams`
+### CloudWatch Describe Log Streams
 
 List log streams within a CloudWatch log group
 
@@ -170,7 +170,7 @@ List log streams within a CloudWatch log group
 |   ↳ `creationTime` | number | Stream creation time in epoch milliseconds |
 |   ↳ `storedBytes` | number | Total stored bytes |
 
-### `cloudwatch_put_log_group_retention`
+### CloudWatch Set Log Group Retention
 
 Set (or clear, for never-expire) the retention period for a CloudWatch log group
 
@@ -192,7 +192,7 @@ Set (or clear, for never-expire) the retention period for a CloudWatch log group
 | `logGroupName` | string | Log group the policy applies to |
 | `retentionInDays` | number | Retention period in days, or null if events never expire |
 
-### `cloudwatch_list_metrics`
+### CloudWatch List Metrics
 
 List available CloudWatch metrics
 
@@ -217,7 +217,7 @@ List available CloudWatch metrics
 |   ↳ `metricName` | string | Metric name \(e.g., CPUUtilization\) |
 |   ↳ `dimensions` | array | Array of name/value dimension pairs |
 
-### `cloudwatch_get_metric_statistics`
+### CloudWatch Get Metric Statistics
 
 Get statistics for a CloudWatch metric over a time range
 
@@ -250,7 +250,7 @@ Get statistics for a CloudWatch metric over a time range
 |   ↳ `sampleCount` | number | Sample count statistic value |
 |   ↳ `unit` | string | Unit of the metric |
 
-### `cloudwatch_put_metric_data`
+### CloudWatch Publish Metric
 
 Publish a custom metric data point to CloudWatch
 
@@ -278,7 +278,7 @@ Publish a custom metric data point to CloudWatch
 | `unit` | string | Metric unit |
 | `timestamp` | string | Timestamp when the metric was published |
 
-### `cloudwatch_describe_alarms`
+### CloudWatch Describe Alarms
 
 List and filter CloudWatch alarms
 
@@ -308,7 +308,7 @@ List and filter CloudWatch alarms
 |   ↳ `threshold` | number | Threshold value \(MetricAlarm only\) |
 |   ↳ `stateUpdatedTimestamp` | number | Epoch ms when state last changed |
 
-### `cloudwatch_describe_alarm_history`
+### CloudWatch Describe Alarm History
 
 Retrieve state-change and configuration history for CloudWatch alarms
 
@@ -337,7 +337,7 @@ Retrieve state-change and configuration history for CloudWatch alarms
 |   ↳ `historyItemType` | string | ConfigurationUpdate, StateUpdate, Action, or contributor variants |
 |   ↳ `historySummary` | string | Human-readable summary of the event |
 
-### `cloudwatch_mute_alarm`
+### CloudWatch Mute Alarm
 
 Create a CloudWatch alarm mute rule that suppresses alarms for a fixed duration
 
@@ -365,7 +365,7 @@ Create a CloudWatch alarm mute rule that suppresses alarms for a fixed duration
 | `expression` | string | Schedule expression used by the mute rule |
 | `duration` | string | ISO 8601 duration of the mute window |
 
-### `cloudwatch_unmute_alarm`
+### CloudWatch Unmute Alarm
 
 Delete a CloudWatch alarm mute rule, restoring alarm notifications
 

--- a/apps/docs/content/docs/en/integrations/codepipeline.mdx
+++ b/apps/docs/content/docs/en/integrations/codepipeline.mdx
@@ -32,7 +32,7 @@ Integrate AWS CodePipeline into workflows. Start, stop, and monitor pipeline exe
 
 ## Actions
 
-### `codepipeline_list_pipelines`
+### CodePipeline List Pipelines
 
 List all CodePipeline pipelines in an AWS account and region
 
@@ -59,7 +59,7 @@ List all CodePipeline pipelines in an AWS account and region
 |   ↳ `updated` | number | Epoch ms when the pipeline was last updated |
 | `nextToken` | string | Pagination token for the next page of results |
 
-### `codepipeline_get_pipeline`
+### CodePipeline Get Pipeline
 
 Get the structure of a CodePipeline pipeline, including its stages, actions, and variables
 
@@ -95,7 +95,7 @@ Get the structure of a CodePipeline pipeline, including its stages, actions, and
 | `created` | number | Epoch ms when the pipeline was created |
 | `updated` | number | Epoch ms when the pipeline was last updated |
 
-### `codepipeline_get_pipeline_state`
+### CodePipeline Get Pipeline State
 
 Get the current state of a CodePipeline pipeline, including stage and action status and pending approval tokens
 
@@ -123,7 +123,7 @@ Get the current state of a CodePipeline pipeline, including stage and action sta
 |   ↳ `inboundTransitionEnabled` | boolean | Whether the inbound transition into the stage is enabled |
 |   ↳ `actionStates` | array | Per-action state with status, summary, error details, and approval token \(for pending manual approvals\) |
 
-### `codepipeline_get_pipeline_execution`
+### CodePipeline Get Pipeline Execution
 
 Get details of a CodePipeline execution, including status, trigger, source revisions, and resolved variables
 
@@ -160,7 +160,7 @@ Get details of a CodePipeline execution, including status, trigger, source revis
 |   ↳ `name` | string | Variable name |
 |   ↳ `resolvedValue` | string | Resolved variable value |
 
-### `codepipeline_list_pipeline_executions`
+### CodePipeline List Pipeline Executions
 
 List recent executions of a CodePipeline pipeline with status and source revisions
 
@@ -195,7 +195,7 @@ List recent executions of a CodePipeline pipeline with status and source revisio
 |   ↳ `sourceRevisions` | array | Source revisions \(commit IDs, summaries, URLs\) for the execution |
 | `nextToken` | string | Pagination token for the next page of results |
 
-### `codepipeline_list_action_executions`
+### CodePipeline List Action Executions
 
 List action-level execution history for a CodePipeline pipeline, including per-action status, timing, and error details
 
@@ -232,7 +232,7 @@ List action-level execution history for a CodePipeline pipeline, including per-a
 |   ↳ `errorMessage` | string | Error message if the action failed |
 | `nextToken` | string | Pagination token for the next page of results |
 
-### `codepipeline_start_execution`
+### CodePipeline Start Execution
 
 Start a CodePipeline pipeline execution, optionally overriding pipeline variables
 
@@ -253,7 +253,7 @@ Start a CodePipeline pipeline execution, optionally overriding pipeline variable
 | --------- | ---- | ----------- |
 | `pipelineExecutionId` | string | ID of the pipeline execution that was started |
 
-### `codepipeline_stop_execution`
+### CodePipeline Stop Execution
 
 Stop a CodePipeline pipeline execution, either finishing in-progress actions or abandoning them
 
@@ -275,7 +275,7 @@ Stop a CodePipeline pipeline execution, either finishing in-progress actions or 
 | --------- | ---- | ----------- |
 | `pipelineExecutionId` | string | ID of the pipeline execution that was stopped |
 
-### `codepipeline_retry_stage_execution`
+### CodePipeline Retry Stage Execution
 
 Retry the failed actions (or all actions) of a failed CodePipeline stage
 
@@ -297,7 +297,7 @@ Retry the failed actions (or all actions) of a failed CodePipeline stage
 | --------- | ---- | ----------- |
 | `pipelineExecutionId` | string | ID of the pipeline execution with the retried stage |
 
-### `codepipeline_put_approval_result`
+### CodePipeline Put Approval Result
 
 Approve or reject a pending CodePipeline manual approval action. The approval token is available from Get Pipeline State on the pending approval action
 
@@ -322,7 +322,7 @@ Approve or reject a pending CodePipeline manual approval action. The approval to
 | `approvedAt` | number | Epoch ms when the approval or rejection was submitted |
 | `status` | string | The submitted approval decision \(Approved or Rejected\) |
 
-### `codepipeline_disable_stage_transition`
+### CodePipeline Disable Stage Transition
 
 Prevent artifacts from transitioning into or out of a CodePipeline stage, freezing the pipeline at that point
 
@@ -346,7 +346,7 @@ Prevent artifacts from transitioning into or out of a CodePipeline stage, freezi
 | `stageName` | string | Stage whose transition was disabled |
 | `transitionType` | string | Transition type that was disabled \(Inbound or Outbound\) |
 
-### `codepipeline_enable_stage_transition`
+### CodePipeline Enable Stage Transition
 
 Re-enable artifacts transitioning into or out of a CodePipeline stage after it was disabled
 

--- a/apps/docs/content/docs/en/integrations/confluence.mdx
+++ b/apps/docs/content/docs/en/integrations/confluence.mdx
@@ -33,7 +33,7 @@ Integrate Confluence into the workflow. Can read, create, update, delete pages, 
 
 ## Actions
 
-### `confluence_retrieve`
+### Confluence Retrieve
 
 Retrieve content from Confluence pages using the Confluence API.
 
@@ -69,7 +69,7 @@ Retrieve content from Confluence pages using the Confluence API.
 |   ↳ `authorId` | string | Account ID of the version author |
 |   ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 
-### `confluence_update`
+### Confluence Update
 
 Update a Confluence page using the Confluence API.
 
@@ -111,7 +111,7 @@ Update a Confluence page using the Confluence API.
 | `url` | string | URL to view the page in Confluence |
 | `success` | boolean | Update operation success status |
 
-### `confluence_create_page`
+### Confluence Create Page
 
 Create a new page in a Confluence space.
 
@@ -154,7 +154,7 @@ Create a new page in a Confluence space.
 |   ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 | `url` | string | Page URL |
 
-### `confluence_delete_page`
+### Confluence Delete Page
 
 Delete a Confluence page. By default moves to trash; use purge=true to permanently delete.
 
@@ -175,7 +175,7 @@ Delete a Confluence page. By default moves to trash; use purge=true to permanent
 | `pageId` | string | Deleted page ID |
 | `deleted` | boolean | Deletion status |
 
-### `confluence_list_pages_in_space`
+### Confluence List Pages in Space
 
 List all pages within a specific Confluence space. Supports pagination and filtering by status.
 
@@ -223,7 +223,7 @@ List all pages within a specific Confluence space. Supports pagination and filte
 |   ↳ `webUrl` | string | URL to view the page in Confluence |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_get_page_children`
+### Confluence Get Page Children
 
 Get all child pages of a specific Confluence page. Useful for navigating page hierarchies.
 
@@ -252,7 +252,7 @@ Get all child pages of a specific Confluence page. Useful for navigating page hi
 |   ↳ `webUrl` | string | URL to view the page |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_get_page_ancestors`
+### Confluence Get Page Ancestors
 
 Get the ancestor (parent) pages of a specific Confluence page. Returns the full hierarchy from the page up to the root.
 
@@ -278,7 +278,7 @@ Get the ancestor (parent) pages of a specific Confluence page. Returns the full 
 |   ↳ `spaceId` | string | Space ID |
 |   ↳ `webUrl` | string | URL to view the page |
 
-### `confluence_list_page_versions`
+### Confluence List Page Versions
 
 List all versions (revision history) of a Confluence page.
 
@@ -306,7 +306,7 @@ List all versions (revision history) of a Confluence page.
 |   ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_get_page_version`
+### Confluence Get Page Version
 
 Get details about a specific version of a Confluence page.
 
@@ -341,7 +341,7 @@ Get details about a specific version of a Confluence page.
 |   ↳ `value` | string | The content value in the specified format |
 |   ↳ `representation` | string | Content representation type |
 
-### `confluence_list_page_properties`
+### Confluence List Page Properties
 
 List all custom properties (metadata) attached to a Confluence page.
 
@@ -373,7 +373,7 @@ List all custom properties (metadata) attached to a Confluence page.
 |     ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_create_page_property`
+### Confluence Create Page Property
 
 Create a new custom property (metadata) on a Confluence page.
 
@@ -403,7 +403,7 @@ Create a new custom property (metadata) on a Confluence page.
 |   ↳ `authorId` | string | Account ID of the version author |
 |   ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 
-### `confluence_delete_page_property`
+### Confluence Delete Page Property
 
 Delete a content property from a Confluence page by its property ID.
 
@@ -425,7 +425,7 @@ Delete a content property from a Confluence page by its property ID.
 | `propertyId` | string | ID of the deleted property |
 | `deleted` | boolean | Deletion status |
 
-### `confluence_search`
+### Confluence Search
 
 Search for content across Confluence pages, blog posts, and other content.
 
@@ -458,7 +458,7 @@ Search for content across Confluence pages, blog posts, and other content.
 |   ↳ `lastModified` | string | ISO 8601 timestamp of last modification |
 |   ↳ `entityType` | string | Entity type identifier \(e.g., content, space\) |
 
-### `confluence_search_in_space`
+### Confluence Search in Space
 
 Search for content within a specific Confluence space. Optionally filter by text query and content type.
 
@@ -495,7 +495,7 @@ Search for content within a specific Confluence space. Optionally filter by text
 |   ↳ `lastModified` | string | ISO 8601 timestamp of last modification |
 |   ↳ `entityType` | string | Entity type identifier \(e.g., content, space\) |
 
-### `confluence_list_blogposts`
+### Confluence List Blog Posts
 
 List all blog posts across all accessible Confluence spaces.
 
@@ -531,7 +531,7 @@ List all blog posts across all accessible Confluence spaces.
 |   ↳ `webUrl` | string | URL to view the blog post |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_get_blogpost`
+### Confluence Get Blog Post
 
 Get a specific Confluence blog post by ID, including its content.
 
@@ -573,7 +573,7 @@ Get a specific Confluence blog post by ID, including its content.
 |     ↳ `representation` | string | Content representation type |
 | `webUrl` | string | URL to view the blog post |
 
-### `confluence_create_blogpost`
+### Confluence Create Blog Post
 
 Create a new blog post in a Confluence space.
 
@@ -616,7 +616,7 @@ Create a new blog post in a Confluence space.
 |   ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 | `webUrl` | string | URL to view the blog post |
 
-### `confluence_list_blogposts_in_space`
+### Confluence List Blog Posts in Space
 
 List all blog posts within a specific Confluence space.
 
@@ -663,7 +663,7 @@ List all blog posts within a specific Confluence space.
 |   ↳ `webUrl` | string | URL to view the blog post |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_create_comment`
+### Confluence Create Comment
 
 Add a comment to a Confluence page.
 
@@ -684,7 +684,7 @@ Add a comment to a Confluence page.
 | `commentId` | string | Created comment ID |
 | `pageId` | string | Page ID |
 
-### `confluence_list_comments`
+### Confluence List Comments
 
 List all comments on a Confluence page.
 
@@ -724,7 +724,7 @@ List all comments on a Confluence page.
 |     ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_update_comment`
+### Confluence Update Comment
 
 Update an existing comment on a Confluence page.
 
@@ -745,7 +745,7 @@ Update an existing comment on a Confluence page.
 | `commentId` | string | Updated comment ID |
 | `updated` | boolean | Update status |
 
-### `confluence_delete_comment`
+### Confluence Delete Comment
 
 Delete a comment from a Confluence page.
 
@@ -765,7 +765,7 @@ Delete a comment from a Confluence page.
 | `commentId` | string | Deleted comment ID |
 | `deleted` | boolean | Deletion status |
 
-### `confluence_upload_attachment`
+### Confluence Upload Attachment
 
 Upload a file as an attachment to a Confluence page.
 
@@ -792,7 +792,7 @@ Upload a file as an attachment to a Confluence page.
 | `downloadUrl` | string | Download URL for the attachment |
 | `pageId` | string | Page ID the attachment was added to |
 
-### `confluence_list_attachments`
+### Confluence List Attachments
 
 List all attachments on a Confluence page.
 
@@ -830,7 +830,7 @@ List all attachments on a Confluence page.
 |     ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_delete_attachment`
+### Confluence Delete Attachment
 
 Delete an attachment from a Confluence page (moves to trash).
 
@@ -850,7 +850,7 @@ Delete an attachment from a Confluence page (moves to trash).
 | `attachmentId` | string | Deleted attachment ID |
 | `deleted` | boolean | Deletion status |
 
-### `confluence_list_labels`
+### Confluence List Labels
 
 List all labels on a Confluence page.
 
@@ -875,7 +875,7 @@ List all labels on a Confluence page.
 |   ↳ `prefix` | string | Label prefix/type \(e.g., global, my, team\) |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_add_label`
+### Confluence Add Label
 
 Add a label to a Confluence page for organization and categorization.
 
@@ -898,7 +898,7 @@ Add a label to a Confluence page for organization and categorization.
 | `labelName` | string | Name of the added label |
 | `labelId` | string | ID of the added label |
 
-### `confluence_delete_label`
+### Confluence Delete Label
 
 Remove a label from a Confluence page.
 
@@ -920,7 +920,7 @@ Remove a label from a Confluence page.
 | `labelName` | string | Name of the removed label |
 | `deleted` | boolean | Deletion status |
 
-### `confluence_get_pages_by_label`
+### Confluence Get Pages by Label
 
 Retrieve all pages that have a specific label applied.
 
@@ -956,7 +956,7 @@ Retrieve all pages that have a specific label applied.
 |     ↳ `createdAt` | string | ISO 8601 timestamp of version creation |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_list_space_labels`
+### Confluence List Space Labels
 
 List all labels associated with a Confluence space.
 
@@ -982,7 +982,7 @@ List all labels associated with a Confluence space.
 |   ↳ `prefix` | string | Label prefix/type \(e.g., global, my, team\) |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_get_space`
+### Confluence Get Space
 
 Get details about a specific Confluence space.
 
@@ -1012,7 +1012,7 @@ Get details about a specific Confluence space.
 |   ↳ `value` | string | Description text content |
 |   ↳ `representation` | string | Content representation format \(e.g., plain, view, storage\) |
 
-### `confluence_create_space`
+### Confluence Create Space
 
 Create a new Confluence space.
 
@@ -1042,7 +1042,7 @@ Create a new Confluence space.
 |   ↳ `value` | string | Description text content |
 |   ↳ `representation` | string | Content representation format \(e.g., plain, view, storage\) |
 
-### `confluence_update_space`
+### Confluence Update Space
 
 Update a Confluence space name or description.
 
@@ -1071,7 +1071,7 @@ Update a Confluence space name or description.
 |   ↳ `value` | string | Description text content |
 |   ↳ `representation` | string | Content representation format \(e.g., plain, view, storage\) |
 
-### `confluence_delete_space`
+### Confluence Delete Space
 
 Delete a Confluence space.
 
@@ -1093,7 +1093,7 @@ Delete a Confluence space.
 | `longTaskId` | string | ID of the long-running deletion task; poll Confluence long-task API to track completion |
 | `longTaskStatusLink` | string | Relative link to the long-task status endpoint |
 
-### `confluence_list_spaces`
+### Confluence List Spaces
 
 List all Confluence spaces accessible to the user.
 
@@ -1125,7 +1125,7 @@ List all Confluence spaces accessible to the user.
 |     ↳ `representation` | string | Content representation format \(e.g., plain, view, storage\) |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_list_space_properties`
+### Confluence List Space Properties
 
 List properties on a Confluence space.
 
@@ -1151,7 +1151,7 @@ List properties on a Confluence space.
 | `spaceId` | string | Space ID |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_create_space_property`
+### Confluence Create Space Property
 
 Create a property on a Confluence space.
 
@@ -1175,7 +1175,7 @@ Create a property on a Confluence space.
 | `value` | json | Property value |
 | `spaceId` | string | Space ID |
 
-### `confluence_delete_space_property`
+### Confluence Delete Space Property
 
 Delete a property from a Confluence space.
 
@@ -1197,7 +1197,7 @@ Delete a property from a Confluence space.
 | `propertyId` | string | Deleted property ID |
 | `deleted` | boolean | Deletion status |
 
-### `confluence_list_space_permissions`
+### Confluence List Space Permissions
 
 List permissions for a Confluence space.
 
@@ -1227,7 +1227,7 @@ List permissions for a Confluence space.
 | `spaceId` | string | Space ID |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_get_page_descendants`
+### Confluence Get Page Descendants
 
 Get all descendants of a Confluence page recursively.
 
@@ -1258,7 +1258,7 @@ Get all descendants of a Confluence page recursively.
 | `pageId` | string | Parent page ID |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_list_tasks`
+### Confluence List Tasks
 
 List inline tasks from Confluence. Optionally filter by page, space, assignee, or status.
 
@@ -1297,7 +1297,7 @@ List inline tasks from Confluence. Optionally filter by page, space, assignee, o
 |   ↳ `completedAt` | string | Completion timestamp |
 | `nextCursor` | string | Cursor for fetching the next page of results |
 
-### `confluence_get_task`
+### Confluence Get Task
 
 Get a specific Confluence inline task by ID.
 
@@ -1329,7 +1329,7 @@ Get a specific Confluence inline task by ID.
 | `dueAt` | string | Due date |
 | `completedAt` | string | Completion timestamp |
 
-### `confluence_update_task`
+### Confluence Update Task
 
 Update the status of a Confluence inline task (complete or incomplete).
 
@@ -1362,7 +1362,7 @@ Update the status of a Confluence inline task (complete or incomplete).
 | `dueAt` | string | Due date |
 | `completedAt` | string | Completion timestamp |
 
-### `confluence_update_blogpost`
+### Confluence Update Blog Post
 
 Update an existing Confluence blog post title and/or content.
 
@@ -1388,7 +1388,7 @@ Update an existing Confluence blog post title and/or content.
 | `version` | json | Version information |
 | `url` | string | URL to view the blog post |
 
-### `confluence_delete_blogpost`
+### Confluence Delete Blog Post
 
 Delete a Confluence blog post.
 
@@ -1408,7 +1408,7 @@ Delete a Confluence blog post.
 | `blogPostId` | string | Deleted blog post ID |
 | `deleted` | boolean | Deletion status |
 
-### `confluence_get_user`
+### Confluence Get User
 
 Get display name and profile info for a Confluence user by account ID.
 

--- a/apps/docs/content/docs/en/integrations/context_dev.mdx
+++ b/apps/docs/content/docs/en/integrations/context_dev.mdx
@@ -32,7 +32,7 @@ Integrate Context.dev into the workflow. Scrape pages to markdown or HTML, captu
 
 ## Actions
 
-### `context_dev_scrape_markdown`
+### Context.dev Scrape Markdown
 
 Scrape any URL and return clean, LLM-ready markdown content.
 
@@ -57,7 +57,7 @@ Scrape any URL and return clean, LLM-ready markdown content.
 | `markdown` | string | Page content as clean markdown |
 | `url` | string | The scraped URL |
 
-### `context_dev_scrape_html`
+### Context.dev Scrape HTML
 
 Scrape any URL and return the raw HTML content of the page.
 
@@ -81,7 +81,7 @@ Scrape any URL and return the raw HTML content of the page.
 | `url` | string | The scraped URL |
 | `type` | string | Detected content type \(html, xml, json, text, csv, markdown, svg, pdf, doc, docx\) |
 
-### `context_dev_scrape_images`
+### Context.dev Scrape Images
 
 Discover every image asset on a page, with optional dimension and type enrichment.
 
@@ -111,7 +111,7 @@ Discover every image asset on a page, with optional dimension and type enrichmen
 |   ↳ `enrichment` | json | Optional enrichment \(width, height, mimetype, url, type\) when requested |
 | `url` | string | The scraped URL |
 
-### `context_dev_screenshot`
+### Context.dev Screenshot
 
 Capture a screenshot of any web page and store it as a downloadable image file.
 
@@ -140,7 +140,7 @@ Capture a screenshot of any web page and store it as a downloadable image file.
 | `width` | number | Screenshot width in pixels |
 | `height` | number | Screenshot height in pixels |
 
-### `context_dev_crawl`
+### Context.dev Crawl
 
 Crawl an entire website and return each discovered page as clean markdown.
 
@@ -171,7 +171,7 @@ Crawl an entire website and return each discovered page as clean markdown.
 |   ↳ `metadata` | json | Page metadata \(url, title, crawlDepth, statusCode\) |
 | `metadata` | object | Crawl summary \(numUrls, maxCrawlDepth, numSucceeded, numFailed, numSkipped\) |
 
-### `context_dev_map`
+### Context.dev Map
 
 Build a sitemap of a domain and return every discovered page URL.
 
@@ -193,7 +193,7 @@ Build a sitemap of a domain and return every discovered page URL.
 | `urls` | array | All page URLs discovered from the sitemap |
 | `meta` | object | Sitemap discovery stats \(sitemapsDiscovered, sitemapsFetched, sitemapsSkipped, errors\) |
 
-### `context_dev_search`
+### Context.dev Search
 
 Search the web with natural language and optionally scrape results to markdown.
 
@@ -224,7 +224,7 @@ Search the web with natural language and optionally scrape results to markdown.
 |   ↳ `markdown` | json | Scraped markdown for the result \(when markdown scraping is enabled\) |
 | `query` | string | The query that was searched |
 
-### `context_dev_extract`
+### Context.dev Extract
 
 Crawl a website and extract structured data matching a provided JSON schema.
 
@@ -254,7 +254,7 @@ Crawl a website and extract structured data matching a provided JSON schema.
 | `data` | json | Structured data matching the requested schema |
 | `metadata` | object | Crawl summary \(numUrls, maxCrawlDepth, numSucceeded, numFailed, numSkipped\) |
 
-### `context_dev_extract_product`
+### Context.dev Extract Product
 
 Detect and extract structured product details from a single product page URL.
 
@@ -289,7 +289,7 @@ Detect and extract structured product details from a single product page URL.
 |   ↳ `images` | json | Product image URLs |
 |   ↳ `sku` | string | Product SKU |
 
-### `context_dev_extract_products`
+### Context.dev Extract Products
 
 Extract the product catalog from a brand's website by domain (beta).
 
@@ -323,7 +323,7 @@ Extract the product catalog from a brand's website by domain (beta).
 |   ↳ `images` | json | Product image URLs |
 |   ↳ `sku` | string | Product SKU |
 
-### `context_dev_scrape_fonts`
+### Context.dev Scrape Fonts
 
 Extract the font families, usage stats, and font files used by a domain.
 
@@ -352,7 +352,7 @@ Extract the font families, usage stats, and font files used by a domain.
 |   ↳ `percent_elements` | number | Percent of elements using the font |
 | `fontLinks` | json | Font family download links keyed by font name \(type, files, category\) |
 
-### `context_dev_scrape_styleguide`
+### Context.dev Scrape Styleguide
 
 Extract a domain's design system: colors, typography, spacing, shadows, and UI components.
 
@@ -373,7 +373,7 @@ Extract a domain's design system: colors, typography, spacing, shadows, and UI c
 | `domain` | string | The domain that was analyzed |
 | `styleguide` | json | Design system: mode, colors, typography, elementSpacing, shadows, fontLinks, components |
 
-### `context_dev_classify_naics`
+### Context.dev Classify NAICS
 
 Classify a brand into NAICS industry codes from its domain or company name.
 
@@ -399,7 +399,7 @@ Classify a brand into NAICS industry codes from its domain or company name.
 |   ↳ `name` | string | Industry name |
 |   ↳ `confidence` | string | Match confidence \(high, medium, low\) |
 
-### `context_dev_classify_sic`
+### Context.dev Classify SIC
 
 Classify a brand into SIC industry codes from its domain or company name.
 
@@ -430,7 +430,7 @@ Classify a brand into SIC industry codes from its domain or company name.
 |   ↳ `majorGroupName` | string | Major group name \(original_sic only\) |
 |   ↳ `office` | string | SEC office \(latest_sec only\) |
 
-### `context_dev_get_brand`
+### Context.dev Get Brand
 
 Retrieve brand data for a domain: logos, colors, backdrops, socials, address, and industry.
 
@@ -468,7 +468,7 @@ Retrieve brand data for a domain: logos, colors, backdrops, socials, address, an
 |   ↳ `links` | json | Key brand links \(careers, privacy, terms, blog, pricing, contact\) |
 |   ↳ `primary_language` | string | Primary language of the brand site |
 
-### `context_dev_get_brand_by_name`
+### Context.dev Get Brand by Name
 
 Retrieve brand data by company name: logos, colors, socials, address, and industry.
 
@@ -507,7 +507,7 @@ Retrieve brand data by company name: logos, colors, socials, address, and indust
 |   ↳ `links` | json | Key brand links \(careers, privacy, terms, blog, pricing, contact\) |
 |   ↳ `primary_language` | string | Primary language of the brand site |
 
-### `context_dev_get_brand_by_email`
+### Context.dev Get Brand by Email
 
 Retrieve brand data from a work email address. Free/disposable emails are rejected (422).
 
@@ -545,7 +545,7 @@ Retrieve brand data from a work email address. Free/disposable emails are reject
 |   ↳ `links` | json | Key brand links \(careers, privacy, terms, blog, pricing, contact\) |
 |   ↳ `primary_language` | string | Primary language of the brand site |
 
-### `context_dev_get_brand_by_ticker`
+### Context.dev Get Brand by Ticker
 
 Retrieve brand data for a public company by its stock ticker symbol.
 
@@ -584,7 +584,7 @@ Retrieve brand data for a public company by its stock ticker symbol.
 |   ↳ `links` | json | Key brand links \(careers, privacy, terms, blog, pricing, contact\) |
 |   ↳ `primary_language` | string | Primary language of the brand site |
 
-### `context_dev_identify_transaction`
+### Context.dev Identify Transaction
 
 Identify the brand behind a raw bank/card transaction descriptor and return its brand data.
 

--- a/apps/docs/content/docs/en/integrations/convex.mdx
+++ b/apps/docs/content/docs/en/integrations/convex.mdx
@@ -42,7 +42,7 @@ Integrate Convex into the workflow. Run query, mutation, and action functions on
 
 ## Actions
 
-### `convex_query`
+### Convex Run Query
 
 Run a Convex query function and return its result
 
@@ -62,7 +62,7 @@ Run a Convex query function and return its result
 | `value` | json | Result returned by the query function |
 | `logLines` | array | Log lines printed during the function execution |
 
-### `convex_mutation`
+### Convex Run Mutation
 
 Run a Convex mutation function to write data and return its result
 
@@ -82,7 +82,7 @@ Run a Convex mutation function to write data and return its result
 | `value` | json | Result returned by the mutation function |
 | `logLines` | array | Log lines printed during the function execution |
 
-### `convex_action`
+### Convex Run Action
 
 Run a Convex action function and return its result
 
@@ -102,7 +102,7 @@ Run a Convex action function and return its result
 | `value` | json | Result returned by the action function |
 | `logLines` | array | Log lines printed during the function execution |
 
-### `convex_run_function`
+### Convex Run Function
 
 Run any Convex function (query, mutation, or action) by path without specifying its type
 
@@ -122,7 +122,7 @@ Run any Convex function (query, mutation, or action) by path without specifying 
 | `value` | json | Result returned by the function |
 | `logLines` | array | Log lines printed during the function execution |
 
-### `convex_list_tables`
+### Convex List Tables
 
 List all tables in a Convex deployment along with their JSON schemas. Requires streaming export, available on Convex paid plans.
 
@@ -140,7 +140,7 @@ List all tables in a Convex deployment along with their JSON schemas. Requires s
 | `tables` | array | Names of the tables in the deployment |
 | `schemas` | json | Map of table name to the JSON schema of its documents |
 
-### `convex_list_documents`
+### Convex List Documents
 
 List documents from a Convex table via a paginated snapshot. Pass the returned snapshot and page cursor back in to fetch the next page. Requires streaming export, available on Convex paid plans.
 
@@ -163,7 +163,7 @@ List documents from a Convex table via a paginated snapshot. Pass the returned s
 | `snapshot` | string | Snapshot timestamp to pass back in when fetching the next page |
 | `pageCursor` | string | Page cursor to pass back in when fetching the next page |
 
-### `convex_document_deltas`
+### Convex Document Deltas
 
 List documents that changed after a snapshot or previous delta cursor. Deleted documents are returned with a _deleted flag. Requires streaming export, available on Convex paid plans.
 

--- a/apps/docs/content/docs/en/integrations/crowdstrike.mdx
+++ b/apps/docs/content/docs/en/integrations/crowdstrike.mdx
@@ -31,7 +31,7 @@ Integrate CrowdStrike Identity Protection into workflows to search sensors, fetc
 
 ## Actions
 
-### `crowdstrike_get_sensor_aggregates`
+### CrowdStrike Get Sensor Aggregates
 
 Get documented CrowdStrike Identity Protection sensor aggregates from a JSON aggregate query body
 
@@ -65,7 +65,7 @@ Get documented CrowdStrike Identity Protection sensor aggregates from a JSON agg
 |   ↳ `sumOtherDocCount` | number | Document count not included in the returned buckets |
 | `count` | number | Number of aggregate result groups returned |
 
-### `crowdstrike_get_sensor_details`
+### CrowdStrike Get Sensor Details
 
 Get documented CrowdStrike Identity Protection sensor details for one or more device IDs
 
@@ -108,7 +108,7 @@ Get documented CrowdStrike Identity Protection sensor details for one or more de
 |   ↳ `offset` | number | Offset returned by CrowdStrike |
 |   ↳ `total` | number | Total records available |
 
-### `crowdstrike_query_sensors`
+### CrowdStrike Query Sensors
 
 Search CrowdStrike identity protection sensors by hostname, IP, or related fields
 

--- a/apps/docs/content/docs/en/integrations/cursor.mdx
+++ b/apps/docs/content/docs/en/integrations/cursor.mdx
@@ -34,7 +34,7 @@ Interact with Cursor Cloud Agents API to launch AI agents that can work on your 
 
 ## Actions
 
-### `cursor_list_agents`
+### Cursor List Agents
 
 List all cloud agents for the authenticated user with optional pagination. Returns API-aligned fields only.
 
@@ -54,7 +54,7 @@ List all cloud agents for the authenticated user with optional pagination. Retur
 | `agents` | array | Array of agent objects |
 | `nextCursor` | string | Pagination cursor for next page |
 
-### `cursor_get_agent`
+### Cursor Get Agent
 
 Retrieve the current status and results of a cloud agent. Returns API-aligned fields only.
 
@@ -77,7 +77,7 @@ Retrieve the current status and results of a cloud agent. Returns API-aligned fi
 | `summary` | string | Agent summary |
 | `createdAt` | string | Creation timestamp |
 
-### `cursor_get_conversation`
+### Cursor Get Conversation
 
 Retrieve the conversation history of a cloud agent, including all user prompts and assistant responses. Returns API-aligned fields only.
 
@@ -95,7 +95,7 @@ Retrieve the conversation history of a cloud agent, including all user prompts a
 | `id` | string | Agent ID |
 | `messages` | array | Array of conversation messages |
 
-### `cursor_launch_agent`
+### Cursor Launch Agent
 
 Start a new cloud agent to work on a GitHub repository with the given instructions. Returns API-aligned fields only.
 
@@ -121,7 +121,7 @@ Start a new cloud agent to work on a GitHub repository with the given instructio
 | `id` | string | Agent ID |
 | `url` | string | Agent URL |
 
-### `cursor_add_followup`
+### Cursor Add Follow-up
 
 Add a follow-up instruction to an existing cloud agent. Returns API-aligned fields only.
 
@@ -140,7 +140,7 @@ Add a follow-up instruction to an existing cloud agent. Returns API-aligned fiel
 | --------- | ---- | ----------- |
 | `id` | string | Agent ID |
 
-### `cursor_stop_agent`
+### Cursor Stop Agent
 
 Stop a running cloud agent. Returns API-aligned fields only.
 
@@ -157,7 +157,7 @@ Stop a running cloud agent. Returns API-aligned fields only.
 | --------- | ---- | ----------- |
 | `id` | string | Agent ID |
 
-### `cursor_delete_agent`
+### Cursor Delete Agent
 
 Permanently delete a cloud agent. Returns API-aligned fields only.
 
@@ -174,7 +174,7 @@ Permanently delete a cloud agent. Returns API-aligned fields only.
 | --------- | ---- | ----------- |
 | `id` | string | Agent ID |
 
-### `cursor_list_artifacts`
+### Cursor List Artifacts
 
 List generated artifact files for a cloud agent. Returns API-aligned fields only.
 
@@ -193,7 +193,7 @@ List generated artifact files for a cloud agent. Returns API-aligned fields only
 |   ↳ `path` | string | Artifact file path |
 |   ↳ `size` | number | File size in bytes |
 
-### `cursor_download_artifact`
+### Cursor Download Artifact
 
 Download a generated artifact file from a cloud agent. Returns the file for execution storage.
 
@@ -211,7 +211,7 @@ Download a generated artifact file from a cloud agent. Returns the file for exec
 | --------- | ---- | ----------- |
 | `file` | file | Downloaded artifact file stored in execution files |
 
-### `cursor_list_models`
+### Cursor List Models
 
 List the models available for launching cloud agents. Returns API-aligned fields only.
 
@@ -227,7 +227,7 @@ List the models available for launching cloud agents. Returns API-aligned fields
 | --------- | ---- | ----------- |
 | `models` | array | Array of available model names |
 
-### `cursor_list_repositories`
+### Cursor List Repositories
 
 List the GitHub repositories accessible to the authenticated user. Returns API-aligned fields only.
 
@@ -246,7 +246,7 @@ List the GitHub repositories accessible to the authenticated user. Returns API-a
 |   ↳ `name` | string | Repository name |
 |   ↳ `repository` | string | Repository URL |
 
-### `cursor_get_api_key_info`
+### Cursor Get API Key Info
 
 Retrieve details about the API key currently in use. Returns API-aligned fields only.
 

--- a/apps/docs/content/docs/en/integrations/dagster.mdx
+++ b/apps/docs/content/docs/en/integrations/dagster.mdx
@@ -32,7 +32,7 @@ Connect to a Dagster instance to launch job runs, monitor run status, list avail
 
 ## Actions
 
-### `dagster_launch_run`
+### Dagster Launch Run
 
 Launch a job run on a Dagster instance.
 
@@ -54,7 +54,7 @@ Launch a job run on a Dagster instance.
 | --------- | ---- | ----------- |
 | `runId` | string | The globally unique ID of the launched run |
 
-### `dagster_get_run`
+### Dagster Get Run
 
 Get the status and details of a Dagster run by its ID.
 
@@ -85,7 +85,7 @@ Get the status and details of a Dagster run by its ID.
 | `runConfigYaml` | string | Run configuration as YAML |
 | `tags` | json | Run tags as array of \{key, value\} objects |
 
-### `dagster_get_run_logs`
+### Dagster Get Run Logs
 
 Fetch execution event logs for a Dagster run.
 
@@ -113,7 +113,7 @@ Fetch execution event logs for a Dagster run.
 | `cursor` | string | Cursor for fetching the next page of log events |
 | `hasMore` | boolean | Whether more log events are available beyond this page |
 
-### `dagster_list_runs`
+### Dagster List Runs
 
 List Dagster runs with optional filters by job name, status, and creation-time range, plus cursor pagination.
 
@@ -144,7 +144,7 @@ List Dagster runs with optional filters by job name, status, and creation-time r
 | `cursor` | string | Run ID of the last returned run — pass as cursor to fetch the next page |
 | `hasMore` | boolean | Whether more runs are likely available beyond this page |
 
-### `dagster_list_jobs`
+### Dagster List Jobs
 
 List all jobs across repositories in a Dagster instance.
 
@@ -163,7 +163,7 @@ List all jobs across repositories in a Dagster instance.
 |   ↳ `name` | string | Job name |
 |   ↳ `repositoryName` | string | Repository name |
 
-### `dagster_reexecute_run`
+### Dagster Reexecute Run
 
 Reexecute an existing Dagster run, optionally resuming only from failed steps.
 
@@ -182,7 +182,7 @@ Reexecute an existing Dagster run, optionally resuming only from failed steps.
 | --------- | ---- | ----------- |
 | `runId` | string | The ID of the newly launched reexecution run |
 
-### `dagster_terminate_run`
+### Dagster Terminate Run
 
 Terminate an in-progress Dagster run.
 
@@ -202,7 +202,7 @@ Terminate an in-progress Dagster run.
 | `runId` | string | The ID of the terminated run |
 | `message` | string | Error or status message if termination failed |
 
-### `dagster_delete_run`
+### Dagster Delete Run
 
 Permanently delete a Dagster run record.
 
@@ -220,7 +220,7 @@ Permanently delete a Dagster run record.
 | --------- | ---- | ----------- |
 | `runId` | string | The ID of the deleted run |
 
-### `dagster_list_schedules`
+### Dagster List Schedules
 
 List all schedules in a Dagster repository, optionally filtered by status.
 
@@ -247,7 +247,7 @@ List all schedules in a Dagster repository, optionally filtered by status.
 |   ↳ `description` | string | Human-readable schedule description |
 |   ↳ `executionTimezone` | string | Timezone for cron evaluation |
 
-### `dagster_start_schedule`
+### Dagster Start Schedule
 
 Enable (start) a schedule in a Dagster repository.
 
@@ -268,7 +268,7 @@ Enable (start) a schedule in a Dagster repository.
 | `id` | string | Instigator state ID of the schedule |
 | `status` | string | Updated schedule status \(RUNNING or STOPPED\) |
 
-### `dagster_stop_schedule`
+### Dagster Stop Schedule
 
 Disable (stop) a running schedule in Dagster.
 
@@ -287,7 +287,7 @@ Disable (stop) a running schedule in Dagster.
 | `id` | string | Instigator state ID of the schedule |
 | `status` | string | Updated schedule status \(RUNNING or STOPPED\) |
 
-### `dagster_list_sensors`
+### Dagster List Sensors
 
 List all sensors in a Dagster repository, optionally filtered by status.
 
@@ -312,7 +312,7 @@ List all sensors in a Dagster repository, optionally filtered by status.
 |   ↳ `id` | string | Instigator state ID — use this to start or stop the sensor |
 |   ↳ `description` | string | Human-readable sensor description |
 
-### `dagster_start_sensor`
+### Dagster Start Sensor
 
 Enable (start) a sensor in a Dagster repository.
 
@@ -333,7 +333,7 @@ Enable (start) a sensor in a Dagster repository.
 | `id` | string | Instigator state ID of the sensor |
 | `status` | string | Updated sensor status \(RUNNING or STOPPED\) |
 
-### `dagster_stop_sensor`
+### Dagster Stop Sensor
 
 Disable (stop) a running sensor in Dagster.
 
@@ -352,7 +352,7 @@ Disable (stop) a running sensor in Dagster.
 | `id` | string | Instigator state ID of the sensor |
 | `status` | string | Updated sensor status \(RUNNING or STOPPED\) |
 
-### `dagster_list_assets`
+### Dagster List Assets
 
 List assets tracked by a Dagster instance, optionally filtered by key prefix.
 
@@ -376,7 +376,7 @@ List assets tracked by a Dagster instance, optionally filtered by key prefix.
 | `cursor` | string | Cursor to pass on the next call to fetch more assets |
 | `hasMore` | boolean | Whether more assets are likely available beyond this page |
 
-### `dagster_get_asset`
+### Dagster Get Asset
 
 Get an asset definition and its latest materialization by asset key.
 
@@ -405,7 +405,7 @@ Get an asset definition and its latest materialization by asset key.
 |   ↳ `partition` | string | Partition key, if partitioned |
 |   ↳ `stepKey` | string | Step key that emitted it |
 
-### `dagster_materialize_assets`
+### Dagster Materialize Assets
 
 Materialize selected assets by launching their asset job with an asset selection.
 
@@ -427,7 +427,7 @@ Materialize selected assets by launching their asset job with an asset selection
 | --------- | ---- | ----------- |
 | `runId` | string | The globally unique ID of the launched materialization run |
 
-### `dagster_report_asset_materialization`
+### Dagster Report Asset Materialization
 
 Report an external (runless) materialization or observation for an asset.
 
@@ -449,7 +449,7 @@ Report an external (runless) materialization or observation for an asset.
 | `success` | boolean | Whether the event was reported successfully |
 | `assetKey` | string | Slash-joined asset key the event was reported against |
 
-### `dagster_wipe_asset`
+### Dagster Wipe Asset
 
 DESTRUCTIVE: permanently wipes ALL materialization history (every partition) for an asset. This cannot be undone.
 

--- a/apps/docs/content/docs/en/integrations/databricks.mdx
+++ b/apps/docs/content/docs/en/integrations/databricks.mdx
@@ -33,7 +33,7 @@ Connect to Databricks to execute SQL queries against SQL warehouses, trigger and
 
 ## Actions
 
-### `databricks_execute_sql`
+### Databricks Execute SQL
 
 Execute a SQL statement against a Databricks SQL warehouse and return results inline. Supports parameterized queries and Unity Catalog.
 
@@ -64,7 +64,7 @@ Execute a SQL statement against a Databricks SQL warehouse and return results in
 | `totalRows` | number | Total number of rows in the result |
 | `truncated` | boolean | Whether the result set was truncated due to row_limit or byte_limit |
 
-### `databricks_get_statement`
+### Databricks Get Statement
 
 Poll a SQL statement by its ID to retrieve status and results. Use this after Execute SQL when a query runs longer than the wait timeout.
 
@@ -90,7 +90,7 @@ Poll a SQL statement by its ID to retrieve status and results. Use this after Ex
 | `totalRows` | number | Total number of rows in the result |
 | `truncated` | boolean | Whether the result set was truncated due to row_limit or byte_limit |
 
-### `databricks_list_warehouses`
+### Databricks List Warehouses
 
 List all SQL warehouses in a Databricks workspace including their size, state, and type. Use this to discover the warehouse ID needed for Execute SQL.
 
@@ -119,7 +119,7 @@ List all SQL warehouses in a Databricks workspace including their size, state, a
 |   ↳ `numActiveSessions` | number | Number of active sessions |
 |   ↳ `enableServerlessCompute` | boolean | Whether serverless compute is enabled |
 
-### `databricks_list_jobs`
+### Databricks List Jobs
 
 List all jobs in a Databricks workspace with optional filtering by name.
 
@@ -148,7 +148,7 @@ List all jobs in a Databricks workspace with optional filtering by name.
 | `hasMore` | boolean | Whether more jobs are available for pagination |
 | `nextPageToken` | string | Token for fetching the next page of results |
 
-### `databricks_get_job`
+### Databricks Get Job
 
 Get the full definition and settings of a single Databricks job by its job ID.
 
@@ -176,7 +176,7 @@ Get the full definition and settings of a single Databricks job by its job ID.
 | `tags` | object | Key-value tags applied to the job |
 | `tasks` | array | Task definitions for the job \(empty for single-task jobs\) |
 
-### `databricks_run_job`
+### Databricks Run Job
 
 Trigger an existing Databricks job to run immediately with optional job-level or notebook parameters.
 
@@ -198,7 +198,7 @@ Trigger an existing Databricks job to run immediately with optional job-level or
 | `runId` | number | The globally unique ID of the triggered run |
 | `numberInJob` | number | The sequence number of this run among all runs of the job |
 
-### `databricks_get_run`
+### Databricks Get Run
 
 Get the status, timing, and details of a Databricks job run by its run ID.
 
@@ -235,7 +235,7 @@ Get the status, timing, and details of a Databricks job run by its run ID.
 | `runPageUrl` | string | URL to the run detail page in Databricks UI |
 | `creatorUserName` | string | Email of the user who triggered the run |
 
-### `databricks_list_runs`
+### Databricks List Runs
 
 List job runs in a Databricks workspace with optional filtering by job, status, and time range.
 
@@ -273,7 +273,7 @@ List job runs in a Databricks workspace with optional filtering by job, status, 
 | `hasMore` | boolean | Whether more runs are available for pagination |
 | `nextPageToken` | string | Token for fetching the next page of results |
 
-### `databricks_cancel_run`
+### Databricks Cancel Run
 
 Cancel a running or pending Databricks job run. Cancellation is asynchronous; poll the run status to confirm termination.
 
@@ -291,7 +291,7 @@ Cancel a running or pending Databricks job run. Cancellation is asynchronous; po
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the cancel request was accepted |
 
-### `databricks_get_run_output`
+### Databricks Get Run Output
 
 Get the output of a completed Databricks job run, including notebook results, error messages, and logs. For multi-task jobs, use the task run ID (not the parent run ID).
 
@@ -315,7 +315,7 @@ Get the output of a completed Databricks job run, including notebook results, er
 | `logs` | string | Log output \(last 5 MB\) from spark_jar, spark_python, or python_wheel tasks |
 | `logsTruncated` | boolean | Whether the log output was truncated |
 
-### `databricks_list_clusters`
+### Databricks List Clusters
 
 List all clusters in a Databricks workspace including their state, configuration, and resource details.
 
@@ -347,7 +347,7 @@ List all clusters in a Databricks workspace including their state, configuration
 |   ↳ `autoterminationMinutes` | number | Minutes of inactivity before auto-termination \(0 = disabled\) |
 |   ↳ `startTime` | number | Cluster start timestamp \(epoch ms\) |
 
-### `databricks_get_cluster`
+### Databricks Get Cluster
 
 Get the state, configuration, and resource details of a single Databricks cluster by its cluster ID.
 

--- a/apps/docs/content/docs/en/integrations/datadog.mdx
+++ b/apps/docs/content/docs/en/integrations/datadog.mdx
@@ -33,7 +33,7 @@ Integrate Datadog monitoring into workflows. Submit metrics, manage monitors, qu
 
 ## Actions
 
-### `datadog_submit_metrics`
+### Datadog Submit Metrics
 
 Submit custom metrics to Datadog. Use for tracking application performance, business metrics, or custom monitoring data.
 
@@ -52,7 +52,7 @@ Submit custom metrics to Datadog. Use for tracking application performance, busi
 | `success` | boolean | Whether the metrics were submitted successfully |
 | `errors` | array | Any errors that occurred during submission |
 
-### `datadog_query_timeseries`
+### Datadog Query Timeseries
 
 Query metric timeseries data from Datadog. Use for analyzing trends, creating reports, or retrieving metric values.
 
@@ -74,7 +74,7 @@ Query metric timeseries data from Datadog. Use for analyzing trends, creating re
 | `series` | array | Array of timeseries data with metric name, tags, and data points |
 | `status` | string | Query status |
 
-### `datadog_create_event`
+### Datadog Create Event
 
 Post an event to the Datadog event stream. Use for deployment notifications, alerts, or any significant occurrences.
 
@@ -109,7 +109,7 @@ Post an event to the Datadog event stream. Use for deployment notifications, ale
 |   ↳ `tags` | array | Event tags |
 |   ↳ `url` | string | URL to view the event in Datadog |
 
-### `datadog_create_monitor`
+### Datadog Create Monitor
 
 Create a new monitor/alert in Datadog. Monitors can track metrics, service checks, events, and more.
 
@@ -144,7 +144,7 @@ Create a new monitor/alert in Datadog. Monitors can track metrics, service check
 |   ↳ `created` | string | Creation timestamp |
 |   ↳ `modified` | string | Last modification timestamp |
 
-### `datadog_get_monitor`
+### Datadog Get Monitor
 
 Retrieve details of a specific monitor by ID.
 
@@ -175,7 +175,7 @@ Retrieve details of a specific monitor by ID.
 |   ↳ `created` | string | Creation timestamp |
 |   ↳ `modified` | string | Last modification timestamp |
 
-### `datadog_list_monitors`
+### Datadog List Monitors
 
 List all monitors in Datadog with optional filtering by name, tags, or state.
 
@@ -206,7 +206,7 @@ List all monitors in Datadog with optional filtering by name, tags, or state.
 |   ↳ `overall_state` | string | Current state |
 |   ↳ `tags` | array | Tags |
 
-### `datadog_mute_monitor`
+### Datadog Mute Monitor
 
 Mute a monitor to temporarily suppress notifications.
 
@@ -227,7 +227,7 @@ Mute a monitor to temporarily suppress notifications.
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the monitor was successfully muted |
 
-### `datadog_query_logs`
+### Datadog Query Logs
 
 Search and retrieve logs from Datadog. Use for troubleshooting, analysis, or monitoring.
 
@@ -259,7 +259,7 @@ Search and retrieve logs from Datadog. Use for troubleshooting, analysis, or mon
 |     ↳ `status` | string | Log status/level |
 | `nextLogId` | string | Cursor for pagination |
 
-### `datadog_send_logs`
+### Datadog Send Logs
 
 Send log entries to Datadog for centralized logging and analysis.
 
@@ -277,7 +277,7 @@ Send log entries to Datadog for centralized logging and analysis.
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the logs were sent successfully |
 
-### `datadog_create_downtime`
+### Datadog Create Downtime
 
 Schedule a downtime to suppress monitor notifications during maintenance windows.
 
@@ -309,7 +309,7 @@ Schedule a downtime to suppress monitor notifications during maintenance windows
 |   ↳ `end` | number | End time \(Unix timestamp\) |
 |   ↳ `active` | boolean | Whether downtime is currently active |
 
-### `datadog_list_downtimes`
+### Datadog List Downtimes
 
 List all scheduled downtimes in Datadog.
 
@@ -335,7 +335,7 @@ List all scheduled downtimes in Datadog.
 |   ↳ `end` | number | End time \(Unix timestamp\) |
 |   ↳ `active` | boolean | Whether downtime is currently active |
 
-### `datadog_cancel_downtime`
+### Datadog Cancel Downtime
 
 Cancel a scheduled downtime.
 

--- a/apps/docs/content/docs/en/integrations/datagma.mdx
+++ b/apps/docs/content/docs/en/integrations/datagma.mdx
@@ -33,7 +33,7 @@ Integrate Datagma to find verified work emails from a name and company, enrich p
 
 ## Actions
 
-### `datagma_find_email`
+### Datagma Find Email
 
 Find a verified work email from a person's full name and company. Uses 1 credit when a verified email is found.
 
@@ -59,7 +59,7 @@ Find a verified work email from a person's full name and company. Uses 1 credit 
 | `smtpCheck` | boolean | Whether SMTP validation succeeded |
 | `catchAll` | boolean | Whether the domain is catch-all |
 
-### `datagma_enrich_person`
+### Datagma Enrich Person
 
 Enrich a person's profile using their email, LinkedIn URL, or full name and company. Returns job title, company, location, and social data. Uses 2 credits per match; add 30 credits when a phone number is found.
 
@@ -96,7 +96,7 @@ Enrich a person's profile using their email, LinkedIn URL, or full name and comp
 | `phone` | string | Mobile phone number |
 | `personConfidenceScore` | number | Confidence score for the person match \(0–1\) |
 
-### `datagma_enrich_company`
+### Datagma Enrich Company
 
 Enrich a company profile using a domain, company name, or SIREN number (France). Returns size, industry, revenue, and description. Uses 2 credits per match.
 
@@ -123,7 +123,7 @@ Enrich a company profile using a domain, company name, or SIREN number (France).
 | `revenueRange` | string | Estimated annual revenue range |
 | `headquarters` | string | Headquarters location |
 
-### `datagma_find_phone`
+### Datagma Find Phone
 
 Find a mobile phone number from a person's LinkedIn URL. Optionally supply an email to improve match accuracy. Uses 30 credits when a number is found.
 
@@ -144,7 +144,7 @@ Find a mobile phone number from a person's LinkedIn URL. Optionally supply an em
 | `countryCode` | string | Country code prefix \(e.g., +1\) |
 | `isWhatsapp` | boolean | Whether the number is linked to WhatsApp |
 
-### `datagma_get_credits`
+### Datagma Get Credits
 
 Check remaining credit balance on a Datagma account. Free — no credits consumed.
 

--- a/apps/docs/content/docs/en/integrations/daytona.mdx
+++ b/apps/docs/content/docs/en/integrations/daytona.mdx
@@ -41,7 +41,7 @@ Integrate Daytona into your workflow to run AI-generated code in secure, isolate
 
 ## Actions
 
-### `daytona_create_sandbox`
+### Daytona Create Sandbox
 
 Create a new Daytona sandbox for running AI-generated code in isolation
 
@@ -70,7 +70,7 @@ Create a new Daytona sandbox for running AI-generated code in isolation
 | --------- | ---- | ----------- |
 | `sandbox` | json | The created sandbox |
 
-### `daytona_list_sandboxes`
+### Daytona List Sandboxes
 
 List Daytona sandboxes in the organization
 
@@ -91,7 +91,7 @@ List Daytona sandboxes in the organization
 | `sandboxes` | array | Sandboxes in the organization |
 | `nextCursor` | string | Cursor for the next page of results |
 
-### `daytona_get_sandbox`
+### Daytona Get Sandbox
 
 Get details of a Daytona sandbox
 
@@ -108,7 +108,7 @@ Get details of a Daytona sandbox
 | --------- | ---- | ----------- |
 | `sandbox` | json | The sandbox details |
 
-### `daytona_start_sandbox`
+### Daytona Start Sandbox
 
 Start a stopped Daytona sandbox
 
@@ -125,7 +125,7 @@ Start a stopped Daytona sandbox
 | --------- | ---- | ----------- |
 | `sandbox` | json | The started sandbox |
 
-### `daytona_stop_sandbox`
+### Daytona Stop Sandbox
 
 Stop a running Daytona sandbox
 
@@ -142,7 +142,7 @@ Stop a running Daytona sandbox
 | --------- | ---- | ----------- |
 | `sandbox` | json | The stopped sandbox |
 
-### `daytona_delete_sandbox`
+### Daytona Delete Sandbox
 
 Delete a Daytona sandbox
 
@@ -159,7 +159,7 @@ Delete a Daytona sandbox
 | --------- | ---- | ----------- |
 | `sandbox` | json | The deleted sandbox |
 
-### `daytona_execute_command`
+### Daytona Execute Command
 
 Execute a shell command inside a Daytona sandbox
 
@@ -181,7 +181,7 @@ Execute a shell command inside a Daytona sandbox
 | `exitCode` | number | Exit code of the command \(-1 if missing from the response\) |
 | `result` | string | Combined stdout/stderr output of the command |
 
-### `daytona_run_code`
+### Daytona Run Code
 
 Run Python, JavaScript, or TypeScript code inside a Daytona sandbox
 
@@ -204,7 +204,7 @@ Run Python, JavaScript, or TypeScript code inside a Daytona sandbox
 | `result` | string | Combined stdout/stderr output of the code run |
 | `artifacts` | json | Artifacts produced by the run \(e.g., matplotlib charts\) |
 
-### `daytona_upload_file`
+### Daytona Upload File
 
 Upload a file to a Daytona sandbox
 
@@ -227,7 +227,7 @@ Upload a file to a Daytona sandbox
 | `name` | string | Name of the uploaded file |
 | `size` | number | Size of the uploaded file in bytes |
 
-### `daytona_download_file`
+### Daytona Download File
 
 Download a file from a Daytona sandbox
 
@@ -248,7 +248,7 @@ Download a file from a Daytona sandbox
 | `mimeType` | string | MIME type of the downloaded file |
 | `size` | number | Size of the downloaded file in bytes |
 
-### `daytona_list_files`
+### Daytona List Files
 
 List files in a directory of a Daytona sandbox
 
@@ -274,7 +274,7 @@ List files in a directory of a Daytona sandbox
 |   ↳ `group` | string | Owning group |
 |   ↳ `modifiedAt` | string | Last modification timestamp |
 
-### `daytona_git_clone`
+### Daytona Git Clone
 
 Clone a Git repository into a Daytona sandbox
 

--- a/apps/docs/content/docs/en/integrations/deployments.mdx
+++ b/apps/docs/content/docs/en/integrations/deployments.mdx
@@ -29,7 +29,7 @@ Deploy, undeploy, and roll back workflows in the current workspace. Promote a pr
 
 ## Actions
 
-### `deployments_deploy`
+### Deploy Workflow
 
 Deploy a workflow’s current draft state, creating a new deployment version and making it live for API execution. Requires admin permission on the workflow’s workspace.
 
@@ -51,7 +51,7 @@ Deploy a workflow’s current draft state, creating a new deployment version and
 | `version` | number | The deployment version that is now active |
 | `warnings` | array | Non-fatal warnings \(e.g. trigger or schedule sync still in progress\) |
 
-### `deployments_undeploy`
+### Undeploy Workflow
 
 Take a deployed workflow offline. API execution stops and schedules, webhooks, and other deployment side effects are removed. Requires admin permission on the workflow’s workspace.
 
@@ -70,7 +70,7 @@ Take a deployed workflow offline. API execution stops and schedules, webhooks, a
 | `deployedAt` | string | Always null after an undeploy |
 | `warnings` | array | Non-fatal warnings \(e.g. trigger or schedule cleanup still in progress\) |
 
-### `deployments_promote`
+### Promote Version to Live
 
 Make a specific deployment version the live one without creating a new version — the same operation as Promote to live in the deploy modal. Useful for rolling back to a known-good version. Also works on an undeployed workflow: it re-deploys the workflow live at that version. Requires admin permission on the workflow’s workspace.
 
@@ -91,7 +91,7 @@ Make a specific deployment version the live one without creating a new version �
 | `version` | number | The deployment version that is now live |
 | `warnings` | array | Non-fatal warnings \(e.g. trigger or schedule sync still in progress\) |
 
-### `deployments_list_versions`
+### List Deployment Versions
 
 List every deployment version of a workflow, newest first, including which version is currently live.
 
@@ -108,7 +108,7 @@ List every deployment version of a workflow, newest first, including which versi
 | `workflowId` | string | ID of the workflow |
 | `versions` | array | Deployment versions, newest first \(id, version, name, description, isActive, createdAt, createdBy, deployedByName\) |
 
-### `deployments_get_version`
+### Get Deployment Version
 
 Fetch a single deployment version of a workflow, including its metadata and the full workflow state snapshot that was deployed.
 

--- a/apps/docs/content/docs/en/integrations/devin.mdx
+++ b/apps/docs/content/docs/en/integrations/devin.mdx
@@ -41,7 +41,7 @@ Integrate Devin into your workflow. Create sessions to assign coding tasks, send
 
 ## Actions
 
-### `devin_create_session`
+### create_session
 
 Create a new Devin session with a prompt. Devin will autonomously work on the task described in the prompt.
 
@@ -74,7 +74,7 @@ Create a new Devin session with a prompt. Devin will autonomously work on the ta
 | `playbookId` | string | Associated playbook ID |
 | `isArchived` | boolean | Whether the session is archived |
 
-### `devin_get_session`
+### get_session
 
 Retrieve details of an existing Devin session including status, tags, pull requests, and structured output.
 
@@ -104,7 +104,7 @@ Retrieve details of an existing Devin session including status, tags, pull reque
 | `playbookId` | string | Associated playbook ID |
 | `isArchived` | boolean | Whether the session is archived |
 
-### `devin_list_sessions`
+### list_sessions
 
 List Devin sessions in the organization. Returns up to 100 sessions by default.
 
@@ -138,7 +138,7 @@ List Devin sessions in the organization. Returns up to 100 sessions by default.
 | `hasNextPage` | boolean | Whether more sessions are available |
 | `total` | number | Total number of sessions, if provided |
 
-### `devin_send_message`
+### send_message
 
 Send a message to a Devin session. If the session is suspended, it will be automatically resumed. Returns the updated session state.
 
@@ -169,7 +169,7 @@ Send a message to a Devin session. If the session is suspended, it will be autom
 | `playbookId` | string | Associated playbook ID |
 | `isArchived` | boolean | Whether the session is archived |
 
-### `devin_list_session_messages`
+### list_session_messages
 
 List the messages exchanged in a Devin session, including messages from both the user and Devin.
 
@@ -196,7 +196,7 @@ List the messages exchanged in a Devin session, including messages from both the
 | `hasNextPage` | boolean | Whether more messages are available |
 | `total` | number | Total number of messages, if provided |
 
-### `devin_list_session_attachments`
+### list_session_attachments
 
 List the files uploaded to or produced by a Devin session.
 
@@ -219,7 +219,7 @@ List the files uploaded to or produced by a Devin session.
 |   ↳ `source` | string | Origin of the attachment \(devin or user\) |
 |   ↳ `contentType` | string | MIME type of the attachment |
 
-### `devin_get_session_tags`
+### get_session_tags
 
 Retrieve the tags currently applied to a Devin session.
 
@@ -237,7 +237,7 @@ Retrieve the tags currently applied to a Devin session.
 | --------- | ---- | ----------- |
 | `tags` | json | Tags applied to the session \(array of strings\) |
 
-### `devin_append_session_tags`
+### append_session_tags
 
 Add tags to a Devin session without removing existing tags (max 50 tags total).
 
@@ -256,7 +256,7 @@ Add tags to a Devin session without removing existing tags (max 50 tags total).
 | --------- | ---- | ----------- |
 | `tags` | json | Updated list of tags on the session \(array of strings\) |
 
-### `devin_replace_session_tags`
+### replace_session_tags
 
 Replace all tags on a Devin session with a new set of tags (max 50 tags).
 
@@ -275,7 +275,7 @@ Replace all tags on a Devin session with a new set of tags (max 50 tags).
 | --------- | ---- | ----------- |
 | `tags` | json | Updated list of tags on the session \(array of strings\) |
 
-### `devin_archive_session`
+### archive_session
 
 Archive a Devin session. Archived sessions can still be viewed but cannot be modified or resumed.
 
@@ -305,7 +305,7 @@ Archive a Devin session. Archived sessions can still be viewed but cannot be mod
 | `playbookId` | string | Associated playbook ID |
 | `isArchived` | boolean | Whether the session is archived |
 
-### `devin_terminate_session`
+### terminate_session
 
 Terminate a Devin session. Optionally archive the session instead of permanently terminating it.
 

--- a/apps/docs/content/docs/en/integrations/discord.mdx
+++ b/apps/docs/content/docs/en/integrations/discord.mdx
@@ -44,7 +44,7 @@ Comprehensive Discord integration: messages, threads, channels, roles, members, 
 
 ## Actions
 
-### `discord_send_message`
+### Discord Send Message
 
 Send a message to a Discord channel
 
@@ -81,7 +81,7 @@ Send a message to a Discord channel
 |   ↳ `mention_roles` | array | Role mentions in message |
 |   ↳ `mention_everyone` | boolean | Whether message mentions everyone |
 
-### `discord_get_messages`
+### Discord Get Messages
 
 Retrieve messages from a Discord channel
 
@@ -117,7 +117,7 @@ Retrieve messages from a Discord channel
 |     ↳ `mention_everyone` | boolean | Whether message mentions everyone |
 |   ↳ `channel_id` | string | Channel ID |
 
-### `discord_get_server`
+### Discord Get Server
 
 Retrieve information about a Discord server (guild)
 
@@ -143,7 +143,7 @@ Retrieve information about a Discord server (guild)
 |   ↳ `approximate_member_count` | number | Approximate total member count |
 |   ↳ `approximate_presence_count` | number | Approximate online member count |
 
-### `discord_get_user`
+### Discord Get User
 
 Retrieve information about a Discord user
 
@@ -169,7 +169,7 @@ Retrieve information about a Discord user
 |   ↳ `email` | string | User email \(if available\) |
 |   ↳ `verified` | boolean | Whether user email is verified |
 
-### `discord_edit_message`
+### Discord Edit Message
 
 Edit an existing message in a Discord channel
 
@@ -194,7 +194,7 @@ Edit an existing message in a Discord channel
 |   ↳ `channel_id` | string | Channel ID |
 |   ↳ `edited_timestamp` | string | Message edited timestamp |
 
-### `discord_delete_message`
+### Discord Delete Message
 
 Delete a message from a Discord channel
 
@@ -213,7 +213,7 @@ Delete a message from a Discord channel
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_bulk_delete_messages`
+### Discord Bulk Delete Messages
 
 Delete 2-100 messages from a Discord channel in a single request
 
@@ -232,7 +232,7 @@ Delete 2-100 messages from a Discord channel in a single request
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_add_reaction`
+### Discord Add Reaction
 
 Add a reaction emoji to a Discord message
 
@@ -252,7 +252,7 @@ Add a reaction emoji to a Discord message
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_remove_reaction`
+### Discord Remove Reaction
 
 Remove a reaction from a Discord message
 
@@ -273,7 +273,7 @@ Remove a reaction from a Discord message
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_pin_message`
+### Discord Pin Message
 
 Pin a message in a Discord channel
 
@@ -292,7 +292,7 @@ Pin a message in a Discord channel
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_unpin_message`
+### Discord Unpin Message
 
 Unpin a message in a Discord channel
 
@@ -311,7 +311,7 @@ Unpin a message in a Discord channel
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_get_pinned_messages`
+### Discord Get Pinned Messages
 
 Retrieve all pinned messages in a Discord channel
 
@@ -340,7 +340,7 @@ Retrieve all pinned messages in a Discord channel
 |     ↳ `username` | string | Author username |
 | `hasMore` | boolean | Whether more pinned messages exist beyond this page |
 
-### `discord_create_thread`
+### Discord Create Thread
 
 Create a thread in a Discord channel
 
@@ -368,7 +368,7 @@ Create a thread in a Discord channel
 |   ↳ `guild_id` | string | Server ID |
 |   ↳ `parent_id` | string | Parent channel ID |
 
-### `discord_join_thread`
+### Discord Join Thread
 
 Join a thread in Discord
 
@@ -386,7 +386,7 @@ Join a thread in Discord
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_leave_thread`
+### Discord Leave Thread
 
 Leave a thread in Discord
 
@@ -404,7 +404,7 @@ Leave a thread in Discord
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_archive_thread`
+### Discord Archive Thread
 
 Archive or unarchive a thread in Discord
 
@@ -426,7 +426,7 @@ Archive or unarchive a thread in Discord
 |   ↳ `id` | string | Thread ID |
 |   ↳ `archived` | boolean | Whether thread is archived |
 
-### `discord_create_channel`
+### Discord Create Channel
 
 Create a new channel in a Discord server
 
@@ -452,7 +452,7 @@ Create a new channel in a Discord server
 |   ↳ `type` | number | Channel type |
 |   ↳ `guild_id` | string | Server ID |
 
-### `discord_update_channel`
+### Discord Update Channel
 
 Update a Discord channel
 
@@ -477,7 +477,7 @@ Update a Discord channel
 |   ↳ `type` | number | Channel type |
 |   ↳ `topic` | string | Channel topic |
 
-### `discord_delete_channel`
+### Discord Delete Channel
 
 Delete a Discord channel
 
@@ -500,7 +500,7 @@ Delete a Discord channel
 |   ↳ `type` | number | Channel type |
 |   ↳ `guild_id` | string | Server ID |
 
-### `discord_get_channel`
+### Discord Get Channel
 
 Get information about a Discord channel
 
@@ -524,7 +524,7 @@ Get information about a Discord channel
 |   ↳ `topic` | string | Channel topic |
 |   ↳ `guild_id` | string | Server ID |
 
-### `discord_list_channels`
+### Discord List Channels
 
 List all channels in a Discord server
 
@@ -548,7 +548,7 @@ List all channels in a Discord server
 |   ↳ `parent_id` | string | Parent category ID |
 |   ↳ `position` | number | Sort position within the channel list |
 
-### `discord_create_role`
+### Discord Create Role
 
 Create a new role in a Discord server
 
@@ -575,7 +575,7 @@ Create a new role in a Discord server
 |   ↳ `hoist` | boolean | Whether role is hoisted |
 |   ↳ `mentionable` | boolean | Whether role is mentionable |
 
-### `discord_update_role`
+### Discord Update Role
 
 Update a role in a Discord server
 
@@ -601,7 +601,7 @@ Update a role in a Discord server
 |   ↳ `name` | string | Role name |
 |   ↳ `color` | number | Role color |
 
-### `discord_delete_role`
+### Discord Delete Role
 
 Delete a role from a Discord server
 
@@ -619,7 +619,7 @@ Delete a role from a Discord server
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_assign_role`
+### Discord Assign Role
 
 Assign a role to a member in a Discord server
 
@@ -638,7 +638,7 @@ Assign a role to a member in a Discord server
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_remove_role`
+### Discord Remove Role
 
 Remove a role from a member in a Discord server
 
@@ -657,7 +657,7 @@ Remove a role from a member in a Discord server
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_list_roles`
+### Discord List Roles
 
 List all roles in a Discord server
 
@@ -681,7 +681,7 @@ List all roles in a Discord server
 |   ↳ `position` | number | Role position in the hierarchy |
 |   ↳ `mentionable` | boolean | Whether role is mentionable |
 
-### `discord_kick_member`
+### Discord Kick Member
 
 Kick a member from a Discord server
 
@@ -700,7 +700,7 @@ Kick a member from a Discord server
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_ban_member`
+### Discord Ban Member
 
 Ban a member from a Discord server
 
@@ -720,7 +720,7 @@ Ban a member from a Discord server
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_unban_member`
+### Discord Unban Member
 
 Unban a member from a Discord server
 
@@ -739,7 +739,7 @@ Unban a member from a Discord server
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_get_member`
+### Discord Get Member
 
 Get information about a member in a Discord server
 
@@ -765,7 +765,7 @@ Get information about a member in a Discord server
 |   ↳ `roles` | array | Array of role IDs |
 |   ↳ `joined_at` | string | When the member joined |
 
-### `discord_update_member`
+### Discord Update Member
 
 Update a member in a Discord server (e.g., change nickname)
 
@@ -790,7 +790,7 @@ Update a member in a Discord server (e.g., change nickname)
 |   ↳ `mute` | boolean | Voice mute status |
 |   ↳ `deaf` | boolean | Voice deaf status |
 
-### `discord_create_invite`
+### Discord Create Invite
 
 Create an invite link for a Discord channel
 
@@ -817,7 +817,7 @@ Create an invite link for a Discord channel
 |   ↳ `max_uses` | number | Max uses |
 |   ↳ `temporary` | boolean | Whether temporary |
 
-### `discord_get_invite`
+### Discord Get Invite
 
 Get information about a Discord invite
 
@@ -841,7 +841,7 @@ Get information about a Discord invite
 |   ↳ `approximate_member_count` | number | Approximate member count |
 |   ↳ `approximate_presence_count` | number | Approximate online count |
 
-### `discord_delete_invite`
+### Discord Delete Invite
 
 Delete a Discord invite
 
@@ -859,7 +859,7 @@ Delete a Discord invite
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
 
-### `discord_create_webhook`
+### Discord Create Webhook
 
 Create a webhook in a Discord channel
 
@@ -884,7 +884,7 @@ Create a webhook in a Discord channel
 |   ↳ `url` | string | Webhook URL |
 |   ↳ `channel_id` | string | Channel ID |
 
-### `discord_execute_webhook`
+### Discord Execute Webhook
 
 Execute a Discord webhook to send a message
 
@@ -909,7 +909,7 @@ Execute a Discord webhook to send a message
 |   ↳ `channel_id` | string | Channel ID |
 |   ↳ `timestamp` | string | Message timestamp |
 
-### `discord_get_webhook`
+### Discord Get Webhook
 
 Get information about a Discord webhook
 
@@ -933,7 +933,7 @@ Get information about a Discord webhook
 |   ↳ `guild_id` | string | Server ID |
 |   ↳ `token` | string | Webhook token |
 
-### `discord_delete_webhook`
+### Discord Delete Webhook
 
 Delete a Discord webhook
 

--- a/apps/docs/content/docs/en/integrations/docusign.mdx
+++ b/apps/docs/content/docs/en/integrations/docusign.mdx
@@ -35,7 +35,7 @@ Create and send envelopes for e-signature, use templates, check signing status, 
 
 ## Actions
 
-### `docusign_send_envelope`
+### Send DocuSign Envelope
 
 Create and send a DocuSign envelope with a document for e-signature
 
@@ -61,7 +61,7 @@ Create and send a DocuSign envelope with a document for e-signature
 | `statusDateTime` | string | Status change datetime |
 | `uri` | string | Envelope URI |
 
-### `docusign_create_from_template`
+### Send from DocuSign Template
 
 Create and send a DocuSign envelope using a pre-built template
 
@@ -84,7 +84,7 @@ Create and send a DocuSign envelope using a pre-built template
 | `statusDateTime` | string | Status change datetime |
 | `uri` | string | Envelope URI |
 
-### `docusign_get_envelope`
+### Get DocuSign Envelope
 
 Get the details and status of a DocuSign envelope
 
@@ -109,7 +109,7 @@ Get the details and status of a DocuSign envelope
 | `signerCount` | number | Number of signers |
 | `documentCount` | number | Number of documents |
 
-### `docusign_list_envelopes`
+### List DocuSign Envelopes
 
 List envelopes from your DocuSign account with optional filters
 
@@ -138,7 +138,7 @@ List envelopes from your DocuSign account with optional filters
 | `totalSetSize` | number | Total number of matching envelopes |
 | `resultSetSize` | number | Number of envelopes returned in this response |
 
-### `docusign_void_envelope`
+### Void DocuSign Envelope
 
 Void (cancel) a sent DocuSign envelope that has not yet been completed
 
@@ -156,7 +156,7 @@ Void (cancel) a sent DocuSign envelope that has not yet been completed
 | `envelopeId` | string | Voided envelope ID |
 | `status` | string | Envelope status \(voided\) |
 
-### `docusign_download_document`
+### Download DocuSign Document
 
 Download a signed document from a completed DocuSign envelope
 
@@ -176,7 +176,7 @@ Download a signed document from a completed DocuSign envelope
 | `mimeType` | string | MIME type of the document |
 | `fileName` | string | Original file name |
 
-### `docusign_list_templates`
+### List DocuSign Templates
 
 List available templates in your DocuSign account
 
@@ -201,7 +201,7 @@ List available templates in your DocuSign account
 | `totalSetSize` | number | Total number of matching templates |
 | `resultSetSize` | number | Number of templates returned in this response |
 
-### `docusign_list_recipients`
+### List DocuSign Recipients
 
 Get the recipient status details for a DocuSign envelope
 

--- a/apps/docs/content/docs/en/integrations/downdetector.mdx
+++ b/apps/docs/content/docs/en/integrations/downdetector.mdx
@@ -32,7 +32,7 @@ Track real-time service outages with the Downdetector Enterprise API. Search mon
 
 ## Actions
 
-### `downdetector_search_companies`
+### Downdetector Search Companies
 
 Search Downdetector for monitored companies by name, slug, country, or category. Returns matching companies with their ids and slugs, which you can use with the other Downdetector operations.
 
@@ -60,7 +60,7 @@ Search Downdetector for monitored companies by name, slug, country, or category.
 |   ↳ `countryIso` | string | ISO-2 country code |
 |   ↳ `categoryId` | number | Category id |
 
-### `downdetector_get_company`
+### Downdetector Get Company
 
 Get details for a Downdetector company by id, including its current status, 24h report statistics, baseline, and available problem indicators.
 
@@ -91,7 +91,7 @@ Get details for a Downdetector company by id, including its current status, 24h 
 |   ↳ `indicators` | array | List of available problem indicators |
 |   ↳ `description` | string | Company description |
 
-### `downdetector_get_company_status`
+### Downdetector Get Company Status
 
 Get the current detected status for a Downdetector company. Returns "success" (no problems), "warning", or "danger" (likely outage).
 
@@ -109,7 +109,7 @@ Get the current detected status for a Downdetector company. Returns "success" (n
 | --------- | ---- | ----------- |
 | `status` | string | Current status: "success", "warning", or "danger" |
 
-### `downdetector_get_company_baseline`
+### Downdetector Get Company Baseline
 
 Get the current baseline report value for a Downdetector company. This is the expected average number of reports for the current period, used to judge whether current reports are abnormal.
 
@@ -126,7 +126,7 @@ Get the current baseline report value for a Downdetector company. This is the ex
 | --------- | ---- | ----------- |
 | `baseline` | number | The current baseline \(expected average reports\) for this period |
 
-### `downdetector_get_company_last_15`
+### Downdetector Get Company Last 15 Minutes
 
 Get the number of outage reports for a Downdetector company over the last 15 minutes. A convenient near-real-time signal for threshold-based alerting.
 
@@ -143,7 +143,7 @@ Get the number of outage reports for a Downdetector company over the last 15 min
 | --------- | ---- | ----------- |
 | `count` | number | Number of reports over the last 15 minutes |
 
-### `downdetector_get_company_indicators`
+### Downdetector Get Company Indicators
 
 Get the problem indicators (e.g. "App crashing", "Login", "Server connection") reported for a Downdetector company over a time period, with the report counts and percentages for each.
 
@@ -167,7 +167,7 @@ Get the problem indicators (e.g. "App crashing", "Login", "Server connection") r
 |   ↳ `amount` | number | Number of reports for this indicator |
 |   ↳ `percentage` | number | Share of total reports \(percentage\) |
 
-### `downdetector_get_reports`
+### Downdetector Get Reports
 
 Get the number of outage reports over time for one or more company slugs, bucketed by interval. Useful for plotting report trends or detecting spikes. Defaults to the last 24 hours.
 
@@ -191,7 +191,7 @@ Get the number of outage reports over time for one or more company slugs, bucket
 |   ↳ `indicators` | number | Number of indicator reports |
 |   ↳ `other` | number | Number of reports from other sources |
 
-### `downdetector_get_company_incidents`
+### Downdetector Get Company Incidents
 
 Get the list of incidents (outages) for a Downdetector company. Defaults to the last 24 hours unless a date range is provided.
 
@@ -213,7 +213,7 @@ Get the list of incidents (outages) for a Downdetector company. Defaults to the 
 | --------- | ---- | ----------- |
 | `incidents` | array | List of incidents for the company |
 
-### `downdetector_get_company_attribution`
+### Downdetector Get Company Attribution
 
 Get the incident attribution for a Downdetector company while it is in an outage state — whether the issue is internal (isolated) or external (a dependency), the estimated user impact, and the related incident. Requires Incident Attribution access.
 
@@ -238,7 +238,7 @@ Get the incident attribution for a Downdetector company while it is in an outage
 |   ↳ `incidentId` | number | Id of the related incident \(null when attribution is N/A\) |
 |   ↳ `incidentCreatedAt` | string | ISO 8601 timestamp when the related incident was created |
 
-### `downdetector_get_company_events`
+### Downdetector Get Company Events
 
 Get the published events (such as detected outages) for a Downdetector company, including the measured vs expected report volume for each event.
 
@@ -271,7 +271,7 @@ Get the published events (such as detected outages) for a Downdetector company, 
 |     ↳ `expected` | number | Expected reports based on historic data |
 |     ↳ `actual` | number | Actual reports in the window |
 
-### `downdetector_get_site_companies`
+### Downdetector Get Site Companies
 
 List the companies monitored on a Downdetector site, including each company’s current status. Useful for discovering the companies available on a regional status page.
 
@@ -298,7 +298,7 @@ List the companies monitored on a Downdetector site, including each company’s 
 |   ↳ `countryIso` | string | ISO-2 country code |
 |   ↳ `categoryId` | number | Category id |
 
-### `downdetector_get_provider`
+### Downdetector Get Provider
 
 Get details for a Downdetector provider (ISP or network operator) by id, such as its name and Downdetector id.
 
@@ -318,7 +318,7 @@ Get details for a Downdetector provider (ISP or network operator) by id, such as
 |   ↳ `name` | string | Provider name |
 |   ↳ `downdetectorId` | number | Downdetector internal provider id |
 
-### `downdetector_list_incidents`
+### Downdetector List Incidents
 
 List all incidents (outages) across every company that were active in the chosen time period, or in the last 24 hours if no date range is provided.
 
@@ -339,7 +339,7 @@ List all incidents (outages) across every company that were active in the chosen
 | --------- | ---- | ----------- |
 | `incidents` | array | List of incidents across all companies |
 
-### `downdetector_list_categories`
+### Downdetector List Categories
 
 List all Downdetector categories (e.g. "Telecom", "Gaming", "Social Media"). Use the returned category id to filter company searches.
 
@@ -358,7 +358,7 @@ List all Downdetector categories (e.g. "Telecom", "Gaming", "Social Media"). Use
 |   ↳ `name` | string | Category name |
 |   ↳ `slug` | string | Category slug |
 
-### `downdetector_list_sites`
+### Downdetector List Sites
 
 List all available Downdetector sites (regional status-page domains). Each site groups the companies monitored for a given country/region.
 

--- a/apps/docs/content/docs/en/integrations/dropbox.mdx
+++ b/apps/docs/content/docs/en/integrations/dropbox.mdx
@@ -34,7 +34,7 @@ Integrate Dropbox into your workflow for file management, sharing, and collabora
 
 ## Actions
 
-### `dropbox_upload`
+### Dropbox Upload File
 
 Upload a file to Dropbox
 
@@ -65,7 +65,7 @@ Upload a file to Dropbox
 |   ↳ `rev` | string | Revision identifier |
 |   ↳ `content_hash` | string | Content hash for the file |
 
-### `dropbox_download`
+### Dropbox Download File
 
 Download a file from Dropbox with metadata and content
 
@@ -84,7 +84,7 @@ Download a file from Dropbox with metadata and content
 | `temporaryLink` | string | Temporary link to download the file \(valid for ~4 hours\) |
 | `content` | string | Base64 encoded file content \(if fetched\) |
 
-### `dropbox_list_folder`
+### Dropbox List Folder
 
 List the contents of a folder in Dropbox
 
@@ -110,7 +110,7 @@ List the contents of a folder in Dropbox
 | `cursor` | string | Cursor for pagination |
 | `hasMore` | boolean | Whether there are more results |
 
-### `dropbox_create_folder`
+### Dropbox Create Folder
 
 Create a new folder in Dropbox
 
@@ -131,7 +131,7 @@ Create a new folder in Dropbox
 |   ↳ `path_display` | string | Display path of the folder |
 |   ↳ `path_lower` | string | Lowercase path of the folder |
 
-### `dropbox_delete`
+### Dropbox Delete
 
 Delete a file or folder in Dropbox (moves to trash)
 
@@ -150,7 +150,7 @@ Delete a file or folder in Dropbox (moves to trash)
 |   ↳ `path_display` | string | Display path |
 | `deleted` | boolean | Whether the deletion was successful |
 
-### `dropbox_copy`
+### Dropbox Copy
 
 Copy a file or folder in Dropbox
 
@@ -172,7 +172,7 @@ Copy a file or folder in Dropbox
 |   ↳ `path_display` | string | Display path |
 |   ↳ `size` | number | Size in bytes \(files only\) |
 
-### `dropbox_move`
+### Dropbox Move
 
 Move or rename a file or folder in Dropbox
 
@@ -194,7 +194,7 @@ Move or rename a file or folder in Dropbox
 |   ↳ `path_display` | string | Display path |
 |   ↳ `size` | number | Size in bytes \(files only\) |
 
-### `dropbox_get_metadata`
+### Dropbox Get Metadata
 
 Get metadata for a file or folder in Dropbox
 
@@ -221,7 +221,7 @@ Get metadata for a file or folder in Dropbox
 |   ↳ `rev` | string | Revision identifier \(files only\) |
 |   ↳ `content_hash` | string | Content hash \(files only\) |
 
-### `dropbox_create_shared_link`
+### Dropbox Create Shared Link
 
 Create a shareable link for a file or folder in Dropbox
 
@@ -245,7 +245,7 @@ Create a shareable link for a file or folder in Dropbox
 |   ↳ `expires` | string | Expiration date if set |
 |   ↳ `link_permissions` | object | Permissions for the shared link |
 
-### `dropbox_list_shared_links`
+### Dropbox List Shared Links
 
 List shared links for a path, or for the entire account if no path is given
 
@@ -269,7 +269,7 @@ List shared links for a path, or for the entire account if no path is given
 | `hasMore` | boolean | Whether there are more results |
 | `cursor` | string | Cursor for pagination \(only returned when no path is given\) |
 
-### `dropbox_search`
+### Dropbox Search
 
 Search for files and folders in Dropbox
 
@@ -292,7 +292,7 @@ Search for files and folders in Dropbox
 | `hasMore` | boolean | Whether there are more results |
 | `cursor` | string | Cursor for pagination |
 
-### `dropbox_list_revisions`
+### Dropbox List Revisions
 
 List the revision history for a file in Dropbox (files only, not folders)
 
@@ -318,7 +318,7 @@ List the revision history for a file in Dropbox (files only, not folders)
 | `isDeleted` | boolean | Whether the file identified by the latest revision is deleted or moved |
 | `hasMore` | boolean | Whether there are more revisions available |
 
-### `dropbox_restore`
+### Dropbox Restore
 
 Restore a specific revision of a file to the given path
 

--- a/apps/docs/content/docs/en/integrations/dropcontact.mdx
+++ b/apps/docs/content/docs/en/integrations/dropcontact.mdx
@@ -31,7 +31,7 @@ Use Dropcontact to verify and enrich B2B contacts. Submit a contact with their n
 
 ## Actions
 
-### `dropcontact_enrich_contact`
+### Dropcontact Enrich Contact
 
 Enrich a contact with verified B2B email, phone, company data, and LinkedIn info via Dropcontact. Submits an async enrichment request, then polls until the result is ready (up to 2 minutes). Charges 1 credit only when a verified email is returned. Provide at least one of: email, first_name+last_name+company, full_name+company, or linkedin URL.
 

--- a/apps/docs/content/docs/en/integrations/dspy.mdx
+++ b/apps/docs/content/docs/en/integrations/dspy.mdx
@@ -32,7 +32,7 @@ Integrate with your self-hosted DSPy programs for LLM-powered predictions. Suppo
 
 ## Actions
 
-### `dspy_predict`
+### DSPy Predict
 
 Run a prediction using a self-hosted DSPy program endpoint
 
@@ -57,7 +57,7 @@ Run a prediction using a self-hosted DSPy program endpoint
 | `status` | string | Response status from the DSPy server \(success or error\) |
 | `rawOutput` | json | The complete raw output from the DSPy program \(result.toDict\(\)\) |
 
-### `dspy_chain_of_thought`
+### DSPy Chain of Thought
 
 Run a Chain of Thought prediction using a self-hosted DSPy ChainOfThought program endpoint
 
@@ -80,7 +80,7 @@ Run a Chain of Thought prediction using a self-hosted DSPy ChainOfThought progra
 | `status` | string | Response status from the DSPy server \(success or error\) |
 | `rawOutput` | json | The complete raw output from the DSPy program \(result.toDict\(\)\) |
 
-### `dspy_react`
+### DSPy ReAct
 
 Run a ReAct agent using a self-hosted DSPy ReAct program endpoint for multi-step reasoning and action
 

--- a/apps/docs/content/docs/en/integrations/dub.mdx
+++ b/apps/docs/content/docs/en/integrations/dub.mdx
@@ -35,7 +35,7 @@ Create, manage, and track short links with Dub. Supports custom domains, UTM par
 
 ## Actions
 
-### `dub_create_link`
+### Dub Create Link
 
 Create a new short link with Dub. Supports custom domains, slugs, UTM parameters, and more.
 
@@ -97,7 +97,7 @@ Create a new short link with Dub. Supports custom domains, slugs, UTM parameters
 | `utm_term` | string | UTM term parameter |
 | `utm_content` | string | UTM content parameter |
 
-### `dub_upsert_link`
+### Dub Upsert Link
 
 Create or update a short link by its URL. If a link with the same URL already exists, update it. Otherwise, create a new link.
 
@@ -159,7 +159,7 @@ Create or update a short link by its URL. If a link with the same URL already ex
 | `utm_term` | string | UTM term parameter |
 | `utm_content` | string | UTM content parameter |
 
-### `dub_get_link`
+### Dub Get Link
 
 Retrieve information about a short link by its link ID, external ID, or domain + key combination.
 
@@ -205,7 +205,7 @@ Retrieve information about a short link by its link ID, external ID, or domain +
 | `utm_term` | string | UTM term parameter |
 | `utm_content` | string | UTM content parameter |
 
-### `dub_update_link`
+### Dub Update Link
 
 Update an existing short link. You can modify the destination URL, slug, metadata, UTM parameters, and more.
 
@@ -268,7 +268,7 @@ Update an existing short link. You can modify the destination URL, slug, metadat
 | `utm_term` | string | UTM term parameter |
 | `utm_content` | string | UTM content parameter |
 
-### `dub_delete_link`
+### Dub Delete Link
 
 Delete a short link by its link ID or external ID (prefixed with ext_).
 
@@ -285,7 +285,7 @@ Delete a short link by its link ID or external ID (prefixed with ext_).
 | --------- | ---- | ----------- |
 | `id` | string | ID of the deleted link |
 
-### `dub_list_links`
+### Dub List Links
 
 Retrieve a paginated list of short links for the authenticated workspace. Supports filtering by domain, search query, tags, and sorting.
 
@@ -312,7 +312,7 @@ Retrieve a paginated list of short links for the authenticated workspace. Suppor
 | `links` | json | Array of link objects \(id, domain, key, url, shortLink, clicks, tags, createdAt\) |
 | `count` | number | Number of links returned |
 
-### `dub_get_links_count`
+### Dub Count Links
 
 Retrieve the number of short links for the authenticated workspace, optionally filtered and grouped by domain, tag, user, or folder.
 
@@ -336,7 +336,7 @@ Retrieve the number of short links for the authenticated workspace, optionally f
 | `count` | number | Total number of links matching the filters |
 | `groups` | json | Per-group counts when groupBy is set \(e.g. \[\{ domain, count \}\]\) |
 
-### `dub_bulk_create_links`
+### Dub Bulk Create Links
 
 Create up to 100 short links in a single request. Returns the created links alongside any per-link errors.
 
@@ -355,7 +355,7 @@ Create up to 100 short links in a single request. Returns the created links alon
 | `errors` | json | Array of per-link errors \(\{ link, error, code \}\) for links that failed |
 | `count` | number | Number of links successfully created |
 
-### `dub_bulk_update_links`
+### Dub Bulk Update Links
 
 Apply the same set of field updates to up to 100 links at once, selected by link IDs or external IDs.
 
@@ -375,7 +375,7 @@ Apply the same set of field updates to up to 100 links at once, selected by link
 | `updated` | json | Array of updated link objects |
 | `count` | number | Number of links updated |
 
-### `dub_bulk_delete_links`
+### Dub Bulk Delete Links
 
 Delete up to 100 short links in a single request by their link IDs. Non-existing IDs are ignored.
 
@@ -392,7 +392,7 @@ Delete up to 100 short links in a single request by their link IDs. Non-existing
 | --------- | ---- | ----------- |
 | `deletedCount` | number | Number of links that were deleted |
 
-### `dub_get_analytics`
+### Dub Get Analytics
 
 Retrieve analytics for links including clicks, leads, and sales. Supports filtering by link, time range, and grouping by various dimensions.
 
@@ -422,7 +422,7 @@ Retrieve analytics for links including clicks, leads, and sales. Supports filter
 | `saleAmount` | number | Total sale amount in cents |
 | `data` | json | Grouped analytics data \(timeseries, countries, devices, etc.\) |
 
-### `dub_get_events`
+### Dub List Events
 
 Retrieve a paginated stream of individual click, lead, and sale events for links, with filtering by link, time range, and location.
 
@@ -451,7 +451,7 @@ Retrieve a paginated stream of individual click, lead, and sale events for links
 | `events` | json | Array of event objects \(event, timestamp, click, link, and customer/sale data when applicable\) |
 | `count` | number | Number of events returned |
 
-### `dub_get_qr_code`
+### Dub Get QR Code
 
 Generate a customizable QR code (PNG) for a short link, with control over size, error correction, colors, and margin.
 
@@ -476,7 +476,7 @@ Generate a customizable QR code (PNG) for a short link, with control over size, 
 | `file` | file | Generated QR code image stored in execution files |
 | `content` | string | Base64-encoded PNG image data |
 
-### `dub_list_domains`
+### Dub List Domains
 
 Retrieve the custom domains registered in the workspace, so links can be created against the right domain.
 
@@ -497,7 +497,7 @@ Retrieve the custom domains registered in the workspace, so links can be created
 | `domains` | json | Array of domain objects \(slug, verified, primary, archived\) |
 | `count` | number | Number of domains returned |
 
-### `dub_list_tags`
+### Dub List Tags
 
 Retrieve the tags defined in the workspace, so the right tag IDs can be assigned to links.
 
@@ -519,7 +519,7 @@ Retrieve the tags defined in the workspace, so the right tag IDs can be assigned
 | `tags` | json | Array of tag objects \(id, name, color\) |
 | `count` | number | Number of tags returned |
 
-### `dub_create_tag`
+### Dub Create Tag
 
 Create a new tag in the workspace for organizing and filtering short links.
 
@@ -539,7 +539,7 @@ Create a new tag in the workspace for organizing and filtering short links.
 | `name` | string | Name of the tag |
 | `color` | string | Color assigned to the tag |
 
-### `dub_list_folders`
+### Dub List Folders
 
 Retrieve the folders defined in the workspace, so the right folder ID can be used to organize links.
 

--- a/apps/docs/content/docs/en/integrations/duckduckgo.mdx
+++ b/apps/docs/content/docs/en/integrations/duckduckgo.mdx
@@ -33,7 +33,7 @@ Search the web using DuckDuckGo Instant Answers API. Returns instant answers, ab
 
 ## Actions
 
-### `duckduckgo_search`
+### DuckDuckGo Search
 
 Search the web using DuckDuckGo Instant Answers API. Returns instant answers, abstracts, and related topics for your query. Free to use without an API key.
 

--- a/apps/docs/content/docs/en/integrations/dynamodb.mdx
+++ b/apps/docs/content/docs/en/integrations/dynamodb.mdx
@@ -43,7 +43,7 @@ Integrate Amazon DynamoDB into workflows. Supports Get, Put, Query, Scan, Update
 
 ## Actions
 
-### `dynamodb_get`
+### DynamoDB Get
 
 Get an item from a DynamoDB table by primary key
 
@@ -65,7 +65,7 @@ Get an item from a DynamoDB table by primary key
 | `message` | string | Operation status message |
 | `item` | json | Retrieved item |
 
-### `dynamodb_put`
+### DynamoDB Put
 
 Put an item into a DynamoDB table
 
@@ -89,7 +89,7 @@ Put an item into a DynamoDB table
 | `message` | string | Operation status message |
 | `item` | json | Created item |
 
-### `dynamodb_query`
+### DynamoDB Query
 
 Query items from a DynamoDB table using key conditions
 
@@ -119,7 +119,7 @@ Query items from a DynamoDB table using key conditions
 | `count` | number | Number of items returned |
 | `lastEvaluatedKey` | json | Pagination token to pass as exclusiveStartKey to fetch the next page of results |
 
-### `dynamodb_scan`
+### DynamoDB Scan
 
 Scan all items in a DynamoDB table
 
@@ -147,7 +147,7 @@ Scan all items in a DynamoDB table
 | `count` | number | Number of items returned |
 | `lastEvaluatedKey` | json | Pagination token to pass as exclusiveStartKey to fetch the next page of results |
 
-### `dynamodb_update`
+### DynamoDB Update
 
 Update an item in a DynamoDB table
 
@@ -172,7 +172,7 @@ Update an item in a DynamoDB table
 | `message` | string | Operation status message |
 | `item` | json | Updated item with all attributes |
 
-### `dynamodb_delete`
+### DynamoDB Delete
 
 Delete an item from a DynamoDB table
 
@@ -195,7 +195,7 @@ Delete an item from a DynamoDB table
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `dynamodb_introspect`
+### DynamoDB Introspect
 
 Introspect DynamoDB to list tables or get detailed schema information for a specific table
 

--- a/apps/docs/content/docs/en/integrations/elasticsearch.mdx
+++ b/apps/docs/content/docs/en/integrations/elasticsearch.mdx
@@ -34,7 +34,7 @@ Integrate Elasticsearch into workflows for powerful search, indexing, and data m
 
 ## Actions
 
-### `elasticsearch_search`
+### Elasticsearch Search
 
 Search documents in Elasticsearch using Query DSL. Returns matching documents with scores and metadata.
 
@@ -67,7 +67,7 @@ Search documents in Elasticsearch using Query DSL. Returns matching documents wi
 | `hits` | object | Search results with total count and matching documents |
 | `aggregations` | json | Aggregation results if any |
 
-### `elasticsearch_index_document`
+### Elasticsearch Index Document
 
 Index (create or update) a document in Elasticsearch.
 
@@ -96,7 +96,7 @@ Index (create or update) a document in Elasticsearch.
 | `_version` | number | Document version |
 | `result` | string | Operation result \(created or updated\) |
 
-### `elasticsearch_get_document`
+### Elasticsearch Get Document
 
 Retrieve a document by ID from Elasticsearch.
 
@@ -126,7 +126,7 @@ Retrieve a document by ID from Elasticsearch.
 | `found` | boolean | Whether the document was found |
 | `_source` | json | Document content |
 
-### `elasticsearch_update_document`
+### Elasticsearch Update Document
 
 Partially update a document in Elasticsearch using doc merge.
 
@@ -155,7 +155,7 @@ Partially update a document in Elasticsearch using doc merge.
 | `_version` | number | New document version |
 | `result` | string | Operation result \(updated or noop\) |
 
-### `elasticsearch_delete_document`
+### Elasticsearch Delete Document
 
 Delete a document from Elasticsearch by ID.
 
@@ -183,7 +183,7 @@ Delete a document from Elasticsearch by ID.
 | `_version` | number | Document version |
 | `result` | string | Operation result \(deleted or not_found\) |
 
-### `elasticsearch_bulk`
+### Elasticsearch Bulk Operations
 
 Perform multiple index, create, delete, or update operations in a single request for high performance.
 
@@ -210,7 +210,7 @@ Perform multiple index, create, delete, or update operations in a single request
 | `errors` | boolean | Whether any operation had an error |
 | `items` | array | Results for each operation |
 
-### `elasticsearch_count`
+### Elasticsearch Count
 
 Count documents matching a query in Elasticsearch.
 
@@ -235,7 +235,7 @@ Count documents matching a query in Elasticsearch.
 | `count` | number | Number of documents matching the query |
 | `_shards` | object | Shard statistics |
 
-### `elasticsearch_create_index`
+### Elasticsearch Create Index
 
 Create a new index with optional settings and mappings.
 
@@ -262,7 +262,7 @@ Create a new index with optional settings and mappings.
 | `shards_acknowledged` | boolean | Whether the shards were acknowledged |
 | `index` | string | Created index name |
 
-### `elasticsearch_delete_index`
+### Elasticsearch Delete Index
 
 Delete an index and all its documents. This operation is irreversible.
 
@@ -285,7 +285,7 @@ Delete an index and all its documents. This operation is irreversible.
 | --------- | ---- | ----------- |
 | `acknowledged` | boolean | Whether the deletion was acknowledged |
 
-### `elasticsearch_get_index`
+### Elasticsearch Get Index
 
 Retrieve index information including settings, mappings, and aliases.
 
@@ -308,7 +308,7 @@ Retrieve index information including settings, mappings, and aliases.
 | --------- | ---- | ----------- |
 | `index` | json | Index information including aliases, mappings, and settings |
 
-### `elasticsearch_cluster_health`
+### Elasticsearch Cluster Health
 
 Get the health status of the Elasticsearch cluster.
 
@@ -337,7 +337,7 @@ Get the health status of the Elasticsearch cluster.
 | `active_shards` | number | Number of active shards |
 | `unassigned_shards` | number | Number of unassigned shards |
 
-### `elasticsearch_cluster_stats`
+### Elasticsearch Cluster Stats
 
 Get comprehensive statistics about the Elasticsearch cluster.
 
@@ -362,7 +362,7 @@ Get comprehensive statistics about the Elasticsearch cluster.
 | `nodes` | object | Node statistics including count and versions |
 | `indices` | object | Index statistics including document count and store size |
 
-### `elasticsearch_list_indices`
+### Elasticsearch List Indices
 
 List all indices in the Elasticsearch cluster with their health, status, and statistics.
 

--- a/apps/docs/content/docs/en/integrations/elevenlabs.mdx
+++ b/apps/docs/content/docs/en/integrations/elevenlabs.mdx
@@ -33,7 +33,7 @@ Integrate ElevenLabs into the workflow. Convert text to speech, generate sound e
 
 ## Actions
 
-### `elevenlabs_tts`
+### ElevenLabs TTS
 
 Convert text to speech using ElevenLabs voices
 
@@ -55,7 +55,7 @@ Convert text to speech using ElevenLabs voices
 | `audioUrl` | string | The URL of the generated audio |
 | `audioFile` | file | The generated audio file |
 
-### `elevenlabs_sound_effects`
+### ElevenLabs Sound Effects
 
 Generate a sound effect from a text prompt using ElevenLabs
 
@@ -77,7 +77,7 @@ Generate a sound effect from a text prompt using ElevenLabs
 | `audioUrl` | string | URL of the generated sound effect |
 | `audioFile` | file | The generated sound effect file |
 
-### `elevenlabs_speech_to_speech`
+### ElevenLabs Speech to Speech
 
 Convert audio into a chosen ElevenLabs voice while preserving content and emotion
 
@@ -98,7 +98,7 @@ Convert audio into a chosen ElevenLabs voice while preserving content and emotio
 | `audioUrl` | string | URL of the converted audio |
 | `audioFile` | file | The converted audio file |
 
-### `elevenlabs_audio_isolation`
+### ElevenLabs Audio Isolation
 
 Remove background noise from an audio file, isolating the speech using ElevenLabs
 
@@ -116,7 +116,7 @@ Remove background noise from an audio file, isolating the speech using ElevenLab
 | `audioUrl` | string | URL of the isolated audio |
 | `audioFile` | file | The isolated audio file |
 
-### `elevenlabs_list_voices`
+### ElevenLabs List Voices
 
 List the voices available in your ElevenLabs account
 
@@ -146,7 +146,7 @@ List the voices available in your ElevenLabs account
 | `hasMore` | boolean | Whether more voices are available |
 | `nextPageToken` | string | Token to fetch the next page |
 
-### `elevenlabs_get_voice`
+### ElevenLabs Get Voice
 
 Get metadata and settings for a specific ElevenLabs voice
 
@@ -172,7 +172,7 @@ Get metadata and settings for a specific ElevenLabs voice
 | `highQualityBaseModelIds` | array | Model IDs that support high-quality output for this voice |
 | `isOwner` | boolean | Whether the current user owns this voice |
 
-### `elevenlabs_get_voice_settings`
+### ElevenLabs Get Voice Settings
 
 Get the configured settings for a specific ElevenLabs voice
 
@@ -193,7 +193,7 @@ Get the configured settings for a specific ElevenLabs voice
 | `useSpeakerBoost` | boolean | Whether speaker boost is enabled |
 | `speed` | number | Speech speed \(1.0 = normal\) |
 
-### `elevenlabs_edit_voice_settings`
+### ElevenLabs Edit Voice Settings
 
 Update the settings for a specific ElevenLabs voice
 
@@ -215,7 +215,7 @@ Update the settings for a specific ElevenLabs voice
 | --------- | ---- | ----------- |
 | `status` | string | Request outcome \("ok" on success\) |
 
-### `elevenlabs_list_models`
+### ElevenLabs List Models
 
 List the models available in ElevenLabs
 
@@ -241,7 +241,7 @@ List the models available in ElevenLabs
 |     ↳ `languageId` | string | Language code |
 |     ↳ `name` | string | Language name |
 
-### `elevenlabs_get_user`
+### ElevenLabs Get User
 
 Get account and subscription information for the ElevenLabs user
 

--- a/apps/docs/content/docs/en/integrations/emailbison.mdx
+++ b/apps/docs/content/docs/en/integrations/emailbison.mdx
@@ -32,7 +32,7 @@ Integrate Email Bison into workflows. Create and update leads, manage campaigns,
 
 ## Actions
 
-### `emailbison_list_leads`
+### Email Bison List Leads
 
 Retrieves leads from Email Bison with optional search and tag filters.
 
@@ -65,7 +65,7 @@ Retrieves leads from Email Bison with optional search and tag filters.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_get_lead`
+### Email Bison Get Lead
 
 Retrieves a lead by Email Bison lead ID or email address.
 
@@ -94,7 +94,7 @@ Retrieves a lead by Email Bison lead ID or email address.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_create_lead`
+### Email Bison Create Lead
 
 Creates a single lead in Email Bison.
 
@@ -129,7 +129,7 @@ Creates a single lead in Email Bison.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_update_lead`
+### Email Bison Update Lead
 
 Updates an existing Email Bison lead. Fields omitted from a PUT update may be cleared by Email Bison.
 
@@ -165,7 +165,7 @@ Updates an existing Email Bison lead. Fields omitted from a PUT update may be cl
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_list_campaigns`
+### Email Bison List Campaigns
 
 Retrieves Email Bison campaigns.
 
@@ -193,7 +193,7 @@ Retrieves Email Bison campaigns.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_create_campaign`
+### Email Bison Create Campaign
 
 Creates a new Email Bison campaign.
 
@@ -223,7 +223,7 @@ Creates a new Email Bison campaign.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_update_campaign`
+### Email Bison Update Campaign
 
 Updates Email Bison campaign settings.
 
@@ -261,7 +261,7 @@ Updates Email Bison campaign settings.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_update_campaign_status`
+### Email Bison Update Campaign Status
 
 Pauses, resumes, or archives an Email Bison campaign.
 
@@ -291,7 +291,7 @@ Pauses, resumes, or archives an Email Bison campaign.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_attach_leads_to_campaign`
+### Email Bison Attach Leads to Campaign
 
 Adds existing Email Bison leads to a campaign.
 
@@ -322,7 +322,7 @@ Adds existing Email Bison leads to a campaign.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_list_replies`
+### Email Bison List Replies
 
 Retrieves Email Bison replies with optional status, folder, campaign, sender, lead, and tag filters.
 
@@ -358,7 +358,7 @@ Retrieves Email Bison replies with optional status, folder, campaign, sender, le
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_list_tags`
+### Email Bison List Tags
 
 Retrieves all Email Bison tags for the authenticated workspace.
 
@@ -386,7 +386,7 @@ Retrieves all Email Bison tags for the authenticated workspace.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_create_tag`
+### Email Bison Create Tag
 
 Creates a new Email Bison tag.
 
@@ -415,7 +415,7 @@ Creates a new Email Bison tag.
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
-### `emailbison_attach_tags_to_leads`
+### Email Bison Attach Tags to Leads
 
 Attaches Email Bison tags to one or more leads.
 

--- a/apps/docs/content/docs/en/integrations/embeddings.mdx
+++ b/apps/docs/content/docs/en/integrations/embeddings.mdx
@@ -31,7 +31,7 @@ Turn text into embedding vectors for semantic search, clustering, and similarity
 
 ## Actions
 
-### `embeddings_openai`
+### OpenAI Embeddings
 
 Generate embeddings from text using OpenAI's embedding models
 
@@ -55,7 +55,7 @@ Generate embeddings from text using OpenAI's embedding models
 | `dimensions` | number | Dimensionality of each vector |
 | `usage` | json | Token usage |
 
-### `embeddings_gemini`
+### Gemini Embeddings
 
 Generate embeddings from text using Google's Gemini embedding models
 
@@ -79,7 +79,7 @@ Generate embeddings from text using Google's Gemini embedding models
 | `dimensions` | number | Dimensionality of each vector |
 | `usage` | json | Token usage |
 
-### `embeddings_cohere`
+### Cohere Embeddings
 
 Generate embeddings from text using Cohere's embedding models
 
@@ -103,7 +103,7 @@ Generate embeddings from text using Cohere's embedding models
 | `dimensions` | number | Dimensionality of each vector |
 | `usage` | json | Token usage |
 
-### `embeddings_mistral`
+### Mistral Embeddings
 
 Generate embeddings from text using Mistral's embedding models
 

--- a/apps/docs/content/docs/en/integrations/enrich.mdx
+++ b/apps/docs/content/docs/en/integrations/enrich.mdx
@@ -34,7 +34,7 @@ Access real-time B2B data intelligence with Enrich.so. Enrich profiles from emai
 
 ## Actions
 
-### `enrich_check_credits`
+### Enrich Check Credits
 
 Check your Enrich API credit usage and remaining balance.
 
@@ -52,7 +52,7 @@ Check your Enrich API credit usage and remaining balance.
 | `creditsUsed` | number | Credits consumed so far |
 | `creditsRemaining` | number | Available credits remaining |
 
-### `enrich_email_to_profile`
+### Enrich Email to Profile
 
 Retrieve detailed LinkedIn profile information using an email address including work history, education, and skills.
 
@@ -101,7 +101,7 @@ Retrieve detailed LinkedIn profile information using an email address including 
 | `locale` | string | Profile locale \(e.g., en_US\) |
 | `version` | number | Profile version number |
 
-### `enrich_email_to_person_lite`
+### Enrich Email to Person Lite
 
 Retrieve basic LinkedIn profile information from an email address. A lighter version with essential data only.
 
@@ -137,7 +137,7 @@ Retrieve basic LinkedIn profile information from an email address. A lighter ver
 | `certifications` | array | Certifications |
 | `volunteerExperience` | array | Volunteer experience |
 
-### `enrich_linkedin_profile`
+### Enrich LinkedIn Profile
 
 Enrich a LinkedIn profile URL with detailed information including positions, education, and social metrics.
 
@@ -179,7 +179,7 @@ Enrich a LinkedIn profile URL with detailed information including positions, edu
 |   ↳ `endDate` | string | End date |
 | `websites` | array | Personal websites |
 
-### `enrich_find_email`
+### Enrich Find Email
 
 Find a person's work email address using their full name and company domain.
 
@@ -202,7 +202,7 @@ Find a person's work email address using their full name and company domain.
 | `found` | boolean | Whether an email was found |
 | `acceptAll` | boolean | Whether the domain accepts all emails |
 
-### `enrich_linkedin_to_work_email`
+### Enrich LinkedIn to Work Email
 
 Find a work email address from a LinkedIn profile URL.
 
@@ -221,7 +221,7 @@ Find a work email address from a LinkedIn profile URL.
 | `found` | boolean | Whether an email was found |
 | `status` | string | Request status \(in_progress or completed\) |
 
-### `enrich_linkedin_to_personal_email`
+### Enrich LinkedIn to Personal Email
 
 Find personal email address from a LinkedIn profile URL.
 
@@ -240,7 +240,7 @@ Find personal email address from a LinkedIn profile URL.
 | `found` | boolean | Whether an email was found |
 | `status` | string | Request status |
 
-### `enrich_phone_finder`
+### Enrich Phone Finder
 
 Find a phone number from a LinkedIn profile URL.
 
@@ -260,7 +260,7 @@ Find a phone number from a LinkedIn profile URL.
 | `found` | boolean | Whether a phone number was found |
 | `status` | string | Request status \(in_progress or completed\) |
 
-### `enrich_email_to_phone`
+### Enrich Email to Phone
 
 Find a phone number associated with an email address.
 
@@ -280,7 +280,7 @@ Find a phone number associated with an email address.
 | `found` | boolean | Whether a phone number was found |
 | `status` | string | Request status \(in_progress or completed\) |
 
-### `enrich_verify_email`
+### Enrich Verify Email
 
 Verify an email address for deliverability, including catch-all detection and provider identification.
 
@@ -304,7 +304,7 @@ Verify an email address for deliverability, including catch-all detection and pr
 | `mailAcceptAll` | boolean | Whether the domain is a catch-all domain |
 | `free` | boolean | Whether the email uses a free email service |
 
-### `enrich_disposable_email_check`
+### Enrich Disposable Email Check
 
 Check if an email address is from a disposable or temporary email provider. Returns a score and validation details.
 
@@ -329,7 +329,7 @@ Check if an email address is from a disposable or temporary email provider. Retu
 |   ↳ `host` | string | MX record host |
 |   ↳ `pref` | number | MX record preference |
 
-### `enrich_email_to_ip`
+### Enrich Email to IP
 
 Discover an IP address associated with an email address.
 
@@ -348,7 +348,7 @@ Discover an IP address associated with an email address.
 | `ip` | string | Associated IP address |
 | `found` | boolean | Whether an IP address was found |
 
-### `enrich_ip_to_company`
+### Enrich IP to Company
 
 Identify a company from an IP address with detailed firmographic information.
 
@@ -381,7 +381,7 @@ Identify a company from an IP address with detailed firmographic information.
 | `twitterUrl` | string | Twitter URL |
 | `facebookUrl` | string | Facebook URL |
 
-### `enrich_company_lookup`
+### Enrich Company Lookup
 
 Look up comprehensive company information by name or domain including funding, location, and social profiles.
 
@@ -423,7 +423,7 @@ Look up comprehensive company information by name or domain including funding, l
 |   ↳ `currency` | string | Currency |
 |   ↳ `investors` | array | Investors |
 
-### `enrich_company_funding`
+### Enrich Company Funding
 
 Retrieve company funding history, traffic metrics, and executive information by domain.
 
@@ -455,7 +455,7 @@ Retrieve company funding history, traffic metrics, and executive information by 
 |   ↳ `name` | string | Name |
 |   ↳ `title` | string | Title |
 
-### `enrich_company_revenue`
+### Enrich Company Revenue
 
 Retrieve company revenue data, CEO information, and competitive analysis by domain.
 
@@ -497,7 +497,7 @@ Retrieve company revenue data, CEO information, and competitive analysis by doma
 |   ↳ `employeeCount` | number | Employee count |
 |   ↳ `headquarters` | string | Headquarters |
 
-### `enrich_search_people`
+### Enrich Search People
 
 Search for professionals by various criteria including name, title, skills, education, and company.
 
@@ -547,7 +547,7 @@ Search for professionals by various criteria including name, title, skills, educ
 |   ↳ `country` | string | Country |
 |   ↳ `expertSkills` | array | Skills |
 
-### `enrich_search_company`
+### Enrich Search Company
 
 Search for companies by various criteria including name, industry, location, and size.
 
@@ -590,7 +590,7 @@ Search for companies by various criteria including name, industry, location, and
 |   ↳ `teamSize` | number | Team size |
 |   ↳ `linkedInProfile` | string | LinkedIn URL |
 
-### `enrich_search_company_employees`
+### Enrich Search Company Employees
 
 Search for employees within specific companies by location and job title.
 
@@ -625,7 +625,7 @@ Search for employees within specific companies by location and job title.
 |   ↳ `country` | string | Country |
 |   ↳ `expertSkills` | array | Skills |
 
-### `enrich_search_similar_companies`
+### Enrich Search Similar Companies
 
 Find companies similar to a given company by LinkedIn URL with filters for location and size.
 
@@ -660,7 +660,7 @@ Find companies similar to a given company by LinkedIn URL with filters for locat
 |   ↳ `relevancyScore` | number | Relevancy score |
 |   ↳ `relevancyValue` | string | Relevancy value |
 
-### `enrich_sales_pointer_people`
+### Enrich Sales Pointer People
 
 Advanced people search with complex filters for location, company size, seniority, experience, and more.
 
@@ -690,7 +690,7 @@ Advanced people search with complex filters for location, company size, seniorit
 |   ↳ `start` | number | Start position |
 |   ↳ `limit` | number | Limit |
 
-### `enrich_search_jobs`
+### Enrich Search Jobs
 
 Search LinkedIn job postings by keywords with filters for location, job type, workplace type, experience level, and company.
 
@@ -725,7 +725,7 @@ Search LinkedIn job postings by keywords with filters for location, job type, wo
 |   ↳ `hiringStatus` | string | Hiring status |
 |   ↳ `criteria` | object | Employment criteria \(seniority, type, function\) |
 
-### `enrich_search_posts`
+### Enrich Search Posts
 
 Search LinkedIn posts by keywords with date filtering.
 
@@ -758,7 +758,7 @@ Search LinkedIn posts by keywords with date filtering.
 |   ↳ `reactions` | number | Number of reactions |
 |   ↳ `commentsCount` | number | Number of comments |
 
-### `enrich_get_post_details`
+### Enrich Get Post Details
 
 Get detailed information about a LinkedIn post by URL.
 
@@ -786,7 +786,7 @@ Get detailed information about a LinkedIn post by URL.
 | `reactions` | number | Number of reactions |
 | `commentsCount` | number | Number of comments |
 
-### `enrich_search_post_reactions`
+### Enrich Search Post Reactions
 
 Get reactions on a LinkedIn post with filtering by reaction type.
 
@@ -815,7 +815,7 @@ Get reactions on a LinkedIn post with filtering by reaction type.
 |     ↳ `profilePicture` | string | Profile picture URL |
 |     ↳ `linkedInUrl` | string | LinkedIn URL |
 
-### `enrich_search_post_reactions_by_url`
+### Enrich Search Post Reactions by URL
 
 Get reactions on a LinkedIn post by its URL, filtered by reaction type.
 
@@ -844,7 +844,7 @@ Get reactions on a LinkedIn post by its URL, filtered by reaction type.
 |     ↳ `profilePicture` | string | Profile picture URL |
 |     ↳ `linkedInUrl` | string | LinkedIn URL |
 
-### `enrich_search_post_comments`
+### Enrich Search Post Comments
 
 Get comments on a LinkedIn post.
 
@@ -882,7 +882,7 @@ Get comments on a LinkedIn post.
 |     ↳ `empathy` | number | Number of empathy reactions |
 |     ↳ `other` | number | Number of other reactions |
 
-### `enrich_search_post_comments_by_url`
+### Enrich Search Post Comments by URL
 
 Get comments on a LinkedIn post by its URL.
 
@@ -920,7 +920,7 @@ Get comments on a LinkedIn post by its URL.
 |     ↳ `empathy` | number | Number of empathy reactions |
 |     ↳ `other` | number | Number of other reactions |
 
-### `enrich_search_people_activities`
+### Enrich Search People Activities
 
 Get a person's LinkedIn activities (posts, comments, or articles) by profile ID.
 
@@ -955,7 +955,7 @@ Get a person's LinkedIn activities (posts, comments, or articles) by profile ID.
 |     ↳ `other` | number | Other reactions |
 |   ↳ `attachments` | array | Attachment URLs |
 
-### `enrich_search_company_activities`
+### Enrich Search Company Activities
 
 Get a company's LinkedIn activities (posts, comments, or articles) by company ID.
 
@@ -991,7 +991,7 @@ Get a company's LinkedIn activities (posts, comments, or articles) by company ID
 |     ↳ `other` | number | Other reactions |
 |   ↳ `attachments` | array | Attachments |
 
-### `enrich_reverse_hash_lookup`
+### Enrich Reverse Hash Lookup
 
 Convert an MD5 email hash back to the original email address and display name.
 
@@ -1011,7 +1011,7 @@ Convert an MD5 email hash back to the original email address and display name.
 | `displayName` | string | Display name associated with the email |
 | `found` | boolean | Whether an email was found for the hash |
 
-### `enrich_search_logo`
+### Enrich Search Logo
 
 Get a company logo image URL by domain.
 

--- a/apps/docs/content/docs/en/integrations/enrichment.mdx
+++ b/apps/docs/content/docs/en/integrations/enrichment.mdx
@@ -25,7 +25,7 @@ Run a Sim enrichment to look up data — work email, phone number, company domai
 
 ## Actions
 
-### `enrichment_run`
+### Run Enrichment
 
 Run a Sim enrichment (e.g. Work Email, Phone Number) and return its outputs
 

--- a/apps/docs/content/docs/en/integrations/enrow.mdx
+++ b/apps/docs/content/docs/en/integrations/enrow.mdx
@@ -30,7 +30,7 @@ Integrate Enrow to find verified B2B email addresses from a full name and compan
 
 ## Actions
 
-### `enrow_find_email`
+### Enrow Find Email
 
 Find a verified B2B email address from a full name and company domain or name. Uses the Enrow async finder — submits a search and polls until the result is ready. Costs 1 credit per valid email found. (https://enrow.readme.io/reference/find-single-email)
 
@@ -55,7 +55,7 @@ Find a verified B2B email address from a full name and company domain or name. U
 | `company_domain` | string | Company domain associated with the result |
 | `linkedin_url` | string | LinkedIn profile URL of the person |
 
-### `enrow_verify_email`
+### Enrow Verify Email
 
 Verify the deliverability of an email address using the Enrow async verifier. Submits a verification request and polls until the result is ready. Costs 0.25 credits per verification. (https://enrow.readme.io/reference/verify-single-email)
 

--- a/apps/docs/content/docs/en/integrations/evernote.mdx
+++ b/apps/docs/content/docs/en/integrations/evernote.mdx
@@ -33,7 +33,7 @@ Integrate with Evernote to manage notes, notebooks, and tags. Create, read, upda
 
 ## Actions
 
-### `evernote_copy_note`
+### Evernote Copy Note
 
 Copy a note to another notebook in Evernote
 
@@ -56,7 +56,7 @@ Copy a note to another notebook in Evernote
 |   ↳ `created` | number | Creation timestamp in milliseconds |
 |   ↳ `updated` | number | Last updated timestamp in milliseconds |
 
-### `evernote_create_note`
+### Evernote Create Note
 
 Create a new note in Evernote
 
@@ -83,7 +83,7 @@ Create a new note in Evernote
 |   ↳ `created` | number | Creation timestamp in milliseconds |
 |   ↳ `updated` | number | Last updated timestamp in milliseconds |
 
-### `evernote_create_notebook`
+### Evernote Create Notebook
 
 Create a new notebook in Evernote
 
@@ -107,7 +107,7 @@ Create a new notebook in Evernote
 |   ↳ `serviceUpdated` | number | Last updated timestamp in milliseconds |
 |   ↳ `stack` | string | Notebook stack name |
 
-### `evernote_create_tag`
+### Evernote Create Tag
 
 Create a new tag in Evernote
 
@@ -129,7 +129,7 @@ Create a new tag in Evernote
 |   ↳ `parentGuid` | string | Parent tag GUID |
 |   ↳ `updateSequenceNum` | number | Update sequence number |
 
-### `evernote_delete_note`
+### Evernote Delete Note
 
 Move a note to the trash in Evernote
 
@@ -147,7 +147,7 @@ Move a note to the trash in Evernote
 | `success` | boolean | Whether the note was successfully deleted |
 | `noteGuid` | string | GUID of the deleted note |
 
-### `evernote_get_note`
+### Evernote Get Note
 
 Retrieve a note from Evernote by its GUID
 
@@ -175,7 +175,7 @@ Retrieve a note from Evernote by its GUID
 |   ↳ `updated` | number | Last updated timestamp in milliseconds |
 |   ↳ `active` | boolean | Whether the note is active \(not in trash\) |
 
-### `evernote_get_notebook`
+### Evernote Get Notebook
 
 Retrieve a notebook from Evernote by its GUID
 
@@ -198,7 +198,7 @@ Retrieve a notebook from Evernote by its GUID
 |   ↳ `serviceUpdated` | number | Last updated timestamp in milliseconds |
 |   ↳ `stack` | string | Notebook stack name |
 
-### `evernote_list_notebooks`
+### Evernote List Notebooks
 
 List all notebooks in an Evernote account
 
@@ -214,7 +214,7 @@ List all notebooks in an Evernote account
 | --------- | ---- | ----------- |
 | `notebooks` | array | List of notebooks |
 
-### `evernote_list_tags`
+### Evernote List Tags
 
 List all tags in an Evernote account
 
@@ -230,7 +230,7 @@ List all tags in an Evernote account
 | --------- | ---- | ----------- |
 | `tags` | array | List of tags |
 
-### `evernote_search_notes`
+### Evernote Search Notes
 
 Search for notes in Evernote using the Evernote search grammar
 
@@ -251,7 +251,7 @@ Search for notes in Evernote using the Evernote search grammar
 | `totalNotes` | number | Total number of matching notes |
 | `notes` | array | List of matching note metadata |
 
-### `evernote_update_note`
+### Evernote Update Note
 
 Update an existing note in Evernote
 

--- a/apps/docs/content/docs/en/integrations/exa.mdx
+++ b/apps/docs/content/docs/en/integrations/exa.mdx
@@ -38,7 +38,7 @@ Integrate Exa into the workflow. Can search the web, get page contents, find sim
 
 ## Actions
 
-### `exa_search`
+### Exa Search
 
 Search the web using Exa AI. Returns relevant search results with titles, URLs, and text snippets.
 
@@ -96,7 +96,7 @@ Search the web using Exa AI. Returns relevant search results with titles, URLs, 
 | `structuredOutput` | json | Synthesized answer matching outputSchema, when one was supplied |
 | `grounding` | json | Field-level citations backing the synthesized output |
 
-### `exa_get_contents`
+### Exa Get Contents
 
 Retrieve the contents of webpages using Exa AI. Returns the title, text content, and optional summaries for each URL.
 
@@ -137,7 +137,7 @@ Retrieve the contents of webpages using Exa AI. Returns the title, text content,
 | `statuses` | json | Per-URL crawl outcome, showing which pages succeeded and whether they came from cache |
 | `requestId` | string | Exa request identifier, useful for support |
 
-### `exa_find_similar_links`
+### Exa Find Similar Links
 
 Find webpages similar to a given URL using Exa AI. Deprecated by Exa in favor of Search — prefer Search for new workflows.
 
@@ -173,7 +173,7 @@ Find webpages similar to a given URL using Exa AI. Deprecated by Exa in favor of
 |   ↳ `score` | number | Similarity score indicating how similar the page is |
 | `requestId` | string | Exa request identifier, useful for support |
 
-### `exa_answer`
+### Exa Answer
 
 Get an AI-generated answer to a question with citations from the web using Exa AI.
 
@@ -200,7 +200,7 @@ Get an AI-generated answer to a question with citations from the web using Exa A
 |   ↳ `publishedDate` | string | Publication date of the cited source |
 | `requestId` | string | Exa request identifier, useful for support |
 
-### `exa_agent`
+### Exa Agent
 
 Run a deep research task with Exa Agent. Handles multi-step list building, enrichment, and research, returning a written answer with field-level citations and optional structured output.
 

--- a/apps/docs/content/docs/en/integrations/extend.mdx
+++ b/apps/docs/content/docs/en/integrations/extend.mdx
@@ -25,7 +25,7 @@ Integrate Extend AI into the workflow. Parse and extract structured content from
 
 ## Actions
 
-### `extend_parser`
+### Extend Document Parser
 
 #### Input
 

--- a/apps/docs/content/docs/en/integrations/fathom.mdx
+++ b/apps/docs/content/docs/en/integrations/fathom.mdx
@@ -33,7 +33,7 @@ Integrate Fathom AI Notetaker into your workflow. List meetings, get transcripts
 
 ## Actions
 
-### `fathom_list_meetings`
+### Fathom List Meetings
 
 List recent meetings recorded by the user or shared to their team.
 
@@ -127,7 +127,7 @@ List recent meetings recorded by the user or shared to their team.
 |     ↳ `error` | string | CRM match error, if any |
 | `next_cursor` | string | Pagination cursor for next page |
 
-### `fathom_list_meeting_types`
+### Fathom List Meeting Types
 
 List meeting types configured in your Fathom organization.
 
@@ -148,7 +148,7 @@ List meeting types configured in your Fathom organization.
 |   ↳ `created_at` | string | Date the meeting type was created |
 | `next_cursor` | string | Pagination cursor for next page |
 
-### `fathom_get_summary`
+### Fathom Get Summary
 
 Get the call summary for a specific meeting recording.
 
@@ -166,7 +166,7 @@ Get the call summary for a specific meeting recording.
 | `template_name` | string | Name of the summary template used |
 | `markdown_formatted` | string | Markdown-formatted summary text |
 
-### `fathom_get_transcript`
+### Fathom Get Transcript
 
 Get the full transcript for a specific meeting recording.
 
@@ -188,7 +188,7 @@ Get the full transcript for a specific meeting recording.
 |   ↳ `text` | string | Transcript text |
 |   ↳ `timestamp` | string | Timestamp \(HH:MM:SS\) |
 
-### `fathom_list_team_members`
+### Fathom List Team Members
 
 List team members in your Fathom organization.
 
@@ -210,7 +210,7 @@ List team members in your Fathom organization.
 |   ↳ `created_at` | string | Date the member was added |
 | `next_cursor` | string | Pagination cursor for next page |
 
-### `fathom_list_teams`
+### Fathom List Teams
 
 List teams in your Fathom organization.
 

--- a/apps/docs/content/docs/en/integrations/file.mdx
+++ b/apps/docs/content/docs/en/integrations/file.mdx
@@ -33,7 +33,7 @@ Read workspace file objects, extract the text content of files, fetch and parse 
 
 ## Actions
 
-### `file_read`
+### File Read
 
 #### Input
 
@@ -48,7 +48,7 @@ Read workspace file objects, extract the text content of files, fetch and parse 
 | --------- | ---- | ----------- |
 | `files` | file[] | Workspace file objects |
 
-### `file_get_content`
+### File Get Content
 
 Extract the text content of one or more workspace files from selected file objects or canonical workspace file IDs.
 
@@ -65,7 +65,7 @@ Extract the text content of one or more workspace files from selected file objec
 | --------- | ---- | ----------- |
 | `contents` | array | Array of file text contents, one entry per file in input order |
 
-### `file_fetch`
+### File Fetch
 
 Fetch and parse a file from a URL with optional custom headers.
 
@@ -82,7 +82,7 @@ Fetch and parse a file from a URL with optional custom headers.
 | `files` | file[] | Fetched files as UserFile objects |
 | `combinedContent` | string | Combined content of all fetched files |
 
-### `file_write`
+### File Write
 
 Create a new workspace file. If a file with the same name already exists, a numeric suffix is added (e.g., "data (1).csv").
 
@@ -103,7 +103,7 @@ Create a new workspace file. If a file with the same name already exists, a nume
 | `size` | number | File size in bytes |
 | `url` | string | URL to access the file |
 
-### `file_append`
+### File Append
 
 Append content to an existing workspace file. The file must already exist. Content is added to the end of the file.
 
@@ -123,9 +123,9 @@ Append content to an existing workspace file. The file must already exist. Conte
 | `size` | number | File size in bytes |
 | `url` | string | URL to access the file |
 
-### `file_compress`
+### File Compress
 
-Compress one or more workspace files into a single .zip archive stored in the workspace, for bundling files to download, transfer, or store.
+Compress one or more workspace files into a single .zip archive stored in the workspace, for bundling files to download, transfer, or store. Preserves the workspace folder structure of the selected files.
 
 #### Input
 
@@ -145,7 +145,7 @@ Compress one or more workspace files into a single .zip archive stored in the wo
 | `url` | string | URL to access the compressed archive |
 | `files` | file[] | Compressed archive file object, as a single-item array |
 
-### `file_decompress`
+### File Decompress
 
 Extract the contents of a .zip archive into the workspace, preserving the archive folder structure.
 
@@ -162,7 +162,7 @@ Extract the contents of a .zip archive into the workspace, preserving the archiv
 | --------- | ---- | ----------- |
 | `files` | file[] | Extracted workspace file objects |
 
-### `file_manage_sharing`
+### Manage Sharing
 
 Enable or disable the public share link for a workspace file, and set its access mode (public, password, email, or SSO). Idempotent: the public link stays stable across changes.
 

--- a/apps/docs/content/docs/en/integrations/findymail.mdx
+++ b/apps/docs/content/docs/en/integrations/findymail.mdx
@@ -36,7 +36,7 @@ Integrate Findymail to find verified work emails by name, domain, or LinkedIn UR
 
 ## Actions
 
-### `findymail_verify_email`
+### Findymail Verify Email
 
 Verifies the deliverability of an email address. Uses one verifier credit.
 
@@ -55,7 +55,7 @@ Verifies the deliverability of an email address. Uses one verifier credit.
 | `verified` | boolean | Whether the email is verified as deliverable |
 | `provider` | string | Email service provider \(e.g., Google, Microsoft\) |
 
-### `findymail_find_email_from_name`
+### Findymail Find Email From Name
 
 Find someone's email from their name and a company domain or company name. Uses one finder credit when a verified email is found.
 
@@ -76,7 +76,7 @@ Find someone's email from their name and a company domain or company name. Uses 
 |   ↳ `email` | string | Contact email address |
 |   ↳ `domain` | string | Email domain |
 
-### `findymail_find_emails_by_domain`
+### Findymail Find Emails By Domain
 
 Find verified contacts at a given domain matching one or more target roles (max 3 roles). Limited to 5 concurrent synchronous requests.
 
@@ -97,7 +97,7 @@ Find verified contacts at a given domain matching one or more target roles (max 
 |   ↳ `email` | string | Contact email address |
 |   ↳ `domain` | string | Email domain |
 
-### `findymail_find_email_from_linkedin`
+### Findymail Find Email From LinkedIn
 
 Find someone's email from a LinkedIn profile URL or username. Uses one finder credit when a verified email is found.
 
@@ -117,7 +117,7 @@ Find someone's email from a LinkedIn profile URL or username. Uses one finder cr
 |   ↳ `email` | string | Contact email address |
 |   ↳ `domain` | string | Email domain |
 
-### `findymail_reverse_email_lookup`
+### Findymail Reverse Email Lookup
 
 Find a business profile from an email address. Uses 1 finder credit if a profile is found, 2 credits if returning full profile data.
 
@@ -153,7 +153,7 @@ Find a business profile from an email address. Uses 1 finder credit if a profile
 | `educations` | array | Education history \(school, degree, fieldOfStudy, startDate, endDate\) |
 | `certificates` | array | Certifications \(name, issuingOrganization, issueDate, expirationDate\) |
 
-### `findymail_get_company`
+### Findymail Get Company
 
 Retrieve company information from a LinkedIn URL, domain, or company name. Uses 1 finder credit per successful response.
 
@@ -177,7 +177,7 @@ Retrieve company information from a LinkedIn URL, domain, or company name. Uses 
 | `linkedin_url` | string | Company LinkedIn URL |
 | `description` | string | Company description |
 
-### `findymail_find_employees`
+### Findymail Find Employees
 
 Find employees at a company by website and target job titles. Uses 1 credit per found contact. Does not return email addresses.
 
@@ -201,7 +201,7 @@ Find employees at a company by website and target job titles. Uses 1 credit per 
 |   ↳ `companyName` | string | Company name |
 |   ↳ `jobTitle` | string | Job title |
 
-### `findymail_find_phone`
+### Findymail Find Phone
 
 Find someone's phone number from a LinkedIn profile URL. Uses 10 finder credits if a phone is found. EU citizens are excluded for legal reasons.
 
@@ -219,7 +219,7 @@ Find someone's phone number from a LinkedIn profile URL. Uses 10 finder credits 
 | `phone` | string | Phone number in E.164 format. Only available for US numbers. |
 | `line_type` | string | Phone line type \(e.g., "Mobile", "Landline"\) |
 
-### `findymail_search_technologies`
+### Findymail Search Technologies
 
 Search the technology catalog by name. Returns up to 25 technologies. Free endpoint, rate limited to 10 requests per minute.
 
@@ -240,7 +240,7 @@ Search the technology catalog by name. Returns up to 25 technologies. Free endpo
 |   ↳ `subcategory` | string | Technology subcategory |
 |   ↳ `last_detected_at` | string | Last detection timestamp \(ISO 8601\) |
 
-### `findymail_lookup_technologies`
+### Findymail Lookup Technologies
 
 Get the technology stack for a company by domain. Optionally filter by technology names. 1 finder credit if technologies are found, free otherwise.
 
@@ -263,7 +263,7 @@ Get the technology stack for a company by domain. Optionally filter by technolog
 |   ↳ `last_detected_at` | string | Last detection timestamp \(ISO 8601\) |
 | `domain` | string | The resolved company domain |
 
-### `findymail_get_credits`
+### Findymail Get Credits
 
 Retrieve the remaining finder and verifier credits for the authenticated account.
 

--- a/apps/docs/content/docs/en/integrations/firecrawl.mdx
+++ b/apps/docs/content/docs/en/integrations/firecrawl.mdx
@@ -42,7 +42,7 @@ Integrate Firecrawl into the workflow. Scrape pages, search the web, crawl entir
 
 ## Actions
 
-### `firecrawl_scrape`
+### Firecrawl Website Scraper
 
 Extract structured content from web pages with comprehensive metadata support. Converts content to markdown or HTML while capturing SEO metadata, Open Graph tags, and page information.
 
@@ -51,6 +51,7 @@ Extract structured content from web pages with comprehensive metadata support. C
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
 | `url` | string | Yes | The URL to scrape content from \(e.g., "https://example.com/page"\) |
+| `formats` | json | No | Output formats supplied by existing Firecrawl block configurations |
 | `scrapeOptions` | json | No | Options for content scraping |
 | `apiKey` | string | Yes | Firecrawl API key |
 
@@ -76,7 +77,7 @@ Extract structured content from web pages with comprehensive metadata support. C
 |   ↳ `ogSiteName` | string | Open Graph site name |
 |   ↳ `error` | string | Error message if scrape failed |
 
-### `firecrawl_batch_scrape`
+### Firecrawl Batch Scrape
 
 Scrape multiple URLs in a single batch job and retrieve structured content from each page.
 
@@ -114,7 +115,7 @@ Scrape multiple URLs in a single batch job and retrieve structured content from 
 | `completed` | number | Number of pages successfully scraped |
 | `invalidURLs` | array | URLs that were skipped because they were invalid |
 
-### `firecrawl_batch_scrape_status`
+### Firecrawl Batch Scrape Status
 
 Check the status and retrieve results of a previously started Firecrawl batch scrape job by its job ID.
 
@@ -149,7 +150,7 @@ Check the status and retrieve results of a previously started Firecrawl batch sc
 |     ↳ `statusCode` | number | HTTP status code |
 |     ↳ `ogLocaleAlternate` | array | Alternate locale versions |
 
-### `firecrawl_search`
+### Firecrawl Search
 
 Search for information on the web using Firecrawl
 
@@ -158,6 +159,7 @@ Search for information on the web using Firecrawl
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
 | `query` | string | Yes | The search query to use |
+| `scrapeOptions` | json | No | Advanced scrape options supplied by existing configurations |
 | `apiKey` | string | Yes | Firecrawl API key |
 
 #### Output
@@ -180,7 +182,7 @@ Search for information on the web using Firecrawl
 |     ↳ `statusCode` | number | HTTP status code |
 |     ↳ `error` | string | Error message if scrape failed |
 
-### `firecrawl_crawl`
+### Firecrawl Crawl
 
 Crawl entire websites and extract structured content from all accessible pages
 
@@ -192,6 +194,8 @@ Crawl entire websites and extract structured content from all accessible pages
 | `limit` | number | No | Maximum number of pages to crawl \(e.g., 50, 100, 500\). Default: 100 |
 | `maxDepth` | number | No | Maximum depth to crawl from the starting URL \(e.g., 1, 2, 3\). Controls how many levels deep to follow links |
 | `formats` | json | No | Output formats for scraped content \(e.g., \["markdown"\], \["markdown", "html"\], \["markdown", "links"\]\) |
+| `prompt` | string | No | Natural-language crawl guidance supplied by existing configurations |
+| `scrapeOptions` | json | No | Advanced scrape options supplied by existing configurations |
 | `excludePaths` | json | No | URL paths to exclude from crawling \(e.g., \["/blog/*", "/admin/*", "/*.pdf"\]\) |
 | `includePaths` | json | No | URL paths to include in crawling \(e.g., \["/docs/*", "/api/*"\]\). Only these paths will be crawled |
 | `onlyMainContent` | boolean | No | Extract only main content from pages |
@@ -216,7 +220,7 @@ Crawl entire websites and extract structured content from all accessible pages
 |     ↳ `ogLocaleAlternate` | array | Alternate locale versions |
 | `total` | number | Total number of pages found during crawl |
 
-### `firecrawl_crawl_status`
+### Firecrawl Crawl Status
 
 Check the status and retrieve results of a previously started Firecrawl crawl job by its job ID.
 
@@ -251,7 +255,7 @@ Check the status and retrieve results of a previously started Firecrawl crawl jo
 |     ↳ `statusCode` | number | HTTP status code |
 |     ↳ `ogLocaleAlternate` | array | Alternate locale versions |
 
-### `firecrawl_cancel_crawl`
+### Firecrawl Cancel Crawl
 
 Cancel an in-progress Firecrawl crawl job by its job ID.
 
@@ -268,7 +272,7 @@ Cancel an in-progress Firecrawl crawl job by its job ID.
 | --------- | ---- | ----------- |
 | `status` | string | Status of the cancelled crawl job \(e.g., "cancelled"\) |
 
-### `firecrawl_map`
+### Firecrawl Map
 
 Get a complete list of URLs from any website quickly and reliably. Useful for discovering all pages on a site without crawling them.
 
@@ -293,7 +297,7 @@ Get a complete list of URLs from any website quickly and reliably. Useful for di
 | `success` | boolean | Whether the mapping operation was successful |
 | `links` | array | Array of discovered URLs from the website |
 
-### `firecrawl_extract`
+### Firecrawl Extract
 
 Extract structured data from entire webpages using natural language prompts and JSON schema. Powerful agentic feature for intelligent data extraction.
 
@@ -319,7 +323,7 @@ Extract structured data from entire webpages using natural language prompts and 
 | `success` | boolean | Whether the extraction operation was successful |
 | `data` | object | Extracted structured data according to the schema or prompt |
 
-### `firecrawl_extract_status`
+### Firecrawl Extract Status
 
 Check the status and retrieve results of a previously started Firecrawl extract job by its job ID.
 
@@ -340,7 +344,7 @@ Check the status and retrieve results of a previously started Firecrawl extract 
 | `creditsUsed` | number | Number of credits used by the extract job |
 | `tokensUsed` | number | Number of tokens used by the extract job |
 
-### `firecrawl_agent`
+### Firecrawl Agent
 
 Autonomous web data extraction agent. Searches and gathers information based on natural language prompts without requiring specific URLs.
 
@@ -365,7 +369,7 @@ Autonomous web data extraction agent. Searches and gathers information based on 
 | `expiresAt` | string | Timestamp when the results expire \(24 hours\) |
 | `sources` | object | Array of source URLs used by the agent |
 
-### `firecrawl_parse`
+### Firecrawl Document Parser
 
 Parse uploaded documents (PDF, DOCX, HTML, etc.) into clean markdown using Firecrawl. Supports .html, .htm, .pdf, .docx, .doc, .odt, .rtf, .xlsx, .xls.
 
@@ -408,7 +412,7 @@ Parse uploaded documents (PDF, DOCX, HTML, etc.) into clean markdown using Firec
 |   ↳ `error` | string | Error message if parse failed |
 | `warning` | string | Warning message from the parse operation |
 
-### `firecrawl_credit_usage`
+### Firecrawl Credit Usage
 
 Retrieve the remaining and allocated Firecrawl credits for the team.
 

--- a/apps/docs/content/docs/en/integrations/fireflies.mdx
+++ b/apps/docs/content/docs/en/integrations/fireflies.mdx
@@ -35,7 +35,7 @@ Integrate Fireflies.ai into the workflow. Manage meeting transcripts, add bot to
 
 ## Actions
 
-### `fireflies_list_transcripts`
+### Fireflies List Transcripts
 
 List meeting transcripts from Fireflies.ai with optional filtering
 
@@ -59,7 +59,7 @@ List meeting transcripts from Fireflies.ai with optional filtering
 | `transcripts` | array | List of transcripts |
 | `count` | number | Number of transcripts returned |
 
-### `fireflies_get_transcript`
+### Fireflies Get Transcript
 
 Get a single transcript with full details including summary, action items, and analytics
 
@@ -88,7 +88,7 @@ Get a single transcript with full details including summary, action items, and a
 |   ↳ `summary` | object | Meeting summary and action items |
 |   ↳ `analytics` | object | Meeting analytics and sentiment |
 
-### `fireflies_get_user`
+### Fireflies Get User
 
 Get user information from Fireflies.ai. Returns current user if no ID specified.
 
@@ -114,7 +114,7 @@ Get user information from Fireflies.ai. Returns current user if no ID specified.
 |   ↳ `recent_transcript` | string | Most recent transcript ID |
 |   ↳ `recent_meeting` | string | Most recent meeting date |
 
-### `fireflies_list_users`
+### Fireflies List Users
 
 List all users within your Fireflies.ai team
 
@@ -130,7 +130,7 @@ List all users within your Fireflies.ai team
 | --------- | ---- | ----------- |
 | `users` | array | List of team users |
 
-### `fireflies_upload_audio`
+### Fireflies Upload Audio
 
 Upload an audio file URL to Fireflies.ai for transcription
 
@@ -155,7 +155,7 @@ Upload an audio file URL to Fireflies.ai for transcription
 | `title` | string | Title of the uploaded meeting |
 | `message` | string | Status message from Fireflies |
 
-### `fireflies_delete_transcript`
+### Fireflies Delete Transcript
 
 Delete a transcript from Fireflies.ai
 
@@ -179,7 +179,7 @@ Delete a transcript from Fireflies.ai
 |   ↳ `host_email` | string | Host email address |
 |   ↳ `organizer_email` | string | Organizer email address |
 
-### `fireflies_add_to_live_meeting`
+### Fireflies Add to Live Meeting
 
 Add the Fireflies.ai bot to an ongoing meeting to record and transcribe
 
@@ -200,7 +200,7 @@ Add the Fireflies.ai bot to an ongoing meeting to record and transcribe
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the bot was successfully added to the meeting |
 
-### `fireflies_create_bite`
+### Fireflies Create Bite
 
 Create a soundbite/highlight from a specific time range in a transcript
 
@@ -225,7 +225,7 @@ Create a soundbite/highlight from a specific time range in a transcript
 |   ↳ `name` | string | Bite name |
 |   ↳ `status` | string | Processing status |
 
-### `fireflies_list_bites`
+### Fireflies List Bites
 
 List soundbites/highlights from Fireflies.ai
 
@@ -245,7 +245,7 @@ List soundbites/highlights from Fireflies.ai
 | --------- | ---- | ----------- |
 | `bites` | array | List of bites/soundbites |
 
-### `fireflies_list_contacts`
+### Fireflies List Contacts
 
 List all contacts from your Fireflies.ai meetings
 

--- a/apps/docs/content/docs/en/integrations/flint.mdx
+++ b/apps/docs/content/docs/en/integrations/flint.mdx
@@ -41,7 +41,7 @@ Create background agent tasks that modify your Flint sites from natural-language
 
 ## Actions
 
-### `flint_create_task`
+### Flint Create Task
 
 Start a background Flint agent task that modifies a site from a natural-language prompt.
 
@@ -62,7 +62,7 @@ Start a background Flint agent task that modifies a site from a natural-language
 | `status` | string | Initial task status \(running\) |
 | `createdAt` | string | ISO 8601 timestamp when the task was created |
 
-### `flint_generate_pages`
+### Flint Generate Pages
 
 Start a background Flint agent task that generates up to 10 pages from a template page.
 
@@ -84,7 +84,7 @@ Start a background Flint agent task that generates up to 10 pages from a templat
 | `status` | string | Initial task status \(running\) |
 | `createdAt` | string | ISO 8601 timestamp when the task was created |
 
-### `flint_get_task`
+### Flint Get Task
 
 Get the status and results of a background Flint agent task.
 

--- a/apps/docs/content/docs/en/integrations/gamma.mdx
+++ b/apps/docs/content/docs/en/integrations/gamma.mdx
@@ -32,7 +32,7 @@ Integrate Gamma into the workflow. Can generate presentations, documents, webpag
 
 ## Actions
 
-### `gamma_generate`
+### Gamma Generate
 
 Generate a new Gamma presentation, document, webpage, or social post from text input.
 
@@ -65,7 +65,7 @@ Generate a new Gamma presentation, document, webpage, or social post from text i
 | --------- | ---- | ----------- |
 | `generationId` | string | The ID of the generation job. Use with Check Status to poll for completion. |
 
-### `gamma_generate_from_template`
+### Gamma Generate from Template
 
 Generate a new Gamma by adapting an existing template with a prompt.
 
@@ -88,7 +88,7 @@ Generate a new Gamma by adapting an existing template with a prompt.
 | --------- | ---- | ----------- |
 | `generationId` | string | The ID of the generation job. Use with Check Status to poll for completion. |
 
-### `gamma_check_status`
+### Gamma Check Status
 
 Check the status of a Gamma generation job. Returns the gamma URL when completed, or error details if failed.
 
@@ -113,7 +113,7 @@ Check the status of a Gamma generation job. Returns the gamma URL when completed
 |   ↳ `message` | string | Human-readable error message |
 |   ↳ `statusCode` | number | HTTP status code of the error |
 
-### `gamma_list_themes`
+### Gamma List Themes
 
 List available themes in your Gamma workspace. Returns theme IDs, names, and keywords for styling.
 
@@ -139,7 +139,7 @@ List available themes in your Gamma workspace. Returns theme IDs, names, and key
 | `hasMore` | boolean | Whether more results are available on the next page |
 | `nextCursor` | string | Pagination cursor to pass as the after parameter for the next page |
 
-### `gamma_list_folders`
+### Gamma List Folders
 
 List available folders in your Gamma workspace. Returns folder IDs and names for organizing generated content.
 

--- a/apps/docs/content/docs/en/integrations/github.mdx
+++ b/apps/docs/content/docs/en/integrations/github.mdx
@@ -35,7 +35,7 @@ Integrate Github into the workflow. Can get get PR details, create PR comment, g
 
 ## Actions
 
-### `github_pr`
+### GitHub PR Reader
 
 Fetch PR details including diff and files changed
 
@@ -103,7 +103,7 @@ Fetch PR details including diff and files changed
 |   ↳ `patch` | string | Diff patch |
 |   ↳ `previous_filename` | string | Previous filename \(for renames\) |
 
-### `github_comment`
+### GitHub PR Commenter
 
 Create comments on GitHub PRs
 
@@ -143,7 +143,7 @@ Create comments on GitHub PRs
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 
-### `github_repo_info`
+### GitHub Repository Info
 
 Retrieve comprehensive GitHub repository metadata including stars, forks, issues, and primary language. Supports both public and private repositories with optional authentication.
 
@@ -194,7 +194,7 @@ Retrieve comprehensive GitHub repository metadata including stars, forks, issues
 |   ↳ `name` | string | License name |
 |   ↳ `spdx_id` | string | SPDX identifier |
 
-### `github_latest_commit`
+### GitHub Latest Commit
 
 Retrieve the latest commit from a GitHub repository
 
@@ -252,7 +252,7 @@ Retrieve the latest commit from a GitHub repository
 | `sha` | string | Commit SHA |
 | `html_url` | string | GitHub web URL |
 
-### `github_issue_comment`
+### GitHub Issue Comment Creator
 
 Create a comment on a GitHub issue
 
@@ -286,7 +286,7 @@ Create a comment on a GitHub issue
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 
-### `github_list_issue_comments`
+### GitHub Issue Comments Lister
 
 List all comments on a GitHub issue
 
@@ -324,7 +324,7 @@ List all comments on a GitHub issue
 |   ↳ `updated_at` | string | Last update timestamp |
 | `count` | number | Number of comments returned |
 
-### `github_update_comment`
+### GitHub Comment Updater
 
 Update an existing comment on a GitHub issue or pull request
 
@@ -358,7 +358,7 @@ Update an existing comment on a GitHub issue or pull request
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 
-### `github_delete_comment`
+### GitHub Comment Deleter
 
 Delete a comment on a GitHub issue or pull request
 
@@ -378,7 +378,7 @@ Delete a comment on a GitHub issue or pull request
 | `deleted` | boolean | Whether deletion was successful |
 | `comment_id` | number | Deleted comment ID |
 
-### `github_list_pr_comments`
+### GitHub PR Review Comments Lister
 
 List all review comments on a GitHub pull request
 
@@ -422,7 +422,7 @@ List all review comments on a GitHub pull request
 |   ↳ `updated_at` | string | Last update timestamp |
 | `count` | number | Number of comments returned |
 
-### `github_create_pr`
+### GitHub Create Pull Request
 
 Create a new pull request in a GitHub repository
 
@@ -458,7 +458,7 @@ Create a new pull request in a GitHub repository
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 
-### `github_update_pr`
+### GitHub Update Pull Request
 
 Update an existing pull request in a GitHub repository
 
@@ -493,7 +493,7 @@ Update an existing pull request in a GitHub repository
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 
-### `github_merge_pr`
+### GitHub Merge Pull Request
 
 Merge a pull request in a GitHub repository
 
@@ -517,7 +517,7 @@ Merge a pull request in a GitHub repository
 | `merged` | boolean | Whether merge was successful |
 | `message` | string | Response message |
 
-### `github_list_prs`
+### GitHub List Pull Requests
 
 List pull requests in a GitHub repository
 
@@ -571,7 +571,7 @@ List pull requests in a GitHub repository
 |   ↳ `merged_at` | string | Merge timestamp |
 | `count` | number | Number of PRs returned |
 
-### `github_get_pr_files`
+### GitHub Get PR Files
 
 Get the list of files changed in a pull request
 
@@ -604,7 +604,7 @@ Get the list of files changed in a pull request
 |   ↳ `previous_filename` | string | Previous filename \(for renames\) |
 | `count` | number | Total number of files |
 
-### `github_close_pr`
+### GitHub Close Pull Request
 
 Close a pull request in a GitHub repository
 
@@ -636,7 +636,7 @@ Close a pull request in a GitHub repository
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 
-### `github_request_reviewers`
+### GitHub Request Reviewers
 
 Request reviewers for a pull request
 
@@ -662,7 +662,7 @@ Request reviewers for a pull request
 | `requested_reviewers` | array | Array of requested reviewer objects |
 | `requested_teams` | array | Array of requested team objects |
 
-### `github_create_pr_review`
+### GitHub Create PR Review
 
 Submit a review for a pull request. Use APPROVE, REQUEST_CHANGES, or COMMENT. A body is required for REQUEST_CHANGES and COMMENT reviews.
 
@@ -697,7 +697,7 @@ Submit a review for a pull request. Use APPROVE, REQUEST_CHANGES, or COMMENT. A 
 | `commit_id` | string | SHA of the reviewed commit |
 | `submitted_at` | string | Review submission timestamp |
 
-### `github_get_file_content`
+### GitHub Get File Content
 
 Get the content of a file from a GitHub repository. Supports files up to 1MB. Content is returned decoded and human-readable.
 
@@ -728,7 +728,7 @@ Get the content of a file from a GitHub repository. Supports files up to 1MB. Co
 | `_links` | json | Related links |
 | `file` | file | Downloaded file stored in execution files |
 
-### `github_create_file`
+### GitHub Create File
 
 Create a new file in a GitHub repository. The file content will be automatically Base64 encoded. Supports files up to 1MB.
 
@@ -751,7 +751,7 @@ Create a new file in a GitHub repository. The file content will be automatically
 | `content` | json | Created file content info |
 | `commit` | json | Commit information |
 
-### `github_update_file`
+### GitHub Update File
 
 Update an existing file in a GitHub repository. Requires the file SHA. Content will be automatically Base64 encoded. Supports files up to 1MB.
 
@@ -775,7 +775,7 @@ Update an existing file in a GitHub repository. Requires the file SHA. Content w
 | `content` | json | Updated file content info |
 | `commit` | json | Commit information |
 
-### `github_delete_file`
+### GitHub Delete File
 
 Delete a file from a GitHub repository. Requires the file SHA. This operation cannot be undone through the API.
 
@@ -798,7 +798,7 @@ Delete a file from a GitHub repository. Requires the file SHA. This operation ca
 | `content` | json | File content info \(null for delete\) |
 | `commit` | json | Commit information |
 
-### `github_get_tree`
+### GitHub Get Repository Tree
 
 Get the contents of a directory in a GitHub repository. Returns a list of files and subdirectories. Use empty path or omit to get root directory contents.
 
@@ -829,7 +829,7 @@ Get the contents of a directory in a GitHub repository. Returns a list of files 
 |   ↳ `_links` | json | Related links |
 | `count` | number | Total number of items |
 
-### `github_get_readme`
+### GitHub Get README
 
 Get the preferred README for a GitHub repository, with its content decoded to plain text.
 
@@ -855,7 +855,7 @@ Get the preferred README for a GitHub repository, with its content decoded to pl
 | `download_url` | string | Raw download URL for the README |
 | `content` | string | Decoded README text content |
 
-### `github_list_tags`
+### GitHub List Tags
 
 List tags for a GitHub repository. Returns tag names with their commit SHA and download URLs.
 
@@ -883,7 +883,7 @@ List tags for a GitHub repository. Returns tag names with their commit SHA and d
 |     ↳ `url` | string | Commit API URL |
 | `count` | number | Number of tags returned |
 
-### `github_list_branches`
+### GitHub List Branches
 
 List all branches in a GitHub repository. Optionally filter by protected status and control pagination.
 
@@ -910,7 +910,7 @@ List all branches in a GitHub repository. Optionally filter by protected status 
 |   ↳ `protected` | boolean | Whether branch is protected |
 | `count` | number | Number of branches returned |
 
-### `github_get_branch`
+### GitHub Get Branch
 
 Get detailed information about a specific branch in a GitHub repository, including commit details and protection status.
 
@@ -935,7 +935,7 @@ Get detailed information about a specific branch in a GitHub repository, includi
 | `protection` | json | Protection settings object |
 | `protection_url` | string | URL to protection settings |
 
-### `github_create_branch`
+### GitHub Create Branch
 
 Create a new branch in a GitHub repository by creating a git reference pointing to a specific commit SHA.
 
@@ -958,7 +958,7 @@ Create a new branch in a GitHub repository by creating a git reference pointing 
 | `url` | string | API URL for the reference |
 | `object` | json | Git object with type and sha |
 
-### `github_delete_branch`
+### GitHub Delete Branch
 
 Delete a branch from a GitHub repository by removing its git reference. Protected branches cannot be deleted.
 
@@ -978,7 +978,7 @@ Delete a branch from a GitHub repository by removing its git reference. Protecte
 | `deleted` | boolean | Whether the branch was deleted |
 | `branch` | string | Name of the deleted branch |
 
-### `github_get_branch_protection`
+### GitHub Get Branch Protection
 
 Get the branch protection rules for a specific branch, including status checks, review requirements, and restrictions.
 
@@ -1007,7 +1007,7 @@ Get the branch protection rules for a specific branch, including status checks, 
 | `required_conversation_resolution` | json | Conversation resolution requirement |
 | `required_signatures` | json | Signature requirements |
 
-### `github_update_branch_protection`
+### GitHub Update Branch Protection
 
 Update branch protection rules for a specific branch, including status checks, review requirements, admin enforcement, and push restrictions.
 
@@ -1040,7 +1040,7 @@ Update branch protection rules for a specific branch, including status checks, r
 | `required_conversation_resolution` | json | Conversation resolution requirement |
 | `required_signatures` | json | Signature requirements |
 
-### `github_create_issue`
+### GitHub Create Issue
 
 Create a new issue in a GitHub repository
 
@@ -1108,7 +1108,7 @@ Create a new issue in a GitHub repository
 |   ↳ `updated_at` | string | Last update timestamp |
 |   ↳ `closed_at` | string | Close timestamp |
 
-### `github_update_issue`
+### GitHub Update Issue
 
 Update an existing issue in a GitHub repository
 
@@ -1177,7 +1177,7 @@ Update an existing issue in a GitHub repository
 |   ↳ `updated_at` | string | Last update timestamp |
 |   ↳ `closed_at` | string | Close timestamp |
 
-### `github_list_issues`
+### GitHub List Issues
 
 List issues in a GitHub repository. Note: This includes pull requests as PRs are considered issues in GitHub
 
@@ -1211,7 +1211,7 @@ List issues in a GitHub repository. Note: This includes pull requests as PRs are
 |   ↳ `default` | boolean | Whether this is a default label |
 | `count` | number | Number of issues returned |
 
-### `github_get_issue`
+### GitHub Get Issue
 
 Get detailed information about a specific issue in a GitHub repository
 
@@ -1281,7 +1281,7 @@ Get detailed information about a specific issue in a GitHub repository
 |   ↳ `html_url` | string | Profile URL |
 |   ↳ `type` | string | Account type \(User or Organization\) |
 
-### `github_close_issue`
+### GitHub Close Issue
 
 Close an issue in a GitHub repository
 
@@ -1330,7 +1330,7 @@ Close an issue in a GitHub repository
 |   ↳ `html_url` | string | Profile URL |
 |   ↳ `type` | string | Account type \(User or Organization\) |
 
-### `github_add_labels`
+### GitHub Add Labels
 
 Add labels to an issue in a GitHub repository
 
@@ -1355,7 +1355,7 @@ Add labels to an issue in a GitHub repository
 |   ↳ `description` | string | Label description |
 | `count` | number | Number of labels |
 
-### `github_remove_label`
+### GitHub Remove Label
 
 Remove a label from an issue in a GitHub repository
 
@@ -1380,7 +1380,7 @@ Remove a label from an issue in a GitHub repository
 |   ↳ `description` | string | Label description |
 | `count` | number | Number of remaining labels |
 
-### `github_add_assignees`
+### GitHub Add Assignees
 
 Add assignees to an issue in a GitHub repository
 
@@ -1410,7 +1410,7 @@ Add assignees to an issue in a GitHub repository
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 
-### `github_create_release`
+### GitHub Create Release
 
 Create a new release for a GitHub repository. Specify tag name, target commit, title, description, and whether it should be a draft or prerelease.
 
@@ -1470,7 +1470,7 @@ Create a new release for a GitHub repository. Specify tag name, target commit, t
 |   ↳ `created_at` | string | Upload timestamp |
 |   ↳ `updated_at` | string | Last update timestamp |
 
-### `github_update_release`
+### GitHub Update Release
 
 Update an existing GitHub release. Modify tag name, target commit, title, description, draft status, or prerelease status.
 
@@ -1531,7 +1531,7 @@ Update an existing GitHub release. Modify tag name, target commit, title, descri
 |   ↳ `created_at` | string | Upload timestamp |
 |   ↳ `updated_at` | string | Last update timestamp |
 
-### `github_list_releases`
+### GitHub List Releases
 
 List all releases for a GitHub repository. Returns release information including tags, names, and download URLs.
 
@@ -1589,7 +1589,7 @@ List all releases for a GitHub repository. Returns release information including
 |     ↳ `updated_at` | string | Last update timestamp |
 | `count` | number | Number of releases returned |
 
-### `github_get_release`
+### GitHub Get Release
 
 Get detailed information about a specific GitHub release by ID. Returns release metadata including assets and download URLs.
 
@@ -1644,7 +1644,7 @@ Get detailed information about a specific GitHub release by ID. Returns release 
 |   ↳ `created_at` | string | Upload timestamp |
 |   ↳ `updated_at` | string | Last update timestamp |
 
-### `github_get_latest_release`
+### GitHub Get Latest Release
 
 Get the latest published, non-draft, non-prerelease release for a GitHub repository. Returns release metadata including assets and download URLs.
 
@@ -1698,7 +1698,7 @@ Get the latest published, non-draft, non-prerelease release for a GitHub reposit
 |   ↳ `created_at` | string | Upload timestamp |
 |   ↳ `updated_at` | string | Last update timestamp |
 
-### `github_delete_release`
+### GitHub Delete Release
 
 Delete a GitHub release by ID. This permanently removes the release but does not delete the associated Git tag.
 
@@ -1718,7 +1718,7 @@ Delete a GitHub release by ID. This permanently removes the release but does not
 | `deleted` | boolean | Whether the release was deleted |
 | `release_id` | number | ID of the deleted release |
 
-### `github_list_workflows`
+### GitHub List Workflows
 
 List all workflows in a GitHub repository. Returns workflow details including ID, name, path, state, and badge URL.
 
@@ -1750,7 +1750,7 @@ List all workflows in a GitHub repository. Returns workflow details including ID
 |   ↳ `updated_at` | string | Last update timestamp |
 |   ↳ `deleted_at` | string | Deletion timestamp |
 
-### `github_get_workflow`
+### GitHub Get Workflow
 
 Get details of a specific GitHub Actions workflow by ID or filename. Returns workflow information including name, path, state, and badge URL.
 
@@ -1779,7 +1779,7 @@ Get details of a specific GitHub Actions workflow by ID or filename. Returns wor
 | `updated_at` | string | Last update timestamp |
 | `deleted_at` | string | Deletion timestamp |
 
-### `github_trigger_workflow`
+### GitHub Trigger Workflow
 
 Trigger a workflow dispatch event for a GitHub Actions workflow. The workflow must have a workflow_dispatch trigger configured. Returns 204 No Content on success.
 
@@ -1802,7 +1802,7 @@ Trigger a workflow dispatch event for a GitHub Actions workflow. The workflow mu
 | `workflow_id` | string | Workflow ID or filename |
 | `ref` | string | Git reference used |
 
-### `github_list_workflow_runs`
+### GitHub List Workflow Runs
 
 List workflow runs for a repository. Supports filtering by actor, branch, event, and status. Returns run details including status, conclusion, and links.
 
@@ -1830,7 +1830,7 @@ List workflow runs for a repository. Supports filtering by actor, branch, event,
 |   ↳ `number` | number | Pull request number |
 |   ↳ `url` | string | API URL |
 
-### `github_get_workflow_run`
+### GitHub Get Workflow Run
 
 Get detailed information about a specific workflow run by ID. Returns status, conclusion, timing, and links to the run.
 
@@ -1884,7 +1884,7 @@ Get detailed information about a specific workflow run by ID. Returns status, co
 |   ↳ `sha` | string | Commit SHA of referenced workflow |
 |   ↳ `ref` | string | Git ref of referenced workflow |
 
-### `github_cancel_workflow_run`
+### GitHub Cancel Workflow Run
 
 Cancel a workflow run. Returns 202 Accepted if cancellation is initiated, or 409 Conflict if the run cannot be cancelled (already completed).
 
@@ -1904,7 +1904,7 @@ Cancel a workflow run. Returns 202 Accepted if cancellation is initiated, or 409
 | `cancelled` | boolean | Whether cancellation was initiated |
 | `run_id` | number | Workflow run ID |
 
-### `github_rerun_workflow`
+### GitHub Rerun Workflow
 
 Rerun a workflow run. Optionally enable debug logging for the rerun. Returns 201 Created on success.
 
@@ -1925,7 +1925,7 @@ Rerun a workflow run. Optionally enable debug logging for the rerun. Returns 201
 | `rerun_requested` | boolean | Whether rerun was requested |
 | `run_id` | number | Workflow run ID |
 
-### `github_list_projects`
+### GitHub List Projects
 
 List GitHub Projects V2 for an organization or user. Returns up to 20 projects with their details including ID, title, number, URL, and status.
 
@@ -1951,7 +1951,7 @@ List GitHub Projects V2 for an organization or user. Returns up to 20 projects w
 |   ↳ `shortDescription` | string | Short description |
 | `totalCount` | number | Total number of projects |
 
-### `github_get_project`
+### GitHub Get Project
 
 Get detailed information about a specific GitHub Project V2 by its number. Returns project details including ID, title, description, URL, and status.
 
@@ -1979,7 +1979,7 @@ Get detailed information about a specific GitHub Project V2 by its number. Retur
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last update timestamp |
 
-### `github_create_project`
+### GitHub Create Project
 
 Create a new GitHub Project V2. Requires the owner Node ID (not login name). Returns the created project with ID, title, and URL.
 
@@ -2003,7 +2003,7 @@ Create a new GitHub Project V2. Requires the owner Node ID (not login name). Ret
 | `public` | boolean | Whether project is public |
 | `shortDescription` | string | Short description |
 
-### `github_update_project`
+### GitHub Update Project
 
 Update an existing GitHub Project V2. Can update title, description, visibility (public), or status (closed). Requires the project Node ID.
 
@@ -2030,7 +2030,7 @@ Update an existing GitHub Project V2. Can update title, description, visibility 
 | `public` | boolean | Whether project is public |
 | `shortDescription` | string | Short description |
 
-### `github_delete_project`
+### GitHub Delete Project
 
 Delete a GitHub Project V2. This action is permanent and cannot be undone. Requires the project Node ID.
 
@@ -2050,7 +2050,7 @@ Delete a GitHub Project V2. This action is permanent and cannot be undone. Requi
 | `number` | number | Deleted project number |
 | `url` | string | Deleted project URL |
 
-### `github_search_code`
+### GitHub Search Code
 
 Search for code across GitHub repositories. Use qualifiers like repo:owner/name, language:js, path:src, extension:py
 
@@ -2107,9 +2107,9 @@ Search for code across GitHub repositories. Use qualifiers like repo:owner/name,
 |       ↳ `text` | string | Matched text |
 |       ↳ `indices` | array | Start and end indices |
 
-### `github_search_commits`
+### GitHub Search Commits
 
-Search for commits across GitHub. Use qualifiers like repo:owner/name, author:user, committer:user, author-date:>2023-01-01
+Search for commits across GitHub. Use qualifiers like repo:owner/name, author:user, committer:user, author-date:&gt;2023-01-01
 
 #### Input
 
@@ -2190,7 +2190,7 @@ Search for commits across GitHub. Use qualifiers like repo:owner/name, author:us
 |     ↳ `url` | string | Parent API URL |
 |     ↳ `html_url` | string | Parent web URL |
 
-### `github_search_issues`
+### GitHub Search Issues
 
 Search for issues and pull requests across GitHub. Use qualifiers like repo:owner/name, is:issue, is:pr, state:open, label:bug, author:user
 
@@ -2278,9 +2278,9 @@ Search for issues and pull requests across GitHub. Use qualifiers like repo:owne
 |     ↳ `diff_url` | string | Diff URL |
 |     ↳ `patch_url` | string | Patch URL |
 
-### `github_search_repos`
+### GitHub Search Repositories
 
-Search for repositories across GitHub. Use qualifiers like language:python, stars:>1000, topic:react, user:owner, org:name
+Search for repositories across GitHub. Use qualifiers like language:python, stars:&gt;1000, topic:react, user:owner, org:name
 
 #### Input
 
@@ -2338,9 +2338,9 @@ Search for repositories across GitHub. Use qualifiers like language:python, star
 |     ↳ `type` | string | User or Organization |
 |     ↳ `site_admin` | boolean | GitHub staff indicator |
 
-### `github_search_users`
+### GitHub Search Users
 
-Search for users and organizations on GitHub. Use qualifiers like type:user, type:org, followers:>1000, repos:>10, location:city
+Search for users and organizations on GitHub. Use qualifiers like type:user, type:org, followers:&gt;1000, repos:&gt;10, location:city
 
 #### Input
 
@@ -2377,7 +2377,7 @@ Search for users and organizations on GitHub. Use qualifiers like type:user, typ
 |   ↳ `site_admin` | boolean | GitHub staff indicator |
 |   ↳ `score` | number | Search relevance score |
 
-### `github_list_commits`
+### GitHub List Commits
 
 List commits in a repository with optional filtering by SHA, path, author, committer, or date range
 
@@ -2451,7 +2451,7 @@ List commits in a repository with optional filtering by SHA, path, author, commi
 |     ↳ `html_url` | string | Parent web URL |
 | `count` | number | Number of commits returned |
 
-### `github_get_commit`
+### GitHub Get Commit
 
 Get detailed information about a specific commit including files changed and stats
 
@@ -2532,7 +2532,7 @@ Get detailed information about a specific commit including files changed and sta
 |   ↳ `url` | string | Parent API URL |
 |   ↳ `html_url` | string | Parent web URL |
 
-### `github_compare_commits`
+### GitHub Compare Commits
 
 Compare two commits or branches to see the diff, commits between them, and changed files
 
@@ -2659,7 +2659,7 @@ Compare two commits or branches to see the diff, commits between them, and chang
 |   ↳ `patch` | string | Diff patch |
 |   ↳ `previous_filename` | string | Previous filename \(for renames\) |
 
-### `github_create_gist`
+### GitHub Create Gist
 
 Create a new gist with one or more files
 
@@ -2702,7 +2702,7 @@ Create a new gist with one or more files
 |   ↳ `type` | string | User or Organization |
 |   ↳ `site_admin` | boolean | GitHub staff indicator |
 
-### `github_get_gist`
+### GitHub Get Gist
 
 Get a gist by ID including its file contents
 
@@ -2750,7 +2750,7 @@ Get a gist by ID including its file contents
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 
-### `github_list_gists`
+### GitHub List Gists
 
 List gists for a user or the authenticated user
 
@@ -2803,7 +2803,7 @@ List gists for a user or the authenticated user
 |   ↳ `updated_at` | string | Last update timestamp |
 | `count` | number | Number of gists returned |
 
-### `github_update_gist`
+### GitHub Update Gist
 
 Update a gist description or files. To delete a file, set its value to null in files object
 
@@ -2846,7 +2846,7 @@ Update a gist description or files. To delete a file, set its value to null in f
 |   ↳ `type` | string | User or Organization |
 |   ↳ `site_admin` | boolean | GitHub staff indicator |
 
-### `github_delete_gist`
+### GitHub Delete Gist
 
 Delete a gist by ID
 
@@ -2864,7 +2864,7 @@ Delete a gist by ID
 | `deleted` | boolean | Whether deletion succeeded |
 | `gist_id` | string | The deleted gist ID |
 
-### `github_fork_gist`
+### GitHub Fork Gist
 
 Fork a gist to create your own copy
 
@@ -2887,7 +2887,7 @@ Fork a gist to create your own copy
 | `owner` | object | Owner info |
 | `files` | object | Files |
 
-### `github_star_gist`
+### GitHub Star Gist
 
 Star a gist
 
@@ -2905,7 +2905,7 @@ Star a gist
 | `starred` | boolean | Whether starring succeeded |
 | `gist_id` | string | The gist ID |
 
-### `github_unstar_gist`
+### GitHub Unstar Gist
 
 Unstar a gist
 
@@ -2923,7 +2923,7 @@ Unstar a gist
 | `unstarred` | boolean | Whether unstarring succeeded |
 | `gist_id` | string | The gist ID |
 
-### `github_fork_repo`
+### GitHub Fork Repository
 
 Fork a repository to your account or an organization
 
@@ -2975,7 +2975,7 @@ Fork a repository to your account or an organization
 |   ↳ `full_name` | string | Full name |
 |   ↳ `html_url` | string | Web URL |
 
-### `github_list_forks`
+### GitHub List Forks
 
 List forks of a repository
 
@@ -3028,7 +3028,7 @@ List forks of a repository
 |     ↳ `site_admin` | boolean | GitHub staff indicator |
 | `count` | number | Number of forks returned |
 
-### `github_create_milestone`
+### GitHub Create Milestone
 
 Create a milestone in a repository
 
@@ -3073,7 +3073,7 @@ Create a milestone in a repository
 | `updated_at` | string | Last update timestamp |
 | `closed_at` | string | Close timestamp |
 
-### `github_get_milestone`
+### GitHub Get Milestone
 
 Get a specific milestone by number
 
@@ -3115,7 +3115,7 @@ Get a specific milestone by number
 | `updated_at` | string | Last update timestamp |
 | `closed_at` | string | Close timestamp |
 
-### `github_list_milestones`
+### GitHub List Milestones
 
 List milestones in a repository
 
@@ -3163,7 +3163,7 @@ List milestones in a repository
 |   ↳ `closed_at` | string | Close timestamp |
 | `count` | number | Number of milestones returned |
 
-### `github_update_milestone`
+### GitHub Update Milestone
 
 Update a milestone in a repository
 
@@ -3209,7 +3209,7 @@ Update a milestone in a repository
 |   ↳ `type` | string | User or Organization |
 |   ↳ `site_admin` | boolean | GitHub staff indicator |
 
-### `github_delete_milestone`
+### GitHub Delete Milestone
 
 Delete a milestone from a repository
 
@@ -3229,7 +3229,7 @@ Delete a milestone from a repository
 | `deleted` | boolean | Whether deletion succeeded |
 | `milestone_number` | number | The deleted milestone number |
 
-### `github_create_issue_reaction`
+### GitHub Create Issue Reaction
 
 Add a reaction to an issue
 
@@ -3258,7 +3258,7 @@ Add a reaction to an issue
 |   ↳ `html_url` | string | Profile URL |
 |   ↳ `type` | string | Account type \(User or Organization\) |
 
-### `github_delete_issue_reaction`
+### GitHub Delete Issue Reaction
 
 Remove a reaction from an issue
 
@@ -3279,7 +3279,7 @@ Remove a reaction from an issue
 | `deleted` | boolean | Whether deletion succeeded |
 | `reaction_id` | number | The deleted reaction ID |
 
-### `github_create_comment_reaction`
+### GitHub Create Comment Reaction
 
 Add a reaction to an issue comment
 
@@ -3308,7 +3308,7 @@ Add a reaction to an issue comment
 |   ↳ `html_url` | string | Profile URL |
 |   ↳ `type` | string | Account type \(User or Organization\) |
 
-### `github_delete_comment_reaction`
+### GitHub Delete Comment Reaction
 
 Remove a reaction from an issue comment
 
@@ -3329,7 +3329,7 @@ Remove a reaction from an issue comment
 | `deleted` | boolean | Whether deletion succeeded |
 | `reaction_id` | number | The deleted reaction ID |
 
-### `github_star_repo`
+### GitHub Star Repository
 
 Star a repository
 
@@ -3349,7 +3349,7 @@ Star a repository
 | `owner` | string | Repository owner |
 | `repo` | string | Repository name |
 
-### `github_unstar_repo`
+### GitHub Unstar Repository
 
 Remove star from a repository
 
@@ -3369,7 +3369,7 @@ Remove star from a repository
 | `owner` | string | Repository owner |
 | `repo` | string | Repository name |
 
-### `github_check_star`
+### GitHub Check Star
 
 Check if you have starred a repository
 
@@ -3389,7 +3389,7 @@ Check if you have starred a repository
 | `owner` | string | Repository owner |
 | `repo` | string | Repository name |
 
-### `github_list_stargazers`
+### GitHub List Stargazers
 
 List users who have starred a repository
 

--- a/apps/docs/content/docs/en/integrations/gitlab.mdx
+++ b/apps/docs/content/docs/en/integrations/gitlab.mdx
@@ -33,7 +33,7 @@ Integrate GitLab into the workflow. Can manage projects, issues, merge requests,
 
 ## Actions
 
-### `gitlab_list_projects`
+### GitLab List Projects
 
 List GitLab projects accessible to the authenticated user
 
@@ -58,7 +58,7 @@ List GitLab projects accessible to the authenticated user
 | `projects` | array | List of GitLab projects |
 | `total` | number | Total number of projects |
 
-### `gitlab_get_project`
+### GitLab Get Project
 
 Get details of a specific GitLab project
 
@@ -75,7 +75,7 @@ Get details of a specific GitLab project
 | --------- | ---- | ----------- |
 | `project` | object | The GitLab project details |
 
-### `gitlab_list_groups`
+### GitLab List Groups
 
 List GitLab groups accessible to the authenticated user
 
@@ -102,7 +102,7 @@ List GitLab groups accessible to the authenticated user
 | `groups` | array | List of GitLab groups |
 | `total` | number | Total number of groups |
 
-### `gitlab_get_group`
+### GitLab Get Group
 
 Get details of a specific GitLab group
 
@@ -119,7 +119,7 @@ Get details of a specific GitLab group
 | --------- | ---- | ----------- |
 | `group` | object | The GitLab group details |
 
-### `gitlab_list_user_memberships`
+### GitLab List User Memberships
 
 List a user's project and group memberships. Requires an administrator access token (GET /users/:id/memberships is admin-only). For a non-admin path, iterate List Members on each project or group instead.
 
@@ -140,7 +140,7 @@ List a user's project and group memberships. Requires an administrator access to
 | `memberships` | array | The user's project and group memberships |
 | `total` | number | Total number of memberships |
 
-### `gitlab_list_issues`
+### GitLab List Issues
 
 List issues in a GitLab project
 
@@ -167,7 +167,7 @@ List issues in a GitLab project
 | `issues` | array | List of GitLab issues |
 | `total` | number | Total number of issues |
 
-### `gitlab_get_issue`
+### GitLab Get Issue
 
 Get details of a specific GitLab issue
 
@@ -185,7 +185,7 @@ Get details of a specific GitLab issue
 | --------- | ---- | ----------- |
 | `issue` | object | The GitLab issue details |
 
-### `gitlab_create_issue`
+### GitLab Create Issue
 
 Create a new issue in a GitLab project
 
@@ -209,7 +209,7 @@ Create a new issue in a GitLab project
 | --------- | ---- | ----------- |
 | `issue` | object | The created GitLab issue |
 
-### `gitlab_update_issue`
+### GitLab Update Issue
 
 Update an existing issue in a GitLab project
 
@@ -235,7 +235,7 @@ Update an existing issue in a GitLab project
 | --------- | ---- | ----------- |
 | `issue` | object | The updated GitLab issue |
 
-### `gitlab_delete_issue`
+### GitLab Delete Issue
 
 Delete an issue from a GitLab project
 
@@ -253,7 +253,7 @@ Delete an issue from a GitLab project
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the issue was deleted successfully |
 
-### `gitlab_create_issue_note`
+### GitLab Create Issue Comment
 
 Add a comment to a GitLab issue
 
@@ -273,7 +273,7 @@ Add a comment to a GitLab issue
 | --------- | ---- | ----------- |
 | `note` | object | The created comment |
 
-### `gitlab_list_merge_requests`
+### GitLab List Merge Requests
 
 List merge requests in a GitLab project
 
@@ -299,7 +299,7 @@ List merge requests in a GitLab project
 | `mergeRequests` | array | List of GitLab merge requests |
 | `total` | number | Total number of merge requests |
 
-### `gitlab_get_merge_request`
+### GitLab Get Merge Request
 
 Get details of a specific GitLab merge request
 
@@ -317,7 +317,7 @@ Get details of a specific GitLab merge request
 | --------- | ---- | ----------- |
 | `mergeRequest` | object | The GitLab merge request details |
 
-### `gitlab_create_merge_request`
+### GitLab Create Merge Request
 
 Create a new merge request in a GitLab project
 
@@ -344,7 +344,7 @@ Create a new merge request in a GitLab project
 | --------- | ---- | ----------- |
 | `mergeRequest` | object | The created GitLab merge request |
 
-### `gitlab_update_merge_request`
+### GitLab Update Merge Request
 
 Update an existing merge request in a GitLab project
 
@@ -372,7 +372,7 @@ Update an existing merge request in a GitLab project
 | --------- | ---- | ----------- |
 | `mergeRequest` | object | The updated GitLab merge request |
 
-### `gitlab_merge_merge_request`
+### GitLab Merge Merge Request
 
 Merge a merge request in a GitLab project
 
@@ -395,7 +395,7 @@ Merge a merge request in a GitLab project
 | --------- | ---- | ----------- |
 | `mergeRequest` | object | The merged GitLab merge request |
 
-### `gitlab_create_merge_request_note`
+### GitLab Create Merge Request Comment
 
 Add a comment to a GitLab merge request
 
@@ -415,7 +415,7 @@ Add a comment to a GitLab merge request
 | --------- | ---- | ----------- |
 | `note` | object | The created comment |
 
-### `gitlab_list_pipelines`
+### GitLab List Pipelines
 
 List pipelines in a GitLab project
 
@@ -439,7 +439,7 @@ List pipelines in a GitLab project
 | `pipelines` | array | List of GitLab pipelines |
 | `total` | number | Total number of pipelines |
 
-### `gitlab_get_pipeline`
+### GitLab Get Pipeline
 
 Get details of a specific GitLab pipeline
 
@@ -457,7 +457,7 @@ Get details of a specific GitLab pipeline
 | --------- | ---- | ----------- |
 | `pipeline` | object | The GitLab pipeline details |
 
-### `gitlab_create_pipeline`
+### GitLab Create Pipeline
 
 Trigger a new pipeline in a GitLab project
 
@@ -477,7 +477,7 @@ Trigger a new pipeline in a GitLab project
 | --------- | ---- | ----------- |
 | `pipeline` | object | The created GitLab pipeline |
 
-### `gitlab_retry_pipeline`
+### GitLab Retry Pipeline
 
 Retry a failed GitLab pipeline
 
@@ -495,7 +495,7 @@ Retry a failed GitLab pipeline
 | --------- | ---- | ----------- |
 | `pipeline` | object | The retried GitLab pipeline |
 
-### `gitlab_cancel_pipeline`
+### GitLab Cancel Pipeline
 
 Cancel a running GitLab pipeline
 
@@ -513,7 +513,7 @@ Cancel a running GitLab pipeline
 | --------- | ---- | ----------- |
 | `pipeline` | object | The cancelled GitLab pipeline |
 
-### `gitlab_list_repository_tree`
+### GitLab List Repository Tree
 
 List files and directories in a GitLab project repository
 
@@ -536,7 +536,7 @@ List files and directories in a GitLab project repository
 | `tree` | array | List of repository tree entries |
 | `total` | number | Total number of tree entries |
 
-### `gitlab_get_file`
+### GitLab Get File
 
 Get the contents of a file from a GitLab project repository
 
@@ -562,7 +562,7 @@ Get the contents of a file from a GitLab project repository
 | `content` | string | The decoded file content, truncated to 1M characters |
 | `truncated` | boolean | Whether the content was truncated |
 
-### `gitlab_create_file`
+### GitLab Create File
 
 Create a new file in a GitLab project repository
 
@@ -588,7 +588,7 @@ Create a new file in a GitLab project repository
 | `filePath` | string | The created file path |
 | `branch` | string | The branch the file was committed to |
 
-### `gitlab_update_file`
+### GitLab Update File
 
 Update an existing file in a GitLab project repository
 
@@ -615,7 +615,7 @@ Update an existing file in a GitLab project repository
 | `filePath` | string | The updated file path |
 | `branch` | string | The branch the update was committed to |
 
-### `gitlab_create_branch`
+### GitLab Create Branch
 
 Create a new branch in a GitLab project repository
 
@@ -637,7 +637,7 @@ Create a new branch in a GitLab project repository
 | `protected` | boolean | Whether the branch is protected |
 | `commit` | object | The commit the branch points to |
 
-### `gitlab_delete_branch`
+### GitLab Delete Branch
 
 Delete a branch from a GitLab project repository
 
@@ -655,7 +655,7 @@ Delete a branch from a GitLab project repository
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the branch was deleted successfully |
 
-### `gitlab_compare_branches`
+### GitLab Compare Branches
 
 Compare two branches, tags, or commits in a GitLab project repository
 
@@ -682,7 +682,7 @@ Compare two branches, tags, or commits in a GitLab project repository
 | `compareSameRef` | boolean | Whether both references point to the same commit |
 | `webUrl` | string | The web URL for viewing the comparison |
 
-### `gitlab_list_branches`
+### GitLab List Branches
 
 List branches in a GitLab project repository
 
@@ -703,7 +703,7 @@ List branches in a GitLab project repository
 | `branches` | array | List of branches |
 | `total` | number | Total number of branches |
 
-### `gitlab_list_commits`
+### GitLab List Commits
 
 List commits in a GitLab project repository
 
@@ -728,7 +728,7 @@ List commits in a GitLab project repository
 | `commits` | array | List of commits |
 | `total` | number | Number of commits returned on this page \(GitLab does not report a grand total for commits\) |
 
-### `gitlab_get_merge_request_changes`
+### GitLab Get Merge Request Changes
 
 Get the file changes (diffs) of a GitLab merge request
 
@@ -749,7 +749,7 @@ Get the file changes (diffs) of a GitLab merge request
 | `changesCount` | number | Number of changed files returned \(first 100\) |
 | `hasMore` | boolean | Whether the merge request has more than 100 changed files \(results truncated\) |
 
-### `gitlab_approve_merge_request`
+### GitLab Approve Merge Request
 
 Approve a GitLab merge request
 
@@ -770,7 +770,7 @@ Approve a GitLab merge request
 | `approvalsLeft` | number | Number of approvals still needed |
 | `approvedBy` | array | List of approvers |
 
-### `gitlab_list_pipeline_jobs`
+### GitLab List Pipeline Jobs
 
 List jobs for a GitLab pipeline
 
@@ -793,7 +793,7 @@ List jobs for a GitLab pipeline
 | `jobs` | array | List of pipeline jobs |
 | `total` | number | Total number of jobs |
 
-### `gitlab_get_job_log`
+### GitLab Get Job Log
 
 Get the log (trace) of a GitLab job
 
@@ -812,7 +812,7 @@ Get the log (trace) of a GitLab job
 | `log` | string | The job log \(trace\) output, truncated to 200k characters |
 | `truncated` | boolean | Whether the log was truncated |
 
-### `gitlab_play_job`
+### GitLab Play Job
 
 Trigger (play) a manual GitLab job
 
@@ -834,7 +834,7 @@ Trigger (play) a manual GitLab job
 | `status` | string | The job status |
 | `webUrl` | string | The web URL of the job |
 
-### `gitlab_list_releases`
+### GitLab List Releases
 
 List releases in a GitLab project
 
@@ -856,7 +856,7 @@ List releases in a GitLab project
 | `releases` | array | List of GitLab releases |
 | `total` | number | Total number of releases |
 
-### `gitlab_create_release`
+### GitLab Create Release
 
 Create a new release in a GitLab project
 
@@ -881,7 +881,7 @@ Create a new release in a GitLab project
 | --------- | ---- | ----------- |
 | `release` | object | The created GitLab release |
 
-### `gitlab_list_members`
+### GitLab List Members
 
 List members of a GitLab project or group. Includes members inherited from ancestor groups by default.
 
@@ -907,7 +907,7 @@ List members of a GitLab project or group. Includes members inherited from ances
 | `members` | array | List of project or group members |
 | `total` | number | Total number of members |
 
-### `gitlab_add_member`
+### GitLab Add Member
 
 Add an existing GitLab user to a project or group at a given access level
 
@@ -931,7 +931,7 @@ Add an existing GitLab user to a project or group at a given access level
 | `member` | object | The added member |
 | `alreadyMember` | boolean | Whether the user was already a member \(add was a no-op\) |
 
-### `gitlab_update_member`
+### GitLab Update Member
 
 Update a member's access level in a GitLab project or group
 
@@ -953,7 +953,7 @@ Update a member's access level in a GitLab project or group
 | --------- | ---- | ----------- |
 | `member` | object | The updated member |
 
-### `gitlab_remove_member`
+### GitLab Remove Member
 
 Remove a member from a GitLab project or group
 
@@ -974,7 +974,7 @@ Remove a member from a GitLab project or group
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the member was removed successfully |
 
-### `gitlab_invite_member`
+### GitLab Invite Member
 
 Invite a person to a GitLab project or group by email address
 
@@ -998,7 +998,7 @@ Invite a person to a GitLab project or group by email address
 | `status` | string | Invitation status returned by GitLab |
 | `message` | object | Per-email result detail, if any |
 
-### `gitlab_list_invitations`
+### GitLab List Invitations
 
 List pending email invitations for a GitLab project or group
 
@@ -1020,7 +1020,7 @@ List pending email invitations for a GitLab project or group
 | `invitations` | array | List of pending invitations |
 | `total` | number | Total number of invitations |
 
-### `gitlab_update_invitation`
+### GitLab Update Invitation
 
 Update a pending invitation to a GitLab project or group
 
@@ -1041,7 +1041,7 @@ Update a pending invitation to a GitLab project or group
 | --------- | ---- | ----------- |
 | `invitation` | object | The updated invitation |
 
-### `gitlab_revoke_invitation`
+### GitLab Revoke Invitation
 
 Revoke a pending email invitation to a GitLab project or group
 
@@ -1060,7 +1060,7 @@ Revoke a pending email invitation to a GitLab project or group
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the invitation was revoked successfully |
 
-### `gitlab_list_access_requests`
+### GitLab List Access Requests
 
 List pending access requests for a GitLab project or group
 
@@ -1081,7 +1081,7 @@ List pending access requests for a GitLab project or group
 | `accessRequests` | array | List of pending access requests |
 | `total` | number | Total number of access requests |
 
-### `gitlab_approve_access_request`
+### GitLab Approve Access Request
 
 Approve a pending access request for a GitLab project or group
 
@@ -1101,7 +1101,7 @@ Approve a pending access request for a GitLab project or group
 | --------- | ---- | ----------- |
 | `accessRequest` | object | The approved access request |
 
-### `gitlab_deny_access_request`
+### GitLab Deny Access Request
 
 Deny (delete) a pending access request for a GitLab project or group
 
@@ -1120,7 +1120,7 @@ Deny (delete) a pending access request for a GitLab project or group
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the access request was denied successfully |
 
-### `gitlab_list_saml_group_links`
+### GitLab List SAML Group Links
 
 List SAML group links for a GitLab group. Use this to detect whether a group is governed by SAML group sync before provisioning members.
 
@@ -1138,7 +1138,7 @@ List SAML group links for a GitLab group. Use this to detect whether a group is 
 | `samlGroupLinks` | array | List of SAML group links |
 | `total` | number | Number of SAML group links |
 
-### `gitlab_search_users`
+### GitLab Search Users
 
 Search for GitLab users by name, username, or email. Email matches must be exact; private emails match only with an admin token. Use this to resolve an email to a user ID before adding a member.
 
@@ -1158,7 +1158,7 @@ Search for GitLab users by name, username, or email. Email matches must be exact
 | `users` | array | List of matching users |
 | `total` | number | Total number of matching users |
 
-### `gitlab_create_user`
+### GitLab Create User
 
 Create a new GitLab user. Requires an administrator token with admin_mode on the instance.
 
@@ -1182,7 +1182,7 @@ Create a new GitLab user. Requires an administrator token with admin_mode on the
 | --------- | ---- | ----------- |
 | `user` | object | The created user |
 
-### `gitlab_update_user`
+### GitLab Update User
 
 Modify an existing GitLab user. Requires an administrator token with admin_mode on the instance.
 
@@ -1203,7 +1203,7 @@ Modify an existing GitLab user. Requires an administrator token with admin_mode 
 | --------- | ---- | ----------- |
 | `user` | object | The updated user |
 
-### `gitlab_delete_user`
+### GitLab Delete User
 
 Delete a GitLab user. Requires an administrator token with admin_mode on the instance.
 
@@ -1221,7 +1221,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the user was deleted successfully |
 
-### `gitlab_block_user`
+### GitLab Block User
 
 #### Input
 
@@ -1291,7 +1291,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
 | `success` | boolean | Operation success status |
 
-### `gitlab_unblock_user`
+### GitLab Unblock User
 
 #### Input
 
@@ -1361,7 +1361,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
 | `success` | boolean | Operation success status |
 
-### `gitlab_deactivate_user`
+### GitLab Deactivate User
 
 #### Input
 
@@ -1431,7 +1431,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
 | `success` | boolean | Operation success status |
 
-### `gitlab_activate_user`
+### GitLab Activate User
 
 #### Input
 
@@ -1501,7 +1501,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
 | `success` | boolean | Operation success status |
 
-### `gitlab_ban_user`
+### GitLab Ban User
 
 #### Input
 
@@ -1571,7 +1571,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
 | `success` | boolean | Operation success status |
 
-### `gitlab_unban_user`
+### GitLab Unban User
 
 #### Input
 
@@ -1641,7 +1641,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
 | `success` | boolean | Operation success status |
 
-### `gitlab_approve_user`
+### GitLab Approve User
 
 #### Input
 
@@ -1711,7 +1711,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
 | `success` | boolean | Operation success status |
 
-### `gitlab_reject_user`
+### GitLab Reject User
 
 #### Input
 
@@ -1781,7 +1781,7 @@ Delete a GitLab user. Requires an administrator token with admin_mode on the ins
 | `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
 | `success` | boolean | Operation success status |
 
-### `gitlab_delete_user_identity`
+### GitLab Delete User Identity
 
 Delete a user's authentication identity (e.g. SAML or LDAP). Requires an administrator token with admin_mode on the instance.
 
@@ -1799,7 +1799,7 @@ Delete a user's authentication identity (e.g. SAML or LDAP). Requires an adminis
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the identity was deleted successfully |
 
-### `gitlab_add_saml_group_link`
+### GitLab Add SAML Group Link
 
 Add a SAML group link that maps an identity-provider group to a GitLab group at a given access level (GitLab Premium/Ultimate)
 
@@ -1820,7 +1820,7 @@ Add a SAML group link that maps an identity-provider group to a GitLab group at 
 | --------- | ---- | ----------- |
 | `samlGroupLink` | object | The created SAML group link |
 
-### `gitlab_delete_saml_group_link`
+### GitLab Delete SAML Group Link
 
 Delete a SAML group link from a GitLab group (GitLab Premium/Ultimate)
 

--- a/apps/docs/content/docs/en/integrations/gmail.mdx
+++ b/apps/docs/content/docs/en/integrations/gmail.mdx
@@ -37,7 +37,7 @@ Integrate Gmail into the workflow. Can send, read, search, and move emails. Can 
 
 ## Actions
 
-### `gmail_send`
+### Gmail Send
 
 Send emails using Gmail. Returns API-aligned fields only.
 
@@ -63,7 +63,7 @@ Send emails using Gmail. Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Email labels |
 
-### `gmail_draft`
+### Gmail Draft
 
 Draft emails using Gmail. Returns API-aligned fields only.
 
@@ -90,7 +90,7 @@ Draft emails using Gmail. Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Email labels |
 
-### `gmail_edit_draft`
+### Gmail Edit Draft
 
 Update an existing Gmail draft in place without deleting and recreating it.
 
@@ -118,7 +118,7 @@ Update an existing Gmail draft in place without deleting and recreating it.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Email labels |
 
-### `gmail_read`
+### Gmail Read
 
 Read emails from Gmail. Returns API-aligned fields only.
 
@@ -149,7 +149,7 @@ Read emails from Gmail. Returns API-aligned fields only.
 | `attachments` | file[] | Downloaded attachments \(if enabled\) |
 | `results` | json | Summary results when reading multiple messages |
 
-### `gmail_search`
+### Gmail Search
 
 Search emails in Gmail. Returns API-aligned fields only.
 
@@ -166,7 +166,7 @@ Search emails in Gmail. Returns API-aligned fields only.
 | --------- | ---- | ----------- |
 | `results` | json | Array of search results |
 
-### `gmail_move`
+### Gmail Move
 
 Move emails between labels/folders in Gmail. Returns API-aligned fields only.
 
@@ -186,7 +186,7 @@ Move emails between labels/folders in Gmail. Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Email labels |
 
-### `gmail_mark_read`
+### Gmail Mark as Read
 
 Mark a Gmail message as read. Returns API-aligned fields only.
 
@@ -204,7 +204,7 @@ Mark a Gmail message as read. Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Updated email labels |
 
-### `gmail_mark_unread`
+### Gmail Mark as Unread
 
 Mark a Gmail message as unread. Returns API-aligned fields only.
 
@@ -222,7 +222,7 @@ Mark a Gmail message as unread. Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Updated email labels |
 
-### `gmail_archive`
+### Gmail Archive
 
 Archive a Gmail message (remove from inbox). Returns API-aligned fields only.
 
@@ -240,7 +240,7 @@ Archive a Gmail message (remove from inbox). Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Updated email labels |
 
-### `gmail_unarchive`
+### Gmail Unarchive
 
 Unarchive a Gmail message (move back to inbox). Returns API-aligned fields only.
 
@@ -258,7 +258,7 @@ Unarchive a Gmail message (move back to inbox). Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Updated email labels |
 
-### `gmail_delete`
+### Gmail Delete
 
 Delete a Gmail message (move to trash). Returns API-aligned fields only.
 
@@ -276,7 +276,7 @@ Delete a Gmail message (move to trash). Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Updated email labels |
 
-### `gmail_add_label`
+### Gmail Add Label
 
 Add label(s) to a Gmail message. Returns API-aligned fields only.
 
@@ -295,7 +295,7 @@ Add label(s) to a Gmail message. Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Updated email labels |
 
-### `gmail_remove_label`
+### Gmail Remove Label
 
 Remove label(s) from a Gmail message. Returns API-aligned fields only.
 

--- a/apps/docs/content/docs/en/integrations/gong.mdx
+++ b/apps/docs/content/docs/en/integrations/gong.mdx
@@ -37,7 +37,7 @@ Integrate Gong into your workflow. Access call recordings, transcripts, user dat
 
 ## Actions
 
-### `gong_list_calls`
+### Gong List Calls
 
 Retrieve call data by date range from Gong.
 
@@ -83,7 +83,7 @@ Retrieve call data by date range from Gong.
 | `currentPageSize` | number | Number of records in the current page |
 | `currentPageNumber` | number | Current page number |
 
-### `gong_create_call`
+### Gong Create Call
 
 Upload call metadata to Gong and let Gong pull the media from a URL.
 
@@ -113,7 +113,7 @@ Upload call metadata to Gong and let Gong pull the media from a URL.
 | `callId` | string | Gong's unique numeric identifier for the created call |
 | `requestId` | string | Gong request reference ID for troubleshooting |
 
-### `gong_get_call`
+### Gong Get Call
 
 Retrieve detailed data for a specific call from Gong.
 
@@ -151,7 +151,7 @@ Retrieve detailed data for a specific call from Gong.
 | `isPrivate` | boolean | Whether the call is private |
 | `calendarEventId` | string | Calendar event identifier |
 
-### `gong_get_call_transcript`
+### Gong Get Call Transcript
 
 Retrieve transcripts of calls from Gong by call IDs or date range.
 
@@ -183,7 +183,7 @@ Retrieve transcripts of calls from Gong by call IDs or date range.
 |       ↳ `text` | string | The sentence text |
 | `cursor` | string | Pagination cursor for the next page |
 
-### `gong_get_extensive_calls`
+### Gong Get Extensive Calls
 
 Retrieve detailed call data including trackers, topics, highlights, and AI spotlight content (brief, outline, key points, call outcome) from Gong.
 
@@ -302,7 +302,7 @@ Retrieve detailed call data including trackers, topics, highlights, and AI spotl
 |     ↳ `videoUrl` | string | Video download URL |
 | `cursor` | string | Pagination cursor for the next page |
 
-### `gong_list_users`
+### Gong List Users
 
 List all users in your Gong account.
 
@@ -351,7 +351,7 @@ List all users in your Gong account.
 | `currentPageSize` | number | Number of records in the current page |
 | `currentPageNumber` | number | Current page number |
 
-### `gong_get_user`
+### Gong Get User
 
 Retrieve details for a specific user from Gong.
 
@@ -394,7 +394,7 @@ Retrieve details for a specific user from Gong.
 |   ↳ `language` | string | Language code |
 |   ↳ `primary` | boolean | Whether this is the primary language |
 
-### `gong_aggregate_activity`
+### Gong Aggregate Activity
 
 Retrieve aggregated activity statistics for users by date range from Gong.
 
@@ -437,7 +437,7 @@ Retrieve aggregated activity statistics for users by date range from Gong.
 | `toDateTime` | string | End of results in ISO-8601 format |
 | `cursor` | string | Pagination cursor for the next page |
 
-### `gong_day_by_day_activity`
+### Gong Day-by-Day Activity
 
 Retrieve detailed day-by-day activity (call IDs per activity type) for users by date range from Gong.
 
@@ -480,7 +480,7 @@ Retrieve detailed day-by-day activity (call IDs per activity type) for users by 
 |     ↳ `callsMarkedAsFeedbackReceived` | array | IDs of the user's calls marked as reviewed by others |
 | `cursor` | string | Pagination cursor for the next page |
 
-### `gong_aggregate_by_period`
+### Gong Aggregate by Period
 
 Retrieve aggregated user activity grouped into time periods (day, week, month, quarter, year) by date range from Gong.
 
@@ -524,7 +524,7 @@ Retrieve aggregated user activity grouped into time periods (day, week, month, q
 |     ↳ `callsMarkedAsFeedbackReceived` | number | The user's calls marked as reviewed by others |
 | `cursor` | string | Pagination cursor for the next page |
 
-### `gong_interaction_stats`
+### Gong Interaction Stats
 
 Retrieve interaction statistics for users by date range from Gong. Only includes calls with Whisper enabled.
 
@@ -555,7 +555,7 @@ Retrieve interaction statistics for users by date range from Gong. Only includes
 | `toDateTime` | string | End of results in ISO-8601 format |
 | `cursor` | string | Pagination cursor for the next page |
 
-### `gong_answered_scorecards`
+### Gong Answered Scorecards
 
 Retrieve answered scorecards for reviewed users or by date range from Gong.
 
@@ -598,7 +598,7 @@ Retrieve answered scorecards for reviewed users or by date range from Gong.
 |     ↳ `selectedOptions` | array | Identifiers of the options selected for select-type questions, null otherwise |
 | `cursor` | string | Pagination cursor for the next page |
 
-### `gong_list_library_folders`
+### Gong List Library Folders
 
 Retrieve library folders from Gong.
 
@@ -622,7 +622,7 @@ Retrieve library folders from Gong.
 |   ↳ `createdBy` | string | Gong unique numeric identifier for the user who added the folder |
 |   ↳ `updated` | string | Folder's last update time in ISO-8601 format |
 
-### `gong_get_folder_content`
+### Gong Get Folder Content
 
 Retrieve the list of calls in a specific library folder from Gong.
 
@@ -654,7 +654,7 @@ Retrieve the list of calls in a specific library folder from Gong.
 |     ↳ `fromSec` | number | Snippet start in seconds relative to call start |
 |     ↳ `toSec` | number | Snippet end in seconds relative to call start |
 
-### `gong_list_scorecards`
+### Gong List Scorecards
 
 Retrieve scorecard definitions from Gong settings.
 
@@ -692,7 +692,7 @@ Retrieve scorecard definitions from Gong settings.
 |       ↳ `id` | number | Identifier of the option |
 |       ↳ `text` | string | Display text of the option |
 
-### `gong_list_trackers`
+### Gong List Trackers
 
 Retrieve smart tracker and keyword tracker definitions from Gong settings.
 
@@ -729,7 +729,7 @@ Retrieve smart tracker and keyword tracker definitions from Gong settings.
 |   ↳ `updated` | string | Last modification timestamp in ISO-8601 format |
 |   ↳ `updaterUserId` | string | ID of the user who last modified the tracker |
 
-### `gong_list_workspaces`
+### Gong List Workspaces
 
 List all company workspaces in Gong.
 
@@ -750,7 +750,7 @@ List all company workspaces in Gong.
 |   ↳ `name` | string | Display name of the workspace |
 |   ↳ `description` | string | Description of the workspace's purpose or content |
 
-### `gong_list_flows`
+### Gong List Flows
 
 List Gong Engage flows (sales engagement sequences).
 
@@ -782,7 +782,7 @@ List Gong Engage flows (sales engagement sequences).
 | `currentPageNumber` | number | Current page number |
 | `cursor` | string | Pagination cursor for retrieving the next page of records |
 
-### `gong_assign_flow_prospects`
+### Gong Assign Flow Prospects
 
 Assign up to 200 CRM prospects (contacts or leads) to a Gong Engage flow.
 
@@ -818,7 +818,7 @@ Assign up to 200 CRM prospects (contacts or leads) to a Gong Engage flow.
 |   ↳ `errorCode` | string | Failure reason: InvalidArgument, InvalidState, or UnexpectedError |
 |   ↳ `errorMessage` | string | Human-readable failure message |
 
-### `gong_unassign_flow_prospects`
+### Gong Unassign Flow Prospects
 
 Remove a prospect from Gong Engage flows. Omit the flow ID to remove the prospect from all flows they are assigned to.
 
@@ -839,7 +839,7 @@ Remove a prospect from Gong Engage flows. Omit the flow ID to remove the prospec
 | `requestId` | string | A Gong request reference ID for troubleshooting purposes |
 | `unassignedFlowInstanceIds` | array | IDs of the flow instances the prospect was successfully removed from |
 
-### `gong_get_prospect_flows`
+### Gong Get Prospect Flows
 
 Get the Gong Engage flows currently assigned to the given CRM prospects.
 
@@ -868,7 +868,7 @@ Get the Gong Engage flows currently assigned to the given CRM prospects.
 |   ↳ `workspaceId` | string | Workspace ID |
 |   ↳ `exclusive` | boolean | Whether this prospect can be added to other flows |
 
-### `gong_get_coaching`
+### Gong Get Coaching
 
 Retrieve coaching metrics for a manager from Gong.
 
@@ -904,7 +904,7 @@ Retrieve coaching metrics for a manager from Gong.
 |       ↳ `title` | string | Job title of the Gong user |
 |     ↳ `metrics` | json | A map of metric names to arrays of string values representing coaching metrics |
 
-### `gong_ask_anything`
+### Gong Ask Anything
 
 Ask a natural-language question about a CRM account, deal, contact, or lead. Gong answers from up to 60 calls and 500 emails associated with the entity. Consumes Gong credits.
 
@@ -934,7 +934,7 @@ Ask a natural-language question about a CRM account, deal, contact, or lead. Gon
 |   ↳ `callFindings` | array | Evidence from calls used to generate this answer item |
 |   ↳ `emailFindings` | array | Evidence from emails used to generate this answer item |
 
-### `gong_get_brief`
+### Gong Get Brief
 
 Generate an AI brief (configured in Gong Agent Studio) for a CRM account, deal, contact, or lead. Consumes Gong credits.
 
@@ -967,7 +967,7 @@ Generate an AI brief (configured in Gong Agent Studio) for a CRM account, deal, 
 |   ↳ `webFindings` | array | Evidence from web search results used to generate this section |
 |   ↳ `mcpResult` | object | Result from an MCP data source used to generate this section |
 
-### `gong_get_logs`
+### Gong Get Logs
 
 Retrieve Gong log entries of a specific type within a time range.
 
@@ -1002,7 +1002,7 @@ Retrieve Gong log entries of a specific type within a time range.
 | `currentPageSize` | number | Number of records in the current page |
 | `currentPageNumber` | number | Current page number |
 
-### `gong_lookup_email`
+### Gong Lookup Email
 
 Find all references to an email address in Gong (calls, email messages, meetings, CRM data, engagement).
 
@@ -1054,7 +1054,7 @@ Find all references to an email address in Gong (calls, email messages, meetings
 |   ↳ `reportingSystem` | string | Event reporting system |
 |   ↳ `sourceEventId` | string | Source event ID |
 
-### `gong_lookup_phone`
+### Gong Lookup Phone
 
 Find all references to a phone number in Gong (calls, email messages, meetings, CRM data, and associated contacts).
 
@@ -1101,7 +1101,7 @@ Find all references to a phone number in Gong (calls, email messages, meetings, 
 |       ↳ `name` | string | Field name |
 |       ↳ `value` | json | Field value |
 
-### `gong_purge_email_address`
+### Gong Purge Email Address
 
 Erase all Gong data (calls, email messages, leads, contacts) referencing an email address. Asynchronous and irreversible.
 
@@ -1119,7 +1119,7 @@ Erase all Gong data (calls, email messages, leads, contacts) referencing an emai
 | --------- | ---- | ----------- |
 | `requestId` | string | A Gong request reference ID for troubleshooting purposes |
 
-### `gong_purge_phone_number`
+### Gong Purge Phone Number
 
 Erase all Gong data (calls, leads, contacts) referencing a phone number. Asynchronous and irreversible.
 

--- a/apps/docs/content/docs/en/integrations/google_ads.mdx
+++ b/apps/docs/content/docs/en/integrations/google_ads.mdx
@@ -25,7 +25,7 @@ Connect to Google Ads to list accessible accounts, list campaigns, view ad group
 
 ## Actions
 
-### `google_ads_list_customers`
+### List Google Ads Customers
 
 List all Google Ads customer accounts accessible by the authenticated user
 
@@ -42,7 +42,7 @@ List all Google Ads customer accounts accessible by the authenticated user
 | `customerIds` | array | List of accessible customer IDs |
 | `totalCount` | number | Total number of accessible customer accounts |
 
-### `google_ads_search`
+### Google Ads Search (GAQL)
 
 Run a custom Google Ads Query Language (GAQL) query
 
@@ -64,7 +64,7 @@ Run a custom Google Ads Query Language (GAQL) query
 | `totalResultsCount` | number | Total number of matching results |
 | `nextPageToken` | string | Token for the next page of results |
 
-### `google_ads_list_campaigns`
+### List Google Ads Campaigns
 
 List campaigns in a Google Ads account with optional status filtering
 
@@ -92,7 +92,7 @@ List campaigns in a Google Ads account with optional status filtering
 |   ↳ `budgetAmountMicros` | string | Daily budget in micros \(divide by 1,000,000 for currency value\) |
 | `totalCount` | number | Total number of campaigns returned |
 
-### `google_ads_campaign_performance`
+### Google Ads Campaign Performance
 
 Get performance metrics for Google Ads campaigns over a date range
 
@@ -124,7 +124,7 @@ Get performance metrics for Google Ads campaigns over a date range
 |   ↳ `date` | string | Date for this row \(YYYY-MM-DD\) |
 | `totalCount` | number | Total number of result rows |
 
-### `google_ads_list_ad_groups`
+### List Google Ads Ad Groups
 
 List ad groups in a Google Ads campaign
 
@@ -152,7 +152,7 @@ List ad groups in a Google Ads campaign
 |   ↳ `campaignName` | string | Parent campaign name |
 | `totalCount` | number | Total number of ad groups returned |
 
-### `google_ads_ad_performance`
+### Google Ads Ad Performance
 
 Get performance metrics for individual ads over a date range
 

--- a/apps/docs/content/docs/en/integrations/google_appsheet.mdx
+++ b/apps/docs/content/docs/en/integrations/google_appsheet.mdx
@@ -44,7 +44,7 @@ Integrate Google AppSheet into your workflow. Find, add, edit, and delete rows i
 
 ## Actions
 
-### `google_appsheet_find_rows`
+### AppSheet Find Rows
 
 Read rows from an AppSheet table. Omit the selector to return every row, or provide a Selector expression (Filter/Select/OrderBy/Top) to narrow and shape the results.
 
@@ -66,7 +66,7 @@ Read rows from an AppSheet table. Omit the selector to return every row, or prov
 | `metadata` | json | Operation metadata |
 |   ↳ `rowCount` | number | Number of rows returned |
 
-### `google_appsheet_add_rows`
+### AppSheet Add Rows
 
 Add new rows to an AppSheet table. The key column value must be provided explicitly, or omitted when its Initial value expression generates it automatically (e.g. UNIQUEID()).
 
@@ -88,7 +88,7 @@ Add new rows to an AppSheet table. The key column value must be provided explici
 | `metadata` | json | Operation metadata |
 |   ↳ `rowCount` | number | Number of rows added |
 
-### `google_appsheet_edit_rows`
+### AppSheet Edit Rows
 
 Update existing rows in an AppSheet table. Each row must explicitly include the key column name and value, plus any columns to change.
 
@@ -110,7 +110,7 @@ Update existing rows in an AppSheet table. Each row must explicitly include the 
 | `metadata` | json | Operation metadata |
 |   ↳ `rowCount` | number | Number of rows updated |
 
-### `google_appsheet_delete_rows`
+### AppSheet Delete Rows
 
 Delete rows from an AppSheet table. Each row only needs to include the key column name and value.
 

--- a/apps/docs/content/docs/en/integrations/google_bigquery.mdx
+++ b/apps/docs/content/docs/en/integrations/google_bigquery.mdx
@@ -32,7 +32,7 @@ Connect to Google BigQuery to run SQL queries, list datasets and tables, get tab
 
 ## Actions
 
-### `google_bigquery_query`
+### BigQuery Run Query
 
 Run a SQL query against Google BigQuery and return the results
 
@@ -63,7 +63,7 @@ Run a SQL query against Google BigQuery and return the results
 |   ↳ `location` | string | Geographic location of the job |
 | `pageToken` | string | Token for fetching additional result pages |
 
-### `google_bigquery_get_query_results`
+### BigQuery Get Query Results
 
 Fetch results for a previously submitted BigQuery job, or the next page of a Run Query result
 
@@ -95,7 +95,7 @@ Fetch results for a previously submitted BigQuery job, or the next page of a Run
 |   ↳ `location` | string | Geographic location of the job |
 | `pageToken` | string | Token for fetching additional result pages |
 
-### `google_bigquery_list_datasets`
+### BigQuery List Datasets
 
 List all datasets in a Google BigQuery project
 
@@ -118,7 +118,7 @@ List all datasets in a Google BigQuery project
 |   ↳ `location` | string | Geographic location where the data resides |
 | `nextPageToken` | string | Token for fetching next page of results |
 
-### `google_bigquery_create_dataset`
+### BigQuery Create Dataset
 
 Create a new dataset in a Google BigQuery project
 
@@ -143,7 +143,7 @@ Create a new dataset in a Google BigQuery project
 | `location` | string | Geographic location where the data resides |
 | `creationTime` | string | Dataset creation time \(milliseconds since epoch\) |
 
-### `google_bigquery_delete_dataset`
+### BigQuery Delete Dataset
 
 Delete a dataset from a Google BigQuery project
 
@@ -161,7 +161,7 @@ Delete a dataset from a Google BigQuery project
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the dataset was deleted |
 
-### `google_bigquery_list_tables`
+### BigQuery List Tables
 
 List all tables in a Google BigQuery dataset
 
@@ -188,7 +188,7 @@ List all tables in a Google BigQuery dataset
 | `totalItems` | number | Total number of tables in the dataset |
 | `nextPageToken` | string | Token for fetching next page of results |
 
-### `google_bigquery_get_table`
+### BigQuery Get Table
 
 Get metadata and schema for a Google BigQuery table
 
@@ -220,7 +220,7 @@ Get metadata and schema for a Google BigQuery table
 | `lastModifiedTime` | string | Last modification time \(milliseconds since epoch\) |
 | `location` | string | Geographic location where the table resides |
 
-### `google_bigquery_create_table`
+### BigQuery Create Table
 
 Create a new table in a Google BigQuery dataset
 
@@ -252,7 +252,7 @@ Create a new table in a Google BigQuery dataset
 | `creationTime` | string | Table creation time \(milliseconds since epoch\) |
 | `location` | string | Geographic location where the table resides |
 
-### `google_bigquery_delete_table`
+### BigQuery Delete Table
 
 Delete a table from a Google BigQuery dataset
 
@@ -270,7 +270,7 @@ Delete a table from a Google BigQuery dataset
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the table was deleted |
 
-### `google_bigquery_list_table_data`
+### BigQuery List Table Data
 
 Preview rows from a Google BigQuery table without running a query. Pair with Get Table to know the column order.
 
@@ -294,7 +294,7 @@ Preview rows from a Google BigQuery table without running a query. Pair with Get
 | `totalRows` | string | Total number of rows in the table |
 | `pageToken` | string | Token for fetching the next page of results |
 
-### `google_bigquery_insert_rows`
+### BigQuery Insert Rows
 
 Insert rows into a Google BigQuery table using streaming insert
 

--- a/apps/docs/content/docs/en/integrations/google_books.mdx
+++ b/apps/docs/content/docs/en/integrations/google_books.mdx
@@ -30,7 +30,7 @@ Search for books using the Google Books API. Find volumes by title, author, ISBN
 
 ## Actions
 
-### `google_books_volume_search`
+### Google Books Volume Search
 
 Search for books using the Google Books API
 
@@ -71,7 +71,7 @@ Search for books using the Google Books API
 |   ↳ `isbn10` | string | ISBN-10 identifier |
 |   ↳ `isbn13` | string | ISBN-13 identifier |
 
-### `google_books_volume_details`
+### Google Books Volume Details
 
 Get detailed information about a specific book volume
 

--- a/apps/docs/content/docs/en/integrations/google_calendar.mdx
+++ b/apps/docs/content/docs/en/integrations/google_calendar.mdx
@@ -36,7 +36,7 @@ Integrate Google Calendar into the workflow. Can create, read, update, and list 
 
 ## Actions
 
-### `google_calendar_create`
+### Google Calendar Create Event
 
 Create a new event in Google Calendar. Returns API-aligned fields only.
 
@@ -74,7 +74,7 @@ Create a new event in Google Calendar. Returns API-aligned fields only.
 | `creator` | json | Event creator |
 | `organizer` | json | Event organizer |
 
-### `google_calendar_list`
+### Google Calendar List Events
 
 List events from Google Calendar. Returns API-aligned fields only.
 
@@ -99,7 +99,7 @@ List events from Google Calendar. Returns API-aligned fields only.
 | `timeZone` | string | Calendar time zone |
 | `events` | json | List of events |
 
-### `google_calendar_get`
+### Google Calendar Get Event
 
 Get a specific event from Google Calendar. Returns API-aligned fields only.
 
@@ -126,7 +126,7 @@ Get a specific event from Google Calendar. Returns API-aligned fields only.
 | `creator` | json | Event creator |
 | `organizer` | json | Event organizer |
 
-### `google_calendar_update`
+### Google Calendar Update Event
 
 Update an existing event in Google Calendar. Returns API-aligned fields only.
 
@@ -165,7 +165,7 @@ Update an existing event in Google Calendar. Returns API-aligned fields only.
 | `creator` | json | Event creator |
 | `organizer` | json | Event organizer |
 
-### `google_calendar_delete`
+### Google Calendar Delete Event
 
 Delete an event from Google Calendar. Returns API-aligned fields only.
 
@@ -184,7 +184,7 @@ Delete an event from Google Calendar. Returns API-aligned fields only.
 | `eventId` | string | Deleted event ID |
 | `deleted` | boolean | Whether deletion was successful |
 
-### `google_calendar_move`
+### Google Calendar Move Event
 
 Move an event to a different calendar. Returns API-aligned fields only.
 
@@ -213,7 +213,7 @@ Move an event to a different calendar. Returns API-aligned fields only.
 | `creator` | json | Event creator |
 | `organizer` | json | Event organizer |
 
-### `google_calendar_instances`
+### Google Calendar Get Instances
 
 Get instances of a recurring event from Google Calendar. Returns API-aligned fields only.
 
@@ -237,7 +237,7 @@ Get instances of a recurring event from Google Calendar. Returns API-aligned fie
 | `timeZone` | string | Calendar time zone |
 | `instances` | json | List of recurring event instances |
 
-### `google_calendar_list_calendars`
+### Google Calendar List Calendars
 
 List all calendars in the user's calendar list. Returns API-aligned fields only.
 
@@ -269,7 +269,7 @@ List all calendars in the user's calendar list. Returns API-aligned fields only.
 |   ↳ `hidden` | boolean | Whether the calendar is hidden |
 |   ↳ `selected` | boolean | Whether the calendar is selected |
 
-### `google_calendar_quick_add`
+### Google Calendar Quick Add
 
 Create events from natural language text. Returns API-aligned fields only.
 
@@ -298,7 +298,7 @@ Create events from natural language text. Returns API-aligned fields only.
 | `creator` | json | Event creator |
 | `organizer` | json | Event organizer |
 
-### `google_calendar_invite`
+### Google Calendar Invite Attendees
 
 Invite attendees to an existing Google Calendar event. Returns API-aligned fields only.
 
@@ -328,7 +328,7 @@ Invite attendees to an existing Google Calendar event. Returns API-aligned field
 | `creator` | json | Event creator |
 | `organizer` | json | Event organizer |
 
-### `google_calendar_freebusy`
+### Google Calendar Free/Busy
 
 Query free/busy information for one or more Google Calendars. Returns API-aligned fields only.
 
@@ -349,7 +349,7 @@ Query free/busy information for one or more Google Calendars. Returns API-aligne
 | `timeMax` | string | End of the queried time range |
 | `calendars` | json | Per-calendar free/busy data with busy periods and any errors |
 
-### `google_calendar_create_calendar`
+### Google Calendar Create Calendar
 
 Create a new secondary calendar. Returns API-aligned fields only.
 
@@ -372,7 +372,7 @@ Create a new secondary calendar. Returns API-aligned fields only.
 | `location` | string | Calendar location |
 | `timeZone` | string | Calendar time zone |
 
-### `google_calendar_update_calendar`
+### Google Calendar Update Calendar
 
 Update a secondary calendar's metadata. Returns API-aligned fields only.
 
@@ -396,7 +396,7 @@ Update a secondary calendar's metadata. Returns API-aligned fields only.
 | `location` | string | Calendar location |
 | `timeZone` | string | Calendar time zone |
 
-### `google_calendar_delete_calendar`
+### Google Calendar Delete Calendar
 
 Permanently delete a secondary calendar. Returns API-aligned fields only.
 
@@ -413,7 +413,7 @@ Permanently delete a secondary calendar. Returns API-aligned fields only.
 | `calendarId` | string | Deleted calendar ID |
 | `deleted` | boolean | Whether deletion was successful |
 
-### `google_calendar_share_calendar`
+### Google Calendar Share Calendar
 
 Grant a user, group, or domain access to a calendar. Returns API-aligned fields only.
 
@@ -435,7 +435,7 @@ Grant a user, group, or domain access to a calendar. Returns API-aligned fields 
 | `role` | string | Granted access role |
 | `scope` | json | Grantee scope \(type and value\) |
 
-### `google_calendar_update_acl`
+### Google Calendar Update Sharing
 
 Change the access role granted by an existing calendar sharing (ACL) rule. Returns API-aligned fields only.
 
@@ -456,7 +456,7 @@ Change the access role granted by an existing calendar sharing (ACL) rule. Retur
 | `role` | string | Granted access role |
 | `scope` | json | Grantee scope \(type and value\) |
 
-### `google_calendar_list_acl`
+### Google Calendar List Sharing
 
 List the access control rules (sharing) for a calendar. Returns API-aligned fields only.
 
@@ -479,7 +479,7 @@ List the access control rules (sharing) for a calendar. Returns API-aligned fiel
 |   ↳ `role` | string | Access role |
 |   ↳ `scope` | json | Grantee scope \(type and value\) |
 
-### `google_calendar_unshare_calendar`
+### Google Calendar Remove Sharing
 
 Revoke an access control rule (sharing) from a calendar. Returns API-aligned fields only.
 

--- a/apps/docs/content/docs/en/integrations/google_contacts.mdx
+++ b/apps/docs/content/docs/en/integrations/google_contacts.mdx
@@ -31,7 +31,7 @@ Integrate Google Contacts into the workflow. Can create, read, update, delete, l
 
 ## Actions
 
-### `google_contacts_create`
+### Google Contacts Create
 
 Create a new contact in Google Contacts
 
@@ -56,7 +56,7 @@ Create a new contact in Google Contacts
 | `content` | string | Contact creation confirmation message |
 | `metadata` | json | Created contact metadata including resource name and details |
 
-### `google_contacts_get`
+### Google Contacts Get
 
 Get a specific contact from Google Contacts
 
@@ -73,7 +73,7 @@ Get a specific contact from Google Contacts
 | `content` | string | Contact retrieval confirmation message |
 | `metadata` | json | Contact details including name, email, phone, and organization |
 
-### `google_contacts_list`
+### Google Contacts List
 
 List contacts from Google Contacts
 
@@ -92,7 +92,7 @@ List contacts from Google Contacts
 | `content` | string | Summary of found contacts count |
 | `metadata` | json | List of contacts with pagination tokens |
 
-### `google_contacts_search`
+### Google Contacts Search
 
 Search contacts in Google Contacts by name, email, phone, or organization
 
@@ -110,7 +110,7 @@ Search contacts in Google Contacts by name, email, phone, or organization
 | `content` | string | Summary of search results count |
 | `metadata` | json | Search results with matching contacts |
 
-### `google_contacts_update`
+### Google Contacts Update
 
 Update an existing contact in Google Contacts
 
@@ -137,7 +137,7 @@ Update an existing contact in Google Contacts
 | `content` | string | Contact update confirmation message |
 | `metadata` | json | Updated contact metadata |
 
-### `google_contacts_delete`
+### Google Contacts Delete
 
 Delete a contact from Google Contacts
 

--- a/apps/docs/content/docs/en/integrations/google_docs.mdx
+++ b/apps/docs/content/docs/en/integrations/google_docs.mdx
@@ -33,7 +33,7 @@ Integrate Google Docs into the workflow. Read, write, and create documents, inse
 
 ## Actions
 
-### `google_docs_read`
+### Read Google Docs Document
 
 Read content from a Google Docs document
 
@@ -54,7 +54,7 @@ Read content from a Google Docs document
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_write`
+### Write to Google Docs Document
 
 Append content to a Google Docs document. Content is inserted literally; Markdown is not interpreted. For formatted output from Markdown, use the Create operation with the markdown toggle enabled.
 
@@ -76,7 +76,7 @@ Append content to a Google Docs document. Content is inserted literally; Markdow
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_create`
+### Create Google Docs Document
 
 Create a new Google Docs document
 
@@ -100,7 +100,7 @@ Create a new Google Docs document
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_insert_text`
+### Insert Text into Google Docs Document
 
 Insert text at a specific index in a Google Docs document. When no index is provided, text is appended to the end of the document. Text is inserted literally; Markdown is not interpreted.
 
@@ -123,7 +123,7 @@ Insert text at a specific index in a Google Docs document. When no index is prov
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_replace_text`
+### Find and Replace Text in Google Docs Document
 
 Replace all occurrences of a search string with new text across a Google Docs document.
 
@@ -147,7 +147,7 @@ Replace all occurrences of a search string with new text across a Google Docs do
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_insert_table`
+### Insert Table into Google Docs Document
 
 Insert an empty table with the given number of rows and columns into a Google Docs document. When no index is provided, the table is appended to the end of the document.
 
@@ -171,7 +171,7 @@ Insert an empty table with the given number of rows and columns into a Google Do
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_insert_image`
+### Insert Image into Google Docs Document
 
 Insert an inline image from a public URL into a Google Docs document. The image must be publicly accessible and under 50 MB. When no index is provided, the image is appended to the end of the document.
 
@@ -196,7 +196,7 @@ Insert an inline image from a public URL into a Google Docs document. The image 
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_insert_page_break`
+### Insert Page Break into Google Docs Document
 
 Insert a page break into a Google Docs document. When no index is provided, the page break is appended to the end of the document.
 
@@ -218,7 +218,7 @@ Insert a page break into a Google Docs document. When no index is provided, the 
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_update_text_style`
+### Apply Text Style in Google Docs Document
 
 Apply bold, italic, underline, and/or font size to a range of text in a Google Docs document, identified by its start and end character index.
 
@@ -245,7 +245,7 @@ Apply bold, italic, underline, and/or font size to a range of text in a Google D
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_update_paragraph_style`
+### Update Paragraph Style in Google Docs Document
 
 Apply a named paragraph style (such as a heading or title) and/or alignment to the paragraphs overlapping a range of text in a Google Docs document, identified by its start and end character index.
 
@@ -270,7 +270,7 @@ Apply a named paragraph style (such as a heading or title) and/or alignment to t
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_create_paragraph_bullets`
+### Create Paragraph Bullets in Google Docs Document
 
 Add bulleted or numbered list formatting to the paragraphs overlapping a range of text in a Google Docs document, using a chosen bullet glyph preset.
 
@@ -294,7 +294,7 @@ Add bulleted or numbered list formatting to the paragraphs overlapping a range o
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_delete_paragraph_bullets`
+### Delete Paragraph Bullets in Google Docs Document
 
 Remove bullet or numbered list formatting from the paragraphs overlapping a range of text in a Google Docs document, identified by its start and end character index.
 
@@ -317,7 +317,7 @@ Remove bullet or numbered list formatting from the paragraphs overlapping a rang
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_delete_content_range`
+### Delete Content Range in Google Docs Document
 
 Delete all content between a start and end character index in a Google Docs document. The endIndex is exclusive and must be greater than the startIndex.
 
@@ -340,7 +340,7 @@ Delete all content between a start and end character index in a Google Docs docu
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_create_named_range`
+### Create Named Range in Google Docs Document
 
 Create a named range over a span of content in a Google Docs document so it can be referenced or deleted later. The name may be 1-256 characters and need not be unique.
 
@@ -364,7 +364,7 @@ Create a named range over a span of content in a Google Docs document so it can 
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
 
-### `google_docs_delete_named_range`
+### Delete Named Range in Google Docs Document
 
 Delete one or more named ranges from a Google Docs document by their ID or by name. Provide exactly one of namedRangeId or name; deleting by name removes all ranges sharing that name. The content itself is not removed.
 

--- a/apps/docs/content/docs/en/integrations/google_drive.mdx
+++ b/apps/docs/content/docs/en/integrations/google_drive.mdx
@@ -34,7 +34,7 @@ Integrate Google Drive into the workflow. Can create, upload, download, copy, mo
 
 ## Actions
 
-### `google_drive_list`
+### List Google Drive Files
 
 List files and folders in Google Drive with complete metadata
 
@@ -107,7 +107,7 @@ List files and folders in Google Drive with complete metadata
 |   ↳ `linkShareMetadata` | json | Link share metadata |
 | `nextPageToken` | string | Token for fetching the next page of results |
 
-### `google_drive_get_file`
+### Get Google Drive File
 
 Get metadata for a specific file in Google Drive by its ID
 
@@ -146,7 +146,7 @@ Get metadata for a specific file in Google Drive by its ID
 |   ↳ `md5Checksum` | string | MD5 hash |
 |   ↳ `version` | string | Version number |
 
-### `google_drive_get_content`
+### Get Content from Google Drive
 
 Get content from a file in Google Drive with complete metadata (exports Google Workspace files automatically)
 
@@ -218,7 +218,7 @@ Get content from a file in Google Drive with complete metadata (exports Google W
 |   ↳ `linkShareMetadata` | json | Link share metadata |
 |   ↳ `revisions` | json | File revision history \(first 100 revisions only\) |
 
-### `google_drive_create_folder`
+### Create Folder in Google Drive
 
 Create a new folder in Google Drive with complete metadata returned
 
@@ -273,7 +273,7 @@ Create a new folder in Google Drive with complete metadata returned
 |   ↳ `contentRestrictions` | json | Content restrictions |
 |   ↳ `linkShareMetadata` | json | Link share metadata |
 
-### `google_drive_upload`
+### Upload to Google Drive
 
 Upload a file to Google Drive with complete metadata returned
 
@@ -346,7 +346,7 @@ Upload a file to Google Drive with complete metadata returned
 |   ↳ `contentRestrictions` | json | Content restrictions |
 |   ↳ `linkShareMetadata` | json | Link share metadata |
 
-### `google_drive_download`
+### Download File from Google Drive
 
 Download a file from Google Drive with complete metadata (exports Google Workspace files automatically)
 
@@ -419,7 +419,7 @@ Download a file from Google Drive with complete metadata (exports Google Workspa
 |   ↳ `linkShareMetadata` | json | Link share metadata |
 |   ↳ `revisions` | json | File revision history \(first 100 revisions only\) |
 
-### `google_drive_copy`
+### Copy Google Drive File
 
 Create a copy of a file in Google Drive
 
@@ -447,7 +447,7 @@ Create a copy of a file in Google Drive
 |   ↳ `owners` | json | List of file owners |
 |   ↳ `size` | string | File size in bytes |
 
-### `google_drive_move`
+### Move Google Drive File
 
 Move a file or folder to a different folder in Google Drive
 
@@ -475,7 +475,7 @@ Move a file or folder to a different folder in Google Drive
 |   ↳ `owners` | json | List of file owners |
 |   ↳ `size` | string | File size in bytes |
 
-### `google_drive_search`
+### Search Google Drive Files
 
 Search for files in Google Drive using advanced query syntax (e.g., fullText contains, mimeType, modifiedTime, etc.)
 
@@ -520,7 +520,7 @@ Search for files in Google Drive using advanced query syntax (e.g., fullText con
 |   ↳ `version` | string | Version number |
 | `nextPageToken` | string | Token for fetching the next page of results |
 
-### `google_drive_update`
+### Update Google Drive File
 
 Update file metadata in Google Drive (rename, move, star, add description)
 
@@ -550,7 +550,7 @@ Update file metadata in Google Drive (rename, move, star, add description)
 |   ↳ `parents` | json | Parent folder IDs |
 |   ↳ `modifiedTime` | string | Last modification time |
 
-### `google_drive_trash`
+### Trash Google Drive File
 
 Move a file to the trash in Google Drive (can be restored later)
 
@@ -573,7 +573,7 @@ Move a file to the trash in Google Drive (can be restored later)
 |   ↳ `trashedTime` | string | When file was trashed |
 |   ↳ `webViewLink` | string | URL to view in browser |
 
-### `google_drive_untrash`
+### Restore Google Drive File
 
 Restore a file from the trash in Google Drive
 
@@ -596,7 +596,7 @@ Restore a file from the trash in Google Drive
 |   ↳ `webViewLink` | string | URL to view in browser |
 |   ↳ `parents` | json | Parent folder IDs |
 
-### `google_drive_delete`
+### Delete Google Drive File
 
 Permanently delete a file from Google Drive (bypasses trash)
 
@@ -613,7 +613,7 @@ Permanently delete a file from Google Drive (bypasses trash)
 | `deleted` | boolean | Whether the file was successfully deleted |
 | `fileId` | string | The ID of the deleted file |
 
-### `google_drive_share`
+### Share Google Drive File
 
 Share a file with a user, group, domain, or make it public
 
@@ -645,7 +645,7 @@ Share a file with a user, group, domain, or make it public
 |   ↳ `expirationTime` | string | Expiration time |
 |   ↳ `deleted` | boolean | Whether grantee is deleted |
 
-### `google_drive_unshare`
+### Unshare Google Drive File
 
 Remove a permission from a file (revoke access)
 
@@ -664,7 +664,7 @@ Remove a permission from a file (revoke access)
 | `fileId` | string | The ID of the file |
 | `permissionId` | string | The ID of the removed permission |
 
-### `google_drive_list_permissions`
+### List Google Drive Permissions
 
 List all permissions (who has access) for a file in Google Drive
 
@@ -694,7 +694,7 @@ List all permissions (who has access) for a file in Google Drive
 |   ↳ `permissionDetails` | json | Details about inherited permissions |
 | `nextPageToken` | string | Token for fetching the next page of permissions |
 
-### `google_drive_export`
+### Export Google Drive File
 
 Export a Google Workspace file (Docs, Sheets, Slides, Drawings) to a chosen format such as PDF, DOCX, XLSX, or CSV
 
@@ -713,7 +713,7 @@ Export a Google Workspace file (Docs, Sheets, Slides, Drawings) to a chosen form
 | `file` | file | Exported file stored in execution files |
 | `exportedMimeType` | string | The MIME type the file was exported to |
 
-### `google_drive_list_revisions`
+### List Google Drive Revisions
 
 List the revision history of a file in Google Drive
 
@@ -743,7 +743,7 @@ List the revision history of a file in Google Drive
 |   ↳ `exportLinks` | json | Export format links for the revision |
 | `nextPageToken` | string | Token for fetching the next page of revisions |
 
-### `google_drive_get_revision`
+### Get Google Drive Revision
 
 Get metadata for a specific revision of a file in Google Drive
 
@@ -771,7 +771,7 @@ Get metadata for a specific revision of a file in Google Drive
 |   ↳ `size` | string | Size of the revision in bytes |
 |   ↳ `exportLinks` | json | Export format links for the revision |
 
-### `google_drive_list_comments`
+### List Google Drive Comments
 
 List comments on a file in Google Drive
 
@@ -803,7 +803,7 @@ List comments on a file in Google Drive
 |   ↳ `replies` | json | Threaded replies to the comment |
 | `nextPageToken` | string | Token for fetching the next page of comments |
 
-### `google_drive_create_comment`
+### Create Google Drive Comment
 
 Add a comment to a file in Google Drive
 
@@ -832,7 +832,7 @@ Add a comment to a file in Google Drive
 |   ↳ `quotedFileContent` | json | The file content the comment quotes |
 |   ↳ `replies` | json | Threaded replies to the comment |
 
-### `google_drive_delete_comment`
+### Delete Google Drive Comment
 
 Delete a comment from a file in Google Drive
 
@@ -851,7 +851,7 @@ Delete a comment from a file in Google Drive
 | `fileId` | string | The ID of the file |
 | `commentId` | string | The ID of the deleted comment |
 
-### `google_drive_get_about`
+### Get Google Drive Info
 
 Get information about the user and their Google Drive (storage quota, capabilities)
 

--- a/apps/docs/content/docs/en/integrations/google_forms.mdx
+++ b/apps/docs/content/docs/en/integrations/google_forms.mdx
@@ -35,7 +35,7 @@ Integrate Google Forms into your workflow. Read form structure, get responses, c
 
 ## Actions
 
-### `google_forms_get_responses`
+### Google Forms: Get Responses
 
 Retrieve a single response or list responses from a Google Form
 
@@ -66,7 +66,7 @@ Retrieve a single response or list responses from a Google Form
 |   ↳ `answers` | json | Map of question IDs to answer values |
 | `raw` | json | Raw API response data |
 
-### `google_forms_get_form`
+### Google Forms: Get Form
 
 Retrieve a form structure including its items, settings, and metadata
 
@@ -94,7 +94,7 @@ Retrieve a form structure including its items, settings, and metadata
 | `settings` | json | Form settings |
 | `publishSettings` | json | Form publish settings |
 
-### `google_forms_create_form`
+### Google Forms: Create Form
 
 Create a new Google Form with a title
 
@@ -116,7 +116,7 @@ Create a new Google Form with a title
 | `responderUri` | string | The URI to share with responders |
 | `revisionId` | string | The revision ID of the form |
 
-### `google_forms_batch_update`
+### Google Forms: Batch Update
 
 Apply multiple updates to a form (add items, update info, change settings, etc.)
 
@@ -154,7 +154,7 @@ Apply multiple updates to a form (add items, update info, change settings, etc.)
 |       ↳ `isPublished` | boolean | Whether the form is published |
 |       ↳ `isAcceptingResponses` | boolean | Whether the form is accepting responses |
 
-### `google_forms_set_publish_settings`
+### Google Forms: Set Publish Settings
 
 Update the publish settings of a form (publish/unpublish, accept responses)
 
@@ -176,7 +176,7 @@ Update the publish settings of a form (publish/unpublish, accept responses)
 |     ↳ `isPublished` | boolean | Whether the form is published |
 |     ↳ `isAcceptingResponses` | boolean | Whether the form accepts responses |
 
-### `google_forms_create_watch`
+### Google Forms: Create Watch
 
 Create a notification watch for form changes (schema changes or new responses)
 
@@ -200,7 +200,7 @@ Create a notification watch for form changes (schema changes or new responses)
 | `expireTime` | string | When the watch expires \(7 days after creation\) |
 | `state` | string | The watch state \(ACTIVE, SUSPENDED\) |
 
-### `google_forms_list_watches`
+### Google Forms: List Watches
 
 List all notification watches for a form
 
@@ -221,7 +221,7 @@ List all notification watches for a form
 |   ↳ `expireTime` | string | When the watch expires |
 |   ↳ `state` | string | Watch state |
 
-### `google_forms_delete_watch`
+### Google Forms: Delete Watch
 
 Delete a notification watch from a form
 
@@ -238,7 +238,7 @@ Delete a notification watch from a form
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the watch was successfully deleted |
 
-### `google_forms_renew_watch`
+### Google Forms: Renew Watch
 
 Renew a notification watch for another 7 days
 

--- a/apps/docs/content/docs/en/integrations/google_groups.mdx
+++ b/apps/docs/content/docs/en/integrations/google_groups.mdx
@@ -35,7 +35,7 @@ Connect to Google Workspace to create, update, and manage groups and their membe
 
 ## Actions
 
-### `google_groups_list_groups`
+### Google Groups List Groups
 
 List all groups in a Google Workspace domain
 
@@ -56,7 +56,7 @@ List all groups in a Google Workspace domain
 | `groups` | json | Array of group objects |
 | `nextPageToken` | string | Token for fetching next page of results |
 
-### `google_groups_get_group`
+### Google Groups Get Group
 
 Get details of a specific Google Group by email or group ID
 
@@ -72,7 +72,7 @@ Get details of a specific Google Group by email or group ID
 | --------- | ---- | ----------- |
 | `group` | json | Group object |
 
-### `google_groups_create_group`
+### Google Groups Create Group
 
 Create a new Google Group in the domain
 
@@ -90,7 +90,7 @@ Create a new Google Group in the domain
 | --------- | ---- | ----------- |
 | `group` | json | Created group object |
 
-### `google_groups_update_group`
+### Google Groups Update Group
 
 Update an existing Google Group
 
@@ -109,7 +109,7 @@ Update an existing Google Group
 | --------- | ---- | ----------- |
 | `group` | json | Updated group object |
 
-### `google_groups_delete_group`
+### Google Groups Delete Group
 
 Delete a Google Group
 
@@ -125,7 +125,7 @@ Delete a Google Group
 | --------- | ---- | ----------- |
 | `message` | string | Success message |
 
-### `google_groups_list_members`
+### Google Groups List Members
 
 List all members of a Google Group
 
@@ -145,7 +145,7 @@ List all members of a Google Group
 | `members` | json | Array of member objects |
 | `nextPageToken` | string | Token for fetching next page of results |
 
-### `google_groups_get_member`
+### Google Groups Get Member
 
 Get details of a specific member in a Google Group
 
@@ -162,7 +162,7 @@ Get details of a specific member in a Google Group
 | --------- | ---- | ----------- |
 | `member` | json | Member object |
 
-### `google_groups_add_member`
+### Google Groups Add Member
 
 Add a new member to a Google Group
 
@@ -180,7 +180,7 @@ Add a new member to a Google Group
 | --------- | ---- | ----------- |
 | `member` | json | Added member object |
 
-### `google_groups_remove_member`
+### Google Groups Remove Member
 
 Remove a member from a Google Group
 
@@ -197,7 +197,7 @@ Remove a member from a Google Group
 | --------- | ---- | ----------- |
 | `message` | string | Success message |
 
-### `google_groups_update_member`
+### Google Groups Update Member
 
 Update a member's role in a Google Group (promote or demote)
 
@@ -215,7 +215,7 @@ Update a member's role in a Google Group (promote or demote)
 | --------- | ---- | ----------- |
 | `member` | json | Updated member object |
 
-### `google_groups_has_member`
+### Google Groups Has Member
 
 Check if a user is a member of a Google Group
 
@@ -232,7 +232,7 @@ Check if a user is a member of a Google Group
 | --------- | ---- | ----------- |
 | `isMember` | boolean | Whether the user is a member of the group |
 
-### `google_groups_list_aliases`
+### Google Groups List Aliases
 
 List all email aliases for a Google Group
 
@@ -253,7 +253,7 @@ List all email aliases for a Google Group
 |   ↳ `kind` | string | API resource type |
 |   ↳ `etag` | string | Resource version identifier |
 
-### `google_groups_add_alias`
+### Google Groups Add Alias
 
 Add an email alias to a Google Group
 
@@ -274,7 +274,7 @@ Add an email alias to a Google Group
 | `kind` | string | API resource type |
 | `etag` | string | Resource version identifier |
 
-### `google_groups_remove_alias`
+### Google Groups Remove Alias
 
 Remove an email alias from a Google Group
 
@@ -291,7 +291,7 @@ Remove an email alias from a Google Group
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the alias was successfully deleted |
 
-### `google_groups_get_settings`
+### Google Groups Get Settings
 
 Get the settings for a Google Group including access permissions, moderation, and posting options
 
@@ -339,7 +339,7 @@ Get the settings for a Google Group including access permissions, moderation, an
 | `whoCanDiscoverGroup` | string | Who can discover the group |
 | `defaultSender` | string | Default sender identity \(DEFAULT_SELF or GROUP\) |
 
-### `google_groups_update_settings`
+### Google Groups Update Settings
 
 Update the settings for a Google Group including access permissions, moderation, and posting options
 

--- a/apps/docs/content/docs/en/integrations/google_maps.mdx
+++ b/apps/docs/content/docs/en/integrations/google_maps.mdx
@@ -38,7 +38,7 @@ Integrate Google Maps Platform APIs into your workflow. Supports geocoding addre
 
 ## Actions
 
-### `google_maps_air_quality`
+### Google Maps Air Quality
 
 Get current air quality data for a location
 
@@ -75,7 +75,7 @@ Get current air quality data for a location
 |   ↳ `additionalInfo` | object | Additional info about sources and effects |
 | `healthRecommendations` | object | Health recommendations for different populations |
 
-### `google_maps_directions`
+### Google Maps Directions
 
 Get directions and route information between two locations
 
@@ -120,7 +120,7 @@ Get directions and route information between two locations
 |   ↳ `maneuver` | string | Maneuver type \(turn-left, etc.\) |
 | `polyline` | string | Encoded polyline for the primary route |
 
-### `google_maps_distance_matrix`
+### Google Maps Distance Matrix
 
 Calculate travel distance and time between multiple origins and destinations
 
@@ -152,7 +152,7 @@ Calculate travel distance and time between multiple origins and destinations
 |     ↳ `durationInTrafficSeconds` | number | Duration in traffic in seconds |
 |     ↳ `status` | string | Element status \(OK, NOT_FOUND, ZERO_RESULTS\) |
 
-### `google_maps_elevation`
+### Google Maps Elevation
 
 Get elevation data for a location
 
@@ -173,7 +173,7 @@ Get elevation data for a location
 | `lng` | number | Longitude of the elevation sample |
 | `resolution` | number | Maximum distance between data points \(meters\) from which elevation was interpolated |
 
-### `google_maps_geocode`
+### Google Maps Geocode
 
 Convert an address into geographic coordinates (latitude and longitude)
 
@@ -201,7 +201,7 @@ Convert an address into geographic coordinates (latitude and longitude)
 |   ↳ `types` | array | Component types |
 | `locationType` | string | Location accuracy type \(ROOFTOP, RANGE_INTERPOLATED, etc.\) |
 
-### `google_maps_geolocate`
+### Google Maps Geolocate
 
 Geolocate a device using WiFi access points, cell towers, or IP address
 
@@ -226,7 +226,7 @@ Geolocate a device using WiFi access points, cell towers, or IP address
 | `lng` | number | Longitude coordinate |
 | `accuracy` | number | Accuracy radius in meters |
 
-### `google_maps_place_details`
+### Google Maps Place Details
 
 Get detailed information about a specific place
 
@@ -275,7 +275,7 @@ Get detailed information about a specific place
 | `vicinity` | string | Simplified address \(neighborhood/street\) |
 | `businessStatus` | string | Business status \(OPERATIONAL, CLOSED_TEMPORARILY, CLOSED_PERMANENTLY\) |
 
-### `google_maps_places_nearby`
+### Google Maps Places Nearby Search
 
 Search for places of a given type within a radius of a location
 
@@ -310,7 +310,7 @@ Search for places of a given type within a radius of a location
 |   ↳ `openNow` | boolean | Whether currently open |
 |   ↳ `businessStatus` | string | Business status |
 
-### `google_maps_places_search`
+### Google Maps Places Search
 
 Search for places using a text query
 
@@ -346,7 +346,7 @@ Search for places using a text query
 |   ↳ `businessStatus` | string | Business status |
 | `nextPageToken` | string | Token for fetching the next page of results |
 
-### `google_maps_pollen`
+### Google Maps Pollen
 
 Get a daily pollen forecast (grass, tree, weed) for a location
 
@@ -381,7 +381,7 @@ Get a daily pollen forecast (grass, tree, weed) for a location
 |     ↳ `indexInfo` | object | Universal Pollen Index \(UPI\) info |
 |     ↳ `plantDescription` | object | Plant details \(type, family, season, cross-reactions\) |
 
-### `google_maps_reverse_geocode`
+### Google Maps Reverse Geocode
 
 Convert geographic coordinates (latitude and longitude) into a human-readable address
 
@@ -406,7 +406,7 @@ Convert geographic coordinates (latitude and longitude) into a human-readable ad
 |   ↳ `types` | array | Component types |
 | `types` | array | Address types \(e.g., street_address, route\) |
 
-### `google_maps_snap_to_roads`
+### Google Maps Snap to Roads
 
 Snap GPS coordinates to the nearest road segment
 
@@ -430,7 +430,7 @@ Snap GPS coordinates to the nearest road segment
 |   ↳ `placeId` | string | Place ID for this road segment |
 | `warningMessage` | string | Warning message if any \(e.g., if points could not be snapped\) |
 
-### `google_maps_solar`
+### Google Maps Solar
 
 Get solar potential and panel insights for the building nearest a location
 
@@ -458,7 +458,7 @@ Get solar potential and panel insights for the building nearest a location
 | `administrativeArea` | string | Administrative area \(e.g., state or province\) |
 | `solarPotential` | object | Solar potential: max panel count/area, sunshine hours, carbon offset, panel specs, and configs |
 
-### `google_maps_speed_limits`
+### Google Maps Speed Limits
 
 Get speed limits for road segments. Requires either path coordinates or placeIds.
 
@@ -486,7 +486,7 @@ Get speed limits for road segments. Requires either path coordinates or placeIds
 |   ↳ `originalIndex` | number | Index in the original path |
 |   ↳ `placeId` | string | Place ID for this road segment |
 
-### `google_maps_timezone`
+### Google Maps Timezone
 
 Get timezone information for a location
 
@@ -511,7 +511,7 @@ Get timezone information for a location
 | `totalOffsetSeconds` | number | Total UTC offset in seconds \(rawOffset + dstOffset\) |
 | `totalOffsetHours` | number | Total UTC offset in hours \(e.g., -5 for EST, -4 for EDT\) |
 
-### `google_maps_validate_address`
+### Google Maps Validate Address
 
 Validate and standardize a postal address
 

--- a/apps/docs/content/docs/en/integrations/google_meet.mdx
+++ b/apps/docs/content/docs/en/integrations/google_meet.mdx
@@ -35,7 +35,7 @@ Integrate Google Meet into your workflow. Create meeting spaces, get space detai
 
 ## Actions
 
-### `google_meet_create_space`
+### Google Meet Create Space
 
 Create a new Google Meet meeting space
 
@@ -56,7 +56,7 @@ Create a new Google Meet meeting space
 | `accessType` | string | Access type configuration |
 | `entryPointAccess` | string | Entry point access configuration |
 
-### `google_meet_get_space`
+### Google Meet Get Space
 
 Get details of a Google Meet meeting space by name or meeting code
 
@@ -77,7 +77,7 @@ Get details of a Google Meet meeting space by name or meeting code
 | `entryPointAccess` | string | Entry point access configuration |
 | `activeConference` | string | Active conference record name |
 
-### `google_meet_end_conference`
+### Google Meet End Conference
 
 End the active conference in a Google Meet space
 
@@ -93,7 +93,7 @@ End the active conference in a Google Meet space
 | --------- | ---- | ----------- |
 | `ended` | boolean | Whether the conference was ended successfully |
 
-### `google_meet_list_conference_records`
+### Google Meet List Conference Records
 
 List conference records for meetings you organized
 
@@ -112,7 +112,7 @@ List conference records for meetings you organized
 | `conferenceRecords` | json | List of conference records with name, start/end times, and space |
 | `nextPageToken` | string | Token for next page of results |
 
-### `google_meet_get_conference_record`
+### Google Meet Get Conference Record
 
 Get details of a specific conference record
 
@@ -132,7 +132,7 @@ Get details of a specific conference record
 | `expireTime` | string | Conference record expiration time |
 | `space` | string | Associated space resource name |
 
-### `google_meet_list_participants`
+### Google Meet List Participants
 
 List participants of a conference record
 

--- a/apps/docs/content/docs/en/integrations/google_pagespeed.mdx
+++ b/apps/docs/content/docs/en/integrations/google_pagespeed.mdx
@@ -42,7 +42,7 @@ Analyze web pages for performance, accessibility, SEO, and best practices using 
 
 ## Actions
 
-### `google_pagespeed_analyze`
+### Google PageSpeed Analyze
 
 Analyze a webpage for performance, accessibility, SEO, and best practices using Google PageSpeed Insights.
 

--- a/apps/docs/content/docs/en/integrations/google_search.mdx
+++ b/apps/docs/content/docs/en/integrations/google_search.mdx
@@ -29,7 +29,7 @@ Integrate Google Search into the workflow. Can search the web.
 
 ## Actions
 
-### `google_search`
+### Google Search
 
 Search the web with the Custom Search API
 

--- a/apps/docs/content/docs/en/integrations/google_sheets.mdx
+++ b/apps/docs/content/docs/en/integrations/google_sheets.mdx
@@ -36,7 +36,7 @@ Integrate Google Sheets into the workflow with explicit sheet selection. Can rea
 
 ## Actions
 
-### `google_sheets_read`
+### Read from Google Sheets V2
 
 Read data from a specific sheet in a Google Sheets spreadsheet
 
@@ -62,7 +62,7 @@ Read data from a specific sheet in a Google Sheets spreadsheet
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_write`
+### Write to Google Sheets V2
 
 Write data to a specific sheet in a Google Sheets spreadsheet
 
@@ -89,7 +89,7 @@ Write data to a specific sheet in a Google Sheets spreadsheet
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_update`
+### Update Google Sheets V2
 
 Update data in a specific sheet in a Google Sheets spreadsheet
 
@@ -116,7 +116,7 @@ Update data in a specific sheet in a Google Sheets spreadsheet
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_append`
+### Append to Google Sheets V2
 
 Append data to the end of a specific sheet in a Google Sheets spreadsheet
 
@@ -144,7 +144,7 @@ Append data to the end of a specific sheet in a Google Sheets spreadsheet
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_clear`
+### Clear Google Sheets Range V2
 
 Clear values from a specific range in a Google Sheets spreadsheet
 
@@ -166,7 +166,7 @@ Clear values from a specific range in a Google Sheets spreadsheet
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_get_spreadsheet`
+### Get Spreadsheet Info V2
 
 Get metadata about a Google Sheets spreadsheet including title and sheet list
 
@@ -194,7 +194,7 @@ Get metadata about a Google Sheets spreadsheet including title and sheet list
 |   ↳ `columnCount` | number | Number of columns in the sheet |
 |   ↳ `hidden` | boolean | Whether the sheet is hidden |
 
-### `google_sheets_create_spreadsheet`
+### Create Spreadsheet V2
 
 Create a new Google Sheets spreadsheet
 
@@ -219,7 +219,7 @@ Create a new Google Sheets spreadsheet
 |   ↳ `title` | string | The sheet title/name |
 |   ↳ `index` | number | The sheet index \(position\) |
 
-### `google_sheets_batch_get`
+### Batch Read Google Sheets V2
 
 Read multiple ranges from a Google Sheets spreadsheet in a single request
 
@@ -245,7 +245,7 @@ Read multiple ranges from a Google Sheets spreadsheet in a single request
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_batch_update`
+### Batch Update Google Sheets V2
 
 Update multiple ranges in a Google Sheets spreadsheet in a single request
 
@@ -276,7 +276,7 @@ Update multiple ranges in a Google Sheets spreadsheet in a single request
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_batch_clear`
+### Batch Clear Google Sheets V2
 
 Clear multiple ranges in a Google Sheets spreadsheet in a single request
 
@@ -297,7 +297,7 @@ Clear multiple ranges in a Google Sheets spreadsheet in a single request
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_copy_sheet`
+### Copy Sheet V2
 
 Copy a sheet from one spreadsheet to another
 
@@ -320,7 +320,7 @@ Copy a sheet from one spreadsheet to another
 | `destinationSpreadsheetId` | string | The ID of the destination spreadsheet |
 | `destinationSpreadsheetUrl` | string | URL to the destination spreadsheet |
 
-### `google_sheets_delete_rows`
+### Delete Rows from Google Sheets V2
 
 Delete rows from a sheet in a Google Sheets spreadsheet
 
@@ -344,7 +344,7 @@ Delete rows from a sheet in a Google Sheets spreadsheet
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_delete_sheet`
+### Delete Sheet V2
 
 Delete a sheet/tab from a Google Sheets spreadsheet
 
@@ -365,7 +365,7 @@ Delete a sheet/tab from a Google Sheets spreadsheet
 |   ↳ `spreadsheetId` | string | Google Sheets spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `google_sheets_delete_spreadsheet`
+### Delete Spreadsheet V2
 
 Permanently delete a Google Sheets spreadsheet using the Google Drive API
 

--- a/apps/docs/content/docs/en/integrations/google_slides.mdx
+++ b/apps/docs/content/docs/en/integrations/google_slides.mdx
@@ -36,7 +36,7 @@ Build, edit, and export branded Google Slides presentations end-to-end. Copy a t
 
 ## Actions
 
-### `google_slides_read`
+### Read Google Slides Presentation
 
 Read content from a Google Slides presentation
 
@@ -60,7 +60,7 @@ Read content from a Google Slides presentation
 |   ↳ `mimeType` | string | The mime type of the presentation |
 |   ↳ `url` | string | URL to open the presentation |
 
-### `google_slides_write`
+### Write to Google Slides Presentation
 
 Write or update content in a Google Slides presentation
 
@@ -83,7 +83,7 @@ Write or update content in a Google Slides presentation
 |   ↳ `mimeType` | string | The mime type of the presentation |
 |   ↳ `url` | string | URL to open the presentation |
 
-### `google_slides_create`
+### Create Google Slides Presentation
 
 Create a new Google Slides presentation
 
@@ -106,7 +106,7 @@ Create a new Google Slides presentation
 |   ↳ `mimeType` | string | The mime type of the presentation |
 |   ↳ `url` | string | URL to open the presentation |
 
-### `google_slides_replace_all_text`
+### Replace All Text in Google Slides
 
 Find and replace all occurrences of text throughout a Google Slides presentation
 
@@ -131,7 +131,7 @@ Find and replace all occurrences of text throughout a Google Slides presentation
 |   ↳ `replaceText` | string | The text that replaced the matches |
 |   ↳ `url` | string | URL to open the presentation |
 
-### `google_slides_add_slide`
+### Add Slide to Google Slides
 
 Add a new slide to a Google Slides presentation with a specified layout
 
@@ -155,7 +155,7 @@ Add a new slide to a Google Slides presentation with a specified layout
 |   ↳ `insertionIndex` | number | The zero-based index where the slide was inserted |
 |   ↳ `url` | string | URL to open the presentation |
 
-### `google_slides_add_image`
+### Add Image to Google Slides
 
 Insert an image into a specific slide in a Google Slides presentation
 
@@ -182,7 +182,7 @@ Insert an image into a specific slide in a Google Slides presentation
 |   ↳ `imageUrl` | string | The source image URL |
 |   ↳ `url` | string | URL to open the presentation |
 
-### `google_slides_get_thumbnail`
+### Get Slide Thumbnail
 
 Generate a thumbnail image of a specific slide in a Google Slides presentation
 
@@ -208,7 +208,7 @@ Generate a thumbnail image of a specific slide in a Google Slides presentation
 |   ↳ `thumbnailSize` | string | The requested thumbnail size |
 |   ↳ `mimeType` | string | The thumbnail MIME type |
 
-### `google_slides_get_page`
+### Get Slide Page
 
 Get detailed information about a specific slide/page in a Google Slides presentation
 
@@ -234,7 +234,7 @@ Get detailed information about a specific slide/page in a Google Slides presenta
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_delete_object`
+### Delete Object from Google Slides
 
 Delete a page element (shape, image, table, etc.) or an entire slide from a Google Slides presentation
 
@@ -255,7 +255,7 @@ Delete a page element (shape, image, table, etc.) or an entire slide from a Goog
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_duplicate_object`
+### Duplicate Object in Google Slides
 
 Duplicate an object (slide, shape, image, table, etc.) in a Google Slides presentation
 
@@ -277,7 +277,7 @@ Duplicate an object (slide, shape, image, table, etc.) in a Google Slides presen
 |   ↳ `sourceObjectId` | string | The original object ID that was duplicated |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_slides_position`
+### Reorder Slides in Google Slides
 
 Move one or more slides to a new position in a Google Slides presentation
 
@@ -300,7 +300,7 @@ Move one or more slides to a new position in a Google Slides presentation
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_create_table`
+### Create Table in Google Slides
 
 Create a new table on a slide in a Google Slides presentation
 
@@ -329,7 +329,7 @@ Create a new table on a slide in a Google Slides presentation
 |   ↳ `pageObjectId` | string | The page object ID where the table was created |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_create_shape`
+### Create Shape in Google Slides
 
 Create a shape (rectangle, ellipse, text box, arrow, etc.) on a slide in a Google Slides presentation
 
@@ -356,7 +356,7 @@ Create a shape (rectangle, ellipse, text box, arrow, etc.) on a slide in a Googl
 |   ↳ `pageObjectId` | string | The page object ID where the shape was created |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_insert_text`
+### Insert Text in Google Slides
 
 Insert text into a shape or table cell in a Google Slides presentation. Use this to add text to text boxes, shapes, or table cells.
 
@@ -380,7 +380,7 @@ Insert text into a shape or table cell in a Google Slides presentation. Use this
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_text_style`
+### Update Text Style in Google Slides
 
 Update the styling of text in a shape or table cell (bold, italic, font family, font size, foreground/background color, link, etc.). Only the fields you set are applied.
 
@@ -420,7 +420,7 @@ Update the styling of text in a shape or table cell (bold, italic, font family, 
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_paragraph_style`
+### Update Paragraph Style in Google Slides
 
 Update paragraph styling — alignment, line spacing, indents, space above/below — for text in a shape or table cell.
 
@@ -458,7 +458,7 @@ Update paragraph styling — alignment, line spacing, indents, space above/below
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_delete_text`
+### Delete Text in Google Slides
 
 Delete text from a shape or table cell. Use range type ALL to clear all text, or FIXED_RANGE / FROM_START_INDEX to delete a specific span.
 
@@ -484,7 +484,7 @@ Delete text from a shape or table cell. Use range type ALL to clear all text, or
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_create_paragraph_bullets`
+### Create Paragraph Bullets in Google Slides
 
 Convert paragraphs in a shape or table cell into a bulleted or numbered list using a Google Slides bullet preset.
 
@@ -511,7 +511,7 @@ Convert paragraphs in a shape or table cell into a bulleted or numbered list usi
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_delete_paragraph_bullets`
+### Delete Paragraph Bullets in Google Slides
 
 Remove bullets/numbering from paragraphs in a shape or table cell.
 
@@ -537,7 +537,7 @@ Remove bullets/numbering from paragraphs in a shape or table cell.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_replace_all_shapes_with_image`
+### Replace All Shapes With Image in Google Slides
 
 Find every shape whose text matches the given token (e.g. \{\{cover-image\}\}) and replace it with an image, preserving the shape's position and bounds.
 
@@ -563,7 +563,7 @@ Find every shape whose text matches the given token (e.g. \{\{cover-image\}\}) a
 |   ↳ `imageUrl` | string | The image URL inserted |
 |   ↳ `findText` | string | The matched text token |
 
-### `google_slides_replace_image`
+### Replace Image in Google Slides
 
 Replace the source of an existing image with a new image URL, preserving the image's position, size, and properties.
 
@@ -587,7 +587,7 @@ Replace the source of an existing image with a new image URL, preserving the ima
 |   ↳ `url` | string | URL to the presentation |
 |   ↳ `imageUrl` | string | The new image URL |
 
-### `google_slides_update_image_properties`
+### Update Image Properties in Google Slides
 
 Update image properties — brightness, contrast, transparency, crop, outline, link — on an existing image.
 
@@ -623,7 +623,7 @@ Update image properties — brightness, contrast, transparency, crop, outline, l
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_shape_properties`
+### Update Shape Properties in Google Slides
 
 Update a shape's appearance — background fill color, outline, link, content alignment, autofit. Pass only the properties you want to change.
 
@@ -657,7 +657,7 @@ Update a shape's appearance — background fill color, outline, link, content al
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_page_properties`
+### Update Page Properties in Google Slides
 
 Update slide/page background — solid color or stretched picture — and other page properties.
 
@@ -685,7 +685,7 @@ Update slide/page background — solid color or stretched picture — and other 
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_slide_properties`
+### Update Slide Properties in Google Slides
 
 Update slide-specific properties such as whether the slide is skipped during presentation.
 
@@ -710,7 +710,7 @@ Update slide-specific properties such as whether the slide is skipped during pre
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_page_element_alt_text`
+### Update Alt Text in Google Slides
 
 Set the accessibility title and/or description (alt text) of a page element such as an image, shape, or group.
 
@@ -733,7 +733,7 @@ Set the accessibility title and/or description (alt text) of a page element such
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_page_element_transform`
+### Update Page Element Transform in Google Slides
 
 Move, resize, scale, or shear a page element. Translate is specified in points; applyMode controls whether the transform is absolute (default) or relative (multiplied with the current transform).
 
@@ -761,7 +761,7 @@ Move, resize, scale, or shear a page element. Translate is specified in points; 
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_page_elements_z_order`
+### Update Z-Order in Google Slides
 
 Bring elements to front, send to back, or step them one layer forward/backward.
 
@@ -784,7 +784,7 @@ Bring elements to front, send to back, or step them one layer forward/backward.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_group_objects`
+### Group Objects in Google Slides
 
 Group two or more page elements on the same slide into a single object group.
 
@@ -807,7 +807,7 @@ Group two or more page elements on the same slide into a single object group.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_ungroup_objects`
+### Ungroup Objects in Google Slides
 
 Ungroup one or more object groups, releasing their children back to the slide.
 
@@ -828,7 +828,7 @@ Ungroup one or more object groups, releasing their children back to the slide.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_create_line`
+### Create Line in Google Slides
 
 Create a line or connector on a slide.
 
@@ -855,7 +855,7 @@ Create a line or connector on a slide.
 |   ↳ `pageObjectId` | string | The slide ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_line_properties`
+### Update Line Properties in Google Slides
 
 Update line appearance — color, weight, dash style, arrows, link.
 
@@ -885,7 +885,7 @@ Update line appearance — color, weight, dash style, arrows, link.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_line_category`
+### Update Line Category in Google Slides
 
 Change a connector line's category (STRAIGHT, BENT, or CURVED).
 
@@ -908,7 +908,7 @@ Change a connector line's category (STRAIGHT, BENT, or CURVED).
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_reroute_line`
+### Reroute Line in Google Slides
 
 Reroute a connector line so it efficiently connects its endpoint shapes — useful after moving the shapes the line connects.
 
@@ -929,7 +929,7 @@ Reroute a connector line so it efficiently connects its endpoint shapes — usef
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_insert_table_rows`
+### Insert Table Rows in Google Slides
 
 Insert one or more rows into a table, above or below a reference cell.
 
@@ -955,7 +955,7 @@ Insert one or more rows into a table, above or below a reference cell.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_insert_table_columns`
+### Insert Table Columns in Google Slides
 
 Insert one or more columns into a table, left or right of a reference cell.
 
@@ -981,7 +981,7 @@ Insert one or more columns into a table, left or right of a reference cell.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_delete_table_row`
+### Delete Table Row in Google Slides
 
 Delete the row containing the reference cell from a table.
 
@@ -1004,7 +1004,7 @@ Delete the row containing the reference cell from a table.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_delete_table_column`
+### Delete Table Column in Google Slides
 
 Delete the column containing the reference cell from a table.
 
@@ -1027,7 +1027,7 @@ Delete the column containing the reference cell from a table.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_merge_table_cells`
+### Merge Table Cells in Google Slides
 
 Merge a rectangular range of table cells into a single cell. The range starts at (rowIndex, columnIndex) and covers rowSpan × columnSpan cells.
 
@@ -1052,7 +1052,7 @@ Merge a rectangular range of table cells into a single cell. The range starts at
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_unmerge_table_cells`
+### Unmerge Table Cells in Google Slides
 
 Unmerge any merged cells within the given table range.
 
@@ -1077,7 +1077,7 @@ Unmerge any merged cells within the given table range.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_table_cell_properties`
+### Update Table Cell Properties in Google Slides
 
 Update background fill and content alignment for a range of table cells.
 
@@ -1108,7 +1108,7 @@ Update background fill and content alignment for a range of table cells.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_table_border_properties`
+### Update Table Border Properties in Google Slides
 
 Update border color, weight, and dash style for a position (e.g. ALL, INNER, OUTER) in a table range.
 
@@ -1140,7 +1140,7 @@ Update border color, weight, and dash style for a position (e.g. ALL, INNER, OUT
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_table_column_properties`
+### Update Table Column Properties in Google Slides
 
 Update column widths and other column-level table properties.
 
@@ -1166,7 +1166,7 @@ Update column widths and other column-level table properties.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_table_row_properties`
+### Update Table Row Properties in Google Slides
 
 Update minimum row heights and other row-level table properties.
 
@@ -1192,7 +1192,7 @@ Update minimum row heights and other row-level table properties.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_create_sheets_chart`
+### Embed Google Sheets Chart in Slides
 
 Embed a chart from a Google Sheets spreadsheet onto a slide. LINKED charts can be refreshed; NOT_LINKED_IMAGE inserts a static image of the chart.
 
@@ -1220,7 +1220,7 @@ Embed a chart from a Google Sheets spreadsheet onto a slide. LINKED charts can b
 |   ↳ `pageObjectId` | string | The slide ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_refresh_sheets_chart`
+### Refresh Sheets Chart in Slides
 
 Refresh an embedded linked Sheets chart so it reflects the latest spreadsheet data.
 
@@ -1241,7 +1241,7 @@ Refresh an embedded linked Sheets chart so it reflects the latest spreadsheet da
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_replace_all_shapes_with_sheets_chart`
+### Replace All Shapes With Sheets Chart in Slides
 
 Find every shape matching a text token (e.g. \{\{revenue-chart\}\}) and replace each with the same embedded Sheets chart, preserving the shape's position and bounds.
 
@@ -1269,7 +1269,7 @@ Find every shape matching a text token (e.g. \{\{revenue-chart\}\}) and replace 
 |   ↳ `spreadsheetId` | string | Source spreadsheet ID |
 |   ↳ `chartId` | number | Source chart ID |
 
-### `google_slides_create_video`
+### Embed Video in Google Slides
 
 Embed a YouTube or Google Drive video on a slide.
 
@@ -1296,7 +1296,7 @@ Embed a YouTube or Google Drive video on a slide.
 |   ↳ `pageObjectId` | string | The slide ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_update_video_properties`
+### Update Video Properties in Google Slides
 
 Update video playback options (autoPlay, mute, start/end) and outline.
 
@@ -1327,7 +1327,7 @@ Update video playback options (autoPlay, mute, start/end) and outline.
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 
-### `google_slides_batch_update`
+### Batch Update Google Slides (Raw)
 
 Run a raw Slides API batchUpdate with a list of Request objects. Use this when the higher-level tools do not cover an operation, or to bundle multiple operations into a single atomic batch (all-or-nothing).
 
@@ -1350,7 +1350,7 @@ Run a raw Slides API batchUpdate with a list of Request objects. Use this when t
 |   ↳ `url` | string | URL to the presentation |
 |   ↳ `requestCount` | number | Number of replies returned |
 
-### `google_slides_copy_presentation`
+### Copy Google Slides Presentation
 
 Copy a template presentation in Drive to a new file. Use this before merging data so the original template is never modified.
 
@@ -1375,7 +1375,7 @@ Copy a template presentation in Drive to a new file. Use this before merging dat
 |   ↳ `mimeType` | string | MIME type of the presentation |
 |   ↳ `url` | string | URL to the new presentation |
 
-### `google_slides_export_presentation`
+### Export Google Slides Presentation
 
 Export a presentation to PDF, PPTX, ODP, TXT, PNG, JPEG, or SVG via the Drive export endpoint. Stores the exported file as an execution file when execution context is available.
 

--- a/apps/docs/content/docs/en/integrations/google_tasks.mdx
+++ b/apps/docs/content/docs/en/integrations/google_tasks.mdx
@@ -34,7 +34,7 @@ Integrate Google Tasks into your workflow. Create, read, update, delete, and lis
 
 ## Actions
 
-### `google_tasks_create`
+### Google Tasks Create Task
 
 Create a new task in a Google Tasks list
 
@@ -67,7 +67,7 @@ Create a new task in a Google Tasks list
 | `completed` | string | Completion date |
 | `deleted` | boolean | Whether the task is deleted |
 
-### `google_tasks_list`
+### Google Tasks List Tasks
 
 List all tasks in a Google Tasks list
 
@@ -111,7 +111,7 @@ List all tasks in a Google Tasks list
 |     ↳ `link` | string | The URL |
 | `nextPageToken` | string | Token for retrieving the next page of results |
 
-### `google_tasks_get`
+### Google Tasks Get Task
 
 Retrieve a specific task by ID from a Google Tasks list
 
@@ -139,7 +139,7 @@ Retrieve a specific task by ID from a Google Tasks list
 | `completed` | string | Completion date |
 | `deleted` | boolean | Whether the task is deleted |
 
-### `google_tasks_update`
+### Google Tasks Update Task
 
 Update an existing task in a Google Tasks list
 
@@ -171,7 +171,7 @@ Update an existing task in a Google Tasks list
 | `completed` | string | Completion date |
 | `deleted` | boolean | Whether the task is deleted |
 
-### `google_tasks_delete`
+### Google Tasks Delete Task
 
 Delete a task from a Google Tasks list
 
@@ -189,7 +189,7 @@ Delete a task from a Google Tasks list
 | `taskId` | string | Deleted task ID |
 | `deleted` | boolean | Whether deletion was successful |
 
-### `google_tasks_list_task_lists`
+### Google Tasks List Task Lists
 
 Retrieve all task lists for the authenticated user
 

--- a/apps/docs/content/docs/en/integrations/google_translate.mdx
+++ b/apps/docs/content/docs/en/integrations/google_translate.mdx
@@ -30,7 +30,7 @@ Translate and detect languages using the Google Cloud Translation API. Supports 
 
 ## Actions
 
-### `google_translate_text`
+### Google Translate
 
 Translate text between languages using the Google Cloud Translation API. Supports auto-detection of the source language.
 
@@ -51,7 +51,7 @@ Translate text between languages using the Google Cloud Translation API. Support
 | `translatedText` | string | The translated text |
 | `detectedSourceLanguage` | string | The detected source language code \(if source was not specified\) |
 
-### `google_translate_detect`
+### Google Translate Detect Language
 
 Detect the language of text using the Google Cloud Translation API.
 

--- a/apps/docs/content/docs/en/integrations/google_vault.mdx
+++ b/apps/docs/content/docs/en/integrations/google_vault.mdx
@@ -34,7 +34,7 @@ Connect Google Vault to manage the full matter lifecycle, create and manage hold
 
 ## Actions
 
-### `google_vault_create_matters_export`
+### Vault Create Export
 
 Create an export in a matter
 
@@ -57,7 +57,7 @@ Create an export in a matter
 | --------- | ---- | ----------- |
 | `export` | json | Created export object |
 
-### `google_vault_list_matters_export`
+### Vault List Exports
 
 List exports for a matter
 
@@ -78,7 +78,7 @@ List exports for a matter
 | `export` | json | Single export object \(when exportId is provided\) |
 | `nextPageToken` | string | Token for fetching next page of results |
 
-### `google_vault_delete_matters_export`
+### Vault Delete Export
 
 Delete an export from a matter
 
@@ -95,7 +95,7 @@ Delete an export from a matter
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the export was deleted |
 
-### `google_vault_download_export_file`
+### Vault Download Export File
 
 Download a single file from a Google Vault export (GCS object)
 
@@ -114,7 +114,7 @@ Download a single file from a Google Vault export (GCS object)
 | --------- | ---- | ----------- |
 | `file` | file | Downloaded Vault export file stored in execution files |
 
-### `google_vault_create_matters_holds`
+### Vault Create Hold
 
 Create a hold in a matter
 
@@ -138,7 +138,7 @@ Create a hold in a matter
 | --------- | ---- | ----------- |
 | `hold` | json | Created hold object |
 
-### `google_vault_list_matters_holds`
+### Vault List Holds
 
 List holds for a matter
 
@@ -159,7 +159,7 @@ List holds for a matter
 | `hold` | json | Single hold object \(when holdId is provided\) |
 | `nextPageToken` | string | Token for fetching next page of results |
 
-### `google_vault_update_matters_holds`
+### Vault Update Hold
 
 Replace the name, query, and scope of an existing hold. This is a full-resource update: fetch the current hold first (Vault List Holds) and resupply every field you want to keep — any field left blank is cleared, not left unchanged.
 
@@ -184,7 +184,7 @@ Replace the name, query, and scope of an existing hold. This is a full-resource 
 | --------- | ---- | ----------- |
 | `hold` | json | Updated hold object |
 
-### `google_vault_delete_matters_holds`
+### Vault Delete Hold
 
 Delete a hold and release its covered accounts
 
@@ -201,7 +201,7 @@ Delete a hold and release its covered accounts
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the hold was deleted |
 
-### `google_vault_add_held_accounts`
+### Vault Add Held Accounts
 
 Add accounts to an existing hold
 
@@ -221,7 +221,7 @@ Add accounts to an existing hold
 |   ↳ `account` | json | Held account \(accountId, email\) |
 |   ↳ `status` | json | Status \(code, message\) if the add failed |
 
-### `google_vault_remove_held_accounts`
+### Vault Remove Held Accounts
 
 Remove accounts from an existing hold
 
@@ -239,7 +239,7 @@ Remove accounts from an existing hold
 | --------- | ---- | ----------- |
 | `statuses` | array | Per-account removal status, in request order |
 
-### `google_vault_create_matters`
+### Vault Create Matter
 
 Create a new matter in Google Vault
 
@@ -256,7 +256,7 @@ Create a new matter in Google Vault
 | --------- | ---- | ----------- |
 | `matter` | json | Created matter object |
 
-### `google_vault_list_matters`
+### Vault List Matters
 
 List matters, or get a specific matter if matterId is provided
 
@@ -276,7 +276,7 @@ List matters, or get a specific matter if matterId is provided
 | `matter` | json | Single matter object \(when matterId is provided\) |
 | `nextPageToken` | string | Token for fetching next page of results |
 
-### `google_vault_update_matters`
+### Vault Update Matter
 
 Update the name and/or description of a matter
 
@@ -294,7 +294,7 @@ Update the name and/or description of a matter
 | --------- | ---- | ----------- |
 | `matter` | json | Updated matter object |
 
-### `google_vault_close_matters`
+### Vault Close Matter
 
 Close a matter
 
@@ -310,7 +310,7 @@ Close a matter
 | --------- | ---- | ----------- |
 | `matter` | json | Closed matter object |
 
-### `google_vault_reopen_matters`
+### Vault Reopen Matter
 
 Reopen a closed matter
 
@@ -326,7 +326,7 @@ Reopen a closed matter
 | --------- | ---- | ----------- |
 | `matter` | json | Reopened matter object |
 
-### `google_vault_delete_matters`
+### Vault Delete Matter
 
 Permanently delete a matter (must be closed first)
 
@@ -342,7 +342,7 @@ Permanently delete a matter (must be closed first)
 | --------- | ---- | ----------- |
 | `matter` | json | Deleted matter object |
 
-### `google_vault_undelete_matters`
+### Vault Undelete Matter
 
 Restore a deleted matter
 
@@ -358,7 +358,7 @@ Restore a deleted matter
 | --------- | ---- | ----------- |
 | `matter` | json | Restored matter object |
 
-### `google_vault_add_matters_permissions`
+### Vault Add Matter Collaborator
 
 Add a collaborator (or transfer ownership) to a matter
 
@@ -378,7 +378,7 @@ Add a collaborator (or transfer ownership) to a matter
 | --------- | ---- | ----------- |
 | `permission` | json | Created matter permission \(accountId, role\) |
 
-### `google_vault_remove_matters_permissions`
+### Vault Remove Matter Collaborator
 
 Remove a collaborator from a matter
 
@@ -395,7 +395,7 @@ Remove a collaborator from a matter
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the collaborator was removed |
 
-### `google_vault_create_saved_query`
+### Vault Create Saved Query
 
 Save a reusable search query in a matter
 
@@ -418,7 +418,7 @@ Save a reusable search query in a matter
 | --------- | ---- | ----------- |
 | `savedQuery` | json | Created saved query object |
 
-### `google_vault_list_saved_queries`
+### Vault List Saved Queries
 
 List saved queries in a matter, or get a specific one if savedQueryId is provided
 
@@ -439,7 +439,7 @@ List saved queries in a matter, or get a specific one if savedQueryId is provide
 | `savedQuery` | json | Single saved query object \(when savedQueryId is provided\) |
 | `nextPageToken` | string | Token for fetching next page of results |
 
-### `google_vault_delete_saved_query`
+### Vault Delete Saved Query
 
 Delete a saved query from a matter
 

--- a/apps/docs/content/docs/en/integrations/grafana.mdx
+++ b/apps/docs/content/docs/en/integrations/grafana.mdx
@@ -38,7 +38,7 @@ Integrate Grafana into workflows. Manage dashboards, alerts, annotations, data s
 
 ## Actions
 
-### `grafana_get_dashboard`
+### Grafana Get Dashboard
 
 Get a dashboard by its UID
 
@@ -58,7 +58,7 @@ Get a dashboard by its UID
 | `dashboard` | json | The full dashboard JSON object |
 | `meta` | json | Dashboard metadata \(version, permissions, etc.\) |
 
-### `grafana_list_dashboards`
+### Grafana List Dashboards
 
 Search and list all dashboards
 
@@ -89,7 +89,7 @@ Search and list all dashboards
 |   ↳ `tags` | array | Dashboard tags |
 |   ↳ `folderTitle` | string | Parent folder title |
 
-### `grafana_create_dashboard`
+### Grafana Create Dashboard
 
 Create a new dashboard
 
@@ -120,7 +120,7 @@ Create a new dashboard
 | `version` | number | The version number of the dashboard |
 | `slug` | string | URL-friendly slug of the dashboard |
 
-### `grafana_update_dashboard`
+### Grafana Update Dashboard
 
 Update an existing dashboard. Fetches the current dashboard and merges your changes.
 
@@ -152,7 +152,7 @@ Update an existing dashboard. Fetches the current dashboard and merges your chan
 | `version` | number | The new version number of the dashboard |
 | `slug` | string | URL-friendly slug of the dashboard |
 
-### `grafana_delete_dashboard`
+### Grafana Delete Dashboard
 
 Delete a dashboard by its UID
 
@@ -173,7 +173,7 @@ Delete a dashboard by its UID
 | `message` | string | Confirmation message |
 | `id` | number | The ID of the deleted dashboard |
 
-### `grafana_list_alert_rules`
+### Grafana List Alert Rules
 
 List all alert rules in the Grafana instance
 
@@ -211,7 +211,7 @@ List all alert rules in the Grafana instance
 |   ↳ `notification_settings` | json | Per-rule notification settings \(overrides\) |
 |   ↳ `record` | json | Recording rule configuration \(recording rules only\) |
 
-### `grafana_get_alert_rule`
+### Grafana Get Alert Rule
 
 Get a specific alert rule by its UID
 
@@ -249,7 +249,7 @@ Get a specific alert rule by its UID
 | `notification_settings` | json | Per-rule notification settings \(overrides\) |
 | `record` | json | Recording rule configuration \(recording rules only\) |
 
-### `grafana_create_alert_rule`
+### Grafana Create Alert Rule
 
 Create a new alert rule
 
@@ -303,7 +303,7 @@ Create a new alert rule
 | `notification_settings` | json | Per-rule notification settings \(overrides\) |
 | `record` | json | Recording rule configuration \(recording rules only\) |
 
-### `grafana_update_alert_rule`
+### Grafana Update Alert Rule
 
 Update an existing alert rule. Fetches the current rule and merges your changes.
 
@@ -357,7 +357,7 @@ Update an existing alert rule. Fetches the current rule and merges your changes.
 | `notification_settings` | json | Per-rule notification settings \(overrides\) |
 | `record` | json | Recording rule configuration \(recording rules only\) |
 
-### `grafana_delete_alert_rule`
+### Grafana Delete Alert Rule
 
 Delete an alert rule by its UID
 
@@ -376,7 +376,7 @@ Delete an alert rule by its UID
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message |
 
-### `grafana_list_contact_points`
+### Grafana List Contact Points
 
 List all alert notification contact points
 
@@ -401,7 +401,7 @@ List all alert notification contact points
 |   ↳ `disableResolveMessage` | boolean | Whether resolve messages are disabled |
 |   ↳ `provenance` | string | Provisioning source \(empty if API-managed\) |
 
-### `grafana_create_contact_point`
+### Grafana Create Contact Point
 
 Create a notification contact point (e.g., Slack, email, PagerDuty)
 
@@ -429,7 +429,7 @@ Create a notification contact point (e.g., Slack, email, PagerDuty)
 | `disableResolveMessage` | boolean | Whether resolve notifications are suppressed |
 | `provenance` | string | Provisioning source \(empty if API-managed\) |
 
-### `grafana_create_annotation`
+### Grafana Create Annotation
 
 Create an annotation on a dashboard or as a global annotation
 
@@ -454,7 +454,7 @@ Create an annotation on a dashboard or as a global annotation
 | `id` | number | The ID of the created annotation |
 | `message` | string | Confirmation message |
 
-### `grafana_list_annotations`
+### Grafana List Annotations
 
 Query annotations by time range, dashboard, or tags
 
@@ -497,7 +497,7 @@ Query annotations by time range, dashboard, or tags
 |   ↳ `tags` | array | Annotation tags |
 |   ↳ `data` | json | Additional annotation data object from Grafana |
 
-### `grafana_update_annotation`
+### Grafana Update Annotation
 
 Update an existing annotation
 
@@ -521,7 +521,7 @@ Update an existing annotation
 | `id` | number | The ID of the updated annotation |
 | `message` | string | Confirmation message |
 
-### `grafana_delete_annotation`
+### Grafana Delete Annotation
 
 Delete an annotation by its ID
 
@@ -540,7 +540,7 @@ Delete an annotation by its ID
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message |
 
-### `grafana_list_data_sources`
+### Grafana List Data Sources
 
 List all data sources configured in Grafana
 
@@ -576,7 +576,7 @@ List all data sources configured in Grafana
 |   ↳ `version` | number | Data source version |
 |   ↳ `readOnly` | boolean | Whether the data source is read-only |
 
-### `grafana_get_data_source`
+### Grafana Get Data Source
 
 Get a data source by its ID or UID
 
@@ -612,7 +612,7 @@ Get a data source by its ID or UID
 | `version` | number | Data source version |
 | `readOnly` | boolean | Whether the data source is read-only |
 
-### `grafana_check_data_source_health`
+### Grafana Check Data Source Health
 
 Test connectivity to a data source by its UID
 
@@ -632,7 +632,7 @@ Test connectivity to a data source by its UID
 | `status` | string | Health status of the data source \(e.g., OK\) |
 | `message` | string | Detailed health message from the data source |
 
-### `grafana_list_folders`
+### Grafana List Folders
 
 List all folders in Grafana
 
@@ -668,7 +668,7 @@ List all folders in Grafana
 |   ↳ `updated` | string | Timestamp when the folder was last updated |
 |   ↳ `version` | number | Folder version number |
 
-### `grafana_create_folder`
+### Grafana Create Folder
 
 Create a new folder in Grafana
 
@@ -703,7 +703,7 @@ Create a new folder in Grafana
 | `updated` | string | Timestamp when the folder was last updated |
 | `version` | number | Version number of the folder |
 
-### `grafana_get_folder`
+### Grafana Get Folder
 
 Get a folder by its UID
 
@@ -736,7 +736,7 @@ Get a folder by its UID
 | `updated` | string | Timestamp when the folder was last updated |
 | `version` | number | Version number of the folder |
 
-### `grafana_update_folder`
+### Grafana Update Folder
 
 Update (rename) a folder. Fetches the current folder and merges your changes.
 
@@ -770,7 +770,7 @@ Update (rename) a folder. Fetches the current folder and merges your changes.
 | `updated` | string | Timestamp when the folder was last updated |
 | `version` | number | Version number of the folder |
 
-### `grafana_delete_folder`
+### Grafana Delete Folder
 
 Delete a folder by its UID
 
@@ -791,7 +791,7 @@ Delete a folder by its UID
 | `uid` | string | The UID of the deleted folder |
 | `message` | string | Confirmation message |
 
-### `grafana_get_health`
+### Grafana Get Health
 
 Check the health of the Grafana instance (version, database status)
 

--- a/apps/docs/content/docs/en/integrations/grain.mdx
+++ b/apps/docs/content/docs/en/integrations/grain.mdx
@@ -39,7 +39,7 @@ Integrate Grain into your workflow. Access meeting recordings, transcripts, high
 
 ## Actions
 
-### `grain_list_recordings`
+### Grain List Recordings
 
 List recordings from Grain with optional filters and pagination
 
@@ -79,7 +79,7 @@ List recordings from Grain with optional filters and pagination
 |   ↳ `meeting_type` | object | Meeting type info |
 | `cursor` | string | Cursor for next page \(null if no more\) |
 
-### `grain_get_recording`
+### Grain Get Recording
 
 Get details of a single recording by ID
 
@@ -119,7 +119,7 @@ Get details of a single recording by ID
 | `calendar_event` | object | Calendar event data \(if included\) |
 | `hubspot` | object | HubSpot associations \(if included\) |
 
-### `grain_get_transcript`
+### Grain Get Transcript
 
 Get the full transcript of a recording
 
@@ -141,7 +141,7 @@ Get the full transcript of a recording
 |   ↳ `end` | number | End timestamp in ms |
 |   ↳ `text` | string | Transcript text |
 
-### `grain_list_teams`
+### Grain List Teams
 
 List all teams in the workspace
 
@@ -159,7 +159,7 @@ List all teams in the workspace
 |   ↳ `id` | string | Team UUID |
 |   ↳ `name` | string | Team name |
 
-### `grain_list_meeting_types`
+### Grain List Meeting Types
 
 List all meeting types in the workspace
 
@@ -178,7 +178,7 @@ List all meeting types in the workspace
 |   ↳ `name` | string | Meeting type name |
 |   ↳ `scope` | string | internal or external |
 
-### `grain_create_hook`
+### Grain Create Webhook
 
 Create a webhook for a specific Grain event type (v2 API)
 
@@ -202,7 +202,7 @@ Create a webhook for a specific Grain event type (v2 API)
 | `include` | json | Include object the hook was created with |
 | `inserted_at` | string | ISO8601 creation timestamp |
 
-### `grain_list_hooks`
+### Grain List Webhooks
 
 List webhooks for the account (v2 API)
 
@@ -226,7 +226,7 @@ List webhooks for the account (v2 API)
 |   ↳ `include` | object | Include object the hook was created with |
 |   ↳ `inserted_at` | string | Creation timestamp |
 
-### `grain_delete_hook`
+### Grain Delete Webhook
 
 Delete a webhook by ID (v2 API)
 

--- a/apps/docs/content/docs/en/integrations/granola.mdx
+++ b/apps/docs/content/docs/en/integrations/granola.mdx
@@ -31,7 +31,7 @@ Integrate Granola into your workflow to retrieve meeting notes, summaries, atten
 
 ## Actions
 
-### `granola_list_notes`
+### Granola List Notes
 
 Lists meeting notes from Granola with optional date filters and pagination.
 
@@ -61,7 +61,7 @@ Lists meeting notes from Granola with optional date filters and pagination.
 | `hasMore` | boolean | Whether more notes are available |
 | `cursor` | string | Pagination cursor for the next page |
 
-### `granola_get_note`
+### Granola Get Note
 
 Retrieves a specific meeting note from Granola by ID, including summary, attendees, calendar event details, and optionally the transcript.
 
@@ -106,7 +106,7 @@ Retrieves a specific meeting note from Granola by ID, including summary, attende
 |   ↳ `startTime` | string | Segment start time |
 |   ↳ `endTime` | string | Segment end time |
 
-### `granola_list_folders`
+### Granola List Folders
 
 Lists folders from Granola, sorted alphabetically, with pagination.
 

--- a/apps/docs/content/docs/en/integrations/greenhouse.mdx
+++ b/apps/docs/content/docs/en/integrations/greenhouse.mdx
@@ -33,7 +33,7 @@ Integrate Greenhouse into the workflow. List and retrieve candidates, jobs, appl
 
 ## Actions
 
-### `greenhouse_list_candidates`
+### Greenhouse List Candidates
 
 Lists candidates from Greenhouse with optional filtering by date, job, or email
 
@@ -74,7 +74,7 @@ Lists candidates from Greenhouse with optional filtering by date, job, or email
 |   ↳ `last_activity` | string | Last activity timestamp \(ISO 8601\) |
 | `count` | number | Number of candidates returned |
 
-### `greenhouse_get_candidate`
+### Greenhouse Get Candidate
 
 Retrieves a specific candidate by ID with full details including contact info, education, and employment history
 
@@ -147,7 +147,7 @@ Retrieves a specific candidate by ID with full details including contact info, e
 |   ↳ `end_date` | string | End date \(ISO 8601\) |
 | `custom_fields` | object | Custom field values |
 
-### `greenhouse_list_jobs`
+### Greenhouse List Jobs
 
 Lists jobs from Greenhouse with optional filtering by status, department, or office
 
@@ -187,7 +187,7 @@ Lists jobs from Greenhouse with optional filtering by status, department, or off
 |   ↳ `updated_at` | string | Last updated timestamp \(ISO 8601\) |
 | `count` | number | Number of jobs returned |
 
-### `greenhouse_get_job`
+### Greenhouse Get Job
 
 Retrieves a specific job by ID with full details including hiring team, openings, and custom fields
 
@@ -239,7 +239,7 @@ Retrieves a specific job by ID with full details including hiring team, openings
 |     ↳ `name` | string | Close reason name |
 | `custom_fields` | object | Custom field values |
 
-### `greenhouse_list_applications`
+### Greenhouse List Applications
 
 Lists applications from Greenhouse with optional filtering by job, status, or date
 
@@ -276,7 +276,7 @@ Lists applications from Greenhouse with optional filtering by job, status, or da
 |   ↳ `last_activity_at` | string | Last activity date \(ISO 8601\) |
 | `count` | number | Number of applications returned |
 
-### `greenhouse_get_application`
+### Greenhouse Get Application
 
 Retrieves a specific application by ID with full details including source, stage, answers, and attachments
 
@@ -344,7 +344,7 @@ Retrieves a specific application by ID with full details including source, stage
 |   ↳ `created_at` | string | Upload timestamp |
 | `custom_fields` | object | Custom field values |
 
-### `greenhouse_list_users`
+### Greenhouse List Users
 
 Lists Greenhouse users (recruiters, hiring managers, admins) with optional filtering
 
@@ -380,7 +380,7 @@ Lists Greenhouse users (recruiters, hiring managers, admins) with optional filte
 |   ↳ `updated_at` | string | Last updated timestamp \(ISO 8601\) |
 | `count` | number | Number of users returned |
 
-### `greenhouse_get_user`
+### Greenhouse Get User
 
 Retrieves a specific Greenhouse user by ID
 
@@ -408,7 +408,7 @@ Retrieves a specific Greenhouse user by ID
 | `created_at` | string | Creation timestamp \(ISO 8601\) |
 | `updated_at` | string | Last updated timestamp \(ISO 8601\) |
 
-### `greenhouse_list_departments`
+### Greenhouse List Departments
 
 Lists all departments configured in Greenhouse
 
@@ -432,7 +432,7 @@ Lists all departments configured in Greenhouse
 |   ↳ `external_id` | string | External system ID |
 | `count` | number | Number of departments returned |
 
-### `greenhouse_list_offices`
+### Greenhouse List Offices
 
 Lists all offices configured in Greenhouse
 
@@ -459,7 +459,7 @@ Lists all offices configured in Greenhouse
 |   ↳ `external_id` | string | External system ID |
 | `count` | number | Number of offices returned |
 
-### `greenhouse_list_job_stages`
+### Greenhouse List Job Stages
 
 Lists all interview stages for a specific job in Greenhouse
 

--- a/apps/docs/content/docs/en/integrations/greptile.mdx
+++ b/apps/docs/content/docs/en/integrations/greptile.mdx
@@ -38,7 +38,7 @@ Query and search codebases using natural language with Greptile. Get AI-generate
 
 ## Actions
 
-### `greptile_query`
+### Greptile Query
 
 Query repositories in natural language and get answers with relevant code references. Greptile uses AI to understand your codebase and answer questions.
 
@@ -68,7 +68,7 @@ Query repositories in natural language and get answers with relevant code refere
 |   ↳ `summary` | string | Summary of the code section |
 |   ↳ `distance` | number | Similarity score \(lower = more relevant\) |
 
-### `greptile_search`
+### Greptile Search
 
 Search repositories in natural language and get relevant code references without generating an answer. Useful for finding specific code locations.
 
@@ -97,7 +97,7 @@ Search repositories in natural language and get relevant code references without
 |   ↳ `summary` | string | Summary of the code section |
 |   ↳ `distance` | number | Similarity score \(lower = more relevant\) |
 
-### `greptile_index_repo`
+### Greptile Index Repository
 
 Submit a repository to be indexed by Greptile. Indexing must complete before the repository can be queried. Small repos take 3-5 minutes, larger ones can take over an hour.
 
@@ -121,7 +121,7 @@ Submit a repository to be indexed by Greptile. Indexing must complete before the
 | `statusEndpoint` | string | URL endpoint to check indexing status |
 | `message` | string | Status message about the indexing operation |
 
-### `greptile_status`
+### Greptile Repository Status
 
 Check the indexing status of a repository. Use this to verify if a repository is ready to be queried or to monitor indexing progress.
 

--- a/apps/docs/content/docs/en/integrations/hex.mdx
+++ b/apps/docs/content/docs/en/integrations/hex.mdx
@@ -40,7 +40,7 @@ Integrate Hex into your workflow. Run projects, check run status, manage collect
 
 ## Actions
 
-### `hex_cancel_run`
+### Hex Cancel Run
 
 Cancel an active Hex project run.
 
@@ -60,7 +60,7 @@ Cancel an active Hex project run.
 | `projectId` | string | Project UUID |
 | `runId` | string | Run UUID that was cancelled |
 
-### `hex_create_collection`
+### Hex Create Collection
 
 Create a new collection in the Hex workspace to organize projects.
 
@@ -83,7 +83,7 @@ Create a new collection in the Hex workspace to organize projects.
 |   ↳ `email` | string | Creator email |
 |   ↳ `id` | string | Creator UUID |
 
-### `hex_create_group`
+### Hex Create Group
 
 Create a new group in the Hex workspace, optionally with initial members.
 
@@ -103,7 +103,7 @@ Create a new group in the Hex workspace, optionally with initial members.
 | `name` | string | Group name |
 | `createdAt` | string | Creation timestamp |
 
-### `hex_deactivate_user`
+### Hex Deactivate User
 
 Deactivate a user in the Hex workspace.
 
@@ -121,7 +121,7 @@ Deactivate a user in the Hex workspace.
 | `success` | boolean | Whether the user was successfully deactivated |
 | `userId` | string | User UUID that was deactivated |
 
-### `hex_delete_group`
+### Hex Delete Group
 
 Delete a group from the Hex workspace.
 
@@ -139,7 +139,7 @@ Delete a group from the Hex workspace.
 | `success` | boolean | Whether the group was successfully deleted |
 | `groupId` | string | Group UUID that was deleted |
 
-### `hex_get_collection`
+### Hex Get Collection
 
 Retrieve details for a specific Hex collection by its ID.
 
@@ -161,7 +161,7 @@ Retrieve details for a specific Hex collection by its ID.
 |   ↳ `email` | string | Creator email |
 |   ↳ `id` | string | Creator UUID |
 
-### `hex_get_data_connection`
+### Hex Get Data Connection
 
 Retrieve details for a specific data connection including type, description, and configuration flags.
 
@@ -184,7 +184,7 @@ Retrieve details for a specific data connection including type, description, and
 | `includeMagic` | boolean | Whether Magic AI features are enabled |
 | `allowWritebackCells` | boolean | Whether writeback cells are allowed |
 
-### `hex_get_group`
+### Hex Get Group
 
 Retrieve details for a specific Hex group.
 
@@ -203,7 +203,7 @@ Retrieve details for a specific Hex group.
 | `name` | string | Group name |
 | `createdAt` | string | Creation timestamp |
 
-### `hex_get_project`
+### Hex Get Project
 
 Get metadata and details for a specific Hex project by its ID.
 
@@ -237,7 +237,7 @@ Get metadata and details for a specific Hex project by its ID.
 | `archivedAt` | string | ISO 8601 archived timestamp |
 | `trashedAt` | string | ISO 8601 trashed timestamp |
 
-### `hex_get_project_runs`
+### Hex Get Project Runs
 
 Retrieve API-triggered runs for a Hex project with optional filtering by status and pagination.
 
@@ -271,7 +271,7 @@ Retrieve API-triggered runs for a Hex project with optional filtering by status 
 | `nextPage` | string | Cursor for the next page of runs |
 | `previousPage` | string | Cursor for the previous page of runs |
 
-### `hex_get_queried_tables`
+### Hex Get Queried Tables
 
 Return the warehouse tables queried by a Hex project, including data connection and table names.
 
@@ -293,7 +293,7 @@ Return the warehouse tables queried by a Hex project, including data connection 
 |   ↳ `tableName` | string | Table name |
 | `total` | number | Total number of tables returned |
 
-### `hex_get_run_status`
+### Hex Get Run Status
 
 Check the status of a Hex project run by its run ID.
 
@@ -319,7 +319,7 @@ Check the status of a Hex project run by its run ID.
 | `traceId` | string | Trace ID for debugging |
 | `projectVersion` | number | Project version number |
 
-### `hex_list_collections`
+### Hex List Collections
 
 List all collections in the Hex workspace.
 
@@ -348,7 +348,7 @@ List all collections in the Hex workspace.
 | `after` | string | Cursor for the next page of results |
 | `before` | string | Cursor for the previous page of results |
 
-### `hex_list_data_connections`
+### Hex List Data Connections
 
 List all data connections in the Hex workspace (e.g., Snowflake, PostgreSQL, BigQuery).
 
@@ -379,7 +379,7 @@ List all data connections in the Hex workspace (e.g., Snowflake, PostgreSQL, Big
 | `after` | string | Cursor for the next page of results |
 | `before` | string | Cursor for the previous page of results |
 
-### `hex_list_groups`
+### Hex List Groups
 
 List all groups in the Hex workspace with optional sorting.
 
@@ -406,7 +406,7 @@ List all groups in the Hex workspace with optional sorting.
 | `after` | string | Cursor for the next page of results |
 | `before` | string | Cursor for the previous page of results |
 
-### `hex_list_projects`
+### Hex List Projects
 
 List all projects in your Hex workspace with optional filtering by status.
 
@@ -452,7 +452,7 @@ List all projects in your Hex workspace with optional filtering by status.
 | `after` | string | Cursor for the next page of results |
 | `before` | string | Cursor for the previous page of results |
 
-### `hex_list_users`
+### Hex List Users
 
 List all users in the Hex workspace with optional filtering and sorting.
 
@@ -483,7 +483,7 @@ List all users in the Hex workspace with optional filtering and sorting.
 | `after` | string | Cursor for the next page of results |
 | `before` | string | Cursor for the previous page of results |
 
-### `hex_run_project`
+### Hex Run Project
 
 Execute a published Hex project. Optionally pass input parameters and control caching behavior.
 
@@ -512,7 +512,7 @@ Execute a published Hex project. Optionally pass input parameters and control ca
 | `traceId` | string | Trace ID for debugging |
 | `projectVersion` | number | Project version number |
 
-### `hex_update_collection`
+### Hex Update Collection
 
 Update the name or description of an existing Hex collection.
 
@@ -536,7 +536,7 @@ Update the name or description of an existing Hex collection.
 |   ↳ `email` | string | Creator email |
 |   ↳ `id` | string | Creator UUID |
 
-### `hex_update_group`
+### Hex Update Group
 
 Rename a Hex group or add/remove members from it.
 
@@ -558,7 +558,7 @@ Rename a Hex group or add/remove members from it.
 | `name` | string | Group name |
 | `createdAt` | string | Creation timestamp |
 
-### `hex_update_project`
+### Hex Update Project
 
 Update a Hex project status label (e.g., endorsement or custom workspace statuses).
 

--- a/apps/docs/content/docs/en/integrations/hubspot.mdx
+++ b/apps/docs/content/docs/en/integrations/hubspot.mdx
@@ -34,7 +34,7 @@ Integrate HubSpot into your workflow. Manage contacts, companies, deals, tickets
 
 ## Actions
 
-### `hubspot_get_users`
+### Get Users from HubSpot
 
 Retrieve all users from HubSpot account
 
@@ -63,7 +63,7 @@ Retrieve all users from HubSpot account
 | `totalItems` | number | Total number of users returned |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_contacts`
+### List Contacts from HubSpot
 
 Retrieve all contacts from HubSpot account with pagination support
 
@@ -109,7 +109,7 @@ Retrieve all contacts from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_contact`
+### Get Contact from HubSpot
 
 Retrieve a single contact by ID or email from HubSpot
 
@@ -150,7 +150,7 @@ Retrieve a single contact by ID or email from HubSpot
 | `contactId` | string | The retrieved contact ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_contact`
+### Create Contact in HubSpot
 
 Create a new contact in HubSpot. Requires at least one of: email, firstname, or lastname
 
@@ -189,7 +189,7 @@ Create a new contact in HubSpot. Requires at least one of: email, firstname, or 
 | `contactId` | string | The created contact ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_update_contact`
+### Update Contact in HubSpot
 
 Update an existing contact in HubSpot by ID or email
 
@@ -229,7 +229,7 @@ Update an existing contact in HubSpot by ID or email
 | `contactId` | string | The updated contact ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_search_contacts`
+### Search Contacts in HubSpot
 
 Search for contacts in HubSpot using filters, sorting, and queries
 
@@ -278,7 +278,7 @@ Search for contacts in HubSpot using filters, sorting, and queries
 | `total` | number | Total number of matching contacts |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_companies`
+### List Companies from HubSpot
 
 Retrieve all companies from HubSpot account with pagination support
 
@@ -325,7 +325,7 @@ Retrieve all companies from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_company`
+### Get Company from HubSpot
 
 Retrieve a single company by ID or domain from HubSpot
 
@@ -367,7 +367,7 @@ Retrieve a single company by ID or domain from HubSpot
 | `companyId` | string | The retrieved company ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_company`
+### Create Company in HubSpot
 
 Create a new company in HubSpot
 
@@ -407,7 +407,7 @@ Create a new company in HubSpot
 | `companyId` | string | The created company ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_update_company`
+### Update Company in HubSpot
 
 Update an existing company in HubSpot by ID or domain
 
@@ -448,7 +448,7 @@ Update an existing company in HubSpot by ID or domain
 | `companyId` | string | The updated company ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_search_companies`
+### Search Companies in HubSpot
 
 Search for companies in HubSpot using filters, sorting, and queries
 
@@ -498,7 +498,7 @@ Search for companies in HubSpot using filters, sorting, and queries
 | `total` | number | Total number of matching companies |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_deals`
+### List Deals from HubSpot
 
 Retrieve all deals from HubSpot account with pagination support
 
@@ -536,7 +536,7 @@ Retrieve all deals from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_deal`
+### Get Deal from HubSpot
 
 Retrieve a single deal by ID from HubSpot
 
@@ -569,7 +569,7 @@ Retrieve a single deal by ID from HubSpot
 | `dealId` | string | The retrieved deal ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_deal`
+### Create Deal in HubSpot
 
 Create a new deal in HubSpot with the given properties (e.g., dealname, amount, dealstage)
 
@@ -600,7 +600,7 @@ Create a new deal in HubSpot with the given properties (e.g., dealname, amount, 
 | `dealId` | string | The created deal ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_update_deal`
+### Update Deal in HubSpot
 
 Update an existing deal in HubSpot by ID
 
@@ -632,7 +632,7 @@ Update an existing deal in HubSpot by ID
 | `dealId` | string | The updated deal ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_search_deals`
+### Search Deals in HubSpot
 
 Search for deals in HubSpot using filters, sorting, and queries
 
@@ -673,7 +673,7 @@ Search for deals in HubSpot using filters, sorting, and queries
 | `total` | number | Total number of matching deals |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_tickets`
+### List Tickets from HubSpot
 
 Retrieve all tickets from HubSpot account with pagination support
 
@@ -709,7 +709,7 @@ Retrieve all tickets from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_ticket`
+### Get Ticket from HubSpot
 
 Retrieve a single ticket by ID from HubSpot
 
@@ -740,7 +740,7 @@ Retrieve a single ticket by ID from HubSpot
 | `ticketId` | string | The retrieved ticket ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_ticket`
+### Create Ticket in HubSpot
 
 Create a new ticket in HubSpot. Requires subject and hs_pipeline_stage properties
 
@@ -769,7 +769,7 @@ Create a new ticket in HubSpot. Requires subject and hs_pipeline_stage propertie
 | `ticketId` | string | The created ticket ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_update_ticket`
+### Update Ticket in HubSpot
 
 Update an existing ticket in HubSpot by ID
 
@@ -799,7 +799,7 @@ Update an existing ticket in HubSpot by ID
 | `ticketId` | string | The updated ticket ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_search_tickets`
+### Search Tickets in HubSpot
 
 Search for tickets in HubSpot using filters, sorting, and queries
 
@@ -838,7 +838,7 @@ Search for tickets in HubSpot using filters, sorting, and queries
 | `total` | number | Total number of matching tickets |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_notes`
+### List Notes from HubSpot
 
 Retrieve all notes from HubSpot account with pagination support
 
@@ -871,7 +871,7 @@ Retrieve all notes from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_note`
+### Get Note from HubSpot
 
 Retrieve a single note by ID from HubSpot
 
@@ -898,7 +898,7 @@ Retrieve a single note by ID from HubSpot
 | `noteId` | string | The retrieved note ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_note`
+### Create Note in HubSpot
 
 Log a note in HubSpot and optionally associate it with contacts, companies, or deals. Requires hs_timestamp and hs_note_body properties
 
@@ -924,7 +924,7 @@ Log a note in HubSpot and optionally associate it with contacts, companies, or d
 | `noteId` | string | The created note ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_search_notes`
+### Search Notes in HubSpot
 
 Search for notes in HubSpot using filters, sorting, and queries
 
@@ -960,7 +960,7 @@ Search for notes in HubSpot using filters, sorting, and queries
 | `total` | number | Total number of matching notes |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_emails`
+### List Emails from HubSpot
 
 Retrieve all email engagements from HubSpot account with pagination support
 
@@ -999,7 +999,7 @@ Retrieve all email engagements from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_email`
+### Get Email from HubSpot
 
 Retrieve a single email engagement by ID from HubSpot (content requires the sales-email-read scope)
 
@@ -1032,7 +1032,7 @@ Retrieve a single email engagement by ID from HubSpot (content requires the sale
 | `emailId` | string | The retrieved email engagement ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_email`
+### Create Email in HubSpot
 
 Log an email engagement in HubSpot and optionally associate it with contacts. Requires the hs_timestamp property
 
@@ -1064,7 +1064,7 @@ Log an email engagement in HubSpot and optionally associate it with contacts. Re
 | `emailId` | string | The created email engagement ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_search_emails`
+### Search Emails in HubSpot
 
 Search for email engagements in HubSpot using filters, sorting, and queries
 
@@ -1106,7 +1106,7 @@ Search for email engagements in HubSpot using filters, sorting, and queries
 | `total` | number | Total number of matching emails |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_properties`
+### Get Properties from HubSpot
 
 Read property definitions and their enumeration (picklist) options for a HubSpot object type, e.g. the values for lifecyclestage or hs_lead_status on contacts
 
@@ -1133,7 +1133,7 @@ Read property definitions and their enumeration (picklist) options for a HubSpot
 |   ↳ `objectType` | string | Object type the properties belong to |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_associations`
+### List Associations in HubSpot
 
 List records of one object type associated with a given record, e.g. all emails or notes logged on a contact
 
@@ -1165,7 +1165,7 @@ List records of one object type associated with a given record, e.g. all emails 
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_association`
+### Create Association in HubSpot
 
 Associate two HubSpot records. Creates the default (unlabeled) association unless an association type ID is provided
 
@@ -1189,7 +1189,7 @@ Associate two HubSpot records. Creates the default (unlabeled) association unles
 | `labels` | array | Association labels \(empty for default associations\) |
 | `success` | boolean | Operation success status |
 
-### `hubspot_delete_association`
+### Delete Association in HubSpot
 
 Remove all associations between two HubSpot records
 
@@ -1211,7 +1211,7 @@ Remove all associations between two HubSpot records
 | `deleted` | boolean | Whether the associations were removed |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_association_labels`
+### Get Association Labels from HubSpot
 
 Retrieve the association types (category, typeId, label) defined between two HubSpot object types
 
@@ -1232,7 +1232,7 @@ Retrieve the association types (category, typeId, label) defined between two Hub
 |   ↳ `label` | string | Human-readable label \(null for unlabeled defaults\) |
 | `success` | boolean | Operation success status |
 
-### `hubspot_delete_contact`
+### Delete Contact from HubSpot
 
 Archive a contact in HubSpot by ID (moves it to the recycling bin)
 
@@ -1250,7 +1250,7 @@ Archive a contact in HubSpot by ID (moves it to the recycling bin)
 | `deleted` | boolean | Whether the contact was archived |
 | `success` | boolean | Operation success status |
 
-### `hubspot_delete_company`
+### Delete Company from HubSpot
 
 Archive a company in HubSpot by ID (moves it to the recycling bin)
 
@@ -1268,7 +1268,7 @@ Archive a company in HubSpot by ID (moves it to the recycling bin)
 | `deleted` | boolean | Whether the company was archived |
 | `success` | boolean | Operation success status |
 
-### `hubspot_delete_deal`
+### Delete Deal from HubSpot
 
 Archive a deal in HubSpot by ID (moves it to the recycling bin)
 
@@ -1286,7 +1286,7 @@ Archive a deal in HubSpot by ID (moves it to the recycling bin)
 | `deleted` | boolean | Whether the deal was archived |
 | `success` | boolean | Operation success status |
 
-### `hubspot_delete_ticket`
+### Delete Ticket from HubSpot
 
 Archive a ticket in HubSpot by ID (moves it to the recycling bin)
 
@@ -1304,7 +1304,7 @@ Archive a ticket in HubSpot by ID (moves it to the recycling bin)
 | `deleted` | boolean | Whether the ticket was archived |
 | `success` | boolean | Operation success status |
 
-### `hubspot_delete_line_item`
+### Delete Line Item from HubSpot
 
 Archive a line item in HubSpot by ID (moves it to the recycling bin)
 
@@ -1322,7 +1322,7 @@ Archive a line item in HubSpot by ID (moves it to the recycling bin)
 | `deleted` | boolean | Whether the line item was archived |
 | `success` | boolean | Operation success status |
 
-### `hubspot_search_line_items`
+### Search Line Items in HubSpot
 
 Search for line items in HubSpot using filters, sorting, and queries
 
@@ -1364,7 +1364,7 @@ Search for line items in HubSpot using filters, sorting, and queries
 | `total` | number | Total number of matching line items |
 | `success` | boolean | Operation success status |
 
-### `hubspot_search_quotes`
+### Search Quotes in HubSpot
 
 Search for quotes in HubSpot using filters, sorting, and queries
 
@@ -1400,7 +1400,7 @@ Search for quotes in HubSpot using filters, sorting, and queries
 | `total` | number | Total number of matching quotes |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_list_memberships`
+### Get List Members from HubSpot
 
 Retrieve the record IDs that are members of a HubSpot list, ordered by record ID
 
@@ -1427,7 +1427,7 @@ Retrieve the record IDs that are members of a HubSpot list, ordered by record ID
 |   ↳ `membershipTimestamp` | string | When the record was added to the list |
 | `success` | boolean | Operation success status |
 
-### `hubspot_add_list_memberships`
+### Add List Members in HubSpot
 
 Add records to a manual (static) HubSpot list by record ID
 
@@ -1446,7 +1446,7 @@ Add records to a manual (static) HubSpot list by record ID
 | `recordIdsMissing` | array | IDs of the requested records that were not found |
 | `success` | boolean | Operation success status |
 
-### `hubspot_remove_list_memberships`
+### Remove List Members in HubSpot
 
 Remove records from a manual (static) HubSpot list by record ID
 
@@ -1465,7 +1465,7 @@ Remove records from a manual (static) HubSpot list by record ID
 | `recordIdsMissing` | array | IDs of the requested records that were not found |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_line_items`
+### List Line Items from HubSpot
 
 Retrieve all line items from HubSpot account with pagination support
 
@@ -1504,7 +1504,7 @@ Retrieve all line items from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_line_item`
+### Get Line Item from HubSpot
 
 Retrieve a single line item by ID from HubSpot
 
@@ -1538,7 +1538,7 @@ Retrieve a single line item by ID from HubSpot
 | `lineItemId` | string | The retrieved line item ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_line_item`
+### Create Line Item in HubSpot
 
 Create a new line item in HubSpot. Requires at least a name property
 
@@ -1570,7 +1570,7 @@ Create a new line item in HubSpot. Requires at least a name property
 | `lineItemId` | string | The created line item ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_update_line_item`
+### Update Line Item in HubSpot
 
 Update an existing line item in HubSpot by ID
 
@@ -1603,7 +1603,7 @@ Update an existing line item in HubSpot by ID
 | `lineItemId` | string | The updated line item ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_quotes`
+### List Quotes from HubSpot
 
 Retrieve all quotes from HubSpot account with pagination support
 
@@ -1636,7 +1636,7 @@ Retrieve all quotes from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_quote`
+### Get Quote from HubSpot
 
 Retrieve a single quote by ID from HubSpot
 
@@ -1664,7 +1664,7 @@ Retrieve a single quote by ID from HubSpot
 | `quoteId` | string | The retrieved quote ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_appointments`
+### List Appointments from HubSpot
 
 Retrieve all appointments from HubSpot account with pagination support
 
@@ -1698,7 +1698,7 @@ Retrieve all appointments from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_appointment`
+### Get Appointment from HubSpot
 
 Retrieve a single appointment by ID from HubSpot
 
@@ -1727,7 +1727,7 @@ Retrieve a single appointment by ID from HubSpot
 | `appointmentId` | string | The retrieved appointment ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_appointment`
+### Create Appointment in HubSpot
 
 Create a new appointment in HubSpot
 
@@ -1754,7 +1754,7 @@ Create a new appointment in HubSpot
 | `appointmentId` | string | The created appointment ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_update_appointment`
+### Update Appointment in HubSpot
 
 Update an existing appointment in HubSpot by ID
 
@@ -1782,7 +1782,7 @@ Update an existing appointment in HubSpot by ID
 | `appointmentId` | string | The updated appointment ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_carts`
+### List Carts from HubSpot
 
 Retrieve all carts from HubSpot account with pagination support
 
@@ -1814,7 +1814,7 @@ Retrieve all carts from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_cart`
+### Get Cart from HubSpot
 
 Retrieve a single cart by ID from HubSpot
 
@@ -1840,7 +1840,7 @@ Retrieve a single cart by ID from HubSpot
 | `cartId` | string | The retrieved cart ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_owners`
+### List Owners from HubSpot
 
 Retrieve all owners from HubSpot account with pagination support
 
@@ -1876,7 +1876,7 @@ Retrieve all owners from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_marketing_events`
+### List Marketing Events from HubSpot
 
 Retrieve all marketing events from HubSpot account with pagination support
 
@@ -1918,7 +1918,7 @@ Retrieve all marketing events from HubSpot account with pagination support
 |   ↳ `hasMore` | boolean | Whether more records are available |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_marketing_event`
+### Get Marketing Event from HubSpot
 
 Retrieve a single marketing event by ID from HubSpot
 
@@ -1954,7 +1954,7 @@ Retrieve a single marketing event by ID from HubSpot
 | `eventId` | string | The retrieved marketing event ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_list_lists`
+### List Lists from HubSpot
 
 Search and retrieve lists from HubSpot account
 
@@ -1988,7 +1988,7 @@ Search and retrieve lists from HubSpot account
 |   ↳ `total` | number | Total number of lists matching the query |
 | `success` | boolean | Operation success status |
 
-### `hubspot_get_list`
+### Get List from HubSpot
 
 Retrieve a single list by ID from HubSpot
 
@@ -2014,7 +2014,7 @@ Retrieve a single list by ID from HubSpot
 | `listId` | string | The retrieved list ID |
 | `success` | boolean | Operation success status |
 
-### `hubspot_create_list`
+### Create List in HubSpot
 
 Create a new list in HubSpot. Specify the object type and processing type (MANUAL or DYNAMIC)
 

--- a/apps/docs/content/docs/en/integrations/huggingface.mdx
+++ b/apps/docs/content/docs/en/integrations/huggingface.mdx
@@ -29,7 +29,7 @@ Integrate Hugging Face into the workflow. Can generate completions using the Hug
 
 ## Actions
 
-### `huggingface_chat`
+### Hugging Face Chat
 
 Generate completions using Hugging Face Inference API
 

--- a/apps/docs/content/docs/en/integrations/hunter.mdx
+++ b/apps/docs/content/docs/en/integrations/hunter.mdx
@@ -33,7 +33,7 @@ Integrate Hunter into the workflow. Can search domains, find email addresses, ve
 
 ## Actions
 
-### `hunter_discover`
+### Hunter Discover
 
 Returns companies matching a set of criteria using Hunter.io AI-powered search.
 
@@ -59,7 +59,7 @@ Returns companies matching a set of criteria using Hunter.io AI-powered search.
 |   ↳ `generic_emails` | number | Count of generic \(role-based\) emails |
 |   ↳ `total_emails` | number | Total emails found for the company |
 
-### `hunter_domain_search`
+### Hunter Domain Search
 
 Returns all the email addresses found using one given domain name, with sources.
 
@@ -109,7 +109,7 @@ Returns all the email addresses found using one given domain name, with sources.
 | `organization` | string | The organization/company name |
 | `linked_domains` | array | Other domains linked to the organization |
 
-### `hunter_email_finder`
+### Hunter Email Finder
 
 Finds the most likely email address for a person given their name and company domain.
 
@@ -148,7 +148,7 @@ Finds the most likely email address for a person given their name and company do
 | `phone_number` | string | Phone number |
 | `company` | string | Company name |
 
-### `hunter_email_verifier`
+### Hunter Email Verifier
 
 Verifies the deliverability of an email address and provides detailed verification status.
 
@@ -183,7 +183,7 @@ Verifies the deliverability of an email address and provides detailed verificati
 | `block` | boolean | Whether the domain is blocking verification \(validity could not be determined\) |
 | `status` | string | Verification status: valid, invalid, accept_all, webmail, disposable, unknown, or blocked |
 
-### `hunter_companies_find`
+### Hunter Companies Find
 
 Enriches company data using domain name.
 
@@ -217,7 +217,7 @@ Enriches company data using domain name.
 | `phone` | string | Company phone number |
 | `tech` | array | Technologies used by the company |
 
-### `hunter_email_count`
+### Hunter Email Count
 
 Returns the total number of email addresses found for a domain or company.
 

--- a/apps/docs/content/docs/en/integrations/iam.mdx
+++ b/apps/docs/content/docs/en/integrations/iam.mdx
@@ -33,7 +33,7 @@ Integrate AWS Identity and Access Management into your workflow. Create and mana
 
 ## Actions
 
-### `iam_list_users`
+### IAM List Users
 
 List IAM users in your AWS account
 
@@ -57,7 +57,7 @@ List IAM users in your AWS account
 | `marker` | string | Pagination marker for the next page of results |
 | `count` | number | Number of users returned |
 
-### `iam_get_user`
+### IAM Get User
 
 Get detailed information about an IAM user
 
@@ -83,7 +83,7 @@ Get detailed information about an IAM user
 | `permissionsBoundaryArn` | string | ARN of the permissions boundary policy |
 | `tags` | json | Tags attached to the user \(key, value pairs\) |
 
-### `iam_create_user`
+### IAM Create User
 
 Create a new IAM user
 
@@ -108,7 +108,7 @@ Create a new IAM user
 | `path` | string | The path of the created user |
 | `createDate` | string | Date the user was created |
 
-### `iam_delete_user`
+### IAM Delete User
 
 Delete an IAM user
 
@@ -127,7 +127,7 @@ Delete an IAM user
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_list_roles`
+### IAM List Roles
 
 List IAM roles in your AWS account
 
@@ -151,7 +151,7 @@ List IAM roles in your AWS account
 | `marker` | string | Pagination marker for the next page of results |
 | `count` | number | Number of roles returned |
 
-### `iam_get_role`
+### IAM Get Role
 
 Get detailed information about an IAM role
 
@@ -179,7 +179,7 @@ Get detailed information about an IAM role
 | `roleLastUsedDate` | string | Date the role was last used |
 | `roleLastUsedRegion` | string | AWS region where the role was last used |
 
-### `iam_create_role`
+### IAM Create Role
 
 Create a new IAM role with a trust policy
 
@@ -207,7 +207,7 @@ Create a new IAM role with a trust policy
 | `path` | string | The path of the created role |
 | `createDate` | string | Date the role was created |
 
-### `iam_delete_role`
+### IAM Delete Role
 
 Delete an IAM role
 
@@ -226,7 +226,7 @@ Delete an IAM role
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_attach_user_policy`
+### IAM Attach User Policy
 
 Attach a managed policy to an IAM user
 
@@ -246,7 +246,7 @@ Attach a managed policy to an IAM user
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_detach_user_policy`
+### IAM Detach User Policy
 
 Remove a managed policy from an IAM user
 
@@ -266,7 +266,7 @@ Remove a managed policy from an IAM user
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_attach_role_policy`
+### IAM Attach Role Policy
 
 Attach a managed policy to an IAM role
 
@@ -286,7 +286,7 @@ Attach a managed policy to an IAM role
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_detach_role_policy`
+### IAM Detach Role Policy
 
 Remove a managed policy from an IAM role
 
@@ -306,7 +306,7 @@ Remove a managed policy from an IAM role
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_list_policies`
+### IAM List Policies
 
 List managed IAM policies
 
@@ -332,7 +332,7 @@ List managed IAM policies
 | `marker` | string | Pagination marker for the next page of results |
 | `count` | number | Number of policies returned |
 
-### `iam_create_access_key`
+### IAM Create Access Key
 
 Create a new access key pair for an IAM user
 
@@ -356,7 +356,7 @@ Create a new access key pair for an IAM user
 | `status` | string | Status of the access key \(Active\) |
 | `createDate` | string | Date the key was created |
 
-### `iam_delete_access_key`
+### IAM Delete Access Key
 
 Delete an access key pair for an IAM user
 
@@ -376,7 +376,7 @@ Delete an access key pair for an IAM user
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_list_groups`
+### IAM List Groups
 
 List IAM groups in your AWS account
 
@@ -400,7 +400,7 @@ List IAM groups in your AWS account
 | `marker` | string | Pagination marker for the next page of results |
 | `count` | number | Number of groups returned |
 
-### `iam_add_user_to_group`
+### IAM Add User to Group
 
 Add an IAM user to a group
 
@@ -420,7 +420,7 @@ Add an IAM user to a group
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_remove_user_from_group`
+### IAM Remove User from Group
 
 Remove an IAM user from a group
 
@@ -440,7 +440,7 @@ Remove an IAM user from a group
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 
-### `iam_list_attached_role_policies`
+### IAM List Attached Role Policies
 
 List all managed policies attached to an IAM role
 
@@ -465,7 +465,7 @@ List all managed policies attached to an IAM role
 | `marker` | string | Pagination marker for the next page of results |
 | `count` | number | Number of attached policies returned |
 
-### `iam_list_attached_user_policies`
+### IAM List Attached User Policies
 
 List all managed policies attached to an IAM user
 
@@ -490,7 +490,7 @@ List all managed policies attached to an IAM user
 | `marker` | string | Pagination marker for the next page of results |
 | `count` | number | Number of attached policies returned |
 
-### `iam_simulate_principal_policy`
+### IAM Simulate Principal Policy
 
 Simulate whether a user, role, or group is allowed to perform specific AWS actions — useful for pre-flight access checks
 

--- a/apps/docs/content/docs/en/integrations/icypeas.mdx
+++ b/apps/docs/content/docs/en/integrations/icypeas.mdx
@@ -30,7 +30,7 @@ Integrate Icypeas to find a professional email address from a name and company d
 
 ## Actions
 
-### `icypeas_find_email`
+### Icypeas Find Email
 
 Find a professional email address from a first name, last name, and company domain or name. Submits the search and polls until a result is available. Costs 1 credit per found email (https://www.icypeas.com/pricing).
 
@@ -54,7 +54,7 @@ Find a professional email address from a first name, last name, and company doma
 | `firstname` | string | Found person's first name |
 | `lastname` | string | Found person's last name |
 
-### `icypeas_verify_email`
+### Icypeas Verify Email
 
 Verify whether an email address is valid and deliverable. Submits the verification and polls until a result is available. Costs 0.1 credit per verification (https://www.icypeas.com/pricing).
 

--- a/apps/docs/content/docs/en/integrations/identity_center.mdx
+++ b/apps/docs/content/docs/en/integrations/identity_center.mdx
@@ -35,7 +35,7 @@ Provision and revoke temporary access to AWS accounts via IAM Identity Center (S
 
 ## Actions
 
-### `identity_center_list_instances`
+### Identity Center List Instances
 
 List all AWS IAM Identity Center instances in your account
 
@@ -57,7 +57,7 @@ List all AWS IAM Identity Center instances in your account
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of instances returned |
 
-### `identity_center_list_accounts`
+### Identity Center List Accounts
 
 List all AWS accounts in your organization
 
@@ -79,7 +79,7 @@ List all AWS accounts in your organization
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of accounts returned |
 
-### `identity_center_describe_account`
+### Identity Center Describe Account
 
 Retrieve details about a specific AWS account by its ID
 
@@ -103,7 +103,7 @@ Retrieve details about a specific AWS account by its ID
 | `status` | string | Account status \(ACTIVE, SUSPENDED, etc.\) |
 | `joinedTimestamp` | string | Date the account joined the organization |
 
-### `identity_center_list_permission_sets`
+### Identity Center List Permission Sets
 
 List all permission sets defined in an IAM Identity Center instance
 
@@ -126,7 +126,7 @@ List all permission sets defined in an IAM Identity Center instance
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of permission sets returned |
 
-### `identity_center_get_user`
+### Identity Center Get User
 
 Look up a user in the Identity Store by email address
 
@@ -149,7 +149,7 @@ Look up a user in the Identity Store by email address
 | `displayName` | string | Display name of the user |
 | `email` | string | Email address of the user |
 
-### `identity_center_get_group`
+### Identity Center Get Group
 
 Look up a group in the Identity Store by display name
 
@@ -171,7 +171,7 @@ Look up a group in the Identity Store by display name
 | `displayName` | string | Display name of the group |
 | `description` | string | Group description |
 
-### `identity_center_list_groups`
+### Identity Center List Groups
 
 List all groups in the Identity Store
 
@@ -194,7 +194,7 @@ List all groups in the Identity Store
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of groups returned |
 
-### `identity_center_create_account_assignment`
+### Identity Center Create Account Assignment
 
 Grant a user or group access to an AWS account via a permission set (temporary elevated access)
 
@@ -225,7 +225,7 @@ Grant a user or group access to an AWS account via a permission set (temporary e
 | `failureReason` | string | Reason for failure if status is FAILED |
 | `createdDate` | string | Date the request was created |
 
-### `identity_center_delete_account_assignment`
+### Identity Center Delete Account Assignment
 
 Revoke a user or group access to an AWS account by removing a permission set assignment
 
@@ -256,7 +256,7 @@ Revoke a user or group access to an AWS account by removing a permission set ass
 | `failureReason` | string | Reason for failure if status is FAILED |
 | `createdDate` | string | Date the request was created |
 
-### `identity_center_check_assignment_status`
+### Identity Center Check Assignment Status
 
 Check the provisioning status of an account assignment creation request
 
@@ -284,7 +284,7 @@ Check the provisioning status of an account assignment creation request
 | `failureReason` | string | Reason for failure if status is FAILED |
 | `createdDate` | string | Date the request was created |
 
-### `identity_center_check_assignment_deletion_status`
+### Identity Center Check Assignment Deletion Status
 
 Check the deprovisioning status of an account assignment deletion request
 
@@ -312,7 +312,7 @@ Check the deprovisioning status of an account assignment deletion request
 | `failureReason` | string | Reason for failure if status is FAILED |
 | `createdDate` | string | Date the request was created |
 
-### `identity_center_list_account_assignments`
+### Identity Center List Account Assignments
 
 List all account assignments for a specific user or group across all accounts
 

--- a/apps/docs/content/docs/en/integrations/incidentio.mdx
+++ b/apps/docs/content/docs/en/integrations/incidentio.mdx
@@ -40,7 +40,7 @@ Integrate incident.io into the workflow. Manage incidents, actions, follow-ups, 
 
 ## Actions
 
-### `incidentio_incidents_list`
+### incident.io Incidents List
 
 List incidents from incident.io. Returns a list of incidents with their details including severity, status, and timestamps.
 
@@ -91,7 +91,7 @@ List incidents from incident.io. Returns a list of incidents with their details 
 |   ↳ `page_size` | number | Number of items per page |
 |   ↳ `total_record_count` | number | Total number of records |
 
-### `incidentio_incidents_create`
+### incident.io Incidents Create
 
 Create a new incident in incident.io. Requires idempotency_key, severity_id, and visibility. Optionally accepts name, summary, type, and status.
 
@@ -137,7 +137,7 @@ Create a new incident in incident.io. Requires idempotency_key, severity_id, and
 |   ↳ `slack_channel_name` | string | Associated Slack channel name |
 |   ↳ `visibility` | string | Incident visibility |
 
-### `incidentio_incidents_show`
+### incident.io Incidents Show
 
 Retrieve detailed information about a specific incident from incident.io by its ID. Returns full incident details including custom fields and role assignments.
 
@@ -180,7 +180,7 @@ Retrieve detailed information about a specific incident from incident.io by its 
 |   ↳ `custom_field_entries` | array | Custom field values for the incident |
 |   ↳ `incident_role_assignments` | array | Role assignments for the incident |
 
-### `incidentio_incidents_update`
+### incident.io Incidents Update
 
 Update an existing incident in incident.io. Can update name, summary, severity, status, or type.
 
@@ -226,7 +226,7 @@ Update an existing incident in incident.io. Can update name, summary, severity, 
 |   ↳ `slack_channel_name` | string | Associated Slack channel name |
 |   ↳ `visibility` | string | Incident visibility |
 
-### `incidentio_actions_list`
+### incident.io Actions List
 
 List actions from incident.io. Optionally filter by incident ID.
 
@@ -264,7 +264,7 @@ List actions from incident.io. Optionally filter by incident ID.
 |     ↳ `issue_name` | string | Issue identifier |
 |     ↳ `issue_permalink` | string | URL to the external issue |
 
-### `incidentio_actions_show`
+### incident.io Actions Show
 
 Get detailed information about a specific action from incident.io.
 
@@ -301,7 +301,7 @@ Get detailed information about a specific action from incident.io.
 |     ↳ `issue_name` | string | Issue identifier |
 |     ↳ `issue_permalink` | string | URL to the external issue |
 
-### `incidentio_follow_ups_list`
+### incident.io Follow-ups List
 
 List follow-ups from incident.io. Optionally filter by incident ID.
 
@@ -345,7 +345,7 @@ List follow-ups from incident.io. Optionally filter by incident ID.
 |     ↳ `issue_name` | string | External issue name or ID |
 |     ↳ `issue_permalink` | string | Permalink to external issue |
 
-### `incidentio_follow_ups_show`
+### incident.io Follow-ups Show
 
 Get detailed information about a specific follow-up from incident.io.
 
@@ -388,7 +388,7 @@ Get detailed information about a specific follow-up from incident.io.
 |     ↳ `issue_name` | string | External issue name or ID |
 |     ↳ `issue_permalink` | string | Permalink to external issue |
 
-### `incidentio_users_list`
+### Incident.io Users List
 
 List all users in your Incident.io workspace. Returns user details including id, name, email, and role.
 
@@ -416,7 +416,7 @@ List all users in your Incident.io workspace. Returns user details including id,
 |   ↳ `page_size` | number | Number of items per page |
 |   ↳ `total_record_count` | number | Total number of records |
 
-### `incidentio_users_show`
+### Incident.io Users Show
 
 Get detailed information about a specific user in your Incident.io workspace by their ID.
 
@@ -437,7 +437,7 @@ Get detailed information about a specific user in your Incident.io workspace by 
 |   ↳ `email` | string | Email address of the user |
 |   ↳ `role` | string | Role of the user in the workspace |
 
-### `incidentio_workflows_list`
+### incident.io Workflows List
 
 List all workflows in your incident.io workspace.
 
@@ -471,7 +471,7 @@ List all workflows in your incident.io workspace.
 |   ↳ `runs_from` | string | When the workflow runs from |
 |   ↳ `shortform` | string | Workflow shortform identifier |
 
-### `incidentio_workflows_create`
+### incident.io Workflows Create
 
 Create a new workflow in incident.io.
 
@@ -519,7 +519,7 @@ Create a new workflow in incident.io.
 |   ↳ `shortform` | string | Workflow shortform identifier |
 | `management_meta` | json | Workflow management metadata |
 
-### `incidentio_workflows_show`
+### incident.io Workflows Show
 
 Get details of a specific workflow in incident.io.
 
@@ -556,7 +556,7 @@ Get details of a specific workflow in incident.io.
 |   ↳ `shortform` | string | Workflow shortform identifier |
 | `management_meta` | json | Workflow management metadata |
 
-### `incidentio_workflows_update`
+### incident.io Workflows Update
 
 Update an existing workflow in incident.io.
 
@@ -604,7 +604,7 @@ Update an existing workflow in incident.io.
 |   ↳ `shortform` | string | Workflow shortform identifier |
 | `management_meta` | json | Workflow management metadata |
 
-### `incidentio_workflows_delete`
+### incident.io Workflows Delete
 
 Delete a workflow in incident.io.
 
@@ -621,7 +621,7 @@ Delete a workflow in incident.io.
 | --------- | ---- | ----------- |
 | `message` | string | Success message |
 
-### `incidentio_schedules_list`
+### List Schedules
 
 List all schedules in incident.io
 
@@ -647,7 +647,7 @@ List all schedules in incident.io
 |   ↳ `after` | string | Cursor for next page |
 |   ↳ `page_size` | number | Number of results per page |
 
-### `incidentio_schedules_create`
+### Create Schedule
 
 Create a new schedule in incident.io
 
@@ -671,7 +671,7 @@ Create a new schedule in incident.io
 |   ↳ `created_at` | string | When the schedule was created |
 |   ↳ `updated_at` | string | When the schedule was last updated |
 
-### `incidentio_schedules_show`
+### Show Schedule
 
 Get details of a specific schedule in incident.io
 
@@ -693,7 +693,7 @@ Get details of a specific schedule in incident.io
 |   ↳ `created_at` | string | When the schedule was created |
 |   ↳ `updated_at` | string | When the schedule was last updated |
 
-### `incidentio_schedules_update`
+### Update Schedule
 
 Update an existing schedule in incident.io
 
@@ -718,7 +718,7 @@ Update an existing schedule in incident.io
 |   ↳ `created_at` | string | When the schedule was created |
 |   ↳ `updated_at` | string | When the schedule was last updated |
 
-### `incidentio_schedules_delete`
+### Delete Schedule
 
 Delete a schedule in incident.io
 
@@ -735,7 +735,7 @@ Delete a schedule in incident.io
 | --------- | ---- | ----------- |
 | `message` | string | Success message |
 
-### `incidentio_escalations_list`
+### List Escalations
 
 List all escalation policies in incident.io
 
@@ -760,7 +760,7 @@ List all escalation policies in incident.io
 |   ↳ `after` | string | Cursor for next page |
 |   ↳ `page_size` | number | Number of results per page |
 
-### `incidentio_escalations_create`
+### Create Escalation
 
 Create a new escalation policy in incident.io
 
@@ -784,7 +784,7 @@ Create a new escalation policy in incident.io
 |   ↳ `created_at` | string | When the escalation policy was created |
 |   ↳ `updated_at` | string | When the escalation policy was last updated |
 
-### `incidentio_escalations_show`
+### Show Escalation
 
 Get details of a specific escalation policy in incident.io
 
@@ -805,7 +805,7 @@ Get details of a specific escalation policy in incident.io
 |   ↳ `created_at` | string | When the escalation policy was created |
 |   ↳ `updated_at` | string | When the escalation policy was last updated |
 
-### `incidentio_custom_fields_list`
+### incident.io Custom Fields List
 
 List all custom fields from incident.io.
 
@@ -827,7 +827,7 @@ List all custom fields from incident.io.
 |   ↳ `created_at` | string | Creation timestamp |
 |   ↳ `updated_at` | string | Last update timestamp |
 
-### `incidentio_custom_fields_create`
+### incident.io Custom Fields Create
 
 Create a new custom field in incident.io.
 
@@ -852,7 +852,7 @@ Create a new custom field in incident.io.
 |   ↳ `created_at` | string | Creation timestamp |
 |   ↳ `updated_at` | string | Last update timestamp |
 
-### `incidentio_custom_fields_show`
+### incident.io Custom Fields Show
 
 Get detailed information about a specific custom field from incident.io.
 
@@ -875,7 +875,7 @@ Get detailed information about a specific custom field from incident.io.
 |   ↳ `created_at` | string | Creation timestamp |
 |   ↳ `updated_at` | string | Last update timestamp |
 
-### `incidentio_custom_fields_update`
+### incident.io Custom Fields Update
 
 Update an existing custom field in incident.io.
 
@@ -900,7 +900,7 @@ Update an existing custom field in incident.io.
 |   ↳ `created_at` | string | Creation timestamp |
 |   ↳ `updated_at` | string | Last update timestamp |
 
-### `incidentio_custom_fields_delete`
+### incident.io Custom Fields Delete
 
 Delete a custom field from incident.io.
 
@@ -917,7 +917,7 @@ Delete a custom field from incident.io.
 | --------- | ---- | ----------- |
 | `message` | string | Success message |
 
-### `incidentio_severities_list`
+### Incident.io Severities List
 
 List all severity levels configured in your Incident.io workspace. Returns severity details including id, name, description, and rank.
 
@@ -937,7 +937,7 @@ List all severity levels configured in your Incident.io workspace. Returns sever
 |   ↳ `description` | string | Description of the severity level |
 |   ↳ `rank` | number | Rank/order of the severity level |
 
-### `incidentio_incident_statuses_list`
+### Incident.io Incident Statuses List
 
 List all incident statuses configured in your Incident.io workspace. Returns status details including id, name, description, and category.
 
@@ -957,7 +957,7 @@ List all incident statuses configured in your Incident.io workspace. Returns sta
 |   ↳ `description` | string | Description of the incident status |
 |   ↳ `category` | string | Category of the incident status |
 
-### `incidentio_incident_types_list`
+### Incident.io Incident Types List
 
 List all incident types configured in your Incident.io workspace. Returns type details including id, name, description, and default flag.
 
@@ -977,7 +977,7 @@ List all incident types configured in your Incident.io workspace. Returns type d
 |   ↳ `description` | string | Description of the incident type |
 |   ↳ `is_default` | boolean | Whether this is the default incident type |
 
-### `incidentio_incident_roles_list`
+### List Incident Roles
 
 List all incident roles in incident.io
 
@@ -1002,7 +1002,7 @@ List all incident roles in incident.io
 |   ↳ `created_at` | string | When the role was created |
 |   ↳ `updated_at` | string | When the role was last updated |
 
-### `incidentio_incident_roles_create`
+### Create Incident Role
 
 Create a new incident role in incident.io
 
@@ -1031,7 +1031,7 @@ Create a new incident role in incident.io
 |   ↳ `created_at` | string | When the role was created |
 |   ↳ `updated_at` | string | When the role was last updated |
 
-### `incidentio_incident_roles_show`
+### Show Incident Role
 
 Get details of a specific incident role in incident.io
 
@@ -1057,7 +1057,7 @@ Get details of a specific incident role in incident.io
 |   ↳ `created_at` | string | When the role was created |
 |   ↳ `updated_at` | string | When the role was last updated |
 
-### `incidentio_incident_roles_update`
+### Update Incident Role
 
 Update an existing incident role in incident.io
 
@@ -1087,7 +1087,7 @@ Update an existing incident role in incident.io
 |   ↳ `created_at` | string | When the role was created |
 |   ↳ `updated_at` | string | When the role was last updated |
 
-### `incidentio_incident_roles_delete`
+### Delete Incident Role
 
 Delete an incident role in incident.io
 
@@ -1104,7 +1104,7 @@ Delete an incident role in incident.io
 | --------- | ---- | ----------- |
 | `message` | string | Success message |
 
-### `incidentio_incident_timestamps_list`
+### List Incident Timestamps
 
 List all incident timestamp definitions in incident.io
 
@@ -1125,7 +1125,7 @@ List all incident timestamp definitions in incident.io
 |   ↳ `created_at` | string | When the timestamp was created |
 |   ↳ `updated_at` | string | When the timestamp was last updated |
 
-### `incidentio_incident_timestamps_show`
+### Show Incident Timestamp
 
 Get details of a specific incident timestamp definition in incident.io
 
@@ -1147,7 +1147,7 @@ Get details of a specific incident timestamp definition in incident.io
 |   ↳ `created_at` | string | When the timestamp was created |
 |   ↳ `updated_at` | string | When the timestamp was last updated |
 
-### `incidentio_incident_updates_list`
+### List Incident Updates
 
 List all updates for a specific incident in incident.io
 
@@ -1186,7 +1186,7 @@ List all updates for a specific incident in incident.io
 |   ↳ `after` | string | Cursor for next page |
 |   ↳ `page_size` | number | Number of results per page |
 
-### `incidentio_schedule_entries_list`
+### List Schedule Entries
 
 List all entries for a specific schedule in incident.io
 
@@ -1211,7 +1211,7 @@ List all entries for a specific schedule in incident.io
 |   ↳ `after` | string | Cursor for next page |
 |   ↳ `after_url` | string | URL for next page |
 
-### `incidentio_schedule_overrides_create`
+### Create Schedule Override
 
 Create a new schedule override in incident.io
 
@@ -1247,7 +1247,7 @@ Create a new schedule override in incident.io
 |   ↳ `created_at` | string | When the override was created |
 |   ↳ `updated_at` | string | When the override was last updated |
 
-### `incidentio_escalation_paths_list`
+### List Escalation Paths
 
 List escalation paths in incident.io
 
@@ -1272,7 +1272,7 @@ List escalation paths in incident.io
 |   ↳ `after` | string | Cursor for next page |
 |   ↳ `page_size` | number | Number of results per page |
 
-### `incidentio_escalation_paths_create`
+### Create Escalation Path
 
 Create a new escalation path in incident.io
 
@@ -1305,7 +1305,7 @@ Create a new escalation path in incident.io
 |     ↳ `start_time` | string | Start time |
 |     ↳ `end_time` | string | End time |
 
-### `incidentio_escalation_paths_show`
+### Show Escalation Path
 
 Get details of a specific escalation path in incident.io
 
@@ -1336,7 +1336,7 @@ Get details of a specific escalation path in incident.io
 |     ↳ `start_time` | string | Start time |
 |     ↳ `end_time` | string | End time |
 
-### `incidentio_escalation_paths_update`
+### Update Escalation Path
 
 Update an existing escalation path in incident.io
 
@@ -1370,7 +1370,7 @@ Update an existing escalation path in incident.io
 |     ↳ `start_time` | string | Start time |
 |     ↳ `end_time` | string | End time |
 
-### `incidentio_escalation_paths_delete`
+### Delete Escalation Path
 
 Delete an escalation path in incident.io
 

--- a/apps/docs/content/docs/en/integrations/infisical.mdx
+++ b/apps/docs/content/docs/en/integrations/infisical.mdx
@@ -33,7 +33,7 @@ Integrate Infisical into your workflow. List, get, create, update, and delete se
 
 ## Actions
 
-### `infisical_list_secrets`
+### Infisical List Secrets
 
 List all secrets in a project environment. Returns secret keys, values, comments, tags, and metadata.
 
@@ -91,7 +91,7 @@ List all secrets in a project environment. Returns secret keys, values, comments
 |   ↳ `updatedAt` | string | Last update timestamp |
 | `count` | number | Total number of secrets returned |
 
-### `infisical_get_secret`
+### Infisical Get Secret
 
 Retrieve a single secret by name from a project environment.
 
@@ -148,7 +148,7 @@ Retrieve a single secret by name from a project environment.
 |   ↳ `createdAt` | string | Creation timestamp |
 |   ↳ `updatedAt` | string | Last update timestamp |
 
-### `infisical_create_secret`
+### Infisical Create Secret
 
 Create a new secret in a project environment.
 
@@ -205,7 +205,7 @@ Create a new secret in a project environment.
 |   ↳ `createdAt` | string | Creation timestamp |
 |   ↳ `updatedAt` | string | Last update timestamp |
 
-### `infisical_update_secret`
+### Infisical Update Secret
 
 Update an existing secret in a project environment.
 
@@ -263,7 +263,7 @@ Update an existing secret in a project environment.
 |   ↳ `createdAt` | string | Creation timestamp |
 |   ↳ `updatedAt` | string | Last update timestamp |
 
-### `infisical_delete_secret`
+### Infisical Delete Secret
 
 Delete a secret from a project environment.
 

--- a/apps/docs/content/docs/en/integrations/instantly.mdx
+++ b/apps/docs/content/docs/en/integrations/instantly.mdx
@@ -32,7 +32,7 @@ Integrate Instantly API V2 into workflows. Create, update, and list leads, manag
 
 ## Actions
 
-### `instantly_list_leads`
+### Instantly List Leads
 
 Retrieves Instantly V2 leads with search, campaign, list, and pagination filters.
 
@@ -82,7 +82,7 @@ Retrieves Instantly V2 leads with search, campaign, list, and pagination filters
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_get_lead`
+### Instantly Get Lead
 
 Retrieves an Instantly V2 lead by ID.
 
@@ -116,7 +116,7 @@ Retrieves an Instantly V2 lead by ID.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_create_lead`
+### Instantly Create Lead
 
 Creates an Instantly V2 lead in a campaign or lead list.
 
@@ -169,7 +169,7 @@ Creates an Instantly V2 lead in a campaign or lead list.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_patch_lead`
+### Instantly Patch Lead
 
 Updates fields on an existing Instantly V2 lead.
 
@@ -214,7 +214,7 @@ Updates fields on an existing Instantly V2 lead.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_delete_leads`
+### Instantly Delete Leads
 
 Deletes Instantly V2 leads in bulk from a campaign or lead list.
 
@@ -234,7 +234,7 @@ Deletes Instantly V2 leads in bulk from a campaign or lead list.
 | --------- | ---- | ----------- |
 | `count` | number | Number of leads deleted |
 
-### `instantly_update_lead_interest_status`
+### Instantly Update Lead Interest Status
 
 Submits an Instantly V2 background job to update a lead interest status.
 
@@ -255,7 +255,7 @@ Submits an Instantly V2 background job to update a lead interest status.
 | --------- | ---- | ----------- |
 | `message` | string | Background job submission message |
 
-### `instantly_list_campaigns`
+### Instantly List Campaigns
 
 Retrieves Instantly V2 campaigns with search, status, tag, and pagination filters.
 
@@ -294,7 +294,7 @@ Retrieves Instantly V2 campaigns with search, status, tag, and pagination filter
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_create_campaign`
+### Instantly Create Campaign
 
 Creates an Instantly V2 campaign using the documented campaign schedule schema.
 
@@ -339,7 +339,7 @@ Creates an Instantly V2 campaign using the documented campaign schedule schema.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_patch_campaign`
+### Instantly Patch Campaign
 
 Updates documented Instantly V2 campaign fields.
 
@@ -385,7 +385,7 @@ Updates documented Instantly V2 campaign fields.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_activate_campaign`
+### Instantly Activate Campaign
 
 Activates, starts, or resumes an Instantly V2 campaign.
 
@@ -419,7 +419,7 @@ Activates, starts, or resumes an Instantly V2 campaign.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_pause_campaign`
+### Instantly Pause Campaign
 
 Pauses a running Instantly V2 campaign, stopping further email sends.
 
@@ -453,7 +453,7 @@ Pauses a running Instantly V2 campaign, stopping further email sends.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_delete_campaign`
+### Instantly Delete Campaign
 
 Permanently deletes an Instantly V2 campaign.
 
@@ -487,7 +487,7 @@ Permanently deletes an Instantly V2 campaign.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_list_emails`
+### Instantly List Emails
 
 Retrieves Instantly V2 Unibox emails with search and pagination filters.
 
@@ -529,7 +529,7 @@ Retrieves Instantly V2 Unibox emails with search and pagination filters.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_reply_to_email`
+### Instantly Reply To Email
 
 Sends an Instantly V2 reply to an existing Unibox email.
 
@@ -568,7 +568,7 @@ Sends an Instantly V2 reply to an existing Unibox email.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_list_lead_lists`
+### Instantly List Lead Lists
 
 Retrieves Instantly V2 lead lists with search and pagination filters.
 
@@ -605,7 +605,7 @@ Retrieves Instantly V2 lead lists with search and pagination filters.
 | `thread_id` | string | Email thread ID |
 | `message` | string | Operation message |
 
-### `instantly_create_lead_list`
+### Instantly Create Lead List
 
 Creates an Instantly V2 lead list.
 

--- a/apps/docs/content/docs/en/integrations/intercom.mdx
+++ b/apps/docs/content/docs/en/integrations/intercom.mdx
@@ -35,7 +35,7 @@ Integrate Intercom into the workflow. Can create, get, update, list, search, and
 
 ## Actions
 
-### `intercom_create_contact`
+### Create Contact in Intercom
 
 Create a new contact in Intercom with email, external_id, or role. Returns API-aligned fields only.
 
@@ -107,7 +107,7 @@ Create a new contact in Intercom with email, external_id, or role. Returns API-a
 |   ↳ `unsubscribed_from_emails` | boolean | Whether contact is unsubscribed from emails |
 | `contactId` | string | ID of the created contact |
 
-### `intercom_get_contact`
+### Get Single Contact from Intercom
 
 Get a single contact by ID from Intercom. Returns API-aligned fields only.
 
@@ -182,7 +182,7 @@ Get a single contact by ID from Intercom. Returns API-aligned fields only.
 |     ↳ `username` | string | Username on the social network |
 |     ↳ `id` | string | User ID on the social network |
 
-### `intercom_update_contact`
+### Update Contact in Intercom
 
 Update an existing contact in Intercom. Returns API-aligned fields only.
 
@@ -230,7 +230,7 @@ Update an existing contact in Intercom. Returns API-aligned fields only.
 |   ↳ `unsubscribed_from_emails` | boolean | Whether contact is unsubscribed from emails |
 | `contactId` | string | ID of the updated contact |
 
-### `intercom_list_contacts`
+### List Contacts from Intercom
 
 List all contacts from Intercom with pagination support
 
@@ -266,7 +266,7 @@ List all contacts from Intercom with pagination support
 |   ↳ `total_pages` | number | Total number of pages |
 | `total_count` | number | Total number of contacts |
 
-### `intercom_search_contacts`
+### Search Contacts in Intercom
 
 Search for contacts in Intercom using a query
 
@@ -313,7 +313,7 @@ Search for contacts in Intercom using a query
 |   ↳ `total_pages` | number | Total number of pages |
 | `total_count` | number | Total number of matching contacts |
 
-### `intercom_delete_contact`
+### Delete Contact from Intercom
 
 Delete a contact from Intercom by ID. Returns API-aligned fields only.
 
@@ -330,7 +330,7 @@ Delete a contact from Intercom by ID. Returns API-aligned fields only.
 | `id` | string | ID of deleted contact |
 | `deleted` | boolean | Whether the contact was deleted |
 
-### `intercom_create_company`
+### Create Company in Intercom
 
 Create or update a company in Intercom
 
@@ -377,7 +377,7 @@ Create or update a company in Intercom
 |     ↳ `segments` | array | Array of segment objects |
 | `companyId` | string | ID of the created/updated company |
 
-### `intercom_get_company`
+### Get Company from Intercom
 
 Retrieve a single company by ID from Intercom
 
@@ -410,7 +410,7 @@ Retrieve a single company by ID from Intercom
 |   ↳ `tags` | object | Tags associated with the company |
 |   ↳ `segments` | object | Segments the company belongs to |
 
-### `intercom_list_companies`
+### List Companies from Intercom
 
 List all companies from Intercom with pagination support. Note: This endpoint has a limit of 10,000 companies that can be returned using pagination. For datasets larger than 10,000 companies, use the Scroll API instead.
 
@@ -450,7 +450,7 @@ List all companies from Intercom with pagination support. Note: This endpoint ha
 | `total_count` | number | Total number of companies |
 | `success` | boolean | Operation success status |
 
-### `intercom_get_conversation`
+### Get Conversation from Intercom
 
 Retrieve a single conversation by ID from Intercom
 
@@ -488,7 +488,7 @@ Retrieve a single conversation by ID from Intercom
 |   ↳ `statistics` | object | Conversation statistics |
 | `success` | boolean | Operation success status |
 
-### `intercom_list_conversations`
+### List Conversations from Intercom
 
 List all conversations from Intercom with pagination support
 
@@ -529,7 +529,7 @@ List all conversations from Intercom with pagination support
 | `total_count` | number | Total number of conversations |
 | `success` | boolean | Operation success status |
 
-### `intercom_reply_conversation`
+### Reply to Conversation in Intercom
 
 Reply to a conversation as an admin in Intercom
 
@@ -568,7 +568,7 @@ Reply to a conversation as an admin in Intercom
 | `conversationId` | string | ID of the conversation |
 | `success` | boolean | Operation success status |
 
-### `intercom_search_conversations`
+### Search Conversations in Intercom
 
 Search for conversations in Intercom using a query. Returns API-aligned fields only.
 
@@ -610,7 +610,7 @@ Search for conversations in Intercom using a query. Returns API-aligned fields o
 | `total_count` | number | Total number of matching conversations |
 | `success` | boolean | Operation success status |
 
-### `intercom_create_ticket`
+### Create Ticket in Intercom
 
 Create a new ticket in Intercom. Returns API-aligned fields only.
 
@@ -649,7 +649,7 @@ Create a new ticket in Intercom. Returns API-aligned fields only.
 | `ticketId` | string | ID of the created ticket |
 | `success` | boolean | Operation success status |
 
-### `intercom_get_ticket`
+### Get Ticket from Intercom
 
 Retrieve a single ticket by ID from Intercom. Returns API-aligned fields only.
 
@@ -682,7 +682,7 @@ Retrieve a single ticket by ID from Intercom. Returns API-aligned fields only.
 | `ticketId` | string | ID of the retrieved ticket |
 | `success` | boolean | Operation success status |
 
-### `intercom_update_ticket`
+### Update Ticket in Intercom
 
 Update a ticket in Intercom (change state, assignment, attributes)
 
@@ -718,7 +718,7 @@ Update a ticket in Intercom (change state, assignment, attributes)
 | `ticketId` | string | ID of the updated ticket |
 | `ticket_state` | string | Current state of the ticket |
 
-### `intercom_create_message`
+### Create Message in Intercom
 
 Create and send a new admin-initiated message in Intercom. Returns API-aligned fields only.
 
@@ -751,7 +751,7 @@ Create and send a new admin-initiated message in Intercom. Returns API-aligned f
 | `messageId` | string | ID of the created message |
 | `success` | boolean | Operation success status |
 
-### `intercom_list_admins`
+### List Admins from Intercom
 
 Fetch a list of all admins for the workspace
 
@@ -778,7 +778,7 @@ Fetch a list of all admins for the workspace
 |   ↳ `email_verified` | boolean | Whether email is verified |
 | `type` | string | Object type \(admin.list\) |
 
-### `intercom_close_conversation`
+### Close Conversation in Intercom
 
 Close a conversation in Intercom
 
@@ -805,7 +805,7 @@ Close a conversation in Intercom
 | `conversationId` | string | ID of the closed conversation |
 | `state` | string | State of the conversation \(closed\) |
 
-### `intercom_open_conversation`
+### Open Conversation in Intercom
 
 Open a closed or snoozed conversation in Intercom
 
@@ -831,7 +831,7 @@ Open a closed or snoozed conversation in Intercom
 | `conversationId` | string | ID of the opened conversation |
 | `state` | string | State of the conversation \(open\) |
 
-### `intercom_snooze_conversation`
+### Snooze Conversation in Intercom
 
 Snooze a conversation to reopen at a future time
 
@@ -859,7 +859,7 @@ Snooze a conversation to reopen at a future time
 | `state` | string | State of the conversation \(snoozed\) |
 | `snoozed_until` | number | Unix timestamp when conversation will reopen |
 
-### `intercom_assign_conversation`
+### Assign Conversation in Intercom
 
 Assign a conversation to an admin or team in Intercom
 
@@ -889,7 +889,7 @@ Assign a conversation to an admin or team in Intercom
 | `admin_assignee_id` | number | ID of the assigned admin |
 | `team_assignee_id` | string | ID of the assigned team |
 
-### `intercom_list_tags`
+### List Tags from Intercom
 
 Fetch a list of all tags in the workspace
 
@@ -908,7 +908,7 @@ Fetch a list of all tags in the workspace
 |   ↳ `name` | string | Name of the tag |
 | `type` | string | Object type \(list\) |
 
-### `intercom_create_tag`
+### Create Tag in Intercom
 
 Create a new tag or update an existing tag name
 
@@ -927,7 +927,7 @@ Create a new tag or update an existing tag name
 | `name` | string | Name of the tag |
 | `type` | string | Object type \(tag\) |
 
-### `intercom_tag_contact`
+### Tag Contact in Intercom
 
 Add a tag to a specific contact
 
@@ -946,7 +946,7 @@ Add a tag to a specific contact
 | `name` | string | Name of the tag |
 | `type` | string | Object type \(tag\) |
 
-### `intercom_untag_contact`
+### Untag Contact in Intercom
 
 Remove a tag from a specific contact
 
@@ -965,7 +965,7 @@ Remove a tag from a specific contact
 | `name` | string | Name of the tag that was removed |
 | `type` | string | Object type \(tag\) |
 
-### `intercom_tag_conversation`
+### Tag Conversation in Intercom
 
 Add a tag to a specific conversation
 
@@ -985,7 +985,7 @@ Add a tag to a specific conversation
 | `name` | string | Name of the tag |
 | `type` | string | Object type \(tag\) |
 
-### `intercom_create_note`
+### Create Note in Intercom
 
 Add a note to a specific contact
 
@@ -1014,7 +1014,7 @@ Add a note to a specific contact
 |   ↳ `type` | string | Contact type |
 |   ↳ `id` | string | Contact ID |
 
-### `intercom_create_event`
+### Create Event in Intercom
 
 Track a custom event for a contact in Intercom
 
@@ -1035,7 +1035,7 @@ Track a custom event for a contact in Intercom
 | --------- | ---- | ----------- |
 | `accepted` | boolean | Whether the event was accepted \(202 Accepted\) |
 
-### `intercom_attach_contact_to_company`
+### Attach Contact to Company in Intercom
 
 Attach a contact to a company in Intercom
 
@@ -1064,7 +1064,7 @@ Attach a contact to a company in Intercom
 | `companyId` | string | ID of the company |
 | `name` | string | Name of the company |
 
-### `intercom_detach_contact_from_company`
+### Detach Contact from Company in Intercom
 
 Remove a contact from a company in Intercom
 

--- a/apps/docs/content/docs/en/integrations/jina.mdx
+++ b/apps/docs/content/docs/en/integrations/jina.mdx
@@ -35,7 +35,7 @@ Integrate Jina AI into the workflow. Search the web and get LLM-friendly results
 
 ## Actions
 
-### `jina_read_url`
+### Jina Reader
 
 Extract and process web content into clean, LLM-friendly text using Jina AI Reader. Supports advanced content parsing, link gathering, and multiple output formats with configurable processing options.
 
@@ -66,7 +66,7 @@ Extract and process web content into clean, LLM-friendly text using Jina AI Read
 | `content` | string | The extracted content from the URL, processed into clean, LLM-friendly text |
 | `tokensUsed` | number | Number of Jina tokens consumed by this request |
 
-### `jina_search`
+### Jina Search
 
 Search the web and return top 5 results with LLM-friendly content. Each result is automatically processed through Jina Reader API. Supports geographic filtering, site restrictions, and pagination.
 

--- a/apps/docs/content/docs/en/integrations/jira.mdx
+++ b/apps/docs/content/docs/en/integrations/jira.mdx
@@ -38,7 +38,7 @@ Integrate Jira into the workflow. Can read, write, and update issues. Can also t
 
 ## Actions
 
-### `jira_retrieve`
+### Jira Retrieve
 
 Retrieve detailed information about a specific Jira issue
 
@@ -240,7 +240,7 @@ Retrieve detailed information about a specific Jira issue
 | `issue` | json | Complete raw Jira issue object from the API |
 | `files` | file[] | Downloaded attachment files \(only when includeAttachments is true\) |
 
-### `jira_update`
+### Jira Update
 
 Update a Jira issue
 
@@ -273,7 +273,7 @@ Update a Jira issue
 | `issueKey` | string | Updated issue key \(e.g., PROJ-123\) |
 | `summary` | string | Issue summary after update |
 
-### `jira_write`
+### Jira Write
 
 Create a new Jira issue
 
@@ -312,7 +312,7 @@ Create a new Jira issue
 | `url` | string | URL to the created issue in Jira |
 | `assigneeId` | string | Account ID of the assigned user \(null if no assignee was set\) |
 
-### `jira_bulk_read`
+### Jira Bulk Read
 
 Retrieve multiple Jira issues from a project in bulk
 
@@ -353,7 +353,7 @@ Retrieve multiple Jira issues from a project in bulk
 | `nextPageToken` | string | Cursor token for the next page. Null when no more results. |
 | `isLast` | boolean | Whether this is the last page of results |
 
-### `jira_delete_issue`
+### Jira Delete Issue
 
 Delete a Jira issue
 
@@ -374,7 +374,7 @@ Delete a Jira issue
 | `success` | boolean | Operation success status |
 | `issueKey` | string | Deleted issue key |
 
-### `jira_assign_issue`
+### Jira Assign Issue
 
 Assign a Jira issue to a user
 
@@ -396,9 +396,9 @@ Assign a Jira issue to a user
 | `issueKey` | string | Issue key that was assigned |
 | `assigneeId` | string | Account ID of the assignee \(use "-1" for auto-assign, null to unassign\) |
 
-### `jira_transition_issue`
+### Jira Transition Issue
 
-Move a Jira issue between workflow statuses (e.g., To Do -> In Progress)
+Move a Jira issue between workflow statuses (e.g., To Do -&gt; In Progress)
 
 #### Input
 
@@ -424,7 +424,7 @@ Move a Jira issue between workflow statuses (e.g., To Do -> In Progress)
 |   ↳ `id` | string | Status ID |
 |   ↳ `name` | string | Status name |
 
-### `jira_search_issues`
+### Jira Search Issues
 
 Search for Jira issues using JQL (Jira Query Language)
 
@@ -508,7 +508,7 @@ Search for Jira issues using JQL (Jira Query Language)
 | `isLast` | boolean | Whether this is the last page of results |
 | `total` | number | Always null. The Jira /search/jql endpoint does not return a total count; use isLast and nextPageToken for pagination. |
 
-### `jira_add_comment`
+### Jira Add Comment
 
 Add a comment to a Jira issue
 
@@ -542,7 +542,7 @@ Add a comment to a Jira issue
 | `created` | string | ISO 8601 timestamp when the comment was created |
 | `updated` | string | ISO 8601 timestamp when the comment was last updated |
 
-### `jira_get_comments`
+### Jira Get Comments
 
 Get all comments from a Jira issue
 
@@ -592,7 +592,7 @@ Get all comments from a Jira issue
 |     ↳ `type` | string | Restriction type \(e.g., role, group\) |
 |     ↳ `value` | string | Restriction value \(e.g., Administrators\) |
 
-### `jira_update_comment`
+### Jira Update Comment
 
 Update an existing comment on a Jira issue
 
@@ -627,7 +627,7 @@ Update an existing comment on a Jira issue
 | `created` | string | ISO 8601 timestamp when the comment was created |
 | `updated` | string | ISO 8601 timestamp when the comment was last updated |
 
-### `jira_delete_comment`
+### Jira Delete Comment
 
 Delete a comment from a Jira issue
 
@@ -649,7 +649,7 @@ Delete a comment from a Jira issue
 | `issueKey` | string | Issue key |
 | `commentId` | string | Deleted comment ID |
 
-### `jira_get_attachments`
+### Jira Get Attachments
 
 Get all attachments from a Jira issue
 
@@ -687,7 +687,7 @@ Get all attachments from a Jira issue
 |   ↳ `created` | string | ISO 8601 timestamp when the attachment was created |
 | `files` | file[] | Downloaded attachment files \(only when includeAttachments is true\) |
 
-### `jira_add_attachment`
+### Jira Add Attachment
 
 Add attachments to a Jira issue
 
@@ -715,7 +715,7 @@ Add attachments to a Jira issue
 | `attachmentIds` | array | Array of attachment IDs |
 | `files` | file[] | Uploaded attachment files |
 
-### `jira_delete_attachment`
+### Jira Delete Attachment
 
 Delete an attachment from a Jira issue
 
@@ -735,7 +735,7 @@ Delete an attachment from a Jira issue
 | `success` | boolean | Operation success status |
 | `attachmentId` | string | Deleted attachment ID |
 
-### `jira_add_worklog`
+### Jira Add Worklog
 
 Add a time tracking worklog entry to a Jira issue
 
@@ -772,7 +772,7 @@ Add a time tracking worklog entry to a Jira issue
 | `started` | string | ISO 8601 timestamp when the work started |
 | `created` | string | ISO 8601 timestamp when the worklog was created |
 
-### `jira_get_worklogs`
+### Jira Get Worklogs
 
 Get all worklog entries from a Jira issue
 
@@ -821,7 +821,7 @@ Get all worklog entries from a Jira issue
 |   ↳ `created` | string | ISO 8601 timestamp when the worklog was created |
 |   ↳ `updated` | string | ISO 8601 timestamp when the worklog was last updated |
 
-### `jira_update_worklog`
+### Jira Update Worklog
 
 Update an existing worklog entry on a Jira issue
 
@@ -869,7 +869,7 @@ Update an existing worklog entry on a Jira issue
 | `created` | string | Worklog creation time |
 | `updated` | string | Worklog last update time |
 
-### `jira_delete_worklog`
+### Jira Delete Worklog
 
 Delete a worklog entry from a Jira issue
 
@@ -891,7 +891,7 @@ Delete a worklog entry from a Jira issue
 | `issueKey` | string | Issue key |
 | `worklogId` | string | Deleted worklog ID |
 
-### `jira_create_issue_link`
+### Jira Create Issue Link
 
 Create a link relationship between two Jira issues
 
@@ -917,7 +917,7 @@ Create a link relationship between two Jira issues
 | `linkType` | string | Type of issue link |
 | `linkId` | string | Created link ID |
 
-### `jira_delete_issue_link`
+### Jira Delete Issue Link
 
 Delete a link between two Jira issues
 
@@ -937,7 +937,7 @@ Delete a link between two Jira issues
 | `success` | boolean | Operation success status |
 | `linkId` | string | Deleted link ID |
 
-### `jira_add_watcher`
+### Jira Add Watcher
 
 Add a watcher to a Jira issue to receive notifications about updates
 
@@ -959,7 +959,7 @@ Add a watcher to a Jira issue to receive notifications about updates
 | `issueKey` | string | Issue key |
 | `watcherAccountId` | string | Added watcher account ID |
 
-### `jira_remove_watcher`
+### Jira Remove Watcher
 
 Remove a watcher from a Jira issue
 
@@ -981,7 +981,7 @@ Remove a watcher from a Jira issue
 | `issueKey` | string | Issue key |
 | `watcherAccountId` | string | Removed watcher account ID |
 
-### `jira_get_users`
+### Jira Get Users
 
 Get Jira users. If an account ID is provided, returns a single user. Otherwise, returns a list of all users.
 
@@ -1014,7 +1014,7 @@ Get Jira users. If an account ID is provided, returns a single user. Otherwise, 
 | `startAt` | number | Pagination start index |
 | `maxResults` | number | Maximum results per page |
 
-### `jira_search_users`
+### Jira Search Users
 
 Search for Jira users by email address or display name. Returns matching users with their accountId, displayName, and emailAddress.
 
@@ -1046,7 +1046,7 @@ Search for Jira users by email address or display name. Returns matching users w
 | `startAt` | number | Pagination start index |
 | `maxResults` | number | Maximum results per page |
 
-### `jira_list_projects`
+### Jira List Projects
 
 List Jira projects visible to the user, with optional name/key filtering and pagination. Returns each project with id, key, name, and type.
 
@@ -1081,7 +1081,7 @@ List Jira projects visible to the user, with optional name/key filtering and pag
 | `maxResults` | number | Maximum results per page |
 | `isLast` | boolean | Whether this is the last page of results |
 
-### `jira_get_project`
+### Jira Get Project
 
 Get the details of a single Jira project by its ID or key, including its type, lead, components, issue types, and versions.
 
@@ -1114,7 +1114,7 @@ Get the details of a single Jira project by its ID or key, including its type, l
 |   ↳ `name` | string | Issue type name \(e.g., Task, Bug, Story\) |
 |   ↳ `subtask` | boolean | Whether this issue type is a subtask |
 
-### `jira_get_transitions`
+### Jira Get Transitions
 
 Get the workflow transitions available for an issue in its current status. Use the returned transition IDs with the Transition Issue operation.
 
@@ -1142,7 +1142,7 @@ Get the workflow transitions available for an issue in its current status. Use t
 |   ↳ `hasScreen` | boolean | Whether the transition requires a screen with fields |
 | `total` | number | Number of available transitions |
 
-### `jira_list_issue_types`
+### Jira List Issue Types
 
 List all issue types visible to the user across projects (e.g., Task, Bug, Story, Epic, Subtask). Useful for discovering valid issue types before creating an issue.
 
@@ -1168,7 +1168,7 @@ List all issue types visible to the user across projects (e.g., Task, Bug, Story
 |   ↳ `scope` | string | Project ID if this issue type is scoped to a team-managed project |
 | `total` | number | Number of issue types returned |
 
-### `jira_get_fields`
+### Jira Get Fields
 
 Get all system and custom fields defined in the Jira instance. Useful for discovering custom field IDs (e.g., customfield_10001) to use when writing or updating issues.
 
@@ -1617,7 +1617,7 @@ Trigger workflow when an issue is updated in Jira
 | --------- | ---- | -------- | ----------- |
 | `webhookSecret` | string | No | Optional secret to validate webhook deliveries from Jira using HMAC signature |
 | `jqlFilter` | string | No | Filter which issue updates trigger this workflow using JQL |
-| `fieldFilters` | string | No | Comma-separated list of fields to monitor. Only trigger when these fields change. |
+| `fieldFilters` | string | No | Comma-separated list of Jira field names. Only trigger when one of these fields changes. Leave empty to trigger on any field change. |
 
 #### Output
 
@@ -1864,32 +1864,6 @@ Trigger workflow on any Jira webhook event
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
 | `webhookSecret` | string | No | Optional secret to validate webhook deliveries from Jira using HMAC signature |
-
-#### Output
-
-| Parameter | Type | Description |
-| --------- | ---- | ----------- |
-| `changelog` | object | changelog output from the tool |
-|   ↳ `id` | string | Changelog ID |
-| `comment` | object | comment output from the tool |
-|   ↳ `id` | string | Comment ID |
-|   ↳ `body` | string | Comment text/body |
-|   ↳ `author` | object | author output from the tool |
-|     ↳ `displayName` | string | Comment author display name |
-|     ↳ `accountId` | string | Comment author account ID |
-|     ↳ `emailAddress` | string | Comment author email address |
-|   ↳ `created` | string | Comment creation date \(ISO format\) |
-|   ↳ `updated` | string | Comment last updated date \(ISO format\) |
-| `worklog` | object | worklog output from the tool |
-|   ↳ `id` | string | Worklog entry ID |
-|   ↳ `author` | object | author output from the tool |
-|     ↳ `displayName` | string | Worklog author display name |
-|     ↳ `accountId` | string | Worklog author account ID |
-|     ↳ `emailAddress` | string | Worklog author email address |
-|   ↳ `timeSpent` | string | Time spent \(e.g., "2h 30m"\) |
-|   ↳ `timeSpentSeconds` | number | Time spent in seconds |
-|   ↳ `comment` | string | Worklog comment/description |
-|   ↳ `started` | string | When the work was started \(ISO format\) |
 
 
 ---

--- a/apps/docs/content/docs/en/integrations/jira_service_management.mdx
+++ b/apps/docs/content/docs/en/integrations/jira_service_management.mdx
@@ -36,7 +36,7 @@ Integrate with Jira Service Management for IT service management. Create and man
 
 ## Actions
 
-### `jsm_get_service_desks`
+### JSM Get Service Desks
 
 Get all service desks from Jira Service Management
 
@@ -66,7 +66,7 @@ Get all service desks from Jira Service Management
 | `total` | number | Total number of service desks |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_get_request_types`
+### JSM Get Request Types
 
 Get request types for a service desk in Jira Service Management
 
@@ -101,7 +101,7 @@ Get request types for a service desk in Jira Service Management
 | `total` | number | Total number of request types |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_create_request`
+### JSM Create Request
 
 Create a new service request in Jira Service Management
 
@@ -136,7 +136,7 @@ Create a new service request in Jira Service Management
 | `success` | boolean | Whether the request was created successfully |
 | `url` | string | URL to the created request |
 
-### `jsm_get_request`
+### JSM Get Request
 
 Get a single service request from Jira Service Management
 
@@ -176,7 +176,7 @@ Get a single service request from Jira Service Management
 | `url` | string | URL to the request |
 | `request` | json | The service request object |
 
-### `jsm_get_requests`
+### JSM Get Requests
 
 Get multiple service requests from Jira Service Management
 
@@ -223,7 +223,7 @@ Get multiple service requests from Jira Service Management
 | `total` | number | Total number of requests in current page |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_add_comment`
+### JSM Add Comment
 
 Add a comment (public or internal) to a service request in Jira Service Management
 
@@ -254,7 +254,7 @@ Add a comment (public or internal) to a service request in Jira Service Manageme
 | `createdDate` | json | Comment creation date with iso8601, friendly, epochMillis |
 | `success` | boolean | Whether the comment was added successfully |
 
-### `jsm_get_comments`
+### JSM Get Comments
 
 Get comments for a service request in Jira Service Management
 
@@ -291,7 +291,7 @@ Get comments for a service request in Jira Service Management
 | `total` | number | Total number of comments |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_get_customers`
+### JSM Get Customers
 
 Get customers for a service desk in Jira Service Management
 
@@ -320,7 +320,7 @@ Get customers for a service desk in Jira Service Management
 | `total` | number | Total number of customers |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_add_customer`
+### JSM Add Customer
 
 Add customers to a service desk in Jira Service Management
 
@@ -341,7 +341,7 @@ Add customers to a service desk in Jira Service Management
 | `serviceDeskId` | string | Service desk ID |
 | `success` | boolean | Whether customers were added successfully |
 
-### `jsm_get_organizations`
+### JSM Get Organizations
 
 Get organizations for a service desk in Jira Service Management
 
@@ -366,7 +366,7 @@ Get organizations for a service desk in Jira Service Management
 | `total` | number | Total number of organizations |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_create_organization`
+### JSM Create Organization
 
 Create a new organization in Jira Service Management
 
@@ -387,7 +387,7 @@ Create a new organization in Jira Service Management
 | `name` | string | Name of the created organization |
 | `success` | boolean | Whether the operation succeeded |
 
-### `jsm_add_organization`
+### JSM Add Organization
 
 Add an organization to a service desk in Jira Service Management
 
@@ -409,7 +409,7 @@ Add an organization to a service desk in Jira Service Management
 | `organizationId` | string | Organization ID added |
 | `success` | boolean | Whether the operation succeeded |
 
-### `jsm_get_queues`
+### JSM Get Queues
 
 Get queues for a service desk in Jira Service Management
 
@@ -438,7 +438,7 @@ Get queues for a service desk in Jira Service Management
 | `total` | number | Total number of queues |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_get_sla`
+### JSM Get SLA
 
 Get SLA information for a service request in Jira Service Management
 
@@ -466,7 +466,7 @@ Get SLA information for a service request in Jira Service Management
 | `total` | number | Total number of SLAs |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_get_transitions`
+### JSM Get Transitions
 
 Get available transitions for a service request in Jira Service Management
 
@@ -492,7 +492,7 @@ Get available transitions for a service request in Jira Service Management
 | `total` | number | Total number of transitions |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_transition_request`
+### JSM Transition Request
 
 Transition a service request to a new status in Jira Service Management
 
@@ -515,7 +515,7 @@ Transition a service request to a new status in Jira Service Management
 | `transitionId` | string | Applied transition ID |
 | `success` | boolean | Whether the transition was successful |
 
-### `jsm_get_participants`
+### JSM Get Participants
 
 Get participants for a request in Jira Service Management
 
@@ -543,7 +543,7 @@ Get participants for a request in Jira Service Management
 | `total` | number | Total number of participants |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_add_participants`
+### JSM Add Participants
 
 Add participants to a request in Jira Service Management
 
@@ -569,7 +569,7 @@ Add participants to a request in Jira Service Management
 |   ↳ `active` | boolean | Whether the account is active |
 | `success` | boolean | Whether the operation succeeded |
 
-### `jsm_get_approvals`
+### JSM Get Approvals
 
 Get approvals for a request in Jira Service Management
 
@@ -606,7 +606,7 @@ Get approvals for a request in Jira Service Management
 | `total` | number | Total number of approvals |
 | `isLastPage` | boolean | Whether this is the last page |
 
-### `jsm_answer_approval`
+### JSM Answer Approval
 
 Approve or decline an approval request in Jira Service Management
 
@@ -644,7 +644,7 @@ Approve or decline an approval request in Jira Service Management
 | `approval` | json | The approval object |
 | `success` | boolean | Whether the operation succeeded |
 
-### `jsm_get_request_type_fields`
+### JSM Get Request Type Fields
 
 Get the fields required to create a request of a specific type in Jira Service Management
 
@@ -677,7 +677,7 @@ Get the fields required to create a request of a specific type in Jira Service M
 |   ↳ `defaultValues` | json | Default values for the field |
 |   ↳ `jiraSchema` | json | Jira field schema with type, system, custom, customId |
 
-### `jsm_get_form_templates`
+### JSM Get Form Templates
 
 List forms (ProForma/JSM Forms) in a Jira project to discover form IDs for request types
 
@@ -705,7 +705,7 @@ List forms (ProForma/JSM Forms) in a Jira project to discover form IDs for reque
 |   ↳ `recommendedIssueRequestTypeIds` | json | Request type IDs that recommend this form |
 | `total` | number | Total number of forms |
 
-### `jsm_get_form_structure`
+### JSM Get Form Structure
 
 Get the full structure of a ProForma/JSM form including all questions, field types, choices, layout, and conditions
 
@@ -729,7 +729,7 @@ Get the full structure of a ProForma/JSM form including all questions, field typ
 | `updated` | string | Last updated timestamp |
 | `publish` | json | Publishing and request type configuration |
 
-### `jsm_get_issue_forms`
+### JSM Get Issue Forms
 
 List forms (ProForma/JSM Forms) attached to a Jira issue with metadata (name, submitted status, lock)
 
@@ -757,7 +757,7 @@ List forms (ProForma/JSM Forms) attached to a Jira issue with metadata (name, su
 |   ↳ `formTemplateId` | string | Source form template ID \(UUID\) |
 | `total` | number | Total number of forms |
 
-### `jsm_attach_form`
+### JSM Attach Form
 
 Attach a form template to an existing Jira issue or JSM request
 
@@ -784,7 +784,7 @@ Attach a form template to an existing Jira issue or JSM request
 | `internal` | boolean | Whether the form is internal only |
 | `formTemplateId` | string | Form template ID |
 
-### `jsm_save_form_answers`
+### JSM Save Form Answers
 
 Save answers to a form attached to a Jira issue or JSM request
 
@@ -808,7 +808,7 @@ Save answers to a form attached to a Jira issue or JSM request
 | `state` | json | Form state with status \(open, submitted, locked\) |
 | `updated` | string | Last updated timestamp |
 
-### `jsm_submit_form`
+### JSM Submit Form
 
 Submit a form on a Jira issue or JSM request, locking it from further edits
 
@@ -830,7 +830,7 @@ Submit a form on a Jira issue or JSM request, locking it from further edits
 | `formId` | string | Form instance UUID |
 | `status` | string | Form status after submission \(open, submitted, locked\) |
 
-### `jsm_get_form`
+### JSM Get Form
 
 Get a single form with full design, state, and answers from a Jira issue
 
@@ -854,7 +854,7 @@ Get a single form with full design, state, and answers from a Jira issue
 | `state` | json | Form state with answers map, status \(o=open, s=submitted, l=locked\), visibility \(i=internal, e=external\) |
 | `updated` | string | Last updated timestamp |
 
-### `jsm_get_form_answers`
+### JSM Get Form Answers
 
 Get simplified answers from a form attached to a Jira issue or JSM request
 
@@ -876,7 +876,7 @@ Get simplified answers from a form attached to a Jira issue or JSM request
 | `formId` | string | Form instance UUID |
 | `answers` | json | Simplified form answers as key-value pairs \(question label to answer text/choices\) |
 
-### `jsm_reopen_form`
+### JSM Reopen Form
 
 Reopen a submitted form on a Jira issue or JSM request, allowing further edits
 
@@ -898,7 +898,7 @@ Reopen a submitted form on a Jira issue or JSM request, allowing further edits
 | `formId` | string | Form instance UUID |
 | `status` | string | Form status after reopening \(open, submitted, locked\) |
 
-### `jsm_delete_form`
+### JSM Delete Form
 
 Remove a form from a Jira issue or JSM request
 
@@ -920,7 +920,7 @@ Remove a form from a Jira issue or JSM request
 | `formId` | string | Deleted form instance UUID |
 | `deleted` | boolean | Whether the form was successfully deleted |
 
-### `jsm_externalise_form`
+### JSM Externalise Form
 
 Make a form visible to customers on a Jira issue or JSM request
 
@@ -942,7 +942,7 @@ Make a form visible to customers on a Jira issue or JSM request
 | `formId` | string | Form instance UUID |
 | `visibility` | string | Form visibility after change \(internal or external\) |
 
-### `jsm_internalise_form`
+### JSM Internalise Form
 
 Make a form internal only (not visible to customers) on a Jira issue or JSM request
 
@@ -964,7 +964,7 @@ Make a form internal only (not visible to customers) on a Jira issue or JSM requ
 | `formId` | string | Form instance UUID |
 | `visibility` | string | Form visibility after change \(internal or external\) |
 
-### `jsm_copy_forms`
+### JSM Copy Forms
 
 Copy forms from one Jira issue to another
 
@@ -988,7 +988,7 @@ Copy forms from one Jira issue to another
 | `copiedForms` | json | Array of successfully copied forms |
 | `errors` | json | Array of errors encountered during copy |
 
-### `jsm_list_object_schemas`
+### JSM List Asset Schemas
 
 List Assets (Insight/CMDB) object schemas in Jira Service Management
 
@@ -1019,7 +1019,7 @@ List Assets (Insight/CMDB) object schemas in Jira Service Management
 | `total` | number | Total number of schemas |
 | `isLast` | boolean | Whether this is the last page |
 
-### `jsm_get_object_schema`
+### JSM Get Asset Schema
 
 Get a single Assets (Insight/CMDB) object schema by ID
 
@@ -1046,7 +1046,7 @@ Get a single Assets (Insight/CMDB) object schema by ID
 |   ↳ `objectCount` | number | Number of objects |
 |   ↳ `objectTypeCount` | number | Number of object types |
 
-### `jsm_list_object_types`
+### JSM List Asset Object Types
 
 List object types within an Assets (Insight/CMDB) object schema
 
@@ -1075,7 +1075,7 @@ List object types within an Assets (Insight/CMDB) object schema
 |   ↳ `inherited` | boolean | Whether the type inherits attributes |
 | `total` | number | Total number of object types |
 
-### `jsm_get_object_type_attributes`
+### JSM Get Asset Object Type Attributes
 
 Get the attribute definitions for an Assets (Insight/CMDB) object type. Use the returned attribute IDs to build create/update payloads or map columns.
 
@@ -1107,7 +1107,7 @@ Get the attribute definitions for an Assets (Insight/CMDB) object type. Use the 
 |   ↳ `uniqueAttribute` | boolean | Whether values must be unique |
 | `total` | number | Total number of attributes |
 
-### `jsm_search_objects_aql`
+### JSM Search Assets (AQL)
 
 Search Assets (Insight/CMDB) objects using AQL (Assets Query Language), e.g. objectType = "Host" AND Status = "Running". Supports pagination.
 
@@ -1140,7 +1140,7 @@ Search Assets (Insight/CMDB) objects using AQL (Assets Query Language), e.g. obj
 | `pageNumber` | number | Current page number |
 | `pageSize` | number | Number of objects on this page |
 
-### `jsm_get_object`
+### JSM Get Asset Object
 
 Get a single Assets (Insight/CMDB) object by ID, including its attribute values
 
@@ -1170,7 +1170,7 @@ Get a single Assets (Insight/CMDB) object by ID, including its attribute values
 |   ↳ `updated` | string | Last update timestamp |
 |   ↳ `link` | string | Self link to the object |
 
-### `jsm_create_object`
+### JSM Create Asset Object
 
 Create an Assets (Insight/CMDB) object of a given object type. Attributes use objectTypeAttributeId values from the object type definition.
 
@@ -1201,7 +1201,7 @@ Create an Assets (Insight/CMDB) object of a given object type. Attributes use ob
 |   ↳ `updated` | string | Last update timestamp |
 |   ↳ `link` | string | Self link to the object |
 
-### `jsm_update_object`
+### JSM Update Asset Object
 
 Update an existing Assets (Insight/CMDB) object. Provide the attributes to change using their objectTypeAttributeId values.
 
@@ -1233,7 +1233,7 @@ Update an existing Assets (Insight/CMDB) object. Provide the attributes to chang
 |   ↳ `updated` | string | Last update timestamp |
 |   ↳ `link` | string | Self link to the object |
 
-### `jsm_delete_object`
+### JSM Delete Asset Object
 
 Delete an Assets (Insight/CMDB) object by ID
 

--- a/apps/docs/content/docs/en/integrations/jupyter.mdx
+++ b/apps/docs/content/docs/en/integrations/jupyter.mdx
@@ -31,7 +31,7 @@ Integrate a self-hosted Jupyter server into the workflow. Browse, read, create, 
 
 ## Actions
 
-### `jupyter_list_contents`
+### Jupyter List Contents
 
 List files, notebooks, and subdirectories at a path on a Jupyter server
 
@@ -59,7 +59,7 @@ List files, notebooks, and subdirectories at a path on a Jupyter server
 |   ↳ `format` | string | json, text, or base64 |
 | `path` | string | The listed directory path |
 
-### `jupyter_get_content`
+### Jupyter Get Content
 
 Read a file or notebook from a Jupyter server
 
@@ -81,7 +81,7 @@ Read a file or notebook from a Jupyter server
 | `text` | string | Text content, for text files and notebooks \(JSON-stringified\) |
 | `file` | file | Binary content stored as a file, for base64-format content |
 
-### `jupyter_create_file`
+### Jupyter Create File
 
 Create a file, notebook, or directory on a Jupyter server
 
@@ -105,7 +105,7 @@ Create a file, notebook, or directory on a Jupyter server
 | `createdAt` | string | Creation timestamp |
 | `lastModified` | string | Last modified timestamp |
 
-### `jupyter_upload_file`
+### Jupyter Upload File
 
 Upload a file to a Jupyter server
 
@@ -129,7 +129,7 @@ Upload a file to a Jupyter server
 | `size` | number | File size in bytes |
 | `lastModified` | string | Last modified timestamp |
 
-### `jupyter_rename_content`
+### Jupyter Rename Content
 
 Rename or move a file, notebook, or directory on a Jupyter server
 
@@ -150,7 +150,7 @@ Rename or move a file, notebook, or directory on a Jupyter server
 | `path` | string | New entry path |
 | `lastModified` | string | Last modified timestamp |
 
-### `jupyter_delete_content`
+### Jupyter Delete Content
 
 Delete a file, notebook, or directory on a Jupyter server
 
@@ -169,7 +169,7 @@ Delete a file, notebook, or directory on a Jupyter server
 | `success` | boolean | Whether the entry was deleted |
 | `path` | string | Deleted entry path |
 
-### `jupyter_copy_content`
+### Jupyter Copy Content
 
 Duplicate a file or notebook into a directory on a Jupyter server
 
@@ -190,7 +190,7 @@ Duplicate a file or notebook into a directory on a Jupyter server
 | `path` | string | Path of the copied entry |
 | `createdAt` | string | Creation timestamp |
 
-### `jupyter_list_kernels`
+### Jupyter List Kernels
 
 List running kernels on a Jupyter server
 
@@ -212,7 +212,7 @@ List running kernels on a Jupyter server
 |   ↳ `executionState` | string | Kernel execution state |
 |   ↳ `connections` | number | Active connection count |
 
-### `jupyter_start_kernel`
+### Jupyter Start Kernel
 
 Start a new kernel on a Jupyter server
 
@@ -234,7 +234,7 @@ Start a new kernel on a Jupyter server
 | `executionState` | string | Kernel execution state |
 | `connections` | number | Active connection count |
 
-### `jupyter_stop_kernel`
+### Jupyter Stop Kernel
 
 Shut down a running kernel on a Jupyter server
 
@@ -253,7 +253,7 @@ Shut down a running kernel on a Jupyter server
 | `success` | boolean | Whether the kernel was shut down |
 | `kernelId` | string | Shut down kernel ID |
 
-### `jupyter_restart_kernel`
+### Jupyter Restart Kernel
 
 Restart a running kernel on a Jupyter server
 
@@ -275,7 +275,7 @@ Restart a running kernel on a Jupyter server
 | `executionState` | string | Kernel execution state |
 | `connections` | number | Active connection count |
 
-### `jupyter_interrupt_kernel`
+### Jupyter Interrupt Kernel
 
 Interrupt a running kernel on a Jupyter server
 
@@ -294,7 +294,7 @@ Interrupt a running kernel on a Jupyter server
 | `success` | boolean | Whether the interrupt was sent |
 | `kernelId` | string | Interrupted kernel ID |
 
-### `jupyter_list_kernelspecs`
+### Jupyter List Kernel Specs
 
 List available kernel specs (languages/runtimes) on a Jupyter server
 
@@ -317,7 +317,7 @@ List available kernel specs (languages/runtimes) on a Jupyter server
 |   ↳ `argv` | array | Launch command arguments |
 |   ↳ `interruptMode` | string | Interrupt mode |
 
-### `jupyter_list_sessions`
+### Jupyter List Sessions
 
 List active sessions (notebook-to-kernel bindings) on a Jupyter server
 
@@ -344,7 +344,7 @@ List active sessions (notebook-to-kernel bindings) on a Jupyter server
 |     ↳ `executionState` | string | Kernel execution state |
 |     ↳ `connections` | number | Active connection count |
 
-### `jupyter_create_session`
+### Jupyter Create Session
 
 Create a session that binds a notebook path to a (new or existing) kernel
 
@@ -374,7 +374,7 @@ Create a session that binds a notebook path to a (new or existing) kernel
 |   ↳ `executionState` | string | Kernel execution state |
 |   ↳ `connections` | number | Active connection count |
 
-### `jupyter_delete_session`
+### Jupyter Delete Session
 
 Delete a session on a Jupyter server (does not shut down its kernel)
 

--- a/apps/docs/content/docs/en/integrations/kalshi.mdx
+++ b/apps/docs/content/docs/en/integrations/kalshi.mdx
@@ -34,7 +34,7 @@ Integrate Kalshi prediction markets into the workflow. Can get markets, market, 
 
 ## Actions
 
-### `kalshi_get_markets`
+### Get Markets from Kalshi V2
 
 Retrieve a list of prediction markets from Kalshi with all filtering options (V2 - full API response)
 
@@ -91,7 +91,7 @@ Retrieve a list of prediction markets from Kalshi with all filtering options (V2
 |   ↳ `category` | string | Market category |
 | `cursor` | string | Pagination cursor for fetching more results |
 
-### `kalshi_get_market`
+### Get Market from Kalshi V2
 
 Retrieve details of a specific prediction market by ticker (V2 - full API response)
 
@@ -158,7 +158,7 @@ Retrieve details of a specific prediction market by ticker (V2 - full API respon
 |   ↳ `no_bid_fp` | number | No bid \(fixed-point\) |
 |   ↳ `no_ask_fp` | number | No ask \(fixed-point\) |
 
-### `kalshi_get_events`
+### Get Events from Kalshi V2
 
 Retrieve a list of events from Kalshi with optional filtering (V2 - exact API response)
 
@@ -200,7 +200,7 @@ Retrieve a list of events from Kalshi with optional filtering (V2 - exact API re
 |   ↳ `last_updated_ts` | string | Last updated time \(ISO 8601\) |
 | `cursor` | string | Pagination cursor for fetching more results |
 
-### `kalshi_get_event`
+### Get Event from Kalshi V2
 
 Retrieve details of a specific event by ticker (V2 - exact API response)
 
@@ -229,7 +229,7 @@ Retrieve details of a specific event by ticker (V2 - exact API response)
 |   ↳ `product_metadata` | object | Product metadata |
 |   ↳ `markets` | array | Nested markets \(if requested\) |
 
-### `kalshi_get_balance`
+### Get Balance from Kalshi V2
 
 Retrieve your account balance and portfolio value from Kalshi (V2 - exact API response)
 
@@ -248,7 +248,7 @@ Retrieve your account balance and portfolio value from Kalshi (V2 - exact API re
 | `portfolio_value` | number | Portfolio value in cents |
 | `updated_ts` | number | Unix timestamp of last update \(seconds\) |
 
-### `kalshi_get_positions`
+### Get Positions from Kalshi V2
 
 Retrieve your open positions from Kalshi (V2 - exact API response)
 
@@ -287,7 +287,7 @@ Retrieve your open positions from Kalshi (V2 - exact API response)
 |   ↳ `total_cost` | number | Total cost basis in cents |
 | `cursor` | string | Pagination cursor for fetching more results |
 
-### `kalshi_get_orders`
+### Get Orders from Kalshi V2
 
 Retrieve your orders from Kalshi with optional filtering (V2 with full API response)
 
@@ -331,7 +331,7 @@ Retrieve your orders from Kalshi with optional filtering (V2 with full API respo
 |   ↳ `last_update_time` | string | Last order update time |
 | `cursor` | string | Pagination cursor for fetching more results |
 
-### `kalshi_get_order`
+### Get Order from Kalshi V2
 
 Retrieve details of a specific order by ID from Kalshi (V2 with full API response)
 
@@ -382,7 +382,7 @@ Retrieve details of a specific order by ID from Kalshi (V2 with full API respons
 |   ↳ `order_group_id` | string | Order group ID |
 |   ↳ `cancel_order_on_pause` | boolean | Cancel on market pause |
 
-### `kalshi_get_orderbook`
+### Get Market Orderbook from Kalshi V2
 
 Retrieve the orderbook (yes and no bids) for a specific market (V2 - includes depth and fp fields)
 
@@ -406,7 +406,7 @@ Retrieve the orderbook (yes and no bids) for a specific market (V2 - includes de
 |   ↳ `yes_dollars` | array | Yes side bids as tuples \[dollars_string, fp_count_string\] |
 |   ↳ `no_dollars` | array | No side bids as tuples \[dollars_string, fp_count_string\] |
 
-### `kalshi_get_trades`
+### Get Trades from Kalshi V2
 
 Retrieve recent trades with additional filtering options (V2 - includes trade_id and count_fp)
 
@@ -433,7 +433,7 @@ Retrieve recent trades with additional filtering options (V2 - includes trade_id
 |   ↳ `created_time` | string | Trade time \(ISO 8601\) |
 | `cursor` | string | Pagination cursor for fetching more results |
 
-### `kalshi_get_candlesticks`
+### Get Market Candlesticks from Kalshi V2
 
 Retrieve OHLC candlestick data for a specific market (V2 - full API response)
 
@@ -454,7 +454,7 @@ Retrieve OHLC candlestick data for a specific market (V2 - full API response)
 | `ticker` | string | Market ticker |
 | `candlesticks` | array | Array of OHLC candlestick data with nested bid/ask/price objects |
 
-### `kalshi_get_event_candlesticks`
+### Get Event Candlesticks from Kalshi V2
 
 Retrieve OHLC candlestick data aggregated across all markets in an event (V2 - full API response)
 
@@ -476,7 +476,7 @@ Retrieve OHLC candlestick data aggregated across all markets in an event (V2 - f
 | `adjusted_end_ts` | number | Adjusted end timestamp used for the candlestick range \(Unix seconds\) |
 | `market_candlesticks` | array | Array of event-level aggregated OHLC candlestick data with nested bid/ask/price |
 
-### `kalshi_get_fills`
+### Get Fills from Kalshi V2
 
 Retrieve your portfolio's fills/trades from Kalshi (V2 - exact API response)
 
@@ -511,7 +511,7 @@ Retrieve your portfolio's fills/trades from Kalshi (V2 - exact API response)
 |   ↳ `created_time` | string | Trade execution time \(ISO 8601\) |
 | `cursor` | string | Pagination cursor for fetching more results |
 
-### `kalshi_get_settlements`
+### Get Settlements from Kalshi V2
 
 Retrieve your portfolio settlement history from Kalshi (V2 - exact API response)
 
@@ -547,7 +547,7 @@ Retrieve your portfolio settlement history from Kalshi (V2 - exact API response)
 |   ↳ `value` | number | Single yes contract payout in cents |
 | `cursor` | string | Pagination cursor for fetching more results |
 
-### `kalshi_get_series_by_ticker`
+### Get Series by Ticker from Kalshi V2
 
 Retrieve details of a specific market series by ticker (V2 - exact API response)
 
@@ -578,7 +578,7 @@ Retrieve details of a specific market series by ticker (V2 - exact API response)
 |   ↳ `volume` | number | Series volume |
 |   ↳ `volume_fp` | number | Volume \(fixed-point\) |
 
-### `kalshi_get_series_list`
+### Get Series List from Kalshi V2
 
 Retrieve a list of market series from Kalshi with optional filtering (V2 - exact API response)
 
@@ -604,7 +604,7 @@ Retrieve a list of market series from Kalshi with optional filtering (V2 - exact
 |   ↳ `tags` | array | Series tags |
 |   ↳ `contract_url` | string | Contract rules URL |
 
-### `kalshi_get_exchange_status`
+### Get Exchange Status from Kalshi V2
 
 Retrieve the current status of the Kalshi exchange (V2 - exact API response)
 
@@ -621,7 +621,7 @@ Retrieve the current status of the Kalshi exchange (V2 - exact API response)
 | `trading_active` | boolean | Whether trading is active |
 | `exchange_estimated_resume_time` | string | Estimated time when exchange will resume \(if inactive\) |
 
-### `kalshi_get_exchange_schedule`
+### Get Exchange Schedule from Kalshi V2
 
 Retrieve the Kalshi exchange trading schedule and maintenance windows (V2 - exact API response)
 
@@ -638,7 +638,7 @@ Retrieve the Kalshi exchange trading schedule and maintenance windows (V2 - exac
 |   ↳ `standard_hours` | array | Weekly schedules with per-day open/close trading sessions |
 |   ↳ `maintenance_windows` | array | Scheduled maintenance windows with start_datetime and end_datetime |
 
-### `kalshi_get_exchange_announcements`
+### Get Exchange Announcements from Kalshi V2
 
 Retrieve exchange-wide announcements from Kalshi (V2 - exact API response)
 
@@ -657,7 +657,7 @@ Retrieve exchange-wide announcements from Kalshi (V2 - exact API response)
 |   ↳ `delivery_time` | string | Delivery time \(ISO 8601\) |
 |   ↳ `status` | string | Announcement status \(active, inactive\) |
 
-### `kalshi_create_order`
+### Create Order on Kalshi V2
 
 Create a new order on a Kalshi prediction market (V2 with full API response)
 
@@ -727,7 +727,7 @@ Create a new order on a Kalshi prediction market (V2 with full API response)
 |   ↳ `order_group_id` | string | Order group ID |
 |   ↳ `cancel_order_on_pause` | boolean | Cancel on market pause |
 
-### `kalshi_cancel_order`
+### Cancel Order on Kalshi V2
 
 Cancel an existing order on Kalshi (V2 with full API response)
 
@@ -780,7 +780,7 @@ Cancel an existing order on Kalshi (V2 with full API response)
 | `reduced_by` | number | Number of contracts canceled |
 | `reduced_by_fp` | string | Number of contracts canceled in fixed-point format |
 
-### `kalshi_amend_order`
+### Amend Order on Kalshi V2
 
 Modify the price or quantity of an existing order on Kalshi (V2 with full API response)
 

--- a/apps/docs/content/docs/en/integrations/ketch.mdx
+++ b/apps/docs/content/docs/en/integrations/ketch.mdx
@@ -34,7 +34,7 @@ Integrate Ketch into the workflow. Retrieve and update consent preferences, mana
 
 ## Actions
 
-### `ketch_get_consent`
+### Ketch Get Consent
 
 Retrieve consent status for a data subject. Returns the current consent preferences for each configured purpose.
 
@@ -58,7 +58,7 @@ Retrieve consent status for a data subject. Returns the current consent preferen
 |   ↳ `legalBasisCode` | string | Legal basis code \(e.g., "consent_optin", "consent_optout", "disclosure", "other"\) |
 | `vendors` | object | Map of vendor consent statuses |
 
-### `ketch_set_consent`
+### Ketch Set Consent
 
 Update consent preferences for a data subject. Sets the consent status for specified purposes with the appropriate legal basis.
 
@@ -82,7 +82,7 @@ Update consent preferences for a data subject. Sets the consent status for speci
 |   ↳ `allowed` | string | Consent status for the purpose: "granted" or "denied" |
 |   ↳ `legalBasisCode` | string | Legal basis code \(e.g., "consent_optin", "consent_optout", "disclosure", "other"\) |
 
-### `ketch_get_subscriptions`
+### Ketch Get Subscriptions
 
 Retrieve subscription preferences for a data subject. Returns the current subscription topic and control statuses.
 
@@ -102,7 +102,7 @@ Retrieve subscription preferences for a data subject. Returns the current subscr
 | `topics` | object | Map of topic codes to contact method settings \(e.g., \{"newsletter": \{"email": \{"status": "granted"\}\}\}\) |
 | `controls` | object | Map of control codes to settings \(e.g., \{"global_unsubscribe": \{"status": "denied"\}\}\) |
 
-### `ketch_set_subscriptions`
+### Ketch Set Subscriptions
 
 Update subscription preferences for a data subject. Sets topic and control statuses for email, SMS, and other contact methods.
 
@@ -123,7 +123,7 @@ Update subscription preferences for a data subject. Sets topic and control statu
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the subscription preferences were updated |
 
-### `ketch_invoke_right`
+### Ketch Invoke Right
 
 Submit a data subject rights request (e.g., access, delete, correct, restrict processing). Initiates a privacy rights workflow in Ketch.
 

--- a/apps/docs/content/docs/en/integrations/knowledge.mdx
+++ b/apps/docs/content/docs/en/integrations/knowledge.mdx
@@ -31,7 +31,7 @@ Integrate Knowledge into the workflow. Perform full CRUD operations on documents
 
 ## Actions
 
-### `knowledge_search`
+### Knowledge Search
 
 Search for similar content in a knowledge base using vector similarity
 
@@ -66,7 +66,7 @@ Search for similar content in a knowledge base using vector similarity
 | `totalResults` | number | Total number of results found |
 | `cost` | object | Cost information for the search operation |
 
-### `knowledge_upload_chunk`
+### Knowledge Upload Chunk
 
 Upload a new chunk to a document in a knowledge base
 
@@ -96,7 +96,7 @@ Upload a new chunk to a document in a knowledge base
 | `documentName` | string | Name of the document the chunk was added to |
 | `cost` | object | Cost information for the upload operation |
 
-### `knowledge_create_document`
+### Knowledge Create Document
 
 Create a new document in a knowledge base
 
@@ -124,7 +124,7 @@ Create a new document in a knowledge base
 | `message` | string | Success or error message describing the operation result |
 | `documentId` | string | ID of the created document |
 
-### `knowledge_upsert_document`
+### Knowledge Upsert Document
 
 Create or update a document in a knowledge base. If a document with the given ID or filename already exists, it will be replaced with the new content.
 
@@ -155,7 +155,7 @@ Create or update a document in a knowledge base. If a document with the given ID
 | `message` | string | Success or error message describing the operation result |
 | `documentId` | string | ID of the upserted document |
 
-### `knowledge_list_tags`
+### Knowledge List Tags
 
 List all tag definitions for a knowledge base
 
@@ -179,7 +179,7 @@ List all tag definitions for a knowledge base
 |   ↳ `updatedAt` | string | Last update timestamp |
 | `totalTags` | number | Total number of tag definitions |
 
-### `knowledge_list_documents`
+### Knowledge List Documents
 
 List documents in a knowledge base with optional filtering, search, and pagination
 
@@ -216,7 +216,7 @@ List documents in a knowledge base with optional filtering, search, and paginati
 | `limit` | number | Page size used |
 | `offset` | number | Offset used for pagination |
 
-### `knowledge_get_document`
+### Knowledge Get Document
 
 Get full details of a single document including tags, connector metadata, and processing status
 
@@ -248,7 +248,7 @@ Get full details of a single document including tags, connector metadata, and pr
 | `externalId` | string | External ID from the source system |
 | `tags` | object | Tag values keyed by tag slot \(tag1-7, number1-5, date1-2, boolean1-3\) |
 
-### `knowledge_delete_document`
+### Knowledge Delete Document
 
 Delete a document from a knowledge base
 
@@ -266,7 +266,7 @@ Delete a document from a knowledge base
 | `documentId` | string | ID of the deleted document |
 | `message` | string | Confirmation message |
 
-### `knowledge_list_chunks`
+### Knowledge List Chunks
 
 List chunks for a document in a knowledge base with optional filtering and pagination
 
@@ -300,7 +300,7 @@ List chunks for a document in a knowledge base with optional filtering and pagin
 | `limit` | number | Page size used |
 | `offset` | number | Offset used for pagination |
 
-### `knowledge_update_chunk`
+### Knowledge Update Chunk
 
 Update the content or enabled status of a chunk in a knowledge base
 
@@ -327,7 +327,7 @@ Update the content or enabled status of a chunk in a knowledge base
 | `enabled` | boolean | Whether the chunk is enabled |
 | `updatedAt` | string | Last update timestamp |
 
-### `knowledge_delete_chunk`
+### Knowledge Delete Chunk
 
 Delete a chunk from a document in a knowledge base
 
@@ -347,7 +347,7 @@ Delete a chunk from a document in a knowledge base
 | `documentId` | string | ID of the parent document |
 | `message` | string | Confirmation message |
 
-### `knowledge_list_connectors`
+### Knowledge List Connectors
 
 List all connectors for a knowledge base, showing sync status, type, and document counts
 
@@ -376,7 +376,7 @@ List all connectors for a knowledge base, showing sync status, type, and documen
 |   ↳ `updatedAt` | string | Last update timestamp |
 | `totalConnectors` | number | Total number of connectors |
 
-### `knowledge_get_connector`
+### Knowledge Get Connector
 
 Get detailed connector information including recent sync logs for monitoring sync health
 
@@ -414,7 +414,7 @@ Get detailed connector information including recent sync logs for monitoring syn
 |   ↳ `docsUnchanged` | number | Documents unchanged |
 |   ↳ `errorMessage` | string | Error message if sync failed |
 
-### `knowledge_trigger_sync`
+### Knowledge Trigger Sync
 
 Trigger a manual sync for a knowledge base connector
 

--- a/apps/docs/content/docs/en/integrations/langsmith.mdx
+++ b/apps/docs/content/docs/en/integrations/langsmith.mdx
@@ -35,7 +35,7 @@ Send run data to LangSmith to trace executions, attach metadata, and monitor wor
 
 ## Actions
 
-### `langsmith_create_run`
+### LangSmith Create Run
 
 Forward a single run to LangSmith for ingestion.
 
@@ -70,7 +70,7 @@ Forward a single run to LangSmith for ingestion.
 | `runId` | string | Run identifier provided in the request |
 | `message` | string | Response message from LangSmith |
 
-### `langsmith_create_runs_batch`
+### LangSmith Create Runs Batch
 
 Forward multiple runs to LangSmith in a single batch.
 
@@ -91,7 +91,7 @@ Forward multiple runs to LangSmith in a single batch.
 | `message` | string | Response message from LangSmith |
 | `messages` | array | Per-run response messages, when provided |
 
-### `langsmith_update_run`
+### LangSmith Update Run
 
 Patch an existing LangSmith run with outputs, status, or timing once it completes.
 
@@ -107,7 +107,7 @@ Patch an existing LangSmith run with outputs, status, or timing once it complete
 
 This tool does not produce any outputs.
 
-### `langsmith_get_run`
+### LangSmith Get Run
 
 Retrieve a single LangSmith run by ID.
 
@@ -139,7 +139,7 @@ Retrieve a single LangSmith run by ID.
 | `totalTokens` | number | Total tokens consumed by the run |
 | `totalCost` | string | Total cost of the run |
 
-### `langsmith_create_feedback`
+### LangSmith Create Feedback
 
 Attach a score, correction, or comment to a LangSmith run.
 

--- a/apps/docs/content/docs/en/integrations/latex.mdx
+++ b/apps/docs/content/docs/en/integrations/latex.mdx
@@ -35,7 +35,7 @@ Integrates LaTeX into the workflow. Compiles LaTeX source into a PDF file with p
 
 ## Actions
 
-### `latex_compile`
+### LaTeX Compile
 
 Compile a LaTeX document into a PDF via the public LaTeX-on-HTTP service (latex.ytotech.com). Supports pdflatex, xelatex, lualatex, platex, uplatex, and context, plus supporting resources such as images, included .tex files, and bibliographies.
 
@@ -57,7 +57,7 @@ Compile a LaTeX document into a PDF via the public LaTeX-on-HTTP service (latex.
 | `fileName` | string | Name of the compiled PDF file |
 | `compiler` | string | LaTeX compiler used for the build |
 
-### `latex_search_packages`
+### LaTeX Search Packages
 
 Search the TeX Live packages available to the LaTeX compiler by name or description, e.g. to check which packages can be used in a document.
 
@@ -79,7 +79,7 @@ Search the TeX Live packages available to the LaTeX compiler by name or descript
 |   ↳ `ctanUrl` | string | CTAN page for the package |
 | `totalMatches` | number | Total number of packages matching the query, before truncation |
 
-### `latex_get_package`
+### LaTeX Get Package
 
 Get details about a specific TeX Live package available to the LaTeX compiler, including whether it is installed, its description, license, and related packages.
 
@@ -105,7 +105,7 @@ Get details about a specific TeX Live package available to the LaTeX compiler, i
 |   ↳ `homepage` | string | Package homepage URL |
 |   ↳ `ctanUrl` | string | CTAN page for the package |
 
-### `latex_list_fonts`
+### LaTeX List Fonts
 
 List the system fonts available to the LaTeX compiler, optionally filtered by name, e.g. to pick a font for xelatex or lualatex documents using fontspec.
 

--- a/apps/docs/content/docs/en/integrations/launchdarkly.mdx
+++ b/apps/docs/content/docs/en/integrations/launchdarkly.mdx
@@ -42,7 +42,7 @@ Integrate LaunchDarkly into your workflow. List, create, update, toggle, and del
 
 ## Actions
 
-### `launchdarkly_create_flag`
+### LaunchDarkly Create Flag
 
 Create a new feature flag in a LaunchDarkly project.
 
@@ -78,7 +78,7 @@ Create a new feature flag in a LaunchDarkly project.
 | `maintainerId` | string | The ID of the member who maintains this flag |
 | `maintainerEmail` | string | The email of the member who maintains this flag |
 
-### `launchdarkly_delete_flag`
+### LaunchDarkly Delete Flag
 
 Delete a feature flag from a LaunchDarkly project.
 
@@ -96,7 +96,7 @@ Delete a feature flag from a LaunchDarkly project.
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the flag was successfully deleted |
 
-### `launchdarkly_get_audit_log`
+### LaunchDarkly Get Audit Log
 
 List audit log entries from your LaunchDarkly account.
 
@@ -124,7 +124,7 @@ List audit log entries from your LaunchDarkly account.
 |   ↳ `targetKind` | string | Resource specifier of the target \(e.g. proj/default:env/production:flag/my-flag\) |
 | `totalCount` | number | Total number of audit log entries |
 
-### `launchdarkly_get_flag`
+### LaunchDarkly Get Flag
 
 Get a single feature flag by key from a LaunchDarkly project.
 
@@ -158,7 +158,7 @@ Get a single feature flag by key from a LaunchDarkly project.
 | `maintainerEmail` | string | The email of the member who maintains this flag |
 | `on` | boolean | Whether the flag is on in the requested environment \(null when the flag spans multiple environments and no environment key was provided\) |
 
-### `launchdarkly_get_flag_status`
+### LaunchDarkly Get Flag Status
 
 Get the status of a feature flag across environments (active, inactive, launched, etc.).
 
@@ -179,7 +179,7 @@ Get the status of a feature flag across environments (active, inactive, launched
 | `lastRequested` | string | Timestamp of the last evaluation |
 | `defaultVal` | string | The default variation value |
 
-### `launchdarkly_list_environments`
+### LaunchDarkly List Environments
 
 List environments in a LaunchDarkly project.
 
@@ -205,7 +205,7 @@ List environments in a LaunchDarkly project.
 |   ↳ `tags` | array | Tags applied to the environment |
 | `totalCount` | number | Total number of environments |
 
-### `launchdarkly_list_flags`
+### LaunchDarkly List Flags
 
 List feature flags in a LaunchDarkly project.
 
@@ -241,7 +241,7 @@ List feature flags in a LaunchDarkly project.
 |   ↳ `maintainerEmail` | string | The email of the member who maintains this flag |
 | `totalCount` | number | Total number of flags |
 
-### `launchdarkly_list_members`
+### LaunchDarkly List Members
 
 List account members in your LaunchDarkly organization.
 
@@ -267,7 +267,7 @@ List account members in your LaunchDarkly organization.
 |   ↳ `verified` | boolean | Whether the member email is verified |
 | `totalCount` | number | Total number of members |
 
-### `launchdarkly_list_projects`
+### LaunchDarkly List Projects
 
 List all projects in your LaunchDarkly account.
 
@@ -289,7 +289,7 @@ List all projects in your LaunchDarkly account.
 |   ↳ `tags` | array | Tags applied to the project |
 | `totalCount` | number | Total number of projects |
 
-### `launchdarkly_list_segments`
+### LaunchDarkly List Segments
 
 List user segments in a LaunchDarkly project and environment.
 
@@ -317,7 +317,7 @@ List user segments in a LaunchDarkly project and environment.
 |   ↳ `excluded` | array | User keys explicitly excluded from the segment |
 | `totalCount` | number | Total number of segments |
 
-### `launchdarkly_toggle_flag`
+### LaunchDarkly Toggle Flag
 
 Toggle a feature flag on or off in a specific LaunchDarkly environment.
 
@@ -352,7 +352,7 @@ Toggle a feature flag on or off in a specific LaunchDarkly environment.
 | `maintainerEmail` | string | The email of the member who maintains this flag |
 | `on` | boolean | Whether the flag is now on in the target environment |
 
-### `launchdarkly_update_flag`
+### LaunchDarkly Update Flag
 
 Update feature flag metadata (name, description, tags, temporary, archived) using semantic patch.
 

--- a/apps/docs/content/docs/en/integrations/leadmagic.mdx
+++ b/apps/docs/content/docs/en/integrations/leadmagic.mdx
@@ -33,7 +33,7 @@ Integrate LeadMagic to find verified work emails by name or company, validate em
 
 ## Actions
 
-### `leadmagic_validate_email`
+### LeadMagic Validate Email
 
 Verify an email address for deliverability. Charges 0.25 credits for definitive SMTP results (valid/invalid); unknown and RFC-invalid results are free.
 
@@ -61,7 +61,7 @@ Verify an email address for deliverability. Charges 0.25 credits for definitive 
 | `company_industry` | string | Industry of the company |
 | `company_size` | string | Company size range |
 
-### `leadmagic_find_email`
+### LeadMagic Find Email
 
 Find someone's verified work email from their name and company domain. Charges 1 credit when a valid email is found; free when no result.
 
@@ -93,7 +93,7 @@ Find someone's verified work email from their name and company domain. Charges 1
 | `company_size` | string | Company size range |
 | `company_profile_url` | string | Company LinkedIn/B2B profile URL |
 
-### `leadmagic_find_mobile`
+### LeadMagic Find Mobile
 
 Find a person's direct mobile number from their LinkedIn profile URL or email. Charges 5 credits when a number is found; free when no result.
 
@@ -116,7 +116,7 @@ Find a person's direct mobile number from their LinkedIn profile URL or email. C
 | `credits_consumed` | number | Credits charged \(5 when mobile found\) |
 | `message` | string | Status message from the API |
 
-### `leadmagic_profile_search`
+### LeadMagic Profile Search
 
 Enrich a LinkedIn profile with work history, education, skills, and contact data. Charges 1 credit per successful enrichment; free when profile not found.
 
@@ -152,7 +152,7 @@ Enrich a LinkedIn profile with work history, education, skills, and contact data
 | `credits_consumed` | number | Credits charged \(1 when profile found\) |
 | `message` | string | Human-readable status message |
 
-### `leadmagic_profile_to_email`
+### LeadMagic Profile to Email
 
 Extract a verified work email from a LinkedIn profile URL. Charges 5 credits when an email is found; free when no result.
 
@@ -172,7 +172,7 @@ Extract a verified work email from a LinkedIn profile URL. Charges 5 credits whe
 | `credits_consumed` | number | Credits charged \(5 when email found\) |
 | `message` | string | Human-readable status message |
 
-### `leadmagic_email_to_profile`
+### LeadMagic Email to Profile
 
 Retrieve a LinkedIn profile URL from a work or personal email address. Charges 10 credits when a profile is found; free when no result.
 
@@ -192,7 +192,7 @@ Retrieve a LinkedIn profile URL from a work or personal email address. Charges 1
 | `credits_consumed` | number | Credits charged \(10 when profile found\) |
 | `message` | string | Human-readable status message |
 
-### `leadmagic_company_search`
+### LeadMagic Company Search
 
 Enrich company data including firmographics, headcount, funding, and social profiles by domain, LinkedIn URL, or name. Charges 1 credit when a company is found; free when no result.
 
@@ -229,7 +229,7 @@ Enrich company data including firmographics, headcount, funding, and social prof
 | `credits_consumed` | number | Credits charged \(1 when company found\) |
 | `message` | string | Human-readable status message |
 
-### `leadmagic_role_finder`
+### LeadMagic Role Finder
 
 Find the person holding a specific job role at a company. Charges 2 credits when a matching person is found; free when no result.
 
@@ -256,7 +256,7 @@ Find the person holding a specific job role at a company. Charges 2 credits when
 | `credits_consumed` | number | Credits charged \(2 when person found\) |
 | `message` | string | Human-readable status message |
 
-### `leadmagic_get_credits`
+### LeadMagic Get Credits
 
 Retrieve the current credit balance for the authenticated LeadMagic account. This endpoint is free and consumes no credits.
 

--- a/apps/docs/content/docs/en/integrations/lemlist.mdx
+++ b/apps/docs/content/docs/en/integrations/lemlist.mdx
@@ -36,7 +36,7 @@ Integrate Lemlist into your workflow. Retrieve campaign activities and replies, 
 
 ## Actions
 
-### `lemlist_get_activities`
+### Lemlist Get Activities
 
 Retrieves campaign activities and steps performed, including email opens, clicks, replies, and other events.
 
@@ -66,7 +66,7 @@ Retrieves campaign activities and steps performed, including email opens, clicks
 |   ↳ `createdAt` | string | When the activity occurred |
 | `count` | number | Number of activities returned |
 
-### `lemlist_get_lead`
+### Lemlist Get Lead
 
 Retrieves lead information by email address or lead ID.
 
@@ -93,7 +93,7 @@ Retrieves lead information by email address or lead ID.
 | `contactId` | string | Contact ID |
 | `emailStatus` | string | Email deliverability status |
 
-### `lemlist_send_email`
+### Lemlist Send Email
 
 Sends an email to a contact through the Lemlist inbox.
 

--- a/apps/docs/content/docs/en/integrations/linear.mdx
+++ b/apps/docs/content/docs/en/integrations/linear.mdx
@@ -37,7 +37,7 @@ Integrate Linear into the workflow. Can manage issues, comments, projects, label
 
 ## Actions
 
-### `linear_read_issues`
+### Linear Issue Reader
 
 Fetch and filter issues from Linear
 
@@ -95,7 +95,7 @@ Fetch and filter issues from Linear
 |     ↳ `name` | string | Label name |
 |     ↳ `color` | string | Label color \(hex\) |
 
-### `linear_get_issue`
+### Linear Get Issue
 
 Get a single issue by ID from Linear with full details
 
@@ -137,7 +137,7 @@ Get a single issue by ID from Linear with full details
 |     ↳ `name` | string | Label name |
 |     ↳ `color` | string | Label color \(hex\) |
 
-### `linear_create_issue`
+### Linear Issue Writer
 
 Create a new issue in Linear
 
@@ -199,7 +199,7 @@ Create a new issue in Linear
 |   ↳ `projectMilestoneId` | string | Project milestone ID |
 |   ↳ `projectMilestoneName` | string | Project milestone name |
 
-### `linear_update_issue`
+### Linear Update Issue
 
 Update an existing issue in Linear
 
@@ -261,7 +261,7 @@ Update an existing issue in Linear
 |   ↳ `projectMilestoneId` | string | Project milestone ID |
 |   ↳ `projectMilestoneName` | string | Project milestone name |
 
-### `linear_archive_issue`
+### Linear Archive Issue
 
 Archive an issue in Linear
 
@@ -278,7 +278,7 @@ Archive an issue in Linear
 | `success` | boolean | Whether the archive operation was successful |
 | `issueId` | string | The ID of the archived issue |
 
-### `linear_unarchive_issue`
+### Linear Unarchive Issue
 
 Unarchive (restore) an archived issue in Linear
 
@@ -295,7 +295,7 @@ Unarchive (restore) an archived issue in Linear
 | `success` | boolean | Whether the unarchive operation was successful |
 | `issueId` | string | The ID of the unarchived issue |
 
-### `linear_delete_issue`
+### Linear Delete Issue
 
 Delete (trash) an issue in Linear
 
@@ -311,7 +311,7 @@ Delete (trash) an issue in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the delete operation was successful |
 
-### `linear_search_issues`
+### Linear Search Issues
 
 Search for issues in Linear using full-text search
 
@@ -360,7 +360,7 @@ Search for issues in Linear using full-text search
 |     ↳ `name` | string | Label name |
 |     ↳ `color` | string | Label color \(hex\) |
 
-### `linear_add_label_to_issue`
+### Linear Add Label to Issue
 
 Add a label to an issue in Linear
 
@@ -378,7 +378,7 @@ Add a label to an issue in Linear
 | `success` | boolean | Whether the label was successfully added |
 | `issueId` | string | The ID of the issue |
 
-### `linear_remove_label_from_issue`
+### Linear Remove Label from Issue
 
 Remove a label from an issue in Linear
 
@@ -396,7 +396,7 @@ Remove a label from an issue in Linear
 | `success` | boolean | Whether the label was successfully removed |
 | `issueId` | string | The ID of the issue |
 
-### `linear_create_comment`
+### Linear Create Comment
 
 Add a comment to an issue in Linear
 
@@ -424,7 +424,7 @@ Add a comment to an issue in Linear
 |     ↳ `id` | string | Issue ID |
 |     ↳ `title` | string | Issue title |
 
-### `linear_update_comment`
+### Linear Update Comment
 
 Edit a comment in Linear
 
@@ -452,7 +452,7 @@ Edit a comment in Linear
 |     ↳ `id` | string | Issue ID |
 |     ↳ `title` | string | Issue title |
 
-### `linear_delete_comment`
+### Linear Delete Comment
 
 Delete a comment from Linear
 
@@ -468,7 +468,7 @@ Delete a comment from Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the delete operation was successful |
 
-### `linear_list_comments`
+### Linear List Comments
 
 List all comments on an issue in Linear
 
@@ -500,7 +500,7 @@ List all comments on an issue in Linear
 |     ↳ `id` | string | Issue ID |
 |     ↳ `title` | string | Issue title |
 
-### `linear_list_projects`
+### Linear List Projects
 
 List projects in Linear with optional filtering
 
@@ -537,7 +537,7 @@ List projects in Linear with optional filtering
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_get_project`
+### Linear Get Project
 
 Get a single project by ID from Linear
 
@@ -568,7 +568,7 @@ Get a single project by ID from Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_create_project`
+### Linear Create Project
 
 Create a new project in Linear
 
@@ -605,7 +605,7 @@ Create a new project in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_update_project`
+### Linear Update Project
 
 Update an existing project in Linear
 
@@ -643,7 +643,7 @@ Update an existing project in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_archive_project`
+### Linear Archive Project
 
 Archive a project in Linear
 
@@ -660,7 +660,7 @@ Archive a project in Linear
 | `success` | boolean | Whether the archive operation was successful |
 | `projectId` | string | The ID of the archived project |
 
-### `linear_list_users`
+### Linear List Users
 
 List all users in the Linear workspace
 
@@ -688,7 +688,7 @@ List all users in the Linear workspace
 |   ↳ `admin` | boolean | Whether user is admin |
 |   ↳ `avatarUrl` | string | Avatar URL |
 
-### `linear_list_teams`
+### Linear List Teams
 
 List all teams in the Linear workspace
 
@@ -712,7 +712,7 @@ List all teams in the Linear workspace
 |   ↳ `key` | string | Team key \(used in issue identifiers\) |
 |   ↳ `description` | string | Team description |
 
-### `linear_get_viewer`
+### Linear Get Current User
 
 Get the currently authenticated user (viewer) information
 
@@ -734,7 +734,7 @@ Get the currently authenticated user (viewer) information
 |   ↳ `admin` | boolean | Whether user is admin |
 |   ↳ `avatarUrl` | string | Avatar URL |
 
-### `linear_list_labels`
+### Linear List Labels
 
 List all labels in Linear workspace or team
 
@@ -766,7 +766,7 @@ List all labels in Linear workspace or team
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_create_label`
+### Linear Create Label
 
 Create a new label in Linear
 
@@ -796,7 +796,7 @@ Create a new label in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_update_label`
+### Linear Update Label
 
 Update an existing label in Linear
 
@@ -826,7 +826,7 @@ Update an existing label in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_archive_label`
+### Linear Archive Label
 
 Archive a label in Linear
 
@@ -843,7 +843,7 @@ Archive a label in Linear
 | `success` | boolean | Whether the archive operation was successful |
 | `labelId` | string | The ID of the archived label |
 
-### `linear_list_workflow_states`
+### Linear List Workflow States
 
 List all workflow states (statuses) in Linear
 
@@ -876,7 +876,7 @@ List all workflow states (statuses) in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_create_workflow_state`
+### Linear Create Workflow State
 
 Create a new workflow state (status) in Linear
 
@@ -909,7 +909,7 @@ Create a new workflow state (status) in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_update_workflow_state`
+### Linear Update Workflow State
 
 Update an existing workflow state in Linear
 
@@ -941,7 +941,7 @@ Update an existing workflow state in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_list_cycles`
+### Linear List Cycles
 
 List cycles (sprints/iterations) in Linear
 
@@ -973,7 +973,7 @@ List cycles (sprints/iterations) in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_get_cycle`
+### Linear Get Cycle
 
 Get a single cycle by ID from Linear
 
@@ -1000,7 +1000,7 @@ Get a single cycle by ID from Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_create_cycle`
+### Linear Create Cycle
 
 Create a new cycle (sprint/iteration) in Linear
 
@@ -1030,7 +1030,7 @@ Create a new cycle (sprint/iteration) in Linear
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_get_active_cycle`
+### Linear Get Active Cycle
 
 Get the currently active cycle for a team
 
@@ -1057,7 +1057,7 @@ Get the currently active cycle for a team
 |     ↳ `id` | string | Team ID |
 |     ↳ `name` | string | Team name |
 
-### `linear_create_attachment`
+### Linear Create Attachment
 
 Add an attachment to an issue in Linear
 
@@ -1083,7 +1083,7 @@ Add an attachment to an issue in Linear
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 
-### `linear_list_attachments`
+### Linear List Attachments
 
 List all attachments on an issue in Linear
 
@@ -1110,7 +1110,7 @@ List all attachments on an issue in Linear
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 
-### `linear_update_attachment`
+### Linear Update Attachment
 
 Update an attachment metadata in Linear
 
@@ -1134,7 +1134,7 @@ Update an attachment metadata in Linear
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 
-### `linear_delete_attachment`
+### Linear Delete Attachment
 
 Delete an attachment from Linear
 
@@ -1150,7 +1150,7 @@ Delete an attachment from Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the delete operation was successful |
 
-### `linear_create_issue_relation`
+### Linear Create Issue Relation
 
 Link two issues together in Linear (blocks, relates to, duplicates)
 
@@ -1172,7 +1172,7 @@ Link two issues together in Linear (blocks, relates to, duplicates)
 |   ↳ `issue` | object | Source issue |
 |   ↳ `relatedIssue` | object | Target issue |
 
-### `linear_list_issue_relations`
+### Linear List Issue Relations
 
 List all relations (dependencies) for an issue in Linear
 
@@ -1195,7 +1195,7 @@ List all relations (dependencies) for an issue in Linear
 |   ↳ `relatedIssue` | object | Target issue |
 | `pageInfo` | object | Pagination information |
 
-### `linear_delete_issue_relation`
+### Linear Delete Issue Relation
 
 Remove a relation between two issues in Linear
 
@@ -1211,7 +1211,7 @@ Remove a relation between two issues in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the delete operation was successful |
 
-### `linear_create_favorite`
+### Linear Create Favorite
 
 Bookmark an issue, project, cycle, or label in Linear
 
@@ -1235,7 +1235,7 @@ Bookmark an issue, project, cycle, or label in Linear
 |   ↳ `project` | object | Favorited project \(if applicable\) |
 |   ↳ `cycle` | object | Favorited cycle \(if applicable\) |
 
-### `linear_list_favorites`
+### Linear List Favorites
 
 List all bookmarked items for the current user in Linear
 
@@ -1258,7 +1258,7 @@ List all bookmarked items for the current user in Linear
 |   ↳ `cycle` | object | Favorited cycle |
 | `pageInfo` | object | Pagination information |
 
-### `linear_create_project_update`
+### Linear Create Project Update
 
 Post a status update for a project in Linear
 
@@ -1281,7 +1281,7 @@ Post a status update for a project in Linear
 |   ↳ `createdAt` | string | Creation timestamp |
 |   ↳ `user` | object | User who created the update |
 
-### `linear_list_project_updates`
+### Linear List Project Updates
 
 List all status updates for a project in Linear
 
@@ -1305,7 +1305,7 @@ List all status updates for a project in Linear
 |   ↳ `user` | object | User who created the update |
 | `pageInfo` | object | Pagination information |
 
-### `linear_list_notifications`
+### Linear List Notifications
 
 List notifications for the current user in Linear
 
@@ -1328,7 +1328,7 @@ List notifications for the current user in Linear
 |   ↳ `issue` | object | Related issue |
 | `pageInfo` | object | Pagination information |
 
-### `linear_update_notification`
+### Linear Update Notification
 
 Mark a notification as read or unread in Linear
 
@@ -1350,7 +1350,7 @@ Mark a notification as read or unread in Linear
 |   ↳ `readAt` | string | Read timestamp |
 |   ↳ `issue` | object | Related issue |
 
-### `linear_create_customer`
+### Linear Create Customer
 
 Create a new customer in Linear
 
@@ -1386,7 +1386,7 @@ Create a new customer in Linear
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_list_customers`
+### Linear List Customers
 
 List all customers in Linear
 
@@ -1419,7 +1419,7 @@ List all customers in Linear
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_create_customer_request`
+### Linear Create Customer Request
 
 Create a customer request (need) in Linear. Assign to customer, set urgency (priority: 0 = Not important, 1 = Important), and optionally link to an issue.
 
@@ -1450,7 +1450,7 @@ Create a customer request (need) in Linear. Assign to customer, set urgency (pri
 |   ↳ `creator` | object | User who created the request |
 |   ↳ `url` | string | URL to the customer request |
 
-### `linear_update_customer_request`
+### Linear Update Customer Request
 
 Update a customer request (need) in Linear. Can change urgency, description, customer assignment, and linked issue.
 
@@ -1482,7 +1482,7 @@ Update a customer request (need) in Linear. Can change urgency, description, cus
 |   ↳ `creator` | object | User who created the request |
 |   ↳ `url` | string | URL to the customer request |
 
-### `linear_list_customer_requests`
+### Linear List Customer Requests
 
 List all customer requests (needs) in Linear
 
@@ -1512,7 +1512,7 @@ List all customer requests (needs) in Linear
 |   ↳ `url` | string | URL to the customer request |
 | `pageInfo` | object | Pagination information |
 
-### `linear_get_customer`
+### Linear Get Customer
 
 Get a single customer by ID in Linear
 
@@ -1540,7 +1540,7 @@ Get a single customer by ID in Linear
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_update_customer`
+### Linear Update Customer
 
 Update a customer in Linear
 
@@ -1577,7 +1577,7 @@ Update a customer in Linear
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_delete_customer`
+### Linear Delete Customer
 
 Delete a customer in Linear
 
@@ -1593,7 +1593,7 @@ Delete a customer in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the deletion was successful |
 
-### `linear_merge_customers`
+### Linear Merge Customers
 
 Merge two customers in Linear by moving all data from source to target
 
@@ -1610,7 +1610,7 @@ Merge two customers in Linear by moving all data from source to target
 | --------- | ---- | ----------- |
 | `customer` | object | The merged target customer |
 
-### `linear_create_customer_status`
+### Linear Create Customer Status
 
 Create a new customer status in Linear
 
@@ -1639,7 +1639,7 @@ Create a new customer status in Linear
 |   ↳ `updatedAt` | string | Last updated timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_update_customer_status`
+### Linear Update Customer Status
 
 Update a customer status in Linear
 
@@ -1669,7 +1669,7 @@ Update a customer status in Linear
 |   ↳ `updatedAt` | string | Last updated timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_delete_customer_status`
+### Linear Delete Customer Status
 
 Delete a customer status in Linear
 
@@ -1685,7 +1685,7 @@ Delete a customer status in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the deletion was successful |
 
-### `linear_list_customer_statuses`
+### Linear List Customer Statuses
 
 List all customer statuses in Linear
 
@@ -1714,7 +1714,7 @@ List all customer statuses in Linear
 |   ↳ `updatedAt` | string | Last updated timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_create_customer_tier`
+### Linear Create Customer Tier
 
 Create a new customer tier in Linear
 
@@ -1742,7 +1742,7 @@ Create a new customer tier in Linear
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_update_customer_tier`
+### Linear Update Customer Tier
 
 Update a customer tier in Linear
 
@@ -1763,7 +1763,7 @@ Update a customer tier in Linear
 | --------- | ---- | ----------- |
 | `customerTier` | object | The updated customer tier |
 
-### `linear_delete_customer_tier`
+### Linear Delete Customer Tier
 
 Delete a customer tier in Linear
 
@@ -1779,7 +1779,7 @@ Delete a customer tier in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the deletion was successful |
 
-### `linear_list_customer_tiers`
+### Linear List Customer Tiers
 
 List all customer tiers in Linear
 
@@ -1807,7 +1807,7 @@ List all customer tiers in Linear
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_delete_project`
+### Linear Delete Project
 
 Delete a project in Linear
 
@@ -1823,7 +1823,7 @@ Delete a project in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the deletion was successful |
 
-### `linear_create_project_label`
+### Linear Create Project Label
 
 Create a new project label in Linear
 
@@ -1851,7 +1851,7 @@ Create a new project label in Linear
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_update_project_label`
+### Linear Update Project Label
 
 Update a project label in Linear
 
@@ -1878,7 +1878,7 @@ Update a project label in Linear
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_delete_project_label`
+### Linear Delete Project Label
 
 Delete a project label in Linear
 
@@ -1894,7 +1894,7 @@ Delete a project label in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the deletion was successful |
 
-### `linear_list_project_labels`
+### Linear List Project Labels
 
 List all project labels in Linear
 
@@ -1923,7 +1923,7 @@ List all project labels in Linear
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_add_label_to_project`
+### Linear Add Label to Project
 
 Add a label to a project in Linear
 
@@ -1941,7 +1941,7 @@ Add a label to a project in Linear
 | `success` | boolean | Whether the label was added successfully |
 | `projectId` | string | The project ID |
 
-### `linear_remove_label_from_project`
+### Linear Remove Label from Project
 
 Remove a label from a project in Linear
 
@@ -1959,7 +1959,7 @@ Remove a label from a project in Linear
 | `success` | boolean | Whether the label was removed successfully |
 | `projectId` | string | The project ID |
 
-### `linear_create_project_milestone`
+### Linear Create Project Milestone
 
 Create a new project milestone in Linear
 
@@ -1988,7 +1988,7 @@ Create a new project milestone in Linear
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_update_project_milestone`
+### Linear Update Project Milestone
 
 Update a project milestone in Linear
 
@@ -2017,7 +2017,7 @@ Update a project milestone in Linear
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_delete_project_milestone`
+### Linear Delete Project Milestone
 
 Delete a project milestone in Linear
 
@@ -2033,7 +2033,7 @@ Delete a project milestone in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the deletion was successful |
 
-### `linear_list_project_milestones`
+### Linear List Project Milestones
 
 List all milestones for a project in Linear
 
@@ -2064,7 +2064,7 @@ List all milestones for a project in Linear
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_create_project_status`
+### Linear Create Project Status
 
 Create a new project status in Linear
 
@@ -2095,7 +2095,7 @@ Create a new project status in Linear
 |   ↳ `updatedAt` | string | Last updated timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_update_project_status`
+### Linear Update Project Status
 
 Update a project status in Linear
 
@@ -2126,7 +2126,7 @@ Update a project status in Linear
 |   ↳ `updatedAt` | string | Last updated timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-### `linear_delete_project_status`
+### Linear Delete Project Status
 
 Delete a project status in Linear
 
@@ -2142,7 +2142,7 @@ Delete a project status in Linear
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the deletion was successful |
 
-### `linear_list_project_statuses`
+### Linear List Project Statuses
 
 List all project statuses in Linear
 

--- a/apps/docs/content/docs/en/integrations/linkedin.mdx
+++ b/apps/docs/content/docs/en/integrations/linkedin.mdx
@@ -32,7 +32,7 @@ Integrate LinkedIn into workflows. Share posts to your personal feed and access 
 
 ## Actions
 
-### `linkedin_share_post`
+### Share Post on LinkedIn
 
 Share a post to your personal LinkedIn feed
 
@@ -61,7 +61,7 @@ Share a post to your personal LinkedIn feed
 | `profile` | json | LinkedIn profile information |
 | `error` | string | Error message if operation failed |
 
-### `linkedin_get_profile`
+### Get LinkedIn Profile
 
 Retrieve your LinkedIn profile information
 

--- a/apps/docs/content/docs/en/integrations/linkup.mdx
+++ b/apps/docs/content/docs/en/integrations/linkup.mdx
@@ -32,7 +32,7 @@ Integrate Linkup into the workflow. Can search the web.
 
 ## Actions
 
-### `linkup_search`
+### Linkup Search
 
 Search the web for information using Linkup
 

--- a/apps/docs/content/docs/en/integrations/linq.mdx
+++ b/apps/docs/content/docs/en/integrations/linq.mdx
@@ -40,7 +40,7 @@ Reach people on iMessage, SMS, and RCS through Linq. Start chats, send messages 
 
 ## Actions
 
-### `linq_add_participant`
+### Add Participant
 
 Add a participant to a group chat (3+ existing participants)
 
@@ -60,7 +60,7 @@ Add a participant to a group chat (3+ existing participants)
 | `status` | string | Queued action status |
 | `traceId` | string | Trace ID for the queued action |
 
-### `linq_check_imessage`
+### Check iMessage Capability
 
 Check whether an address (phone number or email) supports iMessage
 
@@ -79,7 +79,7 @@ Check whether an address (phone number or email) supports iMessage
 | `address` | string | The address that was checked |
 | `available` | boolean | Whether the address supports iMessage |
 
-### `linq_check_rcs`
+### Check RCS Capability
 
 Check whether an address (phone number or email) supports RCS
 
@@ -98,7 +98,7 @@ Check whether an address (phone number or email) supports RCS
 | `address` | string | The address that was checked |
 | `available` | boolean | Whether the address supports RCS |
 
-### `linq_create_attachment`
+### Upload Attachment
 
 Upload a file to Linq as a reusable attachment (max 100MB) and get an attachment ID to send in messages
 
@@ -123,7 +123,7 @@ Upload a file to Linq as a reusable attachment (max 100MB) and get an attachment
 | `sizeBytes` | number | File size in bytes |
 | `status` | string | Upload status |
 
-### `linq_create_chat`
+### Create Chat
 
 Start a new iMessage, SMS, or RCS chat and send the first message
 
@@ -156,7 +156,7 @@ Start a new iMessage, SMS, or RCS chat and send the first message
 | `healthStatus` | json | Messaging line health status |
 | `message` | json | The sent message object with parts and delivery info |
 
-### `linq_create_contact_card`
+### Create Contact Card
 
 Set up a contact card (Name and Photo Sharing) for a phone number
 
@@ -180,7 +180,7 @@ Set up a contact card (Name and Photo Sharing) for a phone number
 | `imageUrl` | string | Profile photo URL |
 | `isActive` | boolean | Whether the card is active |
 
-### `linq_create_webhook_subscription`
+### Create Webhook Subscription
 
 Subscribe an HTTPS endpoint to Linq webhook events
 
@@ -206,7 +206,7 @@ Subscribe an HTTPS endpoint to Linq webhook events
 | `updatedAt` | string | ISO 8601 update timestamp |
 | `signingSecret` | string | HMAC-SHA256 signing secret. Store securely — it cannot be retrieved again |
 
-### `linq_delete_attachment`
+### Delete Attachment
 
 Permanently delete an attachment owned by your account
 
@@ -223,7 +223,7 @@ Permanently delete an attachment owned by your account
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the attachment was deleted |
 
-### `linq_delete_message`
+### Delete Message
 
 Delete a message from the Linq API only (does not unsend it; recipients still see it)
 
@@ -240,7 +240,7 @@ Delete a message from the Linq API only (does not unsend it; recipients still se
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the message was deleted |
 
-### `linq_delete_webhook_subscription`
+### Delete Webhook Subscription
 
 Delete a webhook subscription from your account
 
@@ -257,7 +257,7 @@ Delete a webhook subscription from your account
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the subscription was deleted |
 
-### `linq_edit_message`
+### Edit Message
 
 Edit the text of a sent message (up to 5 times, within 15 minutes of sending; iMessage only)
 
@@ -287,7 +287,7 @@ Edit the text of a sent message (up to 5 times, within 15 minutes of sending; iM
 | `parts` | json | Updated message parts with reactions |
 | `message` | json | The full updated message object |
 
-### `linq_get_attachment`
+### Get Attachment
 
 Retrieve metadata for an attachment, including its download URL and status
 
@@ -310,7 +310,7 @@ Retrieve metadata for an attachment, including its download URL and status
 | `downloadUrl` | string | URL to download the file |
 | `createdAt` | string | ISO 8601 creation timestamp |
 
-### `linq_get_chat`
+### Get Chat
 
 Retrieve a chat by ID, including participants and line health
 
@@ -335,7 +335,7 @@ Retrieve a chat by ID, including participants and line health
 | `handles` | json | Participant handles in the chat |
 | `healthStatus` | json | Messaging line health status |
 
-### `linq_get_contact_card`
+### Get Contact Card
 
 Retrieve contact cards, optionally filtered by phone number
 
@@ -357,7 +357,7 @@ Retrieve contact cards, optionally filtered by phone number
 |   ↳ `imageUrl` | string | Profile photo URL |
 |   ↳ `isActive` | boolean | Whether the card is active |
 
-### `linq_get_message`
+### Get Message
 
 Retrieve a single message by ID, including parts, reactions, and delivery status
 
@@ -385,7 +385,7 @@ Retrieve a single message by ID, including parts, reactions, and delivery status
 | `parts` | json | Message parts \(text, media, link\) with reactions |
 | `message` | json | The full message object |
 
-### `linq_get_webhook_subscription`
+### Get Webhook Subscription
 
 Retrieve a webhook subscription by ID
 
@@ -408,7 +408,7 @@ Retrieve a webhook subscription by ID
 | `createdAt` | string | ISO 8601 creation timestamp |
 | `updatedAt` | string | ISO 8601 update timestamp |
 
-### `linq_leave_chat`
+### Leave Chat
 
 Leave an iMessage group chat (4+ active participants; not supported for direct chats)
 
@@ -427,7 +427,7 @@ Leave an iMessage group chat (4+ active participants; not supported for direct c
 | `status` | string | Queued action status \(e.g. accepted\) |
 | `traceId` | string | Trace ID for the queued action |
 
-### `linq_list_chats`
+### List Chats
 
 List chats, optionally filtered by sender or participant handle
 
@@ -448,7 +448,7 @@ List chats, optionally filtered by sender or participant handle
 | `chats` | json | Array of chat objects |
 | `nextCursor` | string | Cursor for the next page, or null if there are no more results |
 
-### `linq_list_messages`
+### List Messages
 
 List messages in a chat with pagination
 
@@ -468,7 +468,7 @@ List messages in a chat with pagination
 | `messages` | json | Array of message objects with parts and reactions |
 | `nextCursor` | string | Cursor for the next page, or null if there are no more results |
 
-### `linq_list_phone_numbers`
+### List Phone Numbers
 
 List all phone numbers assigned to your partner account, with line health
 
@@ -488,7 +488,7 @@ List all phone numbers assigned to your partner account, with line health
 |   ↳ `forwardingNumber` | string | Forwarding number in E.164 format, or null |
 |   ↳ `healthStatus` | json | Line reputation/health status \(status, doc_url\) |
 
-### `linq_list_thread`
+### List Thread Messages
 
 List all messages in the thread that contains a given message
 
@@ -509,7 +509,7 @@ List all messages in the thread that contains a given message
 | `messages` | json | Array of message objects in the thread |
 | `nextCursor` | string | Cursor for the next page, or null if there are no more results |
 
-### `linq_list_webhook_events`
+### List Webhook Events
 
 List all webhook event types available to subscribe to
 
@@ -526,7 +526,7 @@ List all webhook event types available to subscribe to
 | `events` | json | Available webhook event type names |
 | `docUrl` | string | Documentation URL for webhook events |
 
-### `linq_list_webhook_subscriptions`
+### List Webhook Subscriptions
 
 List all webhook subscriptions on your account
 
@@ -549,7 +549,7 @@ List all webhook subscriptions on your account
 |   ↳ `createdAt` | string | ISO 8601 creation timestamp |
 |   ↳ `updatedAt` | string | ISO 8601 update timestamp |
 
-### `linq_mark_chat_read`
+### Mark Chat as Read
 
 Mark messages in a chat as read (only applies to 1:1 iMessage/RCS; no effect on group chats)
 
@@ -566,7 +566,7 @@ Mark messages in a chat as read (only applies to 1:1 iMessage/RCS; no effect on 
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the chat was marked as read |
 
-### `linq_react_to_message`
+### React to Message
 
 Add or remove a tapback reaction on a message
 
@@ -589,7 +589,7 @@ Add or remove a tapback reaction on a message
 | `status` | string | Queued action status |
 | `traceId` | string | Trace ID for the queued action |
 
-### `linq_remove_participant`
+### Remove Participant
 
 Remove a participant from a group chat (minimum 3 participants must remain)
 
@@ -609,7 +609,7 @@ Remove a participant from a group chat (minimum 3 participants must remain)
 | `status` | string | Queued action status |
 | `traceId` | string | Trace ID for the queued action |
 
-### `linq_send_message`
+### Send Message
 
 Send a message to an existing chat, with optional media, link, effect, or reply
 
@@ -641,7 +641,7 @@ Send a message to an existing chat, with optional media, link, effect, or reply
 | `service` | string | Delivery service \(iMessage, SMS, RCS\) |
 | `message` | json | The full sent message object with parts |
 
-### `linq_send_voice_memo`
+### Send Voice Memo
 
 Send a voice memo to a chat from a URL or a pre-uploaded attachment
 
@@ -665,7 +665,7 @@ Send a voice memo to a chat from a URL or a pre-uploaded attachment
 | `service` | string | Delivery service \(iMessage, SMS, RCS\) |
 | `voiceMemo` | json | Audio file metadata \(id, filename, mime_type, size_bytes, url, duration_ms\) |
 
-### `linq_share_contact_card`
+### Share Contact Card
 
 Share your configured contact card (Name and Photo Sharing) with a chat
 
@@ -682,7 +682,7 @@ Share your configured contact card (Name and Photo Sharing) with a chat
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the contact card was shared |
 
-### `linq_start_typing`
+### Start Typing Indicator
 
 Show a typing indicator in a one-on-one chat (iMessage only, not group chats)
 
@@ -699,7 +699,7 @@ Show a typing indicator in a one-on-one chat (iMessage only, not group chats)
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the typing indicator was sent |
 
-### `linq_stop_typing`
+### Stop Typing Indicator
 
 Stop the typing indicator in a one-on-one chat (iMessage only, not group chats)
 
@@ -716,7 +716,7 @@ Stop the typing indicator in a one-on-one chat (iMessage only, not group chats)
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the typing indicator was stopped |
 
-### `linq_update_chat`
+### Update Chat
 
 Update chat properties such as group display name and icon
 
@@ -736,7 +736,7 @@ Update chat properties such as group display name and icon
 | `chatId` | string | ID of the updated chat |
 | `status` | string | Status of the queued update |
 
-### `linq_update_contact_card`
+### Update Contact Card
 
 Partially update an existing active contact card for a phone number
 
@@ -760,7 +760,7 @@ Partially update an existing active contact card for a phone number
 | `imageUrl` | string | Profile photo URL |
 | `isActive` | boolean | Whether the card is active |
 
-### `linq_update_webhook_subscription`
+### Update Webhook Subscription
 
 Update a webhook subscription (target URL, events, phone filter, or active state)
 

--- a/apps/docs/content/docs/en/integrations/logfire.mdx
+++ b/apps/docs/content/docs/en/integrations/logfire.mdx
@@ -34,7 +34,7 @@ Integrate Pydantic Logfire into workflows. Run SQL over your observability data,
 
 ## Actions
 
-### `logfire_query`
+### Logfire Query
 
 Run a read-only SQL query against Logfire traces, logs, and metrics. Reads the records and metrics tables using PostgreSQL-compatible syntax.
 
@@ -63,7 +63,7 @@ Run a read-only SQL query against Logfire traces, logs, and metrics. Reads the r
 |   ↳ `nullable` | boolean | Whether the column is nullable |
 | `rowCount` | number | Number of rows returned |
 
-### `logfire_search_records`
+### Logfire Search Records
 
 Search Logfire spans and logs using structured filters for message text, service, span name, severity, environment, and exceptions. Returns the most recent matches first without writing SQL.
 
@@ -107,7 +107,7 @@ Search Logfire spans and logs using structured filters for message text, service
 | `rowCount` | number | Number of rows returned |
 | `sql` | string | SQL query that was executed against Logfire |
 
-### `logfire_get_trace`
+### Logfire Get Trace
 
 Fetch every span and log belonging to a Logfire trace, ordered from earliest to latest, so a single request can be reconstructed end to end.
 
@@ -146,7 +146,7 @@ Fetch every span and log belonging to a Logfire trace, ordered from earliest to 
 | `rowCount` | number | Number of rows returned |
 | `sql` | string | SQL query that was executed against Logfire |
 
-### `logfire_get_token_info`
+### Logfire Get Token Info
 
 Resolve which Logfire organization and project a read token belongs to. Useful for confirming a credential targets the expected project before querying it.
 

--- a/apps/docs/content/docs/en/integrations/logs.mdx
+++ b/apps/docs/content/docs/en/integrations/logs.mdx
@@ -31,7 +31,7 @@ Query workflow run logs in the current workspace with the same filters as the Lo
 
 ## Actions
 
-### `logs_query_runs`
+### Query Logs
 
 Query workflow run logs in the current workspace with the full Logs-page filter set. Returns matching run IDs.
 
@@ -60,7 +60,7 @@ Query workflow run logs in the current workspace with the full Logs-page filter 
 | --------- | ---- | ----------- |
 | `runIds` | array | IDs of the runs matching the filters |
 
-### `logs_get_run_details`
+### Get Run Details
 
 Fetch details for a single workflow run by its run ID, including the full trace spans.
 

--- a/apps/docs/content/docs/en/integrations/loops.mdx
+++ b/apps/docs/content/docs/en/integrations/loops.mdx
@@ -42,7 +42,7 @@ Integrate Loops into the workflow. Create and manage contacts, send transactiona
 
 ## Actions
 
-### `loops_create_contact`
+### Loops Create Contact
 
 Create a new contact in your Loops audience with an email address and optional properties like name, user group, and mailing list subscriptions.
 
@@ -68,7 +68,7 @@ Create a new contact in your Loops audience with an email address and optional p
 | `success` | boolean | Whether the contact was created successfully |
 | `id` | string | The Loops-assigned ID of the created contact |
 
-### `loops_update_contact`
+### Loops Update Contact
 
 Update an existing contact in Loops by email or userId. Creates a new contact if no match is found (upsert). Can update name, subscription status, user group, mailing lists, and custom properties.
 
@@ -94,7 +94,7 @@ Update an existing contact in Loops by email or userId. Creates a new contact if
 | `success` | boolean | Whether the contact was updated successfully |
 | `id` | string | The Loops-assigned ID of the updated or created contact |
 
-### `loops_find_contact`
+### Loops Find Contact
 
 Find a contact in Loops by email address or userId. Returns an array of matching contacts with all their properties including name, subscription status, user group, and mailing lists.
 
@@ -122,7 +122,7 @@ Find a contact in Loops by email address or userId. Returns an array of matching
 |   ↳ `mailingLists` | object | Mailing list IDs mapped to subscription status |
 |   ↳ `optInStatus` | string | Double opt-in status: pending, accepted, rejected, or null |
 
-### `loops_delete_contact`
+### Loops Delete Contact
 
 Delete a contact from Loops by email address or userId. At least one identifier must be provided.
 
@@ -141,7 +141,7 @@ Delete a contact from Loops by email address or userId. At least one identifier 
 | `success` | boolean | Whether the contact was deleted successfully |
 | `message` | string | Status message from the API |
 
-### `loops_send_transactional_email`
+### Loops Send Transactional Email
 
 Send a transactional email to a recipient using a Loops template. Supports dynamic data variables for personalization and optionally adds the recipient to your audience.
 
@@ -162,7 +162,7 @@ Send a transactional email to a recipient using a Loops template. Supports dynam
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the transactional email was sent successfully |
 
-### `loops_send_event`
+### Loops Send Event
 
 Send an event to Loops to trigger automated email sequences for a contact. Identify the contact by email or userId and include optional event properties and mailing list changes.
 
@@ -183,7 +183,7 @@ Send an event to Loops to trigger automated email sequences for a contact. Ident
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the event was sent successfully |
 
-### `loops_list_mailing_lists`
+### Loops List Mailing Lists
 
 Retrieve all mailing lists from your Loops account. Returns each list with its ID, name, description, and public/private status.
 
@@ -203,7 +203,7 @@ Retrieve all mailing lists from your Loops account. Returns each list with its I
 |   ↳ `description` | string | The mailing list description \(null if not set\) |
 |   ↳ `isPublic` | boolean | Whether the list is public or private |
 
-### `loops_list_transactional_emails`
+### Loops List Transactional Emails
 
 Retrieve a list of published transactional email templates from your Loops account. Returns each template with its ID, name, created/updated timestamps, and data variables.
 
@@ -234,7 +234,7 @@ Retrieve a list of published transactional email templates from your Loops accou
 |   ↳ `nextCursor` | string | Cursor for next page \(null if no more pages\) |
 |   ↳ `nextPage` | string | URL for next page \(null if no more pages\) |
 
-### `loops_create_contact_property`
+### Loops Create Contact Property
 
 Create a new custom contact property in your Loops account. The property name must be in camelCase format.
 
@@ -252,7 +252,7 @@ Create a new custom contact property in your Loops account. The property name mu
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the contact property was created successfully |
 
-### `loops_list_contact_properties`
+### Loops List Contact Properties
 
 Retrieve a list of contact properties from your Loops account. Returns each property with its key, label, and data type. Can filter to show all properties or only custom ones.
 
@@ -272,7 +272,7 @@ Retrieve a list of contact properties from your Loops account. Returns each prop
 |   ↳ `label` | string | The property display label |
 |   ↳ `type` | string | The property data type \(string, number, boolean, date\) |
 
-### `loops_check_contact_suppression`
+### Loops Check Contact Suppression
 
 Check whether a Loops contact is on the suppression list (bounced, complained, or unsubscribed) by email address or userId.
 
@@ -295,7 +295,7 @@ Check whether a Loops contact is on the suppression list (bounced, complained, o
 | `removalQuotaLimit` | number | Total suppression-removal quota for the team |
 | `removalQuotaRemaining` | number | Remaining suppression-removal quota for the team |
 
-### `loops_remove_contact_suppression`
+### Loops Remove Contact Suppression
 
 Remove a Loops contact from the suppression list by email address or userId, allowing them to receive emails again. Subject to a team removal quota.
 
@@ -316,7 +316,7 @@ Remove a Loops contact from the suppression list by email address or userId, all
 | `removalQuotaLimit` | number | Total suppression-removal quota for the team |
 | `removalQuotaRemaining` | number | Remaining suppression-removal quota for the team |
 
-### `loops_get_transactional_email`
+### Loops Get Transactional Email
 
 Retrieve a single transactional email template from your Loops account by its ID, including its data variables and draft/published message IDs.
 

--- a/apps/docs/content/docs/en/integrations/luma.mdx
+++ b/apps/docs/content/docs/en/integrations/luma.mdx
@@ -36,7 +36,7 @@ Integrate Luma into the workflow. Can create, update, look up, and cancel events
 
 ## Actions
 
-### `luma_get_event`
+### Luma Get Event
 
 Retrieve details of a Luma event including name, time, location, hosts, and visibility settings.
 
@@ -77,7 +77,7 @@ Retrieve details of a Luma event including name, time, location, hosts, and visi
 |   ↳ `email` | string | Host email address |
 |   ↳ `avatarUrl` | string | Host avatar image URL |
 
-### `luma_create_event`
+### Luma Create Event
 
 Create a new event on Luma with a name, start time, timezone, and optional details like description, location, and visibility.
 
@@ -126,7 +126,7 @@ Create a new event on Luma with a name, start time, timezone, and optional detai
 |   ↳ `email` | string | Host email address |
 |   ↳ `avatarUrl` | string | Host avatar image URL |
 
-### `luma_update_event`
+### Luma Update Event
 
 Update an existing Luma event. Only the fields you provide will be changed; all other fields remain unchanged.
 
@@ -176,7 +176,7 @@ Update an existing Luma event. Only the fields you provide will be changed; all 
 |   ↳ `email` | string | Host email address |
 |   ↳ `avatarUrl` | string | Host avatar image URL |
 
-### `luma_list_events`
+### Luma List Events
 
 List events from your Luma calendar with optional date range filtering, sorting, and pagination.
 
@@ -217,7 +217,7 @@ List events from your Luma calendar with optional date range filtering, sorting,
 | `hasMore` | boolean | Whether more results are available for pagination |
 | `nextCursor` | string | Cursor to pass as paginationCursor to fetch the next page |
 
-### `luma_lookup_event`
+### Luma Lookup Event
 
 Look up an event by its public URL or event ID to resolve its canonical ID, API ID, and approval status.
 
@@ -239,7 +239,7 @@ Look up an event by its public URL or event ID to resolve its canonical ID, API 
 | `apiId` | string | Resolved event API ID \(deprecated identifier\) |
 | `status` | string | Event approval status \(approved, pending, rejected\) |
 
-### `luma_cancel_event`
+### Luma Cancel Event
 
 Cancel a Luma event. This is irreversible and notifies all registered guests. Requires a cancellation token obtained from the Request Event Cancellation endpoint.
 
@@ -258,7 +258,7 @@ Cancel a Luma event. This is irreversible and notifies all registered guests. Re
 | --------- | ---- | ----------- |
 | `cancelled` | boolean | Whether the event was successfully cancelled |
 
-### `luma_get_guests`
+### Luma Get Guests
 
 Retrieve the guest list for a Luma event with optional filtering by approval status, sorting, and pagination.
 
@@ -293,7 +293,7 @@ Retrieve the guest list for a Luma event with optional filtering by approval sta
 | `hasMore` | boolean | Whether more results are available for pagination |
 | `nextCursor` | string | Cursor to pass as paginationCursor to fetch the next page |
 
-### `luma_get_guest`
+### Luma Get Guest
 
 Retrieve a single guest's details on a Luma event, including approval status, registration timestamps, and contact info.
 
@@ -322,7 +322,7 @@ Retrieve a single guest's details on a Luma event, including approval status, re
 |   ↳ `checkedInAt` | string | Check-in timestamp from the first checked-in ticket \(ISO 8601\) |
 |   ↳ `phoneNumber` | string | Guest phone number |
 
-### `luma_add_guests`
+### Luma Add Guests
 
 Add guests to a Luma event by email. Guests are added with Going (approved) status and receive one ticket of the default ticket type.
 
@@ -340,7 +340,7 @@ Add guests to a Luma event by email. Guests are added with Going (approved) stat
 | --------- | ---- | ----------- |
 | `added` | number | Number of guests submitted to the event \(added with Going/approved status\) |
 
-### `luma_send_invites`
+### Luma Send Invites
 
 Send email invitations to guests for a Luma event. Unlike Add Guests (which registers guests directly), this emails an invite that recipients can accept.
 
@@ -359,7 +359,7 @@ Send email invitations to guests for a Luma event. Unlike Add Guests (which regi
 | --------- | ---- | ----------- |
 | `invited` | number | Number of guests invited to the event |
 
-### `luma_update_guest_status`
+### Luma Update Guest Status
 
 Update a guest's approval status on a Luma event — approve, decline, waitlist, or set to pending. Identify the guest by email or guest ID.
 

--- a/apps/docs/content/docs/en/integrations/mailchimp.mdx
+++ b/apps/docs/content/docs/en/integrations/mailchimp.mdx
@@ -54,7 +54,7 @@ Integrate Mailchimp into the workflow. Can manage audiences (lists), list member
 
 ## Actions
 
-### `mailchimp_get_audiences`
+### Get Audiences from Mailchimp
 
 Retrieve a list of audiences (lists) from Mailchimp
 
@@ -76,7 +76,7 @@ Retrieve a list of audiences (lists) from Mailchimp
 |   ↳ `total_items` | number | Total number of lists |
 |   ↳ `total_returned` | number | Number of lists returned in this response |
 
-### `mailchimp_get_audience`
+### Get Audience from Mailchimp
 
 Retrieve details of a specific audience (list) from Mailchimp
 
@@ -96,7 +96,7 @@ Retrieve details of a specific audience (list) from Mailchimp
 |   ↳ `list` | json | Audience/list object |
 |   ↳ `list_id` | string | The unique ID of the audience |
 
-### `mailchimp_create_audience`
+### Create Audience in Mailchimp
 
 Create a new audience (list) in Mailchimp
 
@@ -121,7 +121,7 @@ Create a new audience (list) in Mailchimp
 |   ↳ `list_id` | string | Created audience/list ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_audience`
+### Update Audience in Mailchimp
 
 Update an existing audience (list) in Mailchimp
 
@@ -146,7 +146,7 @@ Update an existing audience (list) in Mailchimp
 |   ↳ `list_id` | string | List ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_audience`
+### Delete Audience from Mailchimp
 
 Delete an audience (list) from Mailchimp
 
@@ -163,7 +163,7 @@ Delete an audience (list) from Mailchimp
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the audience was successfully deleted |
 
-### `mailchimp_get_members`
+### Get Members from Mailchimp Audience
 
 Retrieve a list of members from a Mailchimp audience
 
@@ -187,7 +187,7 @@ Retrieve a list of members from a Mailchimp audience
 |   ↳ `total_items` | number | Total number of members |
 |   ↳ `total_returned` | number | Number of members returned in this response |
 
-### `mailchimp_get_member`
+### Get Member from Mailchimp Audience
 
 Retrieve details of a specific member from a Mailchimp audience
 
@@ -208,7 +208,7 @@ Retrieve details of a specific member from a Mailchimp audience
 |   ↳ `member` | json | Member object |
 |   ↳ `subscriber_hash` | string | The MD5 hash of the member email address |
 
-### `mailchimp_add_member`
+### Add Member to Mailchimp Audience
 
 Add a new member to a Mailchimp audience
 
@@ -233,7 +233,7 @@ Add a new member to a Mailchimp audience
 |   ↳ `subscriber_hash` | string | Subscriber hash ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_add_or_update_member`
+### Add or Update Member in Mailchimp Audience
 
 Add a new member or update an existing member in a Mailchimp audience (upsert)
 
@@ -259,7 +259,7 @@ Add a new member or update an existing member in a Mailchimp audience (upsert)
 |   ↳ `subscriber_hash` | string | Subscriber hash ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_member`
+### Update Member in Mailchimp Audience
 
 Update an existing member in a Mailchimp audience
 
@@ -285,7 +285,7 @@ Update an existing member in a Mailchimp audience
 |   ↳ `subscriber_hash` | string | Subscriber hash |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_member`
+### Delete Member from Mailchimp Audience
 
 Delete a member from a Mailchimp audience
 
@@ -303,7 +303,7 @@ Delete a member from a Mailchimp audience
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the member was successfully deleted |
 
-### `mailchimp_archive_member`
+### Archive Member from Mailchimp Audience
 
 Permanently archive (delete) a member from a Mailchimp audience
 
@@ -323,7 +323,7 @@ Permanently archive (delete) a member from a Mailchimp audience
 | `output` | object | Archive confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_unarchive_member`
+### Unarchive Member in Mailchimp Audience
 
 Restore an archived member to a Mailchimp audience
 
@@ -347,7 +347,7 @@ Restore an archived member to a Mailchimp audience
 |   ↳ `subscriber_hash` | string | Subscriber hash |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_get_campaigns`
+### Get Campaigns from Mailchimp
 
 Retrieve a list of campaigns from Mailchimp
 
@@ -371,7 +371,7 @@ Retrieve a list of campaigns from Mailchimp
 |   ↳ `total_items` | number | Total number of campaigns |
 |   ↳ `total_returned` | number | Number of campaigns returned in this response |
 
-### `mailchimp_get_campaign`
+### Get Campaign from Mailchimp
 
 Retrieve details of a specific campaign from Mailchimp
 
@@ -391,7 +391,7 @@ Retrieve details of a specific campaign from Mailchimp
 |   ↳ `campaign` | json | Campaign object |
 |   ↳ `campaign_id` | string | The unique ID of the campaign |
 
-### `mailchimp_create_campaign`
+### Create Campaign in Mailchimp
 
 Create a new campaign in Mailchimp
 
@@ -414,7 +414,7 @@ Create a new campaign in Mailchimp
 |   ↳ `campaign_id` | string | Created campaign ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_campaign`
+### Update Campaign in Mailchimp
 
 Update an existing campaign in Mailchimp
 
@@ -437,7 +437,7 @@ Update an existing campaign in Mailchimp
 |   ↳ `campaign_id` | string | Campaign ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_campaign`
+### Delete Campaign from Mailchimp
 
 Delete a campaign from Mailchimp
 
@@ -454,7 +454,7 @@ Delete a campaign from Mailchimp
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the campaign was successfully deleted |
 
-### `mailchimp_send_campaign`
+### Send Campaign in Mailchimp
 
 Send a Mailchimp campaign
 
@@ -473,7 +473,7 @@ Send a Mailchimp campaign
 | `output` | object | Send confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_schedule_campaign`
+### Schedule Campaign in Mailchimp
 
 Schedule a Mailchimp campaign to be sent at a specific time
 
@@ -491,7 +491,7 @@ Schedule a Mailchimp campaign to be sent at a specific time
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the campaign was successfully scheduled |
 
-### `mailchimp_unschedule_campaign`
+### Unschedule Campaign in Mailchimp
 
 Unschedule a previously scheduled Mailchimp campaign
 
@@ -510,7 +510,7 @@ Unschedule a previously scheduled Mailchimp campaign
 | `output` | object | Unschedule confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_replicate_campaign`
+### Replicate Campaign in Mailchimp
 
 Create a copy of an existing Mailchimp campaign
 
@@ -531,7 +531,7 @@ Create a copy of an existing Mailchimp campaign
 |   ↳ `campaign_id` | string | Campaign ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_get_campaign_content`
+### Get Campaign Content from Mailchimp
 
 Retrieve the HTML and plain-text content for a Mailchimp campaign
 
@@ -550,7 +550,7 @@ Retrieve the HTML and plain-text content for a Mailchimp campaign
 | `output` | object | Campaign content data |
 |   ↳ `content` | json | Campaign content object |
 
-### `mailchimp_set_campaign_content`
+### Set Campaign Content in Mailchimp
 
 Set the content for a Mailchimp campaign
 
@@ -573,7 +573,7 @@ Set the content for a Mailchimp campaign
 |   ↳ `content` | object | Campaign content object |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_get_automations`
+### Get Automations from Mailchimp
 
 Retrieve a list of automations from Mailchimp
 
@@ -595,7 +595,7 @@ Retrieve a list of automations from Mailchimp
 |   ↳ `total_items` | number | Total number of automations |
 |   ↳ `total_returned` | number | Number of automations returned in this response |
 
-### `mailchimp_get_automation`
+### Get Automation from Mailchimp
 
 Retrieve details of a specific automation from Mailchimp
 
@@ -615,7 +615,7 @@ Retrieve details of a specific automation from Mailchimp
 |   ↳ `automation` | json | Automation object |
 |   ↳ `workflow_id` | string | The unique ID of the automation workflow |
 
-### `mailchimp_start_automation`
+### Start Automation in Mailchimp
 
 Start all emails in a Mailchimp automation workflow
 
@@ -634,7 +634,7 @@ Start all emails in a Mailchimp automation workflow
 | `output` | object | Start confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_pause_automation`
+### Pause Automation in Mailchimp
 
 Pause all emails in a Mailchimp automation workflow
 
@@ -653,7 +653,7 @@ Pause all emails in a Mailchimp automation workflow
 | `output` | object | Pause confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_add_subscriber_to_automation`
+### Add Subscriber to Automation in Mailchimp
 
 Manually add a subscriber to a workflow email queue
 
@@ -675,7 +675,7 @@ Manually add a subscriber to a workflow email queue
 |   ↳ `subscriber` | json | Subscriber object |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_get_templates`
+### Get Templates from Mailchimp
 
 Retrieve a list of templates from Mailchimp
 
@@ -697,7 +697,7 @@ Retrieve a list of templates from Mailchimp
 |   ↳ `total_items` | number | Total number of templates |
 |   ↳ `total_returned` | number | Number of templates returned in this response |
 
-### `mailchimp_get_template`
+### Get Template from Mailchimp
 
 Retrieve details of a specific template from Mailchimp
 
@@ -717,7 +717,7 @@ Retrieve details of a specific template from Mailchimp
 |   ↳ `template` | json | Template object |
 |   ↳ `template_id` | string | The unique ID of the template |
 
-### `mailchimp_create_template`
+### Create Template in Mailchimp
 
 Create a new template in Mailchimp
 
@@ -739,7 +739,7 @@ Create a new template in Mailchimp
 |   ↳ `template_id` | string | Created template ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_template`
+### Update Template in Mailchimp
 
 Update an existing template in Mailchimp
 
@@ -762,7 +762,7 @@ Update an existing template in Mailchimp
 |   ↳ `template_id` | string | Template ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_template`
+### Delete Template from Mailchimp
 
 Delete a template from Mailchimp
 
@@ -779,7 +779,7 @@ Delete a template from Mailchimp
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the template was successfully deleted |
 
-### `mailchimp_get_campaign_reports`
+### Get Campaign Reports from Mailchimp
 
 Retrieve a list of campaign reports from Mailchimp
 
@@ -801,7 +801,7 @@ Retrieve a list of campaign reports from Mailchimp
 |   ↳ `total_items` | number | Total number of reports |
 |   ↳ `total_returned` | number | Number of reports returned in this response |
 
-### `mailchimp_get_campaign_report`
+### Get Campaign Report from Mailchimp
 
 Retrieve the report for a specific campaign from Mailchimp
 
@@ -821,7 +821,7 @@ Retrieve the report for a specific campaign from Mailchimp
 |   ↳ `report` | json | Campaign report object |
 |   ↳ `campaign_id` | string | The unique ID of the campaign |
 
-### `mailchimp_get_segments`
+### Get Segments from Mailchimp Audience
 
 Retrieve a list of segments from a Mailchimp audience
 
@@ -844,7 +844,7 @@ Retrieve a list of segments from a Mailchimp audience
 |   ↳ `total_items` | number | Total number of segments |
 |   ↳ `total_returned` | number | Number of segments returned in this response |
 
-### `mailchimp_get_segment`
+### Get Segment from Mailchimp Audience
 
 Retrieve details of a specific segment from a Mailchimp audience
 
@@ -865,7 +865,7 @@ Retrieve details of a specific segment from a Mailchimp audience
 |   ↳ `segment` | json | Segment object |
 |   ↳ `segment_id` | string | The unique ID of the segment |
 
-### `mailchimp_create_segment`
+### Create Segment in Mailchimp Audience
 
 Create a new segment in a Mailchimp audience
 
@@ -888,7 +888,7 @@ Create a new segment in a Mailchimp audience
 |   ↳ `segment_id` | string | Created segment ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_segment`
+### Update Segment in Mailchimp Audience
 
 Update an existing segment in a Mailchimp audience
 
@@ -912,7 +912,7 @@ Update an existing segment in a Mailchimp audience
 |   ↳ `segment_id` | string | Segment ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_segment`
+### Delete Segment from Mailchimp Audience
 
 Delete a segment from a Mailchimp audience
 
@@ -930,7 +930,7 @@ Delete a segment from a Mailchimp audience
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the segment was successfully deleted |
 
-### `mailchimp_get_segment_members`
+### Get Segment Members from Mailchimp
 
 Retrieve members of a specific segment from a Mailchimp audience
 
@@ -954,7 +954,7 @@ Retrieve members of a specific segment from a Mailchimp audience
 |   ↳ `total_items` | number | Total number of members |
 |   ↳ `total_returned` | number | Number of members returned in this response |
 
-### `mailchimp_add_segment_member`
+### Add Member to Segment in Mailchimp
 
 Add a member to a specific segment in a Mailchimp audience
 
@@ -976,7 +976,7 @@ Add a member to a specific segment in a Mailchimp audience
 |   ↳ `member` | json | Added member object |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_remove_segment_member`
+### Remove Member from Segment in Mailchimp
 
 Remove a member from a specific segment in a Mailchimp audience
 
@@ -997,7 +997,7 @@ Remove a member from a specific segment in a Mailchimp audience
 | `output` | object | Removal confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_get_member_tags`
+### Get Member Tags from Mailchimp
 
 Retrieve tags associated with a member in a Mailchimp audience
 
@@ -1019,7 +1019,7 @@ Retrieve tags associated with a member in a Mailchimp audience
 |   ↳ `total_items` | number | Total number of tags |
 |   ↳ `total_returned` | number | Number of tags returned in this response |
 
-### `mailchimp_add_member_tags`
+### Add Tags to Member in Mailchimp
 
 Add tags to a member in a Mailchimp audience
 
@@ -1040,7 +1040,7 @@ Add tags to a member in a Mailchimp audience
 | `output` | object | Tag addition confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_remove_member_tags`
+### Remove Tags from Member in Mailchimp
 
 Remove tags from a member in a Mailchimp audience
 
@@ -1061,7 +1061,7 @@ Remove tags from a member in a Mailchimp audience
 | `output` | object | Tag removal confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_get_merge_fields`
+### Get Merge Fields from Mailchimp Audience
 
 Retrieve a list of merge fields from a Mailchimp audience
 
@@ -1084,7 +1084,7 @@ Retrieve a list of merge fields from a Mailchimp audience
 |   ↳ `total_items` | number | Total number of merge fields |
 |   ↳ `total_returned` | number | Number of merge fields returned in this response |
 
-### `mailchimp_get_merge_field`
+### Get Merge Field from Mailchimp Audience
 
 Retrieve details of a specific merge field from a Mailchimp audience
 
@@ -1105,7 +1105,7 @@ Retrieve details of a specific merge field from a Mailchimp audience
 |   ↳ `mergeField` | json | Merge field object |
 |   ↳ `merge_id` | string | The unique ID of the merge field |
 
-### `mailchimp_create_merge_field`
+### Create Merge Field in Mailchimp Audience
 
 Create a new merge field in a Mailchimp audience
 
@@ -1128,7 +1128,7 @@ Create a new merge field in a Mailchimp audience
 |   ↳ `merge_id` | string | Created merge field ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_merge_field`
+### Update Merge Field in Mailchimp Audience
 
 Update an existing merge field in a Mailchimp audience
 
@@ -1151,7 +1151,7 @@ Update an existing merge field in a Mailchimp audience
 |   ↳ `merge_id` | string | Merge field ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_merge_field`
+### Delete Merge Field from Mailchimp Audience
 
 Delete a merge field from a Mailchimp audience
 
@@ -1169,7 +1169,7 @@ Delete a merge field from a Mailchimp audience
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the merge field was successfully deleted |
 
-### `mailchimp_get_interest_categories`
+### Get Interest Categories from Mailchimp Audience
 
 Retrieve a list of interest categories from a Mailchimp audience
 
@@ -1192,7 +1192,7 @@ Retrieve a list of interest categories from a Mailchimp audience
 |   ↳ `total_items` | number | Total number of categories |
 |   ↳ `total_returned` | number | Number of categories returned in this response |
 
-### `mailchimp_get_interest_category`
+### Get Interest Category from Mailchimp Audience
 
 Retrieve details of a specific interest category from a Mailchimp audience
 
@@ -1213,7 +1213,7 @@ Retrieve details of a specific interest category from a Mailchimp audience
 |   ↳ `category` | json | Interest category object |
 |   ↳ `interest_category_id` | string | The unique ID of the interest category |
 
-### `mailchimp_create_interest_category`
+### Create Interest Category in Mailchimp Audience
 
 Create a new interest category in a Mailchimp audience
 
@@ -1236,7 +1236,7 @@ Create a new interest category in a Mailchimp audience
 |   ↳ `interest_category_id` | string | Created interest category ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_interest_category`
+### Update Interest Category in Mailchimp Audience
 
 Update an existing interest category in a Mailchimp audience
 
@@ -1259,7 +1259,7 @@ Update an existing interest category in a Mailchimp audience
 |   ↳ `interest_category_id` | string | Interest category ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_interest_category`
+### Delete Interest Category from Mailchimp Audience
 
 Delete an interest category from a Mailchimp audience
 
@@ -1277,7 +1277,7 @@ Delete an interest category from a Mailchimp audience
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the interest category was successfully deleted |
 
-### `mailchimp_get_interests`
+### Get Interests from Mailchimp Interest Category
 
 Retrieve a list of interests from an interest category in a Mailchimp audience
 
@@ -1301,7 +1301,7 @@ Retrieve a list of interests from an interest category in a Mailchimp audience
 |   ↳ `total_items` | number | Total number of interests |
 |   ↳ `total_returned` | number | Number of interests returned in this response |
 
-### `mailchimp_get_interest`
+### Get Interest from Mailchimp Interest Category
 
 Retrieve details of a specific interest from an interest category in a Mailchimp audience
 
@@ -1323,7 +1323,7 @@ Retrieve details of a specific interest from an interest category in a Mailchimp
 |   ↳ `interest` | json | Interest object |
 |   ↳ `interest_id` | string | The unique ID of the interest |
 
-### `mailchimp_create_interest`
+### Create Interest in Mailchimp Interest Category
 
 Create a new interest in an interest category in a Mailchimp audience
 
@@ -1346,7 +1346,7 @@ Create a new interest in an interest category in a Mailchimp audience
 |   ↳ `interest_id` | string | Created interest ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_interest`
+### Update Interest in Mailchimp Interest Category
 
 Update an existing interest in an interest category in a Mailchimp audience
 
@@ -1370,7 +1370,7 @@ Update an existing interest in an interest category in a Mailchimp audience
 |   ↳ `interest_id` | string | Interest ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_interest`
+### Delete Interest from Mailchimp Interest Category
 
 Delete an interest from an interest category in a Mailchimp audience
 
@@ -1389,7 +1389,7 @@ Delete an interest from an interest category in a Mailchimp audience
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the interest was successfully deleted |
 
-### `mailchimp_get_landing_pages`
+### Get Landing Pages from Mailchimp
 
 Retrieve a list of landing pages from Mailchimp
 
@@ -1411,7 +1411,7 @@ Retrieve a list of landing pages from Mailchimp
 |   ↳ `total_items` | number | Total number of landing pages |
 |   ↳ `total_returned` | number | Number of landing pages returned in this response |
 
-### `mailchimp_get_landing_page`
+### Get Landing Page from Mailchimp
 
 Retrieve details of a specific landing page from Mailchimp
 
@@ -1431,7 +1431,7 @@ Retrieve details of a specific landing page from Mailchimp
 |   ↳ `landingPage` | json | Landing page object |
 |   ↳ `page_id` | string | The unique ID of the landing page |
 
-### `mailchimp_create_landing_page`
+### Create Landing Page in Mailchimp
 
 Create a new landing page in Mailchimp
 
@@ -1453,7 +1453,7 @@ Create a new landing page in Mailchimp
 |   ↳ `page_id` | string | Created landing page ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_update_landing_page`
+### Update Landing Page in Mailchimp
 
 Update an existing landing page in Mailchimp
 
@@ -1475,7 +1475,7 @@ Update an existing landing page in Mailchimp
 |   ↳ `page_id` | string | Landing page ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_landing_page`
+### Delete Landing Page from Mailchimp
 
 Delete a landing page from Mailchimp
 
@@ -1492,7 +1492,7 @@ Delete a landing page from Mailchimp
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the landing page was successfully deleted |
 
-### `mailchimp_publish_landing_page`
+### Publish Landing Page in Mailchimp
 
 Publish a landing page in Mailchimp
 
@@ -1511,7 +1511,7 @@ Publish a landing page in Mailchimp
 | `output` | object | Publish confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_unpublish_landing_page`
+### Unpublish Landing Page in Mailchimp
 
 Unpublish a landing page in Mailchimp
 
@@ -1530,7 +1530,7 @@ Unpublish a landing page in Mailchimp
 | `output` | object | Unpublish confirmation |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_get_batch_operations`
+### Get Batch Operations from Mailchimp
 
 Retrieve a list of batch operations from Mailchimp
 
@@ -1552,7 +1552,7 @@ Retrieve a list of batch operations from Mailchimp
 |   ↳ `total_items` | number | Total number of batch operations |
 |   ↳ `total_returned` | number | Number of batch operations returned in this response |
 
-### `mailchimp_get_batch_operation`
+### Get Batch Operation from Mailchimp
 
 Retrieve details of a specific batch operation from Mailchimp
 
@@ -1572,7 +1572,7 @@ Retrieve details of a specific batch operation from Mailchimp
 |   ↳ `batch` | json | Batch operation object |
 |   ↳ `batch_id` | string | The unique ID of the batch operation |
 
-### `mailchimp_create_batch_operation`
+### Create Batch Operation in Mailchimp
 
 Create a new batch operation in Mailchimp
 
@@ -1593,7 +1593,7 @@ Create a new batch operation in Mailchimp
 |   ↳ `batch_id` | string | Created batch operation ID |
 |   ↳ `success` | boolean | Operation success |
 
-### `mailchimp_delete_batch_operation`
+### Delete Batch Operation from Mailchimp
 
 Delete a batch operation from Mailchimp
 

--- a/apps/docs/content/docs/en/integrations/mailgun.mdx
+++ b/apps/docs/content/docs/en/integrations/mailgun.mdx
@@ -36,7 +36,7 @@ Integrate Mailgun into your workflow. Send transactional emails, manage mailing 
 
 ## Actions
 
-### `mailgun_send_message`
+### Mailgun Send Message
 
 Send an email using Mailgun API
 
@@ -63,7 +63,7 @@ Send an email using Mailgun API
 | `id` | string | Message ID |
 | `message` | string | Response message from Mailgun |
 
-### `mailgun_get_message`
+### Mailgun Get Message
 
 Retrieve a stored message by its key
 
@@ -93,7 +93,7 @@ Retrieve a stored message by its key
 | `messageHeaders` | json | Message headers |
 | `contentIdMap` | json | Content ID map |
 
-### `mailgun_list_messages`
+### Mailgun List Messages
 
 List events (logs) for messages sent through Mailgun
 
@@ -114,7 +114,7 @@ List events (logs) for messages sent through Mailgun
 | `items` | json | Array of event items |
 | `paging` | json | Paging information |
 
-### `mailgun_create_mailing_list`
+### Mailgun Create Mailing List
 
 Create a new mailing list
 
@@ -136,7 +136,7 @@ Create a new mailing list
 | `message` | string | Response message |
 | `list` | json | Created mailing list details |
 
-### `mailgun_get_mailing_list`
+### Mailgun Get Mailing List
 
 Get details of a mailing list
 
@@ -154,7 +154,7 @@ Get details of a mailing list
 | `success` | boolean | Whether the request was successful |
 | `list` | json | Mailing list details |
 
-### `mailgun_add_list_member`
+### Mailgun Add List Member
 
 Add a member to a mailing list
 
@@ -177,7 +177,7 @@ Add a member to a mailing list
 | `message` | string | Response message |
 | `member` | json | Added member details |
 
-### `mailgun_list_domains`
+### Mailgun List Domains
 
 List all domains for your Mailgun account
 
@@ -195,7 +195,7 @@ List all domains for your Mailgun account
 | `totalCount` | number | Total number of domains |
 | `items` | json | Array of domain objects |
 
-### `mailgun_get_domain`
+### Mailgun Get Domain
 
 Get details of a specific domain
 

--- a/apps/docs/content/docs/en/integrations/managed_agent.mdx
+++ b/apps/docs/content/docs/en/integrations/managed_agent.mdx
@@ -34,7 +34,7 @@ Invoke a Claude Platform Managed Agent from a workflow. Select a Claude Platform
 
 ## Actions
 
-### `managed_agent_run_session`
+### Managed Agent Run Session
 
 Open a Claude Platform Managed Agent session and return the assistant response as text.
 
@@ -54,6 +54,7 @@ Open a Claude Platform Managed Agent session and return the assistant response a
 | `memoryInstructions` | string | No | Per-attachment guidance for how the agent should use the memory store. |
 | `files` | array | No | File attachments \(cloud envs only\), as \[\{fileId, mountPath?\}\]. |
 | `sessionParameters` | object | No | Key/value session metadata forwarded to the session. |
+| `modelInput` | string | No | No description |
 
 #### Output
 
@@ -64,7 +65,7 @@ Open a Claude Platform Managed Agent session and return the assistant response a
 | `inputTokens` | number | Cumulative input tokens for the session. |
 | `outputTokens` | number | Cumulative output tokens for the session. |
 
-### `managed_agent_create_session`
+### Managed Agent Create Session
 
 Create a Claude Platform Managed Agent session and return its id without waiting for a reply.
 
@@ -91,7 +92,7 @@ Create a Claude Platform Managed Agent session and return its id without waiting
 | `sessionId` | string | Anthropic session id \(sesn_...\). |
 | `started` | boolean | True when a first message was seeded, so the agent is already running. |
 
-### `managed_agent_send_message`
+### Managed Agent Send Message
 
 Send a user message to an existing Claude Platform Managed Agent session.
 
@@ -108,7 +109,7 @@ Send a user message to an existing Claude Platform Managed Agent session.
 | `sessionId` | string | The session the message was sent to. |
 | `sent` | boolean | True when the event was accepted by the API. |
 
-### `managed_agent_get_session`
+### Managed Agent Get Session
 
 Read a Managed Agent session: status, stop reason, token usage, metadata, and any tool calls awaiting approval.
 
@@ -131,7 +132,7 @@ Read a Managed Agent session: status, stop reason, token usage, metadata, and an
 | `inputTokens` | number | Cumulative input tokens. |
 | `outputTokens` | number | Cumulative output tokens. |
 
-### `managed_agent_list_events`
+### Managed Agent List Events
 
 Read a Managed Agent session's event history and the agent's reply text.
 
@@ -152,7 +153,7 @@ Read a Managed Agent session's event history and the agent's reply text.
 | `assistantText` | string | Concatenated text of every persisted agent.message, in order. |
 | `truncated` | boolean | True when the limit was hit and older events were dropped. |
 
-### `managed_agent_update_session`
+### Managed Agent Update Session
 
 Update a Managed Agent session's title or metadata.
 
@@ -173,7 +174,7 @@ Update a Managed Agent session's title or metadata.
 | `metadata` | json | Metadata after the update. |
 | `title` | string | Title after the update. |
 
-### `managed_agent_interrupt_session`
+### Managed Agent Interrupt Session
 
 Stop a running Managed Agent session; it stays usable afterwards.
 
@@ -189,7 +190,7 @@ Stop a running Managed Agent session; it stays usable afterwards.
 | `sessionId` | string | The session that was interrupted. |
 | `interrupted` | boolean | True when the interrupt was accepted. |
 
-### `managed_agent_respond_tool_confirmation`
+### Managed Agent Respond To Tool Confirmation
 
 Allow or deny the tool calls a Managed Agent session is waiting on before it can continue.
 
@@ -209,7 +210,7 @@ Allow or deny the tool calls a Managed Agent session is waiting on before it can
 | `decision` | string | The decision applied — 'allow' or 'deny'. |
 | `confirmedToolUseIds` | json | The tool-use event ids that were answered. |
 
-### `managed_agent_respond_custom_tool`
+### Managed Agent Respond To Custom Tool
 
 Return the result of a custom tool a Managed Agent session is waiting on so it can continue.
 
@@ -228,7 +229,7 @@ Return the result of a custom tool a Managed Agent session is waiting on so it c
 | `sessionId` | string | The session that was answered. |
 | `answeredToolUseId` | string | The custom tool-use event id that was answered. |
 
-### `managed_agent_archive_session`
+### Managed Agent Archive Session
 
 Archive a Managed Agent session, preserving its history. Not reversible.
 
@@ -244,7 +245,7 @@ Archive a Managed Agent session, preserving its history. Not reversible.
 | `sessionId` | string | The session that was archived. |
 | `archived` | boolean | True when the archive was accepted. |
 
-### `managed_agent_delete_session`
+### Managed Agent Delete Session
 
 Permanently delete a Managed Agent session, its events, and its sandbox. Not reversible.
 

--- a/apps/docs/content/docs/en/integrations/mem0.mdx
+++ b/apps/docs/content/docs/en/integrations/mem0.mdx
@@ -34,7 +34,7 @@ Integrate Mem0 into the workflow. Can add, search, and retrieve memories.
 
 ## Actions
 
-### `mem0_add_memories`
+### Add Memories
 
 Add memories to Mem0 for persistent storage and retrieval
 
@@ -54,7 +54,7 @@ Add memories to Mem0 for persistent storage and retrieval
 | `status` | string | Processing status returned by Mem0 |
 | `event_id` | string | Event ID for polling memory processing status |
 
-### `mem0_search_memories`
+### Search Memories
 
 Search for memories in Mem0 using semantic search
 
@@ -86,7 +86,7 @@ Search for memories in Mem0 using semantic search
 |   ↳ `score` | number | Similarity score from vector search |
 | `ids` | array | Array of memory IDs found in the search results |
 
-### `mem0_get_memories`
+### Get Memories
 
 Retrieve memories from Mem0 by ID or filter criteria
 

--- a/apps/docs/content/docs/en/integrations/memory.mdx
+++ b/apps/docs/content/docs/en/integrations/memory.mdx
@@ -32,7 +32,7 @@ Integrate Memory into the workflow. Can add, get a memory, get all memories, and
 
 ## Actions
 
-### `memory_add`
+### Add Memory
 
 Add a new memory to the database or append to existing memory with the same ID.
 
@@ -53,7 +53,7 @@ Add a new memory to the database or append to existing memory with the same ID.
 | `memories` | array | Array of memory objects including the new or updated memory |
 | `error` | string | Error message if operation failed |
 
-### `memory_get`
+### Get Memory
 
 Retrieve memory by conversationId. Returns matching memories.
 
@@ -73,7 +73,7 @@ Retrieve memory by conversationId. Returns matching memories.
 | `message` | string | Success or error message |
 | `error` | string | Error message if operation failed |
 
-### `memory_get_all`
+### Get All Memories
 
 Retrieve all memories from the database
 
@@ -91,7 +91,7 @@ Retrieve all memories from the database
 | `message` | string | Success or error message |
 | `error` | string | Error message if operation failed |
 
-### `memory_delete`
+### Delete Memory
 
 Delete memories by conversationId.
 

--- a/apps/docs/content/docs/en/integrations/microsoft_ad.mdx
+++ b/apps/docs/content/docs/en/integrations/microsoft_ad.mdx
@@ -37,7 +37,7 @@ Integrate Azure Active Directory into your workflows. List, create, update, and 
 
 ## Actions
 
-### `microsoft_ad_list_users`
+### List Azure AD Users
 
 List users in Azure AD (Microsoft Entra ID)
 
@@ -58,7 +58,7 @@ List users in Azure AD (Microsoft Entra ID)
 | `userCount` | number | Number of users returned |
 | `nextLink` | string | Continuation URL for the next page of results, or null if there are no more |
 
-### `microsoft_ad_get_user`
+### Get Azure AD User
 
 Get a user by ID or user principal name from Azure AD
 
@@ -85,7 +85,7 @@ Get a user by ID or user principal name from Azure AD
 |   ↳ `mobilePhone` | string | Mobile phone number |
 |   ↳ `accountEnabled` | boolean | Whether the account is enabled |
 
-### `microsoft_ad_create_user`
+### Create Azure AD User
 
 Create a new user in Azure AD (Microsoft Entra ID)
 
@@ -122,7 +122,7 @@ Create a new user in Azure AD (Microsoft Entra ID)
 |   ↳ `mobilePhone` | string | Mobile phone number |
 |   ↳ `accountEnabled` | boolean | Whether the account is enabled |
 
-### `microsoft_ad_update_user`
+### Update Azure AD User
 
 Update user properties in Azure AD (Microsoft Entra ID)
 
@@ -147,7 +147,7 @@ Update user properties in Azure AD (Microsoft Entra ID)
 | `updated` | boolean | Whether the update was successful |
 | `userId` | string | ID of the updated user |
 
-### `microsoft_ad_delete_user`
+### Delete Azure AD User
 
 Delete a user from Azure AD (Microsoft Entra ID). The user is moved to a temporary container and can be restored within 30 days.
 
@@ -164,7 +164,7 @@ Delete a user from Azure AD (Microsoft Entra ID). The user is moved to a tempora
 | `deleted` | boolean | Whether the deletion was successful |
 | `userId` | string | ID of the deleted user |
 
-### `microsoft_ad_list_groups`
+### List Azure AD Groups
 
 List groups in Azure AD (Microsoft Entra ID)
 
@@ -185,7 +185,7 @@ List groups in Azure AD (Microsoft Entra ID)
 | `groupCount` | number | Number of groups returned |
 | `nextLink` | string | Continuation URL for the next page of results, or null if there are no more |
 
-### `microsoft_ad_get_group`
+### Get Azure AD Group
 
 Get a group by ID from Azure AD (Microsoft Entra ID)
 
@@ -211,7 +211,7 @@ Get a group by ID from Azure AD (Microsoft Entra ID)
 |   ↳ `visibility` | string | Group visibility |
 |   ↳ `createdDateTime` | string | Creation date |
 
-### `microsoft_ad_create_group`
+### Create Azure AD Group
 
 Create a new group in Azure AD (Microsoft Entra ID)
 
@@ -243,7 +243,7 @@ Create a new group in Azure AD (Microsoft Entra ID)
 |   ↳ `visibility` | string | Group visibility |
 |   ↳ `createdDateTime` | string | Creation date |
 
-### `microsoft_ad_update_group`
+### Update Azure AD Group
 
 Update group properties in Azure AD (Microsoft Entra ID)
 
@@ -264,7 +264,7 @@ Update group properties in Azure AD (Microsoft Entra ID)
 | `updated` | boolean | Whether the update was successful |
 | `groupId` | string | ID of the updated group |
 
-### `microsoft_ad_delete_group`
+### Delete Azure AD Group
 
 Delete a group from Azure AD (Microsoft Entra ID). Microsoft 365 and security groups can be restored within 30 days.
 
@@ -281,7 +281,7 @@ Delete a group from Azure AD (Microsoft Entra ID). Microsoft 365 and security gr
 | `deleted` | boolean | Whether the deletion was successful |
 | `groupId` | string | ID of the deleted group |
 
-### `microsoft_ad_list_group_members`
+### List Azure AD Group Members
 
 List members of a group in Azure AD (Microsoft Entra ID)
 
@@ -301,7 +301,7 @@ List members of a group in Azure AD (Microsoft Entra ID)
 | `memberCount` | number | Number of members returned |
 | `nextLink` | string | Continuation URL for the next page of results, or null if there are no more |
 
-### `microsoft_ad_add_group_member`
+### Add Azure AD Group Member
 
 Add a member to a group in Azure AD (Microsoft Entra ID)
 
@@ -320,7 +320,7 @@ Add a member to a group in Azure AD (Microsoft Entra ID)
 | `groupId` | string | Group ID |
 | `memberId` | string | Member ID that was added |
 
-### `microsoft_ad_remove_group_member`
+### Remove Azure AD Group Member
 
 Remove a member from a group in Azure AD (Microsoft Entra ID)
 

--- a/apps/docs/content/docs/en/integrations/microsoft_dataverse.mdx
+++ b/apps/docs/content/docs/en/integrations/microsoft_dataverse.mdx
@@ -36,7 +36,7 @@ Integrate Microsoft Dataverse into your workflow. Create, read, update, delete, 
 
 ## Actions
 
-### `microsoft_dataverse_associate`
+### Associate Microsoft Dataverse Records
 
 Associate two records in Microsoft Dataverse via a navigation property. Creates a relationship between a source record and a target record. Supports both collection-valued (POST) and single-valued (PUT) navigation properties.
 
@@ -63,7 +63,7 @@ Associate two records in Microsoft Dataverse via a navigation property. Creates 
 | `targetEntitySetName` | string | Target entity set name used in the association |
 | `targetRecordId` | string | Target record GUID that was associated |
 
-### `microsoft_dataverse_create_multiple`
+### Create Multiple Microsoft Dataverse Records
 
 Create multiple records of the same table type in a single request. Each record in the Targets array must include an @odata.type annotation. Recommended batch size: 100-1000 records for standard tables.
 
@@ -84,7 +84,7 @@ Create multiple records of the same table type in a single request. Each record 
 | `count` | number | Number of records created |
 | `success` | boolean | Whether all records were created successfully |
 
-### `microsoft_dataverse_create_record`
+### Create Microsoft Dataverse Record
 
 Create a new record in a Microsoft Dataverse table. Requires the entity set name (plural table name) and record data as a JSON object.
 
@@ -104,7 +104,7 @@ Create a new record in a Microsoft Dataverse table. Requires the entity set name
 | `record` | object | Dataverse record object. Contains dynamic columns based on the queried table, plus OData metadata fields. |
 | `success` | boolean | Whether the record was created successfully |
 
-### `microsoft_dataverse_delete_record`
+### Delete Microsoft Dataverse Record
 
 Delete a record from a Microsoft Dataverse table by its ID.
 
@@ -123,7 +123,7 @@ Delete a record from a Microsoft Dataverse table by its ID.
 | `recordId` | string | The ID of the deleted record |
 | `success` | boolean | Operation success status |
 
-### `microsoft_dataverse_disassociate`
+### Disassociate Microsoft Dataverse Records
 
 Remove an association between two records in Microsoft Dataverse. For collection-valued navigation properties, provide the target record ID. For single-valued navigation properties, only the navigation property name is needed.
 
@@ -147,7 +147,7 @@ Remove an association between two records in Microsoft Dataverse. For collection
 | `navigationProperty` | string | Navigation property used for the disassociation |
 | `targetRecordId` | string | Target record GUID that was disassociated |
 
-### `microsoft_dataverse_download_file`
+### Download File from Microsoft Dataverse
 
 Download a file from a file or image column on a Dataverse record. Stores the file in execution storage and returns a file reference, plus the base64 content and metadata directly.
 
@@ -172,7 +172,7 @@ Download a file from a file or image column on a Dataverse record. Stores the fi
 | `fileColumn` | string | File column the file was downloaded from |
 | `success` | boolean | Whether the file was downloaded successfully |
 
-### `microsoft_dataverse_execute_action`
+### Execute Microsoft Dataverse Action
 
 Execute a bound or unbound Dataverse action. Actions perform operations with side effects (e.g., Merge, GrantAccess, SendEmail, QualifyLead). For bound actions, provide the entity set name and record ID.
 
@@ -193,7 +193,7 @@ Execute a bound or unbound Dataverse action. Actions perform operations with sid
 | `result` | object | Action response data. Structure varies by action. Null for actions that return 204 No Content. |
 | `success` | boolean | Whether the action executed successfully |
 
-### `microsoft_dataverse_execute_function`
+### Execute Microsoft Dataverse Function
 
 Execute a bound or unbound Dataverse function. Functions are read-only operations (e.g., RetrievePrincipalAccess, RetrieveTotalRecordCount, InitializeFrom). For bound functions, provide the entity set name and record ID.
 
@@ -214,7 +214,7 @@ Execute a bound or unbound Dataverse function. Functions are read-only operation
 | `result` | object | Function response data. Structure varies by function. |
 | `success` | boolean | Whether the function executed successfully |
 
-### `microsoft_dataverse_fetchxml_query`
+### FetchXML Query Microsoft Dataverse
 
 Execute a FetchXML query against a Microsoft Dataverse table. FetchXML supports aggregation, grouping, linked-entity joins, and complex filtering beyond OData capabilities.
 
@@ -236,7 +236,7 @@ Execute a FetchXML query against a Microsoft Dataverse table. FetchXML supports 
 | `moreRecords` | boolean | Whether more records are available beyond the current page |
 | `success` | boolean | Operation success status |
 
-### `microsoft_dataverse_get_entity_metadata`
+### Get Microsoft Dataverse Table Metadata
 
 Retrieve table (entity) and column (attribute) definitions for a Microsoft Dataverse table by its singular logical name. Use this to look up the correct entity set name and column logical names before building record data for other operations.
 
@@ -262,7 +262,7 @@ Retrieve table (entity) and column (attribute) definitions for a Microsoft Datav
 | `metadata` | object | The full raw entity metadata response from Dataverse |
 | `success` | boolean | Whether the metadata was retrieved successfully |
 
-### `microsoft_dataverse_get_record`
+### Get Microsoft Dataverse Record
 
 Retrieve a single record from a Microsoft Dataverse table by its ID. Supports $select and $expand OData query options.
 
@@ -284,7 +284,7 @@ Retrieve a single record from a Microsoft Dataverse table by its ID. Supports $s
 | `recordId` | string | The record primary key ID \(auto-detected from response\) |
 | `success` | boolean | Whether the record was retrieved successfully |
 
-### `microsoft_dataverse_list_records`
+### List Microsoft Dataverse Records
 
 Query and list records from a Microsoft Dataverse table. Supports OData query options for filtering, selecting columns, ordering, and pagination.
 
@@ -311,7 +311,7 @@ Query and list records from a Microsoft Dataverse table. Supports OData query op
 | `nextLink` | string | URL for the next page of results |
 | `success` | boolean | Operation success status |
 
-### `microsoft_dataverse_search`
+### Search Microsoft Dataverse
 
 Perform a full-text relevance search across Microsoft Dataverse tables. Requires Dataverse Search to be enabled on the environment. Supports simple and Lucene query syntax.
 
@@ -346,7 +346,7 @@ Perform a full-text relevance search across Microsoft Dataverse tables. Requires
 | `facets` | object | Facet results when facets were requested. Keys are facet names, values are arrays of facet value objects with count and value properties. |
 | `success` | boolean | Operation success status |
 
-### `microsoft_dataverse_update_multiple`
+### Update Multiple Microsoft Dataverse Records
 
 Update multiple records of the same table type in a single request. Each record must include its primary key. Only include columns that need to be changed. Recommended batch size: 100-1000 records.
 
@@ -365,7 +365,7 @@ Update multiple records of the same table type in a single request. Each record 
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether all records were updated successfully |
 
-### `microsoft_dataverse_update_record`
+### Update Microsoft Dataverse Record
 
 Update an existing record in a Microsoft Dataverse table. Only send the columns you want to change.
 
@@ -385,7 +385,7 @@ Update an existing record in a Microsoft Dataverse table. Only send the columns 
 | `recordId` | string | The ID of the updated record |
 | `success` | boolean | Operation success status |
 
-### `microsoft_dataverse_upload_file`
+### Upload File to Microsoft Dataverse
 
 Upload a file to a file or image column on a Dataverse record. Supports single-request upload for files up to 128 MB. The file content must be provided as a base64-encoded string.
 
@@ -410,7 +410,7 @@ Upload a file to a file or image column on a Dataverse record. Supports single-r
 | `fileName` | string | Name of the uploaded file |
 | `success` | boolean | Whether the file was uploaded successfully |
 
-### `microsoft_dataverse_upsert_record`
+### Upsert Microsoft Dataverse Record
 
 Create or update a record in a Microsoft Dataverse table. If a record with the given ID exists, it is updated; otherwise, a new record is created.
 
@@ -432,7 +432,7 @@ Create or update a record in a Microsoft Dataverse table. If a record with the g
 | `record` | object | Dataverse record object. Contains dynamic columns based on the queried table, plus OData metadata fields. |
 | `success` | boolean | Operation success status |
 
-### `microsoft_dataverse_whoami`
+### Microsoft Dataverse WhoAmI
 
 Retrieve the current authenticated user information from Microsoft Dataverse. Useful for testing connectivity and getting the user ID, business unit ID, and organization ID.
 

--- a/apps/docs/content/docs/en/integrations/microsoft_excel.mdx
+++ b/apps/docs/content/docs/en/integrations/microsoft_excel.mdx
@@ -36,7 +36,7 @@ Integrate Microsoft Excel into the workflow with explicit sheet selection. Can r
 
 ## Actions
 
-### `microsoft_excel_read`
+### Read from Microsoft Excel V2
 
 Read data from a specific sheet in a Microsoft Excel spreadsheet
 
@@ -60,7 +60,7 @@ Read data from a specific sheet in a Microsoft Excel spreadsheet
 |   ↳ `spreadsheetId` | string | Microsoft Excel spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `microsoft_excel_write`
+### Write to Microsoft Excel V2
 
 Write data to a specific sheet in a Microsoft Excel spreadsheet
 
@@ -88,7 +88,7 @@ Write data to a specific sheet in a Microsoft Excel spreadsheet
 |   ↳ `spreadsheetId` | string | Microsoft Excel spreadsheet ID |
 |   ↳ `spreadsheetUrl` | string | Spreadsheet URL |
 
-### `microsoft_excel_clear_range`
+### Clear Microsoft Excel Range
 
 Clear the values and/or formatting of a range in a Microsoft Excel worksheet
 
@@ -113,7 +113,7 @@ Clear the values and/or formatting of a range in a Microsoft Excel worksheet
 |   ↳ `spreadsheetId` | string | The ID of the spreadsheet |
 |   ↳ `spreadsheetUrl` | string | URL to access the spreadsheet |
 
-### `microsoft_excel_format_range`
+### Format Microsoft Excel Range
 
 Apply fill color and/or font formatting to a range in a Microsoft Excel worksheet
 
@@ -150,7 +150,7 @@ Apply fill color and/or font formatting to a range in a Microsoft Excel workshee
 |   ↳ `spreadsheetId` | string | The ID of the spreadsheet |
 |   ↳ `spreadsheetUrl` | string | URL to access the spreadsheet |
 
-### `microsoft_excel_create_table`
+### Create Microsoft Excel Table
 
 Create a new table over a range of cells in a Microsoft Excel workbook
 
@@ -177,7 +177,7 @@ Create a new table over a range of cells in a Microsoft Excel workbook
 |   ↳ `spreadsheetId` | string | The ID of the spreadsheet |
 |   ↳ `spreadsheetUrl` | string | URL to access the spreadsheet |
 
-### `microsoft_excel_delete_worksheet`
+### Delete Microsoft Excel Worksheet
 
 Delete a worksheet (sheet) from a Microsoft Excel workbook
 
@@ -199,7 +199,7 @@ Delete a worksheet (sheet) from a Microsoft Excel workbook
 |   ↳ `spreadsheetId` | string | The ID of the spreadsheet |
 |   ↳ `spreadsheetUrl` | string | URL to access the spreadsheet |
 
-### `microsoft_excel_sort_range`
+### Sort Microsoft Excel Range
 
 Sort a range or table by a column in a Microsoft Excel worksheet
 

--- a/apps/docs/content/docs/en/integrations/microsoft_planner.mdx
+++ b/apps/docs/content/docs/en/integrations/microsoft_planner.mdx
@@ -32,7 +32,7 @@ Integrate Microsoft Planner into the workflow. Manage tasks, plans, buckets, and
 
 ## Actions
 
-### `microsoft_planner_read_task`
+### Read Microsoft Planner Tasks
 
 Read tasks from Microsoft Planner - get all user tasks or all tasks from a specific plan
 
@@ -54,7 +54,7 @@ Read tasks from Microsoft Planner - get all user tasks or all tasks from a speci
 |   ↳ `userId` | string | User ID |
 |   ↳ `planUrl` | string | Microsoft Graph API URL for the plan |
 
-### `microsoft_planner_create_task`
+### Create Microsoft Planner Task
 
 Create a new task in Microsoft Planner
 
@@ -83,7 +83,7 @@ Create a new task in Microsoft Planner
 |   ↳ `taskId` | string | Created task ID |
 |   ↳ `taskUrl` | string | Microsoft Graph API URL for the task |
 
-### `microsoft_planner_update_task`
+### Update Microsoft Planner Task
 
 Update a task in Microsoft Planner
 
@@ -116,7 +116,7 @@ Update a task in Microsoft Planner
 |   ↳ `planId` | string | Parent plan ID |
 |   ↳ `taskUrl` | string | Microsoft Graph API URL for the task |
 
-### `microsoft_planner_delete_task`
+### Delete Microsoft Planner Task
 
 Delete a task from Microsoft Planner
 
@@ -135,7 +135,7 @@ Delete a task from Microsoft Planner
 | `deleted` | boolean | Confirmation of deletion |
 | `metadata` | object | Additional metadata |
 
-### `microsoft_planner_list_plans`
+### List Microsoft Planner Plans
 
 List all plans shared with the current user
 
@@ -154,7 +154,7 @@ List all plans shared with the current user
 |   ↳ `count` | number | Number of plans returned |
 |   ↳ `userId` | string | User ID |
 
-### `microsoft_planner_read_plan`
+### Read Microsoft Planner Plan
 
 Get details of a specific Microsoft Planner plan
 
@@ -174,7 +174,7 @@ Get details of a specific Microsoft Planner plan
 |   ↳ `planId` | string | Plan ID |
 |   ↳ `planUrl` | string | Microsoft Graph API URL for the plan |
 
-### `microsoft_planner_create_plan`
+### Create Microsoft Planner Plan
 
 Create a new Microsoft Planner plan owned by a Microsoft 365 group
 
@@ -195,7 +195,7 @@ Create a new Microsoft Planner plan owned by a Microsoft 365 group
 |   ↳ `planId` | string | Created plan ID |
 |   ↳ `groupId` | string | Owning Microsoft 365 group ID |
 
-### `microsoft_planner_update_plan`
+### Update Microsoft Planner Plan
 
 Rename a Microsoft Planner plan
 
@@ -216,7 +216,7 @@ Rename a Microsoft Planner plan
 | `metadata` | object | Metadata including planId |
 |   ↳ `planId` | string | Updated plan ID |
 
-### `microsoft_planner_get_plan_details`
+### Get Microsoft Planner Plan Details
 
 Get detailed information about a plan including category descriptions and sharing
 
@@ -236,7 +236,7 @@ Get detailed information about a plan including category descriptions and sharin
 | `metadata` | object | Metadata including planId |
 |   ↳ `planId` | string | Plan ID |
 
-### `microsoft_planner_update_plan_details`
+### Update Microsoft Planner Plan Details
 
 Update a plan's category (color label) descriptions and shared-with user list in Microsoft Planner
 
@@ -258,7 +258,7 @@ Update a plan's category (color label) descriptions and shared-with user list in
 | `metadata` | object | Metadata including planId |
 |   ↳ `planId` | string | Plan ID |
 
-### `microsoft_planner_delete_plan`
+### Delete Microsoft Planner Plan
 
 Delete a Microsoft Planner plan
 
@@ -277,7 +277,7 @@ Delete a Microsoft Planner plan
 | `deleted` | boolean | Confirmation of deletion |
 | `metadata` | object | Additional metadata |
 
-### `microsoft_planner_list_buckets`
+### List Microsoft Planner Buckets
 
 List all buckets in a Microsoft Planner plan
 
@@ -297,7 +297,7 @@ List all buckets in a Microsoft Planner plan
 |   ↳ `planId` | string | Plan ID |
 |   ↳ `count` | number | Number of buckets returned |
 
-### `microsoft_planner_read_bucket`
+### Read Microsoft Planner Bucket
 
 Get details of a specific bucket
 
@@ -317,7 +317,7 @@ Get details of a specific bucket
 |   ↳ `bucketId` | string | Bucket ID |
 |   ↳ `planId` | string | Parent plan ID |
 
-### `microsoft_planner_create_bucket`
+### Create Microsoft Planner Bucket
 
 Create a new bucket in a Microsoft Planner plan
 
@@ -338,7 +338,7 @@ Create a new bucket in a Microsoft Planner plan
 |   ↳ `bucketId` | string | Created bucket ID |
 |   ↳ `planId` | string | Parent plan ID |
 
-### `microsoft_planner_update_bucket`
+### Update Microsoft Planner Bucket
 
 Update a bucket in Microsoft Planner
 
@@ -360,7 +360,7 @@ Update a bucket in Microsoft Planner
 |   ↳ `bucketId` | string | Updated bucket ID |
 |   ↳ `planId` | string | Parent plan ID |
 
-### `microsoft_planner_delete_bucket`
+### Delete Microsoft Planner Bucket
 
 Delete a bucket from Microsoft Planner
 
@@ -379,7 +379,7 @@ Delete a bucket from Microsoft Planner
 | `deleted` | boolean | Confirmation of deletion |
 | `metadata` | object | Additional metadata |
 
-### `microsoft_planner_get_task_details`
+### Get Microsoft Planner Task Details
 
 Get detailed information about a task including checklist and references
 
@@ -399,7 +399,7 @@ Get detailed information about a task including checklist and references
 | `metadata` | object | Metadata including taskId |
 |   ↳ `taskId` | string | Task ID |
 
-### `microsoft_planner_update_task_details`
+### Update Microsoft Planner Task Details
 
 Update task details including description, checklist items, and references in Microsoft Planner
 

--- a/apps/docs/content/docs/en/integrations/microsoft_teams.mdx
+++ b/apps/docs/content/docs/en/integrations/microsoft_teams.mdx
@@ -35,7 +35,7 @@ Integrate Microsoft Teams into the workflow. Read, write, update, and delete cha
 
 ## Actions
 
-### `microsoft_teams_read_chat`
+### Read Microsoft Teams Chat
 
 Read content from a Microsoft Teams chat
 
@@ -59,7 +59,7 @@ Read content from a Microsoft Teams chat
 | `content` | string | Formatted content of chat messages |
 | `attachments` | file[] | Uploaded attachments for convenience \(flattened\) |
 
-### `microsoft_teams_write_chat`
+### Write to Microsoft Teams Chat
 
 Write or update content in a Microsoft Teams chat
 
@@ -83,7 +83,7 @@ Write or update content in a Microsoft Teams chat
 | `updatedContent` | boolean | Whether content was successfully updated |
 | `files` | file[] | Files attached to the message |
 
-### `microsoft_teams_read_channel`
+### Read Microsoft Teams Channel
 
 Read content from a Microsoft Teams channel
 
@@ -109,7 +109,7 @@ Read content from a Microsoft Teams channel
 | `content` | string | Formatted content of channel messages |
 | `attachments` | file[] | Uploaded attachments for convenience \(flattened\) |
 
-### `microsoft_teams_write_channel`
+### Write to Microsoft Teams Channel
 
 Write or send a message to a Microsoft Teams channel
 
@@ -135,7 +135,7 @@ Write or send a message to a Microsoft Teams channel
 | `updatedContent` | boolean | Whether content was successfully updated |
 | `files` | file[] | Files attached to the message |
 
-### `microsoft_teams_update_chat_message`
+### Update Microsoft Teams Chat Message
 
 Update an existing message in a Microsoft Teams chat
 
@@ -155,7 +155,7 @@ Update an existing message in a Microsoft Teams chat
 | `messageId` | string | ID of the updated message |
 | `updatedContent` | boolean | Whether content was successfully updated |
 
-### `microsoft_teams_update_channel_message`
+### Update Microsoft Teams Channel Message
 
 Update an existing message in a Microsoft Teams channel
 
@@ -176,7 +176,7 @@ Update an existing message in a Microsoft Teams channel
 | `messageId` | string | ID of the updated message |
 | `updatedContent` | boolean | Whether content was successfully updated |
 
-### `microsoft_teams_delete_chat_message`
+### Delete Microsoft Teams Chat Message
 
 Soft delete a message in a Microsoft Teams chat
 
@@ -195,7 +195,7 @@ Soft delete a message in a Microsoft Teams chat
 | `deleted` | boolean | Confirmation of deletion |
 | `messageId` | string | ID of the deleted message |
 
-### `microsoft_teams_delete_channel_message`
+### Delete Microsoft Teams Channel Message
 
 Soft delete a message in a Microsoft Teams channel
 
@@ -215,7 +215,7 @@ Soft delete a message in a Microsoft Teams channel
 | `deleted` | boolean | Confirmation of deletion |
 | `messageId` | string | ID of the deleted message |
 
-### `microsoft_teams_reply_to_message`
+### Reply to Microsoft Teams Channel Message
 
 Reply to an existing message in a Microsoft Teams channel
 
@@ -236,7 +236,7 @@ Reply to an existing message in a Microsoft Teams channel
 | `messageId` | string | ID of the reply message |
 | `updatedContent` | boolean | Whether content was successfully sent |
 
-### `microsoft_teams_get_message`
+### Get Microsoft Teams Message
 
 Get a specific message from a Microsoft Teams chat or channel
 
@@ -266,7 +266,7 @@ Get a specific message from a Microsoft Teams chat or channel
 |   ↳ `messages` | array | Array of message details |
 |   ↳ `messageCount` | number | Number of messages |
 
-### `microsoft_teams_set_reaction`
+### Add Reaction to Microsoft Teams Message
 
 Add an emoji reaction to a message in Microsoft Teams
 
@@ -288,7 +288,7 @@ Add an emoji reaction to a message in Microsoft Teams
 | `reactionType` | string | The emoji that was added |
 | `messageId` | string | ID of the message |
 
-### `microsoft_teams_unset_reaction`
+### Remove Reaction from Microsoft Teams Message
 
 Remove an emoji reaction from a message in Microsoft Teams
 
@@ -310,7 +310,7 @@ Remove an emoji reaction from a message in Microsoft Teams
 | `reactionType` | string | The emoji that was removed |
 | `messageId` | string | ID of the message |
 
-### `microsoft_teams_list_team_members`
+### List Microsoft Teams Team Members
 
 List all members of a Microsoft Teams team
 
@@ -328,7 +328,7 @@ List all members of a Microsoft Teams team
 | `members` | array | Array of team members |
 | `memberCount` | number | Total number of members |
 
-### `microsoft_teams_list_channel_members`
+### List Microsoft Teams Channel Members
 
 List all members of a Microsoft Teams channel
 
@@ -347,7 +347,7 @@ List all members of a Microsoft Teams channel
 | `members` | array | Array of channel members |
 | `memberCount` | number | Total number of members |
 
-### `microsoft_teams_list_chat_members`
+### List Microsoft Teams Chat Members
 
 List all members of a Microsoft Teams chat
 
@@ -366,7 +366,7 @@ List all members of a Microsoft Teams chat
 | `memberCount` | number | Total number of members |
 | `hasMore` | boolean | Whether Graph indicated additional pages beyond this response |
 
-### `microsoft_teams_list_teams`
+### List Microsoft Teams
 
 List the Microsoft Teams the current user is a direct member of
 
@@ -384,7 +384,7 @@ List the Microsoft Teams the current user is a direct member of
 | `teamCount` | number | Total number of teams |
 | `hasMore` | boolean | Whether Graph indicated additional pages beyond this response |
 
-### `microsoft_teams_list_chats`
+### List Microsoft Teams Chats
 
 List the Microsoft Teams chats the current user is part of
 
@@ -402,7 +402,7 @@ List the Microsoft Teams chats the current user is part of
 | `chatCount` | number | Total number of chats |
 | `hasMore` | boolean | Whether Graph indicated additional pages beyond this response |
 
-### `microsoft_teams_list_channels`
+### List Microsoft Teams Channels
 
 List all channels in a Microsoft Teams team
 

--- a/apps/docs/content/docs/en/integrations/millionverifier.mdx
+++ b/apps/docs/content/docs/en/integrations/millionverifier.mdx
@@ -23,7 +23,7 @@ Integrate MillionVerifier to verify email deliverability in real time — classi
 
 ## Actions
 
-### `millionverifier_verify_email`
+### MillionVerifier Verify Email
 
 Verify the deliverability of an email address. Uses one verification credit.
 
@@ -46,7 +46,7 @@ Verify the deliverability of an email address. Uses one verification credit.
 | `didYouMean` | string | Suggested correction for a likely typo |
 | `subResult` | string | Additional MillionVerifier classification detail |
 
-### `millionverifier_get_credits`
+### MillionVerifier Get Credits
 
 Retrieve the remaining verification credits for the authenticated account.
 

--- a/apps/docs/content/docs/en/integrations/mistral_parse.mdx
+++ b/apps/docs/content/docs/en/integrations/mistral_parse.mdx
@@ -33,7 +33,7 @@ Integrate Mistral Parse into the workflow. Can extract text from uploaded PDF do
 
 ## Actions
 
-### `mistral_parser`
+### Mistral PDF Parser
 
 #### Input
 

--- a/apps/docs/content/docs/en/integrations/monday.mdx
+++ b/apps/docs/content/docs/en/integrations/monday.mdx
@@ -32,7 +32,7 @@ Integrate with Monday.com to list boards, get board details, fetch and search it
 
 ## Actions
 
-### `monday_list_boards`
+### Monday List Boards
 
 List boards from your Monday.com account
 
@@ -58,7 +58,7 @@ List boards from your Monday.com account
 |   ↳ `updatedAt` | string | Last updated timestamp |
 | `count` | number | Number of boards returned |
 
-### `monday_get_board`
+### Monday Get Board
 
 Get a specific Monday.com board with its groups and columns
 
@@ -93,7 +93,7 @@ Get a specific Monday.com board with its groups and columns
 |   ↳ `title` | string | Column title |
 |   ↳ `type` | string | Column type |
 
-### `monday_get_item`
+### Monday Get Item
 
 Get a specific item by ID from Monday.com
 
@@ -123,7 +123,7 @@ Get a specific item by ID from Monday.com
 |   ↳ `updatedAt` | string | Last updated timestamp |
 |   ↳ `url` | string | Item URL |
 
-### `monday_get_items`
+### Monday Get Items
 
 Get items from a Monday.com board
 
@@ -156,7 +156,7 @@ Get items from a Monday.com board
 |   ↳ `url` | string | Item URL |
 | `count` | number | Number of items returned |
 
-### `monday_search_items`
+### Monday Search Items
 
 Search for items on a Monday.com board by column values
 
@@ -191,7 +191,7 @@ Search for items on a Monday.com board by column values
 | `count` | number | Number of items returned |
 | `cursor` | string | Pagination cursor for fetching the next page |
 
-### `monday_create_item`
+### Monday Create Item
 
 Create a new item on a Monday.com board
 
@@ -224,7 +224,7 @@ Create a new item on a Monday.com board
 |   ↳ `updatedAt` | string | Last updated timestamp |
 |   ↳ `url` | string | Item URL |
 
-### `monday_update_item`
+### Monday Update Item
 
 Update column values of an item on a Monday.com board
 
@@ -256,7 +256,7 @@ Update column values of an item on a Monday.com board
 |   ↳ `updatedAt` | string | Last updated timestamp |
 |   ↳ `url` | string | Item URL |
 
-### `monday_change_column_value`
+### Monday Change Column Value
 
 Update a single column's value on a Monday.com item
 
@@ -290,7 +290,7 @@ Update a single column's value on a Monday.com item
 |   ↳ `updatedAt` | string | Last updated timestamp |
 |   ↳ `url` | string | Item URL |
 
-### `monday_duplicate_item`
+### Monday Duplicate Item
 
 Duplicate an existing item on a Monday.com board
 
@@ -322,7 +322,7 @@ Duplicate an existing item on a Monday.com board
 |   ↳ `updatedAt` | string | Last updated timestamp |
 |   ↳ `url` | string | Item URL |
 
-### `monday_delete_item`
+### Monday Delete Item
 
 Delete an item from a Monday.com board
 
@@ -338,7 +338,7 @@ Delete an item from a Monday.com board
 | --------- | ---- | ----------- |
 | `id` | string | The ID of the deleted item |
 
-### `monday_archive_item`
+### Monday Archive Item
 
 Archive an item on a Monday.com board
 
@@ -354,7 +354,7 @@ Archive an item on a Monday.com board
 | --------- | ---- | ----------- |
 | `id` | string | The ID of the archived item |
 
-### `monday_move_item_to_group`
+### Monday Move Item to Group
 
 Move an item to a different group on a Monday.com board
 
@@ -385,7 +385,7 @@ Move an item to a different group on a Monday.com board
 |   ↳ `updatedAt` | string | Last updated timestamp |
 |   ↳ `url` | string | Item URL |
 
-### `monday_create_subitem`
+### Monday Create Subitem
 
 Create a subitem under a parent item on Monday.com
 
@@ -417,7 +417,7 @@ Create a subitem under a parent item on Monday.com
 |   ↳ `updatedAt` | string | Last updated timestamp |
 |   ↳ `url` | string | Item URL |
 
-### `monday_create_update`
+### Monday Create Update
 
 Add an update (comment) to a Monday.com item
 
@@ -440,7 +440,7 @@ Add an update (comment) to a Monday.com item
 |   ↳ `creatorId` | string | Creator user ID |
 |   ↳ `itemId` | string | Item ID |
 
-### `monday_create_group`
+### Monday Create Group
 
 Create a new group on a Monday.com board
 
@@ -464,7 +464,7 @@ Create a new group on a Monday.com board
 |   ↳ `deleted` | boolean | Whether deleted |
 |   ↳ `position` | string | Group position |
 
-### `monday_get_groups`
+### Monday Get Groups
 
 Get the groups on a Monday.com board
 
@@ -487,7 +487,7 @@ Get the groups on a Monday.com board
 |   ↳ `position` | string | Group position |
 | `count` | number | Number of returned groups |
 
-### `monday_create_board`
+### Monday Create Board
 
 Create a new board in Monday.com
 
@@ -515,7 +515,7 @@ Create a new board in Monday.com
 |   ↳ `url` | string | Board URL |
 |   ↳ `updatedAt` | string | Last updated timestamp |
 
-### `monday_create_column`
+### Monday Create Column
 
 Create a new column on a Monday.com board
 
@@ -548,6 +548,13 @@ A **Trigger** is a block that starts a workflow when an event happens in this se
 
 Trigger workflow when any column value changes on a Monday.com board
 
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
+
 #### Output
 
 | Parameter | Type | Description |
@@ -573,6 +580,13 @@ Trigger workflow when any column value changes on a Monday.com board
 
 Trigger workflow when an item is archived on a Monday.com board
 
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
+
 #### Output
 
 | Parameter | Type | Description |
@@ -592,6 +606,13 @@ Trigger workflow when an item is archived on a Monday.com board
 ### Monday Item Created
 
 Trigger workflow when a new item is created on a Monday.com board
+
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
 
 #### Output
 
@@ -613,6 +634,13 @@ Trigger workflow when a new item is created on a Monday.com board
 
 Trigger workflow when an item is deleted on a Monday.com board
 
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
+
 #### Output
 
 | Parameter | Type | Description |
@@ -632,6 +660,13 @@ Trigger workflow when an item is deleted on a Monday.com board
 ### Monday Item Moved to Group
 
 Trigger workflow when an item is moved to any group on a Monday.com board
+
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
 
 #### Output
 
@@ -654,6 +689,13 @@ Trigger workflow when an item is moved to any group on a Monday.com board
 ### Monday Item Name Changed
 
 Trigger workflow when an item name changes on a Monday.com board
+
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
 
 #### Output
 
@@ -680,6 +722,13 @@ Trigger workflow when an item name changes on a Monday.com board
 
 Trigger workflow when a status column value changes on a Monday.com board
 
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
+
 #### Output
 
 | Parameter | Type | Description |
@@ -705,6 +754,13 @@ Trigger workflow when a status column value changes on a Monday.com board
 
 Trigger workflow when a subitem is created on a Monday.com board
 
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
+
 #### Output
 
 | Parameter | Type | Description |
@@ -726,6 +782,13 @@ Trigger workflow when a subitem is created on a Monday.com board
 ### Monday Update Posted
 
 Trigger workflow when an update or comment is posted on a Monday.com item
+
+#### Configuration
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `triggerCredentials` | string | Yes | Select your Monday.com account to create the webhook automatically. |
+| `boardId` | string | Yes | The ID of the board to monitor. Find it in the URL: monday.com/boards/BOARD_ID |
 
 #### Output
 

--- a/apps/docs/content/docs/en/integrations/mongodb.mdx
+++ b/apps/docs/content/docs/en/integrations/mongodb.mdx
@@ -33,7 +33,7 @@ Integrate MongoDB into the workflow. Can find, insert, update, delete, and aggre
 
 ## Actions
 
-### `mongodb_query`
+### MongoDB Query
 
 Execute find operation on MongoDB collection
 
@@ -61,7 +61,7 @@ Execute find operation on MongoDB collection
 | `documents` | array | Array of documents returned from the query |
 | `documentCount` | number | Number of documents returned |
 
-### `mongodb_insert`
+### MongoDB Insert
 
 Insert documents into MongoDB collection
 
@@ -88,7 +88,7 @@ Insert documents into MongoDB collection
 | `insertedId` | string | ID of inserted document \(single insert\) |
 | `insertedIds` | array | Array of inserted document IDs \(multiple insert\) |
 
-### `mongodb_update`
+### MongoDB Update
 
 Update documents in MongoDB collection
 
@@ -119,7 +119,7 @@ Update documents in MongoDB collection
 | `documentCount` | number | Total number of documents affected |
 | `insertedId` | string | ID of inserted document \(if upsert\) |
 
-### `mongodb_delete`
+### MongoDB Delete
 
 Delete documents from MongoDB collection
 
@@ -146,7 +146,7 @@ Delete documents from MongoDB collection
 | `deletedCount` | number | Number of documents deleted |
 | `documentCount` | number | Total number of documents affected |
 
-### `mongodb_execute`
+### MongoDB Execute
 
 Execute MongoDB aggregation pipeline
 
@@ -172,7 +172,7 @@ Execute MongoDB aggregation pipeline
 | `documents` | array | Array of documents returned from aggregation |
 | `documentCount` | number | Number of documents returned |
 
-### `mongodb_introspect`
+### MongoDB Introspect
 
 Introspect MongoDB database to list databases, collections, and indexes
 

--- a/apps/docs/content/docs/en/integrations/mysql.mdx
+++ b/apps/docs/content/docs/en/integrations/mysql.mdx
@@ -32,7 +32,7 @@ Integrate MySQL into the workflow. Can query, insert, update, delete, and execut
 
 ## Actions
 
-### `mysql_query`
+### MySQL Query
 
 Execute SELECT query on MySQL database
 
@@ -56,7 +56,7 @@ Execute SELECT query on MySQL database
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows returned |
 
-### `mysql_insert`
+### MySQL Insert
 
 Insert new record into MySQL database
 
@@ -81,7 +81,7 @@ Insert new record into MySQL database
 | `rows` | array | Array of inserted rows |
 | `rowCount` | number | Number of rows inserted |
 
-### `mysql_update`
+### MySQL Update
 
 Update existing records in MySQL database
 
@@ -107,7 +107,7 @@ Update existing records in MySQL database
 | `rows` | array | Array of updated rows |
 | `rowCount` | number | Number of rows updated |
 
-### `mysql_delete`
+### MySQL Delete
 
 Delete records from MySQL database
 
@@ -132,7 +132,7 @@ Delete records from MySQL database
 | `rows` | array | Array of deleted rows |
 | `rowCount` | number | Number of rows deleted |
 
-### `mysql_execute`
+### MySQL Execute
 
 Execute raw SQL query on MySQL database
 
@@ -156,7 +156,7 @@ Execute raw SQL query on MySQL database
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows affected |
 
-### `mysql_introspect`
+### MySQL Introspect
 
 Introspect MySQL database schema to retrieve table structures, columns, and relationships
 

--- a/apps/docs/content/docs/en/integrations/neo4j.mdx
+++ b/apps/docs/content/docs/en/integrations/neo4j.mdx
@@ -34,7 +34,7 @@ Integrate Neo4j graph database into the workflow. Can query, create, merge, upda
 
 ## Actions
 
-### `neo4j_query`
+### Neo4j Query
 
 Execute MATCH queries to read nodes and relationships from Neo4j graph database. For best performance and to prevent large result sets, include LIMIT in your query (e.g., "MATCH (n:User) RETURN n LIMIT 100") or use LIMIT $limit with a limit parameter.
 
@@ -60,7 +60,7 @@ Execute MATCH queries to read nodes and relationships from Neo4j graph database.
 | `recordCount` | number | Number of records returned |
 | `summary` | json | Query execution summary with timing and counters |
 
-### `neo4j_create`
+### Neo4j Create
 
 Execute CREATE statements to add new nodes and relationships to Neo4j graph database
 
@@ -84,7 +84,7 @@ Execute CREATE statements to add new nodes and relationships to Neo4j graph data
 | `message` | string | Operation status message |
 | `summary` | json | Creation summary with counters for nodes and relationships created |
 
-### `neo4j_merge`
+### Neo4j Merge
 
 Execute MERGE statements to find or create nodes and relationships in Neo4j (upsert operation)
 
@@ -108,7 +108,7 @@ Execute MERGE statements to find or create nodes and relationships in Neo4j (ups
 | `message` | string | Operation status message |
 | `summary` | json | Merge summary with counters for nodes/relationships created or matched |
 
-### `neo4j_update`
+### Neo4j Update
 
 Execute SET statements to update properties of existing nodes and relationships in Neo4j
 
@@ -132,7 +132,7 @@ Execute SET statements to update properties of existing nodes and relationships 
 | `message` | string | Operation status message |
 | `summary` | json | Update summary with counters for properties set |
 
-### `neo4j_delete`
+### Neo4j Delete
 
 Execute DELETE or DETACH DELETE statements to remove nodes and relationships from Neo4j
 
@@ -157,7 +157,7 @@ Execute DELETE or DETACH DELETE statements to remove nodes and relationships fro
 | `message` | string | Operation status message |
 | `summary` | json | Delete summary with counters for nodes and relationships deleted |
 
-### `neo4j_execute`
+### Neo4j Execute
 
 Execute arbitrary Cypher queries on Neo4j graph database for complex operations
 
@@ -183,7 +183,7 @@ Execute arbitrary Cypher queries on Neo4j graph database for complex operations
 | `recordCount` | number | Number of records returned |
 | `summary` | json | Execution summary with timing and counters |
 
-### `neo4j_introspect`
+### Neo4j Introspect
 
 Introspect a Neo4j database to discover its schema including node labels, relationship types, properties, constraints, and indexes.
 

--- a/apps/docs/content/docs/en/integrations/neverbounce.mdx
+++ b/apps/docs/content/docs/en/integrations/neverbounce.mdx
@@ -23,7 +23,7 @@ Integrate NeverBounce to verify email deliverability in real time — classify a
 
 ## Actions
 
-### `neverbounce_verify_email`
+### NeverBounce Verify Email
 
 Verify the deliverability of an email address. Uses one verification credit.
 
@@ -46,7 +46,7 @@ Verify the deliverability of an email address. Uses one verification credit.
 | `didYouMean` | string | Suggested correction for a likely typo |
 | `flags` | array | Raw NeverBounce flags for the address |
 
-### `neverbounce_get_credits`
+### NeverBounce Get Credits
 
 Retrieve the remaining paid and free verification credits for the account.
 

--- a/apps/docs/content/docs/en/integrations/new_relic.mdx
+++ b/apps/docs/content/docs/en/integrations/new_relic.mdx
@@ -32,7 +32,7 @@ Integrate New Relic into workflows. Run NRQL queries, search monitored entities,
 
 ## Actions
 
-### `new_relic_nrql_query`
+### New Relic NRQL Query
 
 Run a NRQL query against a New Relic account using NerdGraph.
 
@@ -53,7 +53,7 @@ Run a NRQL query against a New Relic account using NerdGraph.
 | `results` | array | NRQL result rows. Row fields depend on the query projection. |
 | `resultCount` | number | Number of NRQL result rows returned |
 
-### `new_relic_search_entities`
+### New Relic Search Entities
 
 Search New Relic entities by name, GUID, domain type, tags, or reporting state.
 
@@ -84,7 +84,7 @@ Search New Relic entities by name, GUID, domain type, tags, or reporting state.
 |     ↳ `values` | array | Tag values |
 | `nextCursor` | string | Cursor for the next page of results |
 
-### `new_relic_get_entity`
+### New Relic Get Entity
 
 Fetch a New Relic entity by GUID.
 
@@ -111,7 +111,7 @@ Fetch a New Relic entity by GUID.
 |     ↳ `key` | string | Tag key |
 |     ↳ `values` | array | Tag values |
 
-### `new_relic_create_deployment_event`
+### New Relic Create Deployment Event
 
 Record a deployment change event in New Relic change tracking.
 

--- a/apps/docs/content/docs/en/integrations/notion.mdx
+++ b/apps/docs/content/docs/en/integrations/notion.mdx
@@ -33,7 +33,7 @@ Integrate with Notion into the workflow. Can read page, read database, create pa
 
 ## Actions
 
-### `notion_read`
+### Notion Reader
 
 Read content from a Notion page
 
@@ -53,7 +53,7 @@ Read content from a Notion page
 | `content` | string | Page content in markdown format |
 | `title` | string | Page title |
 
-### `notion_read_database`
+### Read Notion Database
 
 Read database information and structure from Notion
 
@@ -74,7 +74,7 @@ Read database information and structure from Notion
 | `properties` | object | Database properties schema |
 | `title` | string | Database title |
 
-### `notion_write`
+### Notion Content Appender
 
 Append content to a Notion page
 
@@ -91,7 +91,7 @@ Append content to a Notion page
 | --------- | ---- | ----------- |
 | `appended` | boolean | Whether content was successfully appended |
 
-### `notion_create_page`
+### Notion Page Creator
 
 Create a new page in Notion
 
@@ -113,7 +113,7 @@ Create a new page in Notion
 | `last_edited_time` | string | ISO 8601 last edit timestamp |
 | `title` | string | Page title |
 
-### `notion_update_page`
+### Notion Page Updater
 
 Update properties of a Notion page
 
@@ -133,7 +133,7 @@ Update properties of a Notion page
 | `last_edited_time` | string | ISO 8601 last edit timestamp |
 | `title` | string | Page title |
 
-### `notion_query_database`
+### Query Notion Database
 
 Query and filter Notion database entries with advanced filtering
 
@@ -190,7 +190,7 @@ Query and filter Notion database entries with advanced filtering
 | `next_cursor` | string | Cursor for next page of results |
 | `total_results` | number | Number of results returned |
 
-### `notion_search`
+### Search Notion Workspace
 
 Search across all pages and databases in Notion workspace
 
@@ -234,7 +234,7 @@ Search across all pages and databases in Notion workspace
 | `next_cursor` | string | Cursor for next page of results |
 | `total_results` | number | Number of results returned |
 
-### `notion_create_database`
+### Create Notion Database
 
 Create a new database in Notion with custom properties
 
@@ -256,7 +256,7 @@ Create a new database in Notion with custom properties
 | `properties` | object | Database properties schema |
 | `title` | string | Database title |
 
-### `notion_add_database_row`
+### Add Notion Database Row
 
 #### Input
 
@@ -275,7 +275,7 @@ Create a new database in Notion with custom properties
 | `last_edited_time` | string | ISO 8601 last edit timestamp |
 | `title` | string | Row title |
 
-### `notion_append_blocks`
+### Notion Append Block Children
 
 Append new block children (content) to a Notion page or block
 
@@ -312,7 +312,7 @@ Append new block children (content) to a Notion page or block
 | `avatar_url` | string | User avatar image URL |
 | `email` | string | User email address \(person users only\) |
 
-### `notion_retrieve_block`
+### Notion Retrieve Block
 
 Retrieve a single Notion block by its UUID, including its type-specific content
 
@@ -347,7 +347,7 @@ Retrieve a single Notion block by its UUID, including its type-specific content
 | `avatar_url` | string | User avatar image URL |
 | `email` | string | User email address \(person users only\) |
 
-### `notion_retrieve_block_children`
+### Notion Retrieve Block Children
 
 Retrieve the block children (content) of a Notion page or block
 
@@ -384,7 +384,7 @@ Retrieve the block children (content) of a Notion page or block
 | `avatar_url` | string | User avatar image URL |
 | `email` | string | User email address \(person users only\) |
 
-### `notion_update_block`
+### Notion Update Block
 
 Update the content or archived state of a single Notion block
 
@@ -421,7 +421,7 @@ Update the content or archived state of a single Notion block
 | `avatar_url` | string | User avatar image URL |
 | `email` | string | User email address \(person users only\) |
 
-### `notion_delete_block`
+### Notion Delete Block
 
 Delete (move to trash) a single Notion block
 
@@ -456,7 +456,7 @@ Delete (move to trash) a single Notion block
 | `avatar_url` | string | User avatar image URL |
 | `email` | string | User email address \(person users only\) |
 
-### `notion_create_comment`
+### Notion Create Comment
 
 Create a comment on a Notion page or within an existing discussion thread
 
@@ -493,7 +493,7 @@ Create a comment on a Notion page or within an existing discussion thread
 | `avatar_url` | string | User avatar image URL |
 | `email` | string | User email address \(person users only\) |
 
-### `notion_list_comments`
+### Notion List Comments
 
 List unresolved comments on a Notion page or block
 
@@ -530,7 +530,7 @@ List unresolved comments on a Notion page or block
 | `avatar_url` | string | User avatar image URL |
 | `email` | string | User email address \(person users only\) |
 
-### `notion_list_users`
+### Notion List Users
 
 List all users (members and bots) in the Notion workspace
 
@@ -566,7 +566,7 @@ List all users (members and bots) in the Notion workspace
 | `avatar_url` | string | User avatar image URL |
 | `email` | string | User email address \(person users only\) |
 
-### `notion_retrieve_user`
+### Notion Retrieve User
 
 Retrieve a single Notion user by their UUID
 

--- a/apps/docs/content/docs/en/integrations/obsidian.mdx
+++ b/apps/docs/content/docs/en/integrations/obsidian.mdx
@@ -34,7 +34,7 @@ Read, create, update, search, and delete notes in your Obsidian vault. Manage pe
 
 ## Actions
 
-### `obsidian_append_active`
+### Obsidian Append to Active File
 
 Append content to the currently active file in Obsidian
 
@@ -52,7 +52,7 @@ Append content to the currently active file in Obsidian
 | --------- | ---- | ----------- |
 | `appended` | boolean | Whether content was successfully appended |
 
-### `obsidian_append_note`
+### Obsidian Append to Note
 
 Append content to an existing note in your Obsidian vault
 
@@ -72,7 +72,7 @@ Append content to an existing note in your Obsidian vault
 | `filename` | string | Path of the note |
 | `appended` | boolean | Whether content was successfully appended |
 
-### `obsidian_append_periodic_note`
+### Obsidian Append to Periodic Note
 
 Append content to the current periodic note (daily, weekly, monthly, quarterly, or yearly). Creates the note if it does not exist.
 
@@ -92,7 +92,7 @@ Append content to the current periodic note (daily, weekly, monthly, quarterly, 
 | `period` | string | Period type of the note |
 | `appended` | boolean | Whether content was successfully appended |
 
-### `obsidian_create_note`
+### Obsidian Create Note
 
 Create or replace a note in your Obsidian vault
 
@@ -112,7 +112,7 @@ Create or replace a note in your Obsidian vault
 | `filename` | string | Path of the created note |
 | `created` | boolean | Whether the note was successfully created |
 
-### `obsidian_delete_note`
+### Obsidian Delete Note
 
 Delete a note from your Obsidian vault
 
@@ -131,7 +131,7 @@ Delete a note from your Obsidian vault
 | `filename` | string | Path of the deleted note |
 | `deleted` | boolean | Whether the note was successfully deleted |
 
-### `obsidian_execute_command`
+### Obsidian Execute Command
 
 Execute a command in Obsidian (e.g. open daily note, toggle sidebar)
 
@@ -150,7 +150,7 @@ Execute a command in Obsidian (e.g. open daily note, toggle sidebar)
 | `commandId` | string | ID of the executed command |
 | `executed` | boolean | Whether the command was successfully executed |
 
-### `obsidian_get_active`
+### Obsidian Get Active File
 
 Retrieve the content of the currently active file in Obsidian
 
@@ -168,7 +168,7 @@ Retrieve the content of the currently active file in Obsidian
 | `content` | string | Markdown content of the active file |
 | `filename` | string | Path to the active file |
 
-### `obsidian_get_note`
+### Obsidian Get Note
 
 Retrieve the content of a note from your Obsidian vault
 
@@ -187,7 +187,7 @@ Retrieve the content of a note from your Obsidian vault
 | `content` | string | Markdown content of the note |
 | `filename` | string | Path to the note |
 
-### `obsidian_get_periodic_note`
+### Obsidian Get Periodic Note
 
 Retrieve the current periodic note (daily, weekly, monthly, quarterly, or yearly)
 
@@ -206,7 +206,7 @@ Retrieve the current periodic note (daily, weekly, monthly, quarterly, or yearly
 | `content` | string | Markdown content of the periodic note |
 | `period` | string | Period type of the note |
 
-### `obsidian_list_commands`
+### Obsidian List Commands
 
 List all available commands in Obsidian
 
@@ -225,7 +225,7 @@ List all available commands in Obsidian
 |   ↳ `id` | string | Command identifier |
 |   ↳ `name` | string | Human-readable command name |
 
-### `obsidian_list_files`
+### Obsidian List Files
 
 List files and directories in your Obsidian vault
 
@@ -245,7 +245,7 @@ List files and directories in your Obsidian vault
 |   ↳ `path` | string | File or directory path |
 |   ↳ `type` | string | Whether the entry is a file or directory |
 
-### `obsidian_open_file`
+### Obsidian Open File
 
 Open a file in the Obsidian UI (creates the file if it does not exist)
 
@@ -265,7 +265,7 @@ Open a file in the Obsidian UI (creates the file if it does not exist)
 | `filename` | string | Path of the opened file |
 | `opened` | boolean | Whether the file was successfully opened |
 
-### `obsidian_patch_active`
+### Obsidian Patch Active File
 
 Insert or replace content at a specific heading, block reference, or frontmatter field in the active file
 
@@ -288,7 +288,7 @@ Insert or replace content at a specific heading, block reference, or frontmatter
 | --------- | ---- | ----------- |
 | `patched` | boolean | Whether the active file was successfully patched |
 
-### `obsidian_patch_note`
+### Obsidian Patch Note
 
 Insert or replace content at a specific heading, block reference, or frontmatter field in a note
 
@@ -313,7 +313,7 @@ Insert or replace content at a specific heading, block reference, or frontmatter
 | `filename` | string | Path of the patched note |
 | `patched` | boolean | Whether the note was successfully patched |
 
-### `obsidian_search`
+### Obsidian Search
 
 Search for text across notes in your Obsidian vault
 

--- a/apps/docs/content/docs/en/integrations/okta.mdx
+++ b/apps/docs/content/docs/en/integrations/okta.mdx
@@ -38,7 +38,7 @@ Integrate Okta identity management into your workflow. List, create, update, act
 
 ## Actions
 
-### `okta_list_users`
+### List Users from Okta
 
 List all users in your Okta organization with optional search and filtering
 
@@ -74,7 +74,7 @@ List all users in your Okta organization with optional search and filtering
 | `count` | number | Number of users returned |
 | `success` | boolean | Operation success status |
 
-### `okta_get_user`
+### Get User from Okta
 
 Get a specific user by ID or login from your Okta organization
 
@@ -115,7 +115,7 @@ Get a specific user by ID or login from your Okta organization
 | `passwordChanged` | string | Password change timestamp |
 | `success` | boolean | Operation success status |
 
-### `okta_create_user`
+### Create User in Okta
 
 Create a new user in your Okta organization
 
@@ -149,7 +149,7 @@ Create a new user in your Okta organization
 | `lastUpdated` | string | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `okta_update_user`
+### Update User in Okta
 
 Update a user profile in your Okta organization
 
@@ -182,7 +182,7 @@ Update a user profile in your Okta organization
 | `lastUpdated` | string | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-### `okta_activate_user`
+### Activate User in Okta
 
 Activate a user in your Okta organization. Can only be performed on users with STAGED or DEPROVISIONED status. Optionally sends an activation email.
 
@@ -205,7 +205,7 @@ Activate a user in your Okta organization. Can only be performed on users with S
 | `activationToken` | string | Activation token \(only returned when sendEmail is false\) |
 | `success` | boolean | Operation success status |
 
-### `okta_deactivate_user`
+### Deactivate User in Okta
 
 Deactivate a user in your Okta organization. This transitions the user to DEPROVISIONED status.
 
@@ -226,7 +226,7 @@ Deactivate a user in your Okta organization. This transitions the user to DEPROV
 | `deactivated` | boolean | Whether the user was deactivated |
 | `success` | boolean | Operation success status |
 
-### `okta_suspend_user`
+### Suspend User in Okta
 
 Suspend a user in your Okta organization. Only users with ACTIVE status can be suspended. Suspended users cannot log in but retain group and app assignments.
 
@@ -246,7 +246,7 @@ Suspend a user in your Okta organization. Only users with ACTIVE status can be s
 | `suspended` | boolean | Whether the user was suspended |
 | `success` | boolean | Operation success status |
 
-### `okta_unsuspend_user`
+### Unsuspend User in Okta
 
 Unsuspend a previously suspended user in your Okta organization. Returns the user to ACTIVE status.
 
@@ -266,7 +266,7 @@ Unsuspend a previously suspended user in your Okta organization. Returns the use
 | `unsuspended` | boolean | Whether the user was unsuspended |
 | `success` | boolean | Operation success status |
 
-### `okta_reset_password`
+### Reset Password in Okta
 
 Generate a one-time token to reset a user password. Can email the reset link to the user or return it directly. Transitions the user to RECOVERY status.
 
@@ -287,7 +287,7 @@ Generate a one-time token to reset a user password. Can email the reset link to 
 | `resetPasswordUrl` | string | Password reset URL \(only returned when sendEmail is false\) |
 | `success` | boolean | Operation success status |
 
-### `okta_delete_user`
+### Delete User from Okta
 
 Permanently delete a user from your Okta organization. Can only be performed on DEPROVISIONED users. If the user is active, this will first deactivate them and a second call is needed to delete.
 
@@ -308,7 +308,7 @@ Permanently delete a user from your Okta organization. Can only be performed on 
 | `deleted` | boolean | Whether the user was deleted |
 | `success` | boolean | Operation success status |
 
-### `okta_list_groups`
+### List Groups from Okta
 
 List all groups in your Okta organization with optional search and filtering
 
@@ -337,7 +337,7 @@ List all groups in your Okta organization with optional search and filtering
 | `count` | number | Number of groups returned |
 | `success` | boolean | Operation success status |
 
-### `okta_get_group`
+### Get Group from Okta
 
 Get a specific group by ID from your Okta organization
 
@@ -362,7 +362,7 @@ Get a specific group by ID from your Okta organization
 | `lastMembershipUpdated` | string | Last membership change timestamp |
 | `success` | boolean | Operation success status |
 
-### `okta_create_group`
+### Create Group in Okta
 
 Create a new group in your Okta organization
 
@@ -388,7 +388,7 @@ Create a new group in your Okta organization
 | `lastMembershipUpdated` | string | Last membership change timestamp |
 | `success` | boolean | Operation success status |
 
-### `okta_update_group`
+### Update Group in Okta
 
 Update a group profile in your Okta organization. Only groups of OKTA_GROUP type can be updated. All profile properties must be specified (full replacement).
 
@@ -415,7 +415,7 @@ Update a group profile in your Okta organization. Only groups of OKTA_GROUP type
 | `lastMembershipUpdated` | string | Last membership change timestamp |
 | `success` | boolean | Operation success status |
 
-### `okta_delete_group`
+### Delete Group from Okta
 
 Delete a group from your Okta organization. Groups of OKTA_GROUP or APP_GROUP type can be removed.
 
@@ -435,7 +435,7 @@ Delete a group from your Okta organization. Groups of OKTA_GROUP or APP_GROUP ty
 | `deleted` | boolean | Whether the group was deleted |
 | `success` | boolean | Operation success status |
 
-### `okta_add_user_to_group`
+### Add User to Group in Okta
 
 Add a user to a group in your Okta organization
 
@@ -457,7 +457,7 @@ Add a user to a group in your Okta organization
 | `added` | boolean | Whether the user was added |
 | `success` | boolean | Operation success status |
 
-### `okta_remove_user_from_group`
+### Remove User from Group in Okta
 
 Remove a user from a group in your Okta organization
 
@@ -479,7 +479,7 @@ Remove a user from a group in your Okta organization
 | `removed` | boolean | Whether the user was removed |
 | `success` | boolean | Operation success status |
 
-### `okta_list_group_members`
+### List Group Members from Okta
 
 List all members of a specific group in your Okta organization
 

--- a/apps/docs/content/docs/en/integrations/onedrive.mdx
+++ b/apps/docs/content/docs/en/integrations/onedrive.mdx
@@ -36,7 +36,7 @@ Integrate OneDrive into the workflow. Can create text and Excel files, upload fi
 
 ## Actions
 
-### `onedrive_upload`
+### Upload to OneDrive
 
 Upload a file to OneDrive
 
@@ -57,7 +57,7 @@ Upload a file to OneDrive
 | `success` | boolean | Whether the file was uploaded successfully |
 | `file` | object | The uploaded file object with metadata including id, name, webViewLink, webContentLink, and timestamps |
 
-### `onedrive_create_folder`
+### Create Folder in OneDrive
 
 Create a new folder in OneDrive
 
@@ -75,7 +75,7 @@ Create a new folder in OneDrive
 | `success` | boolean | Whether the folder was created successfully |
 | `file` | object | The created folder object with metadata including id, name, webViewLink, and timestamps |
 
-### `onedrive_download`
+### Download File from OneDrive
 
 Download a file from OneDrive
 
@@ -92,7 +92,7 @@ Download a file from OneDrive
 | --------- | ---- | ----------- |
 | `file` | file | Downloaded file stored in execution files |
 
-### `onedrive_list`
+### List OneDrive Files
 
 List files and folders in OneDrive
 
@@ -113,7 +113,7 @@ List files and folders in OneDrive
 | `files` | array | Array of file and folder objects with metadata |
 | `nextPageToken` | string | Token for retrieving the next page of results \(optional\) |
 
-### `onedrive_search`
+### Search OneDrive Files
 
 Search for files and folders across OneDrive by name, metadata, or content (recursive)
 
@@ -133,7 +133,7 @@ Search for files and folders across OneDrive by name, metadata, or content (recu
 | `files` | array | Array of file and folder objects matching the search query |
 | `nextPageToken` | string | Token for retrieving the next page of results \(optional\) |
 
-### `onedrive_get_item`
+### Get OneDrive Item Metadata
 
 Get metadata for a specific OneDrive file or folder by ID, or the drive root
 
@@ -150,7 +150,7 @@ Get metadata for a specific OneDrive file or folder by ID, or the drive root
 | `success` | boolean | Whether the item metadata was retrieved |
 | `file` | object | The file or folder metadata, including id, name, webViewLink, size, and timestamps |
 
-### `onedrive_get_drive_info`
+### Get OneDrive Info
 
 Get information about the OneDrive drive, including storage quota
 
@@ -170,7 +170,7 @@ Get information about the OneDrive drive, including storage quota
 | `owner` | string | Display name of the drive owner |
 | `quota` | object | Storage quota information in bytes \(total, used, remaining, deleted, state\) |
 
-### `onedrive_move`
+### Move or Rename OneDrive File
 
 Move a file or folder to a new parent folder, rename it, or both
 
@@ -189,7 +189,7 @@ Move a file or folder to a new parent folder, rename it, or both
 | `success` | boolean | Whether the move or rename was successful |
 | `file` | object | The updated file object with its new name and/or parent folder |
 
-### `onedrive_copy`
+### Copy OneDrive File
 
 Copy a file or folder to another location within OneDrive
 
@@ -210,7 +210,7 @@ Copy a file or folder to another location within OneDrive
 | `name` | string | The requested name for the copy, if provided |
 | `monitorUrl` | string | URL to poll for the status of the asynchronous copy operation \(copy completes in the background\) |
 
-### `onedrive_create_share_link`
+### Create OneDrive Sharing Link
 
 Create a view or edit sharing link for a OneDrive file or folder
 
@@ -229,7 +229,7 @@ Create a view or edit sharing link for a OneDrive file or folder
 | `success` | boolean | Whether the sharing link was created successfully |
 | `link` | object | The created sharing link, including its type, scope, and URL |
 
-### `onedrive_delete`
+### Delete File from OneDrive
 
 Delete a file or folder from OneDrive
 

--- a/apps/docs/content/docs/en/integrations/onepassword.mdx
+++ b/apps/docs/content/docs/en/integrations/onepassword.mdx
@@ -35,7 +35,7 @@ Access and manage secrets stored in 1Password vaults using the Connect API or Se
 
 ## Actions
 
-### `onepassword_list_vaults`
+### 1Password List Vaults
 
 List all vaults accessible by the Connect token or Service Account
 
@@ -63,7 +63,7 @@ List all vaults accessible by the Connect token or Service Account
 |   ↳ `createdAt` | string | Creation timestamp |
 |   ↳ `updatedAt` | string | Last update timestamp |
 
-### `onepassword_get_vault`
+### 1Password Get Vault
 
 Get details of a specific vault by ID
 
@@ -91,7 +91,7 @@ Get details of a specific vault by ID
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last update timestamp |
 
-### `onepassword_list_items`
+### 1Password List Items
 
 List items in a vault. Returns summaries without field values.
 
@@ -128,7 +128,7 @@ List items in a vault. Returns summaries without field values.
 |   ↳ `updatedAt` | string | Last update timestamp |
 |   ↳ `lastEditedBy` | string | ID of the last editor |
 
-### `onepassword_get_item`
+### 1Password Get Item
 
 Get full details of an item including all fields and secrets
 
@@ -173,7 +173,7 @@ Get full details of an item including all fields and secrets
 | `reference` | string | The original secret reference URI |
 | `file` | file | Downloaded file attachment |
 
-### `onepassword_get_item_file`
+### 1Password Get Item File
 
 Download the content of a file attached to an item
 
@@ -195,7 +195,7 @@ Download the content of a file attached to an item
 | --------- | ---- | ----------- |
 | `file` | file | Downloaded file attachment |
 
-### `onepassword_create_item`
+### 1Password Create Item
 
 Create a new item in a vault
 
@@ -243,7 +243,7 @@ Create a new item in a vault
 | `reference` | string | The original secret reference URI |
 | `file` | file | Downloaded file attachment |
 
-### `onepassword_replace_item`
+### 1Password Replace Item
 
 Replace an entire item with new data (full update)
 
@@ -289,7 +289,7 @@ Replace an entire item with new data (full update)
 | `reference` | string | The original secret reference URI |
 | `file` | file | Downloaded file attachment |
 
-### `onepassword_update_item`
+### 1Password Update Item
 
 Update an existing item using JSON Patch operations (RFC6902)
 
@@ -335,7 +335,7 @@ Update an existing item using JSON Patch operations (RFC6902)
 | `reference` | string | The original secret reference URI |
 | `file` | file | Downloaded file attachment |
 
-### `onepassword_delete_item`
+### 1Password Delete Item
 
 Delete an item from a vault
 
@@ -356,7 +356,7 @@ Delete an item from a vault
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the item was successfully deleted |
 
-### `onepassword_resolve_secret`
+### 1Password Resolve Secret
 
 Resolve a secret reference (op://vault/item/field) to its value. Service Account mode only.
 

--- a/apps/docs/content/docs/en/integrations/outlook.mdx
+++ b/apps/docs/content/docs/en/integrations/outlook.mdx
@@ -43,7 +43,7 @@ Integrate Outlook into the workflow. Can send, draft, read, search, reply, forwa
 
 ## Actions
 
-### `outlook_send`
+### Outlook Send
 
 Send emails using Outlook
 
@@ -69,7 +69,7 @@ Send emails using Outlook
 | `timestamp` | string | Timestamp when email was sent |
 | `message` | string | Success or error message |
 
-### `outlook_draft`
+### Outlook Draft
 
 Draft emails using Outlook
 
@@ -96,7 +96,7 @@ Draft emails using Outlook
 | `timestamp` | string | Timestamp when draft was created |
 | `message` | string | Success or error message |
 
-### `outlook_read`
+### Outlook Read
 
 Read emails from Outlook
 
@@ -139,7 +139,7 @@ Read emails from Outlook
 |   ↳ `importance` | string | Message importance \(low, normal, high\) |
 | `attachments` | file[] | All email attachments flattened from all emails |
 
-### `outlook_search`
+### Outlook Search
 
 Search Outlook messages using a free-text query (Microsoft Graph $search)
 
@@ -180,7 +180,7 @@ Search Outlook messages using a free-text query (Microsoft Graph $search)
 |   ↳ `isRead` | boolean | Whether the message has been read |
 |   ↳ `importance` | string | Message importance \(low, normal, high\) |
 
-### `outlook_reply`
+### Outlook Reply
 
 Reply to the sender of an Outlook message with a comment
 
@@ -202,7 +202,7 @@ Reply to the sender of an Outlook message with a comment
 |   ↳ `httpStatus` | number | HTTP status code returned by the API |
 |   ↳ `requestId` | string | Microsoft Graph request-id header for tracing |
 
-### `outlook_reply_all`
+### Outlook Reply All
 
 Reply to all recipients of an Outlook message with a comment
 
@@ -224,7 +224,7 @@ Reply to all recipients of an Outlook message with a comment
 |   ↳ `httpStatus` | number | HTTP status code returned by the API |
 |   ↳ `requestId` | string | Microsoft Graph request-id header for tracing |
 
-### `outlook_forward`
+### Outlook Forward
 
 Forward an existing Outlook message to specified recipients
 
@@ -249,7 +249,7 @@ Forward an existing Outlook message to specified recipients
 |   ↳ `messageId` | string | Forwarded message ID if provided by API |
 |   ↳ `internetMessageId` | string | RFC 822 Message-ID if provided |
 
-### `outlook_move`
+### Outlook Move
 
 Move emails between Outlook folders
 
@@ -269,7 +269,7 @@ Move emails between Outlook folders
 | `messageId` | string | ID of the moved message |
 | `newFolderId` | string | ID of the destination folder |
 
-### `outlook_copy`
+### Outlook Copy
 
 Copy an Outlook message to another folder
 
@@ -290,7 +290,7 @@ Copy an Outlook message to another folder
 | `copiedMessageId` | string | ID of the copied message |
 | `destinationFolderId` | string | ID of the destination folder |
 
-### `outlook_mark_read`
+### Outlook Mark as Read
 
 Mark an Outlook message as read
 
@@ -309,7 +309,7 @@ Mark an Outlook message as read
 | `messageId` | string | ID of the message |
 | `isRead` | boolean | Read status of the message |
 
-### `outlook_mark_unread`
+### Outlook Mark as Unread
 
 Mark an Outlook message as unread
 
@@ -328,7 +328,7 @@ Mark an Outlook message as unread
 | `messageId` | string | ID of the message |
 | `isRead` | boolean | Read status of the message |
 
-### `outlook_update_message`
+### Outlook Update Message
 
 Set the categories, follow-up flag, and importance on an Outlook message
 
@@ -354,7 +354,7 @@ Set the categories, follow-up flag, and importance on an Outlook message
 |   ↳ `importance` | string | Importance of the message |
 |   ↳ `isRead` | boolean | Whether the message is read |
 
-### `outlook_delete`
+### Outlook Delete
 
 Delete an Outlook message (move to Deleted Items)
 
@@ -373,7 +373,7 @@ Delete an Outlook message (move to Deleted Items)
 | `messageId` | string | ID of the deleted message |
 | `status` | string | Deletion status |
 
-### `outlook_list_folders`
+### Outlook List Folders
 
 List mail folders in the root of the Outlook mailbox
 
@@ -398,7 +398,7 @@ List mail folders in the root of the Outlook mailbox
 |   ↳ `totalItemCount` | number | Total number of items in the folder |
 |   ↳ `isHidden` | boolean | Whether the folder is hidden |
 
-### `outlook_create_folder`
+### Outlook Create Folder
 
 Create a new mail folder in the root of the Outlook mailbox
 
@@ -423,7 +423,7 @@ Create a new mail folder in the root of the Outlook mailbox
 |   ↳ `totalItemCount` | number | Total number of items in the folder |
 |   ↳ `isHidden` | boolean | Whether the folder is hidden |
 
-### `outlook_list_attachments`
+### Outlook List Attachments
 
 List the attachments on an Outlook message (metadata only, without contents)
 
@@ -447,7 +447,7 @@ List the attachments on an Outlook message (metadata only, without contents)
 |   ↳ `attachmentType` | string | Microsoft Graph attachment type \(e.g. #microsoft.graph.fileAttachment\) |
 |   ↳ `lastModifiedDateTime` | string | When the attachment was last modified \(ISO 8601\) |
 
-### `outlook_get_attachment`
+### Outlook Get Attachment
 
 Get a single attachment on an Outlook message, including its file contents
 
@@ -473,7 +473,7 @@ Get a single attachment on an Outlook message, including its file contents
 |   ↳ `lastModifiedDateTime` | string | When the attachment was last modified \(ISO 8601\) |
 | `attachments` | file[] | The downloaded file attachment \(empty for non-file attachment types\) |
 
-### `outlook_calendar_list_events`
+### Outlook List Calendar Events
 
 List Outlook calendar events within a start/end time window
 
@@ -518,7 +518,7 @@ List Outlook calendar events within a start/end time window
 |   ↳ `webLink` | string | URL that opens the event in Outlook on the web |
 | `nextLink` | string | URL for the next page of results, if any |
 
-### `outlook_calendar_get_event`
+### Outlook Get Calendar Event
 
 Get a single Outlook calendar event by ID
 
@@ -557,7 +557,7 @@ Get a single Outlook calendar event by ID
 |     ↳ `joinUrl` | string | URL to join the online meeting |
 |   ↳ `webLink` | string | URL that opens the event in Outlook on the web |
 
-### `outlook_calendar_create_event`
+### Outlook Create Calendar Event
 
 Create a new Outlook calendar event
 
@@ -606,7 +606,7 @@ Create a new Outlook calendar event
 |     ↳ `joinUrl` | string | URL to join the online meeting |
 |   ↳ `webLink` | string | URL that opens the event in Outlook on the web |
 
-### `outlook_calendar_update_event`
+### Outlook Update Calendar Event
 
 Update an existing Outlook calendar event
 
@@ -655,7 +655,7 @@ Update an existing Outlook calendar event
 |     ↳ `joinUrl` | string | URL to join the online meeting |
 |   ↳ `webLink` | string | URL that opens the event in Outlook on the web |
 
-### `outlook_calendar_delete_event`
+### Outlook Delete Calendar Event
 
 Delete an Outlook calendar event by ID
 
@@ -674,7 +674,7 @@ Delete an Outlook calendar event by ID
 |   ↳ `eventId` | string | ID of the deleted event |
 |   ↳ `status` | string | Deletion status |
 
-### `outlook_calendar_respond`
+### Outlook Respond to Calendar Invite
 
 Accept, tentatively accept, or decline an Outlook calendar event invitation
 

--- a/apps/docs/content/docs/en/integrations/pagerduty.mdx
+++ b/apps/docs/content/docs/en/integrations/pagerduty.mdx
@@ -36,7 +36,7 @@ Integrate PagerDuty into your workflow to list, get, create, update, snooze, and
 
 ## Actions
 
-### `pagerduty_list_incidents`
+### PagerDuty List Incidents
 
 List incidents from PagerDuty with optional filters.
 
@@ -76,7 +76,7 @@ List incidents from PagerDuty with optional filters.
 | `more` | boolean | Whether more results are available |
 | `offset` | number | Offset used for this page of results |
 
-### `pagerduty_get_incident`
+### PagerDuty Get Incident
 
 Get a single incident from PagerDuty by ID.
 
@@ -108,7 +108,7 @@ Get a single incident from PagerDuty by ID.
 | `incidentKey` | string | De-duplication key |
 | `htmlUrl` | string | PagerDuty web URL |
 
-### `pagerduty_create_incident`
+### PagerDuty Create Incident
 
 Create a new incident in PagerDuty.
 
@@ -140,7 +140,7 @@ Create a new incident in PagerDuty.
 | `serviceId` | string | Service ID |
 | `htmlUrl` | string | PagerDuty web URL |
 
-### `pagerduty_update_incident`
+### PagerDuty Update Incident
 
 Update an incident in PagerDuty (acknowledge, resolve, change urgency, etc.).
 
@@ -169,7 +169,7 @@ Update an incident in PagerDuty (acknowledge, resolve, change urgency, etc.).
 | `updatedAt` | string | Last updated timestamp |
 | `htmlUrl` | string | PagerDuty web URL |
 
-### `pagerduty_snooze_incident`
+### PagerDuty Snooze Incident
 
 Snooze a triggered PagerDuty incident for a number of seconds, after which it returns to triggered.
 
@@ -191,7 +191,7 @@ Snooze a triggered PagerDuty incident for a number of seconds, after which it re
 | `status` | string | Incident status after snoozing |
 | `htmlUrl` | string | PagerDuty web URL |
 
-### `pagerduty_merge_incidents`
+### PagerDuty Merge Incidents
 
 Merge one or more source incidents into a target incident. Source incidents are resolved and their alerts move to the target.
 
@@ -214,7 +214,7 @@ Merge one or more source incidents into a target incident. Source incidents are 
 | `status` | string | Target incident status |
 | `htmlUrl` | string | PagerDuty web URL |
 
-### `pagerduty_add_note`
+### PagerDuty Add Note
 
 Add a note to an existing PagerDuty incident.
 
@@ -236,7 +236,7 @@ Add a note to an existing PagerDuty incident.
 | `createdAt` | string | Creation timestamp |
 | `userName` | string | Name of the user who created the note |
 
-### `pagerduty_list_incident_alerts`
+### PagerDuty List Incident Alerts
 
 List the individual alerts attached to a PagerDuty incident.
 
@@ -268,7 +268,7 @@ List the individual alerts attached to a PagerDuty incident.
 | `more` | boolean | Whether more results are available |
 | `offset` | number | Offset used for this page of results |
 
-### `pagerduty_list_services`
+### PagerDuty List Services
 
 List services from PagerDuty with optional name filter.
 
@@ -298,7 +298,7 @@ List services from PagerDuty with optional name filter.
 | `more` | boolean | Whether more results are available |
 | `offset` | number | Offset used for this page of results |
 
-### `pagerduty_get_service`
+### PagerDuty Get Service
 
 Get a single service from PagerDuty by ID.
 
@@ -325,7 +325,7 @@ Get a single service from PagerDuty by ID.
 | `escalationPolicyId` | string | Escalation policy ID |
 | `htmlUrl` | string | PagerDuty web URL |
 
-### `pagerduty_list_oncalls`
+### PagerDuty List On-Calls
 
 List current on-call entries from PagerDuty.
 
@@ -359,7 +359,7 @@ List current on-call entries from PagerDuty.
 | `more` | boolean | Whether more results are available |
 | `offset` | number | Offset used for this page of results |
 
-### `pagerduty_list_escalation_policies`
+### PagerDuty List Escalation Policies
 
 List escalation policies from PagerDuty with an optional name filter.
 
@@ -387,7 +387,7 @@ List escalation policies from PagerDuty with an optional name filter.
 | `more` | boolean | Whether more results are available |
 | `offset` | number | Offset used for this page of results |
 
-### `pagerduty_list_schedules`
+### PagerDuty List Schedules
 
 List on-call schedules from PagerDuty with an optional name filter.
 
@@ -414,7 +414,7 @@ List on-call schedules from PagerDuty with an optional name filter.
 | `more` | boolean | Whether more results are available |
 | `offset` | number | Offset used for this page of results |
 
-### `pagerduty_list_users`
+### PagerDuty List Users
 
 List users from PagerDuty with an optional name/email filter.
 
@@ -443,7 +443,7 @@ List users from PagerDuty with an optional name/email filter.
 | `more` | boolean | Whether more results are available |
 | `offset` | number | Offset used for this page of results |
 
-### `pagerduty_send_event`
+### PagerDuty Send Event
 
 Send a trigger, acknowledge, or resolve event to PagerDuty Events API v2 using a service integration key. Used to page from monitoring/alerting sources without a PagerDuty user account.
 

--- a/apps/docs/content/docs/en/integrations/parallel_ai.mdx
+++ b/apps/docs/content/docs/en/integrations/parallel_ai.mdx
@@ -35,7 +35,7 @@ Integrate Parallel AI into the workflow. Can search the web, extract information
 
 ## Actions
 
-### `parallel_search`
+### Parallel AI Search
 
 Search the web using Parallel AI. Provides comprehensive search results with intelligent processing and content extraction.
 
@@ -63,7 +63,7 @@ Search the web using Parallel AI. Provides comprehensive search results with int
 |   ↳ `publish_date` | string | Publication date of the page \(YYYY-MM-DD\) |
 |   ↳ `excerpts` | array | LLM-optimized excerpts from the page |
 
-### `parallel_extract`
+### Parallel AI Extract
 
 Extract targeted information from specific URLs using Parallel AI. Processes provided URLs to pull relevant content based on your objective.
 
@@ -89,7 +89,7 @@ Extract targeted information from specific URLs using Parallel AI. Processes pro
 |   ↳ `excerpts` | array | Relevant text excerpts in markdown |
 |   ↳ `full_content` | string | Full page content as markdown |
 
-### `parallel_deep_research`
+### Parallel AI Deep Research
 
 Conduct comprehensive deep research across the web using Parallel AI. Synthesizes information from multiple sources with citations. Can take up to 45 minutes to complete.
 

--- a/apps/docs/content/docs/en/integrations/peopledatalabs.mdx
+++ b/apps/docs/content/docs/en/integrations/peopledatalabs.mdx
@@ -34,37 +34,37 @@ Enrich a single person or company with People Data Labs, or search the global pe
 
 ## Actions
 
-### `pdl_person_enrich`
+### PDL Person Enrich
 
 
-### `pdl_person_identify`
+### PDL Person Identify
 
 
-### `pdl_person_search`
+### PDL Person Search
 
 
-### `pdl_bulk_person_enrich`
+### PDL Bulk Person Enrich
 
 
-### `pdl_company_enrich`
+### PDL Company Enrich
 
 
-### `pdl_company_search`
+### PDL Company Search
 
 
-### `pdl_bulk_company_enrich`
+### PDL Bulk Company Enrich
 
 
-### `pdl_clean_company`
+### PDL Company Cleaner
 
 
-### `pdl_clean_location`
+### PDL Location Cleaner
 
 
-### `pdl_clean_school`
+### PDL School Cleaner
 
 
-### `pdl_autocomplete`
+### PDL Autocomplete
 
 
 

--- a/apps/docs/content/docs/en/integrations/perplexity.mdx
+++ b/apps/docs/content/docs/en/integrations/perplexity.mdx
@@ -35,7 +35,7 @@ Integrate Perplexity into the workflow. Can generate completions using Perplexit
 
 ## Actions
 
-### `perplexity_chat`
+### Perplexity Chat
 
 Generate completions using Perplexity AI chat models
 
@@ -61,7 +61,7 @@ Generate completions using Perplexity AI chat models
 |   ↳ `completion_tokens` | number | Number of tokens in the completion |
 |   ↳ `total_tokens` | number | Total number of tokens used |
 
-### `perplexity_search`
+### Perplexity Search
 
 Get ranked search results from Perplexity's continuously refreshed index with advanced filtering and customization options
 

--- a/apps/docs/content/docs/en/integrations/persona.mdx
+++ b/apps/docs/content/docs/en/integrations/persona.mdx
@@ -32,7 +32,7 @@ Integrate Persona identity verification into the workflow. Manage the full inqui
 
 ## Actions
 
-### `persona_create_inquiry`
+### Persona Create Inquiry
 
 Create a new identity verification inquiry from an inquiry template. Returns the created inquiry, which can then be completed by the individual via a one-time link.
 
@@ -54,7 +54,7 @@ Create a new identity verification inquiry from an inquiry template. Returns the
 | --------- | ---- | ----------- |
 | `inquiry` | object | The created inquiry |
 
-### `persona_get_inquiry`
+### Persona Get Inquiry
 
 Retrieve a single identity verification inquiry by ID, including its status, collected fields, and decision timestamps.
 
@@ -71,7 +71,7 @@ Retrieve a single identity verification inquiry by ID, including its status, col
 | --------- | ---- | ----------- |
 | `inquiry` | object | The retrieved inquiry |
 
-### `persona_list_inquiries`
+### Persona List Inquiries
 
 List identity verification inquiries, optionally filtered by status, account ID, reference ID, or creation date range. Results are cursor-paginated.
 
@@ -95,7 +95,7 @@ List identity verification inquiries, optionally filtered by status, account ID,
 | `inquiries` | array | Inquiries matching the filters |
 | `nextCursor` | string | Cursor for the next page \(pass as pageAfter\), or null on the last page |
 
-### `persona_update_inquiry`
+### Persona Update Inquiry
 
 Update an inquiry’s note, fields, tags, or redirect URI. Only the provided values are changed.
 
@@ -116,7 +116,7 @@ Update an inquiry’s note, fields, tags, or redirect URI. Only the provided val
 | --------- | ---- | ----------- |
 | `inquiry` | object | The updated inquiry |
 
-### `persona_approve_inquiry`
+### Persona Approve Inquiry
 
 Approve an identity verification inquiry. Approving prevents further progress on the inquiry and triggers any associated workflows and webhooks.
 
@@ -133,7 +133,7 @@ Approve an identity verification inquiry. Approving prevents further progress on
 | --------- | ---- | ----------- |
 | `inquiry` | object | The approved inquiry |
 
-### `persona_decline_inquiry`
+### Persona Decline Inquiry
 
 Decline an identity verification inquiry. Declining prevents further progress on the inquiry and triggers any associated workflows and webhooks.
 
@@ -150,7 +150,7 @@ Decline an identity verification inquiry. Declining prevents further progress on
 | --------- | ---- | ----------- |
 | `inquiry` | object | The declined inquiry |
 
-### `persona_mark_inquiry_for_review`
+### Persona Mark Inquiry for Review
 
 Mark an identity verification inquiry for manual review, moving it to the needs_review status.
 
@@ -167,7 +167,7 @@ Mark an identity verification inquiry for manual review, moving it to the needs_
 | --------- | ---- | ----------- |
 | `inquiry` | object | The inquiry marked for review |
 
-### `persona_resume_inquiry`
+### Persona Resume Inquiry
 
 Resume a pending or expired inquiry, creating a new session so the individual can continue verification. Returns a session token.
 
@@ -185,7 +185,7 @@ Resume a pending or expired inquiry, creating a new session so the individual ca
 | `inquiry` | object | The resumed inquiry |
 | `sessionToken` | string | Session token for the new inquiry session, used to continue the flow in embedded SDKs |
 
-### `persona_expire_inquiry`
+### Persona Expire Inquiry
 
 Expire an in-progress inquiry, invalidating its sessions and one-time links so the individual can no longer continue it.
 
@@ -202,7 +202,7 @@ Expire an in-progress inquiry, invalidating its sessions and one-time links so t
 | --------- | ---- | ----------- |
 | `inquiry` | object | The expired inquiry |
 
-### `persona_generate_inquiry_link`
+### Persona Generate Inquiry Link
 
 Generate a one-time link for an inquiry that the individual can open to complete their identity verification.
 
@@ -222,7 +222,7 @@ Generate a one-time link for an inquiry that the individual can open to complete
 | `oneTimeLink` | string | One-time link the individual can open to complete the inquiry |
 | `oneTimeLinkShort` | string | Shortened version of the one-time link |
 
-### `persona_print_inquiry_pdf`
+### Persona Print Inquiry PDF
 
 Download a PDF summary of an inquiry, including its collected information and verification results.
 
@@ -239,7 +239,7 @@ Download a PDF summary of an inquiry, including its collected information and ve
 | --------- | ---- | ----------- |
 | `file` | file | PDF summary of the inquiry, stored in execution files |
 
-### `persona_redact_inquiry`
+### Persona Redact Inquiry
 
 Permanently delete all personally identifiable information collected by an inquiry, for example to honor a data deletion request. This cannot be undone.
 
@@ -256,7 +256,7 @@ Permanently delete all personally identifiable information collected by an inqui
 | --------- | ---- | ----------- |
 | `inquiry` | object | The redacted inquiry \(PII fields are removed\) |
 
-### `persona_create_account`
+### Persona Create Account
 
 Create an account that represents an individual in Persona. Accounts consolidate inquiries, verifications, and reports for the same person.
 
@@ -277,7 +277,7 @@ Create an account that represents an individual in Persona. Accounts consolidate
 | --------- | ---- | ----------- |
 | `account` | object | The created account |
 
-### `persona_get_account`
+### Persona Get Account
 
 Retrieve a single account by ID, including its reference ID, fields, tags, and status.
 
@@ -294,7 +294,7 @@ Retrieve a single account by ID, including its reference ID, fields, tags, and s
 | --------- | ---- | ----------- |
 | `account` | object | The retrieved account |
 
-### `persona_list_accounts`
+### Persona List Accounts
 
 List accounts in your Persona organization, optionally filtered by reference ID. Results are cursor-paginated.
 
@@ -314,7 +314,7 @@ List accounts in your Persona organization, optionally filtered by reference ID.
 | `accounts` | array | Accounts matching the filters |
 | `nextCursor` | string | Cursor for the next page \(pass as pageAfter\), or null on the last page |
 
-### `persona_update_account`
+### Persona Update Account
 
 Update an account’s reference ID, country code, fields, or tags. Only the provided values are changed.
 
@@ -335,7 +335,7 @@ Update an account’s reference ID, country code, fields, or tags. Only the prov
 | --------- | ---- | ----------- |
 | `account` | object | The updated account |
 
-### `persona_import_accounts`
+### Persona Import Accounts
 
 Bulk-import accounts into Persona from a CSV file. Returns an importer whose status can be polled until processing completes.
 
@@ -352,7 +352,7 @@ Bulk-import accounts into Persona from a CSV file. Returns an importer whose sta
 | --------- | ---- | ----------- |
 | `importer` | object | The created account importer |
 
-### `persona_redact_account`
+### Persona Redact Account
 
 Permanently delete all personally identifiable information stored on an account, for example to honor a data deletion request. This cannot be undone.
 
@@ -369,7 +369,7 @@ Permanently delete all personally identifiable information stored on an account,
 | --------- | ---- | ----------- |
 | `account` | object | The redacted account \(PII fields are removed\) |
 
-### `persona_list_cases`
+### Persona List Cases
 
 List manual review cases, optionally filtered by status, account ID, or reference ID. Results are cursor-paginated.
 
@@ -391,7 +391,7 @@ List manual review cases, optionally filtered by status, account ID, or referenc
 | `cases` | array | Cases matching the filters |
 | `nextCursor` | string | Cursor for the next page \(pass as pageAfter\), or null on the last page |
 
-### `persona_get_case`
+### Persona Get Case
 
 Retrieve a single manual review case by ID, including its status, resolution, and assignee.
 
@@ -408,7 +408,7 @@ Retrieve a single manual review case by ID, including its status, resolution, an
 | --------- | ---- | ----------- |
 | `case` | object | The retrieved case |
 
-### `persona_create_report`
+### Persona Create Report
 
 Run a screening report (watchlist, adverse media, or politically exposed person) against an individual by name or search term.
 
@@ -433,7 +433,7 @@ Run a screening report (watchlist, adverse media, or politically exposed person)
 | --------- | ---- | ----------- |
 | `report` | object | The created report. Reports run asynchronously; poll until status is ready. |
 
-### `persona_get_report`
+### Persona Get Report
 
 Retrieve a single screening report by ID, including its status, match results, and full type-specific attributes.
 
@@ -450,7 +450,7 @@ Retrieve a single screening report by ID, including its status, match results, a
 | --------- | ---- | ----------- |
 | `report` | object | The retrieved report |
 
-### `persona_list_reports`
+### Persona List Reports
 
 List screening reports, optionally filtered by account ID or reference ID. Results are cursor-paginated.
 
@@ -471,7 +471,7 @@ List screening reports, optionally filtered by account ID or reference ID. Resul
 | `reports` | array | Reports matching the filters |
 | `nextCursor` | string | Cursor for the next page \(pass as pageAfter\), or null on the last page |
 
-### `persona_get_verification`
+### Persona Get Verification
 
 Retrieve a single verification by ID (government ID, selfie, document, database, and more), including its status and the checks that ran.
 
@@ -488,7 +488,7 @@ Retrieve a single verification by ID (government ID, selfie, document, database,
 | --------- | ---- | ----------- |
 | `verification` | object | The retrieved verification |
 
-### `persona_get_document`
+### Persona Get Document
 
 Retrieve a single document by ID (government ID, generic document, and more), including its processing status and uploaded files.
 
@@ -505,7 +505,7 @@ Retrieve a single document by ID (government ID, generic document, and more), in
 | --------- | ---- | ----------- |
 | `document` | object | The retrieved document |
 
-### `persona_list_inquiry_templates`
+### Persona List Inquiry Templates
 
 List the inquiry templates in your Persona organization, to discover template IDs for creating inquiries. Results are cursor-paginated.
 

--- a/apps/docs/content/docs/en/integrations/pinecone.mdx
+++ b/apps/docs/content/docs/en/integrations/pinecone.mdx
@@ -35,7 +35,7 @@ Integrate Pinecone into the workflow. Generate embeddings, upsert and update tex
 
 ## Actions
 
-### `pinecone_generate_embeddings`
+### Pinecone Generate Embeddings
 
 Generate embeddings from text using Pinecone's hosted models
 
@@ -56,7 +56,7 @@ Generate embeddings from text using Pinecone's hosted models
 | `vector_type` | string | Type of vector generated \(dense/sparse\) |
 | `usage` | object | Usage statistics for embeddings generation |
 
-### `pinecone_upsert_text`
+### Pinecone Upsert Text
 
 Insert or update text records in a Pinecone index
 
@@ -75,7 +75,7 @@ Insert or update text records in a Pinecone index
 | --------- | ---- | ----------- |
 | `statusText` | string | Status of the upsert operation |
 
-### `pinecone_update_vector`
+### Pinecone Update Vector
 
 Update the values, sparse values, or metadata of a vector in a Pinecone namespace
 
@@ -97,7 +97,7 @@ Update the values, sparse values, or metadata of a vector in a Pinecone namespac
 | --------- | ---- | ----------- |
 | `statusText` | string | Status of the update operation |
 
-### `pinecone_delete_vectors`
+### Pinecone Delete Vectors
 
 Delete vectors from a Pinecone namespace by IDs, by metadata filter, or delete all
 
@@ -118,7 +118,7 @@ Delete vectors from a Pinecone namespace by IDs, by metadata filter, or delete a
 | --------- | ---- | ----------- |
 | `statusText` | string | Status of the delete operation |
 
-### `pinecone_search_text`
+### Pinecone Search Text
 
 Search for similar text in a Pinecone index
 
@@ -148,7 +148,7 @@ Search for similar text in a Pinecone index
 |   ↳ `read_units` | number | Read units consumed |
 |   ↳ `rerank_units` | number | Rerank units used |
 
-### `pinecone_search_vector`
+### Pinecone Search Vector
 
 Search for similar vectors in a Pinecone index
 
@@ -172,7 +172,7 @@ Search for similar vectors in a Pinecone index
 | `matches` | array | Vector search results with ID, score, values, and metadata |
 | `namespace` | string | Namespace where the search was performed |
 
-### `pinecone_fetch`
+### Pinecone Fetch
 
 Fetch vectors by ID from a Pinecone index
 
@@ -200,7 +200,7 @@ Fetch vectors by ID from a Pinecone index
 | `usage` | object | Usage statistics including total read units |
 |   ↳ `total_tokens` | number | Read units consumed |
 
-### `pinecone_list_vector_ids`
+### Pinecone List Vector IDs
 
 List vector IDs in a Pinecone namespace by prefix (serverless indexes only)
 
@@ -226,7 +226,7 @@ List vector IDs in a Pinecone namespace by prefix (serverless indexes only)
 | `usage` | object | Usage statistics including read units |
 |   ↳ `total_tokens` | number | Read units consumed |
 
-### `pinecone_describe_index_stats`
+### Pinecone Describe Index Stats
 
 Get statistics about a Pinecone index, including per-namespace vector counts
 
@@ -247,7 +247,7 @@ Get statistics about a Pinecone index, including per-namespace vector counts
 | `indexFullness` | number | Fullness of the index \(pod-based indexes only\) |
 | `totalVectorCount` | number | Total number of vectors across all namespaces |
 
-### `pinecone_list_indexes`
+### Pinecone List Indexes
 
 List all Pinecone indexes in the project
 
@@ -272,7 +272,7 @@ List all Pinecone indexes in the project
 |   ↳ `spec` | object | Index spec \(serverless or pod configuration\) |
 |   ↳ `status` | object | Index status with ready and state |
 
-### `pinecone_describe_index`
+### Pinecone Describe Index
 
 Get the configuration and status of a Pinecone index by name
 

--- a/apps/docs/content/docs/en/integrations/pipedrive.mdx
+++ b/apps/docs/content/docs/en/integrations/pipedrive.mdx
@@ -35,7 +35,7 @@ Integrate Pipedrive into your workflow. Manage deals, contacts, sales pipeline, 
 
 ## Actions
 
-### `pipedrive_get_all_deals`
+### Get All Deals from Pipedrive
 
 Retrieve all deals from Pipedrive with optional filters
 
@@ -80,7 +80,7 @@ Retrieve all deals from Pipedrive with optional filters
 |   ↳ `next_start` | number | Offset for fetching the next page \(v1 endpoints\) |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_deal`
+### Get Deal Details from Pipedrive
 
 Retrieve detailed information about a specific deal
 
@@ -98,7 +98,7 @@ Retrieve detailed information about a specific deal
 | `deal` | object | Deal object with full details |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_create_deal`
+### Create Deal in Pipedrive
 
 Create a new deal in Pipedrive
 
@@ -124,7 +124,7 @@ Create a new deal in Pipedrive
 | `deal` | object | The created deal object |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_update_deal`
+### Update Deal in Pipedrive
 
 Update an existing deal in Pipedrive
 
@@ -147,7 +147,7 @@ Update an existing deal in Pipedrive
 | `deal` | object | The updated deal object |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_files`
+### Get Files from Pipedrive
 
 Retrieve files from Pipedrive with optional filters
 
@@ -182,7 +182,7 @@ Retrieve files from Pipedrive with optional filters
 | `next_start` | number | Offset for fetching the next page |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_mail_messages`
+### Get Mail Threads from Pipedrive
 
 Retrieve mail threads from Pipedrive mailbox
 
@@ -205,7 +205,7 @@ Retrieve mail threads from Pipedrive mailbox
 | `next_start` | number | Offset for fetching the next page |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_mail_thread`
+### Get Mail Thread Messages from Pipedrive
 
 Retrieve all messages from a specific mail thread
 
@@ -224,7 +224,7 @@ Retrieve all messages from a specific mail thread
 | `metadata` | object | Thread and pagination metadata |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_pipelines`
+### Get Pipelines from Pipedrive
 
 Retrieve all pipelines from Pipedrive
 
@@ -256,7 +256,7 @@ Retrieve all pipelines from Pipedrive
 | `next_start` | number | Offset for fetching the next page |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_pipeline_deals`
+### Get Pipeline Deals from Pipedrive
 
 Retrieve all deals in a specific pipeline
 
@@ -278,7 +278,7 @@ Retrieve all deals in a specific pipeline
 | `metadata` | object | Pipeline and pagination metadata |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_projects`
+### Get Projects from Pipedrive
 
 Retrieve all projects or a specific project from Pipedrive
 
@@ -303,7 +303,7 @@ Retrieve all projects or a specific project from Pipedrive
 | `next_cursor` | string | Cursor for fetching the next page |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_create_project`
+### Create Project in Pipedrive
 
 Create a new project in Pipedrive
 
@@ -324,7 +324,7 @@ Create a new project in Pipedrive
 | `project` | object | The created project object |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_activities`
+### Get Activities from Pipedrive
 
 Retrieve activities (tasks) from Pipedrive with optional filters
 
@@ -362,7 +362,7 @@ Retrieve activities (tasks) from Pipedrive with optional filters
 | `next_start` | number | Offset for fetching the next page |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_create_activity`
+### Create Activity in Pipedrive
 
 Create a new activity (task) in Pipedrive
 
@@ -388,7 +388,7 @@ Create a new activity (task) in Pipedrive
 | `activity` | object | The created activity object |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_update_activity`
+### Update Activity in Pipedrive
 
 Update an existing activity (task) in Pipedrive
 
@@ -412,7 +412,7 @@ Update an existing activity (task) in Pipedrive
 | `activity` | object | The updated activity object |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_get_leads`
+### Get Leads from Pipedrive
 
 Retrieve all leads or a specific lead from Pipedrive
 
@@ -466,7 +466,7 @@ Retrieve all leads or a specific lead from Pipedrive
 | `next_start` | number | Offset for fetching the next page |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_create_lead`
+### Create Lead in Pipedrive
 
 Create a new lead in Pipedrive
 
@@ -491,7 +491,7 @@ Create a new lead in Pipedrive
 | `lead` | object | The created lead object |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_update_lead`
+### Update Lead in Pipedrive
 
 Update an existing lead in Pipedrive
 
@@ -517,7 +517,7 @@ Update an existing lead in Pipedrive
 | `lead` | object | The updated lead object |
 | `success` | boolean | Operation success status |
 
-### `pipedrive_delete_lead`
+### Delete Lead from Pipedrive
 
 Delete a specific lead from Pipedrive
 

--- a/apps/docs/content/docs/en/integrations/polymarket.mdx
+++ b/apps/docs/content/docs/en/integrations/polymarket.mdx
@@ -35,7 +35,7 @@ Integrate Polymarket prediction markets into the workflow. Can get markets, mark
 
 ## Actions
 
-### `polymarket_get_markets`
+### Get Markets from Polymarket
 
 Retrieve a list of prediction markets from Polymarket with optional filtering
 
@@ -71,7 +71,7 @@ Retrieve a list of prediction markets from Polymarket with optional filtering
 |   ↳ `liquidityNum` | number | Liquidity as number |
 |   ↳ `clobTokenIds` | array | CLOB token IDs |
 
-### `polymarket_get_market`
+### Get Market from Polymarket
 
 Retrieve details of a specific prediction market by ID or slug
 
@@ -110,7 +110,7 @@ Retrieve details of a specific prediction market by ID or slug
 |   ↳ `acceptingOrders` | boolean | Whether accepting orders |
 |   ↳ `negRisk` | boolean | Whether negative risk |
 
-### `polymarket_get_events`
+### Get Events from Polymarket
 
 Retrieve a list of events from Polymarket with optional filtering
 
@@ -146,7 +146,7 @@ Retrieve a list of events from Polymarket with optional filtering
 |   ↳ `volume` | number | Total volume |
 |   ↳ `markets` | array | Array of markets in this event |
 
-### `polymarket_get_event`
+### Get Event from Polymarket
 
 Retrieve details of a specific event by ID or slug
 
@@ -181,7 +181,7 @@ Retrieve details of a specific event by ID or slug
 |   ↳ `commentCount` | number | Comment count |
 |   ↳ `markets` | array | Array of markets in this event |
 
-### `polymarket_get_tags`
+### Get Tags from Polymarket
 
 Retrieve available tags for filtering markets from Polymarket
 
@@ -203,7 +203,7 @@ Retrieve available tags for filtering markets from Polymarket
 |   ↳ `createdAt` | string | Creation timestamp |
 |   ↳ `updatedAt` | string | Last update timestamp |
 
-### `polymarket_search`
+### Search Polymarket
 
 Search for markets, events, and profiles on Polymarket
 
@@ -234,7 +234,7 @@ Search for markets, events, and profiles on Polymarket
 |   ↳ `tags` | array | Array of matching tag objects |
 |   ↳ `profiles` | array | Array of matching profile objects |
 
-### `polymarket_get_series`
+### Get Series from Polymarket
 
 Retrieve series (related market groups) from Polymarket
 
@@ -266,7 +266,7 @@ Retrieve series (related market groups) from Polymarket
 |   ↳ `liquidity` | number | Total liquidity |
 |   ↳ `eventCount` | number | Number of events in series |
 
-### `polymarket_get_series_by_id`
+### Get Series by ID from Polymarket
 
 Retrieve a specific series (related market group) by ID from Polymarket
 
@@ -299,7 +299,7 @@ Retrieve a specific series (related market group) by ID from Polymarket
 |   ↳ `eventCount` | number | Number of events in series |
 |   ↳ `events` | array | Array of events in this series |
 
-### `polymarket_get_orderbook`
+### Get Orderbook from Polymarket
 
 Retrieve the order book summary for a specific token
 
@@ -329,7 +329,7 @@ Retrieve the order book summary for a specific token
 |   ↳ `neg_risk` | boolean | Whether negative risk |
 |   ↳ `last_trade_price` | string | Last trade price |
 
-### `polymarket_get_price`
+### Get Price from Polymarket
 
 Retrieve the market price for a specific token and side
 
@@ -346,7 +346,7 @@ Retrieve the market price for a specific token and side
 | --------- | ---- | ----------- |
 | `price` | string | Market price |
 
-### `polymarket_get_midpoint`
+### Get Midpoint Price from Polymarket
 
 Retrieve the midpoint price for a specific token
 
@@ -362,7 +362,7 @@ Retrieve the midpoint price for a specific token
 | --------- | ---- | ----------- |
 | `midpoint` | string | Midpoint price |
 
-### `polymarket_get_price_history`
+### Get Price History from Polymarket
 
 Retrieve historical price data for a specific market token
 
@@ -384,7 +384,7 @@ Retrieve historical price data for a specific market token
 |   ↳ `t` | number | Unix timestamp |
 |   ↳ `p` | number | Price at timestamp |
 
-### `polymarket_get_last_trade_price`
+### Get Last Trade Price from Polymarket
 
 Retrieve the last trade price for a specific token
 
@@ -401,7 +401,7 @@ Retrieve the last trade price for a specific token
 | `price` | string | Last trade price |
 | `side` | string | Side of the last trade \(BUY or SELL\) |
 
-### `polymarket_get_spread`
+### Get Spread from Polymarket
 
 Retrieve the bid-ask spread for a specific token
 
@@ -418,7 +418,7 @@ Retrieve the bid-ask spread for a specific token
 | `spread` | object | Spread value between bid and ask |
 |   ↳ `spread` | string | The spread value |
 
-### `polymarket_get_tick_size`
+### Get Tick Size from Polymarket
 
 Retrieve the minimum tick size for a specific token
 
@@ -434,7 +434,7 @@ Retrieve the minimum tick size for a specific token
 | --------- | ---- | ----------- |
 | `tickSize` | string | Minimum tick size |
 
-### `polymarket_get_positions`
+### Get Positions from Polymarket
 
 Retrieve user positions from Polymarket
 
@@ -485,7 +485,7 @@ Retrieve user positions from Polymarket
 |   ↳ `endDate` | string | End date |
 |   ↳ `negativeRisk` | boolean | Whether negative risk |
 
-### `polymarket_get_trades`
+### Get Trades from Polymarket
 
 Retrieve trade history from Polymarket
 
@@ -528,7 +528,7 @@ Retrieve trade history from Polymarket
 |   ↳ `profileImageOptimized` | string | Optimized profile image URL |
 |   ↳ `transactionHash` | string | Transaction hash |
 
-### `polymarket_get_activity`
+### Get Activity from Polymarket
 
 Retrieve on-chain activity for a user including trades, splits, merges, redemptions, rewards, and conversions
 
@@ -575,7 +575,7 @@ Retrieve on-chain activity for a user including trades, splits, merges, redempti
 |   ↳ `profileImage` | string | User profile image URL |
 |   ↳ `profileImageOptimized` | string | Optimized profile image URL |
 
-### `polymarket_get_leaderboard`
+### Get Leaderboard from Polymarket
 
 Retrieve trader leaderboard rankings by profit/loss or volume
 
@@ -605,7 +605,7 @@ Retrieve trader leaderboard rankings by profit/loss or volume
 |   ↳ `xUsername` | string | Twitter/X username |
 |   ↳ `verifiedBadge` | boolean | Whether user has verified badge |
 
-### `polymarket_get_holders`
+### Get Market Holders from Polymarket
 
 Retrieve top holders of a specific market token
 

--- a/apps/docs/content/docs/en/integrations/postgresql.mdx
+++ b/apps/docs/content/docs/en/integrations/postgresql.mdx
@@ -32,7 +32,7 @@ Integrate PostgreSQL into the workflow. Can query, insert, update, delete, and e
 
 ## Actions
 
-### `postgresql_query`
+### PostgreSQL Query
 
 Execute a SELECT query on PostgreSQL database
 
@@ -56,7 +56,7 @@ Execute a SELECT query on PostgreSQL database
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows returned |
 
-### `postgresql_insert`
+### PostgreSQL Insert
 
 Insert data into PostgreSQL database
 
@@ -81,7 +81,7 @@ Insert data into PostgreSQL database
 | `rows` | array | Inserted data \(if RETURNING clause used\) |
 | `rowCount` | number | Number of rows inserted |
 
-### `postgresql_update`
+### PostgreSQL Update
 
 Update data in PostgreSQL database
 
@@ -107,7 +107,7 @@ Update data in PostgreSQL database
 | `rows` | array | Updated data \(if RETURNING clause used\) |
 | `rowCount` | number | Number of rows updated |
 
-### `postgresql_delete`
+### PostgreSQL Delete
 
 Delete data from PostgreSQL database
 
@@ -132,7 +132,7 @@ Delete data from PostgreSQL database
 | `rows` | array | Deleted data \(if RETURNING clause used\) |
 | `rowCount` | number | Number of rows deleted |
 
-### `postgresql_execute`
+### PostgreSQL Execute
 
 Execute raw SQL query on PostgreSQL database
 
@@ -156,7 +156,7 @@ Execute raw SQL query on PostgreSQL database
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows affected |
 
-### `postgresql_introspect`
+### PostgreSQL Introspect
 
 Introspect PostgreSQL database schema to retrieve table structures, columns, and relationships
 

--- a/apps/docs/content/docs/en/integrations/posthog.mdx
+++ b/apps/docs/content/docs/en/integrations/posthog.mdx
@@ -39,7 +39,7 @@ Integrate PostHog into your workflow. Track events, manage feature flags, analyz
 
 ## Actions
 
-### `posthog_capture_event`
+### PostHog Capture Event
 
 Capture a single event in PostHog. Use this to track user actions, page views, or custom events.
 
@@ -61,7 +61,7 @@ Capture a single event in PostHog. Use this to track user actions, page views, o
 | --------- | ---- | ----------- |
 | `status` | string | Status message indicating whether the event was captured successfully |
 
-### `posthog_batch_events`
+### PostHog Batch Events
 
 Capture multiple events at once in PostHog. Use this for bulk event ingestion to improve performance.
 
@@ -81,7 +81,7 @@ Capture multiple events at once in PostHog. Use this for bulk event ingestion to
 | `status` | string | Status message indicating whether the batch was captured successfully |
 | `events_processed` | number | Number of events processed in the batch |
 
-### `posthog_list_persons`
+### PostHog List Persons
 
 List persons (users) in PostHog. Returns user profiles with their properties and distinct IDs.
 
@@ -110,7 +110,7 @@ List persons (users) in PostHog. Returns user profiles with their properties and
 |   ↳ `uuid` | string | Person UUID |
 | `next` | string | URL for the next page of results \(if available\) |
 
-### `posthog_get_person`
+### PostHog Get Person
 
 Get detailed information about a specific person in PostHog by their ID or UUID.
 
@@ -135,7 +135,7 @@ Get detailed information about a specific person in PostHog by their ID or UUID.
 |   ↳ `created_at` | string | When the person was first seen |
 |   ↳ `uuid` | string | Person UUID |
 
-### `posthog_delete_person`
+### PostHog Delete Person
 
 Delete a person from PostHog. This will remove all associated events and data. Use with caution.
 
@@ -155,7 +155,7 @@ Delete a person from PostHog. This will remove all associated events and data. U
 | --------- | ---- | ----------- |
 | `status` | string | Status message indicating whether the person was deleted successfully |
 
-### `posthog_query`
+### PostHog Query
 
 Execute a HogQL query in PostHog. HogQL is PostHog's SQL-like query language for analytics. Use this for advanced data retrieval and analysis.
 
@@ -180,7 +180,7 @@ Execute a HogQL query in PostHog. HogQL is PostHog's SQL-like query language for
 | `hogql` | string | The actual HogQL query that was executed |
 | `has_more` | boolean | Whether there are more results available |
 
-### `posthog_list_insights`
+### PostHog List Insights
 
 List all insights in a PostHog project. Returns insight configurations and metadata.
 
@@ -213,7 +213,7 @@ List all insights in a PostHog project. Returns insight configurations and metad
 |   ↳ `last_modified_by` | object | User who last modified the insight |
 |   ↳ `dashboards` | array | IDs of dashboards this insight appears on |
 
-### `posthog_get_insight`
+### PostHog Get Insight
 
 Get a specific insight by ID from PostHog. Returns detailed insight configuration and metadata.
 
@@ -243,7 +243,7 @@ Get a specific insight by ID from PostHog. Returns detailed insight configuratio
 | `tags` | array | Tags associated with the insight |
 | `favorited` | boolean | Whether the insight is favorited |
 
-### `posthog_create_insight`
+### PostHog Create Insight
 
 Create a new insight in PostHog. Requires insight name and a query configuration.
 
@@ -275,7 +275,7 @@ Create a new insight in PostHog. Requires insight name and a query configuration
 | `dashboards` | array | IDs of dashboards this insight appears on |
 | `tags` | array | Tags associated with the insight |
 
-### `posthog_update_insight`
+### PostHog Update Insight
 
 Update an existing insight in PostHog. Can modify name, description, query, dashboards, tags, and favorited status.
 
@@ -309,7 +309,7 @@ Update an existing insight in PostHog. Can modify name, description, query, dash
 | `tags` | array | Tags associated with the insight |
 | `favorited` | boolean | Whether the insight is favorited |
 
-### `posthog_list_dashboards`
+### PostHog List Dashboards
 
 List all dashboards in a PostHog project. Returns dashboard configurations, tiles, and metadata.
 
@@ -344,7 +344,7 @@ List all dashboards in a PostHog project. Returns dashboard configurations, tile
 |   ↳ `filters` | object | Global filters for the dashboard |
 |   ↳ `tags` | array | Tags associated with the dashboard |
 
-### `posthog_get_dashboard`
+### PostHog Get Dashboard
 
 Get a specific dashboard by ID from PostHog. Returns detailed dashboard configuration, tiles, and metadata.
 
@@ -375,7 +375,7 @@ Get a specific dashboard by ID from PostHog. Returns detailed dashboard configur
 | `tags` | array | Tags associated with the dashboard |
 | `restriction_level` | number | Access restriction level for the dashboard |
 
-### `posthog_create_dashboard`
+### PostHog Create Dashboard
 
 Create a new dashboard in PostHog. Optionally seed it from a built-in template, then attach insights to it afterward.
 
@@ -406,7 +406,7 @@ Create a new dashboard in PostHog. Optionally seed it from a built-in template, 
 | `filters` | object | Global filters applied to the dashboard |
 | `tags` | array | Tags associated with the dashboard |
 
-### `posthog_list_actions`
+### PostHog List Actions
 
 List all actions in a PostHog project. Returns action definitions, steps, and metadata.
 
@@ -443,7 +443,7 @@ List all actions in a PostHog project. Returns action definitions, steps, and me
 |   ↳ `is_calculating` | boolean | Whether the action is being calculated |
 |   ↳ `last_calculated_at` | string | ISO timestamp of last calculation |
 
-### `posthog_list_cohorts`
+### PostHog List Cohorts
 
 List all cohorts in a PostHog project. Returns cohort definitions, filters, and user counts.
 
@@ -481,7 +481,7 @@ List all cohorts in a PostHog project. Returns cohort definitions, filters, and 
 |   ↳ `count` | number | Number of users in the cohort |
 |   ↳ `is_static` | boolean | Whether the cohort is static |
 
-### `posthog_get_cohort`
+### PostHog Get Cohort
 
 Get a specific cohort by ID from PostHog. Returns detailed cohort definition, filters, and user count.
 
@@ -515,7 +515,7 @@ Get a specific cohort by ID from PostHog. Returns detailed cohort definition, fi
 | `is_static` | boolean | Whether the cohort is static |
 | `version` | number | Version number of the cohort |
 
-### `posthog_create_cohort`
+### PostHog Create Cohort
 
 Create a new cohort in PostHog. Requires cohort name and filter or query configuration.
 
@@ -552,7 +552,7 @@ Create a new cohort in PostHog. Requires cohort name and filter or query configu
 | `is_static` | boolean | Whether the cohort is static |
 | `version` | number | Version number of the cohort |
 
-### `posthog_update_cohort`
+### PostHog Update Cohort
 
 Update an existing cohort in PostHog. Can modify name, description, filters, query, static membership, and deleted status.
 
@@ -590,7 +590,7 @@ Update an existing cohort in PostHog. Can modify name, description, filters, que
 | `is_static` | boolean | Whether the cohort is static |
 | `version` | number | Version number of the cohort |
 
-### `posthog_list_annotations`
+### PostHog List Annotations
 
 List all annotations in a PostHog project. Returns annotation content, timestamps, and associated insights.
 
@@ -626,7 +626,7 @@ List all annotations in a PostHog project. Returns annotation content, timestamp
 |   ↳ `scope` | string | Scope of the annotation \(project or dashboard\) |
 |   ↳ `deleted` | boolean | Whether the annotation is deleted |
 
-### `posthog_create_annotation`
+### PostHog Create Annotation
 
 Create a new annotation in PostHog. Mark important events on your graphs with date and description.
 
@@ -661,7 +661,7 @@ Create a new annotation in PostHog. Mark important events on your graphs with da
 | `scope` | string | Scope of the annotation \(project, organization, dashboard, or dashboard_item\) |
 | `deleted` | boolean | Whether the annotation is deleted |
 
-### `posthog_list_feature_flags`
+### PostHog List Feature Flags
 
 List all feature flags in a PostHog project
 
@@ -696,7 +696,7 @@ List all feature flags in a PostHog project
 | `next` | string | URL to next page of results |
 | `previous` | string | URL to previous page of results |
 
-### `posthog_get_feature_flag`
+### PostHog Get Feature Flag
 
 Get details of a specific feature flag
 
@@ -729,7 +729,7 @@ Get details of a specific feature flag
 |   ↳ `usage_dashboard` | number | Usage dashboard ID |
 |   ↳ `has_enriched_analytics` | boolean | Whether enriched analytics are enabled |
 
-### `posthog_create_feature_flag`
+### PostHog Create Feature Flag
 
 Create a new feature flag in PostHog
 
@@ -765,7 +765,7 @@ Create a new feature flag in PostHog
 |   ↳ `rollout_percentage` | number | Rollout percentage \(if applicable\) |
 |   ↳ `ensure_experience_continuity` | boolean | Whether to ensure experience continuity |
 
-### `posthog_update_feature_flag`
+### PostHog Update Feature Flag
 
 Update an existing feature flag in PostHog
 
@@ -802,7 +802,7 @@ Update an existing feature flag in PostHog
 |   ↳ `rollout_percentage` | number | Rollout percentage \(if applicable\) |
 |   ↳ `ensure_experience_continuity` | boolean | Whether to ensure experience continuity |
 
-### `posthog_delete_feature_flag`
+### PostHog Delete Feature Flag
 
 Delete a feature flag from PostHog
 
@@ -823,7 +823,7 @@ Delete a feature flag from PostHog
 | `success` | boolean | Whether the deletion was successful |
 | `message` | string | Confirmation message |
 
-### `posthog_evaluate_flags`
+### PostHog Evaluate Feature Flags
 
 Evaluate feature flags for a specific user or group. This is a public endpoint that uses the project API key.
 
@@ -847,7 +847,7 @@ Evaluate feature flags for a specific user or group. This is a public endpoint t
 | `feature_flag_payloads` | object | Additional payloads attached to feature flags |
 | `errors_while_computing_flags` | boolean | Whether there were errors while computing flags |
 
-### `posthog_list_experiments`
+### PostHog List Experiments
 
 List all experiments in a PostHog project
 
@@ -883,7 +883,7 @@ List all experiments in a PostHog project
 | `next` | string | URL to next page of results |
 | `previous` | string | URL to previous page of results |
 
-### `posthog_get_experiment`
+### PostHog Get Experiment
 
 Get details of a specific experiment
 
@@ -917,7 +917,7 @@ Get details of a specific experiment
 |   ↳ `metrics` | array | Primary metrics |
 |   ↳ `metrics_secondary` | array | Secondary metrics |
 
-### `posthog_create_experiment`
+### PostHog Create Experiment
 
 Create a new experiment in PostHog
 
@@ -955,7 +955,7 @@ Create a new experiment in PostHog
 |   ↳ `created_by` | object | Creator information |
 |   ↳ `archived` | boolean | Whether the experiment is archived |
 
-### `posthog_update_experiment`
+### PostHog Update Experiment
 
 Update an existing experiment in PostHog. Use this to change dates, archive an experiment, or adjust its parameters and filters.
 
@@ -993,7 +993,7 @@ Update an existing experiment in PostHog. Use this to change dates, archive an e
 |   ↳ `created_at` | string | Creation timestamp |
 |   ↳ `archived` | boolean | Whether the experiment is archived |
 
-### `posthog_list_surveys`
+### PostHog List Surveys
 
 List all surveys in a PostHog project. Surveys allow you to collect feedback from users.
 
@@ -1026,7 +1026,7 @@ List all surveys in a PostHog project. Surveys allow you to collect feedback fro
 | `next` | string | URL for next page of results |
 | `previous` | string | URL for previous page of results |
 
-### `posthog_get_survey`
+### PostHog Get Survey
 
 Get details of a specific survey in PostHog by ID.
 
@@ -1059,7 +1059,7 @@ Get details of a specific survey in PostHog by ID.
 |   ↳ `archived` | boolean | Whether survey is archived |
 |   ↳ `responses_limit` | number | Maximum number of responses |
 
-### `posthog_create_survey`
+### PostHog Create Survey
 
 Create a new survey in PostHog. Supports question types: Basic (open), Link, Rating, and Multiple Choice.
 
@@ -1097,7 +1097,7 @@ Create a new survey in PostHog. Supports question types: Basic (open), Link, Rat
 |   ↳ `start_date` | string | Survey start date |
 |   ↳ `end_date` | string | Survey end date |
 
-### `posthog_update_survey`
+### PostHog Update Survey
 
 Update an existing survey in PostHog. Can modify questions, appearance, conditions, and other settings.
 
@@ -1138,7 +1138,7 @@ Update an existing survey in PostHog. Can modify questions, appearance, conditio
 |   ↳ `end_date` | string | Survey end date |
 |   ↳ `archived` | boolean | Whether survey is archived |
 
-### `posthog_delete_survey`
+### PostHog Delete Survey
 
 Delete a survey from PostHog. Use this to remove expired or unused surveys.
 
@@ -1158,7 +1158,7 @@ Delete a survey from PostHog. Use this to remove expired or unused surveys.
 | --------- | ---- | ----------- |
 | `status` | string | Status message indicating whether the survey was deleted successfully |
 
-### `posthog_list_session_recordings`
+### PostHog List Session Recordings
 
 List session recordings in a PostHog project. Session recordings capture user interactions with your application.
 
@@ -1196,7 +1196,7 @@ List session recordings in a PostHog project. Session recordings capture user in
 | `next` | string | URL for next page of results |
 | `previous` | string | URL for previous page of results |
 
-### `posthog_get_session_recording`
+### PostHog Get Session Recording
 
 Get details of a specific session recording in PostHog by ID.
 
@@ -1231,7 +1231,7 @@ Get details of a specific session recording in PostHog by ID.
 |   ↳ `start_url` | string | Starting URL of the recording |
 |   ↳ `person` | object | Person information |
 
-### `posthog_list_recording_playlists`
+### PostHog List Recording Playlists
 
 List session recording playlists in a PostHog project. Playlists allow you to organize and curate session recordings.
 
@@ -1266,7 +1266,7 @@ List session recording playlists in a PostHog project. Playlists allow you to or
 | `next` | string | URL for next page of results |
 | `previous` | string | URL for previous page of results |
 
-### `posthog_list_event_definitions`
+### PostHog List Event Definitions
 
 List all event definitions in a PostHog project. Event definitions represent tracked events with metadata like descriptions, tags, and usage statistics.
 
@@ -1299,7 +1299,7 @@ List all event definitions in a PostHog project. Event definitions represent tra
 |   ↳ `updated_at` | string | ISO timestamp when the event was updated |
 |   ↳ `updated_by` | object | User who last updated the event |
 
-### `posthog_get_event_definition`
+### PostHog Get Event Definition
 
 Get details of a specific event definition in PostHog. Returns comprehensive information about the event including metadata, usage statistics, and verification status.
 
@@ -1329,7 +1329,7 @@ Get details of a specific event definition in PostHog. Returns comprehensive inf
 | `verified_at` | string | ISO timestamp when the event was verified |
 | `verified_by` | string | User who verified the event |
 
-### `posthog_update_event_definition`
+### PostHog Update Event Definition
 
 Update an event definition in PostHog. Can modify description, tags, and verification status to maintain clean event schemas.
 
@@ -1362,7 +1362,7 @@ Update an event definition in PostHog. Can modify description, tags, and verific
 | `verified_at` | string | ISO timestamp when the event was verified |
 | `verified_by` | string | User who verified the event |
 
-### `posthog_list_property_definitions`
+### PostHog List Property Definitions
 
 List all property definitions in a PostHog project. Property definitions represent tracked properties with metadata like descriptions, tags, types, and usage statistics.
 
@@ -1399,7 +1399,7 @@ List all property definitions in a PostHog project. Property definitions represe
 |   ↳ `updated_at` | string | ISO timestamp when the property was updated |
 |   ↳ `updated_by` | object | User who last updated the property |
 
-### `posthog_get_property_definition`
+### PostHog Get Property Definition
 
 Get details of a specific property definition in PostHog. Returns comprehensive information about the property including metadata, type, usage statistics, and verification status.
 
@@ -1432,7 +1432,7 @@ Get details of a specific property definition in PostHog. Returns comprehensive 
 | `verified_at` | string | ISO timestamp when the property was verified |
 | `verified_by` | string | User who verified the property |
 
-### `posthog_update_property_definition`
+### PostHog Update Property Definition
 
 Update a property definition in PostHog. Can modify description, tags, property type, and verification status to maintain clean property schemas.
 
@@ -1469,7 +1469,7 @@ Update a property definition in PostHog. Can modify description, tags, property 
 | `verified_at` | string | ISO timestamp when the property was verified |
 | `verified_by` | string | User who verified the property |
 
-### `posthog_list_projects`
+### PostHog List Projects
 
 List all projects in the organization. Returns project details including IDs, names, API tokens, and settings. Useful for getting project IDs needed by other endpoints.
 
@@ -1503,7 +1503,7 @@ List all projects in the organization. Returns project details including IDs, na
 |   ↳ `timezone` | string | Project timezone |
 |   ↳ `data_attributes` | array | Custom data attributes |
 
-### `posthog_get_project`
+### PostHog Get Project
 
 Get detailed information about a specific project by ID. Returns comprehensive project configuration, settings, and feature flags.
 
@@ -1545,7 +1545,7 @@ Get detailed information about a specific project by ID. Returns comprehensive p
 |   ↳ `capture_console_log_opt_in` | boolean | Whether console log capture is enabled |
 |   ↳ `capture_performance_opt_in` | boolean | Whether performance capture is enabled |
 
-### `posthog_list_organizations`
+### PostHog List Organizations
 
 List all organizations the user has access to. Returns organization details including name, slug, membership level, and available product features.
 
@@ -1572,7 +1572,7 @@ List all organizations the user has access to. Returns organization details incl
 |   ↳ `teams` | array | List of team IDs in this organization |
 |   ↳ `available_product_features` | array | Available product features and their limits |
 
-### `posthog_get_organization`
+### PostHog Get Organization
 
 Get detailed information about a specific organization by ID. Returns comprehensive organization settings, features, usage, and team information.
 

--- a/apps/docs/content/docs/en/integrations/profound.mdx
+++ b/apps/docs/content/docs/en/integrations/profound.mdx
@@ -36,7 +36,7 @@ Track how your brand appears across AI platforms. Monitor visibility scores, sen
 
 ## Actions
 
-### `profound_list_categories`
+### Profound List Categories
 
 List all organization categories in Profound
 
@@ -54,7 +54,7 @@ List all organization categories in Profound
 |   ↳ `id` | string | Category ID |
 |   ↳ `name` | string | Category name |
 
-### `profound_list_regions`
+### Profound List Regions
 
 List all organization regions in Profound
 
@@ -72,7 +72,7 @@ List all organization regions in Profound
 |   ↳ `id` | string | Region ID \(UUID\) |
 |   ↳ `name` | string | Region name |
 
-### `profound_list_models`
+### Profound List Models
 
 List all AI models/platforms tracked in Profound
 
@@ -90,7 +90,7 @@ List all AI models/platforms tracked in Profound
 |   ↳ `id` | string | Model ID \(UUID\) |
 |   ↳ `name` | string | Model/platform name |
 
-### `profound_list_domains`
+### Profound List Domains
 
 List all organization domains in Profound
 
@@ -109,7 +109,7 @@ List all organization domains in Profound
 |   ↳ `name` | string | Domain name |
 |   ↳ `createdAt` | string | When the domain was added |
 
-### `profound_list_assets`
+### Profound List Assets
 
 List all organization assets (companies/brands) across all categories in Profound
 
@@ -134,7 +134,7 @@ List all organization assets (companies/brands) across all categories in Profoun
 |   ↳ `categoryId` | string | Category ID the asset belongs to |
 |   ↳ `categoryName` | string | Category name |
 
-### `profound_list_personas`
+### Profound List Personas
 
 List all organization personas across all categories in Profound
 
@@ -155,7 +155,7 @@ List all organization personas across all categories in Profound
 |   ↳ `categoryName` | string | Category name |
 |   ↳ `persona` | json | Persona profile with behavior, employment, and demographics |
 
-### `profound_category_topics`
+### Profound Category Topics
 
 List topics for a specific category in Profound
 
@@ -174,7 +174,7 @@ List topics for a specific category in Profound
 |   ↳ `id` | string | Topic ID \(UUID\) |
 |   ↳ `name` | string | Topic name |
 
-### `profound_category_tags`
+### Profound Category Tags
 
 List tags for a specific category in Profound
 
@@ -193,7 +193,7 @@ List tags for a specific category in Profound
 |   ↳ `id` | string | Tag ID \(UUID\) |
 |   ↳ `name` | string | Tag name |
 
-### `profound_category_prompts`
+### Profound Category Prompts
 
 List prompts for a specific category in Profound
 
@@ -229,7 +229,7 @@ List prompts for a specific category in Profound
 |   ↳ `platforms` | json | Associated platforms |
 |   ↳ `createdAt` | string | When the prompt was created |
 
-### `profound_category_assets`
+### Profound Category Assets
 
 List assets (companies/brands) for a specific category in Profound
 
@@ -253,7 +253,7 @@ List assets (companies/brands) for a specific category in Profound
 |   ↳ `createdAt` | string | When the asset was created |
 |   ↳ `logoUrl` | string | URL of the asset logo |
 
-### `profound_category_personas`
+### Profound Category Personas
 
 List personas for a specific category in Profound
 
@@ -273,7 +273,7 @@ List personas for a specific category in Profound
 |   ↳ `name` | string | Persona name |
 |   ↳ `persona` | json | Persona profile with behavior, employment, and demographics |
 
-### `profound_visibility_report`
+### Profound Visibility Report
 
 Query AI visibility report for a category in Profound
 
@@ -300,7 +300,7 @@ Query AI visibility report for a category in Profound
 |   ↳ `metrics` | json | Array of metric values matching requested metrics order |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_sentiment_report`
+### Profound Sentiment Report
 
 Query sentiment report for a category in Profound
 
@@ -327,7 +327,7 @@ Query sentiment report for a category in Profound
 |   ↳ `metrics` | json | Array of metric values matching requested metrics order |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_citations_report`
+### Profound Citations Report
 
 Query citations report for a category in Profound
 
@@ -354,7 +354,7 @@ Query citations report for a category in Profound
 |   ↳ `metrics` | json | Array of metric values matching requested metrics order |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_query_fanouts`
+### Profound Query Fanouts
 
 Query fanout report showing how AI models expand prompts into sub-queries in Profound
 
@@ -381,7 +381,7 @@ Query fanout report showing how AI models expand prompts into sub-queries in Pro
 |   ↳ `metrics` | json | Array of metric values matching requested metrics order |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_prompt_answers`
+### Profound Prompt Answers
 
 Get raw prompt answers data for a category in Profound
 
@@ -413,7 +413,7 @@ Get raw prompt answers data for a category in Profound
 |   ↳ `asset` | string | Asset name |
 |   ↳ `createdAt` | string | Timestamp when the answer was collected |
 
-### `profound_bots_report`
+### Profound Bots Report
 
 Query bot traffic report with hourly granularity for a domain in Profound
 
@@ -440,7 +440,7 @@ Query bot traffic report with hourly granularity for a domain in Profound
 |   ↳ `metrics` | json | Array of metric values matching requested metrics order |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_referrals_report`
+### Profound Referrals Report
 
 Query human referral traffic report with hourly granularity for a domain in Profound
 
@@ -467,7 +467,7 @@ Query human referral traffic report with hourly granularity for a domain in Prof
 |   ↳ `metrics` | json | Array of metric values matching requested metrics order |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_raw_logs`
+### Profound Raw Logs
 
 Get raw traffic logs with filters for a domain in Profound
 
@@ -492,7 +492,7 @@ Get raw traffic logs with filters for a domain in Profound
 |   ↳ `metrics` | json | Array of metric values \(count\) |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_bot_logs`
+### Profound Bot Logs
 
 Get identified bot visit logs with filters for a domain in Profound
 
@@ -517,7 +517,7 @@ Get identified bot visit logs with filters for a domain in Profound
 |   ↳ `metrics` | json | Array of metric values \(count\) |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_list_optimizations`
+### Profound List Optimizations
 
 List content optimization entries for an asset in Profound
 
@@ -543,7 +543,7 @@ List content optimization entries for an asset in Profound
 |   ↳ `type` | string | Content type: file, text, or url |
 |   ↳ `status` | string | Optimization status |
 
-### `profound_optimization_analysis`
+### Profound Optimization Analysis
 
 Get detailed content optimization analysis for a specific content item in Profound
 
@@ -580,7 +580,7 @@ Get detailed content optimization analysis for a specific content item in Profou
 |     ↳ `text` | string | Suggestion text |
 |     ↳ `rationale` | string | Why this recommendation matters |
 
-### `profound_prompt_volume`
+### Profound Prompt Volume
 
 Query prompt volume data to understand search demand across AI platforms in Profound
 
@@ -606,7 +606,7 @@ Query prompt volume data to understand search demand across AI platforms in Prof
 |   ↳ `metrics` | json | Array of metric values matching requested metrics order |
 |   ↳ `dimensions` | json | Array of dimension values matching requested dimensions order |
 
-### `profound_citation_prompts`
+### Profound Citation Prompts
 
 Get prompts that cite a specific domain across AI platforms in Profound
 

--- a/apps/docs/content/docs/en/integrations/prospeo.mdx
+++ b/apps/docs/content/docs/en/integrations/prospeo.mdx
@@ -42,7 +42,7 @@ Find verified work emails and mobile numbers, enrich person and company profiles
 
 ## Actions
 
-### `prospeo_account_information`
+### Prospeo Account Information
 
 Retrieve the current plan, remaining credits, and renewal date of your Prospeo account.
 
@@ -63,7 +63,7 @@ Retrieve the current plan, remaining credits, and renewal date of your Prospeo a
 | `next_quota_renewal_days` | number | Days until the next quota renewal |
 | `next_quota_renewal_date` | string | Date and time of the next quota renewal |
 
-### `prospeo_enrich_person`
+### Prospeo Enrich Person
 
 Enrich a person with complete B2B profile data, email address and mobile.
 
@@ -93,7 +93,7 @@ Enrich a person with complete B2B profile data, email address and mobile.
 | `person` | json | The matched person object including person_id, name, linkedin_url, current_job_title, job_history, mobile, email, location, and skills |
 | `company` | json | The current company of the matched person including name, website, domain, industry, employee_count, location, social URLs, funding, and technology |
 
-### `prospeo_enrich_company`
+### Prospeo Enrich Company
 
 Enrich a company with complete B2B data.
 
@@ -114,7 +114,7 @@ Enrich a company with complete B2B data.
 | `free_enrichment` | boolean | True if this enrichment was free \(already enriched in the past\) |
 | `company` | json | The matched company object including name, website, domain, industry, employee_count, location, social URLs, funding, and technology |
 
-### `prospeo_bulk_enrich_person`
+### Prospeo Bulk Enrich Person
 
 Enrich up to 50 person records at once.
 
@@ -140,7 +140,7 @@ Enrich up to 50 person records at once.
 | `not_matched` | array | Identifiers of records we could not match given the filters |
 | `invalid_datapoints` | array | Identifiers of records that did not meet the minimum matching requirements |
 
-### `prospeo_bulk_enrich_company`
+### Prospeo Bulk Enrich Company
 
 Enrich up to 50 company records at once.
 
@@ -162,7 +162,7 @@ Enrich up to 50 company records at once.
 | `not_matched` | array | Identifiers of records we could not match |
 | `invalid_datapoints` | array | Identifiers of records that did not meet the minimum matching requirements |
 
-### `prospeo_search_person`
+### Prospeo Search Person
 
 Search for leads using 20+ filters to build targeted contact lists.
 
@@ -188,7 +188,7 @@ Search for leads using 20+ filters to build targeted contact lists.
 |   ↳ `person` | json | Matched person \(no email/mobile in search response\) |
 |   ↳ `company` | json | Current company of the person |
 
-### `prospeo_search_company`
+### Prospeo Search Company
 
 Search for companies using 20+ filters to build account lists.
 
@@ -213,7 +213,7 @@ Search for companies using 20+ filters to build account lists.
 | `results` | array | Up to 25 matching companies |
 |   ↳ `company` | json | Matched company object |
 
-### `prospeo_search_suggestions`
+### Prospeo Search Suggestions
 
 Free endpoint to retrieve valid location or job title values for use in Search filters. Provide exactly one of location_search or job_title_search.
 

--- a/apps/docs/content/docs/en/integrations/pulse.mdx
+++ b/apps/docs/content/docs/en/integrations/pulse.mdx
@@ -37,7 +37,7 @@ Integrate Pulse into the workflow. Extract text from PDF documents, images, and 
 
 ## Actions
 
-### `pulse_parser`
+### Pulse Document Parser
 
 #### Input
 

--- a/apps/docs/content/docs/en/integrations/qdrant.mdx
+++ b/apps/docs/content/docs/en/integrations/qdrant.mdx
@@ -39,7 +39,7 @@ Integrate Qdrant into the workflow. Can upsert, search, and fetch points.
 
 ## Actions
 
-### `qdrant_upsert_points`
+### Qdrant Upsert Points
 
 Insert or update points in a Qdrant collection
 
@@ -61,7 +61,7 @@ Insert or update points in a Qdrant collection
 |   ↳ `operation_id` | number | Operation ID for async tracking |
 |   ↳ `status` | string | Operation status \(acknowledged, completed\) |
 
-### `qdrant_search_vector`
+### Qdrant Search Vector
 
 Search for similar vectors in a Qdrant collection
 
@@ -93,7 +93,7 @@ Search for similar vectors in a Qdrant collection
 |   ↳ `shard_key` | string | Shard key for routing |
 |   ↳ `order_value` | number | Order value for sorting |
 
-### `qdrant_fetch_points`
+### Qdrant Fetch Points
 
 Fetch points by ID from a Qdrant collection
 

--- a/apps/docs/content/docs/en/integrations/quartr.mdx
+++ b/apps/docs/content/docs/en/integrations/quartr.mdx
@@ -37,7 +37,7 @@ Integrate Quartr into the workflow. Look up public companies, corporate events, 
 
 ## Actions
 
-### `quartr_list_companies`
+### Quartr List Companies
 
 List companies covered by Quartr, filterable by ticker, ISIN, CIK, OpenFIGI, country, and exchange.
 
@@ -79,7 +79,7 @@ List companies covered by Quartr, filterable by ticker, ISIN, CIK, OpenFIGI, cou
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_get_company`
+### Quartr Get Company
 
 Retrieve a single company from Quartr by its company ID.
 
@@ -109,7 +109,7 @@ Retrieve a single company from Quartr by its company ID.
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 
-### `quartr_list_events`
+### Quartr List Events
 
 List corporate events (earnings calls, capital markets days, etc.) from Quartr, filterable by company, event type, and date range.
 
@@ -152,7 +152,7 @@ List corporate events (earnings calls, capital markets days, etc.) from Quartr, 
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_get_event`
+### Quartr Get Event
 
 Retrieve a single corporate event from Quartr by its event ID.
 
@@ -180,7 +180,7 @@ Retrieve a single corporate event from Quartr by its event ID.
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 
-### `quartr_get_event_summary`
+### Quartr Get Event Summary
 
 Retrieve the AI-generated summary of a corporate event from Quartr, with selectable length and optional plain-text formatting.
 
@@ -208,7 +208,7 @@ Retrieve the AI-generated summary of a corporate event from Quartr, with selecta
 | `summaryCreatedAt` | string | Summary creation timestamp \(ISO 8601\) |
 | `summaryUpdatedAt` | string | Summary last update timestamp \(ISO 8601\) |
 
-### `quartr_list_event_types`
+### Quartr List Event Types
 
 List the event types available in Quartr (e.g., earnings calls), useful for filtering events by type ID.
 
@@ -233,7 +233,7 @@ List the event types available in Quartr (e.g., earnings calls), useful for filt
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_list_documents`
+### Quartr List Documents
 
 List documents of all kinds (reports, slide decks, and transcripts) from Quartr, filterable by company, event, document type, document group, and date range.
 
@@ -281,7 +281,7 @@ List documents of all kinds (reports, slide decks, and transcripts) from Quartr,
 |     ↳ `date` | string | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_list_document_types`
+### Quartr List Document Types
 
 List the document types available in Quartr (e.g., 10-Q quarterly reports), useful for filtering documents by type ID.
 
@@ -309,7 +309,7 @@ List the document types available in Quartr (e.g., 10-Q quarterly reports), usef
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_list_reports`
+### Quartr List Reports
 
 List filings and reports (10-K, 10-Q, earnings releases, etc.) from Quartr, filterable by company, event, document type, document group, and date range.
 
@@ -357,7 +357,7 @@ List filings and reports (10-K, 10-Q, earnings releases, etc.) from Quartr, filt
 |     ↳ `date` | string | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_get_report`
+### Quartr Get Report
 
 Retrieve a filing or report (10-K, 10-Q, earnings release, etc.) from Quartr by its document ID and download the PDF file.
 
@@ -390,7 +390,7 @@ Retrieve a filing or report (10-K, 10-Q, earnings release, etc.) from Quartr by 
 | `fileUrl` | string | URL of the report PDF |
 | `file` | file | Downloaded report PDF stored in execution files |
 
-### `quartr_list_slide_decks`
+### Quartr List Slide Decks
 
 List slide presentations from Quartr, filterable by company, event, document type, document group, and date range.
 
@@ -438,7 +438,7 @@ List slide presentations from Quartr, filterable by company, event, document typ
 |     ↳ `date` | string | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_get_slide_deck`
+### Quartr Get Slide Deck
 
 Retrieve a slide presentation from Quartr by its document ID and download the PDF file.
 
@@ -471,7 +471,7 @@ Retrieve a slide presentation from Quartr by its document ID and download the PD
 | `fileUrl` | string | URL of the slide deck PDF |
 | `file` | file | Downloaded slide deck PDF stored in execution files |
 
-### `quartr_list_transcripts`
+### Quartr List Transcripts
 
 List event transcripts from Quartr, filterable by company, event, document type, document group, and date range.
 
@@ -519,7 +519,7 @@ List event transcripts from Quartr, filterable by company, event, document type,
 |     ↳ `date` | string | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_get_transcript`
+### Quartr Get Transcript
 
 Retrieve an event transcript from Quartr by its document ID and download the transcript JSON file (paragraphs, sentences, timestamps, and speaker identification).
 
@@ -552,7 +552,7 @@ Retrieve an event transcript from Quartr by its document ID and download the tra
 | `fileUrl` | string | URL of the transcript JSON file |
 | `file` | file | Downloaded transcript JSON file stored in execution files |
 
-### `quartr_list_audio`
+### Quartr List Audio
 
 List archived event audio recordings from Quartr, filterable by company, event, and date range. Returns download (MPEG) and streaming (M3U8) URLs.
 
@@ -604,7 +604,7 @@ List archived event audio recordings from Quartr, filterable by company, event, 
 |     ↳ `date` | string | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
-### `quartr_get_audio`
+### Quartr Get Audio
 
 Retrieve an archived event audio recording from Quartr by its audio ID. Returns download (MPEG) and streaming (M3U8) URLs.
 
@@ -641,7 +641,7 @@ Retrieve an archived event audio recording from Quartr by its audio ID. Returns 
 |     ↳ `language` | string | Event language code |
 |     ↳ `date` | string | Event date \(ISO 8601\) |
 
-### `quartr_list_live_events`
+### Quartr List Live Events
 
 List live and upcoming events from Quartr with live audio and transcript stream URLs, filterable by company, live state, and date range.
 

--- a/apps/docs/content/docs/en/integrations/quiver.mdx
+++ b/apps/docs/content/docs/en/integrations/quiver.mdx
@@ -34,7 +34,7 @@ Generate SVG images from text prompts or vectorize raster images into SVGs using
 
 ## Actions
 
-### `quiver_text_to_svg`
+### Quiver Text to SVG
 
 Generate SVG images from text prompts using QuiverAI
 
@@ -68,7 +68,7 @@ Generate SVG images from text prompts using QuiverAI
 |     ↳ `inputTokens` | number | Input tokens used |
 |     ↳ `outputTokens` | number | Output tokens used |
 
-### `quiver_image_to_svg`
+### Quiver Image to SVG
 
 Convert raster images into vector SVG format using QuiverAI
 
@@ -100,7 +100,7 @@ Convert raster images into vector SVG format using QuiverAI
 |     ↳ `inputTokens` | number | Input tokens used |
 |     ↳ `outputTokens` | number | Output tokens used |
 
-### `quiver_list_models`
+### Quiver List Models
 
 List all available QuiverAI models
 

--- a/apps/docs/content/docs/en/integrations/railway.mdx
+++ b/apps/docs/content/docs/en/integrations/railway.mdx
@@ -32,7 +32,7 @@ Integrate Railway into workflows to list projects, manage services and environme
 
 ## Actions
 
-### `railway_list_projects`
+### Railway List Projects
 
 List Railway projects visible to the provided token
 
@@ -61,7 +61,7 @@ List Railway projects visible to the provided token
 |   ↳ `endCursor` | string | Cursor for the next page |
 | `count` | number | Number of projects returned |
 
-### `railway_get_project`
+### Railway Get Project
 
 Get a Railway project with its services and environments
 
@@ -91,7 +91,7 @@ Get a Railway project with its services and environments
 |     ↳ `id` | string | Environment ID |
 |     ↳ `name` | string | Environment name |
 
-### `railway_create_project`
+### Railway Create Project
 
 Create a Railway project
 
@@ -116,7 +116,7 @@ Create a Railway project
 |   ↳ `id` | string | Project ID |
 |   ↳ `name` | string | Project name |
 
-### `railway_update_project`
+### Railway Update Project
 
 Update a Railway project name or description
 
@@ -141,7 +141,7 @@ Update a Railway project name or description
 |   ↳ `name` | string | Project name |
 |   ↳ `description` | string | Project description |
 
-### `railway_delete_project`
+### Railway Delete Project
 
 Delete a Railway project
 
@@ -159,7 +159,7 @@ Delete a Railway project
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the project was deleted |
 
-### `railway_transfer_project`
+### Railway Transfer Project
 
 Transfer a Railway project to another workspace
 
@@ -178,7 +178,7 @@ Transfer a Railway project to another workspace
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the project was transferred |
 
-### `railway_list_project_members`
+### Railway List Project Members
 
 List members for a Railway project
 
@@ -202,7 +202,7 @@ List members for a Railway project
 |   ↳ `avatar` | string | Member avatar URL |
 | `count` | number | Number of members returned |
 
-### `railway_create_environment`
+### Railway Create Environment
 
 Create a Railway project environment
 
@@ -227,7 +227,7 @@ Create a Railway project environment
 |   ↳ `id` | string | Environment ID |
 |   ↳ `name` | string | Environment name |
 
-### `railway_delete_environment`
+### Railway Delete Environment
 
 Delete a Railway project environment
 
@@ -245,7 +245,7 @@ Delete a Railway project environment
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the environment was deleted |
 
-### `railway_create_service`
+### Railway Create Service
 
 Create a Railway service from a GitHub repo or Docker image
 
@@ -269,7 +269,7 @@ Create a Railway service from a GitHub repo or Docker image
 |   ↳ `id` | string | Service ID |
 |   ↳ `name` | string | Service name |
 
-### `railway_delete_service`
+### Railway Delete Service
 
 Delete a Railway service and all of its deployments
 
@@ -287,7 +287,7 @@ Delete a Railway service and all of its deployments
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the service was deleted |
 
-### `railway_list_deployments`
+### Railway List Deployments
 
 List deployments for a Railway service in an environment
 
@@ -320,7 +320,7 @@ List deployments for a Railway service in an environment
 |   ↳ `hasNextPage` | boolean | Whether more deployments are available |
 |   ↳ `endCursor` | string | Cursor for the next page |
 
-### `railway_get_deployment`
+### Railway Get Deployment
 
 Get details for a single Railway deployment
 
@@ -345,7 +345,7 @@ Get details for a single Railway deployment
 |   ↳ `canRollback` | boolean | Whether the deployment can be rolled back to |
 |   ↳ `canRedeploy` | boolean | Whether the deployment can be redeployed |
 
-### `railway_deploy_service`
+### Railway Deploy Service
 
 Trigger a deployment for a Railway service in an environment
 
@@ -365,7 +365,7 @@ Trigger a deployment for a Railway service in an environment
 | --------- | ---- | ----------- |
 | `deploymentId` | string | Created deployment ID |
 
-### `railway_restart_deployment`
+### Railway Restart Deployment
 
 Restart a running Railway deployment without rebuilding
 
@@ -383,7 +383,7 @@ Restart a running Railway deployment without rebuilding
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the deployment was restarted |
 
-### `railway_rollback_deployment`
+### Railway Rollback Deployment
 
 Roll a Railway service back to a previous deployment
 
@@ -401,7 +401,7 @@ Roll a Railway service back to a previous deployment
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the rollback was triggered |
 
-### `railway_get_deployment_logs`
+### Railway Get Deployment Logs
 
 Retrieve runtime logs for a Railway deployment
 
@@ -424,7 +424,7 @@ Retrieve runtime logs for a Railway deployment
 |   ↳ `severity` | string | Log severity |
 | `count` | number | Number of log entries returned |
 
-### `railway_list_variables`
+### Railway List Variables
 
 List Railway environment variables for a service or shared environment
 
@@ -445,7 +445,7 @@ List Railway environment variables for a service or shared environment
 | `variables` | object | Variable names and values |
 | `count` | number | Number of variables returned |
 
-### `railway_upsert_variable`
+### Railway Upsert Variable
 
 Create or update a Railway environment variable
 
@@ -468,7 +468,7 @@ Create or update a Railway environment variable
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the variable was created or updated |
 
-### `railway_delete_variable`
+### Railway Delete Variable
 
 Delete a Railway environment variable
 

--- a/apps/docs/content/docs/en/integrations/rb2b.mdx
+++ b/apps/docs/content/docs/en/integrations/rb2b.mdx
@@ -32,7 +32,7 @@ Resolve IP addresses, hashed emails, and LinkedIn profiles into person-level ide
 
 ## Actions
 
-### `rb2b_credit_check`
+### RB2B Credit Check
 
 Check the number of API credits remaining on your RB2B account.
 
@@ -48,7 +48,7 @@ Check the number of API credits remaining on your RB2B account.
 | --------- | ---- | ----------- |
 | `credits_remaining` | number | Number of API credits remaining on the account |
 
-### `rb2b_ip_to_hem`
+### RB2B IP to HEM
 
 Convert an IP address (and optional user agent) into hashed email addresses (HEM) with accuracy scores.
 
@@ -70,7 +70,7 @@ Convert an IP address (and optional user agent) into hashed email addresses (HEM
 |   ↳ `sha256` | string | SHA-256 hash of the matched email \(only when include_sha256 is true\) |
 |   ↳ `score` | number | Match accuracy score \(0 = probabilistic, 1 = deterministic\) |
 
-### `rb2b_ip_to_maid`
+### RB2B IP to MAID
 
 Resolve an IP address (and optional user agent) into mobile advertising identifiers (MAIDs) observed over the last 60 days.
 
@@ -90,7 +90,7 @@ Resolve an IP address (and optional user agent) into mobile advertising identifi
 |   ↳ `device_id` | string | The mobile advertising identifier |
 |   ↳ `device_type` | string | The identifier type \(e.g. AAID, IDFA\) |
 
-### `rb2b_ip_to_company`
+### RB2B IP to Company
 
 Identify the company domains associated with an IP address, ranked by confidence.
 
@@ -109,7 +109,7 @@ Identify the company domains associated with an IP address, ranked by confidence
 |   ↳ `domain` | string | Company domain associated with the IP |
 |   ↳ `percentage` | string | Confidence percentage for the match |
 
-### `rb2b_hem_to_business_profile`
+### RB2B Email/HEM to Business Profile
 
 Return a full business profile (name, title, company, industry, seniority and more) for an email address or MD5-hashed email.
 
@@ -143,7 +143,7 @@ Return a full business profile (name, title, company, industry, seniority and mo
 | `company_revenue_range` | string | Company revenue range band |
 | `md5` | string | MD5 hash of the resolved email |
 
-### `rb2b_hem_to_best_linkedin`
+### RB2B Email/HEM to Best LinkedIn URL
 
 Return the most recently active LinkedIn profile URL for an email address or MD5-hashed email.
 
@@ -160,7 +160,7 @@ Return the most recently active LinkedIn profile URL for an email address or MD5
 | --------- | ---- | ----------- |
 | `linkedin_url` | string | Best LinkedIn profile URL for the email |
 
-### `rb2b_hem_to_linkedin`
+### RB2B Email/HEM to LinkedIn Slug
 
 Return the LinkedIn slug (the profile identifier portion of the URL) for an email address or MD5-hashed email.
 
@@ -177,7 +177,7 @@ Return the LinkedIn slug (the profile identifier portion of the URL) for an emai
 | --------- | ---- | ----------- |
 | `linkedin_slug` | string | LinkedIn slug for the email |
 
-### `rb2b_hem_to_maid`
+### RB2B Email/HEM to MAID
 
 Return up to five mobile advertising identifiers (MAIDs) associated with an email address or MD5-hashed email.
 
@@ -196,7 +196,7 @@ Return up to five mobile advertising identifiers (MAIDs) associated with an emai
 |   ↳ `device_id` | string | The mobile advertising identifier |
 |   ↳ `device_type` | string | The identifier type \(e.g. AAID, IDFA\) |
 
-### `rb2b_email_to_activity`
+### RB2B Email to Last Active Date
 
 Return the last known active date for an email address.
 
@@ -218,7 +218,7 @@ Return the last known active date for an email address.
 | `credits_charged` | number | Credits charged for this request |
 | `credits_exhausted` | boolean | Whether the account is out of credits |
 
-### `rb2b_linkedin_to_business_profile`
+### RB2B LinkedIn to Business Profile
 
 Return a full business profile (name, title, company, emails and more) for a LinkedIn profile.
 
@@ -251,7 +251,7 @@ Return a full business profile (name, title, company, emails and more) for a Lin
 |   ↳ `website_url` | string | Company website URL |
 |   ↳ `linkedin_url` | string | Company LinkedIn URL |
 
-### `rb2b_linkedin_to_best_personal_email`
+### RB2B LinkedIn to Best Personal Email
 
 Return the personal email with the most recent known network activity for a LinkedIn profile.
 
@@ -268,7 +268,7 @@ Return the personal email with the most recent known network activity for a Link
 | --------- | ---- | ----------- |
 | `email` | string | Best personal email for the LinkedIn profile |
 
-### `rb2b_linkedin_to_personal_email`
+### RB2B LinkedIn to Personal Email
 
 Return the personal email addresses associated with a LinkedIn profile.
 
@@ -285,7 +285,7 @@ Return the personal email addresses associated with a LinkedIn profile.
 | --------- | ---- | ----------- |
 | `emails` | array | Personal email addresses for the LinkedIn profile |
 
-### `rb2b_linkedin_to_hashed_emails`
+### RB2B LinkedIn to Hashed Emails
 
 Return the business and personal hashed emails (MD5 and SHA-256) associated with a LinkedIn profile.
 
@@ -306,7 +306,7 @@ Return the business and personal hashed emails (MD5 and SHA-256) associated with
 | `personal_md5_array` | array | MD5 hashes of personal emails |
 | `personal_sha256_array` | array | SHA-256 hashes of personal emails |
 
-### `rb2b_linkedin_to_mobile_phone`
+### RB2B LinkedIn to Mobile Phone
 
 Return the mobile phone number with the most recent known network activity for a LinkedIn profile.
 
@@ -323,7 +323,7 @@ Return the mobile phone number with the most recent known network activity for a
 | --------- | ---- | ----------- |
 | `mobile_phone` | string | Mobile phone number for the LinkedIn profile |
 
-### `rb2b_linkedin_slug_search`
+### RB2B LinkedIn Slug Search
 
 Find a LinkedIn profile URL from a first name, last name, and company domain.
 

--- a/apps/docs/content/docs/en/integrations/rds.mdx
+++ b/apps/docs/content/docs/en/integrations/rds.mdx
@@ -41,7 +41,7 @@ Integrate Amazon RDS Aurora Serverless into the workflow using the Data API. Can
 
 ## Actions
 
-### `rds_query`
+### RDS Query
 
 Execute a SELECT query on Amazon RDS using the Data API
 
@@ -65,7 +65,7 @@ Execute a SELECT query on Amazon RDS using the Data API
 | `rows` | array | Array of rows returned from the query |
 | `rowCount` | number | Number of rows returned |
 
-### `rds_insert`
+### RDS Insert
 
 Insert data into an Amazon RDS table using the Data API
 
@@ -90,7 +90,7 @@ Insert data into an Amazon RDS table using the Data API
 | `rows` | array | Array of inserted rows |
 | `rowCount` | number | Number of rows inserted |
 
-### `rds_update`
+### RDS Update
 
 Update data in an Amazon RDS table using the Data API
 
@@ -116,7 +116,7 @@ Update data in an Amazon RDS table using the Data API
 | `rows` | array | Array of updated rows |
 | `rowCount` | number | Number of rows updated |
 
-### `rds_delete`
+### RDS Delete
 
 Delete data from an Amazon RDS table using the Data API
 
@@ -141,7 +141,7 @@ Delete data from an Amazon RDS table using the Data API
 | `rows` | array | Array of deleted rows |
 | `rowCount` | number | Number of rows deleted |
 
-### `rds_execute`
+### RDS Execute
 
 Execute raw SQL on Amazon RDS using the Data API
 
@@ -165,7 +165,7 @@ Execute raw SQL on Amazon RDS using the Data API
 | `rows` | array | Array of rows returned or affected |
 | `rowCount` | number | Number of rows affected |
 
-### `rds_introspect`
+### RDS Introspect
 
 Introspect Amazon RDS Aurora database schema to retrieve table structures, columns, and relationships
 

--- a/apps/docs/content/docs/en/integrations/reddit.mdx
+++ b/apps/docs/content/docs/en/integrations/reddit.mdx
@@ -30,7 +30,7 @@ Integrate Reddit into workflows. Read posts, comments, and search content. Submi
 
 ## Actions
 
-### `reddit_get_posts`
+### Get Reddit Posts
 
 Fetch posts from a subreddit with different sorting options
 
@@ -71,7 +71,7 @@ Fetch posts from a subreddit with different sorting options
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_get_comments`
+### Get Reddit Comments
 
 Fetch comments from a specific Reddit post
 
@@ -114,7 +114,7 @@ Fetch comments from a specific Reddit post
 |   ↳ `permalink` | string | Comment permalink |
 |   ↳ `replies` | array | Nested reply comments |
 
-### `reddit_get_controversial`
+### Get Reddit Controversial Posts
 
 Fetch controversial posts from a subreddit
 
@@ -153,7 +153,7 @@ Fetch controversial posts from a subreddit
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_search`
+### Search Reddit
 
 Search for posts within a subreddit
 
@@ -196,7 +196,7 @@ Search for posts within a subreddit
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_submit_post`
+### Submit Reddit Post
 
 Submit a new post to a subreddit (text or link)
 
@@ -227,7 +227,7 @@ Submit a new post to a subreddit (text or link)
 |   ↳ `url` | string | Post URL from API response |
 |   ↳ `permalink` | string | Full Reddit permalink |
 
-### `reddit_vote`
+### Vote on Reddit Post/Comment
 
 Upvote, downvote, or unvote a Reddit post or comment
 
@@ -245,7 +245,7 @@ Upvote, downvote, or unvote a Reddit post or comment
 | `success` | boolean | Whether the vote was successful |
 | `message` | string | Success or error message |
 
-### `reddit_save`
+### Save Reddit Post/Comment
 
 Save a Reddit post or comment to your saved items
 
@@ -263,7 +263,7 @@ Save a Reddit post or comment to your saved items
 | `success` | boolean | Whether the save was successful |
 | `message` | string | Success or error message |
 
-### `reddit_unsave`
+### Unsave Reddit Post/Comment
 
 Remove a Reddit post or comment from your saved items
 
@@ -280,7 +280,7 @@ Remove a Reddit post or comment from your saved items
 | `success` | boolean | Whether the unsave was successful |
 | `message` | string | Success or error message |
 
-### `reddit_reply`
+### Reply to Reddit Post/Comment
 
 Add a comment reply to a Reddit post or comment
 
@@ -304,7 +304,7 @@ Add a comment reply to a Reddit post or comment
 |   ↳ `permalink` | string | Comment permalink |
 |   ↳ `body` | string | Comment body text |
 
-### `reddit_edit`
+### Edit Reddit Post/Comment
 
 Edit the text of your own Reddit post or comment
 
@@ -326,7 +326,7 @@ Edit the text of your own Reddit post or comment
 |   ↳ `body` | string | Updated comment body \(for comments\) |
 |   ↳ `selftext` | string | Updated post text \(for self posts\) |
 
-### `reddit_delete`
+### Delete Reddit Post/Comment
 
 Delete your own Reddit post or comment
 
@@ -343,7 +343,7 @@ Delete your own Reddit post or comment
 | `success` | boolean | Whether the deletion was successful |
 | `message` | string | Success or error message |
 
-### `reddit_subscribe`
+### Subscribe/Unsubscribe from Subreddit
 
 Subscribe or unsubscribe from a subreddit
 
@@ -361,7 +361,7 @@ Subscribe or unsubscribe from a subreddit
 | `success` | boolean | Whether the subscription action was successful |
 | `message` | string | Success or error message |
 
-### `reddit_get_me`
+### Get Reddit User Identity
 
 Get information about the authenticated Reddit user
 
@@ -385,7 +385,7 @@ Get information about the authenticated Reddit user
 | `has_verified_email` | boolean | Whether email is verified |
 | `icon_img` | string | User avatar/icon URL |
 
-### `reddit_get_user`
+### Get Reddit User Profile
 
 Get public profile information about any Reddit user by username
 
@@ -410,7 +410,7 @@ Get public profile information about any Reddit user by username
 | `has_verified_email` | boolean | Whether email is verified |
 | `icon_img` | string | User avatar/icon URL |
 
-### `reddit_send_message`
+### Send Reddit Message
 
 Send a private message to a Reddit user
 
@@ -430,7 +430,7 @@ Send a private message to a Reddit user
 | `success` | boolean | Whether the message was sent successfully |
 | `message` | string | Success or error message |
 
-### `reddit_get_messages`
+### Get Reddit Messages
 
 Retrieve private messages from your Reddit inbox
 
@@ -465,7 +465,7 @@ Retrieve private messages from your Reddit inbox
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_get_subreddit_info`
+### Get Subreddit Info
 
 Get metadata and information about a subreddit
 
@@ -495,7 +495,7 @@ Get metadata and information about a subreddit
 | `icon_img` | string | Subreddit icon URL |
 | `banner_img` | string | Subreddit banner URL |
 
-### `reddit_get_subreddit_rules`
+### Get Subreddit Rules
 
 Get the rules and site-wide rules that apply to a subreddit
 
@@ -520,7 +520,7 @@ Get the rules and site-wide rules that apply to a subreddit
 | `site_rules` | array | Reddit site-wide rules that apply to the subreddit |
 | `site_rules_flow` | array | Structured site-wide rules flow used by the report menu |
 
-### `reddit_get_user_posts`
+### Get Reddit User Posts
 
 Fetch submitted posts (t3) from a Reddit user profile
 
@@ -559,7 +559,7 @@ Fetch submitted posts (t3) from a Reddit user profile
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_get_user_comments`
+### Get Reddit User Comments
 
 Fetch comments (t1) made by a Reddit user
 
@@ -592,7 +592,7 @@ Fetch comments (t1) made by a Reddit user
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_get_saved`
+### Get Reddit Saved Items
 
 Fetch your own saved posts (t3) and comments (t1). You can only read your own saved items
 
@@ -637,7 +637,7 @@ Fetch your own saved posts (t3) and comments (t1). You can only read your own sa
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_get_info`
+### Get Reddit Info
 
 Fetch information about one or more Reddit things (posts, comments, or subreddits) by their fullnames
 
@@ -687,7 +687,7 @@ Fetch information about one or more Reddit things (posts, comments, or subreddit
 |   ↳ `created_utc` | number | Creation time in UTC epoch seconds |
 |   ↳ `accounts_active` | number | Number of currently active users |
 
-### `reddit_search_subreddits`
+### Search Subreddits
 
 Search for subreddits by name and description
 
@@ -723,7 +723,7 @@ Search for subreddits by name and description
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_list_my_subreddits`
+### List My Subreddits
 
 List the subreddits the authenticated user is subscribed to
 
@@ -758,7 +758,7 @@ List the subreddits the authenticated user is subscribed to
 | `after` | string | Fullname of the last item for forward pagination |
 | `before` | string | Fullname of the first item for backward pagination |
 
-### `reddit_report`
+### Report Reddit Post/Comment
 
 Report a Reddit post or comment to subreddit moderators for a rules violation
 
@@ -777,7 +777,7 @@ Report a Reddit post or comment to subreddit moderators for a rules violation
 | `success` | boolean | Whether the report was successful |
 | `message` | string | Success or error message |
 
-### `reddit_hide`
+### Hide Reddit Post
 
 Hide one or more Reddit posts from your listings
 
@@ -794,7 +794,7 @@ Hide one or more Reddit posts from your listings
 | `success` | boolean | Whether the hide was successful |
 | `message` | string | Success or error message |
 
-### `reddit_unhide`
+### Unhide Reddit Post
 
 Unhide one or more previously hidden Reddit posts
 
@@ -811,7 +811,7 @@ Unhide one or more previously hidden Reddit posts
 | `success` | boolean | Whether the unhide was successful |
 | `message` | string | Success or error message |
 
-### `reddit_marknsfw`
+### Mark Reddit Post NSFW
 
 Mark a Reddit post as NSFW (not safe for work)
 
@@ -828,7 +828,7 @@ Mark a Reddit post as NSFW (not safe for work)
 | `success` | boolean | Whether the operation was successful |
 | `message` | string | Success or error message |
 
-### `reddit_unmarknsfw`
+### Unmark Reddit Post NSFW
 
 Remove the NSFW (not safe for work) mark from a Reddit post
 
@@ -845,7 +845,7 @@ Remove the NSFW (not safe for work) mark from a Reddit post
 | `success` | boolean | Whether the operation was successful |
 | `message` | string | Success or error message |
 
-### `reddit_mark_read`
+### Mark Reddit Messages Read
 
 Mark one or more private messages as read
 
@@ -862,7 +862,7 @@ Mark one or more private messages as read
 | `success` | boolean | Whether the operation was successful |
 | `message` | string | Success or error message |
 
-### `reddit_mark_all_read`
+### Mark All Reddit Messages Read
 
 Mark all private messages in the inbox as read
 
@@ -878,7 +878,7 @@ Mark all private messages in the inbox as read
 | `success` | boolean | Whether the operation was successful |
 | `message` | string | Success or error message |
 
-### `reddit_mod_approve`
+### Approve Reddit Post/Comment (Mod)
 
 Approve a reported or removed Reddit post or comment as a moderator
 
@@ -895,7 +895,7 @@ Approve a reported or removed Reddit post or comment as a moderator
 | `success` | boolean | Whether the approval was successful |
 | `message` | string | Success or error message |
 
-### `reddit_mod_remove`
+### Remove Reddit Post/Comment (Mod)
 
 Remove a Reddit post or comment as a moderator, optionally marking it as spam
 
@@ -913,7 +913,7 @@ Remove a Reddit post or comment as a moderator, optionally marking it as spam
 | `success` | boolean | Whether the removal was successful |
 | `message` | string | Success or error message |
 
-### `reddit_mod_distinguish`
+### Distinguish Reddit Post/Comment (Mod)
 
 Distinguish or un-distinguish a Reddit post or comment as a moderator
 
@@ -932,7 +932,7 @@ Distinguish or un-distinguish a Reddit post or comment as a moderator
 | `success` | boolean | Whether the distinguish action was successful |
 | `message` | string | Success or error message |
 
-### `reddit_lock`
+### Lock Reddit Post/Comment (Mod)
 
 Lock a Reddit post or comment to prevent further replies (moderator action)
 
@@ -949,7 +949,7 @@ Lock a Reddit post or comment to prevent further replies (moderator action)
 | `success` | boolean | Whether the lock was successful |
 | `message` | string | Success or error message |
 
-### `reddit_unlock`
+### Unlock Reddit Post/Comment (Mod)
 
 Unlock a Reddit post or comment to allow replies again (moderator action)
 
@@ -966,7 +966,7 @@ Unlock a Reddit post or comment to allow replies again (moderator action)
 | `success` | boolean | Whether the unlock was successful |
 | `message` | string | Success or error message |
 
-### `reddit_mod_sticky`
+### Sticky Reddit Post (Mod)
 
 Sticky or unsticky a Reddit post to the top of a subreddit (moderator action)
 

--- a/apps/docs/content/docs/en/integrations/redis.mdx
+++ b/apps/docs/content/docs/en/integrations/redis.mdx
@@ -34,7 +34,7 @@ Connect to any Redis instance to perform key-value, hash, list, and utility oper
 
 ## Actions
 
-### `redis_get`
+### Redis Get
 
 Get the value of a key from Redis.
 
@@ -52,7 +52,7 @@ Get the value of a key from Redis.
 | `key` | string | The key that was retrieved |
 | `value` | string | The value of the key, or null if the key does not exist |
 
-### `redis_set`
+### Redis Set
 
 Set the value of a key in Redis with an optional expiration time in seconds.
 
@@ -72,7 +72,7 @@ Set the value of a key in Redis with an optional expiration time in seconds.
 | `key` | string | The key that was set |
 | `result` | string | The result of the SET operation \(typically "OK"\) |
 
-### `redis_delete`
+### Redis Delete
 
 Delete a key from Redis.
 
@@ -90,7 +90,7 @@ Delete a key from Redis.
 | `key` | string | The key that was deleted |
 | `deletedCount` | number | Number of keys deleted \(0 if key did not exist, 1 if deleted\) |
 
-### `redis_keys`
+### Redis Keys
 
 List all keys matching a pattern in Redis. Avoid using on large databases in production; use the Redis Command tool with SCAN for large key spaces.
 
@@ -109,7 +109,7 @@ List all keys matching a pattern in Redis. Avoid using on large databases in pro
 | `keys` | array | List of keys matching the pattern |
 | `count` | number | Number of keys found |
 
-### `redis_command`
+### Redis Command
 
 Execute a raw Redis command as a JSON array (e.g. ["HSET", "key", "field", "value"]).
 
@@ -127,7 +127,7 @@ Execute a raw Redis command as a JSON array (e.g. ["HSET", "key", "field", "valu
 | `command` | string | The command that was executed |
 | `result` | json | The result of the command |
 
-### `redis_hset`
+### Redis HSET
 
 Set a field in a hash stored at a key in Redis.
 
@@ -148,7 +148,7 @@ Set a field in a hash stored at a key in Redis.
 | `field` | string | The field that was set |
 | `result` | number | Number of fields added \(1 if new, 0 if updated\) |
 
-### `redis_hget`
+### Redis HGET
 
 Get the value of a field in a hash stored at a key in Redis.
 
@@ -168,7 +168,7 @@ Get the value of a field in a hash stored at a key in Redis.
 | `field` | string | The field that was retrieved |
 | `value` | string | The field value, or null if the field or key does not exist |
 
-### `redis_hgetall`
+### Redis HGETALL
 
 Get all fields and values of a hash stored at a key in Redis.
 
@@ -187,7 +187,7 @@ Get all fields and values of a hash stored at a key in Redis.
 | `fields` | object | All field-value pairs in the hash as a key-value object. Empty object if the key does not exist. |
 | `fieldCount` | number | Number of fields in the hash |
 
-### `redis_hdel`
+### Redis HDEL
 
 Delete a field from a hash stored at a key in Redis.
 
@@ -207,7 +207,7 @@ Delete a field from a hash stored at a key in Redis.
 | `field` | string | The field that was deleted |
 | `deleted` | number | Number of fields removed \(1 if deleted, 0 if field did not exist\) |
 
-### `redis_incr`
+### Redis INCR
 
 Increment the integer value of a key by one in Redis.
 
@@ -225,7 +225,7 @@ Increment the integer value of a key by one in Redis.
 | `key` | string | The key that was incremented |
 | `value` | number | The new value after increment |
 
-### `redis_incrby`
+### Redis INCRBY
 
 Increment the integer value of a key by a given amount in Redis.
 
@@ -244,7 +244,7 @@ Increment the integer value of a key by a given amount in Redis.
 | `key` | string | The key that was incremented |
 | `value` | number | The new value after increment |
 
-### `redis_expire`
+### Redis EXPIRE
 
 Set an expiration time (in seconds) on a key in Redis.
 
@@ -263,7 +263,7 @@ Set an expiration time (in seconds) on a key in Redis.
 | `key` | string | The key that expiration was set on |
 | `result` | number | 1 if the timeout was set, 0 if the key does not exist |
 
-### `redis_ttl`
+### Redis TTL
 
 Get the remaining time to live (in seconds) of a key in Redis.
 
@@ -281,7 +281,7 @@ Get the remaining time to live (in seconds) of a key in Redis.
 | `key` | string | The key that was checked |
 | `ttl` | number | Remaining TTL in seconds. Positive integer if TTL set, -1 if no expiration, -2 if key does not exist. |
 
-### `redis_persist`
+### Redis PERSIST
 
 Remove the expiration from a key in Redis, making it persist indefinitely.
 
@@ -299,7 +299,7 @@ Remove the expiration from a key in Redis, making it persist indefinitely.
 | `key` | string | The key that was persisted |
 | `result` | number | 1 if the expiration was removed, 0 if the key does not exist or has no expiration |
 
-### `redis_lpush`
+### Redis LPUSH
 
 Prepend a value to a list stored at a key in Redis.
 
@@ -318,7 +318,7 @@ Prepend a value to a list stored at a key in Redis.
 | `key` | string | The list key |
 | `length` | number | Length of the list after the push |
 
-### `redis_rpush`
+### Redis RPUSH
 
 Append a value to the end of a list stored at a key in Redis.
 
@@ -337,7 +337,7 @@ Append a value to the end of a list stored at a key in Redis.
 | `key` | string | The list key |
 | `length` | number | Length of the list after the push |
 
-### `redis_lpop`
+### Redis LPOP
 
 Remove and return the first element of a list stored at a key in Redis.
 
@@ -355,7 +355,7 @@ Remove and return the first element of a list stored at a key in Redis.
 | `key` | string | The list key |
 | `value` | string | The removed element, or null if the list is empty |
 
-### `redis_rpop`
+### Redis RPOP
 
 Remove and return the last element of a list stored at a key in Redis.
 
@@ -373,7 +373,7 @@ Remove and return the last element of a list stored at a key in Redis.
 | `key` | string | The list key |
 | `value` | string | The removed element, or null if the list is empty |
 
-### `redis_llen`
+### Redis LLEN
 
 Get the length of a list stored at a key in Redis.
 
@@ -391,7 +391,7 @@ Get the length of a list stored at a key in Redis.
 | `key` | string | The list key |
 | `length` | number | The length of the list, or 0 if the key does not exist |
 
-### `redis_lrange`
+### Redis LRANGE
 
 Get a range of elements from a list stored at a key in Redis.
 
@@ -412,7 +412,7 @@ Get a range of elements from a list stored at a key in Redis.
 | `values` | array | List elements in the specified range |
 | `count` | number | Number of elements returned |
 
-### `redis_exists`
+### Redis EXISTS
 
 Check if a key exists in Redis.
 
@@ -430,7 +430,7 @@ Check if a key exists in Redis.
 | `key` | string | The key that was checked |
 | `exists` | boolean | Whether the key exists \(true\) or not \(false\) |
 
-### `redis_setnx`
+### Redis SETNX
 
 Set the value of a key in Redis only if the key does not already exist.
 

--- a/apps/docs/content/docs/en/integrations/reducto.mdx
+++ b/apps/docs/content/docs/en/integrations/reducto.mdx
@@ -35,7 +35,7 @@ Integrate Reducto Parse into the workflow. Can extract text from uploaded PDF do
 
 ## Actions
 
-### `reducto_parser`
+### Reducto PDF Parser
 
 #### Input
 

--- a/apps/docs/content/docs/en/integrations/resend.mdx
+++ b/apps/docs/content/docs/en/integrations/resend.mdx
@@ -33,7 +33,7 @@ Integrate Resend into your workflow. Send emails, retrieve email status, manage 
 
 ## Actions
 
-### `resend_send`
+### Send Email
 
 Send an email using your own Resend API key and from address
 
@@ -63,7 +63,7 @@ Send an email using your own Resend API key and from address
 | `subject` | string | Email subject |
 | `body` | string | Email body content |
 
-### `resend_get_email`
+### Get Email
 
 Retrieve details of a previously sent email by its ID
 
@@ -94,7 +94,7 @@ Retrieve details of a previously sent email by its ID
 |   ↳ `name` | string | Tag name |
 |   ↳ `value` | string | Tag value |
 
-### `resend_cancel_email`
+### Cancel Email
 
 Cancel a scheduled email before it is sent
 
@@ -111,7 +111,7 @@ Cancel a scheduled email before it is sent
 | --------- | ---- | ----------- |
 | `id` | string | Canceled email ID |
 
-### `resend_create_contact`
+### Create Contact
 
 Create a new contact in Resend
 
@@ -131,7 +131,7 @@ Create a new contact in Resend
 | --------- | ---- | ----------- |
 | `id` | string | Created contact ID |
 
-### `resend_list_contacts`
+### List Contacts
 
 List all contacts in Resend
 
@@ -154,7 +154,7 @@ List all contacts in Resend
 |   ↳ `unsubscribed` | boolean | Whether the contact is unsubscribed |
 | `hasMore` | boolean | Whether there are more contacts to retrieve |
 
-### `resend_get_contact`
+### Get Contact
 
 Retrieve details of a contact by ID or email
 
@@ -176,7 +176,7 @@ Retrieve details of a contact by ID or email
 | `createdAt` | string | Contact creation timestamp |
 | `unsubscribed` | boolean | Whether the contact is unsubscribed |
 
-### `resend_update_contact`
+### Update Contact
 
 Update an existing contact in Resend
 
@@ -196,7 +196,7 @@ Update an existing contact in Resend
 | --------- | ---- | ----------- |
 | `id` | string | Updated contact ID |
 
-### `resend_delete_contact`
+### Delete Contact
 
 Delete a contact from Resend by ID or email
 
@@ -214,7 +214,7 @@ Delete a contact from Resend by ID or email
 | `id` | string | Deleted contact ID |
 | `deleted` | boolean | Whether the contact was successfully deleted |
 
-### `resend_create_audience`
+### Create Audience
 
 Create a new audience in Resend
 
@@ -232,7 +232,7 @@ Create a new audience in Resend
 | `id` | string | Created audience ID |
 | `name` | string | Audience name |
 
-### `resend_get_audience`
+### Get Audience
 
 Retrieve details of an audience by ID
 
@@ -251,7 +251,7 @@ Retrieve details of an audience by ID
 | `name` | string | Audience name |
 | `createdAt` | string | Audience creation timestamp |
 
-### `resend_list_audiences`
+### List Audiences
 
 List all audiences in Resend
 
@@ -271,7 +271,7 @@ List all audiences in Resend
 |   ↳ `created_at` | string | Audience creation timestamp |
 | `hasMore` | boolean | Whether there are more audiences to retrieve |
 
-### `resend_delete_audience`
+### Delete Audience
 
 Delete an audience from Resend by ID
 
@@ -289,7 +289,7 @@ Delete an audience from Resend by ID
 | `id` | string | Deleted audience ID |
 | `deleted` | boolean | Whether the audience was successfully deleted |
 
-### `resend_create_broadcast`
+### Create Broadcast
 
 Create a broadcast email for an audience in Resend
 
@@ -313,7 +313,7 @@ Create a broadcast email for an audience in Resend
 | --------- | ---- | ----------- |
 | `id` | string | Created broadcast ID |
 
-### `resend_send_broadcast`
+### Send Broadcast
 
 Send a broadcast immediately or schedule it for later
 
@@ -331,7 +331,7 @@ Send a broadcast immediately or schedule it for later
 | --------- | ---- | ----------- |
 | `id` | string | Broadcast ID |
 
-### `resend_get_broadcast`
+### Get Broadcast
 
 Retrieve details of a broadcast by ID
 
@@ -359,7 +359,7 @@ Retrieve details of a broadcast by ID
 | `scheduledAt` | string | Scheduled send timestamp |
 | `sentAt` | string | Timestamp the broadcast was sent |
 
-### `resend_list_domains`
+### List Domains
 
 List all verified domains in your Resend account
 
@@ -599,7 +599,7 @@ Trigger workflow when an email is sent
 
 ### Resend Webhook (All Events)
 
-Trigger on Resend webhook events we subscribe to (email lifecycle, contacts, domains—see Resend docs). Flattened email fields may be null for non-email events; use <code>data</code> for the full payload.
+Trigger on Resend webhook events we subscribe to (email lifecycle, contacts, domains—see Resend docs). Flattened email fields may be null for non-email events; use &lt;code&gt;data&lt;/code&gt; for the full payload.
 
 #### Configuration
 

--- a/apps/docs/content/docs/en/integrations/revenuecat.mdx
+++ b/apps/docs/content/docs/en/integrations/revenuecat.mdx
@@ -34,7 +34,7 @@ Integrate RevenueCat into the workflow. Manage subscribers, entitlements, offeri
 
 ## Actions
 
-### `revenuecat_get_customer`
+### RevenueCat Get Customer
 
 Retrieve subscriber information by app user ID
 
@@ -86,7 +86,7 @@ Retrieve subscriber information by app user ID
 |   ↳ `active_entitlements` | number | Number of active entitlements |
 |   ↳ `active_subscriptions` | number | Number of active subscriptions |
 
-### `revenuecat_delete_customer`
+### RevenueCat Delete Customer
 
 Permanently delete a subscriber and all associated data
 
@@ -104,7 +104,7 @@ Permanently delete a subscriber and all associated data
 | `deleted` | boolean | Whether the subscriber was deleted |
 | `app_user_id` | string | The deleted app user ID |
 
-### `revenuecat_create_purchase`
+### RevenueCat Create Purchase
 
 Record a purchase (receipt) for a subscriber via the REST API
 
@@ -163,7 +163,7 @@ Record a purchase (receipt) for a subscriber via the REST API
 |   ↳ `other_purchases` | object | Other purchases attached to the subscriber |
 |   ↳ `subscriber_attributes` | object | Custom attributes set on the subscriber. Only returned when using a secret API key |
 
-### `revenuecat_grant_entitlement`
+### RevenueCat Grant Entitlement
 
 Grant a promotional entitlement to a subscriber
 
@@ -214,7 +214,7 @@ Grant a promotional entitlement to a subscriber
 |   ↳ `other_purchases` | object | Other purchases attached to the subscriber |
 |   ↳ `subscriber_attributes` | object | Custom attributes set on the subscriber. Only returned when using a secret API key |
 
-### `revenuecat_revoke_entitlement`
+### RevenueCat Revoke Entitlement
 
 Revoke all promotional entitlements for a specific entitlement identifier
 
@@ -262,7 +262,7 @@ Revoke all promotional entitlements for a specific entitlement identifier
 |   ↳ `other_purchases` | object | Other purchases attached to the subscriber |
 |   ↳ `subscriber_attributes` | object | Custom attributes set on the subscriber. Only returned when using a secret API key |
 
-### `revenuecat_list_offerings`
+### RevenueCat List Offerings
 
 List all offerings configured for the project
 
@@ -289,7 +289,7 @@ List all offerings configured for the project
 |   ↳ `count` | number | Number of offerings returned |
 |   ↳ `current_offering_id` | string | Current offering identifier |
 
-### `revenuecat_update_subscriber_attributes`
+### RevenueCat Update Subscriber Attributes
 
 Update custom subscriber attributes (e.g., $email, $displayName, or custom key-value pairs)
 
@@ -308,7 +308,7 @@ Update custom subscriber attributes (e.g., $email, $displayName, or custom key-v
 | `updated` | boolean | Whether the subscriber attributes were successfully updated |
 | `app_user_id` | string | The app user ID of the updated subscriber |
 
-### `revenuecat_defer_google_subscription`
+### RevenueCat Defer Google Subscription
 
 Defer a Google Play subscription by extending its billing date by a number of days (Google Play only)
 
@@ -358,7 +358,7 @@ Defer a Google Play subscription by extending its billing date by a number of da
 |   ↳ `other_purchases` | object | Other purchases attached to the subscriber |
 |   ↳ `subscriber_attributes` | object | Custom attributes set on the subscriber. Only returned when using a secret API key |
 
-### `revenuecat_refund_google_subscription`
+### RevenueCat Refund Google Subscription
 
 Refund a specific store transaction by its store transaction identifier and revoke access (subscription or non-subscription, last 365 days)
 
@@ -406,7 +406,7 @@ Refund a specific store transaction by its store transaction identifier and revo
 |   ↳ `other_purchases` | object | Other purchases attached to the subscriber |
 |   ↳ `subscriber_attributes` | object | Custom attributes set on the subscriber. Only returned when using a secret API key |
 
-### `revenuecat_revoke_google_subscription`
+### RevenueCat Revoke Google Subscription
 
 Immediately revoke access to a Google Play subscription and issue a refund (Google Play only)
 

--- a/apps/docs/content/docs/en/integrations/rippling.mdx
+++ b/apps/docs/content/docs/en/integrations/rippling.mdx
@@ -46,7 +46,7 @@ Integrate Rippling Platform into your workflow. Manage workers, users, departmen
 
 ## Actions
 
-### `rippling_list_workers`
+### Rippling List Workers
 
 List all workers with optional filtering and pagination
 
@@ -101,7 +101,7 @@ List all workers with optional filtering and pagination
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_worker`
+### Rippling Get Worker
 
 Get a specific worker by ID
 
@@ -151,7 +151,7 @@ Get a specific worker by ID
 | `country_fields` | json | Country-specific fields |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_users`
+### Rippling List Users
 
 List all users with optional pagination
 
@@ -187,7 +187,7 @@ List all users with optional pagination
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_user`
+### Rippling Get User
 
 Get a specific user by ID
 
@@ -219,7 +219,7 @@ Get a specific user by ID
 | `photos` | json | Photos |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_companies`
+### Rippling List Companies
 
 List all companies
 
@@ -252,7 +252,7 @@ List all companies
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_current_user`
+### Rippling Get Current User
 
 Get SSO information for the current user
 
@@ -274,7 +274,7 @@ Get SSO information for the current user
 | `company_id` | string | Company ID |
 | `company` | json | Expanded company object |
 
-### `rippling_list_entitlements`
+### Rippling List Entitlements
 
 List all entitlements
 
@@ -296,7 +296,7 @@ List all entitlements
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_departments`
+### Rippling List Departments
 
 List all departments
 
@@ -327,7 +327,7 @@ List all departments
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_department`
+### Rippling Get Department
 
 Get a specific department by ID
 
@@ -354,7 +354,7 @@ Get a specific department by ID
 | `department_hierarchy` | json | Expanded department hierarchy |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_create_department`
+### Rippling Create Department
 
 Create a new department
 
@@ -381,7 +381,7 @@ Create a new department
 | `parent` | json | Expanded parent department |
 | `department_hierarchy` | json | Expanded department hierarchy |
 
-### `rippling_update_department`
+### Rippling Update Department
 
 Update an existing department
 
@@ -409,7 +409,7 @@ Update an existing department
 | `parent` | json | Expanded parent department |
 | `department_hierarchy` | json | Expanded department hierarchy |
 
-### `rippling_list_teams`
+### Rippling List Teams
 
 List all teams
 
@@ -437,7 +437,7 @@ List all teams
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_team`
+### Rippling Get Team
 
 Get a specific team by ID
 
@@ -461,7 +461,7 @@ Get a specific team by ID
 | `parent` | json | Expanded parent team |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_employment_types`
+### Rippling List Employment Types
 
 List all employment types
 
@@ -490,7 +490,7 @@ List all employment types
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_employment_type`
+### Rippling Get Employment Type
 
 Get a specific employment type by ID
 
@@ -515,7 +515,7 @@ Get a specific employment type by ID
 | `amount_worked` | string | Amount worked \(PART-TIME, FULL-TIME, TEMPORARY\) |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_titles`
+### Rippling List Titles
 
 List all titles
 
@@ -540,7 +540,7 @@ List all titles
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_title`
+### Rippling Get Title
 
 Get a specific title by ID
 
@@ -561,7 +561,7 @@ Get a specific title by ID
 | `name` | string | Title name |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_create_title`
+### Rippling Create Title
 
 Create a new title
 
@@ -581,7 +581,7 @@ Create a new title
 | `updated_at` | string | Update date |
 | `name` | string | Title name |
 
-### `rippling_update_title`
+### Rippling Update Title
 
 Update an existing title
 
@@ -602,7 +602,7 @@ Update an existing title
 | `updated_at` | string | Update date |
 | `name` | string | Title name |
 
-### `rippling_delete_title`
+### Rippling Delete Title
 
 Delete a title
 
@@ -619,7 +619,7 @@ Delete a title
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_list_custom_fields`
+### Rippling List Custom Fields
 
 List all custom fields
 
@@ -647,7 +647,7 @@ List all custom fields
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_job_functions`
+### Rippling List Job Functions
 
 List all job functions
 
@@ -672,7 +672,7 @@ List all job functions
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_job_function`
+### Rippling Get Job Function
 
 Get a specific job function by ID
 
@@ -693,7 +693,7 @@ Get a specific job function by ID
 | `name` | string | Name |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_work_locations`
+### Rippling List Work Locations
 
 List all work locations
 
@@ -719,7 +719,7 @@ List all work locations
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_work_location`
+### Rippling Get Work Location
 
 Get a specific work location by ID
 
@@ -741,7 +741,7 @@ Get a specific work location by ID
 | `address` | json | Address object |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_create_work_location`
+### Rippling Create Work Location
 
 Create a new work location
 
@@ -768,7 +768,7 @@ Create a new work location
 | `name` | string | Name |
 | `address` | json | Address |
 
-### `rippling_update_work_location`
+### Rippling Update Work Location
 
 Update a work location
 
@@ -796,7 +796,7 @@ Update a work location
 | `name` | string | Name |
 | `address` | json | Address |
 
-### `rippling_delete_work_location`
+### Rippling Delete Work Location
 
 Delete a work location
 
@@ -813,7 +813,7 @@ Delete a work location
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_list_business_partners`
+### Rippling List Business Partners
 
 List all business partners
 
@@ -843,7 +843,7 @@ List all business partners
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_business_partner`
+### Rippling Get Business Partner
 
 Get a specific business partner by ID
 
@@ -868,7 +868,7 @@ Get a specific business partner by ID
 | `client_group_member_count` | number | Client group member count |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_create_business_partner`
+### Rippling Create Business Partner
 
 Create a new business partner
 
@@ -892,7 +892,7 @@ Create a new business partner
 | `client_group_id` | string | Client group ID |
 | `client_group_member_count` | number | Client group member count |
 
-### `rippling_delete_business_partner`
+### Rippling Delete Business Partner
 
 Delete a business partner
 
@@ -909,7 +909,7 @@ Delete a business partner
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_list_business_partner_groups`
+### Rippling List Business Partner Groups
 
 List all business partner groups
 
@@ -937,7 +937,7 @@ List all business partner groups
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_business_partner_group`
+### Rippling Get Business Partner Group
 
 Get a specific business partner group by ID
 
@@ -961,7 +961,7 @@ Get a specific business partner group by ID
 | `default_business_partner_id` | string | Default partner ID |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_create_business_partner_group`
+### Rippling Create Business Partner Group
 
 Create a new business partner group
 
@@ -985,7 +985,7 @@ Create a new business partner group
 | `domain` | string | Domain |
 | `default_business_partner_id` | string | Default partner ID |
 
-### `rippling_delete_business_partner_group`
+### Rippling Delete Business Partner Group
 
 Delete a business partner group
 
@@ -1002,7 +1002,7 @@ Delete a business partner group
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_list_supergroups`
+### Rippling List Supergroups
 
 List all supergroups
 
@@ -1042,7 +1042,7 @@ List all supergroups
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_supergroup`
+### Rippling Get Supergroup
 
 Get a specific supergroup by ID
 
@@ -1078,7 +1078,7 @@ Get a specific supergroup by ID
 | `ignore_prov_group_matching` | boolean | Whether to ignore provisioning group matching |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_supergroup_members`
+### Rippling List Supergroup Members
 
 List members of a supergroup
 
@@ -1107,7 +1107,7 @@ List members of a supergroup
 | `nextLink` | string | Next page link |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_supergroup_inclusion_members`
+### Rippling List Supergroup Inclusion Members
 
 List inclusion members of a supergroup
 
@@ -1136,7 +1136,7 @@ List inclusion members of a supergroup
 | `nextLink` | string | Next page link |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_list_supergroup_exclusion_members`
+### Rippling List Supergroup Exclusion Members
 
 List exclusion members of a supergroup
 
@@ -1165,7 +1165,7 @@ List exclusion members of a supergroup
 | `nextLink` | string | Next page link |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_update_supergroup_inclusion_members`
+### Rippling Update Supergroup Inclusion Members
 
 Update inclusion members of a supergroup
 
@@ -1183,7 +1183,7 @@ Update inclusion members of a supergroup
 | --------- | ---- | ----------- |
 | `ok` | boolean | Whether the operation succeeded |
 
-### `rippling_update_supergroup_exclusion_members`
+### Rippling Update Supergroup Exclusion Members
 
 Update exclusion members of a supergroup
 
@@ -1201,7 +1201,7 @@ Update exclusion members of a supergroup
 | --------- | ---- | ----------- |
 | `ok` | boolean | Whether the operation succeeded |
 
-### `rippling_list_custom_objects`
+### Rippling List Custom Objects
 
 List all custom objects
 
@@ -1231,7 +1231,7 @@ List all custom objects
 | `totalCount` | number | Number of items returned |
 | `nextLink` | string | Link to next page of results |
 
-### `rippling_get_custom_object`
+### Rippling Get Custom Object
 
 Get a custom object by API name
 
@@ -1259,7 +1259,7 @@ Get a custom object by API name
 | `managed_package_install_id` | string | Package install ID |
 | `owner_id` | string | Owner ID |
 
-### `rippling_create_custom_object`
+### Rippling Create Custom Object
 
 Create a new custom object
 
@@ -1289,7 +1289,7 @@ Create a new custom object
 | `managed_package_install_id` | string | Package install ID |
 | `owner_id` | string | Owner ID |
 
-### `rippling_update_custom_object`
+### Rippling Update Custom Object
 
 Update a custom object
 
@@ -1322,7 +1322,7 @@ Update a custom object
 | `managed_package_install_id` | string | Package install ID |
 | `owner_id` | string | Owner ID |
 
-### `rippling_delete_custom_object`
+### Rippling Delete Custom Object
 
 Delete a custom object
 
@@ -1339,7 +1339,7 @@ Delete a custom object
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_list_custom_object_fields`
+### Rippling List Custom Object Fields
 
 List all fields for a custom object
 
@@ -1371,7 +1371,7 @@ List all fields for a custom object
 | `totalCount` | number | Number of fields returned |
 | `nextLink` | string | Next page link |
 
-### `rippling_get_custom_object_field`
+### Rippling Get Custom Object Field
 
 Get a specific field of a custom object
 
@@ -1401,7 +1401,7 @@ Get a specific field of a custom object
 | `enable_history` | boolean | History enabled |
 | `managed_package_install_id` | string | Package install ID |
 
-### `rippling_create_custom_object_field`
+### Rippling Create Custom Object Field
 
 Create a field on a custom object
 
@@ -1441,7 +1441,7 @@ Create a field on a custom object
 | `enable_history` | boolean | History enabled |
 | `managed_package_install_id` | string | Package install ID |
 
-### `rippling_update_custom_object_field`
+### Rippling Update Custom Object Field
 
 Update a field on a custom object
 
@@ -1482,7 +1482,7 @@ Update a field on a custom object
 | `enable_history` | boolean | History enabled |
 | `managed_package_install_id` | string | Package install ID |
 
-### `rippling_delete_custom_object_field`
+### Rippling Delete Custom Object Field
 
 Delete a field from a custom object
 
@@ -1500,7 +1500,7 @@ Delete a field from a custom object
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the field was deleted |
 
-### `rippling_list_custom_object_records`
+### Rippling List Custom Object Records
 
 List all records for a custom object
 
@@ -1529,7 +1529,7 @@ List all records for a custom object
 | `totalCount` | number | Number of records returned |
 | `nextLink` | string | Next page link |
 
-### `rippling_get_custom_object_record`
+### Rippling Get Custom Object Record
 
 Get a specific custom object record
 
@@ -1556,7 +1556,7 @@ Get a specific custom object record
 | `system_updated_at` | string | System update timestamp |
 | `data` | json | Full record data |
 
-### `rippling_get_custom_object_record_by_external_id`
+### Rippling Get Record By External ID
 
 Get a custom object record by external ID
 
@@ -1583,7 +1583,7 @@ Get a custom object record by external ID
 | `system_updated_at` | string | System update timestamp |
 | `data` | json | Full record data |
 
-### `rippling_query_custom_object_records`
+### Rippling Query Custom Object Records
 
 Query custom object records with filters
 
@@ -1615,7 +1615,7 @@ Query custom object records with filters
 | `totalCount` | number | Number of records returned |
 | `cursor` | string | Cursor for next page of results |
 
-### `rippling_create_custom_object_record`
+### Rippling Create Custom Object Record
 
 Create a custom object record
 
@@ -1643,7 +1643,7 @@ Create a custom object record
 | `system_updated_at` | string | System update timestamp |
 | `data` | json | Full record data |
 
-### `rippling_update_custom_object_record`
+### Rippling Update Custom Object Record
 
 Update a custom object record
 
@@ -1672,7 +1672,7 @@ Update a custom object record
 | `system_updated_at` | string | System update timestamp |
 | `data` | json | Full record data |
 
-### `rippling_delete_custom_object_record`
+### Rippling Delete Custom Object Record
 
 Delete a custom object record
 
@@ -1690,7 +1690,7 @@ Delete a custom object record
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the record was deleted |
 
-### `rippling_bulk_create_custom_object_records`
+### Rippling Bulk Create Custom Object Records
 
 Bulk create custom object records
 
@@ -1710,7 +1710,7 @@ Bulk create custom object records
 | `createdRecords` | array | Created custom object records |
 | `totalCount` | number | Number of records created |
 
-### `rippling_bulk_update_custom_object_records`
+### Rippling Bulk Update Custom Object Records
 
 Bulk update custom object records
 
@@ -1730,7 +1730,7 @@ Bulk update custom object records
 | `updatedRecords` | array | Updated custom object records |
 | `totalCount` | number | Number of records updated |
 
-### `rippling_bulk_delete_custom_object_records`
+### Rippling Bulk Delete Custom Object Records
 
 Bulk delete custom object records
 
@@ -1749,7 +1749,7 @@ Bulk delete custom object records
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the bulk delete succeeded |
 
-### `rippling_list_custom_apps`
+### Rippling List CustomApps
 
 List all custom apps
 
@@ -1776,7 +1776,7 @@ List all custom apps
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_custom_app`
+### Rippling Get CustomApp
 
 Get a specific custom app
 
@@ -1801,7 +1801,7 @@ Get a specific custom app
 | `pages` | json | Array of page summaries |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_create_custom_app`
+### Rippling Create Custom App
 
 Create a new custom app
 
@@ -1827,7 +1827,7 @@ Create a new custom app
 | `icon` | string | Icon URL |
 | `pages` | json | Array of page summaries |
 
-### `rippling_update_custom_app`
+### Rippling Update CustomApp
 
 Update a custom app
 
@@ -1854,7 +1854,7 @@ Update a custom app
 | `icon` | string | Icon URL |
 | `pages` | json | Array of page summaries |
 
-### `rippling_delete_custom_app`
+### Rippling Delete CustomApp
 
 Delete a custom app
 
@@ -1871,7 +1871,7 @@ Delete a custom app
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_list_custom_pages`
+### Rippling List CustomPages
 
 List all custom pages
 
@@ -1899,7 +1899,7 @@ List all custom pages
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_custom_page`
+### Rippling Get CustomPage
 
 Get a specific custom page
 
@@ -1925,7 +1925,7 @@ Get a specific custom page
 | `media` | json | Page media |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_create_custom_page`
+### Rippling Create CustomPage
 
 Create a new custom page
 
@@ -1950,7 +1950,7 @@ Create a new custom page
 | `variables` | json | Page variables |
 | `media` | json | Page media |
 
-### `rippling_update_custom_page`
+### Rippling Update CustomPage
 
 Update a custom page
 
@@ -1976,7 +1976,7 @@ Update a custom page
 | `variables` | json | Page variables |
 | `media` | json | Page media |
 
-### `rippling_delete_custom_page`
+### Rippling Delete CustomPage
 
 Delete a custom page
 
@@ -1993,7 +1993,7 @@ Delete a custom page
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_list_custom_settings`
+### Rippling List Custom Settings
 
 List all custom settings
 
@@ -2024,7 +2024,7 @@ List all custom settings
 | `nextLink` | string | Link to next page of results |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_get_custom_setting`
+### Rippling Get Custom Setting
 
 Get a specific custom setting
 
@@ -2051,7 +2051,7 @@ Get a specific custom setting
 | `boolean_value` | boolean | Boolean value |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_create_custom_setting`
+### Rippling Create Custom Setting
 
 Create a new custom setting
 
@@ -2083,7 +2083,7 @@ Create a new custom setting
 | `number_value` | number | Number value |
 | `boolean_value` | boolean | Boolean value |
 
-### `rippling_update_custom_setting`
+### Rippling Update Custom Setting
 
 Update a custom setting
 
@@ -2116,7 +2116,7 @@ Update a custom setting
 | `number_value` | number | Number value |
 | `boolean_value` | boolean | Boolean value |
 
-### `rippling_delete_custom_setting`
+### Rippling Delete Custom Setting
 
 Delete a custom setting
 
@@ -2133,7 +2133,7 @@ Delete a custom setting
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_list_object_categories`
+### Rippling List Object Categories
 
 List all object categories
 
@@ -2156,7 +2156,7 @@ List all object categories
 | `totalCount` | number | Number of items returned |
 | `nextLink` | string | Link to next page of results |
 
-### `rippling_get_object_category`
+### Rippling Get ObjectCategory
 
 Get a specific object category
 
@@ -2177,7 +2177,7 @@ Get a specific object category
 | `name` | string | Name |
 | `description` | string | Description |
 
-### `rippling_create_object_category`
+### Rippling Create ObjectCategory
 
 Create a new object category
 
@@ -2199,7 +2199,7 @@ Create a new object category
 | `name` | string | Name |
 | `description` | string | Description |
 
-### `rippling_update_object_category`
+### Rippling Update ObjectCategory
 
 Update an object category
 
@@ -2222,7 +2222,7 @@ Update an object category
 | `name` | string | Name |
 | `description` | string | Description |
 
-### `rippling_delete_object_category`
+### Rippling Delete ObjectCategory
 
 Delete an object category
 
@@ -2239,7 +2239,7 @@ Delete an object category
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the resource was deleted |
 
-### `rippling_get_report_run`
+### Rippling Get Report Run
 
 Get a report run by ID
 
@@ -2262,7 +2262,7 @@ Get a report run by ID
 | `output_type` | string | Output format \(JSON or CSV\) |
 | `__meta` | json | Metadata including redacted_fields |
 
-### `rippling_trigger_report_run`
+### Rippling Trigger Report Run
 
 Trigger a new report run
 
@@ -2289,7 +2289,7 @@ Trigger a new report run
 | `expires_at` | string | Expiration timestamp for the file URL |
 | `output_type` | string | Output format \(JSON or CSV\) |
 
-### `rippling_create_draft_hires`
+### Rippling Create Draft Hires
 
 Create bulk draft hires
 

--- a/apps/docs/content/docs/en/integrations/rocketlane.mdx
+++ b/apps/docs/content/docs/en/integrations/rocketlane.mdx
@@ -18,7 +18,7 @@ Integrate Rocketlane into your workflow. Rocketlane is a professional-services a
 
 ## Actions
 
-### `rocketlane_create_project`
+### Rocketlane Create Project
 
 Create a new Rocketlane project with a customer, owner, dates, team members, templates, financials, and custom fields
 
@@ -168,7 +168,7 @@ Create a new Rocketlane project with a customer, owner, dates, team members, tem
 |   ↳ `customersJoined` | number | Number of customers who joined the project |
 |   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
 
-### `rocketlane_get_project`
+### Rocketlane Get Project
 
 Retrieve a Rocketlane project by its unique identifier
 
@@ -288,7 +288,7 @@ Retrieve a Rocketlane project by its unique identifier
 |   ↳ `customersJoined` | number | Number of customers who joined the project |
 |   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
 
-### `rocketlane_list_projects`
+### Rocketlane List Projects
 
 List Rocketlane projects with optional filters, sorting, and token-based pagination
 
@@ -431,7 +431,7 @@ List Rocketlane projects with optional filters, sorting, and token-based paginat
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_update_project`
+### Rocketlane Update Project
 
 Update a Rocketlane project by ID, including name, dates, visibility, owner, status, and custom fields
 
@@ -564,7 +564,7 @@ Update a Rocketlane project by ID, including name, dates, visibility, owner, sta
 |   ↳ `customersJoined` | number | Number of customers who joined the project |
 |   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
 
-### `rocketlane_archive_project`
+### Rocketlane Archive Project
 
 Archive a Rocketlane project by ID, making it dormant while preserving its details and history
 
@@ -582,7 +582,7 @@ Archive a Rocketlane project by ID, making it dormant while preserving its detai
 | `archived` | boolean | Whether the project was archived |
 | `projectId` | number | Unique identifier of the archived project |
 
-### `rocketlane_delete_project`
+### Rocketlane Delete Project
 
 Permanently delete a Rocketlane project by ID (irreversible; only Admins, Super Users, and Project Owners can delete)
 
@@ -600,7 +600,7 @@ Permanently delete a Rocketlane project by ID (irreversible; only Admins, Super 
 | `deleted` | boolean | Whether the project was deleted |
 | `projectId` | number | Unique identifier of the deleted project |
 
-### `rocketlane_add_project_members`
+### Rocketlane Add Project Members
 
 Add team members and customer stakeholders to a Rocketlane project
 
@@ -722,7 +722,7 @@ Add team members and customer stakeholders to a Rocketlane project
 |   ↳ `customersJoined` | number | Number of customers who joined the project |
 |   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
 
-### `rocketlane_remove_project_members`
+### Rocketlane Remove Project Members
 
 Remove team members from a Rocketlane project
 
@@ -842,7 +842,7 @@ Remove team members from a Rocketlane project
 |   ↳ `customersJoined` | number | Number of customers who joined the project |
 |   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
 
-### `rocketlane_import_template`
+### Rocketlane Import Template
 
 Import a project template into an existing Rocketlane project
 
@@ -963,7 +963,7 @@ Import a project template into an existing Rocketlane project
 |   ↳ `customersJoined` | number | Number of customers who joined the project |
 |   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
 
-### `rocketlane_list_placeholders`
+### Rocketlane List Placeholders
 
 List the placeholders of a Rocketlane project
 
@@ -996,7 +996,7 @@ List the placeholders of a Rocketlane project
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_assign_placeholders`
+### Rocketlane Assign Placeholders
 
 Assign a placeholder in a Rocketlane project to a user
 
@@ -1132,7 +1132,7 @@ Assign a placeholder in a Rocketlane project to a user
 |   ↳ `hourlyBillRate` | number | Latest hourly bill rate for the placeholder |
 |   ↳ `billRateCurrency` | string | Currency for the bill rate |
 
-### `rocketlane_unassign_placeholders`
+### Rocketlane Unassign Placeholders
 
 Unassign a placeholder from its user in a Rocketlane project
 
@@ -1266,7 +1266,7 @@ Unassign a placeholder from its user in a Rocketlane project
 |   ↳ `hourlyBillRate` | number | Latest hourly bill rate for the placeholder |
 |   ↳ `billRateCurrency` | string | Currency for the bill rate |
 
-### `rocketlane_create_task`
+### Rocketlane Create Task
 
 Create a new task in a Rocketlane project
 
@@ -1363,7 +1363,7 @@ Create a new task in a Rocketlane project
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_get_task`
+### Rocketlane Get Task
 
 Retrieve detailed information about a Rocketlane task by its unique identifier
 
@@ -1442,7 +1442,7 @@ Retrieve detailed information about a Rocketlane task by its unique identifier
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_list_tasks`
+### Rocketlane List Tasks
 
 Retrieve all Rocketlane tasks with optional filters, sorting, and pagination
 
@@ -1541,7 +1541,7 @@ Retrieve all Rocketlane tasks with optional filters, sorting, and pagination
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_update_task`
+### Rocketlane Update Task
 
 Update the properties of an existing Rocketlane task by its unique identifier
 
@@ -1632,7 +1632,7 @@ Update the properties of an existing Rocketlane task by its unique identifier
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_delete_task`
+### Rocketlane Delete Task
 
 Permanently delete a Rocketlane task by its unique identifier
 
@@ -1650,7 +1650,7 @@ Permanently delete a Rocketlane task by its unique identifier
 | `deleted` | boolean | Whether the task was deleted |
 | `taskId` | number | ID of the deleted task |
 
-### `rocketlane_move_task_to_phase`
+### Rocketlane Move Task To Phase
 
 Move a Rocketlane task to a given phase, associating the task with that phase
 
@@ -1728,7 +1728,7 @@ Move a Rocketlane task to a given phase, associating the task with that phase
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_add_task_assignees`
+### Rocketlane Add Task Assignees
 
 Add members as assignees to a Rocketlane task
 
@@ -1807,7 +1807,7 @@ Add members as assignees to a Rocketlane task
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_remove_task_assignees`
+### Rocketlane Remove Task Assignees
 
 Remove assignees from a Rocketlane task
 
@@ -1886,7 +1886,7 @@ Remove assignees from a Rocketlane task
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_add_task_followers`
+### Rocketlane Add Task Followers
 
 Add members as followers to a Rocketlane task
 
@@ -1965,7 +1965,7 @@ Add members as followers to a Rocketlane task
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_remove_task_followers`
+### Rocketlane Remove Task Followers
 
 Remove followers from a Rocketlane task
 
@@ -2044,7 +2044,7 @@ Remove followers from a Rocketlane task
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_add_task_dependencies`
+### Rocketlane Add Task Dependencies
 
 Add finish-to-start dependencies between a Rocketlane task and other tasks
 
@@ -2122,7 +2122,7 @@ Add finish-to-start dependencies between a Rocketlane task and other tasks
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_remove_task_dependencies`
+### Rocketlane Remove Task Dependencies
 
 Remove dependencies from a Rocketlane task
 
@@ -2200,7 +2200,7 @@ Remove dependencies from a Rocketlane task
 |   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
 |   ↳ `private` | boolean | Whether the task is private |
 
-### `rocketlane_create_phase`
+### Rocketlane Create Phase
 
 Create a new phase in a Rocketlane project
 
@@ -2249,7 +2249,7 @@ Create a new phase in a Rocketlane project
 |     ↳ `label` | string | Display label of the status |
 |   ↳ `private` | boolean | Whether the phase is private |
 
-### `rocketlane_get_phase`
+### Rocketlane Get Phase
 
 Retrieve a single Rocketlane phase by ID
 
@@ -2293,7 +2293,7 @@ Retrieve a single Rocketlane phase by ID
 |     ↳ `label` | string | Display label of the status |
 |   ↳ `private` | boolean | Whether the phase is private |
 
-### `rocketlane_list_phases`
+### Rocketlane List Phases
 
 List phases of a Rocketlane project, with optional filters, sorting, and pagination
 
@@ -2348,7 +2348,7 @@ List phases of a Rocketlane project, with optional filters, sorting, and paginat
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_update_phase`
+### Rocketlane Update Phase
 
 Update the name, dates, status, or privacy of an existing Rocketlane phase
 
@@ -2397,7 +2397,7 @@ Update the name, dates, status, or privacy of an existing Rocketlane phase
 |     ↳ `label` | string | Display label of the status |
 |   ↳ `private` | boolean | Whether the phase is private |
 
-### `rocketlane_delete_phase`
+### Rocketlane Delete Phase
 
 Permanently delete a Rocketlane phase by ID
 
@@ -2415,7 +2415,7 @@ Permanently delete a Rocketlane phase by ID
 | `deleted` | boolean | Whether the phase was deleted |
 | `phaseId` | number | ID of the deleted phase |
 
-### `rocketlane_create_field`
+### Rocketlane Create Field
 
 Create a custom field in your Rocketlane account, with options for SINGLE_CHOICE and MULTIPLE_CHOICE field types
 
@@ -2465,7 +2465,7 @@ Create a custom field in your Rocketlane account, with options for SINGLE_CHOICE
 |   ↳ `enabled` | boolean | Whether the field is enabled |
 |   ↳ `private` | boolean | Whether the field is private |
 
-### `rocketlane_get_field`
+### Rocketlane Get Field
 
 Retrieve a single Rocketlane field by ID
 
@@ -2508,7 +2508,7 @@ Retrieve a single Rocketlane field by ID
 |   ↳ `enabled` | boolean | Whether the field is enabled |
 |   ↳ `private` | boolean | Whether the field is private |
 
-### `rocketlane_list_fields`
+### Rocketlane List Fields
 
 List fields in your Rocketlane account, with optional filters, sorting, and pagination
 
@@ -2564,7 +2564,7 @@ List fields in your Rocketlane account, with optional filters, sorting, and pagi
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_update_field`
+### Rocketlane Update Field
 
 Update the label, description, enabled state, or privacy of an existing Rocketlane field
 
@@ -2611,7 +2611,7 @@ Update the label, description, enabled state, or privacy of an existing Rocketla
 |   ↳ `enabled` | boolean | Whether the field is enabled |
 |   ↳ `private` | boolean | Whether the field is private |
 
-### `rocketlane_delete_field`
+### Rocketlane Delete Field
 
 Permanently delete a Rocketlane field by ID
 
@@ -2629,7 +2629,7 @@ Permanently delete a Rocketlane field by ID
 | `deleted` | boolean | Whether the field was deleted |
 | `fieldId` | number | ID of the deleted field |
 
-### `rocketlane_add_field_option`
+### Rocketlane Add Field Option
 
 Add a new option to an existing SINGLE_CHOICE or MULTIPLE_CHOICE Rocketlane field
 
@@ -2651,7 +2651,7 @@ Add a new option to an existing SINGLE_CHOICE or MULTIPLE_CHOICE Rocketlane fiel
 |   ↳ `optionLabel` | string | Display label of the option |
 |   ↳ `optionColor` | string | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
 
-### `rocketlane_update_field_option`
+### Rocketlane Update Field Option
 
 Update the label or color of an existing option on a SINGLE_CHOICE or MULTIPLE_CHOICE Rocketlane field
 
@@ -2674,7 +2674,7 @@ Update the label or color of an existing option on a SINGLE_CHOICE or MULTIPLE_C
 |   ↳ `optionLabel` | string | Display label of the option |
 |   ↳ `optionColor` | string | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
 
-### `rocketlane_create_time_entry`
+### Rocketlane Create Time Entry
 
 Create a time entry in Rocketlane against an adhoc activity, task, project phase, or project
 
@@ -2766,7 +2766,7 @@ Create a time entry in Rocketlane against an adhoc activity, task, project phase
 |     ↳ `fieldValue` | json | Value of the field |
 |     ↳ `fieldValueLabel` | string | String representation of the field value |
 
-### `rocketlane_get_time_entry`
+### Rocketlane Get Time Entry
 
 Get a single Rocketlane time entry by ID
 
@@ -2848,7 +2848,7 @@ Get a single Rocketlane time entry by ID
 |     ↳ `fieldValue` | json | Value of the field |
 |     ↳ `fieldValueLabel` | string | String representation of the field value |
 
-### `rocketlane_list_time_entries`
+### Rocketlane List Time Entries
 
 List Rocketlane time entries with optional filters, sorting, and cursor-based pagination
 
@@ -2963,7 +2963,7 @@ List Rocketlane time entries with optional filters, sorting, and cursor-based pa
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_search_time_entries`
+### Rocketlane Search Time Entries
 
 Search Rocketlane time entries with filters, sorting, and pagination (deprecated by Rocketlane in favor of listing time entries with filters)
 
@@ -3068,7 +3068,7 @@ Search Rocketlane time entries with filters, sorting, and pagination (deprecated
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_update_time_entry`
+### Rocketlane Update Time Entry
 
 Update a Rocketlane time entry by ID. The activityName, notes, billable, and minutes properties can be updated
 
@@ -3156,7 +3156,7 @@ Update a Rocketlane time entry by ID. The activityName, notes, billable, and min
 |     ↳ `fieldValue` | json | Value of the field |
 |     ↳ `fieldValueLabel` | string | String representation of the field value |
 
-### `rocketlane_delete_time_entry`
+### Rocketlane Delete Time Entry
 
 Permanently delete a Rocketlane time entry by ID
 
@@ -3174,7 +3174,7 @@ Permanently delete a Rocketlane time entry by ID
 | `deleted` | boolean | Whether the time entry was deleted |
 | `timeEntryId` | number | ID of the deleted time entry |
 
-### `rocketlane_list_time_entry_categories`
+### Rocketlane List Time Entry Categories
 
 List the time entry categories configured in Rocketlane
 
@@ -3199,7 +3199,7 @@ List the time entry categories configured in Rocketlane
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_create_time_off`
+### Rocketlane Create Time-Off
 
 Create a time-off for a team member in Rocketlane. Holidays and weekends within the date range are automatically excluded from the duration.
 
@@ -3249,7 +3249,7 @@ Create a time-off for a team member in Rocketlane. Holidays and weekends within 
 |     ↳ `lastName` | string | Last name of the user |
 |     ↳ `emailId` | string | Email address of the user |
 
-### `rocketlane_get_time_off`
+### Rocketlane Get Time-Off
 
 Retrieve a Rocketlane time-off by its ID
 
@@ -3290,7 +3290,7 @@ Retrieve a Rocketlane time-off by its ID
 |     ↳ `lastName` | string | Last name of the user |
 |     ↳ `emailId` | string | Email address of the user |
 
-### `rocketlane_list_time_offs`
+### Rocketlane List Time-Offs
 
 List time-offs in Rocketlane with optional date, type, and user filters, sorting, and pagination
 
@@ -3359,7 +3359,7 @@ List time-offs in Rocketlane with optional date, type, and user filters, sorting
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_delete_time_off`
+### Rocketlane Delete Time-Off
 
 Permanently delete a Rocketlane time-off by its ID
 
@@ -3377,7 +3377,7 @@ Permanently delete a Rocketlane time-off by its ID
 | `deleted` | boolean | Whether the time-off was deleted |
 | `timeOffId` | number | ID of the deleted time-off |
 
-### `rocketlane_get_user`
+### Rocketlane Get User
 
 Retrieve a Rocketlane user by their ID
 
@@ -3433,7 +3433,7 @@ Retrieve a Rocketlane user by their ID
 |     ↳ `lastName` | string | Last name of the user |
 |     ↳ `emailId` | string | Email address of the user |
 
-### `rocketlane_list_users`
+### Rocketlane List Users
 
 List users in your Rocketlane account, with optional filters, sorting, and pagination
 
@@ -3533,7 +3533,7 @@ List users in your Rocketlane account, with optional filters, sorting, and pagin
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_create_space`
+### Rocketlane Create Space
 
 Create a new space in a Rocketlane project
 
@@ -3570,7 +3570,7 @@ Create a new space in a Rocketlane project
 |     ↳ `emailId` | string | Email address of the user |
 |   ↳ `private` | boolean | Whether the space is private or shared |
 
-### `rocketlane_get_space`
+### Rocketlane Get Space
 
 Retrieve a Rocketlane space by its ID
 
@@ -3605,7 +3605,7 @@ Retrieve a Rocketlane space by its ID
 |     ↳ `emailId` | string | Email address of the user |
 |   ↳ `private` | boolean | Whether the space is private or shared |
 
-### `rocketlane_list_spaces`
+### Rocketlane List Spaces
 
 List spaces in a Rocketlane project, with optional filters, sorting, and pagination
 
@@ -3663,7 +3663,7 @@ List spaces in a Rocketlane project, with optional filters, sorting, and paginat
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_update_space`
+### Rocketlane Update Space
 
 Update a Rocketlane space by its ID
 
@@ -3699,7 +3699,7 @@ Update a Rocketlane space by its ID
 |     ↳ `emailId` | string | Email address of the user |
 |   ↳ `private` | boolean | Whether the space is private or shared |
 
-### `rocketlane_delete_space`
+### Rocketlane Delete Space
 
 Permanently delete a Rocketlane space by its ID
 
@@ -3717,7 +3717,7 @@ Permanently delete a Rocketlane space by its ID
 | `deleted` | boolean | Whether the space was deleted |
 | `spaceId` | number | ID of the deleted space |
 
-### `rocketlane_create_space_document`
+### Rocketlane Create Space Document
 
 Create a new space document in a Rocketlane space
 
@@ -3761,7 +3761,7 @@ Create a new space document in a Rocketlane space
 |     ↳ `emailId` | string | Email address of the user |
 |   ↳ `private` | boolean | Whether the space document is private or shared |
 
-### `rocketlane_get_space_document`
+### Rocketlane Get Space Document
 
 Retrieve a Rocketlane space document by its ID
 
@@ -3801,7 +3801,7 @@ Retrieve a Rocketlane space document by its ID
 |     ↳ `emailId` | string | Email address of the user |
 |   ↳ `private` | boolean | Whether the space document is private or shared |
 
-### `rocketlane_list_space_documents`
+### Rocketlane List Space Documents
 
 List space documents in a Rocketlane project, with optional filters, sorting, and pagination
 
@@ -3865,7 +3865,7 @@ List space documents in a Rocketlane project, with optional filters, sorting, an
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_update_space_document`
+### Rocketlane Update Space Document
 
 Update a Rocketlane space document by its ID
 
@@ -3907,7 +3907,7 @@ Update a Rocketlane space document by its ID
 |     ↳ `emailId` | string | Email address of the user |
 |   ↳ `private` | boolean | Whether the space document is private or shared |
 
-### `rocketlane_delete_space_document`
+### Rocketlane Delete Space Document
 
 Permanently delete a Rocketlane space document by its ID
 
@@ -3925,7 +3925,7 @@ Permanently delete a Rocketlane space document by its ID
 | `deleted` | boolean | Whether the space document was deleted |
 | `spaceDocumentId` | number | ID of the deleted space document |
 
-### `rocketlane_list_resource_allocations`
+### Rocketlane List Resource Allocations
 
 List resource allocations in Rocketlane within a date range, with optional member, project, and placeholder filters, sorting, and pagination
 
@@ -3996,7 +3996,7 @@ List resource allocations in Rocketlane within a date range, with optional membe
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_get_invoice`
+### Rocketlane Get Invoice
 
 Retrieve a Rocketlane invoice by its ID
 
@@ -4059,7 +4059,7 @@ Retrieve a Rocketlane invoice by its ID
 |     ↳ `thumbLocation` | string | Thumbnail URL of the attachment |
 |     ↳ `visibility` | boolean | Visibility of the attachment |
 
-### `rocketlane_list_invoices`
+### Rocketlane List Invoices
 
 Search invoices in Rocketlane with date, amount, company, invoice-number, and status filters, sorting, and pagination
 
@@ -4175,7 +4175,7 @@ Search invoices in Rocketlane with date, amount, company, invoice-number, and st
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_get_invoice_line_items`
+### Rocketlane Get Invoice Line Items
 
 List line items of a Rocketlane invoice
 
@@ -4217,7 +4217,7 @@ List line items of a Rocketlane invoice
 |   ↳ `totalRecordCount` | number | Total number of records matching the request |
 |   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
 
-### `rocketlane_get_invoice_payments`
+### Rocketlane Get Invoice Payments
 
 List payments recorded against a Rocketlane invoice
 

--- a/apps/docs/content/docs/en/integrations/rootly.mdx
+++ b/apps/docs/content/docs/en/integrations/rootly.mdx
@@ -44,7 +44,7 @@ Integrate Rootly incident management into workflows. Create and manage incidents
 
 ## Actions
 
-### `rootly_create_incident`
+### Rootly Create Incident
 
 Create a new incident in Rootly with optional severity, services, and teams.
 
@@ -90,7 +90,7 @@ Create a new incident in Rootly with optional severity, services, and teams.
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_get_incident`
+### Rootly Get Incident
 
 Retrieve a single incident by ID from Rootly.
 
@@ -125,7 +125,7 @@ Retrieve a single incident by ID from Rootly.
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_update_incident`
+### Rootly Update Incident
 
 Update an existing incident in Rootly (status, severity, summary, etc.).
 
@@ -175,7 +175,7 @@ Update an existing incident in Rootly (status, severity, summary, etc.).
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_list_incidents`
+### Rootly List Incidents
 
 List incidents from Rootly with optional filtering by status, severity, and more.
 
@@ -219,7 +219,7 @@ List incidents from Rootly with optional filtering by status, severity, and more
 |   ↳ `closedAt` | string | Closed date |
 | `totalCount` | number | Total number of incidents returned |
 
-### `rootly_create_alert`
+### Rootly Create Alert
 
 Create a new alert in Rootly for on-call notification and routing.
 
@@ -258,7 +258,7 @@ Create a new alert in Rootly for on-call notification and routing.
 |   ↳ `startedAt` | string | Start date |
 |   ↳ `endedAt` | string | End date |
 
-### `rootly_list_alerts`
+### Rootly List Alerts
 
 List alerts from Rootly with optional filtering by status, source, and services.
 
@@ -295,7 +295,7 @@ List alerts from Rootly with optional filtering by status, source, and services.
 |   ↳ `endedAt` | string | End date |
 | `totalCount` | number | Total number of alerts returned |
 
-### `rootly_add_incident_event`
+### Rootly Add Incident Event
 
 Add a timeline event to an existing incident in Rootly.
 
@@ -319,7 +319,7 @@ Add a timeline event to an existing incident in Rootly.
 | `createdAt` | string | Creation date |
 | `updatedAt` | string | Last update date |
 
-### `rootly_list_services`
+### Rootly List Services
 
 List services from Rootly with optional search filtering.
 
@@ -346,7 +346,7 @@ List services from Rootly with optional search filtering.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of services returned |
 
-### `rootly_list_severities`
+### Rootly List Severities
 
 List severity levels configured in Rootly.
 
@@ -375,7 +375,7 @@ List severity levels configured in Rootly.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of severities returned |
 
-### `rootly_list_teams`
+### Rootly List Teams
 
 List teams (groups) configured in Rootly.
 
@@ -402,7 +402,7 @@ List teams (groups) configured in Rootly.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of teams returned |
 
-### `rootly_list_environments`
+### Rootly List Environments
 
 List environments configured in Rootly.
 
@@ -429,7 +429,7 @@ List environments configured in Rootly.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of environments returned |
 
-### `rootly_list_incident_types`
+### Rootly List Incident Types
 
 List incident types configured in Rootly.
 
@@ -456,7 +456,7 @@ List incident types configured in Rootly.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of incident types returned |
 
-### `rootly_list_functionalities`
+### Rootly List Functionalities
 
 List functionalities configured in Rootly.
 
@@ -483,7 +483,7 @@ List functionalities configured in Rootly.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of functionalities returned |
 
-### `rootly_list_retrospectives`
+### Rootly List Retrospectives
 
 List incident retrospectives (post-mortems) from Rootly.
 
@@ -513,7 +513,7 @@ List incident retrospectives (post-mortems) from Rootly.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of retrospectives returned |
 
-### `rootly_delete_incident`
+### Rootly Delete Incident
 
 Delete an incident by ID from Rootly.
 
@@ -531,7 +531,7 @@ Delete an incident by ID from Rootly.
 | `success` | boolean | Whether the deletion succeeded |
 | `message` | string | Result message |
 
-### `rootly_get_alert`
+### Rootly Get Alert
 
 Retrieve a single alert by ID from Rootly.
 
@@ -561,7 +561,7 @@ Retrieve a single alert by ID from Rootly.
 |   ↳ `startedAt` | string | Start date |
 |   ↳ `endedAt` | string | End date |
 
-### `rootly_update_alert`
+### Rootly Update Alert
 
 Update an existing alert in Rootly.
 
@@ -600,7 +600,7 @@ Update an existing alert in Rootly.
 |   ↳ `startedAt` | string | Start date |
 |   ↳ `endedAt` | string | End date |
 
-### `rootly_acknowledge_alert`
+### Rootly Acknowledge Alert
 
 Acknowledge an alert in Rootly.
 
@@ -630,7 +630,7 @@ Acknowledge an alert in Rootly.
 |   ↳ `startedAt` | string | Start date |
 |   ↳ `endedAt` | string | End date |
 
-### `rootly_resolve_alert`
+### Rootly Resolve Alert
 
 Resolve an alert in Rootly.
 
@@ -662,7 +662,7 @@ Resolve an alert in Rootly.
 |   ↳ `startedAt` | string | Start date |
 |   ↳ `endedAt` | string | End date |
 
-### `rootly_create_action_item`
+### Rootly Create Action Item
 
 Create a new action item for an incident in Rootly.
 
@@ -695,7 +695,7 @@ Create a new action item for an incident in Rootly.
 |   ↳ `createdAt` | string | Creation date |
 |   ↳ `updatedAt` | string | Last update date |
 
-### `rootly_list_action_items`
+### Rootly List Action Items
 
 List action items for an incident in Rootly.
 
@@ -724,7 +724,7 @@ List action items for an incident in Rootly.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of action items returned |
 
-### `rootly_list_users`
+### Rootly List Users
 
 List users from Rootly with optional search and email filtering.
 
@@ -753,7 +753,7 @@ List users from Rootly with optional search and email filtering.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of users returned |
 
-### `rootly_list_on_calls`
+### Rootly List On-Calls
 
 List current on-call entries from Rootly with optional filtering.
 
@@ -782,7 +782,7 @@ List current on-call entries from Rootly with optional filtering.
 |   ↳ `endTime` | string | On-call end time |
 | `totalCount` | number | Total number of on-call entries returned |
 
-### `rootly_list_schedules`
+### Rootly List Schedules
 
 List on-call schedules from Rootly with optional search filtering.
 
@@ -808,7 +808,7 @@ List on-call schedules from Rootly with optional search filtering.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of schedules returned |
 
-### `rootly_list_escalation_policies`
+### Rootly List Escalation Policies
 
 List escalation policies from Rootly with optional search filtering.
 
@@ -836,7 +836,7 @@ List escalation policies from Rootly with optional search filtering.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of escalation policies returned |
 
-### `rootly_list_causes`
+### Rootly List Causes
 
 List causes from Rootly with optional search filtering.
 
@@ -863,7 +863,7 @@ List causes from Rootly with optional search filtering.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of causes returned |
 
-### `rootly_list_playbooks`
+### Rootly List Playbooks
 
 List playbooks from Rootly with pagination support.
 
@@ -888,7 +888,7 @@ List playbooks from Rootly with pagination support.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of playbooks returned |
 
-### `rootly_mitigate_incident`
+### Rootly Mitigate Incident
 
 Transition a Rootly incident to the mitigated state.
 
@@ -924,7 +924,7 @@ Transition a Rootly incident to the mitigated state.
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_resolve_incident`
+### Rootly Resolve Incident
 
 Transition a Rootly incident to the resolved state.
 
@@ -960,7 +960,7 @@ Transition a Rootly incident to the resolved state.
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_assign_incident_role`
+### Rootly Assign Incident Role
 
 Assign an incident role (e.g. commander) to a user on a Rootly incident.
 
@@ -997,7 +997,7 @@ Assign an incident role (e.g. commander) to a user on a Rootly incident.
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_unassign_incident_role`
+### Rootly Unassign Incident Role
 
 Remove an incident role assignment from a user on a Rootly incident.
 
@@ -1034,7 +1034,7 @@ Remove an incident role assignment from a user on a Rootly incident.
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_add_subscribers`
+### Rootly Add Subscribers
 
 Subscribe users to a Rootly incident so they receive updates.
 
@@ -1070,7 +1070,7 @@ Subscribe users to a Rootly incident so they receive updates.
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_remove_subscribers`
+### Rootly Remove Subscribers
 
 Unsubscribe users from a Rootly incident.
 
@@ -1106,7 +1106,7 @@ Unsubscribe users from a Rootly incident.
 |   ↳ `resolvedAt` | string | Resolution date |
 |   ↳ `closedAt` | string | Closed date |
 
-### `rootly_create_status_page_event`
+### Rootly Create Status Page Event
 
 Post a public status page update for a Rootly incident.
 
@@ -1137,7 +1137,7 @@ Post a public status page update for a Rootly incident.
 |   ↳ `createdAt` | string | Creation date |
 |   ↳ `updatedAt` | string | Last update date |
 
-### `rootly_update_action_item`
+### Rootly Update Action Item
 
 Update a Rootly incident action item (status, priority, assignee, etc.).
 
@@ -1170,7 +1170,7 @@ Update a Rootly incident action item (status, priority, assignee, etc.).
 |   ↳ `createdAt` | string | Creation date |
 |   ↳ `updatedAt` | string | Last update date |
 
-### `rootly_delete_action_item`
+### Rootly Delete Action Item
 
 Delete a Rootly incident action item.
 
@@ -1188,7 +1188,7 @@ Delete a Rootly incident action item.
 | `success` | boolean | Whether the action item was deleted |
 | `message` | string | Result message |
 
-### `rootly_snooze_alert`
+### Rootly Snooze Alert
 
 Snooze a Rootly alert for a set number of minutes.
 
@@ -1219,7 +1219,7 @@ Snooze a Rootly alert for a set number of minutes.
 |   ↳ `startedAt` | string | Start date |
 |   ↳ `endedAt` | string | End date |
 
-### `rootly_escalate_alert`
+### Rootly Escalate Alert
 
 Escalate a Rootly alert, optionally to a specific escalation policy or level.
 
@@ -1251,7 +1251,7 @@ Escalate a Rootly alert, optionally to a specific escalation policy or level.
 |   ↳ `startedAt` | string | Start date |
 |   ↳ `endedAt` | string | End date |
 
-### `rootly_list_incident_events`
+### Rootly List Incident Events
 
 List the timeline events for a Rootly incident.
 
@@ -1277,7 +1277,7 @@ List the timeline events for a Rootly incident.
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of events returned |
 
-### `rootly_run_workflow`
+### Rootly Run Workflow
 
 Trigger a Rootly automation workflow, optionally scoped to an incident or alert.
 
@@ -1309,7 +1309,7 @@ Trigger a Rootly automation workflow, optionally scoped to an incident or alert.
 |   ↳ `failedAt` | string | When the run failed |
 |   ↳ `canceledAt` | string | When the run was canceled |
 
-### `rootly_list_incident_roles`
+### Rootly List Incident Roles
 
 List incident roles configured in Rootly (e.g. commander, scribe).
 

--- a/apps/docs/content/docs/en/integrations/s3.mdx
+++ b/apps/docs/content/docs/en/integrations/s3.mdx
@@ -35,7 +35,7 @@ Integrate S3 into the workflow. Upload, download, copy, and delete objects (indi
 
 ## Actions
 
-### `s3_put_object`
+### S3 Put Object
 
 Upload a file to an AWS S3 bucket
 
@@ -61,7 +61,7 @@ Upload a file to an AWS S3 bucket
 | `uri` | string | S3 URI of the uploaded object \(s3://bucket/key\) |
 | `metadata` | object | Upload metadata including ETag and location |
 
-### `s3_get_object`
+### S3 Get Object
 
 Retrieve an object from an AWS S3 bucket
 
@@ -82,7 +82,7 @@ Retrieve an object from an AWS S3 bucket
 | `file` | file | Downloaded file stored in execution files |
 | `metadata` | object | File metadata including type, size, name, and last modified date |
 
-### `s3_list_objects`
+### S3 List Objects
 
 List objects in an AWS S3 bucket
 
@@ -109,7 +109,7 @@ List objects in an AWS S3 bucket
 |   ↳ `etag` | string | Entity tag |
 | `metadata` | object | Listing metadata including pagination info |
 
-### `s3_delete_object`
+### S3 Delete Object
 
 Delete an object from an AWS S3 bucket
 
@@ -130,7 +130,7 @@ Delete an object from an AWS S3 bucket
 | `deleted` | boolean | Whether the object was successfully deleted |
 | `metadata` | object | Deletion metadata |
 
-### `s3_copy_object`
+### S3 Copy Object
 
 Copy an object within or between AWS S3 buckets
 
@@ -155,7 +155,7 @@ Copy an object within or between AWS S3 buckets
 | `uri` | string | S3 URI of the copied object \(s3://bucket/key\) |
 | `metadata` | object | Copy operation metadata |
 
-### `s3_list_buckets`
+### S3 List Buckets
 
 List the S3 buckets owned by the authenticated AWS account
 
@@ -180,7 +180,7 @@ List the S3 buckets owned by the authenticated AWS account
 |   ↳ `region` | string | AWS region where the bucket is located |
 | `metadata` | object | Listing metadata including owner and pagination info |
 
-### `s3_head_object`
+### S3 Head Object
 
 Retrieve metadata for an S3 object without downloading its body
 
@@ -202,7 +202,7 @@ Retrieve metadata for an S3 object without downloading its body
 | `exists` | boolean | Whether the object exists and was reachable |
 | `metadata` | object | Object metadata including size, content type, ETag, and last modified date |
 
-### `s3_create_bucket`
+### S3 Create Bucket
 
 Create a new AWS S3 bucket in the specified region
 
@@ -222,7 +222,7 @@ Create a new AWS S3 bucket in the specified region
 | --------- | ---- | ----------- |
 | `metadata` | object | Created bucket metadata including name and location |
 
-### `s3_delete_bucket`
+### S3 Delete Bucket
 
 Delete an empty AWS S3 bucket
 
@@ -242,7 +242,7 @@ Delete an empty AWS S3 bucket
 | `deleted` | boolean | Whether the bucket was successfully deleted |
 | `metadata` | object | Deletion metadata including bucket name |
 
-### `s3_presigned_url`
+### S3 Presigned URL
 
 Generate a time-limited presigned URL to download or upload an S3 object
 
@@ -266,7 +266,7 @@ Generate a time-limited presigned URL to download or upload an S3 object
 | `url` | string | The generated presigned URL |
 | `metadata` | object | Presigned URL metadata including method and expiration |
 
-### `s3_delete_objects`
+### S3 Delete Objects
 
 Delete multiple objects from an AWS S3 bucket in a single batch request
 

--- a/apps/docs/content/docs/en/integrations/salesforce.mdx
+++ b/apps/docs/content/docs/en/integrations/salesforce.mdx
@@ -33,7 +33,7 @@ Integrate Salesforce into your workflow. Manage accounts, contacts, leads, oppor
 
 ## Actions
 
-### `salesforce_get_accounts`
+### Get Accounts from Salesforce
 
 Retrieve accounts from Salesforce CRM
 
@@ -63,7 +63,7 @@ Retrieve accounts from Salesforce CRM
 |   ↳ `accounts` | array | Array of account objects |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_create_account`
+### Create Account in Salesforce
 
 Create a new account in Salesforce CRM
 
@@ -97,7 +97,7 @@ Create a new account in Salesforce CRM
 |   ↳ `success` | boolean | Whether the create operation was successful |
 |   ↳ `created` | boolean | Whether the record was created \(always true on success\) |
 
-### `salesforce_update_account`
+### Update Account in Salesforce
 
 Update an existing account in Salesforce CRM
 
@@ -131,7 +131,7 @@ Update an existing account in Salesforce CRM
 |   ↳ `id` | string | The Salesforce ID of the updated record |
 |   ↳ `updated` | boolean | Whether the record was updated \(always true on success\) |
 
-### `salesforce_delete_account`
+### Delete Account from Salesforce
 
 Delete an account from Salesforce CRM
 
@@ -152,7 +152,7 @@ Delete an account from Salesforce CRM
 |   ↳ `id` | string | The Salesforce ID of the deleted record |
 |   ↳ `deleted` | boolean | Whether the record was deleted \(always true on success\) |
 
-### `salesforce_get_contacts`
+### Get Contacts from Salesforce
 
 Get contact(s) from Salesforce - single contact if ID provided, or list if not
 
@@ -185,7 +185,7 @@ Get contact(s) from Salesforce - single contact if ID provided, or list if not
 |   ↳ `singleContact` | boolean | Whether single contact was returned |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_create_contact`
+### Create Contact in Salesforce
 
 Create a new contact in Salesforce CRM
 
@@ -219,7 +219,7 @@ Create a new contact in Salesforce CRM
 |   ↳ `success` | boolean | Whether the create operation was successful |
 |   ↳ `created` | boolean | Whether the record was created \(always true on success\) |
 
-### `salesforce_update_contact`
+### Update Contact in Salesforce
 
 Update an existing contact in Salesforce CRM
 
@@ -253,7 +253,7 @@ Update an existing contact in Salesforce CRM
 |   ↳ `id` | string | The Salesforce ID of the updated record |
 |   ↳ `updated` | boolean | Whether the record was updated \(always true on success\) |
 
-### `salesforce_delete_contact`
+### Delete Contact from Salesforce
 
 Delete a contact from Salesforce CRM
 
@@ -274,7 +274,7 @@ Delete a contact from Salesforce CRM
 |   ↳ `id` | string | The Salesforce ID of the deleted record |
 |   ↳ `deleted` | boolean | Whether the record was deleted \(always true on success\) |
 
-### `salesforce_get_leads`
+### Get Leads from Salesforce
 
 Retrieve lead(s) from Salesforce CRM
 
@@ -307,7 +307,7 @@ Retrieve lead(s) from Salesforce CRM
 |   ↳ `singleLead` | boolean | Whether single lead was returned |
 |   ↳ `success` | boolean | Operation success status |
 
-### `salesforce_create_lead`
+### Create Lead in Salesforce
 
 Create a new lead
 
@@ -337,7 +337,7 @@ Create a new lead
 |   ↳ `success` | boolean | Whether the create operation was successful |
 |   ↳ `created` | boolean | Whether the record was created \(always true on success\) |
 
-### `salesforce_update_lead`
+### Update Lead in Salesforce
 
 Update an existing lead
 
@@ -367,7 +367,7 @@ Update an existing lead
 |   ↳ `id` | string | The Salesforce ID of the updated record |
 |   ↳ `updated` | boolean | Whether the record was updated \(always true on success\) |
 
-### `salesforce_delete_lead`
+### Delete Lead from Salesforce
 
 Delete a lead
 
@@ -388,7 +388,7 @@ Delete a lead
 |   ↳ `id` | string | The Salesforce ID of the deleted record |
 |   ↳ `deleted` | boolean | Whether the record was deleted \(always true on success\) |
 
-### `salesforce_get_opportunities`
+### Get Opportunities from Salesforce
 
 Get opportunity(ies) from Salesforce
 
@@ -420,7 +420,7 @@ Get opportunity(ies) from Salesforce
 |   ↳ `opportunities` | array | Array of opportunity objects \(when listing\) |
 |   ↳ `success` | boolean | Operation success status |
 
-### `salesforce_create_opportunity`
+### Create Opportunity in Salesforce
 
 Create a new opportunity
 
@@ -448,7 +448,7 @@ Create a new opportunity
 |   ↳ `success` | boolean | Whether the create operation was successful |
 |   ↳ `created` | boolean | Whether the record was created \(always true on success\) |
 
-### `salesforce_update_opportunity`
+### Update Opportunity in Salesforce
 
 Update an existing opportunity
 
@@ -476,7 +476,7 @@ Update an existing opportunity
 |   ↳ `id` | string | The Salesforce ID of the updated record |
 |   ↳ `updated` | boolean | Whether the record was updated \(always true on success\) |
 
-### `salesforce_delete_opportunity`
+### Delete Opportunity from Salesforce
 
 Delete an opportunity
 
@@ -497,7 +497,7 @@ Delete an opportunity
 |   ↳ `id` | string | The Salesforce ID of the deleted record |
 |   ↳ `deleted` | boolean | Whether the record was deleted \(always true on success\) |
 
-### `salesforce_get_cases`
+### Get Cases from Salesforce
 
 Get case(s) from Salesforce
 
@@ -529,7 +529,7 @@ Get case(s) from Salesforce
 |   ↳ `cases` | array | Array of case objects \(when listing\) |
 |   ↳ `success` | boolean | Operation success status |
 
-### `salesforce_create_case`
+### Create Case in Salesforce
 
 Create a new case
 
@@ -557,7 +557,7 @@ Create a new case
 |   ↳ `success` | boolean | Whether the create operation was successful |
 |   ↳ `created` | boolean | Whether the record was created \(always true on success\) |
 
-### `salesforce_update_case`
+### Update Case in Salesforce
 
 Update an existing case
 
@@ -585,7 +585,7 @@ Update an existing case
 |   ↳ `id` | string | The Salesforce ID of the updated record |
 |   ↳ `updated` | boolean | Whether the record was updated \(always true on success\) |
 
-### `salesforce_delete_case`
+### Delete Case from Salesforce
 
 Delete a case
 
@@ -606,7 +606,7 @@ Delete a case
 |   ↳ `id` | string | The Salesforce ID of the deleted record |
 |   ↳ `deleted` | boolean | Whether the record was deleted \(always true on success\) |
 
-### `salesforce_get_tasks`
+### Get Tasks from Salesforce
 
 Get task(s) from Salesforce
 
@@ -638,7 +638,7 @@ Get task(s) from Salesforce
 |   ↳ `tasks` | array | Array of task objects \(when listing\) |
 |   ↳ `success` | boolean | Operation success status |
 
-### `salesforce_create_task`
+### Create Task in Salesforce
 
 Create a new task
 
@@ -666,7 +666,7 @@ Create a new task
 |   ↳ `success` | boolean | Whether the create operation was successful |
 |   ↳ `created` | boolean | Whether the record was created \(always true on success\) |
 
-### `salesforce_update_task`
+### Update Task in Salesforce
 
 Update an existing task
 
@@ -694,7 +694,7 @@ Update an existing task
 |   ↳ `id` | string | The Salesforce ID of the updated record |
 |   ↳ `updated` | boolean | Whether the record was updated \(always true on success\) |
 
-### `salesforce_delete_task`
+### Delete Task from Salesforce
 
 Delete a task
 
@@ -715,7 +715,7 @@ Delete a task
 |   ↳ `id` | string | The Salesforce ID of the deleted record |
 |   ↳ `deleted` | boolean | Whether the record was deleted \(always true on success\) |
 
-### `salesforce_list_reports`
+### List Reports from Salesforce
 
 Get a list of up to 200 recently viewed reports for the current user
 
@@ -737,7 +737,7 @@ Get a list of up to 200 recently viewed reports for the current user
 |   ↳ `success` | boolean | Salesforce operation success |
 |   ↳ `reports` | array | Array of report objects |
 
-### `salesforce_get_report`
+### Get Report Metadata from Salesforce
 
 Get the describe (definition and metadata) for a specific report
 
@@ -759,7 +759,7 @@ Get the describe (definition and metadata) for a specific report
 |   ↳ `reportId` | string | Report ID |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_run_report`
+### Run Report in Salesforce
 
 Execute a report and retrieve the results
 
@@ -791,7 +791,7 @@ Execute a report and retrieve the results
 |   ↳ `reportFormat` | string | Report format type \(TABULAR, SUMMARY, MATRIX, JOINED\) |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_list_report_types`
+### List Report Types from Salesforce
 
 Get a list of available report types
 
@@ -812,7 +812,7 @@ Get a list of available report types
 |   ↳ `success` | boolean | Salesforce operation success |
 |   ↳ `reportTypes` | array | Array of report type objects |
 
-### `salesforce_list_dashboards`
+### List Dashboards from Salesforce
 
 Get a list of recently used dashboards for the current user
 
@@ -833,7 +833,7 @@ Get a list of recently used dashboards for the current user
 |   ↳ `success` | boolean | Salesforce operation success |
 |   ↳ `dashboards` | array | Array of dashboard objects |
 
-### `salesforce_get_dashboard`
+### Get Dashboard from Salesforce
 
 Get details and results for a specific dashboard
 
@@ -859,7 +859,7 @@ Get details and results for a specific dashboard
 |   ↳ `runningUser` | object | User context under which the dashboard data was retrieved |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_refresh_dashboard`
+### Refresh Dashboard in Salesforce
 
 Refresh a dashboard to get the latest data
 
@@ -886,7 +886,7 @@ Refresh a dashboard to get the latest data
 |   ↳ `dashboardMetadata` | object | Structured dashboard metadata \(attributes, component definitions, layout\) |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_query`
+### Run SOQL Query in Salesforce
 
 Execute a custom SOQL query to retrieve data from Salesforce
 
@@ -911,7 +911,7 @@ Execute a custom SOQL query to retrieve data from Salesforce
 |     ↳ `hasMore` | boolean | Whether more records exist \(inverse of done\) |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_query_more`
+### Get More Query Results from Salesforce
 
 Retrieve additional query results using the nextRecordsUrl from a previous query
 
@@ -935,7 +935,7 @@ Retrieve additional query results using the nextRecordsUrl from a previous query
 |     ↳ `hasMore` | boolean | Whether more records exist \(inverse of done\) |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_describe_object`
+### Describe Salesforce Object
 
 Get metadata and field information for a Salesforce object
 
@@ -990,7 +990,7 @@ Get metadata and field information for a Salesforce object
 |   ↳ `fieldCount` | number | Total number of fields on the object |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_list_objects`
+### List Salesforce Objects
 
 Get a list of all available Salesforce objects
 
@@ -1029,7 +1029,7 @@ Get a list of all available Salesforce objects
 |   ↳ `totalReturned` | number | Number of objects returned |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-### `salesforce_create_custom_field`
+### Create Custom Field in Salesforce
 
 Create a custom field on a Salesforce object (e.g., Account) using the Tooling API
 
@@ -1066,7 +1066,7 @@ Create a custom field on a Salesforce object (e.g., Account) using the Tooling A
 |   ↳ `success` | boolean | Whether the create operation was successful |
 |   ↳ `created` | boolean | Whether the field was created \(always true on success\) |
 
-### `salesforce_update_custom_field`
+### Update Custom Field in Salesforce
 
 Update an existing custom field on a Salesforce object using the Tooling API
 
@@ -1099,7 +1099,7 @@ Update an existing custom field on a Salesforce object using the Tooling API
 |   ↳ `id` | string | Tooling API Id of the updated custom field |
 |   ↳ `updated` | boolean | Whether the field was updated \(always true on success\) |
 
-### `salesforce_delete_custom_field`
+### Delete Custom Field in Salesforce
 
 Delete a custom field from a Salesforce object using the Tooling API
 
@@ -1120,7 +1120,7 @@ Delete a custom field from a Salesforce object using the Tooling API
 |   ↳ `id` | string | Tooling API Id of the deleted custom field |
 |   ↳ `deleted` | boolean | Whether the field was deleted \(always true on success\) |
 
-### `salesforce_create_custom_object`
+### Create Custom Object in Salesforce
 
 Create a custom object in Salesforce using the Tooling API
 
@@ -1148,7 +1148,7 @@ Create a custom object in Salesforce using the Tooling API
 |   ↳ `success` | boolean | Whether the create operation was successful |
 |   ↳ `created` | boolean | Whether the object was created \(always true on success\) |
 
-### `salesforce_tooling_query`
+### Run Tooling SOQL Query in Salesforce
 
 Execute a SOQL query against the Tooling API to inspect metadata objects
 

--- a/apps/docs/content/docs/en/integrations/sap_concur.mdx
+++ b/apps/docs/content/docs/en/integrations/sap_concur.mdx
@@ -40,7 +40,7 @@ Connect SAP Concur via OAuth 2.0. Manage expense reports and line items, allocat
 
 ## Actions
 
-### `sap_concur_approve_expense_report`
+### SAP Concur Approve Expense Report
 
 Approve an expense report as a manager (PATCH /expensereports/v4/reports/\{reportId\}/approve). Required body field: comment.
 
@@ -65,7 +65,7 @@ Approve an expense report as a manager (PATCH /expensereports/v4/reports/\{repor
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty \(204 No Content\) |
 
-### `sap_concur_associate_attendees`
+### SAP Concur Associate Attendees
 
 Associate attendees with an expense (POST /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/expenses/\{expenseId\}/attendees).
 
@@ -94,7 +94,7 @@ Associate attendees with an expense (POST /expensereports/v4/users/\{userId\}/co
 | `data` | json | Concur association response \(201 Created with URI\) |
 |   ↳ `uri` | string | Resource URI of the attendee associations collection |
 
-### `sap_concur_create_cash_advance`
+### SAP Concur Create Cash Advance
 
 Create a cash advance (POST /cashadvance/v4.1/cashadvances).
 
@@ -119,7 +119,7 @@ Create a cash advance (POST /cashadvance/v4.1/cashadvances).
 | `data` | json | Created cash advance payload |
 |   ↳ `cashAdvanceId` | string | Unique identifier of the created cash advance |
 
-### `sap_concur_create_expected_expense`
+### SAP Concur Create Expected Expense
 
 Create an expected expense on a travel request (POST /travelrequest/v4/requests/\{requestUuid\}/expenses).
 
@@ -160,7 +160,7 @@ Create an expected expense on a travel request (POST /travelrequest/v4/requests/
 |   ↳ `parentRequest` | json | Parent travel request resource link \{href, id\} |
 |   ↳ `comments` | json | Comments sub-resource link \{href, id\} |
 
-### `sap_concur_create_expense_report`
+### SAP Concur Create Expense Report
 
 Create an expense report (POST /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports — supported contexts: TRAVELER, PROXY). Required body fields: name, policyId.
 
@@ -187,7 +187,7 @@ Create an expense report (POST /expensereports/v4/users/\{userId\}/context/\{con
 | `data` | json | Created expense report \(Concur returns 201 with a URI to the new report\) |
 |   ↳ `uri` | string | URI of the newly created expense report |
 
-### `sap_concur_create_list_item`
+### SAP Concur Create List Item
 
 Create a list item (POST /list/v4/items).
 
@@ -221,7 +221,7 @@ Create a list item (POST /list/v4/items).
 |     ↳ `id` | string | List UUID |
 |     ↳ `hasChildren` | boolean | Whether this item has children in the list |
 
-### `sap_concur_create_purchase_request`
+### SAP Concur Create Purchase Request
 
 Create a purchase request (POST /purchaserequest/v4/purchaserequests).
 
@@ -251,7 +251,7 @@ Create a purchase request (POST /purchaserequest/v4/purchaserequests).
 |     ↳ `errorMessage` | string | Error message |
 |     ↳ `dataPath` | string | Path to the request data which has the error |
 
-### `sap_concur_create_quick_expense`
+### SAP Concur Create Quick Expense
 
 Create a quick expense (POST /quickexpense/v4/users/\{userId\}/context/TRAVELER/quickexpenses).
 
@@ -278,7 +278,7 @@ Create a quick expense (POST /quickexpense/v4/users/\{userId\}/context/TRAVELER/
 | `data` | json | Created quick expense response \(HTTP 201 Created\) |
 |   ↳ `quickExpenseIdUri` | string | URI of the created quick expense resource |
 
-### `sap_concur_create_quick_expense_with_image`
+### SAP Concur Create Quick Expense With Image
 
 Create a quick expense with an attached image (POST /quickexpense/v4/users/\{userId\}/context/\{contextType\}/quickexpenses/image).
 
@@ -306,7 +306,7 @@ Create a quick expense with an attached image (POST /quickexpense/v4/users/\{use
 | `data` | json | Created quick expense response \(HTTP 201 with attached receipt image\) |
 |   ↳ `quickExpenseIdUri` | string | URI of the created quick expense resource |
 
-### `sap_concur_create_report_comment`
+### SAP Concur Create Report Comment
 
 Create a comment on a report (POST /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/comments).
 
@@ -334,7 +334,7 @@ Create a comment on a report (POST /expensereports/v4/users/\{userId\}/context/\
 | `data` | json | Created comment response \(Concur returns 201 Created with URI\) |
 |   ↳ `uri` | string | Resource URI of the created comment |
 
-### `sap_concur_create_travel_request`
+### SAP Concur Create Travel Request
 
 Create a travel request (POST /travelrequest/v4/requests).
 
@@ -421,7 +421,7 @@ Create a travel request (POST /travelrequest/v4/requests).
 |   ↳ `custom3` | json | Custom field 3 |
 |   ↳ `custom4` | json | Custom field 4 |
 
-### `sap_concur_create_user`
+### SAP Concur Create User
 
 Create a new user identity (POST /profile/identity/v4.1/Users).
 
@@ -445,7 +445,7 @@ Create a new user identity (POST /profile/identity/v4.1/Users).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Created SCIM User payload |
 
-### `sap_concur_delete_expected_expense`
+### SAP Concur Delete Expected Expense
 
 Delete an expected expense (DELETE /travelrequest/v4/expenses/\{expenseUuid\}).
 
@@ -470,7 +470,7 @@ Delete an expected expense (DELETE /travelrequest/v4/expenses/\{expenseUuid\}).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Returns boolean true on 200 OK when the expected expense is deleted. |
 
-### `sap_concur_delete_expense`
+### SAP Concur Delete Expense
 
 Delete an expense (DELETE /expensereports/v4/reports/\{reportId\}/expenses/\{expenseId\}).
 
@@ -495,7 +495,7 @@ Delete an expense (DELETE /expensereports/v4/reports/\{reportId\}/expenses/\{exp
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty body on success \(HTTP 204 No Content\). Error details when status is non-2xx |
 
-### `sap_concur_delete_expense_report`
+### SAP Concur Delete Expense Report
 
 Delete an expense report (DELETE /expensereports/v4/reports/\{reportId\}).
 
@@ -519,7 +519,7 @@ Delete an expense report (DELETE /expensereports/v4/reports/\{reportId\}).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty \(204 No Content\) |
 
-### `sap_concur_delete_list_item`
+### SAP Concur Delete List Item
 
 Delete a list item (DELETE /list/v4/items/\{itemId\}).
 
@@ -543,7 +543,7 @@ Delete a list item (DELETE /list/v4/items/\{itemId\}).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty body on success \(HTTP 204 No Content\). Error details when status is non-2xx |
 
-### `sap_concur_delete_travel_request`
+### SAP Concur Delete Travel Request
 
 Delete a travel request (DELETE /travelrequest/v4/requests/\{requestUuid\}).
 
@@ -568,7 +568,7 @@ Delete a travel request (DELETE /travelrequest/v4/requests/\{requestUuid\}).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Concur delete response payload \(boolean true on 200 OK\) |
 
-### `sap_concur_delete_user`
+### SAP Concur Delete User
 
 Delete a user identity (DELETE /profile/identity/v4.1/Users/\{id\}).
 
@@ -592,7 +592,7 @@ Delete a user identity (DELETE /profile/identity/v4.1/Users/\{id\}).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Deletion response — empty body on HTTP 204 No Content |
 
-### `sap_concur_get_allocation`
+### SAP Concur Get Allocation
 
 Get a single allocation (GET /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/allocations/\{allocationId\}).
 
@@ -636,7 +636,7 @@ Get a single allocation (GET /expensereports/v4/users/\{userId\}/context/\{conte
 |   ↳ `isSystemAllocation` | boolean | True when system-managed |
 |   ↳ `isPercentEdited` | boolean | True when the percentage was manually edited |
 
-### `sap_concur_get_budget`
+### SAP Concur Get Budget
 
 Get a budget item header by ID (GET /budget/v4/budgetItemHeader/\{id\}).
 
@@ -684,7 +684,7 @@ Get a budget item header by ID (GET /budget/v4/budgetItemHeader/\{id\}).
 |   ↳ `budgetItemDetails` | array | Per-period detail entries \(id, currencyCode, amount, budgetItemDetailStatusType, fiscalPeriod, budgetAmounts\) |
 |   ↳ `dateRange` | json | Date range for DATE_RANGE budgets \(startDate, endDate\) |
 
-### `sap_concur_get_cash_advance`
+### SAP Concur Get Cash Advance
 
 Get a cash advance (GET /cashadvance/v4.1/cashadvances/\{cashAdvanceId\}).
 
@@ -733,7 +733,7 @@ Get a cash advance (GET /cashadvance/v4.1/cashadvances/\{cashAdvanceId\}).
 |     ↳ `paymentCode` | string | Payment type code |
 |     ↳ `description` | string | Payment method description |
 
-### `sap_concur_upload_exchange_rates`
+### SAP Concur Upload Exchange Rates
 
 Bulk upload up to 100 custom exchange rates (POST /exchangerate/v4/rates). Body contains a currency_sets array, each with from_crn_code, to_crn_code, start_date (YYYY-MM-DD), and rate.
 
@@ -760,7 +760,7 @@ Bulk upload up to 100 custom exchange rates (POST /exchangerate/v4/rates). Body 
 |   ↳ `message` | string | Top-level result message |
 |   ↳ `currencySets` | json | Per-row results: array of \{ from_crn_code, to_crn_code, start_date, rate, statusCode, statusMessage \} |
 
-### `sap_concur_get_expected_expense`
+### SAP Concur Get Expected Expense
 
 Get an expected expense (GET /travelrequest/v4/expenses/\{expenseUuid\}).
 
@@ -800,7 +800,7 @@ Get an expected expense (GET /travelrequest/v4/expenses/\{expenseUuid\}).
 |   ↳ `parentRequest` | json | Parent travel request resource link \{href, id\} |
 |   ↳ `comments` | json | Comments sub-resource link \{href, id\} |
 
-### `sap_concur_get_expense`
+### SAP Concur Get Expense
 
 Get a single expense (GET /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/expenses/\{expenseId\}).
 
@@ -878,7 +878,7 @@ Get a single expense (GET /expensereports/v4/users/\{userId\}/context/\{contextT
 |   ↳ `expenseSourceIdentifiers` | json | Source reference identifiers |
 |   ↳ `links` | json | HATEOAS links for the expense |
 
-### `sap_concur_get_expense_report`
+### SAP Concur Get Expense Report
 
 Retrieve a single expense report header by id via Expense Report v4 (/expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}).
 
@@ -972,7 +972,7 @@ Retrieve a single expense report header by id via Expense Report v4 (/expenserep
 |   ↳ `employee` | json | Employee object \{ employeeId, employeeUuid \} |
 |   ↳ `links` | array | HATEOAS links |
 
-### `sap_concur_get_itemizations`
+### SAP Concur Get Expense Itemizations
 
 Get expense itemizations (GET /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/expenses/\{expenseId\}/itemizations).
 
@@ -1020,7 +1020,7 @@ Get expense itemizations (GET /expensereports/v4/users/\{userId\}/context/\{cont
 |   ↳ `isPersonalExpense` | boolean | Personal expense |
 |   ↳ `links` | array | HATEOAS links |
 
-### `sap_concur_get_itinerary`
+### SAP Concur Get Trip
 
 Get a single trip/itinerary (GET /api/travel/trip/v1.1/\{tripID\}).
 
@@ -1070,7 +1070,7 @@ Get a single trip/itinerary (GET /api/travel/trip/v1.1/\{tripID\}).
 |   ↳ `RuleViolations` | array | Travel rule violations attached to the trip |
 |   ↳ `Bookings` | array | Bookings \(air/hotel/car/rail\) attached to the trip |
 
-### `sap_concur_get_list`
+### SAP Concur Get List
 
 Get a single custom list (GET /list/v4/lists/\{listId\}).
 
@@ -1106,7 +1106,7 @@ Get a single custom list (GET /list/v4/lists/\{listId\}).
 |   ↳ `managedBy` | string | Identifier of the managing application or service |
 |   ↳ `externalThreshold` | number | Threshold from where the level starts being external |
 
-### `sap_concur_get_list_item`
+### SAP Concur Get List Item
 
 Get a single list item (GET /list/v4/items/\{itemId\}).
 
@@ -1140,7 +1140,7 @@ Get a single list item (GET /list/v4/items/\{itemId\}).
 |     ↳ `id` | string | List UUID |
 |     ↳ `hasChildren` | boolean | Whether this item has children in the list |
 
-### `sap_concur_get_purchase_request`
+### SAP Concur Get Purchase Request
 
 Get a purchase request by ID (GET /purchaserequest/v4/purchaserequests/\{id\}).
 
@@ -1176,7 +1176,7 @@ Get a purchase request by ID (GET /purchaserequest/v4/purchaserequests/\{id\}).
 |     ↳ `prExceptionId` | string | Identifier of the exception record |
 |     ↳ `message` | string | Exception message |
 
-### `sap_concur_get_receipt`
+### SAP Concur Get Receipt
 
 Get a single receipt by ID (GET /receipts/v4/\{receiptId\}).
 
@@ -1208,7 +1208,7 @@ Get a single receipt by ID (GET /receipts/v4/\{receiptId\}).
 |   ↳ `self` | string | URL to this receipt resource |
 |   ↳ `template` | string | URL template for receipts |
 
-### `sap_concur_get_receipt_status`
+### SAP Concur Get Receipt Status
 
 Get receipt processing status (GET /receipts/v4/status/\{receiptId\}).
 
@@ -1237,7 +1237,7 @@ Get receipt processing status (GET /receipts/v4/status/\{receiptId\}).
 |     ↳ `message` | string | Log message |
 |     ↳ `timestamp` | string | Log timestamp |
 
-### `sap_concur_get_travel_profile`
+### SAP Concur Get Travel Profile
 
 Get a travel profile (GET /api/travelprofile/v2.0/profile). Returns the calling user by default; pass userid_type and userid_value to impersonate.
 
@@ -1288,7 +1288,7 @@ Get a travel profile (GET /api/travelprofile/v2.0/profile). Returns the calling 
 |   ↳ `LoginId` | string | Concur login id |
 |   ↳ `ProfileLastModifiedUTC` | string | UTC timestamp the profile was last modified |
 
-### `sap_concur_get_travel_request`
+### SAP Concur Get Travel Request
 
 Get a single travel request (GET /travelrequest/v4/requests/\{requestUuid\}).
 
@@ -1398,7 +1398,7 @@ Get a single travel request (GET /travelrequest/v4/requests/\{requestUuid\}).
 |   ↳ `custom3` | json | Custom field 3 |
 |   ↳ `custom4` | json | Custom field 4 |
 
-### `sap_concur_get_user`
+### SAP Concur Get User
 
 Get a single user by UUID (GET /profile/identity/v4.1/Users/\{id\}).
 
@@ -1424,7 +1424,7 @@ Get a single user by UUID (GET /profile/identity/v4.1/Users/\{id\}).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | SCIM User identity payload |
 
-### `sap_concur_issue_cash_advance`
+### SAP Concur Issue Cash Advance
 
 Issue a cash advance (POST /cashadvance/v4.1/cashadvances/\{cashAdvanceId\}/issue).
 
@@ -1453,7 +1453,7 @@ Issue a cash advance (POST /cashadvance/v4.1/cashadvances/\{cashAdvanceId\}/issu
 |     ↳ `code` | string | Status code |
 |     ↳ `name` | string | Status display name |
 
-### `sap_concur_list_allocations`
+### SAP Concur List Allocations
 
 List allocations on an expense (GET /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/expenses/\{expenseId\}/allocations).
 
@@ -1480,7 +1480,7 @@ List allocations on an expense (GET /expensereports/v4/users/\{userId\}/context/
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Allocations list payload |
 
-### `sap_concur_list_attendee_associations`
+### SAP Concur List Attendee Associations
 
 List attendees associated with an expense (GET /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/expenses/\{expenseId\}/attendees).
 
@@ -1525,7 +1525,7 @@ List attendees associated with an expense (GET /expensereports/v4/users/\{userId
 |       ↳ `isValid` | boolean | Whether the value passes validation |
 |       ↳ `listItemUrl` | string | HATEOAS link for list items |
 
-### `sap_concur_list_budget_categories`
+### SAP Concur List Budget Categories
 
 List budget categories (GET /budget/v4/budgetCategory).
 
@@ -1548,7 +1548,7 @@ List budget categories (GET /budget/v4/budgetCategory).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Budget categories collection payload |
 
-### `sap_concur_list_budgets`
+### SAP Concur List Budgets
 
 List budget item headers (GET /budget/v4/budgetItemHeader).
 
@@ -1577,7 +1577,7 @@ List budget item headers (GET /budget/v4/budgetItemHeader).
 |   ↳ `limit` | number | Page size |
 |   ↳ `totalCount` | number | Total result count |
 
-### `sap_concur_list_exceptions`
+### SAP Concur List Report Exceptions
 
 List exceptions on a report (GET /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/exceptions).
 
@@ -1610,7 +1610,7 @@ List exceptions on a report (GET /expensereports/v4/users/\{userId\}/context/\{c
 |   ↳ `allocationId` | string | Related allocation ID, if any |
 |   ↳ `parentExpenseId` | string | Parent expense ID for itemized entries |
 
-### `sap_concur_list_expected_expenses`
+### SAP Concur List Expected Expenses
 
 List expected expenses on a travel request (GET /travelrequest/v4/requests/\{requestUuid\}/expenses).
 
@@ -1635,7 +1635,7 @@ List expected expenses on a travel request (GET /travelrequest/v4/requests/\{req
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Array of expected expense objects. Each entry includes id, href, expenseType \{id,name\}, transactionDate, transactionAmount, postedAmount, approvedAmount, remainingAmount, businessPurpose, location, exchangeRate, allocations, tripData, parentRequest \{href, id\}, comments \{href, id\}. |
 
-### `sap_concur_list_expenses`
+### SAP Concur List Expenses
 
 List expenses on a report (GET /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/expenses).
 
@@ -1691,7 +1691,7 @@ List expenses on a report (GET /expensereports/v4/users/\{userId\}/context/\{con
 |   ↳ `expenseSourceIdentifiers` | json | Expense source identifiers |
 |   ↳ `links` | array | HATEOAS links |
 
-### `sap_concur_list_expense_reports`
+### SAP Concur List Expense Reports
 
 List expense reports (GET /api/v3.0/expense/reports). Returns a v3 envelope with Items and NextPage.
 
@@ -1753,7 +1753,7 @@ List expense reports (GET /api/v3.0/expense/reports). Returns a v3 envelope with
 |     ↳ `URI` | string | Self URI |
 |   ↳ `NextPage` | string | URI of the next page \(use as offset cursor\) |
 
-### `sap_concur_list_itineraries`
+### SAP Concur List Trips
 
 List travel trips/itineraries (GET /api/travel/trip/v1.1).
 
@@ -1815,7 +1815,7 @@ List travel trips/itineraries (GET /api/travel/trip/v1.1).
 |     ↳ `BookedByLastName` | string | Booker last name |
 |     ↳ `IsPersonal` | boolean | Personal trip flag |
 
-### `sap_concur_list_lists`
+### SAP Concur List Lists
 
 List custom lists (GET /list/v4/lists).
 
@@ -1866,7 +1866,7 @@ List custom lists (GET /list/v4/lists).
 |     ↳ `rel` | string | Link relation |
 |     ↳ `href` | string | Link URL |
 
-### `sap_concur_list_list_items`
+### SAP Concur List List Items
 
 List the top-level items (children) for a custom list (GET /list/v4/lists/\{listId\}/children).
 
@@ -1917,7 +1917,7 @@ List the top-level items (children) for a custom list (GET /list/v4/lists/\{list
 |     ↳ `rel` | string | Link relation |
 |     ↳ `href` | string | Link URL |
 
-### `sap_concur_list_receipts`
+### SAP Concur List Receipts
 
 List receipts for a user (GET /receipts/v4/users/\{userId\}).
 
@@ -1949,7 +1949,7 @@ List receipts for a user (GET /receipts/v4/users/\{userId\}).
 |   ↳ `self` | string | Self URL |
 |   ↳ `template` | string | Template URL |
 
-### `sap_concur_list_report_comments`
+### SAP Concur List Report Comments
 
 List comments on a report (GET /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/comments).
 
@@ -1989,7 +1989,7 @@ List comments on a report (GET /expensereports/v4/users/\{userId\}/context/\{con
 |     ↳ `employeeUuid` | string | Employee UUID |
 |   ↳ `stepInstanceId` | string | Workflow step instance identifier |
 
-### `sap_concur_list_reports_to_approve`
+### SAP Concur List Reports To Approve
 
 List expense reports awaiting approval (GET /expensereports/v4/users/\{userId\}/context/MANAGER/reportsToApprove).
 
@@ -2030,7 +2030,7 @@ List expense reports awaiting approval (GET /expensereports/v4/users/\{userId\}/
 |   ↳ `reportType` | string | Report creation method identifier |
 |   ↳ `links` | array | HATEOAS links |
 
-### `sap_concur_get_request_cash_advance`
+### SAP Concur Get Request Cash Advance
 
 Get a single cash advance assigned to a travel request (GET /travelrequest/v4/cashadvances/\{cashAdvanceUuid\}).
 
@@ -2066,7 +2066,7 @@ Get a single cash advance assigned to a travel request (GET /travelrequest/v4/ca
 |     ↳ `value` | number | Rate value |
 |     ↳ `operation` | string | Multiply or divide |
 
-### `sap_concur_list_travel_profiles_summary`
+### SAP Concur List Travel Profiles Summary
 
 List travel profile summaries (GET /api/travelprofile/v2.0/summary). LastModifiedDate is required by Concur.
 
@@ -2111,7 +2111,7 @@ List travel profile summaries (GET /api/travelprofile/v2.0/summary). LastModifie
 |     ↳ `EmployeeID` | string | Employee ID |
 |     ↳ `CompanyID` | string | Company ID |
 
-### `sap_concur_list_travel_request_comments`
+### SAP Concur List Travel Request Comments
 
 List comments on a travel request (GET /travelrequest/v4/requests/\{requestUuid\}/comments).
 
@@ -2141,7 +2141,7 @@ List comments on a travel request (GET /travelrequest/v4/requests/\{requestUuid\
 |   ↳ `isLatest` | boolean | Whether this is the latest comment |
 |   ↳ `value` | string | Comment text |
 
-### `sap_concur_list_travel_requests`
+### SAP Concur List Travel Requests
 
 List travel requests (GET /travelrequest/v4/requests).
 
@@ -2220,7 +2220,7 @@ List travel requests (GET /travelrequest/v4/requests).
 |     ↳ `method` | string | HTTP method |
 |     ↳ `name` | string | Link name |
 
-### `sap_concur_list_users`
+### SAP Concur List Users
 
 List Concur user identities (GET /profile/identity/v4.1/Users).
 
@@ -2247,7 +2247,7 @@ List Concur user identities (GET /profile/identity/v4.1/Users).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | SCIM ListResponse with Resources array |
 
-### `sap_concur_move_travel_request`
+### SAP Concur Move Travel Request
 
 Move a travel request through workflow (POST /travelrequest/v4/requests/\{requestUuid\}/\{action\}). Valid actions: submit, recall, cancel, approve, sendback, close, reopen.
 
@@ -2288,7 +2288,7 @@ Move a travel request through workflow (POST /travelrequest/v4/requests/\{reques
 |     ↳ `method` | string | HTTP method |
 |     ↳ `name` | string | Link name |
 
-### `sap_concur_recall_expense_report`
+### SAP Concur Recall Expense Report
 
 Recall a submitted expense report (PATCH /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/recall — supported contexts: TRAVELER, PROXY). No request body is required.
 
@@ -2315,7 +2315,7 @@ Recall a submitted expense report (PATCH /expensereports/v4/users/\{userId\}/con
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty \(204 No Content\) |
 
-### `sap_concur_remove_all_attendees`
+### SAP Concur Remove All Attendees
 
 Remove all attendees from an expense (DELETE /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/expenses/\{expenseId\}/attendees).
 
@@ -2342,7 +2342,7 @@ Remove all attendees from an expense (DELETE /expensereports/v4/users/\{userId\}
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty response body \(Concur returns 204 No Content\) |
 
-### `sap_concur_search_locations`
+### SAP Concur Search Locations
 
 Search Concur location reference data (GET /localities/v5/locations).
 
@@ -2398,7 +2398,7 @@ Search Concur location reference data (GET /localities/v5/locations).
 |       ↳ `name` | string | Subdivision name |
 |     ↳ `links` | array | HATEOAS links |
 
-### `sap_concur_search_users`
+### SAP Concur Search Users
 
 Search users via SCIM .search endpoint (POST /profile/identity/v4.1/Users/.search).
 
@@ -2422,7 +2422,7 @@ Search users via SCIM .search endpoint (POST /profile/identity/v4.1/Users/.searc
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | SCIM search ListResponse |
 
-### `sap_concur_send_back_expense_report`
+### SAP Concur Send Back Expense Report
 
 Send back an expense report to the employee (PATCH /expensereports/v4/reports/\{reportId\}/sendBack). Required body field: comment.
 
@@ -2447,7 +2447,7 @@ Send back an expense report to the employee (PATCH /expensereports/v4/reports/\{
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty \(204 No Content\) |
 
-### `sap_concur_submit_expense_report`
+### SAP Concur Submit Expense Report
 
 Submit an expense report into the workflow via Expense Report v4 (PATCH /expensereports/v4/users/\{userId\}/reports/\{reportId\}/submit).
 
@@ -2473,7 +2473,7 @@ Submit an expense report into the workflow via Expense Report v4 (PATCH /expense
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty \(204 No Content\) |
 
-### `sap_concur_update_allocation`
+### SAP Concur Update Allocation
 
 Update an allocation (PATCH /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\}/allocations/\{allocationId\}).
 
@@ -2501,7 +2501,7 @@ Update an allocation (PATCH /expensereports/v4/users/\{userId\}/context/\{contex
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty body on success \(Concur returns 204 No Content\) |
 
-### `sap_concur_update_expected_expense`
+### SAP Concur Update Expected Expense
 
 Update an expected expense (PUT /travelrequest/v4/expenses/\{expenseUuid\}).
 
@@ -2542,7 +2542,7 @@ Update an expected expense (PUT /travelrequest/v4/expenses/\{expenseUuid\}).
 |   ↳ `parentRequest` | json | Parent travel request resource link \{href, id\} |
 |   ↳ `comments` | json | Comments sub-resource link \{href, id\} |
 
-### `sap_concur_update_expense`
+### SAP Concur Update Expense
 
 Update an expense (PATCH /expensereports/v4/reports/\{reportId\}/expenses/\{expenseId\}).
 
@@ -2568,7 +2568,7 @@ Update an expense (PATCH /expensereports/v4/reports/\{reportId\}/expenses/\{expe
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty body on success \(HTTP 204 No Content\). Error details when status is non-2xx |
 
-### `sap_concur_update_expense_report`
+### SAP Concur Update Expense Report
 
 Update an unsubmitted expense report (PATCH /expensereports/v4/users/\{userId\}/context/\{contextType\}/reports/\{reportId\} — supported contexts: TRAVELER, PROXY). Body fields: businessPurpose, comment, customData, name, etc.
 
@@ -2595,7 +2595,7 @@ Update an unsubmitted expense report (PATCH /expensereports/v4/users/\{userId\}/
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Empty \(204 No Content\) |
 
-### `sap_concur_update_list_item`
+### SAP Concur Update List Item
 
 Update a list item (PUT /list/v4/items/\{itemId\}).
 
@@ -2630,7 +2630,7 @@ Update a list item (PUT /list/v4/items/\{itemId\}).
 |     ↳ `id` | string | List UUID |
 |     ↳ `hasChildren` | boolean | Whether this item has children in the list |
 
-### `sap_concur_update_travel_request`
+### SAP Concur Update Travel Request
 
 Update a travel request (PUT /travelrequest/v4/requests/\{requestUuid\}).
 
@@ -2705,7 +2705,7 @@ Update a travel request (PUT /travelrequest/v4/requests/\{requestUuid\}).
 |     ↳ `currency` | string | Currency code |
 |   ↳ `operations` | array | Available workflow actions |
 
-### `sap_concur_update_user`
+### SAP Concur Update User
 
 Patch a user identity (PATCH /profile/identity/v4.1/Users/\{id\}).
 
@@ -2730,7 +2730,7 @@ Patch a user identity (PATCH /profile/identity/v4.1/Users/\{id\}).
 | `status` | number | HTTP status code returned by Concur |
 | `data` | json | Updated SCIM User payload |
 
-### `sap_concur_upload_receipt_image`
+### SAP Concur Upload Receipt Image
 
 Upload an image-only receipt (POST /receipts/v4/users/\{userId\}/image-only-receipts).
 

--- a/apps/docs/content/docs/en/integrations/sap_s4hana.mdx
+++ b/apps/docs/content/docs/en/integrations/sap_s4hana.mdx
@@ -54,7 +54,7 @@ Connect SAP S4HANA Cloud Public Edition with per-tenant OAuth 2.0 client credent
 
 ## Actions
 
-### `sap_s4hana_list_business_partners`
+### SAP S/4HANA List Business Partners
 
 List business partners from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_BusinessPartner) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -101,7 +101,7 @@ List business partners from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_BusinessP
 |   ↳ `LastChangeDate` | string | Date of last change \(OData /Date\(...\)/ literal\) |
 |   ↳ `LastChangedByUser` | string | User who last changed the business partner |
 
-### `sap_s4hana_get_business_partner`
+### SAP S/4HANA Get Business Partner
 
 Retrieve a single business partner by BusinessPartner key from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_BusinessPartner).
 
@@ -147,7 +147,7 @@ Retrieve a single business partner by BusinessPartner key from SAP S/4HANA Cloud
 |   ↳ `LastChangeDate` | string | Date of last change \(OData /Date\(...\)/ literal\) |
 |   ↳ `LastChangedByUser` | string | User who last changed the business partner |
 
-### `sap_s4hana_create_business_partner`
+### SAP S/4HANA Create Business Partner
 
 Create a business partner in SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_BusinessPartner). For Person category 1 provide FirstName and LastName. For Organization category 2 provide OrganizationBPName1.
 
@@ -191,7 +191,7 @@ Create a business partner in SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_Business
 |   ↳ `CreatedByUser` | string | User who created the business partner |
 |   ↳ `LastChangeDate` | string | Date of last change \(OData /Date\(...\)/ literal\) |
 
-### `sap_s4hana_update_business_partner`
+### SAP S/4HANA Update Business Partner
 
 Update fields on an A_BusinessPartner entity in SAP S/4HANA Cloud (API_BUSINESS_PARTNER). Uses HTTP MERGE (OData v2 partial update) — only the fields you provide are written; existing values are preserved. If-Match defaults to a wildcard (unconditional) — for safe concurrent updates pass the ETag from a prior GET to avoid lost updates. Deep updates on nested associations (e.g. to_BusinessPartnerAddress) are not supported by SAP (KBA 2833338) — use the dedicated child endpoints.
 
@@ -229,7 +229,7 @@ Update fields on an A_BusinessPartner entity in SAP S/4HANA Cloud (API_BUSINESS_
 |   ↳ `LastChangeDate` | string | Date of last change \(OData /Date\(...\)/ literal\) |
 |   ↳ `LastChangedByUser` | string | User who last changed the business partner |
 
-### `sap_s4hana_list_customers`
+### SAP S/4HANA List Customers
 
 List customers from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_Customer) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -284,7 +284,7 @@ List customers from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_Customer) with op
 |   ↳ `CreationDate` | string | Creation date \(OData v2 epoch\) |
 |   ↳ `CreatedByUser` | string | User who created the customer |
 
-### `sap_s4hana_get_customer`
+### SAP S/4HANA Get Customer
 
 Retrieve a single customer by Customer key from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_Customer).
 
@@ -336,7 +336,7 @@ Retrieve a single customer by Customer key from SAP S/4HANA Cloud (API_BUSINESS_
 |   ↳ `CreationDate` | string | Creation date \(OData v2 epoch\) |
 |   ↳ `CreatedByUser` | string | User who created the customer |
 
-### `sap_s4hana_update_customer`
+### SAP S/4HANA Update Customer
 
 Update fields on an A_Customer entity in SAP S/4HANA Cloud (API_BUSINESS_PARTNER). Uses HTTP MERGE (OData v2 partial update) — only the fields you provide are written; existing values are preserved. A_Customer is limited to modifiable fields such as OrderIsBlockedForCustomer, DeliveryIsBlocked, BillingIsBlockedForCustomer (Edm.String reason codes like "01"), PostingIsBlocked, and DeletionIndicator (Edm.Boolean). If-Match defaults to a wildcard - for safe concurrent updates pass the ETag from a prior GET to avoid lost updates.
 
@@ -373,7 +373,7 @@ Update fields on an A_Customer entity in SAP S/4HANA Cloud (API_BUSINESS_PARTNER
 |   ↳ `DeliveryIsBlocked` | string | Central delivery block reason code |
 |   ↳ `BillingIsBlockedForCustomer` | string | Central billing block reason code |
 
-### `sap_s4hana_list_suppliers`
+### SAP S/4HANA List Suppliers
 
 List suppliers from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_Supplier) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -445,7 +445,7 @@ List suppliers from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_Supplier) with op
 |       ↳ `VATRegistration` | string | VAT registration number |
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 
-### `sap_s4hana_get_supplier`
+### SAP S/4HANA Get Supplier
 
 Retrieve a single supplier by Supplier key from SAP S/4HANA Cloud (API_BUSINESS_PARTNER, A_Supplier).
 
@@ -512,7 +512,7 @@ Retrieve a single supplier by Supplier key from SAP S/4HANA Cloud (API_BUSINESS_
 |     ↳ `TaxNumberType` | string | Tax number type |
 |     ↳ `VATRegistration` | string | VAT registration number |
 
-### `sap_s4hana_update_supplier`
+### SAP S/4HANA Update Supplier
 
 Update fields on an A_Supplier entity in SAP S/4HANA Cloud (API_BUSINESS_PARTNER). Uses HTTP MERGE (OData v2 partial update) — only the fields you provide are written; existing values are preserved. A_Supplier is limited to modifiable fields such as PostingIsBlocked, PurchasingIsBlocked, PaymentIsBlockedForSupplier, DeletionIndicator, and SupplierAccountGroup; company-code/purchasing-org segments must be updated via the `to_SupplierCompany` / `to_SupplierPurchasingOrg` deep-update endpoints. If-Match defaults to a wildcard - for safe concurrent updates pass the ETag from a prior GET to avoid lost updates.
 
@@ -550,7 +550,7 @@ Update fields on an A_Supplier entity in SAP S/4HANA Cloud (API_BUSINESS_PARTNER
 |     ↳ `PurchasingIsBlocked` | boolean | Purchasing block flag |
 |     ↳ `DeletionIndicator` | boolean | Central deletion flag |
 
-### `sap_s4hana_list_sales_orders`
+### SAP S/4HANA List Sales Orders
 
 List sales orders from SAP S/4HANA Cloud (API_SALES_ORDER_SRV, A_SalesOrder) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -601,7 +601,7 @@ List sales orders from SAP S/4HANA Cloud (API_SALES_ORDER_SRV, A_SalesOrder) wit
 |       ↳ `OverallSDDocumentRejectionSts` | string | Overall sales document rejection status |
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 
-### `sap_s4hana_get_sales_order`
+### SAP S/4HANA Get Sales Order
 
 Retrieve a single sales order by SalesOrder key from SAP S/4HANA Cloud (API_SALES_ORDER_SRV, A_SalesOrder).
 
@@ -650,7 +650,7 @@ Retrieve a single sales order by SalesOrder key from SAP S/4HANA Cloud (API_SALE
 |     ↳ `OverallSDDocumentRejectionSts` | string | Overall sales document rejection status |
 |     ↳ `to_Item` | json | Sales order items \(when $expand=to_Item\) |
 
-### `sap_s4hana_create_sales_order`
+### SAP S/4HANA Create Sales Order
 
 Create a sales order in SAP S/4HANA Cloud (API_SALES_ORDER_SRV, A_SalesOrder) with deep insert of sales order items via to_Item.
 
@@ -696,7 +696,7 @@ Create a sales order in SAP S/4HANA Cloud (API_SALES_ORDER_SRV, A_SalesOrder) wi
 |     ↳ `OverallTotalDeliveryStatus` | string | Overall total delivery status |
 |     ↳ `to_Item` | json | Deep-inserted sales order items as returned by SAP |
 
-### `sap_s4hana_update_sales_order`
+### SAP S/4HANA Update Sales Order
 
 Update fields on an A_SalesOrder header in SAP S/4HANA Cloud (API_SALES_ORDER_SRV). Uses HTTP MERGE (OData v2 partial update) — only the fields you provide are written; existing values are preserved. Header-only — deep updates to to_Item / to_Partner / to_PricingElement navigations are not supported (see SAP KBA 2833338); use A_SalesOrderItem operations for line-level changes. If-Match defaults to a wildcard (unconditional) — for safe concurrent updates pass the ETag from a prior GET to avoid lost updates.
 
@@ -731,7 +731,7 @@ Update fields on an A_SalesOrder header in SAP S/4HANA Cloud (API_SALES_ORDER_SR
 |     ↳ `OverallSDProcessStatus` | string | Overall sales document process status |
 |     ↳ `OverallTotalDeliveryStatus` | string | Overall total delivery status |
 
-### `sap_s4hana_delete_sales_order`
+### SAP S/4HANA Delete Sales Order
 
 Delete an A_SalesOrder entity in SAP S/4HANA Cloud (API_SALES_ORDER_SRV). Only orders without subsequent documents (deliveries, invoices) can be deleted; otherwise reject items via update instead.
 
@@ -759,7 +759,7 @@ Delete an A_SalesOrder entity in SAP S/4HANA Cloud (API_SALES_ORDER_SRV). Only o
 | `status` | number | HTTP status code returned by SAP \(204 on success\) |
 | `data` | json | Null on successful deletion \(SAP returns 204 No Content\) |
 
-### `sap_s4hana_list_outbound_deliveries`
+### SAP S/4HANA List Outbound Deliveries
 
 List outbound deliveries from SAP S/4HANA Cloud (API_OUTBOUND_DELIVERY_SRV;v=0002, A_OutbDeliveryHeader) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -811,7 +811,7 @@ List outbound deliveries from SAP S/4HANA Cloud (API_OUTBOUND_DELIVERY_SRV;v=000
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 |     ↳ `__count` | string | Total count when $inlinecount=allpages is used |
 
-### `sap_s4hana_get_outbound_delivery`
+### SAP S/4HANA Get Outbound Delivery
 
 Retrieve a single outbound delivery by DeliveryDocument key from SAP S/4HANA Cloud (API_OUTBOUND_DELIVERY_SRV;v=0002, A_OutbDeliveryHeader).
 
@@ -859,7 +859,7 @@ Retrieve a single outbound delivery by DeliveryDocument key from SAP S/4HANA Clo
 |     ↳ `to_DeliveryDocumentItem` | json | Delivery items \(when $expand=to_DeliveryDocumentItem\) |
 |     ↳ `to_DeliveryDocumentPartner` | json | Delivery partners \(when $expand=to_DeliveryDocumentPartner\) |
 
-### `sap_s4hana_list_inbound_deliveries`
+### SAP S/4HANA List Inbound Deliveries
 
 List inbound deliveries from SAP S/4HANA Cloud (API_INBOUND_DELIVERY_SRV;v=0002, A_InbDeliveryHeader) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -909,7 +909,7 @@ List inbound deliveries from SAP S/4HANA Cloud (API_INBOUND_DELIVERY_SRV;v=0002,
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 |     ↳ `__count` | string | Total count when $inlinecount=allpages is used |
 
-### `sap_s4hana_get_inbound_delivery`
+### SAP S/4HANA Get Inbound Delivery
 
 Retrieve a single inbound delivery by DeliveryDocument key from SAP S/4HANA Cloud (API_INBOUND_DELIVERY_SRV;v=0002, A_InbDeliveryHeader).
 
@@ -955,7 +955,7 @@ Retrieve a single inbound delivery by DeliveryDocument key from SAP S/4HANA Clou
 |     ↳ `to_DeliveryDocumentItem` | json | Delivery items \(when $expand=to_DeliveryDocumentItem\) |
 |     ↳ `to_DeliveryDocumentPartner` | json | Delivery partners \(when $expand=to_DeliveryDocumentPartner\) |
 
-### `sap_s4hana_list_billing_documents`
+### SAP S/4HANA List Billing Documents
 
 List billing documents (customer invoices) from SAP S/4HANA Cloud (API_BILLING_DOCUMENT_SRV, A_BillingDocument) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -1020,7 +1020,7 @@ List billing documents (customer invoices) from SAP S/4HANA Cloud (API_BILLING_D
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 |     ↳ `__count` | string | Total count when $inlinecount=allpages is used |
 
-### `sap_s4hana_get_billing_document`
+### SAP S/4HANA Get Billing Document
 
 Retrieve a single billing document (customer invoice) by BillingDocument key from SAP S/4HANA Cloud (API_BILLING_DOCUMENT_SRV, A_BillingDocument).
 
@@ -1082,7 +1082,7 @@ Retrieve a single billing document (customer invoice) by BillingDocument key fro
 |     ↳ `to_Partner` | json | Billing document partners \(when $expand=to_Partner\) |
 |     ↳ `to_PricingElement` | json | Billing document pricing elements \(when $expand=to_PricingElement\) |
 
-### `sap_s4hana_list_products`
+### SAP S/4HANA List Products
 
 List products (materials) from SAP S/4HANA Cloud (API_PRODUCT_SRV, A_Product) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -1137,7 +1137,7 @@ List products (materials) from SAP S/4HANA Cloud (API_PRODUCT_SRV, A_Product) wi
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 |     ↳ `__count` | string | Total count when $inlinecount=allpages is used |
 
-### `sap_s4hana_get_product`
+### SAP S/4HANA Get Product
 
 Retrieve a single product (material) by Product key from SAP S/4HANA Cloud (API_PRODUCT_SRV, A_Product).
 
@@ -1189,7 +1189,7 @@ Retrieve a single product (material) by Product key from SAP S/4HANA Cloud (API_
 |     ↳ `to_Plant` | json | Plant-level data \(when $expand=to_Plant\) |
 |     ↳ `to_ProductSales` | json | Sales data \(when $expand=to_ProductSales\) |
 
-### `sap_s4hana_update_product`
+### SAP S/4HANA Update Product
 
 Update fields on an A_Product entity in SAP S/4HANA Cloud (API_PRODUCT_SRV). Uses HTTP MERGE (OData v2 partial update) — only the fields you provide are written; existing values are preserved. Flat scalar header fields only — deep/multi-entity updates across navigation properties are not supported by API_PRODUCT_SRV MERGE/PUT (see SAP KBA 2833338); update child entities (plant, valuation, sales data, etc.) via their own endpoints. If-Match defaults to a wildcard (unconditional) — for safe concurrent updates pass the ETag from a prior GET.
 
@@ -1225,7 +1225,7 @@ Update fields on an A_Product entity in SAP S/4HANA Cloud (API_PRODUCT_SRV). Use
 |     ↳ `IsMarkedForDeletion` | boolean | Deletion flag |
 |     ↳ `LastChangeDate` | string | Last change date |
 
-### `sap_s4hana_list_material_stock`
+### SAP S/4HANA List Material Stock
 
 List material stock quantities from SAP S/4HANA Cloud (API_MATERIAL_STOCK_SRV, A_MatlStkInAcctMod). The entity uses an 11-field composite key (Material, Plant, StorageLocation, Batch, Supplier, Customer, WBSElementInternalID, SDDocument, SDDocumentItem, InventorySpecialStockType, InventoryStockType) — query with $filter on these fields instead of a direct key lookup.
 
@@ -1270,7 +1270,7 @@ List material stock quantities from SAP S/4HANA Cloud (API_MATERIAL_STOCK_SRV, A
 |   ↳ `MatlWrhsStkQtyInMatlBaseUnit` | string | Material warehouse stock quantity in material base unit \(Edm.Decimal serialized as string\) |
 |   ↳ `MaterialBaseUnit` | string | Material base unit of measure |
 
-### `sap_s4hana_list_material_documents`
+### SAP S/4HANA List Material Documents
 
 List material document headers (goods movements) from SAP S/4HANA Cloud (API_MATERIAL_DOCUMENT_SRV, A_MaterialDocumentHeader) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -1317,7 +1317,7 @@ List material document headers (goods movements) from SAP S/4HANA Cloud (API_MAT
 |   ↳ `CtrlPostgForExtWhseMgmtSyst` | string | Control posting for external warehouse management system |
 |   ↳ `to_MaterialDocumentItem` | json | Material document items \(only present when $expand=to_MaterialDocumentItem is supplied\) |
 
-### `sap_s4hana_get_material_document`
+### SAP S/4HANA Get Material Document
 
 Retrieve a single material document header by composite key (MaterialDocument + MaterialDocumentYear) from SAP S/4HANA Cloud (API_MATERIAL_DOCUMENT_SRV, A_MaterialDocumentHeader).
 
@@ -1362,7 +1362,7 @@ Retrieve a single material document header by composite key (MaterialDocument + 
 |   ↳ `CtrlPostgForExtWhseMgmtSyst` | string | Control posting for external warehouse management system |
 |   ↳ `to_MaterialDocumentItem` | json | Material document items \(only present when $expand=to_MaterialDocumentItem is supplied\) |
 
-### `sap_s4hana_list_purchase_requisitions`
+### SAP S/4HANA List Purchase Requisitions
 
 List purchase requisitions from SAP S/4HANA Cloud (API_PURCHASEREQ_PROCESS_SRV, A_PurchaseRequisitionHeader) with optional OData $filter, $top, $skip, $orderby, $select, $expand. Note: API_PURCHASEREQ_PROCESS_SRV is deprecated since S/4HANA Cloud Public Edition 2402; the successor is API_PURCHASEREQUISITION_2 (OData v4). This tool still works against tenants where the legacy service is enabled.
 
@@ -1401,7 +1401,7 @@ List purchase requisitions from SAP S/4HANA Cloud (API_PURCHASEREQ_PROCESS_SRV, 
 |       ↳ `SourceDetermination` | string | Source-of-supply determination flag |
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 
-### `sap_s4hana_get_purchase_requisition`
+### SAP S/4HANA Get Purchase Requisition
 
 Retrieve a single purchase requisition by PurchaseRequisition key from SAP S/4HANA Cloud (API_PURCHASEREQ_PROCESS_SRV, A_PurchaseRequisitionHeader). Note: API_PURCHASEREQ_PROCESS_SRV is deprecated since S/4HANA Cloud Public Edition 2402; the successor is API_PURCHASEREQUISITION_2 (OData v4). This tool still works against tenants where the legacy service is enabled.
 
@@ -1436,7 +1436,7 @@ Retrieve a single purchase requisition by PurchaseRequisition key from SAP S/4HA
 |     ↳ `SourceDetermination` | string | Source-of-supply determination flag |
 |     ↳ `to_PurchaseReqnItem` | json | Expanded PR items \(when $expand=to_PurchaseReqnItem\) |
 
-### `sap_s4hana_create_purchase_requisition`
+### SAP S/4HANA Create Purchase Requisition
 
 Create a purchase requisition in SAP S/4HANA Cloud (API_PURCHASEREQ_PROCESS_SRV, A_PurchaseRequisitionHeader). PurchaseRequisition is auto-assigned by SAP from the document number range; provide line items via the to_PurchaseReqnItem deep-insert array. Note: API_PURCHASEREQ_PROCESS_SRV is deprecated since S/4HANA Cloud Public Edition 2402; the successor is API_PURCHASEREQUISITION_2 (OData v4). This tool still works against tenants where the legacy service is enabled.
 
@@ -1471,7 +1471,7 @@ Create a purchase requisition in SAP S/4HANA Cloud (API_PURCHASEREQ_PROCESS_SRV,
 |     ↳ `SourceDetermination` | string | Source-of-supply determination flag |
 |     ↳ `to_PurchaseReqnItem` | json | Created PR items returned in deep insert |
 
-### `sap_s4hana_update_purchase_requisition`
+### SAP S/4HANA Update Purchase Requisition
 
 Update fields on an A_PurchaseRequisitionHeader entity in SAP S/4HANA Cloud (API_PURCHASEREQ_PROCESS_SRV; deprecated since S/4HANA 2402, successor is API_PURCHASEREQUISITION_2 OData v4). Uses HTTP MERGE (OData v2 partial update) — only the fields you provide are written; existing values are preserved. Header-only — deep updates across navigations are not supported (SAP KBA 2833338); use the A_PurchaseReqnItem entity directly to modify items. If-Match defaults to a wildcard - for safe concurrent updates pass the ETag from a prior GET to avoid lost updates.
 
@@ -1505,7 +1505,7 @@ Update fields on an A_PurchaseRequisitionHeader entity in SAP S/4HANA Cloud (API
 |     ↳ `PurReqnDescription` | string | Purchase requisition description |
 |     ↳ `SourceDetermination` | string | Source-of-supply determination flag |
 
-### `sap_s4hana_list_purchase_orders`
+### SAP S/4HANA List Purchase Orders
 
 List purchase orders from SAP S/4HANA Cloud (API_PURCHASEORDER_PROCESS_SRV, A_PurchaseOrder) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -1552,7 +1552,7 @@ List purchase orders from SAP S/4HANA Cloud (API_PURCHASEORDER_PROCESS_SRV, A_Pu
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 |     ↳ `__count` | string | Total count when $inlinecount=allpages is used |
 
-### `sap_s4hana_get_purchase_order`
+### SAP S/4HANA Get Purchase Order
 
 Retrieve a single purchase order by PurchaseOrder key from SAP S/4HANA Cloud (API_PURCHASEORDER_PROCESS_SRV, A_PurchaseOrder).
 
@@ -1599,7 +1599,7 @@ Retrieve a single purchase order by PurchaseOrder key from SAP S/4HANA Cloud (AP
 |     ↳ `LastChangeDateTime` | string | Last change timestamp \(OData /Date\(ms\)/\) |
 |     ↳ `to_PurchaseOrderItem` | json | Expanded PO items \(when $expand=to_PurchaseOrderItem\) |
 
-### `sap_s4hana_create_purchase_order`
+### SAP S/4HANA Create Purchase Order
 
 Create a purchase order in SAP S/4HANA Cloud (API_PURCHASEORDER_PROCESS_SRV, A_PurchaseOrder). PurchaseOrder is auto-assigned by SAP from the document number range; provide line items via the body parameter.
 
@@ -1642,7 +1642,7 @@ Create a purchase order in SAP S/4HANA Cloud (API_PURCHASEORDER_PROCESS_SRV, A_P
 |     ↳ `CreationDate` | string | Creation date \(OData /Date\(ms\)/\) |
 |     ↳ `to_PurchaseOrderItem` | json | Created PO items returned in deep insert |
 
-### `sap_s4hana_update_purchase_order`
+### SAP S/4HANA Update Purchase Order
 
 Update fields on an A_PurchaseOrder header in SAP S/4HANA Cloud (API_PURCHASEORDER_PROCESS_SRV). Uses HTTP MERGE (OData v2 partial update) — only the fields you provide are written; existing values are preserved. Header-only — line-item changes are not supported via deep update on the header (SAP KBA 2833338); use the A_PurchaseOrderItem entity directly to modify items. If-Match defaults to a wildcard - for safe concurrent updates pass the ETag from a prior GET to avoid lost updates.
 
@@ -1680,7 +1680,7 @@ Update fields on an A_PurchaseOrder header in SAP S/4HANA Cloud (API_PURCHASEORD
 |     ↳ `DocumentCurrency` | string | Document currency |
 |     ↳ `LastChangeDateTime` | string | Last change timestamp |
 
-### `sap_s4hana_list_supplier_invoices`
+### SAP S/4HANA List Supplier Invoices
 
 List supplier invoices from SAP S/4HANA Cloud (API_SUPPLIERINVOICE_PROCESS_SRV, A_SupplierInvoice) with optional OData $filter, $top, $skip, $orderby, $select, $expand.
 
@@ -1731,7 +1731,7 @@ List supplier invoices from SAP S/4HANA Cloud (API_SUPPLIERINVOICE_PROCESS_SRV, 
 |       ↳ `BusinessPlace` | string | Business place \(jurisdiction code\) |
 |     ↳ `__next` | string | OData skiptoken URL for next page |
 
-### `sap_s4hana_get_supplier_invoice`
+### SAP S/4HANA Get Supplier Invoice
 
 Retrieve a single supplier invoice by composite key (SupplierInvoice + FiscalYear) from SAP S/4HANA Cloud (API_SUPPLIERINVOICE_PROCESS_SRV, A_SupplierInvoice).
 
@@ -1778,7 +1778,7 @@ Retrieve a single supplier invoice by composite key (SupplierInvoice + FiscalYea
 |     ↳ `ManualCashDiscount` | string | Manually entered cash discount amount |
 |     ↳ `BusinessPlace` | string | Business place \(jurisdiction code\) |
 
-### `sap_s4hana_odata_query`
+### SAP S/4HANA OData Query
 
 Make an arbitrary OData v2 call against any SAP S/4HANA Cloud whitelisted Communication Scenario. Use when no dedicated tool exists for the entity. The proxy handles auth, CSRF, and OData unwrapping. For write operations (POST/PUT/PATCH/MERGE/DELETE), pass an If-Match ETag obtained from a prior GET to avoid lost updates; misuse will mutate production data.
 

--- a/apps/docs/content/docs/en/integrations/secrets_manager.mdx
+++ b/apps/docs/content/docs/en/integrations/secrets_manager.mdx
@@ -34,7 +34,7 @@ Integrate AWS Secrets Manager into the workflow. Can retrieve, create, update, l
 
 ## Actions
 
-### `secrets_manager_get_secret`
+### Secrets Manager Get Secret
 
 Retrieve a secret value from AWS Secrets Manager
 
@@ -60,7 +60,7 @@ Retrieve a secret value from AWS Secrets Manager
 | `versionStages` | array | Staging labels attached to this version |
 | `createdDate` | string | Date the secret was created |
 
-### `secrets_manager_list_secrets`
+### Secrets Manager List Secrets
 
 List secrets stored in AWS Secrets Manager
 
@@ -82,7 +82,7 @@ List secrets stored in AWS Secrets Manager
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of secrets returned |
 
-### `secrets_manager_create_secret`
+### Secrets Manager Create Secret
 
 Create a new secret in AWS Secrets Manager
 
@@ -106,7 +106,7 @@ Create a new secret in AWS Secrets Manager
 | `arn` | string | ARN of the created secret |
 | `versionId` | string | Version ID of the created secret |
 
-### `secrets_manager_update_secret`
+### Secrets Manager Update Secret
 
 Update the value of an existing secret in AWS Secrets Manager
 
@@ -130,7 +130,7 @@ Update the value of an existing secret in AWS Secrets Manager
 | `arn` | string | ARN of the updated secret |
 | `versionId` | string | Version ID of the updated secret |
 
-### `secrets_manager_delete_secret`
+### Secrets Manager Delete Secret
 
 Delete a secret from AWS Secrets Manager
 
@@ -154,7 +154,7 @@ Delete a secret from AWS Secrets Manager
 | `arn` | string | ARN of the deleted secret |
 | `deletionDate` | string | Scheduled deletion date |
 
-### `secrets_manager_describe_secret`
+### Secrets Manager Describe Secret
 
 Retrieve full metadata for a secret in AWS Secrets Manager, including rotation configuration and replication status, without exposing the secret value
 
@@ -190,7 +190,7 @@ Retrieve full metadata for a secret in AWS Secrets Manager, including rotation c
 | `primaryRegion` | string | The primary region of the secret, if replicated |
 | `replicationStatus` | array | Replication status for each region the secret is replicated to |
 
-### `secrets_manager_tag_resource`
+### Secrets Manager Tag Resource
 
 Attach tags to a secret in AWS Secrets Manager
 
@@ -211,7 +211,7 @@ Attach tags to a secret in AWS Secrets Manager
 | `message` | string | Operation status message |
 | `name` | string | Name or ARN of the tagged secret |
 
-### `secrets_manager_untag_resource`
+### Secrets Manager Untag Resource
 
 Remove tags from a secret in AWS Secrets Manager
 
@@ -232,7 +232,7 @@ Remove tags from a secret in AWS Secrets Manager
 | `message` | string | Operation status message |
 | `name` | string | Name or ARN of the untagged secret |
 
-### `secrets_manager_restore_secret`
+### Secrets Manager Restore Secret
 
 Cancel a scheduled deletion for a secret in AWS Secrets Manager, restoring access to it
 
@@ -253,7 +253,7 @@ Cancel a scheduled deletion for a secret in AWS Secrets Manager, restoring acces
 | `name` | string | Name of the restored secret |
 | `arn` | string | ARN of the restored secret |
 
-### `secrets_manager_rotate_secret`
+### Secrets Manager Rotate Secret
 
 Start or reconfigure rotation for a secret in AWS Secrets Manager
 

--- a/apps/docs/content/docs/en/integrations/sendblue.mdx
+++ b/apps/docs/content/docs/en/integrations/sendblue.mdx
@@ -42,7 +42,7 @@ Send iMessages and SMS to individuals or groups, check whether a number supports
 
 ## Actions
 
-### `sendblue_send_message`
+### Sendblue Send Message
 
 Send an iMessage or SMS to a single recipient via Sendblue.
 
@@ -78,7 +78,7 @@ Send an iMessage or SMS to a single recipient via Sendblue.
 | `date_created` | string | When the message was created |
 | `date_updated` | string | When the message was last updated |
 
-### `sendblue_send_group_message`
+### Sendblue Send Group Message
 
 Send an iMessage or SMS to a group of recipients via Sendblue.
 
@@ -117,7 +117,7 @@ Send an iMessage or SMS to a group of recipients via Sendblue.
 | `date_created` | string | When the message was created |
 | `date_updated` | string | When the message was last updated |
 
-### `sendblue_evaluate_service`
+### Sendblue Evaluate Service
 
 Check whether a phone number can receive iMessage or only SMS.
 
@@ -134,7 +134,7 @@ Check whether a phone number can receive iMessage or only SMS.
 | `number` | string | The evaluated phone number in E.164 format |
 | `service` | string | The service the number supports: iMessage or SMS |
 
-### `sendblue_send_typing_indicator`
+### Sendblue Send Typing Indicator
 
 Display a typing indicator to a recipient (not supported in group chats).
 
@@ -156,7 +156,7 @@ Display a typing indicator to a recipient (not supported in group chats).
 | `number` | string | The recipient phone number |
 | `error_message` | string | Error details, null on success |
 
-### `sendblue_get_message`
+### Sendblue Get Message
 
 Retrieve a single message and its current status by message handle/ID.
 

--- a/apps/docs/content/docs/en/integrations/sendgrid.mdx
+++ b/apps/docs/content/docs/en/integrations/sendgrid.mdx
@@ -42,7 +42,7 @@ Integrate SendGrid into your workflow. Send transactional emails, manage marketi
 
 ## Actions
 
-### `sendgrid_send_mail`
+### SendGrid Send Mail
 
 Send an email using SendGrid API
 
@@ -75,7 +75,7 @@ Send an email using SendGrid API
 | `to` | string | Recipient email address |
 | `subject` | string | Email subject |
 
-### `sendgrid_add_contact`
+### SendGrid Add Contact
 
 Add a new contact to SendGrid
 
@@ -100,7 +100,7 @@ Add a new contact to SendGrid
 | `lastName` | string | Contact last name |
 | `message` | string | Status message |
 
-### `sendgrid_get_contact`
+### SendGrid Get Contact
 
 Get a specific contact by ID from SendGrid
 
@@ -124,7 +124,7 @@ Get a specific contact by ID from SendGrid
 | `listIds` | json | Array of list IDs the contact belongs to |
 | `customFields` | json | Custom field values |
 
-### `sendgrid_search_contacts`
+### SendGrid Search Contacts
 
 Search for contacts in SendGrid using a query
 
@@ -142,7 +142,7 @@ Search for contacts in SendGrid using a query
 | `contacts` | json | Array of matching contacts |
 | `contactCount` | number | Total number of contacts found |
 
-### `sendgrid_delete_contacts`
+### SendGrid Delete Contacts
 
 Delete one or more contacts from SendGrid
 
@@ -159,7 +159,7 @@ Delete one or more contacts from SendGrid
 | --------- | ---- | ----------- |
 | `jobId` | string | Job ID for the deletion request |
 
-### `sendgrid_create_list`
+### SendGrid Create List
 
 Create a new contact list in SendGrid
 
@@ -178,7 +178,7 @@ Create a new contact list in SendGrid
 | `name` | string | List name |
 | `contactCount` | number | Number of contacts in the list |
 
-### `sendgrid_get_list`
+### SendGrid Get List
 
 Get a specific list by ID from SendGrid
 
@@ -197,7 +197,7 @@ Get a specific list by ID from SendGrid
 | `name` | string | List name |
 | `contactCount` | number | Number of contacts in the list |
 
-### `sendgrid_list_all_lists`
+### SendGrid List All Lists
 
 Get all contact lists from SendGrid
 
@@ -216,7 +216,7 @@ Get all contact lists from SendGrid
 | `lists` | json | Array of lists |
 | `nextPageToken` | string | Token to pass as pageToken to fetch the next page, if more results exist |
 
-### `sendgrid_delete_list`
+### SendGrid Delete List
 
 Delete a contact list from SendGrid
 
@@ -233,7 +233,7 @@ Delete a contact list from SendGrid
 | --------- | ---- | ----------- |
 | `message` | string | Success message |
 
-### `sendgrid_add_contacts_to_list`
+### SendGrid Add Contacts to List
 
 Add or update contacts and assign them to a list in SendGrid (uses PUT /v3/marketing/contacts)
 
@@ -252,7 +252,7 @@ Add or update contacts and assign them to a list in SendGrid (uses PUT /v3/marke
 | `jobId` | string | Job ID for tracking the async operation |
 | `message` | string | Status message |
 
-### `sendgrid_remove_contacts_from_list`
+### SendGrid Remove Contacts from List
 
 Remove contacts from a specific list in SendGrid
 
@@ -270,7 +270,7 @@ Remove contacts from a specific list in SendGrid
 | --------- | ---- | ----------- |
 | `jobId` | string | Job ID for the request |
 
-### `sendgrid_create_template`
+### SendGrid Create Template
 
 Create a new email template in SendGrid
 
@@ -292,7 +292,7 @@ Create a new email template in SendGrid
 | `updatedAt` | string | Last update timestamp |
 | `versions` | json | Array of template versions |
 
-### `sendgrid_get_template`
+### SendGrid Get Template
 
 Get a specific template by ID from SendGrid
 
@@ -313,7 +313,7 @@ Get a specific template by ID from SendGrid
 | `updatedAt` | string | Last update timestamp |
 | `versions` | json | Array of template versions |
 
-### `sendgrid_list_templates`
+### SendGrid List Templates
 
 Get all email templates from SendGrid
 
@@ -335,7 +335,7 @@ Get all email templates from SendGrid
 | `templates` | json | Array of templates |
 | `nextPageToken` | string | Token to pass as pageToken to fetch the next page, if more results exist |
 
-### `sendgrid_delete_template`
+### SendGrid Delete Template
 
 Delete an email template from SendGrid
 
@@ -377,7 +377,7 @@ Delete an email template from SendGrid
 | `htmlContent` | string | HTML content |
 | `plainContent` | string | Plain text content |
 
-### `sendgrid_create_template_version`
+### SendGrid Create Template Version
 
 Create a new version of an email template in SendGrid
 

--- a/apps/docs/content/docs/en/integrations/sentry.mdx
+++ b/apps/docs/content/docs/en/integrations/sentry.mdx
@@ -45,7 +45,7 @@ Integrate Sentry into the workflow. Monitor issues, manage projects, track event
 
 ## Actions
 
-### `sentry_issues_list`
+### List Issues
 
 List issues from Sentry for a specific organization and optionally a specific project. Returns issue details including status, error counts, and last seen timestamps.
 
@@ -110,7 +110,7 @@ List issues from Sentry for a specific organization and optionally a specific pr
 |   ↳ `nextCursor` | string | Cursor for the next page of results \(if available\) |
 |   ↳ `hasMore` | boolean | Whether there are more results available |
 
-### `sentry_issues_get`
+### Get Issue
 
 Retrieve detailed information about a specific Sentry issue by its ID. Returns complete issue details including metadata, tags, and statistics.
 
@@ -166,7 +166,7 @@ Retrieve detailed information about a specific Sentry issue by its ID. Returns c
 |   ↳ `lastSeen` | string | When the issue was last seen \(ISO timestamp\) |
 |   ↳ `stats` | object | Statistical information about the issue |
 
-### `sentry_issues_update`
+### Update Issue
 
 Update a Sentry issue by changing its status, assignment, bookmark state, or other properties. Returns the updated issue details.
 
@@ -203,7 +203,7 @@ Update a Sentry issue by changing its status, assignment, bookmark state, or oth
 |   ↳ `isPublic` | boolean | Whether the issue is publicly visible |
 |   ↳ `permalink` | string | Direct link to the issue in Sentry |
 
-### `sentry_projects_list`
+### List Projects
 
 List all projects in a Sentry organization. Returns project details including name, platform, teams, and configuration.
 
@@ -243,7 +243,7 @@ List all projects in a Sentry organization. Returns project details including na
 |   ↳ `nextCursor` | string | Cursor for the next page of results \(if available\) |
 |   ↳ `hasMore` | boolean | Whether there are more results available |
 
-### `sentry_projects_get`
+### Get Project
 
 Retrieve detailed information about a specific Sentry project by its slug. Returns complete project details including teams, features, and configuration.
 
@@ -294,7 +294,7 @@ Retrieve detailed information about a specific Sentry project by its slug. Retur
 |   ↳ `hasReplays` | boolean | Whether the project has session replays enabled |
 |   ↳ `hasSessions` | boolean | Whether the project has sessions enabled |
 
-### `sentry_projects_create`
+### Create Project
 
 Create a new Sentry project in an organization. Requires a team to associate the project with. Returns the created project details.
 
@@ -341,7 +341,7 @@ Create a new Sentry project in an organization. Requires a team to associate the
 |   ↳ `color` | string | Project color code |
 |   ↳ `isPublic` | boolean | Whether the project is public |
 
-### `sentry_projects_update`
+### Update Project
 
 Update a Sentry project by changing its name, slug, platform, or other settings. Returns the updated project details.
 
@@ -378,7 +378,7 @@ Update a Sentry project by changing its name, slug, platform, or other settings.
 |     ↳ `name` | string | Team name |
 |     ↳ `slug` | string | Team slug |
 
-### `sentry_events_list`
+### List Events
 
 List events from a Sentry project. Can be filtered by issue ID, query, or time period. Returns event details including context, tags, and user information.
 
@@ -439,7 +439,7 @@ List events from a Sentry project. Can be filtered by issue ID, query, or time p
 |   ↳ `nextCursor` | string | Cursor for the next page of results \(if available\) |
 |   ↳ `hasMore` | boolean | Whether there are more results available |
 
-### `sentry_events_get`
+### Get Event
 
 Retrieve detailed information about a specific Sentry event by its ID. Returns complete event details including stack traces, breadcrumbs, context, and user information.
 
@@ -493,7 +493,7 @@ Retrieve detailed information about a specific Sentry event by its ID. Returns c
 |     ↳ `name` | string | SDK name |
 |     ↳ `version` | string | SDK version |
 
-### `sentry_releases_list`
+### List Releases
 
 List releases for a Sentry organization or project. Returns release details including version, commits, deploy information, and associated projects.
 
@@ -557,7 +557,7 @@ List releases for a Sentry organization or project. Returns release details incl
 |   ↳ `nextCursor` | string | Cursor for the next page of results \(if available\) |
 |   ↳ `hasMore` | boolean | Whether there are more results available |
 
-### `sentry_releases_create`
+### Create Release
 
 Create a new release in Sentry. A release is a version of your code deployed to an environment. Can include commit information and associated projects. Returns the created release details.
 
@@ -620,7 +620,7 @@ Create a new release in Sentry. A release is a version of your code deployed to 
 |       ↳ `raw` | string | Raw version string |
 |     ↳ `package` | string | Package name |
 
-### `sentry_releases_deploy`
+### Create Deploy
 
 Create a deploy record for a Sentry release in a specific environment. Deploys track when and where releases are deployed. Returns the created deploy details.
 
@@ -649,7 +649,7 @@ Create a deploy record for a Sentry release in a specific environment. Deploys t
 |   ↳ `dateStarted` | string | When the deploy started \(ISO timestamp\) |
 |   ↳ `dateFinished` | string | When the deploy finished \(ISO timestamp\) |
 
-### `sentry_teams_list`
+### List Teams
 
 List all teams in a Sentry organization. Useful for discovering the team slug required when creating a project. Returns team details including slug, name, member count, and associated projects.
 

--- a/apps/docs/content/docs/en/integrations/serper.mdx
+++ b/apps/docs/content/docs/en/integrations/serper.mdx
@@ -33,7 +33,7 @@ Integrate Serper into the workflow. Can search the web.
 
 ## Actions
 
-### `serper_search`
+### Web Search
 
 A powerful web search tool that provides access to Google search results through Serper.dev API. Supports different types of searches including regular web search, news, places, images, videos, and shopping. Returns comprehensive results including organic results, knowledge graph, answer box, people also ask, related searches, and top stories.
 

--- a/apps/docs/content/docs/en/integrations/servicenow.mdx
+++ b/apps/docs/content/docs/en/integrations/servicenow.mdx
@@ -32,7 +32,7 @@ Integrate ServiceNow into your workflow. Create, read, update, and delete record
 
 ## Actions
 
-### `servicenow_create_record`
+### Create ServiceNow Record
 
 Create a new record in a ServiceNow table
 
@@ -53,7 +53,7 @@ Create a new record in a ServiceNow table
 | `record` | json | Created ServiceNow record with sys_id and other fields |
 | `metadata` | json | Operation metadata |
 
-### `servicenow_read_record`
+### Read ServiceNow Records
 
 Read records from a ServiceNow table
 
@@ -80,7 +80,7 @@ Read records from a ServiceNow table
 | `records` | array | Array of ServiceNow records |
 | `metadata` | json | Operation metadata |
 
-### `servicenow_update_record`
+### Update ServiceNow Record
 
 Update an existing record in a ServiceNow table
 
@@ -102,7 +102,7 @@ Update an existing record in a ServiceNow table
 | `record` | json | Updated ServiceNow record |
 | `metadata` | json | Operation metadata |
 
-### `servicenow_delete_record`
+### Delete ServiceNow Record
 
 Delete a record from a ServiceNow table
 
@@ -123,7 +123,7 @@ Delete a record from a ServiceNow table
 | `success` | boolean | Whether the deletion was successful |
 | `metadata` | json | Operation metadata |
 
-### `servicenow_aggregate`
+### Aggregate ServiceNow Records
 
 Compute aggregate statistics (count, sum, average, min, max, group by) over a ServiceNow table
 
@@ -153,7 +153,7 @@ Compute aggregate statistics (count, sum, average, min, max, group by) over a Se
 | `count` | number | Total matching record count \(only present for ungrouped count queries\) |
 | `metadata` | json | Operation metadata \(grouped, groupCount\) |
 
-### `servicenow_list_attachments`
+### List ServiceNow Attachments
 
 List the attachments on a ServiceNow record
 
@@ -180,7 +180,7 @@ List the attachments on a ServiceNow record
 |   ↳ `download_link` | string | Direct download URL for the file |
 | `metadata` | json | Operation metadata \(recordCount\) |
 
-### `servicenow_download_attachment`
+### Download ServiceNow Attachment
 
 Download an attachment file from ServiceNow by its sys_id
 
@@ -200,7 +200,7 @@ Download an attachment file from ServiceNow by its sys_id
 | `file` | file | Downloaded attachment stored in execution files |
 | `content` | string | Base64 encoded file content |
 
-### `servicenow_upload_attachment`
+### Upload ServiceNow Attachment
 
 Attach a file to a ServiceNow record
 

--- a/apps/docs/content/docs/en/integrations/ses.mdx
+++ b/apps/docs/content/docs/en/integrations/ses.mdx
@@ -33,7 +33,7 @@ Integrate AWS SES v2 into the workflow. Send simple, templated, and bulk emails.
 
 ## Actions
 
-### `ses_send_email`
+### SES Send Email
 
 Send an email via AWS SES using simple or HTML content
 
@@ -60,7 +60,7 @@ Send an email via AWS SES using simple or HTML content
 | --------- | ---- | ----------- |
 | `messageId` | string | SES message ID for the sent email |
 
-### `ses_send_templated_email`
+### SES Send Templated Email
 
 Send an email using an SES email template with dynamic template data
 
@@ -85,7 +85,7 @@ Send an email using an SES email template with dynamic template data
 | --------- | ---- | ----------- |
 | `messageId` | string | SES message ID for the sent email |
 
-### `ses_send_bulk_email`
+### SES Send Bulk Email
 
 Send emails to multiple recipients using an SES template with per-recipient data
 
@@ -110,7 +110,7 @@ Send emails to multiple recipients using an SES template with per-recipient data
 | `successCount` | number | Number of successfully sent emails |
 | `failureCount` | number | Number of failed email sends |
 
-### `ses_list_identities`
+### SES List Identities
 
 List all verified email identities (email addresses and domains) in your SES account
 
@@ -132,7 +132,7 @@ List all verified email identities (email addresses and domains) in your SES acc
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of identities returned |
 
-### `ses_get_account`
+### SES Get Account
 
 Get SES account sending quota and status information
 
@@ -153,7 +153,7 @@ Get SES account sending quota and status information
 | `maxSendRate` | number | Maximum emails allowed per second |
 | `sentLast24Hours` | number | Number of emails sent in the last 24 hours |
 
-### `ses_create_template`
+### SES Create Template
 
 Create a new SES email template for use with templated email sending
 
@@ -175,7 +175,7 @@ Create a new SES email template for use with templated email sending
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message for the created template |
 
-### `ses_get_template`
+### SES Get Template
 
 Retrieve the content and details of an SES email template
 
@@ -197,7 +197,7 @@ Retrieve the content and details of an SES email template
 | `textPart` | string | Plain text body of the template |
 | `htmlPart` | string | HTML body of the template |
 
-### `ses_list_templates`
+### SES List Templates
 
 List all SES email templates in your account
 
@@ -219,7 +219,7 @@ List all SES email templates in your account
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of templates returned |
 
-### `ses_delete_template`
+### SES Delete Template
 
 Delete an existing SES email template
 
@@ -238,7 +238,7 @@ Delete an existing SES email template
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message for the deleted template |
 
-### `ses_update_template`
+### SES Update Template
 
 Update the subject, HTML, and text content of an existing SES email template
 
@@ -260,7 +260,7 @@ Update the subject, HTML, and text content of an existing SES email template
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message |
 
-### `ses_put_suppressed_destination`
+### SES Put Suppressed Destination
 
 Add an email address to the account-level SES suppression list
 
@@ -280,7 +280,7 @@ Add an email address to the account-level SES suppression list
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message |
 
-### `ses_delete_suppressed_destination`
+### SES Delete Suppressed Destination
 
 Remove an email address from the account-level SES suppression list
 
@@ -299,7 +299,7 @@ Remove an email address from the account-level SES suppression list
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message |
 
-### `ses_get_suppressed_destination`
+### SES Get Suppressed Destination
 
 Retrieve details for a specific email address on the SES suppression list
 
@@ -322,7 +322,7 @@ Retrieve details for a specific email address on the SES suppression list
 | `messageId` | string | The message ID associated with the bounce or complaint event |
 | `feedbackId` | string | The feedback ID associated with the bounce or complaint event |
 
-### `ses_list_suppressed_destinations`
+### SES List Suppressed Destinations
 
 List email addresses on the account-level SES suppression list
 
@@ -347,7 +347,7 @@ List email addresses on the account-level SES suppression list
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of suppressed destinations returned |
 
-### `ses_create_email_identity`
+### SES Create Email Identity
 
 Start verification of a new SES email address or domain identity
 
@@ -371,7 +371,7 @@ Start verification of a new SES email address or domain identity
 | `verifiedForSendingStatus` | boolean | Whether the identity is verified and can send email |
 | `dkimAttributes` | json | DKIM signing status and CNAME tokens for the identity |
 
-### `ses_delete_email_identity`
+### SES Delete Email Identity
 
 Delete a verified SES email address or domain identity
 
@@ -390,7 +390,7 @@ Delete a verified SES email address or domain identity
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message |
 
-### `ses_get_email_identity`
+### SES Get Email Identity
 
 Retrieve verification status, DKIM, Mail-From, and policy details for an SES identity
 
@@ -418,7 +418,7 @@ Retrieve verification status, DKIM, Mail-From, and policy details for an SES ide
 | `tags` | array | Tags associated with the identity |
 | `verificationInfo` | json | Additional verification diagnostics \(error type, last checked/success time\) |
 
-### `ses_create_configuration_set`
+### SES Create Configuration Set
 
 Create an SES configuration set to control tracking, delivery, reputation, sending, and suppression behavior for emails
 
@@ -445,7 +445,7 @@ Create an SES configuration set to control tracking, delivery, reputation, sendi
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message |
 
-### `ses_send_custom_verification_email`
+### SES Send Custom Verification Email
 
 Send a branded custom verification email to an address using a custom verification email template
 

--- a/apps/docs/content/docs/en/integrations/sftp.mdx
+++ b/apps/docs/content/docs/en/integrations/sftp.mdx
@@ -33,7 +33,7 @@ Upload, download, list, and manage files on remote servers via SFTP. Supports bo
 
 ## Actions
 
-### `sftp_upload`
+### SFTP Upload
 
 Upload files to a remote SFTP server
 
@@ -62,7 +62,7 @@ Upload files to a remote SFTP server
 | `uploadedFiles` | json | Array of uploaded file details \(name, remotePath, size\) |
 | `message` | string | Operation status message |
 
-### `sftp_download`
+### SFTP Download
 
 Download a file from a remote SFTP server
 
@@ -91,7 +91,7 @@ Download a file from a remote SFTP server
 | `encoding` | string | Content encoding \(utf-8 or base64\) |
 | `message` | string | Operation status message |
 
-### `sftp_list`
+### SFTP List Directory
 
 List files and directories on a remote SFTP server
 
@@ -118,7 +118,7 @@ List files and directories on a remote SFTP server
 | `count` | number | Number of entries in the directory |
 | `message` | string | Operation status message |
 
-### `sftp_delete`
+### SFTP Delete
 
 Delete a file or directory on a remote SFTP server
 
@@ -143,7 +143,7 @@ Delete a file or directory on a remote SFTP server
 | `deletedPath` | string | Path that was deleted |
 | `message` | string | Operation status message |
 
-### `sftp_mkdir`
+### SFTP Create Directory
 
 Create a directory on a remote SFTP server
 

--- a/apps/docs/content/docs/en/integrations/sharepoint.mdx
+++ b/apps/docs/content/docs/en/integrations/sharepoint.mdx
@@ -33,7 +33,7 @@ Integrate SharePoint into the workflow. Read/create pages, list sites, and work 
 
 ## Actions
 
-### `sharepoint_create_page`
+### Create SharePoint Page
 
 Create a new page in a SharePoint site
 
@@ -60,7 +60,7 @@ Create a new page in a SharePoint site
 |   ↳ `createdDateTime` | string | When the page was created |
 |   ↳ `lastModifiedDateTime` | string | When the page was last modified |
 
-### `sharepoint_read_page`
+### Read SharePoint Page
 
 Read a specific page from a SharePoint site
 
@@ -107,7 +107,7 @@ Read a specific page from a SharePoint site
 | `totalPages` | number | Total number of pages found |
 | `nextPageUrl` | string | Full Microsoft Graph @odata.nextLink URL for the next page of results |
 
-### `sharepoint_update_page`
+### Update SharePoint Page
 
 Update the title and/or content of a SharePoint page
 
@@ -134,7 +134,7 @@ Update the title and/or content of a SharePoint page
 |   ↳ `createdDateTime` | string | When the page was created |
 |   ↳ `lastModifiedDateTime` | string | When the page was last modified |
 
-### `sharepoint_publish_page`
+### Publish SharePoint Page
 
 Publish the latest version of a SharePoint page, making it available to all users
 
@@ -153,7 +153,7 @@ Publish the latest version of a SharePoint page, making it available to all user
 | `published` | boolean | Whether the page was published |
 | `pageId` | string | The ID of the published page |
 
-### `sharepoint_delete_page`
+### Delete SharePoint Page
 
 Delete a page from a SharePoint site
 
@@ -172,7 +172,7 @@ Delete a page from a SharePoint site
 | `deleted` | boolean | Whether the page was deleted |
 | `pageId` | string | The ID of the deleted page |
 
-### `sharepoint_list_sites`
+### List SharePoint Sites
 
 List details of all SharePoint sites
 
@@ -211,7 +211,7 @@ List details of all SharePoint sites
 |   ↳ `lastModifiedDateTime` | string | When the site was last modified |
 | `nextPageUrl` | string | Full Microsoft Graph @odata.nextLink URL for the next page of results |
 
-### `sharepoint_create_list`
+### Create SharePoint List
 
 Create a new list in a SharePoint site
 
@@ -239,7 +239,7 @@ Create a new list in a SharePoint site
 |   ↳ `lastModifiedDateTime` | string | When the list was last modified |
 |   ↳ `list` | object | List properties \(e.g., template\) |
 
-### `sharepoint_get_list`
+### Get SharePoint List
 
 Get metadata (and optionally columns/items) for a SharePoint list
 
@@ -273,7 +273,7 @@ Get metadata (and optionally columns/items) for a SharePoint list
 |   ↳ `fields` | object | Field values for the item |
 | `nextPageUrl` | string | Full Microsoft Graph @odata.nextLink URL for the next page of results |
 
-### `sharepoint_update_list`
+### Update SharePoint List Item
 
 Update the properties (fields) on a SharePoint list item
 
@@ -295,7 +295,7 @@ Update the properties (fields) on a SharePoint list item
 |   ↳ `id` | string | Item ID |
 |   ↳ `fields` | object | Updated field values |
 
-### `sharepoint_add_list_items`
+### Add SharePoint List Item
 
 Add a new item to a SharePoint list
 
@@ -316,7 +316,7 @@ Add a new item to a SharePoint list
 |   ↳ `id` | string | Item ID |
 |   ↳ `fields` | object | Field values for the new item |
 
-### `sharepoint_get_list_item`
+### Get SharePoint List Item
 
 Get a single item (with field values) from a SharePoint list
 
@@ -337,7 +337,7 @@ Get a single item (with field values) from a SharePoint list
 |   ↳ `id` | string | Item ID |
 |   ↳ `fields` | object | Field values for the item |
 
-### `sharepoint_delete_list_item`
+### Delete SharePoint List Item
 
 Delete an item from a SharePoint list
 
@@ -357,7 +357,7 @@ Delete an item from a SharePoint list
 | `deleted` | boolean | Whether the list item was deleted |
 | `itemId` | string | The ID of the deleted list item |
 
-### `sharepoint_upload_file`
+### Upload File to SharePoint
 
 Upload files to a SharePoint document library
 
@@ -394,7 +394,7 @@ Upload files to a SharePoint document library
 |   ↳ `error` | string | Error message |
 |   ↳ `status` | number | HTTP status from Microsoft Graph |
 
-### `sharepoint_download_file`
+### Download File from SharePoint
 
 Download a file from a SharePoint document library
 
@@ -412,7 +412,7 @@ Download a file from a SharePoint document library
 | --------- | ---- | ----------- |
 | `file` | file | Downloaded file stored in execution files |
 
-### `sharepoint_get_drive_item`
+### Get SharePoint Drive Item
 
 Get metadata for a file or folder in a SharePoint document library
 
@@ -438,7 +438,7 @@ Get metadata for a file or folder in a SharePoint document library
 |   ↳ `folder` | object | Present if the item is a folder \(contains childCount\) |
 |   ↳ `parentReference` | object | Reference to the parent folder/drive |
 
-### `sharepoint_delete_file`
+### Delete SharePoint File
 
 Delete a file (or folder) from a SharePoint document library
 

--- a/apps/docs/content/docs/en/integrations/shopify.mdx
+++ b/apps/docs/content/docs/en/integrations/shopify.mdx
@@ -32,7 +32,7 @@ Integrate Shopify into your workflow. Manage products, orders, customers, and in
 
 ## Actions
 
-### `shopify_create_product`
+### Shopify Create Product
 
 Create a new product in your Shopify store
 
@@ -66,7 +66,7 @@ Create a new product in your Shopify store
 |   ↳ `variants` | object | Product variants with edges/nodes structure |
 |   ↳ `images` | object | Product images with edges/nodes structure |
 
-### `shopify_get_product`
+### Shopify Get Product
 
 Get a single product by ID from your Shopify store
 
@@ -95,7 +95,7 @@ Get a single product by ID from your Shopify store
 |   ↳ `variants` | object | Product variants with edges/nodes structure |
 |   ↳ `images` | object | Product images with edges/nodes structure |
 
-### `shopify_list_products`
+### Shopify List Products
 
 List products from your Shopify store with optional filtering
 
@@ -128,7 +128,7 @@ List products from your Shopify store with optional filtering
 |   ↳ `hasNextPage` | boolean | Whether there are more results after this page |
 |   ↳ `hasPreviousPage` | boolean | Whether there are results before this page |
 
-### `shopify_update_product`
+### Shopify Update Product
 
 Update an existing product in your Shopify store
 
@@ -163,7 +163,7 @@ Update an existing product in your Shopify store
 |   ↳ `variants` | object | Product variants with edges/nodes structure |
 |   ↳ `images` | object | Product images with edges/nodes structure |
 
-### `shopify_delete_product`
+### Shopify Delete Product
 
 Delete a product from your Shopify store
 
@@ -180,7 +180,7 @@ Delete a product from your Shopify store
 | --------- | ---- | ----------- |
 | `deletedId` | string | The ID of the deleted product |
 
-### `shopify_get_order`
+### Shopify Get Order
 
 Get a single order by ID from your Shopify store
 
@@ -218,7 +218,7 @@ Get a single order by ID from your Shopify store
 |   ↳ `billingAddress` | object | Billing address |
 |   ↳ `fulfillments` | array | Order fulfillments |
 
-### `shopify_list_orders`
+### Shopify List Orders
 
 List orders from your Shopify store with optional filtering
 
@@ -261,7 +261,7 @@ List orders from your Shopify store with optional filtering
 |   ↳ `hasNextPage` | boolean | Whether there are more results after this page |
 |   ↳ `hasPreviousPage` | boolean | Whether there are results before this page |
 
-### `shopify_update_order`
+### Shopify Update Order
 
 Update an existing order in your Shopify store (note, tags, email)
 
@@ -302,7 +302,7 @@ Update an existing order in your Shopify store (note, tags, email)
 |   ↳ `billingAddress` | object | Billing address |
 |   ↳ `fulfillments` | array | Order fulfillments |
 
-### `shopify_cancel_order`
+### Shopify Cancel Order
 
 Cancel an order in your Shopify store
 
@@ -327,7 +327,7 @@ Cancel an order in your Shopify store
 |   ↳ `cancelled` | boolean | Whether the cancellation completed |
 |   ↳ `message` | string | Status message |
 
-### `shopify_create_customer`
+### Shopify Create Customer
 
 Create a new customer in your Shopify store
 
@@ -362,7 +362,7 @@ Create a new customer in your Shopify store
 |   ↳ `addresses` | array | Customer addresses |
 |   ↳ `defaultAddress` | object | Customer default address |
 
-### `shopify_get_customer`
+### Shopify Get Customer
 
 Get a single customer by ID from your Shopify store
 
@@ -391,7 +391,7 @@ Get a single customer by ID from your Shopify store
 |   ↳ `addresses` | array | Customer addresses |
 |   ↳ `defaultAddress` | object | Customer default address |
 
-### `shopify_list_customers`
+### Shopify List Customers
 
 List customers from your Shopify store with optional filtering
 
@@ -424,7 +424,7 @@ List customers from your Shopify store with optional filtering
 |   ↳ `hasNextPage` | boolean | Whether there are more results after this page |
 |   ↳ `hasPreviousPage` | boolean | Whether there are results before this page |
 
-### `shopify_update_customer`
+### Shopify Update Customer
 
 Update an existing customer in your Shopify store
 
@@ -459,7 +459,7 @@ Update an existing customer in your Shopify store
 |   ↳ `addresses` | array | Customer addresses |
 |   ↳ `defaultAddress` | object | Customer default address |
 
-### `shopify_delete_customer`
+### Shopify Delete Customer
 
 Delete a customer from your Shopify store
 
@@ -476,7 +476,7 @@ Delete a customer from your Shopify store
 | --------- | ---- | ----------- |
 | `deletedId` | string | The ID of the deleted customer |
 
-### `shopify_list_inventory_items`
+### Shopify List Inventory Items
 
 List inventory items from your Shopify store. Use this to find inventory item IDs by SKU.
 
@@ -514,7 +514,7 @@ List inventory items from your Shopify store. Use this to find inventory item ID
 |   ↳ `hasNextPage` | boolean | Whether there are more results after this page |
 |   ↳ `hasPreviousPage` | boolean | Whether there are results before this page |
 
-### `shopify_get_inventory_level`
+### Shopify Get Inventory Level
 
 Get inventory level for a product variant at a specific location
 
@@ -545,7 +545,7 @@ Get inventory level for a product variant at a specific location
 |       ↳ `id` | string | Location identifier \(GID\) |
 |       ↳ `name` | string | Location name |
 
-### `shopify_adjust_inventory`
+### Shopify Adjust Inventory
 
 Adjust inventory quantity for a product variant at a specific location
 
@@ -577,7 +577,7 @@ Adjust inventory quantity for a product variant at a specific location
 |       ↳ `id` | string | Location identifier \(GID\) |
 |       ↳ `name` | string | Location name |
 
-### `shopify_list_locations`
+### Shopify List Locations
 
 List inventory locations from your Shopify store. Use this to find location IDs needed for inventory operations.
 
@@ -603,7 +603,7 @@ List inventory locations from your Shopify store. Use this to find location IDs 
 |   ↳ `hasNextPage` | boolean | Whether there are more results after this page |
 |   ↳ `hasPreviousPage` | boolean | Whether there are results before this page |
 
-### `shopify_create_fulfillment`
+### Shopify Create Fulfillment
 
 Create a fulfillment to mark order items as shipped. Requires a fulfillment order ID (get this from the order details).
 
@@ -634,7 +634,7 @@ Create a fulfillment to mark order items as shipped. Requires a fulfillment orde
 |     ↳ `lineItem` | object | Associated order line item |
 |       ↳ `title` | string | Product title |
 
-### `shopify_list_collections`
+### Shopify List Collections
 
 List product collections from your Shopify store. Filter by title, type (custom/smart), or handle.
 
@@ -664,7 +664,7 @@ List product collections from your Shopify store. Filter by title, type (custom/
 |   ↳ `hasNextPage` | boolean | Whether there are more results after this page |
 |   ↳ `hasPreviousPage` | boolean | Whether there are results before this page |
 
-### `shopify_get_collection`
+### Shopify Get Collection
 
 Get a specific collection by ID, including its products. Use this to retrieve products within a collection.
 

--- a/apps/docs/content/docs/en/integrations/similarweb.mdx
+++ b/apps/docs/content/docs/en/integrations/similarweb.mdx
@@ -32,7 +32,7 @@ Access comprehensive website analytics including traffic estimates, engagement m
 
 ## Actions
 
-### `similarweb_website_overview`
+### SimilarWeb Website Overview
 
 Get comprehensive website analytics including traffic, rankings, engagement, and traffic sources
 
@@ -68,7 +68,7 @@ Get comprehensive website analytics including traffic, rankings, engagement, and
 |   ↳ `mail` | number | Email traffic share |
 |   ↳ `paidReferrals` | number | Paid referral traffic share |
 
-### `similarweb_traffic_visits`
+### SimilarWeb Traffic Visits
 
 Get total website visits over time (desktop and mobile combined)
 
@@ -96,7 +96,7 @@ Get total website visits over time (desktop and mobile combined)
 |   ↳ `date` | string | Date \(YYYY-MM-DD\) |
 |   ↳ `visits` | number | Number of visits |
 
-### `similarweb_bounce_rate`
+### SimilarWeb Bounce Rate
 
 Get website bounce rate over time (desktop and mobile combined)
 
@@ -124,7 +124,7 @@ Get website bounce rate over time (desktop and mobile combined)
 |   ↳ `date` | string | Date \(YYYY-MM-DD\) |
 |   ↳ `bounceRate` | number | Bounce rate \(0-1\) |
 
-### `similarweb_pages_per_visit`
+### SimilarWeb Pages Per Visit
 
 Get average pages per visit over time (desktop and mobile combined)
 
@@ -152,7 +152,7 @@ Get average pages per visit over time (desktop and mobile combined)
 |   ↳ `date` | string | Date \(YYYY-MM-DD\) |
 |   ↳ `pagesPerVisit` | number | Average pages per visit |
 
-### `similarweb_visit_duration`
+### SimilarWeb Visit Duration
 
 Get average desktop visit duration over time (in seconds)
 
@@ -180,7 +180,7 @@ Get average desktop visit duration over time (in seconds)
 |   ↳ `date` | string | Date \(YYYY-MM-DD\) |
 |   ↳ `durationSeconds` | number | Average visit duration in seconds |
 
-### `similarweb_page_views`
+### SimilarWeb Page Views
 
 Get total page views over time (desktop and mobile combined)
 

--- a/apps/docs/content/docs/en/integrations/sixtyfour.mdx
+++ b/apps/docs/content/docs/en/integrations/sixtyfour.mdx
@@ -32,7 +32,7 @@ Find emails, phone numbers, and enrich lead or company data with contact informa
 
 ## Actions
 
-### `sixtyfour_find_phone`
+### Sixtyfour Find Phone
 
 Find phone numbers for a lead using Sixtyfour AI.
 
@@ -56,7 +56,7 @@ Find phone numbers for a lead using Sixtyfour AI.
 | `phone` | string | Phone number\(s\) found |
 | `linkedinUrl` | string | LinkedIn profile URL |
 
-### `sixtyfour_find_email`
+### Sixtyfour Find Email
 
 Find email addresses for a lead using Sixtyfour AI.
 
@@ -91,7 +91,7 @@ Find email addresses for a lead using Sixtyfour AI.
 |   ↳ `status` | string | Validation status \(OK or UNKNOWN\) |
 |   ↳ `type` | string | Email type \(COMPANY or PERSONAL\) |
 
-### `sixtyfour_enrich_lead`
+### Sixtyfour Enrich Lead
 
 Enrich lead information with contact details, social profiles, and company data using Sixtyfour AI.
 
@@ -113,7 +113,7 @@ Enrich lead information with contact details, social profiles, and company data 
 | `references` | json | Source URLs and descriptions used for enrichment |
 | `confidenceScore` | number | Quality score for the returned data \(0-10\) |
 
-### `sixtyfour_enrich_company`
+### Sixtyfour Enrich Company
 
 Enrich company data with additional information and find associated people using Sixtyfour AI.
 

--- a/apps/docs/content/docs/en/integrations/slack.mdx
+++ b/apps/docs/content/docs/en/integrations/slack.mdx
@@ -45,7 +45,7 @@ Integrate Slack into the workflow. Can send, update, and delete messages, send e
 
 ## Actions
 
-### `slack_message`
+### Slack Message
 
 Send messages to Slack channels or direct messages. Supports Slack mrkdwn formatting.
 
@@ -127,7 +127,7 @@ Send messages to Slack channels or direct messages. Supports Slack mrkdwn format
 | `fileCount` | number | Number of files uploaded \(when files are attached\) |
 | `files` | file[] | Files attached to the message |
 
-### `slack_ephemeral_message`
+### Slack Ephemeral Message
 
 Send an ephemeral message visible only to a specific user in a channel. Optionally reply in a thread. The message does not persist across sessions.
 
@@ -150,7 +150,7 @@ Send an ephemeral message visible only to a specific user in a channel. Optional
 | `messageTs` | string | Timestamp of the ephemeral message \(cannot be used with chat.update\) |
 | `channel` | string | Channel ID where the ephemeral message was sent |
 
-### `slack_canvas`
+### Slack Canvas Writer
 
 Create and share Slack canvases in channels. Canvases are collaborative documents within Slack.
 
@@ -171,7 +171,7 @@ Create and share Slack canvases in channels. Canvases are collaborative document
 | --------- | ---- | ----------- |
 | `canvas_id` | string | Unique canvas identifier |
 
-### `slack_message_reader`
+### Slack Message Reader
 
 Read the latest messages from Slack channels. Retrieve conversation history with filtering options.
 
@@ -248,7 +248,7 @@ Read the latest messages from Slack channels. Retrieve conversation history with
 |     ↳ `user` | string | User ID who edited the message |
 |     ↳ `ts` | string | Timestamp of the edit |
 
-### `slack_get_message`
+### Slack Get Message
 
 Retrieve a specific message by its timestamp. Useful for getting a thread parent message.
 
@@ -321,7 +321,7 @@ Retrieve a specific message by its timestamp. Useful for getting a thread parent
 |     ↳ `user` | string | User ID who edited the message |
 |     ↳ `ts` | string | Timestamp of the edit |
 
-### `slack_get_thread`
+### Slack Get Thread
 
 Retrieve an entire thread including the parent message and all replies. Useful for getting full conversation context.
 
@@ -507,7 +507,7 @@ Retrieve an entire thread including the parent message and all replies. Useful f
 | `replyCount` | number | Number of replies returned in this response |
 | `hasMore` | boolean | Whether there are more messages in the thread \(pagination needed\) |
 
-### `slack_get_thread_replies`
+### Slack Get Thread Replies
 
 Fetch every message in a Slack thread, automatically following pagination across all pages. Returns the parent message and the full set of replies.
 
@@ -700,7 +700,7 @@ Fetch every message in a Slack thread, automatically following pagination across
 | `nextCursor` | string | Cursor to fetch the next page; null when there are no more pages |
 | `pages` | number | Number of pages fetched in this invocation |
 
-### `slack_get_channel_history`
+### Slack Get Channel History
 
 Fetch message history from a Slack channel, automatically following pagination. Optionally filter by a time range to scrape messages since a given timestamp.
 
@@ -782,7 +782,7 @@ Fetch message history from a Slack channel, automatically following pagination. 
 | `nextCursor` | string | Cursor to fetch the next page; null when there are no more pages |
 | `pages` | number | Number of pages fetched in this invocation |
 
-### `slack_get_permalink`
+### Slack Get Permalink
 
 Get a stable permalink URL to a specific Slack message.
 
@@ -803,7 +803,7 @@ Get a stable permalink URL to a specific Slack message.
 | `channel` | string | Channel ID containing the message |
 | `permalink` | string | The permalink URL to the message |
 
-### `slack_set_status`
+### Slack Set Assistant Status
 
 Set or clear the assistant thread status indicator (the loading shimmer) on a Slack AI app thread. Pass an empty status to clear it.
 
@@ -826,7 +826,7 @@ Set or clear the assistant thread status indicator (the loading shimmer) on a Sl
 | `channel` | string | Channel ID the status was set on |
 | `threadTs` | string | Thread timestamp the status was set on |
 
-### `slack_set_title`
+### Slack Set Assistant Title
 
 Set the title of a Slack assistant thread (shown in the AI app thread header).
 
@@ -848,7 +848,7 @@ Set the title of a Slack assistant thread (shown in the AI app thread header).
 | `channel` | string | Channel ID the title was set on |
 | `threadTs` | string | Thread timestamp the title was set on |
 
-### `slack_set_suggested_prompts`
+### Slack Set Suggested Prompts
 
 Set the clickable suggested prompts shown in a Slack assistant thread (the prompt chips in an AI app).
 
@@ -871,7 +871,7 @@ Set the clickable suggested prompts shown in a Slack assistant thread (the promp
 | `channel` | string | Channel ID the prompts were set on |
 | `threadTs` | string | Thread timestamp the prompts were set on |
 
-### `slack_list_channels`
+### Slack List Channels
 
 List all channels in a Slack workspace. Returns public and private channels the bot has access to.
 
@@ -912,7 +912,7 @@ List all channels in a Slack workspace. Returns public and private channels the 
 | `count` | number | Total number of channels returned |
 | `nextCursor` | string | Cursor for the next page; null if no more pages |
 
-### `slack_list_members`
+### Slack List Channel Members
 
 List all members (user IDs) in a Slack channel. Use with Get User Info to resolve IDs to names.
 
@@ -934,7 +934,7 @@ List all members (user IDs) in a Slack channel. Use with Get User Info to resolv
 | `count` | number | Total number of members returned |
 | `nextCursor` | string | Cursor for the next page; null if no more pages |
 
-### `slack_list_users`
+### Slack List Users
 
 List all users in a Slack workspace. Returns user profiles with names and avatars.
 
@@ -971,7 +971,7 @@ List all users in a Slack workspace. Returns user profiles with names and avatar
 | `count` | number | Total number of users returned |
 | `nextCursor` | string | Cursor for the next page; null if no more pages |
 
-### `slack_get_user`
+### Slack Get User Info
 
 Get detailed information about a specific Slack user by their user ID.
 
@@ -1023,7 +1023,7 @@ Get detailed information about a specific Slack user by their user ID.
 |   ↳ `updated` | number | Unix timestamp of last profile update |
 |   ↳ `has_2fa` | boolean | Whether two-factor auth is enabled |
 
-### `slack_download`
+### Download File from Slack
 
 Download a file from Slack
 
@@ -1042,7 +1042,7 @@ Download a file from Slack
 | --------- | ---- | ----------- |
 | `file` | file | Downloaded file stored in execution files |
 
-### `slack_update_message`
+### Slack Update Message
 
 Update a message previously sent by the bot in Slack
 
@@ -1122,7 +1122,7 @@ Update a message previously sent by the bot in Slack
 |   ↳ `timestamp` | string | Message timestamp |
 |   ↳ `text` | string | Updated message text |
 
-### `slack_delete_message`
+### Slack Delete Message
 
 Delete a message previously sent by the bot in Slack
 
@@ -1144,7 +1144,7 @@ Delete a message previously sent by the bot in Slack
 |   ↳ `channel` | string | Channel ID |
 |   ↳ `timestamp` | string | Message timestamp |
 
-### `slack_add_reaction`
+### Slack Add Reaction
 
 Add an emoji reaction to a Slack message
 
@@ -1168,7 +1168,7 @@ Add an emoji reaction to a Slack message
 |   ↳ `timestamp` | string | Message timestamp |
 |   ↳ `reaction` | string | Emoji reaction name |
 
-### `slack_remove_reaction`
+### Slack Remove Reaction
 
 Remove an emoji reaction from a Slack message
 
@@ -1192,7 +1192,7 @@ Remove an emoji reaction from a Slack message
 |   ↳ `timestamp` | string | Message timestamp |
 |   ↳ `reaction` | string | Emoji reaction name |
 
-### `slack_get_channel_info`
+### Slack Get Channel Info
 
 Get detailed information about a Slack channel by its ID
 
@@ -1227,7 +1227,7 @@ Get detailed information about a Slack channel by its ID
 |   ↳ `creator` | string | User ID of channel creator |
 |   ↳ `updated` | number | Unix timestamp of last update |
 
-### `slack_get_user_presence`
+### Slack Get User Presence
 
 Check whether a Slack user is currently active or away
 
@@ -1250,7 +1250,7 @@ Check whether a Slack user is currently active or away
 | `connectionCount` | number | Total number of active connections for the user \(only available when checking own presence\) |
 | `lastActivity` | number | Unix timestamp of last detected activity \(only available when checking own presence\) |
 
-### `slack_edit_canvas`
+### Slack Edit Canvas
 
 Edit an existing Slack canvas by inserting, replacing, or deleting content
 
@@ -1272,7 +1272,7 @@ Edit an existing Slack canvas by inserting, replacing, or deleting content
 | --------- | ---- | ----------- |
 | `content` | string | Success message |
 
-### `slack_create_channel_canvas`
+### Slack Create Channel Canvas
 
 Create a canvas pinned to a Slack channel as its resource hub
 
@@ -1292,7 +1292,7 @@ Create a canvas pinned to a Slack channel as its resource hub
 | --------- | ---- | ----------- |
 | `canvas_id` | string | ID of the created channel canvas |
 
-### `slack_get_canvas`
+### Slack Get Canvas Info
 
 Get Slack canvas file metadata by canvas ID
 
@@ -1334,7 +1334,7 @@ Get Slack canvas file metadata by canvas ID
 |   ↳ `linked_channel_id` | string | Channel ID linked to this canvas |
 |   ↳ `canvas_creator_id` | string | User ID of the canvas creator |
 
-### `slack_list_canvases`
+### Slack List Canvases
 
 List Slack canvases available to the authenticated user or bot
 
@@ -1387,7 +1387,7 @@ List Slack canvases available to the authenticated user or bot
 |   ↳ `page` | number | Current page number |
 |   ↳ `pages` | number | Total number of pages |
 
-### `slack_lookup_canvas_sections`
+### Slack Lookup Canvas Sections
 
 Find Slack canvas section IDs matching criteria for later edits
 
@@ -1407,7 +1407,7 @@ Find Slack canvas section IDs matching criteria for later edits
 | `sections` | array | Canvas sections matching the lookup criteria |
 |   ↳ `id` | string | Canvas section identifier |
 
-### `slack_delete_canvas`
+### Slack Delete Canvas
 
 Delete a Slack canvas by its canvas ID
 
@@ -1425,7 +1425,7 @@ Delete a Slack canvas by its canvas ID
 | --------- | ---- | ----------- |
 | `ok` | boolean | Whether Slack deleted the canvas successfully |
 
-### `slack_create_conversation`
+### Slack Create Conversation
 
 Create a new public or private channel in a Slack workspace.
 
@@ -1461,7 +1461,7 @@ Create a new public or private channel in a Slack workspace.
 |   ↳ `creator` | string | User ID of channel creator |
 |   ↳ `updated` | number | Unix timestamp of last update |
 
-### `slack_invite_to_conversation`
+### Slack Invite to Conversation
 
 Invite one or more users to a Slack channel. Supports up to 100 users at a time.
 
@@ -1501,7 +1501,7 @@ Invite one or more users to a Slack channel. Supports up to 100 users at a time.
 |   ↳ `ok` | boolean | Always false for error entries |
 |   ↳ `error` | string | Error code for this user |
 
-### `slack_open_view`
+### Slack Open View
 
 Open a modal view in Slack using a trigger_id from an interaction payload. Used to display forms, confirmations, and other interactive modals.
 
@@ -1547,7 +1547,7 @@ Open a modal view in Slack using a trigger_id from an interaction payload. Used 
 |   ↳ `app_id` | string | Application identifier |
 |   ↳ `bot_id` | string | Bot identifier |
 
-### `slack_update_view`
+### Slack Update View
 
 Update an existing modal view in Slack. Identify the view by view_id or external_id, and provide the updated view payload.
 
@@ -1594,7 +1594,7 @@ Update an existing modal view in Slack. Identify the view by view_id or external
 |   ↳ `app_id` | string | Application identifier |
 |   ↳ `bot_id` | string | Bot identifier |
 
-### `slack_push_view`
+### Slack Push View
 
 Push a new view onto an existing modal stack in Slack. Limited to 2 additional views after the initial modal is opened.
 
@@ -1640,7 +1640,7 @@ Push a new view onto an existing modal stack in Slack. Limited to 2 additional v
 |   ↳ `app_id` | string | Application identifier |
 |   ↳ `bot_id` | string | Bot identifier |
 
-### `slack_publish_view`
+### Slack Publish View
 
 Publish a static view to a user's Home tab in Slack. Used to create or update the app's Home tab experience.
 
@@ -1686,7 +1686,7 @@ Publish a static view to a user's Home tab in Slack. Used to create or update th
 |   ↳ `app_id` | string | Application identifier |
 |   ↳ `bot_id` | string | Bot identifier |
 
-### `slack_schedule_message`
+### Slack Schedule Message
 
 Schedule a message to be sent to a Slack channel or DM at a future time.
 
@@ -1711,7 +1711,7 @@ Schedule a message to be sent to a Slack channel or DM at a future time.
 | `channel` | string | Channel ID where the message is scheduled |
 | `message` | object | The scheduled message object returned by Slack |
 
-### `slack_list_scheduled_messages`
+### Slack List Scheduled Messages
 
 List pending scheduled messages in a Slack workspace, optionally filtered by channel.
 
@@ -1740,7 +1740,7 @@ List pending scheduled messages in a Slack workspace, optionally filtered by cha
 |   ↳ `text` | string | Scheduled message text |
 | `nextCursor` | string | Cursor for the next page \(null when there are no more pages\) |
 
-### `slack_delete_scheduled_message`
+### Slack Delete Scheduled Message
 
 Delete a pending scheduled message before it posts to Slack.
 
@@ -1759,7 +1759,7 @@ Delete a pending scheduled message before it posts to Slack.
 | --------- | ---- | ----------- |
 | `ok` | boolean | Whether the scheduled message was deleted successfully |
 
-### `slack_archive_conversation`
+### Slack Archive Conversation
 
 Archive a Slack channel so it is closed to new activity.
 
@@ -1777,7 +1777,7 @@ Archive a Slack channel so it is closed to new activity.
 | --------- | ---- | ----------- |
 | `ok` | boolean | Whether the conversation was archived successfully |
 
-### `slack_rename_conversation`
+### Slack Rename Conversation
 
 Rename an existing Slack channel.
 
@@ -1812,7 +1812,7 @@ Rename an existing Slack channel.
 |   ↳ `creator` | string | User ID of channel creator |
 |   ↳ `updated` | number | Unix timestamp of last update |
 
-### `slack_set_conversation_topic`
+### Slack Set Conversation Topic
 
 Set the topic for a Slack channel (max 250 characters).
 
@@ -1847,7 +1847,7 @@ Set the topic for a Slack channel (max 250 characters).
 |   ↳ `creator` | string | User ID of channel creator |
 |   ↳ `updated` | number | Unix timestamp of last update |
 
-### `slack_set_conversation_purpose`
+### Slack Set Conversation Purpose
 
 Set the purpose (description) for a Slack channel (max 250 characters).
 

--- a/apps/docs/content/docs/en/integrations/smartlead.mdx
+++ b/apps/docs/content/docs/en/integrations/smartlead.mdx
@@ -18,7 +18,7 @@ Integrate Smartlead into workflows. Create campaigns, write multi-step email seq
 
 ## Actions
 
-### `smartlead_list_campaigns`
+### Smartlead List Campaigns
 
 Retrieves all Smartlead campaigns for the authenticated account.
 
@@ -128,7 +128,7 @@ Retrieves all Smartlead campaigns for the authenticated account.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign`
+### Smartlead Get Campaign
 
 Retrieves a single Smartlead campaign by ID.
 
@@ -236,7 +236,7 @@ Retrieves a single Smartlead campaign by ID.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_create_campaign`
+### Smartlead Create Campaign
 
 Creates a Smartlead campaign. The campaign starts in DRAFTED status; add sequences, email accounts, and a schedule before starting it.
 
@@ -346,7 +346,7 @@ Creates a Smartlead campaign. The campaign starts in DRAFTED status; add sequenc
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_update_campaign_status`
+### Smartlead Update Campaign Status
 
 Starts, pauses, or stops a Smartlead campaign. START requires the campaign to already have a schedule, sequences, and at least one email account.
 
@@ -455,7 +455,7 @@ Starts, pauses, or stops a Smartlead campaign. START requires the campaign to al
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_update_campaign_schedule`
+### Smartlead Update Campaign Schedule
 
 Sets the sending window, timezone, and throughput limits for a Smartlead campaign. A campaign cannot be started until a schedule exists.
 
@@ -570,7 +570,7 @@ Sets the sending window, timezone, and throughput limits for a Smartlead campaig
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_update_campaign_settings`
+### Smartlead Update Campaign Settings
 
 Updates tracking, stop-on-activity, and sending settings for a Smartlead campaign.
 
@@ -684,7 +684,7 @@ Updates tracking, stop-on-activity, and sending settings for a Smartlead campaig
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign_analytics`
+### Smartlead Get Campaign Analytics
 
 Retrieves lifetime performance totals for a Smartlead campaign — sends, opens, clicks, replies, bounces, and lead counts by state.
 
@@ -792,7 +792,7 @@ Retrieves lifetime performance totals for a Smartlead campaign — sends, opens,
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign_analytics_by_date`
+### Smartlead Get Campaign Analytics By Date
 
 Retrieves Smartlead campaign performance totals for a date range. Smartlead rejects ranges longer than roughly one month.
 
@@ -902,7 +902,7 @@ Retrieves Smartlead campaign performance totals for a date range. Smartlead reje
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign_sequences`
+### Smartlead Get Campaign Sequences
 
 Retrieves the email sequence steps for a Smartlead campaign, including subjects, bodies, and per-step delays.
 
@@ -1010,7 +1010,7 @@ Retrieves the email sequence steps for a Smartlead campaign, including subjects,
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_save_campaign_sequences`
+### Smartlead Save Campaign Sequences
 
 Replaces the email sequence for a Smartlead campaign. Send every step in one call — steps omitted from the request are removed. An empty subject makes a step reply in the previous thread.
 
@@ -1119,7 +1119,7 @@ Replaces the email sequence for a Smartlead campaign. Send every step in one cal
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign_statistics`
+### Smartlead Get Campaign Statistics
 
 Retrieves per-email statistics rows for a Smartlead campaign, filterable by sequence step, engagement status, and sent-time range.
 
@@ -1233,7 +1233,7 @@ Retrieves per-email statistics rows for a Smartlead campaign, filterable by sequ
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_add_leads_to_campaign`
+### Smartlead Add Leads to Campaign
 
 Adds leads to a Smartlead campaign, up to 400 per call. Returns per-reason counts for leads that were skipped as duplicates, blocked, bounced, or invalid.
 
@@ -1346,7 +1346,7 @@ Adds leads to a Smartlead campaign, up to 400 per call. Returns per-reason count
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_campaign_leads`
+### Smartlead List Campaign Leads
 
 Retrieves the leads in a Smartlead campaign with their per-campaign status.
 
@@ -1456,7 +1456,7 @@ Retrieves the leads in a Smartlead campaign with their per-campaign status.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_lead_by_email`
+### Smartlead Get Lead by Email
 
 Looks up a Smartlead lead by email address and returns the lead record plus every campaign it belongs to.
 
@@ -1565,7 +1565,7 @@ Looks up a Smartlead lead by email address and returns the lead record plus ever
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_update_lead`
+### Smartlead Update Lead
 
 Updates a lead in a Smartlead campaign. Smartlead requires the email field even when it is unchanged, and lead edits apply across every campaign the lead belongs to.
 
@@ -1683,7 +1683,7 @@ Updates a lead in a Smartlead campaign. Smartlead requires the email field even 
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_update_lead_category`
+### Smartlead Update Lead Category
 
 Sets the category of a lead in a Smartlead campaign, such as Interested or Not Interested. Use List Lead Categories to resolve a category ID.
 
@@ -1793,7 +1793,7 @@ Sets the category of a lead in a Smartlead campaign, such as Interested or Not I
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_pause_lead`
+### Smartlead Pause Lead
 
 Pauses a lead in a Smartlead campaign so it stops receiving sequence emails.
 
@@ -1901,7 +1901,7 @@ Pauses a lead in a Smartlead campaign so it stops receiving sequence emails.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_resume_lead`
+### Smartlead Resume Lead
 
 Resumes a paused lead in a Smartlead campaign, optionally after a delay.
 
@@ -2010,7 +2010,7 @@ Resumes a paused lead in a Smartlead campaign, optionally after a delay.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_lead_categories`
+### Smartlead List Lead Categories
 
 Retrieves the lead categories configured on the Smartlead account, with the category IDs needed to categorize a lead.
 
@@ -2118,7 +2118,7 @@ Retrieves the lead categories configured on the Smartlead account, with the cate
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_lead_message_history`
+### Smartlead Get Lead Message History
 
 Retrieves the sent-and-received message history for a lead in a Smartlead campaign.
 
@@ -2226,7 +2226,7 @@ Retrieves the sent-and-received message history for a lead in a Smartlead campai
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_campaign_webhooks`
+### Smartlead List Campaign Webhooks
 
 Retrieves the webhooks registered on a Smartlead campaign.
 
@@ -2334,7 +2334,7 @@ Retrieves the webhooks registered on a Smartlead campaign.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_upsert_campaign_webhook`
+### Smartlead Create or Update Campaign Webhook
 
 Creates a webhook on a Smartlead campaign, or updates an existing one when a webhook ID is supplied. Smartlead requires at least one lead category.
 
@@ -2447,7 +2447,7 @@ Creates a webhook on a Smartlead campaign, or updates an existing one when a web
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_delete_campaign_webhook`
+### Smartlead Delete Campaign Webhook
 
 Deletes a webhook from a Smartlead campaign.
 
@@ -2556,7 +2556,7 @@ Deletes a webhook from a Smartlead campaign.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign_webhook_summary`
+### Smartlead Get Campaign Webhook Summary
 
 Retrieves webhook delivery counts for a Smartlead campaign over a time window, for checking whether events are reaching their destination.
 
@@ -2666,9 +2666,9 @@ Retrieves webhook delivery counts for a Smartlead campaign over a time window, f
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_duplicate_campaign`
+### Smartlead Duplicate Campaign
 
-Copies a Smartlead campaign, including its sequences and settings. The copy is named "<original> - copy" and starts in DRAFTED status.
+Copies a Smartlead campaign, including its sequences and settings. The copy is named "&lt;original&gt; - copy" and starts in DRAFTED status.
 
 #### Input
 
@@ -2774,7 +2774,7 @@ Copies a Smartlead campaign, including its sequences and settings. The copy is n
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_delete_campaign`
+### Smartlead Delete Campaign
 
 Permanently deletes a Smartlead campaign along with its sequences, leads, and webhooks. This cannot be undone.
 
@@ -2882,7 +2882,7 @@ Permanently deletes a Smartlead campaign along with its sequences, leads, and we
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_export_campaign_leads`
+### Smartlead Export Campaign Leads
 
 Exports every lead in a Smartlead campaign as CSV, including engagement counts and the sequence step last sent to each lead.
 
@@ -2990,7 +2990,7 @@ Exports every lead in a Smartlead campaign as CSV, including engagement counts a
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_campaign_email_accounts`
+### Smartlead List Campaign Email Accounts
 
 Retrieves the sending email accounts attached to a Smartlead campaign.
 
@@ -3098,7 +3098,7 @@ Retrieves the sending email accounts attached to a Smartlead campaign.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_add_email_accounts_to_campaign`
+### Smartlead Add Email Accounts to Campaign
 
 Attaches sending email accounts to a Smartlead campaign. A campaign needs at least one attached account before it can start.
 
@@ -3207,7 +3207,7 @@ Attaches sending email accounts to a Smartlead campaign. A campaign needs at lea
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_remove_email_accounts_from_campaign`
+### Smartlead Remove Email Accounts from Campaign
 
 Detaches sending email accounts from a Smartlead campaign.
 
@@ -3316,7 +3316,7 @@ Detaches sending email accounts from a Smartlead campaign.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_email_accounts`
+### Smartlead List Email Accounts
 
 Retrieves the sending email accounts on the Smartlead account, including their IDs for attaching to a campaign.
 
@@ -3427,7 +3427,7 @@ Retrieves the sending email accounts on the Smartlead account, including their I
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign_lead_statistics`
+### Smartlead Get Campaign Lead Statistics
 
 Retrieves per-lead engagement statistics for a Smartlead campaign.
 
@@ -3537,7 +3537,7 @@ Retrieves per-lead engagement statistics for a Smartlead campaign.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign_mailbox_statistics`
+### Smartlead Get Campaign Mailbox Statistics
 
 Retrieves per-mailbox sending statistics for a Smartlead campaign, for spotting which sending accounts are underperforming.
 
@@ -3645,7 +3645,7 @@ Retrieves per-mailbox sending statistics for a Smartlead campaign, for spotting 
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_campaign_top_level_analytics_by_date`
+### Smartlead Get Campaign Top-Level Analytics By Date
 
 Retrieves top-level Smartlead campaign counts for a date range, including positive replies, skipped, failed, and stopped counts not present in the standard analytics.
 
@@ -3755,7 +3755,7 @@ Retrieves top-level Smartlead campaign counts for a date range, including positi
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_lead_activities`
+### Smartlead List Lead Activities
 
 Retrieves recent lead activity across all Smartlead campaigns — opens, clicks, replies, and status changes. Smartlead exposes no campaign filter on this endpoint.
 
@@ -3865,7 +3865,7 @@ Retrieves recent lead activity across all Smartlead campaigns — opens, clicks,
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_lead_by_id`
+### Smartlead Get Lead by ID
 
 Looks up a Smartlead lead by its ID.
 
@@ -3974,7 +3974,7 @@ Looks up a Smartlead lead by its ID.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_unsubscribe_lead_from_campaign`
+### Smartlead Unsubscribe Lead from Campaign
 
 Unsubscribes a lead from a single Smartlead campaign, leaving it active in other campaigns.
 
@@ -4082,7 +4082,7 @@ Unsubscribes a lead from a single Smartlead campaign, leaving it active in other
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_unsubscribe_lead_globally`
+### Smartlead Unsubscribe Lead Globally
 
 Unsubscribes a lead across every Smartlead campaign and adds it to the account-wide unsubscribe list.
 
@@ -4191,7 +4191,7 @@ Unsubscribes a lead across every Smartlead campaign and adds it to the account-w
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_mark_lead_complete`
+### Smartlead Mark Lead Complete
 
 Marks a lead as completed in a Smartlead campaign so it stops receiving further sequence steps.
 
@@ -4300,7 +4300,7 @@ Marks a lead as completed in a Smartlead campaign so it stops receiving further 
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_delete_lead_from_campaign`
+### Smartlead Delete Lead from Campaign
 
 Removes a lead from a Smartlead campaign. The lead record itself remains on the account.
 
@@ -4408,7 +4408,7 @@ Removes a lead from a Smartlead campaign. The lead record itself remains on the 
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_inbox_replies`
+### Smartlead List Inbox Replies
 
 Retrieves replies from the Smartlead master inbox across all campaigns, optionally limited to unread replies. Smartlead exposes no campaign filter on this endpoint.
 
@@ -4519,7 +4519,7 @@ Retrieves replies from the Smartlead master inbox across all campaigns, optional
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_lead_lists`
+### Smartlead List Lead Lists
 
 Retrieves the lead lists on the Smartlead account with their lead counts.
 
@@ -4629,7 +4629,7 @@ Retrieves the lead lists on the Smartlead account with their lead counts.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_get_lead_list`
+### Smartlead Get Lead List
 
 Retrieves a single Smartlead lead list by ID.
 
@@ -4738,7 +4738,7 @@ Retrieves a single Smartlead lead list by ID.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_create_lead_list`
+### Smartlead Create Lead List
 
 Creates a lead list on the Smartlead account.
 
@@ -4847,7 +4847,7 @@ Creates a lead list on the Smartlead account.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_update_lead_list`
+### Smartlead Update Lead List
 
 Renames a Smartlead lead list.
 
@@ -4957,7 +4957,7 @@ Renames a Smartlead lead list.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_delete_lead_list`
+### Smartlead Delete Lead List
 
 Deletes a Smartlead lead list.
 
@@ -5066,7 +5066,7 @@ Deletes a Smartlead lead list.
 | `tags` | array | Tags on the record |
 | `email_campaign_id` | number | Campaign the webhook belongs to |
 
-### `smartlead_list_clients`
+### Smartlead List Clients
 
 Retrieves the clients on a Smartlead agency account, including the client IDs used to scope campaigns and email accounts.
 

--- a/apps/docs/content/docs/en/integrations/smtp.mdx
+++ b/apps/docs/content/docs/en/integrations/smtp.mdx
@@ -31,7 +31,7 @@ Send emails using any SMTP server (Gmail, Outlook, custom servers, etc.). Config
 
 ## Actions
 
-### `smtp_send_mail`
+### SMTP Send Mail
 
 Send emails via SMTP server
 

--- a/apps/docs/content/docs/en/integrations/sportmonks.mdx
+++ b/apps/docs/content/docs/en/integrations/sportmonks.mdx
@@ -32,7 +32,7 @@ Integrate the Sportmonks sports data APIs into the workflow from a single block.
 
 ## Actions
 
-### `sportmonks_football_expected_by_player`
+### Get Expected xG by Player
 
 Retrieve lineup-level expected goals (xG) values per player from Sportmonks
 
@@ -61,7 +61,7 @@ Retrieve lineup-level expected goals (xG) values per player from Sportmonks
 |   ↳ `data` | object | The expected value payload |
 |     ↳ `value` | number | The xG value |
 
-### `sportmonks_football_expected_by_team`
+### Get Expected xG by Team
 
 Retrieve fixture-level expected goals (xG) values per team from Sportmonks
 
@@ -89,7 +89,7 @@ Retrieve fixture-level expected goals (xG) values per team from Sportmonks
 |     ↳ `value` | number | The xG value |
 |   ↳ `location` | string | Home or away |
 
-### `sportmonks_football_get_all_commentaries`
+### Get All Commentaries
 
 Retrieve all textual commentaries available within your Sportmonks subscription
 
@@ -118,7 +118,7 @@ Retrieve all textual commentaries available within your Sportmonks subscription
 |   ↳ `is_important` | boolean | Whether the comment is important |
 |   ↳ `order` | number | Order of the comment |
 
-### `sportmonks_football_get_all_fixtures`
+### Get All Fixtures
 
 Retrieve all football fixtures available within your Sportmonks subscription
 
@@ -159,7 +159,7 @@ Retrieve all football fixtures available within your Sportmonks subscription
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_all_players`
+### Get All Players
 
 Retrieve all football players available within your Sportmonks subscription
 
@@ -198,7 +198,7 @@ Retrieve all football players available within your Sportmonks subscription
 |   ↳ `date_of_birth` | string | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
-### `sportmonks_football_get_all_rivals`
+### Get All Rivals
 
 Retrieve all teams with their rivals information from Sportmonks
 
@@ -222,7 +222,7 @@ Retrieve all teams with their rivals information from Sportmonks
 |   ↳ `team_id` | number | Team the rivalry belongs to |
 |   ↳ `rival_id` | number | Rival team id |
 
-### `sportmonks_football_get_all_teams`
+### Get All Teams
 
 Retrieve all football teams available within your Sportmonks subscription
 
@@ -255,7 +255,7 @@ Retrieve all football teams available within your Sportmonks subscription
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the last played match |
 
-### `sportmonks_football_get_all_transfer_rumours`
+### Get All Transfer Rumours
 
 Retrieve all transfer rumours available within your Sportmonks subscription
 
@@ -290,7 +290,7 @@ Retrieve all transfer rumours available within your Sportmonks subscription
 |   ↳ `date` | string | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
-### `sportmonks_football_get_all_transfers`
+### Get All Transfers
 
 Retrieve all transfers available within your Sportmonks subscription
 
@@ -323,7 +323,7 @@ Retrieve all transfers available within your Sportmonks subscription
 |   ↳ `completed` | boolean | Whether the transfer is completed |
 |   ↳ `amount` | number | Transfer fee amount |
 
-### `sportmonks_football_get_brackets_by_season`
+### Get Brackets by Season
 
 Retrieve the knockout-stage tournament bracket (stages and progression edges) for a season ID
 
@@ -341,7 +341,7 @@ Retrieve the knockout-stage tournament bracket (stages and progression edges) fo
 | --------- | ---- | ----------- |
 | `brackets` | json | Bracket object containing stages \(fixtures grouped by knockout round\) and edges \(progression paths between fixtures\) |
 
-### `sportmonks_football_get_coach`
+### Get Coach by ID
 
 Retrieve a single football coach by their ID from Sportmonks
 
@@ -376,7 +376,7 @@ Retrieve a single football coach by their ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the coach |
 |   ↳ `gender` | string | Gender of the coach |
 
-### `sportmonks_football_get_coaches`
+### Get Coaches
 
 Retrieve all football coaches available within your Sportmonks subscription
 
@@ -413,7 +413,7 @@ Retrieve all football coaches available within your Sportmonks subscription
 |   ↳ `date_of_birth` | string | Date of birth of the coach |
 |   ↳ `gender` | string | Gender of the coach |
 
-### `sportmonks_football_get_coaches_by_country`
+### Get Coaches by Country
 
 Retrieve all coaches for a country ID from Sportmonks
 
@@ -451,7 +451,7 @@ Retrieve all coaches for a country ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the coach |
 |   ↳ `gender` | string | Gender of the coach |
 
-### `sportmonks_football_get_commentaries_by_fixture`
+### Get Commentaries by Fixture
 
 Retrieve textual commentary for a fixture by fixture ID from Sportmonks
 
@@ -477,7 +477,7 @@ Retrieve textual commentary for a fixture by fixture ID from Sportmonks
 |   ↳ `is_important` | boolean | Whether the comment is important |
 |   ↳ `order` | number | Order of the comment |
 
-### `sportmonks_football_get_current_leagues_by_team`
+### Get Current Leagues by Team
 
 Retrieve all current leagues for a team ID from Sportmonks
 
@@ -510,7 +510,7 @@ Retrieve all current leagues for a team ID from Sportmonks
 |   ↳ `last_played_at` | string | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
-### `sportmonks_football_get_expected_lineups_by_player`
+### Get Expected Lineups by Player
 
 Retrieve the premium expected lineups for a player ID from Sportmonks
 
@@ -544,7 +544,7 @@ Retrieve the premium expected lineups for a player ID from Sportmonks
 |   ↳ `player_name` | string | Name of the player |
 |   ↳ `jersey_number` | number | Jersey number of the player |
 
-### `sportmonks_football_get_expected_lineups_by_team`
+### Get Expected Lineups by Team
 
 Retrieve the premium expected lineups for a team ID from Sportmonks
 
@@ -578,7 +578,7 @@ Retrieve the premium expected lineups for a team ID from Sportmonks
 |   ↳ `player_name` | string | Name of the player |
 |   ↳ `jersey_number` | number | Jersey number of the player |
 
-### `sportmonks_football_get_extended_team_squad`
+### Get Extended Team Squad
 
 Retrieve all squad entries for a team (based on current seasons) by team ID
 
@@ -606,7 +606,7 @@ Retrieve all squad entries for a team (based on current seasons) by team ID
 |   ↳ `start` | string | Start contract date of the player |
 |   ↳ `end` | string | End contract date of the player |
 
-### `sportmonks_football_get_fixture`
+### Get Fixture by ID
 
 Retrieve a single football fixture by its ID from Sportmonks
 
@@ -645,7 +645,7 @@ Retrieve a single football fixture by its ID from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_fixtures_by_date`
+### Get Fixtures by Date
 
 Retrieve all football fixtures on a specific date (YYYY-MM-DD) from Sportmonks
 
@@ -687,7 +687,7 @@ Retrieve all football fixtures on a specific date (YYYY-MM-DD) from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_fixtures_by_date_range`
+### Get Fixtures by Date Range
 
 Retrieve football fixtures between two dates (YYYY-MM-DD) from Sportmonks. Max range is 100 days.
 
@@ -730,7 +730,7 @@ Retrieve football fixtures between two dates (YYYY-MM-DD) from Sportmonks. Max r
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_fixtures_by_date_range_for_team`
+### Get Fixtures by Date Range for Team
 
 Retrieve fixtures for a team within a date range (YYYY-MM-DD) from Sportmonks
 
@@ -774,7 +774,7 @@ Retrieve fixtures for a team within a date range (YYYY-MM-DD) from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_fixtures_by_ids`
+### Get Fixtures by Multiple IDs
 
 Retrieve multiple football fixtures by a comma-separated list of IDs (max 50)
 
@@ -813,7 +813,7 @@ Retrieve multiple football fixtures by a comma-separated list of IDs (max 50)
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_grouped_standings_by_round`
+### Get Grouped Standings by Round
 
 Retrieve the standing table for a round ID grouped by group where applicable from Sportmonks
 
@@ -832,7 +832,7 @@ Retrieve the standing table for a round ID grouped by group where applicable fro
 | --------- | ---- | ----------- |
 | `standings` | json | Standings for the round: an array of groups \(each with id, name and a standings array\) when groups exist, otherwise a flat array of standing entries |
 
-### `sportmonks_football_get_head_to_head`
+### Get Head to Head
 
 Retrieve the head-to-head fixtures between two teams from Sportmonks
 
@@ -875,7 +875,7 @@ Retrieve the head-to-head fixtures between two teams from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_inplay_livescores`
+### Get Inplay Livescores
 
 Retrieve all fixtures that are currently being played (in-play) from Sportmonks
 
@@ -913,7 +913,7 @@ Retrieve all fixtures that are currently being played (in-play) from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_latest_coaches`
+### Get Last Updated Coaches
 
 Retrieve all coaches that have received updates in the past two hours
 
@@ -950,7 +950,7 @@ Retrieve all coaches that have received updates in the past two hours
 |   ↳ `date_of_birth` | string | Date of birth of the coach |
 |   ↳ `gender` | string | Gender of the coach |
 
-### `sportmonks_football_get_latest_fixtures`
+### Get Latest Updated Fixtures
 
 Retrieve all fixtures that have received updates within the last 10 seconds
 
@@ -988,7 +988,7 @@ Retrieve all fixtures that have received updates within the last 10 seconds
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_latest_livescores`
+### Get Latest Updated Livescores
 
 Retrieve all livescores that have received updates within the last 10 seconds
 
@@ -1026,7 +1026,7 @@ Retrieve all livescores that have received updates within the last 10 seconds
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_latest_players`
+### Get Last Updated Players
 
 Retrieve all players that have received updates in the past two hours
 
@@ -1062,7 +1062,7 @@ Retrieve all players that have received updates in the past two hours
 |   ↳ `date_of_birth` | string | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
-### `sportmonks_football_get_latest_totw`
+### Get Latest Team of the Week
 
 Retrieve the latest Team of the Week (TOTW) for a league ID from Sportmonks
 
@@ -1088,7 +1088,7 @@ Retrieve the latest Team of the Week (TOTW) for a league ID from Sportmonks
 |   ↳ `formation_position` | number | Player position in the TOTW formation |
 |   ↳ `formation` | string | The TOTW's formation |
 
-### `sportmonks_football_get_latest_transfers`
+### Get Latest Transfers
 
 Retrieve the latest transfers available within your Sportmonks subscription
 
@@ -1121,7 +1121,7 @@ Retrieve the latest transfers available within your Sportmonks subscription
 |   ↳ `completed` | boolean | Whether the transfer is completed |
 |   ↳ `amount` | number | Transfer fee amount |
 
-### `sportmonks_football_get_league`
+### Get League by ID
 
 Retrieve a single football league by its ID from Sportmonks
 
@@ -1151,7 +1151,7 @@ Retrieve a single football league by its ID from Sportmonks
 |   ↳ `last_played_at` | string | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
-### `sportmonks_football_get_leagues`
+### Get Leagues
 
 Retrieve all football leagues available within your Sportmonks subscription
 
@@ -1183,7 +1183,7 @@ Retrieve all football leagues available within your Sportmonks subscription
 |   ↳ `last_played_at` | string | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
-### `sportmonks_football_get_leagues_by_country`
+### Get Leagues by Country
 
 Retrieve all leagues for a country ID from Sportmonks
 
@@ -1216,7 +1216,7 @@ Retrieve all leagues for a country ID from Sportmonks
 |   ↳ `last_played_at` | string | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
-### `sportmonks_football_get_leagues_by_date`
+### Get Leagues by Date
 
 Retrieve all leagues with fixtures on a given date (YYYY-MM-DD) from Sportmonks
 
@@ -1249,7 +1249,7 @@ Retrieve all leagues with fixtures on a given date (YYYY-MM-DD) from Sportmonks
 |   ↳ `last_played_at` | string | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
-### `sportmonks_football_get_leagues_by_team`
+### Get Leagues by Team
 
 Retrieve all current and historical leagues for a team ID from Sportmonks
 
@@ -1282,7 +1282,7 @@ Retrieve all current and historical leagues for a team ID from Sportmonks
 |   ↳ `last_played_at` | string | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
-### `sportmonks_football_get_live_leagues`
+### Get Live Leagues
 
 Retrieve all leagues that have fixtures currently being played from Sportmonks
 
@@ -1314,7 +1314,7 @@ Retrieve all leagues that have fixtures currently being played from Sportmonks
 |   ↳ `last_played_at` | string | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
-### `sportmonks_football_get_live_probabilities`
+### Get Live Probabilities
 
 Retrieve all live (in-play) prediction probabilities from Sportmonks
 
@@ -1340,7 +1340,7 @@ Retrieve all live (in-play) prediction probabilities from Sportmonks
 |   ↳ `predictions` | json | Home win, away win and draw probabilities as percentages |
 |   ↳ `type_id` | number | Type of the prediction \(237 for fulltime result\) |
 
-### `sportmonks_football_get_live_probabilities_by_fixture`
+### Get Live Probabilities by Fixture
 
 Retrieve all live (in-play) prediction probabilities for a fixture ID from Sportmonks
 
@@ -1367,7 +1367,7 @@ Retrieve all live (in-play) prediction probabilities for a fixture ID from Sport
 |   ↳ `predictions` | json | Home win, away win and draw probabilities as percentages |
 |   ↳ `type_id` | number | Type of the prediction \(237 for fulltime result\) |
 
-### `sportmonks_football_get_live_standings_by_league`
+### Get Live Standings by League
 
 Retrieve the live standing table for a league ID from Sportmonks
 
@@ -1398,7 +1398,7 @@ Retrieve the live standing table for a league ID from Sportmonks
 |   ↳ `result` | string | Movement of the team in the standing |
 |   ↳ `points` | number | Points the team has gathered |
 
-### `sportmonks_football_get_livescores`
+### Get Livescores
 
 Retrieve fixtures starting within 15 minutes and currently in progress from Sportmonks
 
@@ -1436,7 +1436,7 @@ Retrieve fixtures starting within 15 minutes and currently in progress from Spor
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_match_facts`
+### Get All Match Facts
 
 Retrieve all available match facts within your Sportmonks subscription (beta)
 
@@ -1467,7 +1467,7 @@ Retrieve all available match facts within your Sportmonks subscription (beta)
 |   ↳ `category` | string | Category of the match fact |
 |   ↳ `scope` | string | Scope of the match fact |
 
-### `sportmonks_football_get_match_facts_by_date_range`
+### Get Match Facts by Date Range
 
 Retrieve match facts within a date range (YYYY-MM-DD) from Sportmonks (beta)
 
@@ -1500,7 +1500,7 @@ Retrieve match facts within a date range (YYYY-MM-DD) from Sportmonks (beta)
 |   ↳ `category` | string | Category of the match fact |
 |   ↳ `scope` | string | Scope of the match fact |
 
-### `sportmonks_football_get_match_facts_by_fixture`
+### Get Match Facts by Fixture
 
 Retrieve match facts for a fixture ID from Sportmonks (beta)
 
@@ -1532,7 +1532,7 @@ Retrieve match facts for a fixture ID from Sportmonks (beta)
 |   ↳ `category` | string | Category of the match fact |
 |   ↳ `scope` | string | Scope of the match fact |
 
-### `sportmonks_football_get_match_facts_by_league`
+### Get Match Facts by League
 
 Retrieve match facts for a league ID from Sportmonks (beta)
 
@@ -1564,7 +1564,7 @@ Retrieve match facts for a league ID from Sportmonks (beta)
 |   ↳ `category` | string | Category of the match fact |
 |   ↳ `scope` | string | Scope of the match fact |
 
-### `sportmonks_football_get_past_fixtures_by_tv_station`
+### Get Past Fixtures by TV Station
 
 Retrieve all past fixtures that were available for a TV station ID from Sportmonks
 
@@ -1606,7 +1606,7 @@ Retrieve all past fixtures that were available for a TV station ID from Sportmon
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_player`
+### Get Player by ID
 
 Retrieve a single football player by their ID from Sportmonks
 
@@ -1643,7 +1643,7 @@ Retrieve a single football player by their ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
-### `sportmonks_football_get_players_by_country`
+### Get Players by Country
 
 Retrieve all players for a country ID from Sportmonks
 
@@ -1683,7 +1683,7 @@ Retrieve all players for a country ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
-### `sportmonks_football_get_postmatch_news`
+### Get Post-Match News
 
 Retrieve all post-match news articles available within your Sportmonks subscription
 
@@ -1709,7 +1709,7 @@ Retrieve all post-match news articles available within your Sportmonks subscript
 |   ↳ `title` | string | Title of the news article |
 |   ↳ `type` | string | Type of the news \(prematch or postmatch\) |
 
-### `sportmonks_football_get_postmatch_news_by_season`
+### Get Post-Match News by Season
 
 Retrieve all post-match news articles for a season ID from Sportmonks
 
@@ -1736,7 +1736,7 @@ Retrieve all post-match news articles for a season ID from Sportmonks
 |   ↳ `title` | string | Title of the news article |
 |   ↳ `type` | string | Type of the news \(prematch or postmatch\) |
 
-### `sportmonks_football_get_predictability_by_league`
+### Get Predictability by League
 
 Retrieve the predictions model performance for a league ID from Sportmonks
 
@@ -1762,7 +1762,7 @@ Retrieve the predictions model performance for a league ID from Sportmonks
 |   ↳ `type_id` | number | Type of the predictability |
 |   ↳ `data` | json | Predictability values per market |
 
-### `sportmonks_football_get_prematch_news`
+### Get Pre-Match News
 
 Retrieve all pre-match news articles available within your Sportmonks subscription
 
@@ -1788,7 +1788,7 @@ Retrieve all pre-match news articles available within your Sportmonks subscripti
 |   ↳ `title` | string | Title of the news article |
 |   ↳ `type` | string | Type of the news \(prematch or postmatch\) |
 
-### `sportmonks_football_get_prematch_news_by_season`
+### Get Pre-Match News by Season
 
 Retrieve all pre-match news articles for a season ID from Sportmonks
 
@@ -1815,7 +1815,7 @@ Retrieve all pre-match news articles for a season ID from Sportmonks
 |   ↳ `title` | string | Title of the news article |
 |   ↳ `type` | string | Type of the news \(prematch or postmatch\) |
 
-### `sportmonks_football_get_prematch_news_upcoming`
+### Get Pre-Match News for Upcoming Fixtures
 
 Retrieve all pre-match news articles for upcoming fixtures from Sportmonks
 
@@ -1841,7 +1841,7 @@ Retrieve all pre-match news articles for upcoming fixtures from Sportmonks
 |   ↳ `title` | string | Title of the news article |
 |   ↳ `type` | string | Type of the news \(prematch or postmatch\) |
 
-### `sportmonks_football_get_probabilities`
+### Get Probabilities
 
 Retrieve all prediction probabilities available within your Sportmonks subscription
 
@@ -1866,7 +1866,7 @@ Retrieve all prediction probabilities available within your Sportmonks subscript
 |   ↳ `predictions` | json | Prediction payload \(varies by type: score map, value bet object, etc.\) |
 |   ↳ `type_id` | number | Type of the prediction |
 
-### `sportmonks_football_get_probabilities_by_fixture`
+### Get Predictions by Fixture
 
 Retrieve prediction probabilities for a fixture by fixture ID from Sportmonks
 
@@ -1892,7 +1892,7 @@ Retrieve prediction probabilities for a fixture by fixture ID from Sportmonks
 |   ↳ `predictions` | json | Prediction payload \(varies by type: score map, value bet object, etc.\) |
 |   ↳ `type_id` | number | Type of the prediction |
 
-### `sportmonks_football_get_referee`
+### Get Referee by ID
 
 Retrieve a single football referee by their ID from Sportmonks
 
@@ -1926,7 +1926,7 @@ Retrieve a single football referee by their ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the referee |
 |   ↳ `gender` | string | Gender of the referee |
 
-### `sportmonks_football_get_referees`
+### Get Referees
 
 Retrieve all football referees available within your Sportmonks subscription
 
@@ -1962,7 +1962,7 @@ Retrieve all football referees available within your Sportmonks subscription
 |   ↳ `date_of_birth` | string | Date of birth of the referee |
 |   ↳ `gender` | string | Gender of the referee |
 
-### `sportmonks_football_get_referees_by_country`
+### Get Referees by Country
 
 Retrieve all referees for a country ID from Sportmonks
 
@@ -1999,7 +1999,7 @@ Retrieve all referees for a country ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the referee |
 |   ↳ `gender` | string | Gender of the referee |
 
-### `sportmonks_football_get_referees_by_season`
+### Get Referees by Season
 
 Retrieve all referees for a season ID from Sportmonks
 
@@ -2036,7 +2036,7 @@ Retrieve all referees for a season ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the referee |
 |   ↳ `gender` | string | Gender of the referee |
 
-### `sportmonks_football_get_rivals_by_team`
+### Get Rivals by Team
 
 Retrieve rival teams for a team by team ID from Sportmonks
 
@@ -2057,7 +2057,7 @@ Retrieve rival teams for a team by team ID from Sportmonks
 |   ↳ `team_id` | number | Team the rivalry belongs to |
 |   ↳ `rival_id` | number | Rival team id |
 
-### `sportmonks_football_get_round`
+### Get Round by ID
 
 Retrieve a single football round by its ID from Sportmonks
 
@@ -2087,7 +2087,7 @@ Retrieve a single football round by its ID from Sportmonks
 |   ↳ `ending_at` | string | End date of the round |
 |   ↳ `games_in_current_week` | boolean | Whether the round has fixtures this week |
 
-### `sportmonks_football_get_round_statistics`
+### Get Round Statistics
 
 Retrieve all available statistics for a round ID from Sportmonks
 
@@ -2114,7 +2114,7 @@ Retrieve all available statistics for a round ID from Sportmonks
 |   ↳ `relation_id` | number | Related entity id \(e.g. participant\) when applicable |
 |   ↳ `value` | json | Statistic value payload \(varies by type\) |
 
-### `sportmonks_football_get_rounds`
+### Get Rounds
 
 Retrieve all football rounds available within your Sportmonks subscription
 
@@ -2146,7 +2146,7 @@ Retrieve all football rounds available within your Sportmonks subscription
 |   ↳ `ending_at` | string | End date of the round |
 |   ↳ `games_in_current_week` | boolean | Whether the round has fixtures this week |
 
-### `sportmonks_football_get_rounds_by_season`
+### Get Rounds by Season
 
 Retrieve all rounds for a season ID from Sportmonks
 
@@ -2176,7 +2176,7 @@ Retrieve all rounds for a season ID from Sportmonks
 |   ↳ `ending_at` | string | End date of the round |
 |   ↳ `games_in_current_week` | boolean | Whether the round has fixtures this week |
 
-### `sportmonks_football_get_schedules_by_season`
+### Get Schedules by Season
 
 Retrieve the full schedule (stages, rounds and fixtures) for a season by season ID
 
@@ -2193,7 +2193,7 @@ Retrieve the full schedule (stages, rounds and fixtures) for a season by season 
 | --------- | ---- | ----------- |
 | `schedules` | json | Array of stages, each with nested rounds and their fixtures \(participants, scores\) |
 
-### `sportmonks_football_get_schedules_by_season_and_team`
+### Get Schedules by Season and Team
 
 Retrieve the full season schedule for a specific team by season ID and team ID
 
@@ -2211,7 +2211,7 @@ Retrieve the full season schedule for a specific team by season ID and team ID
 | --------- | ---- | ----------- |
 | `schedules` | json | Array of stages, each with nested rounds and their fixtures for the team in the season |
 
-### `sportmonks_football_get_schedules_by_team`
+### Get Schedules by Team
 
 Retrieve the full schedule (stages, rounds and fixtures) for a team by team ID
 
@@ -2228,7 +2228,7 @@ Retrieve the full schedule (stages, rounds and fixtures) for a team by team ID
 | --------- | ---- | ----------- |
 | `schedules` | json | Array of stages, each with nested rounds and their fixtures \(participants, scores\) |
 
-### `sportmonks_football_get_season`
+### Get Season by ID
 
 Retrieve a single football season by its ID from Sportmonks
 
@@ -2260,7 +2260,7 @@ Retrieve a single football season by its ID from Sportmonks
 |   ↳ `standings_recalculated_at` | string | Last standings recalculation time |
 |   ↳ `games_in_current_week` | boolean | Whether the season has fixtures this week |
 
-### `sportmonks_football_get_seasons`
+### Get Seasons
 
 Retrieve all football seasons available within your Sportmonks subscription
 
@@ -2294,7 +2294,7 @@ Retrieve all football seasons available within your Sportmonks subscription
 |   ↳ `standings_recalculated_at` | string | Last standings recalculation time |
 |   ↳ `games_in_current_week` | boolean | Whether the season has fixtures this week |
 
-### `sportmonks_football_get_seasons_by_team`
+### Get Seasons by Team
 
 Retrieve all seasons for a team ID from Sportmonks
 
@@ -2326,7 +2326,7 @@ Retrieve all seasons for a team ID from Sportmonks
 |   ↳ `standings_recalculated_at` | string | Last standings recalculation time |
 |   ↳ `games_in_current_week` | boolean | Whether the season has fixtures this week |
 
-### `sportmonks_football_get_stage`
+### Get Stage by ID
 
 Retrieve a single football stage by its ID from Sportmonks
 
@@ -2357,7 +2357,7 @@ Retrieve a single football stage by its ID from Sportmonks
 |   ↳ `ending_at` | string | End date of the stage |
 |   ↳ `games_in_current_week` | boolean | Whether the stage has fixtures this week |
 
-### `sportmonks_football_get_stage_statistics`
+### Get Stage Statistics
 
 Retrieve all available statistics for a stage ID from Sportmonks
 
@@ -2384,7 +2384,7 @@ Retrieve all available statistics for a stage ID from Sportmonks
 |   ↳ `relation_id` | number | Related entity id \(e.g. participant\) when applicable |
 |   ↳ `value` | json | Statistic value payload \(varies by type\) |
 
-### `sportmonks_football_get_stages`
+### Get Stages
 
 Retrieve all football stages available within your Sportmonks subscription
 
@@ -2417,7 +2417,7 @@ Retrieve all football stages available within your Sportmonks subscription
 |   ↳ `ending_at` | string | End date of the stage |
 |   ↳ `games_in_current_week` | boolean | Whether the stage has fixtures this week |
 
-### `sportmonks_football_get_stages_by_season`
+### Get Stages by Season
 
 Retrieve all stages for a season ID from Sportmonks
 
@@ -2448,7 +2448,7 @@ Retrieve all stages for a season ID from Sportmonks
 |   ↳ `ending_at` | string | End date of the stage |
 |   ↳ `games_in_current_week` | boolean | Whether the stage has fixtures this week |
 
-### `sportmonks_football_get_standing_corrections_by_season`
+### Get Standing Corrections by Season
 
 Retrieve point corrections (awarded or deducted) for a season ID from Sportmonks
 
@@ -2477,7 +2477,7 @@ Retrieve point corrections (awarded or deducted) for a season ID from Sportmonks
 |   ↳ `participant_id` | number | Participant the correction applies to |
 |   ↳ `active` | boolean | Whether the correction is active |
 
-### `sportmonks_football_get_standings`
+### Get All Standings
 
 Retrieve all standings available within your Sportmonks subscription
 
@@ -2510,7 +2510,7 @@ Retrieve all standings available within your Sportmonks subscription
 |   ↳ `result` | string | Movement of the team in the standing |
 |   ↳ `points` | number | Points the team has gathered |
 
-### `sportmonks_football_get_standings_by_round`
+### Get Standings by Round
 
 Retrieve the full standing table for a round ID from Sportmonks
 
@@ -2541,7 +2541,7 @@ Retrieve the full standing table for a round ID from Sportmonks
 |   ↳ `result` | string | Movement of the team in the standing |
 |   ↳ `points` | number | Points the team has gathered |
 
-### `sportmonks_football_get_standings_by_season`
+### Get Standings by Season
 
 Retrieve the full league standings table for a season by season ID from Sportmonks
 
@@ -2572,7 +2572,7 @@ Retrieve the full league standings table for a season by season ID from Sportmon
 |   ↳ `result` | string | Movement of the team in the standing |
 |   ↳ `points` | number | Points the team has gathered |
 
-### `sportmonks_football_get_state`
+### Get State by ID
 
 Retrieve a single fixture state by its ID from Sportmonks
 
@@ -2594,7 +2594,7 @@ Retrieve a single fixture state by its ID from Sportmonks
 |   ↳ `short_name` | string | Short name of the state \(e.g. NS\) |
 |   ↳ `developer_name` | string | Developer name of the state |
 
-### `sportmonks_football_get_states`
+### Get States
 
 Retrieve all fixture states (e.g. Not Started, 1st Half, Full Time) from Sportmonks
 
@@ -2618,7 +2618,7 @@ Retrieve all fixture states (e.g. Not Started, 1st Half, Full Time) from Sportmo
 |   ↳ `short_name` | string | Short name of the state \(e.g. NS\) |
 |   ↳ `developer_name` | string | Developer name of the state |
 
-### `sportmonks_football_get_team`
+### Get Team by ID
 
 Retrieve a single football team by its ID from Sportmonks
 
@@ -2649,7 +2649,7 @@ Retrieve a single football team by its ID from Sportmonks
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the last played match |
 
-### `sportmonks_football_get_team_rankings`
+### Get All Team Rankings
 
 Retrieve all team rankings available within your Sportmonks subscription (beta)
 
@@ -2674,7 +2674,7 @@ Retrieve all team rankings available within your Sportmonks subscription (beta)
 |   ↳ `current_rank` | number | Placement of the team on that date |
 |   ↳ `scaled_score` | number | Scaled score of the team \(0-100\) |
 
-### `sportmonks_football_get_team_rankings_by_date`
+### Get Team Rankings by Date
 
 Retrieve team rankings for a given date (YYYY-MM-DD) from Sportmonks (beta)
 
@@ -2700,7 +2700,7 @@ Retrieve team rankings for a given date (YYYY-MM-DD) from Sportmonks (beta)
 |   ↳ `current_rank` | number | Placement of the team on that date |
 |   ↳ `scaled_score` | number | Scaled score of the team \(0-100\) |
 
-### `sportmonks_football_get_team_rankings_by_team`
+### Get Team Rankings by Team
 
 Retrieve team rankings for a team ID from Sportmonks (beta)
 
@@ -2726,7 +2726,7 @@ Retrieve team rankings for a team ID from Sportmonks (beta)
 |   ↳ `current_rank` | number | Placement of the team on that date |
 |   ↳ `scaled_score` | number | Scaled score of the team \(0-100\) |
 
-### `sportmonks_football_get_team_squad`
+### Get Team Squad
 
 Retrieve the current domestic squad for a team by team ID from Sportmonks
 
@@ -2754,7 +2754,7 @@ Retrieve the current domestic squad for a team by team ID from Sportmonks
 |   ↳ `start` | string | Start contract date of the player |
 |   ↳ `end` | string | End contract date of the player |
 
-### `sportmonks_football_get_team_squad_by_season`
+### Get Team Squad by Season
 
 Retrieve the (historical) squad for a team in a specific season from Sportmonks
 
@@ -2783,7 +2783,7 @@ Retrieve the (historical) squad for a team in a specific season from Sportmonks
 |   ↳ `start` | string | Start contract date of the player |
 |   ↳ `end` | string | End contract date of the player |
 
-### `sportmonks_football_get_teams_by_country`
+### Get Teams by Country
 
 Retrieve all teams for a country ID from Sportmonks
 
@@ -2817,7 +2817,7 @@ Retrieve all teams for a country ID from Sportmonks
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the last played match |
 
-### `sportmonks_football_get_teams_by_season`
+### Get Teams by Season
 
 Retrieve all teams for a season ID from Sportmonks
 
@@ -2851,7 +2851,7 @@ Retrieve all teams for a season ID from Sportmonks
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the last played match |
 
-### `sportmonks_football_get_topscorers_by_season`
+### Get Topscorers by Season
 
 Retrieve the topscorers (goals, assists, cards) for a season by season ID from Sportmonks
 
@@ -2882,7 +2882,7 @@ Retrieve the topscorers (goals, assists, cards) for a season by season ID from S
 |   ↳ `position` | number | Position of the topscorer |
 |   ↳ `total` | number | Number of goals, assists or cards |
 
-### `sportmonks_football_get_topscorers_by_stage`
+### Get Topscorers by Stage
 
 Retrieve topscorers for a stage by stage ID from Sportmonks
 
@@ -2913,7 +2913,7 @@ Retrieve topscorers for a stage by stage ID from Sportmonks
 |   ↳ `position` | number | Position of the topscorer |
 |   ↳ `total` | number | Number of goals, assists or cards |
 
-### `sportmonks_football_get_totw`
+### Get All Team of the Week
 
 Retrieve all available Team of the Week (TOTW) entries from Sportmonks
 
@@ -2941,7 +2941,7 @@ Retrieve all available Team of the Week (TOTW) entries from Sportmonks
 |   ↳ `formation_position` | number | Player position in the TOTW formation |
 |   ↳ `formation` | string | The TOTW's formation |
 
-### `sportmonks_football_get_totw_by_round`
+### Get Team of the Week by Round
 
 Retrieve the Team of the Week (TOTW) for a round ID from Sportmonks
 
@@ -2967,7 +2967,7 @@ Retrieve the Team of the Week (TOTW) for a round ID from Sportmonks
 |   ↳ `formation_position` | number | Player position in the TOTW formation |
 |   ↳ `formation` | string | The TOTW's formation |
 
-### `sportmonks_football_get_transfer`
+### Get Transfer by ID
 
 Retrieve a single transfer by its ID from Sportmonks
 
@@ -2998,7 +2998,7 @@ Retrieve a single transfer by its ID from Sportmonks
 |   ↳ `completed` | boolean | Whether the transfer is completed |
 |   ↳ `amount` | number | Transfer fee amount |
 
-### `sportmonks_football_get_transfer_rumour`
+### Get Transfer Rumour by ID
 
 Retrieve a single transfer rumour by its ID from Sportmonks
 
@@ -3031,7 +3031,7 @@ Retrieve a single transfer rumour by its ID from Sportmonks
 |   ↳ `date` | string | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
-### `sportmonks_football_get_transfer_rumours_between_dates`
+### Get Transfer Rumours Between Dates
 
 Retrieve transfer rumours within a date range (YYYY-MM-DD) from Sportmonks
 
@@ -3068,7 +3068,7 @@ Retrieve transfer rumours within a date range (YYYY-MM-DD) from Sportmonks
 |   ↳ `date` | string | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
-### `sportmonks_football_get_transfer_rumours_by_player`
+### Get Transfer Rumours by Player
 
 Retrieve transfer rumours for a player ID from Sportmonks
 
@@ -3104,7 +3104,7 @@ Retrieve transfer rumours for a player ID from Sportmonks
 |   ↳ `date` | string | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
-### `sportmonks_football_get_transfer_rumours_by_team`
+### Get Transfer Rumours by Team
 
 Retrieve transfer rumours for a team ID from Sportmonks
 
@@ -3140,7 +3140,7 @@ Retrieve transfer rumours for a team ID from Sportmonks
 |   ↳ `date` | string | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
-### `sportmonks_football_get_transfers_between_dates`
+### Get Transfers Between Dates
 
 Retrieve transfers within a date range (YYYY-MM-DD) from Sportmonks
 
@@ -3175,7 +3175,7 @@ Retrieve transfers within a date range (YYYY-MM-DD) from Sportmonks
 |   ↳ `completed` | boolean | Whether the transfer is completed |
 |   ↳ `amount` | number | Transfer fee amount |
 
-### `sportmonks_football_get_transfers_by_player`
+### Get Transfers by Player
 
 Retrieve transfers for a player by player ID from Sportmonks
 
@@ -3209,7 +3209,7 @@ Retrieve transfers for a player by player ID from Sportmonks
 |   ↳ `completed` | boolean | Whether the transfer is completed |
 |   ↳ `amount` | number | Transfer fee amount |
 
-### `sportmonks_football_get_transfers_by_team`
+### Get Transfers by Team
 
 Retrieve transfers for a team by team ID from Sportmonks
 
@@ -3243,7 +3243,7 @@ Retrieve transfers for a team by team ID from Sportmonks
 |   ↳ `completed` | boolean | Whether the transfer is completed |
 |   ↳ `amount` | number | Transfer fee amount |
 
-### `sportmonks_football_get_tv_station`
+### Get TV Station by ID
 
 Retrieve a single TV station by its ID from Sportmonks
 
@@ -3268,7 +3268,7 @@ Retrieve a single TV station by its ID from Sportmonks
 |   ↳ `type` | string | Type of the TV station \(tv, channel\) |
 |   ↳ `related_id` | number | Related id of the TV station |
 
-### `sportmonks_football_get_tv_stations`
+### Get TV Stations
 
 Retrieve all TV stations available within your Sportmonks subscription
 
@@ -3295,7 +3295,7 @@ Retrieve all TV stations available within your Sportmonks subscription
 |   ↳ `type` | string | Type of the TV station \(tv, channel\) |
 |   ↳ `related_id` | number | Related id of the TV station |
 
-### `sportmonks_football_get_tv_stations_by_fixture`
+### Get TV Stations by Fixture
 
 Retrieve broadcasting TV stations for a fixture by fixture ID from Sportmonks
 
@@ -3323,7 +3323,7 @@ Retrieve broadcasting TV stations for a fixture by fixture ID from Sportmonks
 |   ↳ `type` | string | Type of the TV station \(tv, channel\) |
 |   ↳ `related_id` | number | Related id of the TV station |
 
-### `sportmonks_football_get_upcoming_fixtures_by_market`
+### Get Upcoming Fixtures by Market
 
 Retrieve all upcoming fixtures for a market ID from Sportmonks
 
@@ -3365,7 +3365,7 @@ Retrieve all upcoming fixtures for a market ID from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_upcoming_fixtures_by_tv_station`
+### Get Upcoming Fixtures by TV Station
 
 Retrieve all upcoming fixtures available for a TV station ID from Sportmonks
 
@@ -3407,7 +3407,7 @@ Retrieve all upcoming fixtures available for a TV station ID from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_get_value_bets`
+### Get Value Bets
 
 Retrieve all value bets available within your Sportmonks subscription
 
@@ -3431,7 +3431,7 @@ Retrieve all value bets available within your Sportmonks subscription
 |   ↳ `predictions` | json | Prediction payload \(varies by type: score map, value bet object, etc.\) |
 |   ↳ `type_id` | number | Type of the prediction |
 
-### `sportmonks_football_get_value_bets_by_fixture`
+### Get Value Bets by Fixture
 
 Retrieve value bet predictions for a fixture by fixture ID from Sportmonks
 
@@ -3456,7 +3456,7 @@ Retrieve value bet predictions for a fixture by fixture ID from Sportmonks
 |   ↳ `predictions` | json | Prediction payload \(varies by type: score map, value bet object, etc.\) |
 |   ↳ `type_id` | number | Type of the prediction |
 
-### `sportmonks_football_get_venue`
+### Get Venue by ID
 
 Retrieve a single football venue by its ID from Sportmonks
 
@@ -3488,7 +3488,7 @@ Retrieve a single football venue by its ID from Sportmonks
 |   ↳ `surface` | string | Surface type of the venue |
 |   ↳ `national_team` | boolean | Whether the venue is used by the national team |
 
-### `sportmonks_football_get_venues`
+### Get Venues
 
 Retrieve all football venues available within your Sportmonks subscription
 
@@ -3522,7 +3522,7 @@ Retrieve all football venues available within your Sportmonks subscription
 |   ↳ `surface` | string | Surface type of the venue |
 |   ↳ `national_team` | boolean | Whether the venue is used by the national team |
 
-### `sportmonks_football_get_venues_by_season`
+### Get Venues by Season
 
 Retrieve all venues for a season ID from Sportmonks
 
@@ -3554,7 +3554,7 @@ Retrieve all venues for a season ID from Sportmonks
 |   ↳ `surface` | string | Surface type of the venue |
 |   ↳ `national_team` | boolean | Whether the venue is used by the national team |
 
-### `sportmonks_football_search_coaches`
+### Search Coaches
 
 Search for football coaches by name from Sportmonks
 
@@ -3592,7 +3592,7 @@ Search for football coaches by name from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the coach |
 |   ↳ `gender` | string | Gender of the coach |
 
-### `sportmonks_football_search_fixtures`
+### Search Fixtures
 
 Search for football fixtures by name (participants) from Sportmonks
 
@@ -3634,7 +3634,7 @@ Search for football fixtures by name (participants) from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_football_search_leagues`
+### Search Leagues
 
 Search for football leagues by name from Sportmonks
 
@@ -3667,7 +3667,7 @@ Search for football leagues by name from Sportmonks
 |   ↳ `last_played_at` | string | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
-### `sportmonks_football_search_players`
+### Search Players
 
 Search for football players by name from Sportmonks
 
@@ -3707,7 +3707,7 @@ Search for football players by name from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
-### `sportmonks_football_search_referees`
+### Search Referees
 
 Search for football referees by name from Sportmonks
 
@@ -3744,7 +3744,7 @@ Search for football referees by name from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the referee |
 |   ↳ `gender` | string | Gender of the referee |
 
-### `sportmonks_football_search_rounds`
+### Search Rounds
 
 Search for football rounds by name from Sportmonks
 
@@ -3777,7 +3777,7 @@ Search for football rounds by name from Sportmonks
 |   ↳ `ending_at` | string | End date of the round |
 |   ↳ `games_in_current_week` | boolean | Whether the round has fixtures this week |
 
-### `sportmonks_football_search_seasons`
+### Search Seasons
 
 Search for football seasons by name from Sportmonks
 
@@ -3812,7 +3812,7 @@ Search for football seasons by name from Sportmonks
 |   ↳ `standings_recalculated_at` | string | Last standings recalculation time |
 |   ↳ `games_in_current_week` | boolean | Whether the season has fixtures this week |
 
-### `sportmonks_football_search_stages`
+### Search Stages
 
 Search for football stages by name from Sportmonks
 
@@ -3846,7 +3846,7 @@ Search for football stages by name from Sportmonks
 |   ↳ `ending_at` | string | End date of the stage |
 |   ↳ `games_in_current_week` | boolean | Whether the stage has fixtures this week |
 
-### `sportmonks_football_search_teams`
+### Search Teams
 
 Search for football teams by name from Sportmonks
 
@@ -3880,7 +3880,7 @@ Search for football teams by name from Sportmonks
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the last played match |
 
-### `sportmonks_football_search_venues`
+### Search Venues
 
 Search for football venues by name from Sportmonks
 
@@ -3915,7 +3915,7 @@ Search for football venues by name from Sportmonks
 |   ↳ `surface` | string | Surface type of the venue |
 |   ↳ `national_team` | boolean | Whether the venue is used by the national team |
 
-### `sportmonks_motorsport_get_all_fixtures`
+### Get All Motorsport Fixtures
 
 Retrieve all motorsport fixtures (sessions) from Sportmonks
 
@@ -3956,7 +3956,7 @@ Retrieve all motorsport fixtures (sessions) from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_motorsport_get_current_leagues_by_team`
+### Get Current Leagues by Team
 
 Retrieve the current motorsport leagues for a team by team ID from Sportmonks
 
@@ -3990,7 +3990,7 @@ Retrieve the current motorsport leagues for a team by team ID from Sportmonks
 |   ↳ `category` | number | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_driver`
+### Get Driver by ID
 
 Retrieve a single motorsport driver by their ID from Sportmonks
 
@@ -4027,7 +4027,7 @@ Retrieve a single motorsport driver by their ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
-### `sportmonks_motorsport_get_driver_standings`
+### Get All Driver Standings
 
 Retrieve all driver championship standings from Sportmonks
 
@@ -4060,7 +4060,7 @@ Retrieve all driver championship standings from Sportmonks
 |   ↳ `result` | string | Not used in the Motorsport API |
 |   ↳ `points` | number | Points the participant has gathered |
 
-### `sportmonks_motorsport_get_driver_standings_by_season`
+### Get Driver Standings by Season
 
 Retrieve the drivers championship standings for a season by season ID from Sportmonks
 
@@ -4094,7 +4094,7 @@ Retrieve the drivers championship standings for a season by season ID from Sport
 |   ↳ `result` | string | Not used in the Motorsport API |
 |   ↳ `points` | number | Points the participant has gathered |
 
-### `sportmonks_motorsport_get_drivers`
+### Get Drivers
 
 Retrieve all motorsport drivers from Sportmonks
 
@@ -4133,7 +4133,7 @@ Retrieve all motorsport drivers from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
-### `sportmonks_motorsport_get_drivers_by_country`
+### Get Drivers by Country
 
 Retrieve all motorsport drivers for a country by country ID from Sportmonks
 
@@ -4173,7 +4173,7 @@ Retrieve all motorsport drivers for a country by country ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
-### `sportmonks_motorsport_get_drivers_by_season`
+### Get Drivers by Season
 
 Retrieve all motorsport drivers for a season by season ID from Sportmonks
 
@@ -4213,7 +4213,7 @@ Retrieve all motorsport drivers for a season by season ID from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
-### `sportmonks_motorsport_get_fixture`
+### Get Motorsport Fixture by ID
 
 Retrieve a single motorsport fixture (session) by its ID from Sportmonks
 
@@ -4252,7 +4252,7 @@ Retrieve a single motorsport fixture (session) by its ID from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_motorsport_get_fixtures_by_date`
+### Get Motorsport Fixtures by Date
 
 Retrieve motorsport fixtures (sessions) on a specific date (YYYY-MM-DD) from Sportmonks
 
@@ -4294,7 +4294,7 @@ Retrieve motorsport fixtures (sessions) on a specific date (YYYY-MM-DD) from Spo
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_motorsport_get_fixtures_by_date_range`
+### Get Motorsport Fixtures by Date Range
 
 Retrieve motorsport fixtures (sessions) between two dates (YYYY-MM-DD, max 100 days) from Sportmonks
 
@@ -4337,7 +4337,7 @@ Retrieve motorsport fixtures (sessions) between two dates (YYYY-MM-DD, max 100 d
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_motorsport_get_fixtures_by_ids`
+### Get Motorsport Fixtures by IDs
 
 Retrieve multiple motorsport fixtures (sessions) by their IDs (max 50) from Sportmonks
 
@@ -4379,7 +4379,7 @@ Retrieve multiple motorsport fixtures (sessions) by their IDs (max 50) from Spor
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_motorsport_get_laps_by_fixture`
+### Get Laps by Fixture
 
 Retrieve all laps for a motorsport fixture (session) by fixture ID from Sportmonks
 
@@ -4404,7 +4404,7 @@ Retrieve all laps for a motorsport fixture (session) by fixture ID from Sportmon
 |   ↳ `participant_id` | number | Driver related to the lap/pitstop |
 |   ↳ `is_latest` | boolean | Whether it is the latest lap/pitstop |
 
-### `sportmonks_motorsport_get_laps_by_fixture_and_driver`
+### Get Laps by Fixture and Driver
 
 Retrieve all laps for a motorsport fixture and driver from Sportmonks
 
@@ -4430,7 +4430,7 @@ Retrieve all laps for a motorsport fixture and driver from Sportmonks
 |   ↳ `participant_id` | number | Driver related to the lap/pitstop |
 |   ↳ `is_latest` | boolean | Whether it is the latest lap/pitstop |
 
-### `sportmonks_motorsport_get_laps_by_fixture_and_lap`
+### Get Laps by Fixture and Lap Number
 
 Retrieve all laps for a motorsport fixture and lap number from Sportmonks
 
@@ -4456,7 +4456,7 @@ Retrieve all laps for a motorsport fixture and lap number from Sportmonks
 |   ↳ `participant_id` | number | Driver related to the lap/pitstop |
 |   ↳ `is_latest` | boolean | Whether it is the latest lap/pitstop |
 
-### `sportmonks_motorsport_get_latest_laps_by_fixture`
+### Get Latest Laps by Fixture
 
 Retrieve the latest laps for a motorsport fixture (session) by fixture ID from Sportmonks
 
@@ -4481,7 +4481,7 @@ Retrieve the latest laps for a motorsport fixture (session) by fixture ID from S
 |   ↳ `participant_id` | number | Driver related to the lap/pitstop |
 |   ↳ `is_latest` | boolean | Whether it is the latest lap/pitstop |
 
-### `sportmonks_motorsport_get_latest_pitstops_by_fixture`
+### Get Latest Pitstops by Fixture
 
 Retrieve the latest pitstops for a motorsport fixture (session) by fixture ID from Sportmonks
 
@@ -4506,7 +4506,7 @@ Retrieve the latest pitstops for a motorsport fixture (session) by fixture ID fr
 |   ↳ `participant_id` | number | Driver related to the lap/pitstop |
 |   ↳ `is_latest` | boolean | Whether it is the latest lap/pitstop |
 
-### `sportmonks_motorsport_get_latest_stints_by_fixture`
+### Get Latest Stints by Fixture
 
 Retrieve the latest tyre stints for a motorsport fixture (session) by fixture ID from Sportmonks
 
@@ -4531,7 +4531,7 @@ Retrieve the latest tyre stints for a motorsport fixture (session) by fixture ID
 |   ↳ `participant_id` | number | Driver related to the stint |
 |   ↳ `is_latest` | boolean | Whether it is the latest stint |
 
-### `sportmonks_motorsport_get_latest_updated_drivers`
+### Get Latest Updated Drivers
 
 Retrieve the most recently updated motorsport drivers from Sportmonks
 
@@ -4570,7 +4570,7 @@ Retrieve the most recently updated motorsport drivers from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
-### `sportmonks_motorsport_get_latest_updated_fixtures`
+### Get Latest Updated Motorsport Fixtures
 
 Retrieve the most recently updated motorsport fixtures (sessions) from Sportmonks
 
@@ -4611,7 +4611,7 @@ Retrieve the most recently updated motorsport fixtures (sessions) from Sportmonk
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_motorsport_get_league`
+### Get League by ID
 
 Retrieve a single motorsport league by its ID from Sportmonks
 
@@ -4642,7 +4642,7 @@ Retrieve a single motorsport league by its ID from Sportmonks
 |   ↳ `category` | number | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_leagues`
+### Get All Leagues
 
 Retrieve all motorsport leagues from Sportmonks
 
@@ -4675,7 +4675,7 @@ Retrieve all motorsport leagues from Sportmonks
 |   ↳ `category` | number | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_leagues_by_country`
+### Get Leagues by Country
 
 Retrieve all motorsport leagues for a country by country ID from Sportmonks
 
@@ -4709,7 +4709,7 @@ Retrieve all motorsport leagues for a country by country ID from Sportmonks
 |   ↳ `category` | number | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_leagues_by_date`
+### Get Leagues by Fixture Date
 
 Retrieve all motorsport leagues with fixtures on a specific date (YYYY-MM-DD) from Sportmonks
 
@@ -4743,7 +4743,7 @@ Retrieve all motorsport leagues with fixtures on a specific date (YYYY-MM-DD) fr
 |   ↳ `category` | number | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_leagues_by_live`
+### Get Leagues by Live
 
 Retrieve all motorsport leagues that currently have live fixtures from Sportmonks
 
@@ -4776,7 +4776,7 @@ Retrieve all motorsport leagues that currently have live fixtures from Sportmonk
 |   ↳ `category` | number | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_leagues_by_team`
+### Get Leagues by Team
 
 Retrieve all current and historical motorsport leagues for a team by team ID from Sportmonks
 
@@ -4810,7 +4810,7 @@ Retrieve all current and historical motorsport leagues for a team by team ID fro
 |   ↳ `category` | number | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_livescores`
+### Get Motorsport Livescores
 
 Retrieve all live motorsport fixtures (sessions) from Sportmonks
 
@@ -4851,7 +4851,7 @@ Retrieve all live motorsport fixtures (sessions) from Sportmonks
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `starting_at_timestamp` | number | UNIX timestamp of the start time |
 
-### `sportmonks_motorsport_get_pitstops_by_fixture`
+### Get Pitstops by Fixture
 
 Retrieve all pitstops for a motorsport fixture (session) by fixture ID from Sportmonks
 
@@ -4876,7 +4876,7 @@ Retrieve all pitstops for a motorsport fixture (session) by fixture ID from Spor
 |   ↳ `participant_id` | number | Driver related to the lap/pitstop |
 |   ↳ `is_latest` | boolean | Whether it is the latest lap/pitstop |
 
-### `sportmonks_motorsport_get_pitstops_by_fixture_and_driver`
+### Get Pitstops by Fixture and Driver
 
 Retrieve all pitstops for a motorsport fixture and driver from Sportmonks
 
@@ -4902,7 +4902,7 @@ Retrieve all pitstops for a motorsport fixture and driver from Sportmonks
 |   ↳ `participant_id` | number | Driver related to the lap/pitstop |
 |   ↳ `is_latest` | boolean | Whether it is the latest lap/pitstop |
 
-### `sportmonks_motorsport_get_pitstops_by_fixture_and_lap`
+### Get Pitstops by Fixture and Lap Number
 
 Retrieve all pitstops for a motorsport fixture and lap number from Sportmonks
 
@@ -4928,7 +4928,7 @@ Retrieve all pitstops for a motorsport fixture and lap number from Sportmonks
 |   ↳ `participant_id` | number | Driver related to the lap/pitstop |
 |   ↳ `is_latest` | boolean | Whether it is the latest lap/pitstop |
 
-### `sportmonks_motorsport_get_race_results_by_season_and_driver`
+### Get Race Results by Season and Driver
 
 Retrieve race results (stages with fixtures, lineups and lineup details) for a season and driver from Sportmonks
 
@@ -4964,7 +4964,7 @@ Retrieve race results (stages with fixtures, lineups and lineup details) for a s
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 |   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_race_results_by_season_and_team`
+### Get Race Results by Season and Team
 
 Retrieve race results (stages with fixtures, lineups and lineup details) for a season and team from Sportmonks
 
@@ -5000,7 +5000,7 @@ Retrieve race results (stages with fixtures, lineups and lineup details) for a s
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 |   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_schedules_by_season`
+### Get Schedules by Season
 
 Retrieve the full schedule (stages with nested fixtures and venues) for a season by season ID from Sportmonks
 
@@ -5035,7 +5035,7 @@ Retrieve the full schedule (stages with nested fixtures and venues) for a season
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 |   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_season`
+### Get Season by ID
 
 Retrieve a single motorsport season by its ID from Sportmonks
 
@@ -5066,7 +5066,7 @@ Retrieve a single motorsport season by its ID from Sportmonks
 |   ↳ `standings_recalculated_at` | string | Timestamp when standings were last updated |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_seasons`
+### Get All Seasons
 
 Retrieve all motorsport seasons from Sportmonks
 
@@ -5099,7 +5099,7 @@ Retrieve all motorsport seasons from Sportmonks
 |   ↳ `standings_recalculated_at` | string | Timestamp when standings were last updated |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_stage`
+### Get Stage by ID
 
 Retrieve a single motorsport stage (race weekend) by its ID from Sportmonks
 
@@ -5131,7 +5131,7 @@ Retrieve a single motorsport stage (race weekend) by its ID from Sportmonks
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 |   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_stages`
+### Get All Stages
 
 Retrieve all motorsport stages (race weekends) from Sportmonks
 
@@ -5165,7 +5165,7 @@ Retrieve all motorsport stages (race weekends) from Sportmonks
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 |   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_stages_by_season`
+### Get Stages by Season
 
 Retrieve all motorsport stages (race weekends) for a season by season ID from Sportmonks
 
@@ -5200,7 +5200,7 @@ Retrieve all motorsport stages (race weekends) for a season by season ID from Sp
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 |   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_state`
+### Get State by ID
 
 Retrieve a single motorsport fixture state by its ID from Sportmonks
 
@@ -5224,7 +5224,7 @@ Retrieve a single motorsport fixture state by its ID from Sportmonks
 |   ↳ `short_name` | string | Short name of the state |
 |   ↳ `developer_name` | string | Name recommended for developers to use |
 
-### `sportmonks_motorsport_get_states`
+### Get All States
 
 Retrieve all possible motorsport fixture states from Sportmonks
 
@@ -5250,7 +5250,7 @@ Retrieve all possible motorsport fixture states from Sportmonks
 |   ↳ `short_name` | string | Short name of the state |
 |   ↳ `developer_name` | string | Name recommended for developers to use |
 
-### `sportmonks_motorsport_get_stints_by_fixture`
+### Get Stints by Fixture
 
 Retrieve all tyre stints for a motorsport fixture (session) by fixture ID from Sportmonks
 
@@ -5275,7 +5275,7 @@ Retrieve all tyre stints for a motorsport fixture (session) by fixture ID from S
 |   ↳ `participant_id` | number | Driver related to the stint |
 |   ↳ `is_latest` | boolean | Whether it is the latest stint |
 
-### `sportmonks_motorsport_get_stints_by_fixture_and_driver`
+### Get Stints by Fixture and Driver
 
 Retrieve all tyre stints for a motorsport fixture and driver from Sportmonks
 
@@ -5301,7 +5301,7 @@ Retrieve all tyre stints for a motorsport fixture and driver from Sportmonks
 |   ↳ `participant_id` | number | Driver related to the stint |
 |   ↳ `is_latest` | boolean | Whether it is the latest stint |
 
-### `sportmonks_motorsport_get_stints_by_fixture_and_stint`
+### Get Stints by Fixture and Stint Number
 
 Retrieve all tyre stints for a motorsport fixture and stint number from Sportmonks
 
@@ -5327,7 +5327,7 @@ Retrieve all tyre stints for a motorsport fixture and stint number from Sportmon
 |   ↳ `participant_id` | number | Driver related to the stint |
 |   ↳ `is_latest` | boolean | Whether it is the latest stint |
 
-### `sportmonks_motorsport_get_team`
+### Get Team by ID
 
 Retrieve a single motorsport team (constructor) by its ID from Sportmonks
 
@@ -5358,7 +5358,7 @@ Retrieve a single motorsport team (constructor) by its ID from Sportmonks
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the team's last session |
 
-### `sportmonks_motorsport_get_team_standings`
+### Get All Team Standings
 
 Retrieve all team (constructor) championship standings from Sportmonks
 
@@ -5391,7 +5391,7 @@ Retrieve all team (constructor) championship standings from Sportmonks
 |   ↳ `result` | string | Not used in the Motorsport API |
 |   ↳ `points` | number | Points the participant has gathered |
 
-### `sportmonks_motorsport_get_team_standings_by_season`
+### Get Team Standings by Season
 
 Retrieve the constructors championship standings for a season by season ID from Sportmonks
 
@@ -5425,7 +5425,7 @@ Retrieve the constructors championship standings for a season by season ID from 
 |   ↳ `result` | string | Not used in the Motorsport API |
 |   ↳ `points` | number | Points the participant has gathered |
 
-### `sportmonks_motorsport_get_teams`
+### Get Teams
 
 Retrieve all motorsport teams (constructors) from Sportmonks
 
@@ -5458,7 +5458,7 @@ Retrieve all motorsport teams (constructors) from Sportmonks
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the team's last session |
 
-### `sportmonks_motorsport_get_teams_by_country`
+### Get Teams by Country
 
 Retrieve all motorsport teams (constructors) for a country by country ID from Sportmonks
 
@@ -5492,7 +5492,7 @@ Retrieve all motorsport teams (constructors) for a country by country ID from Sp
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the team's last session |
 
-### `sportmonks_motorsport_get_teams_by_season`
+### Get Teams by Season
 
 Retrieve all motorsport teams (constructors) for a season by season ID from Sportmonks
 
@@ -5526,7 +5526,7 @@ Retrieve all motorsport teams (constructors) for a season by season ID from Spor
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the team's last session |
 
-### `sportmonks_motorsport_get_venue`
+### Get Venue by ID
 
 Retrieve a single motorsport venue (racing track) by its ID from Sportmonks
 
@@ -5558,7 +5558,7 @@ Retrieve a single motorsport venue (racing track) by its ID from Sportmonks
 |   ↳ `surface` | string | Surface of the venue |
 |   ↳ `national_team` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_venues`
+### Get Venues
 
 Retrieve all motorsport venues (racing tracks) from Sportmonks
 
@@ -5592,7 +5592,7 @@ Retrieve all motorsport venues (racing tracks) from Sportmonks
 |   ↳ `surface` | string | Surface of the venue |
 |   ↳ `national_team` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_get_venues_by_season`
+### Get Venues by Season
 
 Retrieve all motorsport venues (racing tracks) for a season by season ID from Sportmonks
 
@@ -5627,7 +5627,7 @@ Retrieve all motorsport venues (racing tracks) for a season by season ID from Sp
 |   ↳ `surface` | string | Surface of the venue |
 |   ↳ `national_team` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_search_drivers`
+### Search Drivers
 
 Search for motorsport drivers by name from Sportmonks
 
@@ -5667,7 +5667,7 @@ Search for motorsport drivers by name from Sportmonks
 |   ↳ `date_of_birth` | string | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
-### `sportmonks_motorsport_search_leagues`
+### Search Leagues
 
 Search for motorsport leagues by name from Sportmonks
 
@@ -5701,7 +5701,7 @@ Search for motorsport leagues by name from Sportmonks
 |   ↳ `category` | number | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_search_stages`
+### Search Stages
 
 Search for motorsport stages (race weekends) by name from Sportmonks
 
@@ -5736,7 +5736,7 @@ Search for motorsport stages (race weekends) by name from Sportmonks
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 |   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
 
-### `sportmonks_motorsport_search_teams`
+### Search Teams
 
 Search for motorsport teams (constructors) by name from Sportmonks
 
@@ -5770,7 +5770,7 @@ Search for motorsport teams (constructors) by name from Sportmonks
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
 |   ↳ `last_played_at` | string | Date and time of the team's last session |
 
-### `sportmonks_motorsport_search_venues`
+### Search Venues
 
 Search for motorsport venues (racing tracks) by name from Sportmonks
 
@@ -5805,7 +5805,7 @@ Search for motorsport venues (racing tracks) by name from Sportmonks
 |   ↳ `surface` | string | Surface of the venue |
 |   ↳ `national_team` | boolean | Not used in the Motorsport API |
 
-### `sportmonks_odds_get_all_historical_odds`
+### Get All Historical Odds
 
 Retrieve all available historical (premium) pre-match odd values from the Sportmonks Odds API
 
@@ -5834,7 +5834,7 @@ Retrieve all available historical (premium) pre-match odd values from the Sportm
 |   ↳ `american` | string | American/moneyline odds |
 |   ↳ `bookmaker_update` | string | Bookmaker's update timestamp for this record \(UTC\) |
 
-### `sportmonks_odds_get_all_inplay_odds`
+### Get All In-play Odds
 
 Retrieve all available live (in-play) odds from the Sportmonks Odds API
 
@@ -5875,7 +5875,7 @@ Retrieve all available live (in-play) odds from the Sportmonks Odds API
 |   ↳ `handicap` | string | Handicap line for handicap markets |
 |   ↳ `participants` | string | Participant ids related to the outcome |
 
-### `sportmonks_odds_get_all_pre_match_odds`
+### Get All Pre-match Odds
 
 Retrieve all available pre-match odds from the Sportmonks Odds API
 
@@ -5915,7 +5915,7 @@ Retrieve all available pre-match odds from the Sportmonks Odds API
 |   ↳ `participants` | string | Participant ids related to the outcome |
 |   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
 
-### `sportmonks_odds_get_all_premium_odds`
+### Get All Premium Odds
 
 Retrieve all available premium (historical) pre-match odds from the Sportmonks Odds API
 
@@ -5955,7 +5955,7 @@ Retrieve all available premium (historical) pre-match odds from the Sportmonks O
 |   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
 |   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
 
-### `sportmonks_odds_get_bookmaker`
+### Get Bookmaker by ID
 
 Retrieve a single bookmaker by its ID from the Sportmonks Odds API
 
@@ -5975,7 +5975,7 @@ Retrieve a single bookmaker by its ID from the Sportmonks Odds API
 |   ↳ `name` | string | Name of the bookmaker |
 |   ↳ `logo` | string | Logo of the bookmaker |
 
-### `sportmonks_odds_get_bookmaker_event_ids_by_fixture`
+### Get Bookmaker Event IDs by Fixture
 
 Retrieve bookmakers' own event ids mapped to a Sportmonks fixture via the Sportmonks Odds API
 
@@ -5999,7 +5999,7 @@ Retrieve bookmakers' own event ids mapped to a Sportmonks fixture via the Sportm
 |   ↳ `bookmaker_name` | string | Name of the bookmaker |
 |   ↳ `bookmaker_event_id` | string | The fixture's event id at the bookmaker |
 
-### `sportmonks_odds_get_bookmakers`
+### Get Bookmakers
 
 Retrieve all bookmakers from the Sportmonks Odds API
 
@@ -6022,7 +6022,7 @@ Retrieve all bookmakers from the Sportmonks Odds API
 |   ↳ `name` | string | Name of the bookmaker |
 |   ↳ `logo` | string | Logo of the bookmaker |
 
-### `sportmonks_odds_get_bookmakers_by_fixture`
+### Get Bookmakers by Fixture
 
 Retrieve all bookmakers available for a fixture from the Sportmonks Odds API
 
@@ -6045,7 +6045,7 @@ Retrieve all bookmakers available for a fixture from the Sportmonks Odds API
 |   ↳ `name` | string | Name of the bookmaker |
 |   ↳ `logo` | string | Logo of the bookmaker |
 
-### `sportmonks_odds_get_inplay_odds_by_fixture`
+### Get In-play Odds by Fixture
 
 Retrieve live (in-play) odds for a fixture by fixture ID from the Sportmonks Odds API
 
@@ -6087,7 +6087,7 @@ Retrieve live (in-play) odds for a fixture by fixture ID from the Sportmonks Odd
 |   ↳ `handicap` | string | Handicap line for handicap markets |
 |   ↳ `participants` | string | Participant ids related to the outcome |
 
-### `sportmonks_odds_get_inplay_odds_by_fixture_and_bookmaker`
+### Get In-play Odds by Fixture and Bookmaker
 
 Retrieve live (in-play) odds for a fixture from a specific bookmaker via the Sportmonks Odds API
 
@@ -6127,7 +6127,7 @@ Retrieve live (in-play) odds for a fixture from a specific bookmaker via the Spo
 |   ↳ `handicap` | string | Handicap line for handicap markets |
 |   ↳ `participants` | string | Participant ids related to the outcome |
 
-### `sportmonks_odds_get_inplay_odds_by_fixture_and_market`
+### Get In-play Odds by Fixture and Market
 
 Retrieve live (in-play) odds for a fixture on a specific market via the Sportmonks Odds API
 
@@ -6167,7 +6167,7 @@ Retrieve live (in-play) odds for a fixture on a specific market via the Sportmon
 |   ↳ `handicap` | string | Handicap line for handicap markets |
 |   ↳ `participants` | string | Participant ids related to the outcome |
 
-### `sportmonks_odds_get_last_updated_inplay_odds`
+### Get Last Updated In-play Odds
 
 Retrieve in-play odds updated in the last 10 seconds from the Sportmonks Odds API
 
@@ -6205,7 +6205,7 @@ Retrieve in-play odds updated in the last 10 seconds from the Sportmonks Odds AP
 |   ↳ `handicap` | string | Handicap line for handicap markets |
 |   ↳ `participants` | string | Participant ids related to the outcome |
 
-### `sportmonks_odds_get_last_updated_pre_match_odds`
+### Get Last Updated Pre-match Odds
 
 Retrieve pre-match odds updated in the last 10 seconds from the Sportmonks Odds API
 
@@ -6242,7 +6242,7 @@ Retrieve pre-match odds updated in the last 10 seconds from the Sportmonks Odds 
 |   ↳ `participants` | string | Participant ids related to the outcome |
 |   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
 
-### `sportmonks_odds_get_market`
+### Get Market by ID
 
 Retrieve a single betting market by its ID from the Sportmonks Odds API
 
@@ -6262,7 +6262,7 @@ Retrieve a single betting market by its ID from the Sportmonks Odds API
 |   ↳ `name` | string | Name of the market |
 |   ↳ `developer_name` | string | Developer \(machine-readable\) name of the market |
 
-### `sportmonks_odds_get_markets`
+### Get Markets
 
 Retrieve all betting markets from the Sportmonks Odds API
 
@@ -6285,7 +6285,7 @@ Retrieve all betting markets from the Sportmonks Odds API
 |   ↳ `name` | string | Name of the market |
 |   ↳ `developer_name` | string | Developer \(machine-readable\) name of the market |
 
-### `sportmonks_odds_get_pre_match_odds_by_fixture`
+### Get Pre-match Odds by Fixture
 
 Retrieve pre-match odds for a fixture by fixture ID from the Sportmonks Odds API
 
@@ -6326,7 +6326,7 @@ Retrieve pre-match odds for a fixture by fixture ID from the Sportmonks Odds API
 |   ↳ `participants` | string | Participant ids related to the outcome |
 |   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
 
-### `sportmonks_odds_get_pre_match_odds_by_fixture_and_bookmaker`
+### Get Pre-match Odds by Fixture and Bookmaker
 
 Retrieve pre-match odds for a fixture from a specific bookmaker via the Sportmonks Odds API
 
@@ -6365,7 +6365,7 @@ Retrieve pre-match odds for a fixture from a specific bookmaker via the Sportmon
 |   ↳ `participants` | string | Participant ids related to the outcome |
 |   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
 
-### `sportmonks_odds_get_pre_match_odds_by_fixture_and_market`
+### Get Pre-match Odds by Fixture and Market
 
 Retrieve pre-match odds for a fixture on a specific market via the Sportmonks Odds API
 
@@ -6404,7 +6404,7 @@ Retrieve pre-match odds for a fixture on a specific market via the Sportmonks Od
 |   ↳ `participants` | string | Participant ids related to the outcome |
 |   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
 
-### `sportmonks_odds_get_premium_odds_by_fixture`
+### Get Premium Odds by Fixture
 
 Retrieve premium (historical) pre-match odds for a fixture from the Sportmonks Odds API
 
@@ -6442,7 +6442,7 @@ Retrieve premium (historical) pre-match odds for a fixture from the Sportmonks O
 |   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
 |   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
 
-### `sportmonks_odds_get_premium_odds_by_fixture_and_bookmaker`
+### Get Premium Odds by Fixture and Bookmaker
 
 Retrieve premium pre-match odds for a fixture from a specific bookmaker via the Sportmonks Odds API
 
@@ -6481,7 +6481,7 @@ Retrieve premium pre-match odds for a fixture from a specific bookmaker via the 
 |   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
 |   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
 
-### `sportmonks_odds_get_premium_odds_by_fixture_and_market`
+### Get Premium Odds by Fixture and Market
 
 Retrieve premium pre-match odds for a fixture on a specific market via the Sportmonks Odds API
 
@@ -6520,7 +6520,7 @@ Retrieve premium pre-match odds for a fixture on a specific market via the Sport
 |   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
 |   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
 
-### `sportmonks_odds_get_updated_historical_odds_between`
+### Get Updated Historical Odds Between Time Range
 
 Retrieve historical (premium) odds updated between two UNIX timestamps (max 5 minutes) from the Sportmonks Odds API
 
@@ -6551,7 +6551,7 @@ Retrieve historical (premium) odds updated between two UNIX timestamps (max 5 mi
 |   ↳ `american` | string | American/moneyline odds |
 |   ↳ `bookmaker_update` | string | Bookmaker's update timestamp for this record \(UTC\) |
 
-### `sportmonks_odds_get_updated_premium_odds_between`
+### Get Updated Premium Odds Between Time Range
 
 Retrieve premium odds updated between two UNIX timestamps (max 5 minutes) from the Sportmonks Odds API
 
@@ -6593,7 +6593,7 @@ Retrieve premium odds updated between two UNIX timestamps (max 5 minutes) from t
 |   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
 |   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
 
-### `sportmonks_odds_search_bookmakers`
+### Search Bookmakers
 
 Search for bookmakers by name from the Sportmonks Odds API
 
@@ -6616,7 +6616,7 @@ Search for bookmakers by name from the Sportmonks Odds API
 |   ↳ `name` | string | Name of the bookmaker |
 |   ↳ `logo` | string | Logo of the bookmaker |
 
-### `sportmonks_odds_search_markets`
+### Search Markets
 
 Search for betting markets by name from the Sportmonks Odds API
 
@@ -6639,7 +6639,7 @@ Search for betting markets by name from the Sportmonks Odds API
 |   ↳ `name` | string | Name of the market |
 |   ↳ `developer_name` | string | Developer \(machine-readable\) name of the market |
 
-### `sportmonks_core_get_cities`
+### Get Cities
 
 Retrieve all cities from the Sportmonks Core API
 
@@ -6667,7 +6667,7 @@ Retrieve all cities from the Sportmonks Core API
 |   ↳ `longitude` | string | Longitude of the city |
 |   ↳ `geonameid` | number | Official geonameid of the city |
 
-### `sportmonks_core_get_city`
+### Get City by ID
 
 Retrieve a single city by its ID from the Sportmonks Core API
 
@@ -6692,7 +6692,7 @@ Retrieve a single city by its ID from the Sportmonks Core API
 |   ↳ `longitude` | string | Longitude of the city |
 |   ↳ `geonameid` | number | Official geonameid of the city |
 
-### `sportmonks_core_get_continent`
+### Get Continent by ID
 
 Retrieve a single continent by its ID from the Sportmonks Core API
 
@@ -6713,7 +6713,7 @@ Retrieve a single continent by its ID from the Sportmonks Core API
 |   ↳ `name` | string | Name of the continent |
 |   ↳ `code` | string | Short code of the continent |
 
-### `sportmonks_core_get_continents`
+### Get Continents
 
 Retrieve all continents from the Sportmonks Core API
 
@@ -6736,7 +6736,7 @@ Retrieve all continents from the Sportmonks Core API
 |   ↳ `name` | string | Name of the continent |
 |   ↳ `code` | string | Short code of the continent |
 
-### `sportmonks_core_get_countries`
+### Get Countries
 
 Retrieve all countries from the Sportmonks Core API
 
@@ -6769,7 +6769,7 @@ Retrieve all countries from the Sportmonks Core API
 |   ↳ `borders` | array | Neighbouring countries \(ISO3 codes\) |
 |   ↳ `image_path` | string | Image path to the country flag |
 
-### `sportmonks_core_get_country`
+### Get Country by ID
 
 Retrieve a single country by its ID from the Sportmonks Core API
 
@@ -6799,7 +6799,7 @@ Retrieve a single country by its ID from the Sportmonks Core API
 |   ↳ `borders` | array | Neighbouring countries \(ISO3 codes\) |
 |   ↳ `image_path` | string | Image path to the country flag |
 
-### `sportmonks_core_get_entity_filters`
+### Get All Entity Filters
 
 Retrieve all available filters grouped per entity from the Sportmonks Core API
 
@@ -6815,7 +6815,7 @@ Retrieve all available filters grouped per entity from the Sportmonks Core API
 | --------- | ---- | ----------- |
 | `entityFilters` | json | Map of entity name to its available filter names, e.g. \{fixture: \["fixtureLeagues", "fixtureSeasons"\], event: \["eventTypes"\]\} |
 
-### `sportmonks_core_get_my_usage`
+### Get My Usage
 
 Retrieve your Sportmonks API usage aggregated per 5 minutes
 
@@ -6841,7 +6841,7 @@ Retrieve your Sportmonks API usage aggregated per 5 minutes
 |   ↳ `period_start` | number | Timestamp representing the aggregation start time |
 |   ↳ `period_end` | number | Timestamp representing the aggregation end time |
 
-### `sportmonks_core_get_region`
+### Get Region by ID
 
 Retrieve a single region by its ID from the Sportmonks Core API
 
@@ -6862,7 +6862,7 @@ Retrieve a single region by its ID from the Sportmonks Core API
 |   ↳ `country_id` | number | Country of the region |
 |   ↳ `name` | string | Name of the region |
 
-### `sportmonks_core_get_regions`
+### Get Regions
 
 Retrieve all regions from the Sportmonks Core API
 
@@ -6886,7 +6886,7 @@ Retrieve all regions from the Sportmonks Core API
 |   ↳ `country_id` | number | Country of the region |
 |   ↳ `name` | string | Name of the region |
 
-### `sportmonks_core_get_timezones`
+### Get Timezones
 
 Retrieve all supported time zones (IANA names) from the Sportmonks Core API
 
@@ -6902,7 +6902,7 @@ Retrieve all supported time zones (IANA names) from the Sportmonks Core API
 | --------- | ---- | ----------- |
 | `timezones` | array | Array of supported IANA time zone names \(e.g. Europe/London\) |
 
-### `sportmonks_core_get_type`
+### Get Type by ID
 
 Retrieve a single type by its ID from the Sportmonks Core API
 
@@ -6926,7 +6926,7 @@ Retrieve a single type by its ID from the Sportmonks Core API
 |   ↳ `group` | string | Group the type falls under |
 |   ↳ `description` | string | Description of the type |
 
-### `sportmonks_core_get_type_by_entity`
+### Get Type by Entity
 
 Retrieve the available types grouped per entity from the Sportmonks Core API
 
@@ -6942,7 +6942,7 @@ Retrieve the available types grouped per entity from the Sportmonks Core API
 | --------- | ---- | ----------- |
 | `typesByEntity` | json | Map of entity name to its available types, e.g. \{CoachStatisticDetail: \{updated_at, types: \[\{id, name, code, developer_name, model_type, stat_group\}\]\}\} |
 
-### `sportmonks_core_get_types`
+### Get Types
 
 Retrieve all types (reference data describing events, statistics, positions, etc.) from the Sportmonks Core API
 
@@ -6968,7 +6968,7 @@ Retrieve all types (reference data describing events, statistics, positions, etc
 |   ↳ `group` | string | Group the type falls under |
 |   ↳ `description` | string | Description of the type |
 
-### `sportmonks_core_search_cities`
+### Search Cities
 
 Search for cities by name from the Sportmonks Core API
 
@@ -6997,7 +6997,7 @@ Search for cities by name from the Sportmonks Core API
 |   ↳ `longitude` | string | Longitude of the city |
 |   ↳ `geonameid` | number | Official geonameid of the city |
 
-### `sportmonks_core_search_countries`
+### Search Countries
 
 Search for countries by name from the Sportmonks Core API
 
@@ -7031,7 +7031,7 @@ Search for countries by name from the Sportmonks Core API
 |   ↳ `borders` | array | Neighbouring countries \(ISO3 codes\) |
 |   ↳ `image_path` | string | Image path to the country flag |
 
-### `sportmonks_core_search_regions`
+### Search Regions
 
 Search for regions by name from the Sportmonks Core API
 

--- a/apps/docs/content/docs/en/integrations/sqs.mdx
+++ b/apps/docs/content/docs/en/integrations/sqs.mdx
@@ -37,7 +37,7 @@ Integrate Amazon SQS into the workflow. Can send messages to SQS queues.
 
 ## Actions
 
-### `sqs_send`
+### SQS Send Message
 
 Send a message to an Amazon SQS queue
 

--- a/apps/docs/content/docs/en/integrations/square.mdx
+++ b/apps/docs/content/docs/en/integrations/square.mdx
@@ -32,7 +32,7 @@ Integrate Square into the workflow. Take and refund payments, manage customers, 
 
 ## Actions
 
-### `square_create_payment`
+### Square Create Payment
 
 Take a payment using a payment source such as a card nonce or a card on file
 
@@ -96,7 +96,7 @@ Take a payment using a payment source such as a card nonce or a card on file
 |   ↳ `status` | string | Current payment status |
 |   ↳ `order_id` | string | Associated order ID |
 
-### `square_get_payment`
+### Square Get Payment
 
 Retrieve details for a single payment by its ID
 
@@ -151,7 +151,7 @@ Retrieve details for a single payment by its ID
 |   ↳ `status` | string | Current payment status |
 |   ↳ `order_id` | string | Associated order ID |
 
-### `square_list_payments`
+### Square List Payments
 
 List payments taken by the account, optionally filtered by location and time range
 
@@ -209,7 +209,7 @@ List payments taken by the account, optionally filtered by location and time ran
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_cancel_payment`
+### Square Cancel Payment
 
 Cancel (void) an authorized payment that has not been captured
 
@@ -264,7 +264,7 @@ Cancel (void) an authorized payment that has not been captured
 |   ↳ `status` | string | Current payment status |
 |   ↳ `order_id` | string | Associated order ID |
 
-### `square_complete_payment`
+### Square Complete Payment
 
 Capture (complete) a payment that was authorized with delayed capture
 
@@ -320,7 +320,7 @@ Capture (complete) a payment that was authorized with delayed capture
 |   ↳ `status` | string | Current payment status |
 |   ↳ `order_id` | string | Associated order ID |
 
-### `square_refund_payment`
+### Square Refund Payment
 
 Refund all or part of a completed payment
 
@@ -357,7 +357,7 @@ Refund all or part of a completed payment
 |   ↳ `status` | string | Current refund status |
 |   ↳ `payment_id` | string | Refunded payment ID |
 
-### `square_get_refund`
+### Square Get Refund
 
 Retrieve a single payment refund by its ID
 
@@ -390,7 +390,7 @@ Retrieve a single payment refund by its ID
 |   ↳ `status` | string | Current refund status |
 |   ↳ `payment_id` | string | Refunded payment ID |
 
-### `square_list_refunds`
+### Square List Refunds
 
 List payment refunds, optionally filtered by location, status, and time range
 
@@ -427,7 +427,7 @@ List payment refunds, optionally filtered by location, status, and time range
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_create_customer`
+### Square Create Customer
 
 Create a new customer profile in the Square customer directory
 
@@ -487,7 +487,7 @@ Create a new customer profile in the Square customer directory
 |   ↳ `given_name` | string | Customer first name |
 |   ↳ `family_name` | string | Customer last name |
 
-### `square_get_customer`
+### Square Get Customer
 
 Retrieve a single customer profile by its ID
 
@@ -537,7 +537,7 @@ Retrieve a single customer profile by its ID
 |   ↳ `given_name` | string | Customer first name |
 |   ↳ `family_name` | string | Customer last name |
 
-### `square_list_customers`
+### Square List Customers
 
 List customer profiles in the Square customer directory
 
@@ -588,7 +588,7 @@ List customer profiles in the Square customer directory
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_search_customers`
+### Square Search Customers
 
 Search customer profiles using filters such as email, phone, or creation date
 
@@ -638,7 +638,7 @@ Search customer profiles using filters such as email, phone, or creation date
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_update_customer`
+### Square Update Customer
 
 Update fields on an existing customer profile
 
@@ -698,7 +698,7 @@ Update fields on an existing customer profile
 |   ↳ `given_name` | string | Customer first name |
 |   ↳ `family_name` | string | Customer last name |
 
-### `square_delete_customer`
+### Square Delete Customer
 
 Delete a customer profile from the Square customer directory
 
@@ -716,7 +716,7 @@ Delete a customer profile from the Square customer directory
 | `deleted` | boolean | Whether the customer was deleted |
 | `id` | string | ID of the deleted customer |
 
-### `square_list_locations`
+### Square List Locations
 
 List all locations associated with the Square account
 
@@ -760,7 +760,7 @@ List all locations associated with the Square account
 | `metadata` | json | List metadata |
 |   ↳ `count` | number | Number of locations returned |
 
-### `square_get_location`
+### Square Get Location
 
 Retrieve a single location by its ID
 
@@ -806,7 +806,7 @@ Retrieve a single location by its ID
 |   ↳ `id` | string | Square location ID |
 |   ↳ `name` | string | Location name |
 
-### `square_create_order`
+### Square Create Order
 
 Create an order with line items, taxes, discounts, and fulfillments
 
@@ -857,7 +857,7 @@ Create an order with line items, taxes, discounts, and fulfillments
 |   ↳ `state` | string | Current order state |
 |   ↳ `location_id` | string | Order location ID |
 
-### `square_get_order`
+### Square Get Order
 
 Retrieve a single order by its ID
 
@@ -907,7 +907,7 @@ Retrieve a single order by its ID
 |   ↳ `state` | string | Current order state |
 |   ↳ `location_id` | string | Order location ID |
 
-### `square_search_orders`
+### Square Search Orders
 
 Search orders across one or more locations using filters and sorting
 
@@ -959,7 +959,7 @@ Search orders across one or more locations using filters and sorting
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_pay_order`
+### Square Pay Order
 
 Pay for an order using one or more already-approved payments
 
@@ -1012,7 +1012,7 @@ Pay for an order using one or more already-approved payments
 |   ↳ `state` | string | Current order state |
 |   ↳ `location_id` | string | Order location ID |
 
-### `square_create_invoice`
+### Square Create Invoice
 
 Create a draft invoice for an existing order and customer
 
@@ -1053,7 +1053,7 @@ Create a draft invoice for an existing order and customer
 |   ↳ `status` | string | Current invoice status |
 |   ↳ `version` | number | Invoice version |
 
-### `square_get_invoice`
+### Square Get Invoice
 
 Retrieve a single invoice by its ID
 
@@ -1093,7 +1093,7 @@ Retrieve a single invoice by its ID
 |   ↳ `status` | string | Current invoice status |
 |   ↳ `version` | number | Invoice version |
 
-### `square_list_invoices`
+### Square List Invoices
 
 List invoices for a specific location
 
@@ -1134,7 +1134,7 @@ List invoices for a specific location
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_search_invoices`
+### Square Search Invoices
 
 Search invoices across one or more locations
 
@@ -1175,7 +1175,7 @@ Search invoices across one or more locations
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_publish_invoice`
+### Square Publish Invoice
 
 Publish a draft invoice so it is sent to the customer and becomes payable
 
@@ -1217,7 +1217,7 @@ Publish a draft invoice so it is sent to the customer and becomes payable
 |   ↳ `status` | string | Current invoice status |
 |   ↳ `version` | number | Invoice version |
 
-### `square_cancel_invoice`
+### Square Cancel Invoice
 
 Cancel a published invoice that is unpaid or partially paid
 
@@ -1258,7 +1258,7 @@ Cancel a published invoice that is unpaid or partially paid
 |   ↳ `status` | string | Current invoice status |
 |   ↳ `version` | number | Invoice version |
 
-### `square_delete_invoice`
+### Square Delete Invoice
 
 Delete a draft invoice
 
@@ -1277,7 +1277,7 @@ Delete a draft invoice
 | `deleted` | boolean | Whether the invoice was deleted |
 | `id` | string | ID of the deleted invoice |
 
-### `square_upsert_catalog_object`
+### Square Upsert Catalog Object
 
 Create or update a catalog object such as an item, variation, or category
 
@@ -1309,7 +1309,7 @@ Create or update a catalog object such as an item, variation, or category
 |   ↳ `type` | string | Catalog object type |
 |   ↳ `version` | number | Catalog object version |
 
-### `square_get_catalog_object`
+### Square Get Catalog Object
 
 Retrieve a single catalog object by its ID
 
@@ -1341,7 +1341,7 @@ Retrieve a single catalog object by its ID
 |   ↳ `type` | string | Catalog object type |
 |   ↳ `version` | number | Catalog object version |
 
-### `square_list_catalog`
+### Square List Catalog
 
 List catalog objects, optionally filtered by type
 
@@ -1372,7 +1372,7 @@ List catalog objects, optionally filtered by type
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_search_catalog_objects`
+### Square Search Catalog Objects
 
 Search catalog objects by type and query filters
 
@@ -1405,7 +1405,7 @@ Search catalog objects by type and query filters
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
 
-### `square_create_catalog_image`
+### Square Create Catalog Image
 
 Upload an image and attach it to the catalog, optionally to a specific item
 
@@ -1440,7 +1440,7 @@ Upload an image and attach it to the catalog, optionally to a specific item
 |   ↳ `type` | string | Catalog object type |
 |   ↳ `version` | number | Catalog object version |
 
-### `square_delete_catalog_object`
+### Square Delete Catalog Object
 
 Delete a catalog object and its children (e.g. an item and its variations)
 
@@ -1459,7 +1459,7 @@ Delete a catalog object and its children (e.g. an item and its variations)
 | `deleted_object_ids` | array | IDs of all catalog objects deleted \(including children\) |
 | `deleted_at` | string | Timestamp when the deletion occurred \(RFC 3339\) |
 
-### `square_batch_retrieve_inventory_counts`
+### Square Batch Retrieve Inventory Counts
 
 Retrieve current inventory counts for catalog items across locations
 

--- a/apps/docs/content/docs/en/integrations/ssh.mdx
+++ b/apps/docs/content/docs/en/integrations/ssh.mdx
@@ -31,7 +31,7 @@ Execute commands, transfer files, and manage remote servers via SSH. Supports pa
 
 ## Actions
 
-### `ssh_execute_command`
+### SSH Execute Command
 
 Execute a shell command on a remote SSH server
 
@@ -58,7 +58,7 @@ Execute a shell command on a remote SSH server
 | `success` | boolean | Whether command succeeded \(exit code 0\) |
 | `message` | string | Operation status message |
 
-### `ssh_execute_script`
+### SSH Execute Script
 
 Upload and execute a multi-line script on a remote SSH server
 
@@ -87,7 +87,7 @@ Upload and execute a multi-line script on a remote SSH server
 | `scriptPath` | string | Temporary path where script was uploaded |
 | `message` | string | Operation status message |
 
-### `ssh_check_command_exists`
+### SSH Check Command Exists
 
 Check if a command/program exists on the remote SSH server
 
@@ -112,7 +112,7 @@ Check if a command/program exists on the remote SSH server
 | `version` | string | Command version output \(if applicable\) |
 | `message` | string | Operation status message |
 
-### `ssh_upload_file`
+### SSH Upload File
 
 Upload a file to a remote SSH server
 
@@ -141,7 +141,7 @@ Upload a file to a remote SSH server
 | `size` | number | File size in bytes |
 | `message` | string | Operation status message |
 
-### `ssh_download_file`
+### SSH Download File
 
 Download a file from a remote SSH server
 
@@ -169,7 +169,7 @@ Download a file from a remote SSH server
 | `size` | number | File size in bytes |
 | `message` | string | Operation status message |
 
-### `ssh_list_directory`
+### SSH List Directory
 
 List files and directories in a remote directory
 
@@ -201,7 +201,7 @@ List files and directories in a remote directory
 | `totalDirectories` | number | Total number of directories |
 | `message` | string | Operation status message |
 
-### `ssh_check_file_exists`
+### SSH Check File Exists
 
 Check if a file or directory exists on the remote SSH server
 
@@ -229,7 +229,7 @@ Check if a file or directory exists on the remote SSH server
 | `modified` | string | Last modified timestamp |
 | `message` | string | Operation status message |
 
-### `ssh_create_directory`
+### SSH Create Directory
 
 Create a directory on the remote SSH server
 
@@ -256,7 +256,7 @@ Create a directory on the remote SSH server
 | `alreadyExists` | boolean | Whether the directory already existed |
 | `message` | string | Operation status message |
 
-### `ssh_delete_file`
+### SSH Delete File
 
 Delete a file or directory from the remote SSH server
 
@@ -282,7 +282,7 @@ Delete a file or directory from the remote SSH server
 | `remotePath` | string | Deleted path |
 | `message` | string | Operation status message |
 
-### `ssh_move_rename`
+### SSH Move/Rename
 
 Move or rename a file or directory on the remote SSH server
 
@@ -309,7 +309,7 @@ Move or rename a file or directory on the remote SSH server
 | `destinationPath` | string | New path |
 | `message` | string | Operation status message |
 
-### `ssh_get_system_info`
+### SSH Get System Info
 
 Retrieve system information from the remote SSH server
 
@@ -336,7 +336,7 @@ Retrieve system information from the remote SSH server
 | `diskSpace` | json | Disk space information \(total, free, used\) |
 | `message` | string | Operation status message |
 
-### `ssh_read_file_content`
+### SSH Read File Content
 
 Read the contents of a remote file
 
@@ -364,7 +364,7 @@ Read the contents of a remote file
 | `remotePath` | string | Remote file path |
 | `message` | string | Operation status message |
 
-### `ssh_write_file_content`
+### SSH Write File Content
 
 Write or append content to a remote file
 

--- a/apps/docs/content/docs/en/integrations/stagehand.mdx
+++ b/apps/docs/content/docs/en/integrations/stagehand.mdx
@@ -38,7 +38,7 @@ Integrate Stagehand into the workflow. Can extract structured data from webpages
 
 ## Actions
 
-### `stagehand_extract`
+### Stagehand Extract
 
 Extract structured data from a webpage using Stagehand
 
@@ -58,7 +58,7 @@ Extract structured data from a webpage using Stagehand
 | --------- | ---- | ----------- |
 | `data` | object | Extracted structured data matching the provided schema |
 
-### `stagehand_agent`
+### Stagehand Agent
 
 Run an autonomous web agent to complete tasks and extract structured data
 

--- a/apps/docs/content/docs/en/integrations/stripe.mdx
+++ b/apps/docs/content/docs/en/integrations/stripe.mdx
@@ -37,7 +37,7 @@ Integrates Stripe into the workflow. Manage payment intents, customers, subscrip
 
 ## Actions
 
-### `stripe_create_payment_intent`
+### Stripe Create Payment Intent
 
 Create a new Payment Intent to process a payment
 
@@ -112,7 +112,7 @@ Create a new Payment Intent to process a payment
 |   ↳ `amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_retrieve_payment_intent`
+### Stripe Retrieve Payment Intent
 
 Retrieve an existing Payment Intent by ID
 
@@ -180,7 +180,7 @@ Retrieve an existing Payment Intent by ID
 |   ↳ `amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_update_payment_intent`
+### Stripe Update Payment Intent
 
 Update an existing Payment Intent
 
@@ -253,7 +253,7 @@ Update an existing Payment Intent
 |   ↳ `amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_confirm_payment_intent`
+### Stripe Confirm Payment Intent
 
 Confirm a Payment Intent to complete the payment
 
@@ -322,7 +322,7 @@ Confirm a Payment Intent to complete the payment
 |   ↳ `amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_capture_payment_intent`
+### Stripe Capture Payment Intent
 
 Capture an authorized Payment Intent
 
@@ -391,7 +391,7 @@ Capture an authorized Payment Intent
 |   ↳ `amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_cancel_payment_intent`
+### Stripe Cancel Payment Intent
 
 Cancel a Payment Intent
 
@@ -460,7 +460,7 @@ Cancel a Payment Intent
 |   ↳ `amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_list_payment_intents`
+### Stripe List Payment Intents
 
 List all Payment Intents
 
@@ -528,7 +528,7 @@ List all Payment Intents
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_search_payment_intents`
+### Stripe Search Payment Intents
 
 Search for Payment Intents using query syntax
 
@@ -595,7 +595,7 @@ Search for Payment Intents using query syntax
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_create_customer`
+### Stripe Create Customer
 
 Create a new customer object
 
@@ -659,7 +659,7 @@ Create a new customer object
 |   ↳ `email` | string | Customer email address |
 |   ↳ `name` | string | Display name |
 
-### `stripe_retrieve_customer`
+### Stripe Retrieve Customer
 
 Retrieve an existing customer by ID
 
@@ -717,7 +717,7 @@ Retrieve an existing customer by ID
 |   ↳ `email` | string | Customer email address |
 |   ↳ `name` | string | Display name |
 
-### `stripe_update_customer`
+### Stripe Update Customer
 
 Update an existing customer
 
@@ -781,7 +781,7 @@ Update an existing customer
 |   ↳ `email` | string | Customer email address |
 |   ↳ `name` | string | Display name |
 
-### `stripe_delete_customer`
+### Stripe Delete Customer
 
 Permanently delete a customer
 
@@ -799,7 +799,7 @@ Permanently delete a customer
 | `deleted` | boolean | Whether the resource was deleted |
 | `id` | string | ID of the deleted resource |
 
-### `stripe_list_customers`
+### Stripe List Customers
 
 List all customers
 
@@ -858,7 +858,7 @@ List all customers
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_search_customers`
+### Stripe Search Customers
 
 Search for customers using query syntax
 
@@ -916,7 +916,7 @@ Search for customers using query syntax
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_create_subscription`
+### Stripe Create Subscription
 
 Create a new subscription for a customer
 
@@ -984,7 +984,7 @@ Create a new subscription for a customer
 |   ↳ `status` | string | Current state of the resource |
 |   ↳ `customer` | string | Associated customer ID |
 
-### `stripe_retrieve_subscription`
+### Stripe Retrieve Subscription
 
 Retrieve an existing subscription by ID
 
@@ -1047,7 +1047,7 @@ Retrieve an existing subscription by ID
 |   ↳ `status` | string | Current state of the resource |
 |   ↳ `customer` | string | Associated customer ID |
 
-### `stripe_update_subscription`
+### Stripe Update Subscription
 
 Update an existing subscription
 
@@ -1113,7 +1113,7 @@ Update an existing subscription
 |   ↳ `status` | string | Current state of the resource |
 |   ↳ `customer` | string | Associated customer ID |
 
-### `stripe_cancel_subscription`
+### Stripe Cancel Subscription
 
 Cancel a subscription
 
@@ -1178,7 +1178,7 @@ Cancel a subscription
 |   ↳ `status` | string | Current state of the resource |
 |   ↳ `customer` | string | Associated customer ID |
 
-### `stripe_resume_subscription`
+### Stripe Resume Subscription
 
 Resume a subscription that was scheduled for cancellation
 
@@ -1241,7 +1241,7 @@ Resume a subscription that was scheduled for cancellation
 |   ↳ `status` | string | Current state of the resource |
 |   ↳ `customer` | string | Associated customer ID |
 
-### `stripe_list_subscriptions`
+### Stripe List Subscriptions
 
 List all subscriptions
 
@@ -1306,7 +1306,7 @@ List all subscriptions
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_search_subscriptions`
+### Stripe Search Subscriptions
 
 Search for subscriptions using query syntax
 
@@ -1369,7 +1369,7 @@ Search for subscriptions using query syntax
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_create_invoice`
+### Stripe Create Invoice
 
 Create a new invoice
 
@@ -1525,7 +1525,7 @@ Create a new invoice
 |   ↳ `amount_due` | number | Amount remaining to be paid in smallest currency unit |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_retrieve_invoice`
+### Stripe Retrieve Invoice
 
 Retrieve an existing invoice by ID
 
@@ -1677,7 +1677,7 @@ Retrieve an existing invoice by ID
 |   ↳ `amount_due` | number | Amount remaining to be paid in smallest currency unit |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_update_invoice`
+### Stripe Update Invoice
 
 Update an existing invoice
 
@@ -1832,7 +1832,7 @@ Update an existing invoice
 |   ↳ `amount_due` | number | Amount remaining to be paid in smallest currency unit |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_delete_invoice`
+### Stripe Delete Invoice
 
 Permanently delete a draft invoice
 
@@ -1850,7 +1850,7 @@ Permanently delete a draft invoice
 | `deleted` | boolean | Whether the invoice was deleted |
 | `id` | string | The ID of the deleted invoice |
 
-### `stripe_finalize_invoice`
+### Stripe Finalize Invoice
 
 Finalize a draft invoice
 
@@ -2003,7 +2003,7 @@ Finalize a draft invoice
 |   ↳ `amount_due` | number | Amount remaining to be paid in smallest currency unit |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_pay_invoice`
+### Stripe Pay Invoice
 
 Pay an invoice
 
@@ -2156,7 +2156,7 @@ Pay an invoice
 |   ↳ `amount_due` | number | Amount remaining to be paid in smallest currency unit |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_void_invoice`
+### Stripe Void Invoice
 
 Void an invoice
 
@@ -2308,7 +2308,7 @@ Void an invoice
 |   ↳ `amount_due` | number | Amount remaining to be paid in smallest currency unit |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_send_invoice`
+### Stripe Send Invoice
 
 Send an invoice to the customer
 
@@ -2330,7 +2330,7 @@ Send an invoice to the customer
 |   ↳ `amount_due` | number | Amount remaining to be paid in smallest currency unit |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_list_invoices`
+### Stripe List Invoices
 
 List all invoices
 
@@ -2352,7 +2352,7 @@ List all invoices
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_search_invoices`
+### Stripe Search Invoices
 
 Search for invoices using query syntax
 
@@ -2373,7 +2373,7 @@ Search for invoices using query syntax
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_create_charge`
+### Stripe Create Charge
 
 Create a new charge to process a payment
 
@@ -2402,7 +2402,7 @@ Create a new charge to process a payment
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 |   ↳ `paid` | boolean | Whether payment has been received |
 
-### `stripe_retrieve_charge`
+### Stripe Retrieve Charge
 
 Retrieve an existing charge by ID
 
@@ -2425,7 +2425,7 @@ Retrieve an existing charge by ID
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 |   ↳ `paid` | boolean | Whether payment has been received |
 
-### `stripe_update_charge`
+### Stripe Update Charge
 
 Update an existing charge
 
@@ -2450,7 +2450,7 @@ Update an existing charge
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 |   ↳ `paid` | boolean | Whether payment has been received |
 
-### `stripe_capture_charge`
+### Stripe Capture Charge
 
 Capture an uncaptured charge
 
@@ -2474,7 +2474,7 @@ Capture an uncaptured charge
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 |   ↳ `paid` | boolean | Whether payment has been received |
 
-### `stripe_list_charges`
+### Stripe List Charges
 
 List all charges
 
@@ -2496,7 +2496,7 @@ List all charges
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_search_charges`
+### Stripe Search Charges
 
 Search for charges using query syntax
 
@@ -2517,7 +2517,7 @@ Search for charges using query syntax
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_create_product`
+### Stripe Create Product
 
 Create a new product object
 
@@ -2542,7 +2542,7 @@ Create a new product object
 |   ↳ `name` | string | Display name |
 |   ↳ `active` | boolean | Whether the resource is currently active |
 
-### `stripe_retrieve_product`
+### Stripe Retrieve Product
 
 Retrieve an existing product by ID
 
@@ -2563,7 +2563,7 @@ Retrieve an existing product by ID
 |   ↳ `name` | string | Display name |
 |   ↳ `active` | boolean | Whether the resource is currently active |
 
-### `stripe_update_product`
+### Stripe Update Product
 
 Update an existing product
 
@@ -2589,7 +2589,7 @@ Update an existing product
 |   ↳ `name` | string | Display name |
 |   ↳ `active` | boolean | Whether the resource is currently active |
 
-### `stripe_delete_product`
+### Stripe Delete Product
 
 Permanently delete a product
 
@@ -2607,7 +2607,7 @@ Permanently delete a product
 | `deleted` | boolean | Whether the product was deleted |
 | `id` | string | The ID of the deleted product |
 
-### `stripe_list_products`
+### Stripe List Products
 
 List all products
 
@@ -2628,7 +2628,7 @@ List all products
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_search_products`
+### Stripe Search Products
 
 Search for products using query syntax
 
@@ -2649,7 +2649,7 @@ Search for products using query syntax
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_create_price`
+### Stripe Create Price
 
 Create a new price for a product
 
@@ -2676,7 +2676,7 @@ Create a new price for a product
 |   ↳ `unit_amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_retrieve_price`
+### Stripe Retrieve Price
 
 Retrieve an existing price by ID
 
@@ -2698,7 +2698,7 @@ Retrieve an existing price by ID
 |   ↳ `unit_amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_update_price`
+### Stripe Update Price
 
 Update an existing price
 
@@ -2722,7 +2722,7 @@ Update an existing price
 |   ↳ `unit_amount` | number | Amount in smallest currency unit \(e.g., cents\) |
 |   ↳ `currency` | string | Three-letter ISO currency code \(lowercase\) |
 
-### `stripe_list_prices`
+### Stripe List Prices
 
 List all prices
 
@@ -2744,7 +2744,7 @@ List all prices
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_search_prices`
+### Stripe Search Prices
 
 Search for prices using query syntax
 
@@ -2765,7 +2765,7 @@ Search for prices using query syntax
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-### `stripe_retrieve_event`
+### Stripe Retrieve Event
 
 Retrieve an existing Event by ID
 
@@ -2786,7 +2786,7 @@ Retrieve an existing Event by ID
 |   ↳ `type` | string | Event type identifier |
 |   ↳ `created` | number | Unix timestamp of creation |
 
-### `stripe_list_events`
+### Stripe List Events
 
 List all Events
 

--- a/apps/docs/content/docs/en/integrations/sts.mdx
+++ b/apps/docs/content/docs/en/integrations/sts.mdx
@@ -32,7 +32,7 @@ Integrate AWS STS into the workflow. Assume roles, get temporary credentials, ve
 
 ## Actions
 
-### `sts_assume_role`
+### STS Assume Role
 
 Assume an IAM role and receive temporary security credentials
 
@@ -67,7 +67,7 @@ Assume an IAM role and receive temporary security credentials
 | `packedPolicySize` | number | Percentage of allowed policy size used |
 | `sourceIdentity` | string | Source identity set on the role session, if any |
 
-### `sts_assume_role_with_web_identity`
+### STS Assume Role With Web Identity
 
 Assume an IAM role using an OIDC/OAuth 2.0 web identity token (e.g. GitHub Actions OIDC, EKS IRSA, Google/Facebook federation) and receive temporary security credentials
 
@@ -100,7 +100,7 @@ Assume an IAM role using an OIDC/OAuth 2.0 web identity token (e.g. GitHub Actio
 | `packedPolicySize` | number | Percentage of allowed policy size used |
 | `sourceIdentity` | string | Source identity set on the role session, if any |
 
-### `sts_assume_role_with_saml`
+### STS Assume Role With SAML
 
 Assume an IAM role using a SAML 2.0 authentication response from an enterprise identity provider and receive temporary security credentials
 
@@ -134,7 +134,7 @@ Assume an IAM role using a SAML 2.0 authentication response from an enterprise i
 | `packedPolicySize` | number | Percentage of allowed policy size used |
 | `sourceIdentity` | string | Source identity set on the role session, if any |
 
-### `sts_get_caller_identity`
+### STS Get Caller Identity
 
 Get details about the IAM user or role whose credentials are used to call the API
 
@@ -154,7 +154,7 @@ Get details about the IAM user or role whose credentials are used to call the AP
 | `arn` | string | ARN of the calling entity |
 | `userId` | string | Unique identifier of the calling entity |
 
-### `sts_get_session_token`
+### STS Get Session Token
 
 Get temporary security credentials for an IAM user, optionally with MFA
 
@@ -178,7 +178,7 @@ Get temporary security credentials for an IAM user, optionally with MFA
 | `sessionToken` | string | Temporary session token |
 | `expiration` | string | Credential expiration timestamp |
 
-### `sts_get_access_key_info`
+### STS Get Access Key Info
 
 Get the AWS account ID associated with an access key
 

--- a/apps/docs/content/docs/en/integrations/supabase.mdx
+++ b/apps/docs/content/docs/en/integrations/supabase.mdx
@@ -42,7 +42,7 @@ Integrate Supabase into the workflow. Supports database operations (query, inser
 
 ## Actions
 
-### `supabase_query`
+### Supabase Query
 
 Query data from a Supabase table
 
@@ -67,7 +67,7 @@ Query data from a Supabase table
 | `message` | string | Operation status message |
 | `results` | array | Array of records returned from the query |
 
-### `supabase_insert`
+### Supabase Insert
 
 Insert data into a Supabase table
 
@@ -88,7 +88,7 @@ Insert data into a Supabase table
 | `message` | string | Operation status message |
 | `results` | array | Array of inserted records |
 
-### `supabase_get_row`
+### Supabase Get Row
 
 Get a single row from a Supabase table based on filter criteria
 
@@ -110,7 +110,7 @@ Get a single row from a Supabase table based on filter criteria
 | `message` | string | Operation status message |
 | `results` | array | Array containing the row data if found, empty array if not found |
 
-### `supabase_update`
+### Supabase Update Row
 
 Update rows in a Supabase table based on filter criteria
 
@@ -132,7 +132,7 @@ Update rows in a Supabase table based on filter criteria
 | `message` | string | Operation status message |
 | `results` | array | Array of updated records |
 
-### `supabase_delete`
+### Supabase Delete Row
 
 Delete rows from a Supabase table based on filter criteria
 
@@ -153,7 +153,7 @@ Delete rows from a Supabase table based on filter criteria
 | `message` | string | Operation status message |
 | `results` | array | Array of deleted records |
 
-### `supabase_upsert`
+### Supabase Upsert
 
 Insert or update data in a Supabase table (upsert operation)
 
@@ -175,7 +175,7 @@ Insert or update data in a Supabase table (upsert operation)
 | `message` | string | Operation status message |
 | `results` | array | Array of upserted records |
 
-### `supabase_count`
+### Supabase Count
 
 Count rows in a Supabase table
 
@@ -197,7 +197,7 @@ Count rows in a Supabase table
 | `message` | string | Operation status message |
 | `count` | number | Number of rows matching the filter |
 
-### `supabase_text_search`
+### Supabase Text Search
 
 Perform full-text search on a Supabase table
 
@@ -223,7 +223,7 @@ Perform full-text search on a Supabase table
 | `message` | string | Operation status message |
 | `results` | array | Array of records matching the search query |
 
-### `supabase_vector_search`
+### Supabase Vector Search
 
 Perform similarity search using pgvector in a Supabase table
 
@@ -245,7 +245,7 @@ Perform similarity search using pgvector in a Supabase table
 | `message` | string | Operation status message |
 | `results` | array | Array of records with similarity scores from the vector search. Each record includes a similarity field \(0-1\) indicating how similar it is to the query vector. |
 
-### `supabase_rpc`
+### Supabase RPC
 
 Call a PostgreSQL function in Supabase
 
@@ -264,7 +264,7 @@ Call a PostgreSQL function in Supabase
 | `message` | string | Operation status message |
 | `results` | json | Result returned from the function |
 
-### `supabase_invoke_function`
+### Supabase Invoke Edge Function
 
 Invoke a Supabase Edge Function over HTTP
 
@@ -286,7 +286,7 @@ Invoke a Supabase Edge Function over HTTP
 | `message` | string | Operation status message |
 | `results` | json | Response body returned by the Edge Function |
 
-### `supabase_introspect`
+### Supabase Introspect
 
 Introspect Supabase database schema from its OpenAPI spec to get table and column structures (best-effort primary/foreign key detection)
 
@@ -327,7 +327,7 @@ Introspect Supabase database schema from its OpenAPI spec to get table and colum
 |     ↳ `unique` | boolean | Whether the index enforces uniqueness |
 | `schemas` | array | List of schemas found in the database |
 
-### `supabase_storage_upload`
+### Supabase Storage Upload
 
 Upload a file to a Supabase storage bucket
 
@@ -357,7 +357,7 @@ Upload a file to a Supabase storage bucket
 |   ↳ `bucket` | string | Name of the bucket the file was uploaded to |
 |   ↳ `publicUrl` | string | Public URL for the uploaded file |
 
-### `supabase_storage_download`
+### Supabase Storage Download
 
 Download a file from a Supabase storage bucket
 
@@ -377,7 +377,7 @@ Download a file from a Supabase storage bucket
 | --------- | ---- | ----------- |
 | `file` | file | Downloaded file stored in execution files |
 
-### `supabase_storage_list`
+### Supabase Storage List
 
 List files in a Supabase storage bucket
 
@@ -415,7 +415,7 @@ List files in a Supabase storage bucket
 |     ↳ `lastModified` | string | Last modified timestamp |
 |     ↳ `eTag` | string | Entity tag for caching |
 
-### `supabase_storage_delete`
+### Supabase Storage Delete
 
 Delete files from a Supabase storage bucket
 
@@ -442,7 +442,7 @@ Delete files from a Supabase storage bucket
 |   ↳ `created_at` | string | File creation timestamp |
 |   ↳ `last_accessed_at` | string | Last access timestamp |
 
-### `supabase_storage_move`
+### Supabase Storage Move
 
 Move a file within a Supabase storage bucket
 
@@ -466,7 +466,7 @@ Move a file within a Supabase storage bucket
 |   ↳ `Id` | string | Identifier of the destination object |
 |   ↳ `Key` | string | Full object key of the destination |
 
-### `supabase_storage_copy`
+### Supabase Storage Copy
 
 Copy a file within a Supabase storage bucket
 
@@ -489,7 +489,7 @@ Copy a file within a Supabase storage bucket
 |   ↳ `Key` | string | Full object key of the copied file |
 |   ↳ `Id` | string | Identifier of the copied object |
 
-### `supabase_storage_create_bucket`
+### Supabase Storage Create Bucket
 
 Create a new storage bucket in Supabase
 
@@ -512,7 +512,7 @@ Create a new storage bucket in Supabase
 | `results` | object | Created bucket result \(name\) |
 |   ↳ `name` | string | Created bucket name |
 
-### `supabase_storage_update_bucket`
+### Supabase Storage Update Bucket
 
 Update the configuration of an existing Supabase storage bucket
 
@@ -535,7 +535,7 @@ Update the configuration of an existing Supabase storage bucket
 | `results` | object | Update operation result |
 |   ↳ `message` | string | Operation status message |
 
-### `supabase_storage_empty_bucket`
+### Supabase Storage Empty Bucket
 
 Delete all objects inside a Supabase storage bucket without deleting the bucket itself
 
@@ -555,7 +555,7 @@ Delete all objects inside a Supabase storage bucket without deleting the bucket 
 | `results` | object | Empty bucket operation result |
 |   ↳ `message` | string | Operation status message |
 
-### `supabase_storage_list_buckets`
+### Supabase Storage List Buckets
 
 List all storage buckets in Supabase
 
@@ -581,7 +581,7 @@ List all storage buckets in Supabase
 |   ↳ `file_size_limit` | number | Maximum file size allowed in bytes |
 |   ↳ `allowed_mime_types` | array | List of allowed MIME types for uploads |
 
-### `supabase_storage_delete_bucket`
+### Supabase Storage Delete Bucket
 
 Delete a storage bucket in Supabase
 
@@ -601,7 +601,7 @@ Delete a storage bucket in Supabase
 | `results` | object | Delete operation result |
 |   ↳ `message` | string | Operation status message |
 
-### `supabase_storage_get_public_url`
+### Supabase Storage Get Public URL
 
 Get the public URL for a file in a Supabase storage bucket
 
@@ -621,7 +621,7 @@ Get the public URL for a file in a Supabase storage bucket
 | `message` | string | Operation status message |
 | `publicUrl` | string | The public URL to access the file |
 
-### `supabase_storage_create_signed_url`
+### Supabase Storage Create Signed URL
 
 Create a temporary signed URL for a file in a Supabase storage bucket
 
@@ -643,7 +643,7 @@ Create a temporary signed URL for a file in a Supabase storage bucket
 | `message` | string | Operation status message |
 | `signedUrl` | string | The temporary signed URL to access the file |
 
-### `supabase_storage_create_signed_upload_url`
+### Supabase Storage Create Signed Upload URL
 
 Create a temporary signed URL a client can use to upload directly to a Supabase storage bucket
 

--- a/apps/docs/content/docs/en/integrations/table.mdx
+++ b/apps/docs/content/docs/en/integrations/table.mdx
@@ -60,7 +60,7 @@ Create and manage custom data tables. Store, query, and manipulate structured da
 
 ## Actions
 
-### `table_insert_row`
+### Insert Row
 
 Insert a new row into a table. IMPORTANT: You must use the "data" parameter (not "values", "row", "fields", or other variations) to specify the row contents.
 
@@ -79,7 +79,7 @@ Insert a new row into a table. IMPORTANT: You must use the "data" parameter (not
 | `row` | json | Inserted row data |
 | `message` | string | Status message |
 
-### `table_batch_insert_rows`
+### Batch Insert Rows
 
 Insert multiple rows into a table at once (up to $\{TABLE_LIMITS.MAX_BATCH_INSERT_SIZE\} rows)
 
@@ -99,7 +99,7 @@ Insert multiple rows into a table at once (up to $\{TABLE_LIMITS.MAX_BATCH_INSER
 | `insertedCount` | number | Number of rows inserted |
 | `message` | string | Status message |
 
-### `table_upsert_row`
+### Upsert Row
 
 Insert or update a row based on unique column constraints. If a row with matching unique field exists, update it; otherwise insert a new row. IMPORTANT: You must use the "data" parameter (not "values", "row", "fields", or other variations) to specify the row contents.
 
@@ -120,7 +120,7 @@ Insert or update a row based on unique column constraints. If a row with matchin
 | `operation` | string | Operation performed: insert or update |
 | `message` | string | Status message |
 
-### `table_update_row`
+### Update Row
 
 Update an existing row in a table. Supports partial updates - only include the fields you want to change. IMPORTANT: You must use the "data" parameter (not "values", "row", "fields", or other variations) to specify the fields to update.
 
@@ -140,7 +140,7 @@ Update an existing row in a table. Supports partial updates - only include the f
 | `row` | json | Updated row data |
 | `message` | string | Status message |
 
-### `table_update_rows_by_filter`
+### Update Rows by Filter
 
 Update multiple rows that match filter criteria. Data is merged with existing row data.
 
@@ -162,7 +162,7 @@ Update multiple rows that match filter criteria. Data is merged with existing ro
 | `updatedRowIds` | array | IDs of updated rows |
 | `message` | string | Status message |
 
-### `table_delete_row`
+### Delete Row
 
 Delete a row from a table
 
@@ -181,7 +181,7 @@ Delete a row from a table
 | `deletedCount` | number | Number of rows deleted |
 | `message` | string | Status message |
 
-### `table_delete_rows_by_filter`
+### Delete Rows by Filter
 
 Delete multiple rows that match filter criteria. Use with caution - supports optional limit for safety.
 
@@ -202,7 +202,7 @@ Delete multiple rows that match filter criteria. Use with caution - supports opt
 | `deletedRowIds` | array | IDs of deleted rows |
 | `message` | string | Status message |
 
-### `table_query_rows`
+### Query Rows
 
 Query rows from a table with filtering, sorting, and pagination
 
@@ -227,7 +227,7 @@ Query rows from a table with filtering, sorting, and pagination
 | `limit` | number | Limit used in query |
 | `offset` | number | Offset used in query |
 
-### `table_get_row`
+### Get Row
 
 Get a single row by ID
 
@@ -246,7 +246,7 @@ Get a single row by ID
 | `row` | json | Row data |
 | `message` | string | Status message |
 
-### `table_get_schema`
+### Get Schema
 
 Get the schema configuration of a table
 

--- a/apps/docs/content/docs/en/integrations/tailscale.mdx
+++ b/apps/docs/content/docs/en/integrations/tailscale.mdx
@@ -51,7 +51,7 @@ Interact with the Tailscale API to manage devices, DNS, ACLs, auth keys, users, 
 
 ## Actions
 
-### `tailscale_list_devices`
+### Tailscale List Devices
 
 List all devices in the tailnet
 
@@ -84,7 +84,7 @@ List all devices in the tailnet
 |   ↳ `created` | string | Creation timestamp |
 | `count` | number | Total number of devices |
 
-### `tailscale_get_device`
+### Tailscale Get Device
 
 Get details of a specific device by ID
 
@@ -120,7 +120,7 @@ Get details of a specific device by ID
 | `machineKey` | string | Machine key |
 | `nodeKey` | string | Node key |
 
-### `tailscale_delete_device`
+### Tailscale Delete Device
 
 Remove a device from the tailnet
 
@@ -139,7 +139,7 @@ Remove a device from the tailnet
 | `success` | boolean | Whether the device was successfully deleted |
 | `deviceId` | string | ID of the deleted device |
 
-### `tailscale_authorize_device`
+### Tailscale Authorize Device
 
 Authorize or deauthorize a device on the tailnet
 
@@ -160,7 +160,7 @@ Authorize or deauthorize a device on the tailnet
 | `deviceId` | string | Device ID |
 | `authorized` | boolean | Authorization status after the operation |
 
-### `tailscale_set_device_tags`
+### Tailscale Set Device Tags
 
 Set tags on a device in the tailnet
 
@@ -181,7 +181,7 @@ Set tags on a device in the tailnet
 | `deviceId` | string | Device ID |
 | `tags` | array | Tags set on the device |
 
-### `tailscale_get_device_routes`
+### Tailscale Get Device Routes
 
 Get the subnet routes for a device
 
@@ -200,7 +200,7 @@ Get the subnet routes for a device
 | `advertisedRoutes` | array | Subnet routes the device is advertising |
 | `enabledRoutes` | array | Subnet routes that are approved/enabled |
 
-### `tailscale_set_device_routes`
+### Tailscale Set Device Routes
 
 Set the enabled subnet routes for a device
 
@@ -220,7 +220,7 @@ Set the enabled subnet routes for a device
 | `advertisedRoutes` | array | Subnet routes the device is advertising |
 | `enabledRoutes` | array | Subnet routes that are now enabled |
 
-### `tailscale_update_device_key`
+### Tailscale Update Device Key
 
 Enable or disable key expiry on a device
 
@@ -241,7 +241,7 @@ Enable or disable key expiry on a device
 | `deviceId` | string | Device ID |
 | `keyExpiryDisabled` | boolean | Whether key expiry is now disabled |
 
-### `tailscale_expire_device_key`
+### Tailscale Expire Device Key
 
 Immediately expire a device's node key, requiring it to re-authenticate before it can reconnect to the tailnet
 
@@ -260,7 +260,7 @@ Immediately expire a device's node key, requiring it to re-authenticate before i
 | `success` | boolean | Whether the device's key was successfully expired |
 | `deviceId` | string | Device ID |
 
-### `tailscale_list_dns_nameservers`
+### Tailscale List DNS Nameservers
 
 Get the DNS nameservers configured for the tailnet
 
@@ -277,7 +277,7 @@ Get the DNS nameservers configured for the tailnet
 | --------- | ---- | ----------- |
 | `dns` | array | List of DNS nameserver addresses |
 
-### `tailscale_set_dns_nameservers`
+### Tailscale Set DNS Nameservers
 
 Set the DNS nameservers for the tailnet
 
@@ -296,7 +296,7 @@ Set the DNS nameservers for the tailnet
 | `dns` | array | Updated list of DNS nameserver addresses |
 | `magicDNS` | boolean | Whether MagicDNS is enabled |
 
-### `tailscale_get_dns_preferences`
+### Tailscale Get DNS Preferences
 
 Get the DNS preferences for the tailnet including MagicDNS status
 
@@ -313,7 +313,7 @@ Get the DNS preferences for the tailnet including MagicDNS status
 | --------- | ---- | ----------- |
 | `magicDNS` | boolean | Whether MagicDNS is enabled |
 
-### `tailscale_set_dns_preferences`
+### Tailscale Set DNS Preferences
 
 Set DNS preferences for the tailnet (enable/disable MagicDNS)
 
@@ -331,7 +331,7 @@ Set DNS preferences for the tailnet (enable/disable MagicDNS)
 | --------- | ---- | ----------- |
 | `magicDNS` | boolean | Updated MagicDNS status |
 
-### `tailscale_get_dns_searchpaths`
+### Tailscale Get DNS Search Paths
 
 Get the DNS search paths configured for the tailnet
 
@@ -348,7 +348,7 @@ Get the DNS search paths configured for the tailnet
 | --------- | ---- | ----------- |
 | `searchPaths` | array | List of DNS search path domains |
 
-### `tailscale_set_dns_searchpaths`
+### Tailscale Set DNS Search Paths
 
 Set the DNS search paths for the tailnet
 
@@ -366,7 +366,7 @@ Set the DNS search paths for the tailnet
 | --------- | ---- | ----------- |
 | `searchPaths` | array | Updated list of DNS search path domains |
 
-### `tailscale_list_users`
+### Tailscale List Users
 
 List all users in the tailnet
 
@@ -394,7 +394,7 @@ List all users in the tailnet
 |   ↳ `deviceCount` | number | Number of devices owned by user |
 | `count` | number | Total number of users |
 
-### `tailscale_suspend_user`
+### Tailscale Suspend User
 
 Suspend a user's access to the tailnet
 
@@ -413,7 +413,7 @@ Suspend a user's access to the tailnet
 | `success` | boolean | Whether the user was successfully suspended |
 | `userId` | string | ID of the suspended user |
 
-### `tailscale_delete_user`
+### Tailscale Delete User
 
 Delete a user from the tailnet
 
@@ -432,7 +432,7 @@ Delete a user from the tailnet
 | `success` | boolean | Whether the user was successfully deleted |
 | `userId` | string | ID of the deleted user |
 
-### `tailscale_create_auth_key`
+### Tailscale Create Auth Key
 
 Create a new auth key for the tailnet to pre-authorize devices
 
@@ -465,7 +465,7 @@ Create a new auth key for the tailnet to pre-authorize devices
 |   ↳ `preauthorized` | boolean | Whether devices are pre-authorized |
 |   ↳ `tags` | array | Tags applied to devices using this key |
 
-### `tailscale_list_auth_keys`
+### Tailscale List Auth Keys
 
 List all auth keys in the tailnet
 
@@ -493,7 +493,7 @@ List all auth keys in the tailnet
 |     ↳ `tags` | array | Tags applied to devices |
 | `count` | number | Total number of auth keys |
 
-### `tailscale_get_auth_key`
+### Tailscale Get Auth Key
 
 Get details of a specific auth key
 
@@ -520,7 +520,7 @@ Get details of a specific auth key
 |   ↳ `preauthorized` | boolean | Whether devices are pre-authorized |
 |   ↳ `tags` | array | Tags applied to devices using this key |
 
-### `tailscale_delete_auth_key`
+### Tailscale Delete Auth Key
 
 Revoke and delete an auth key
 
@@ -539,7 +539,7 @@ Revoke and delete an auth key
 | `success` | boolean | Whether the auth key was successfully deleted |
 | `keyId` | string | ID of the deleted auth key |
 
-### `tailscale_get_acl`
+### Tailscale Get ACL
 
 Get the current ACL policy for the tailnet
 
@@ -557,7 +557,7 @@ Get the current ACL policy for the tailnet
 | `acl` | string | ACL policy as JSON string |
 | `etag` | string | ETag for the current ACL version \(use with If-Match header for updates\) |
 
-### `tailscale_set_acl`
+### Tailscale Set ACL
 
 Replace the ACL policy file for the tailnet
 

--- a/apps/docs/content/docs/en/integrations/tavily.mdx
+++ b/apps/docs/content/docs/en/integrations/tavily.mdx
@@ -33,7 +33,7 @@ Integrate Tavily into the workflow. Can search the web and extract content from 
 
 ## Actions
 
-### `tavily_search`
+### Tavily Search
 
 Perform AI-powered web searches using Tavily's search API. Returns structured results with titles, URLs, snippets, and optional raw content, optimized for relevance and accuracy.
 
@@ -79,7 +79,7 @@ Perform AI-powered web searches using Tavily's search API. Returns structured re
 | `auto_parameters` | object | Automatically selected parameters based on query intent \(if enabled\) |
 | `response_time` | number | Time taken for the search request in seconds |
 
-### `tavily_extract`
+### Tavily Extract
 
 Extract raw content from multiple web pages simultaneously using Tavily's extraction API. Supports basic and advanced extraction depths with detailed error reporting for failed URLs.
 
@@ -108,7 +108,7 @@ Extract raw content from multiple web pages simultaneously using Tavily's extrac
 |   ↳ `error` | string | Error message describing why extraction failed |
 | `response_time` | number | Time taken for the extraction request in seconds |
 
-### `tavily_crawl`
+### Tavily Crawl
 
 Systematically crawl and extract content from websites using Tavily's crawl API. Supports depth control, path filtering, domain restrictions, and natural language instructions for targeted crawling.
 
@@ -144,7 +144,7 @@ Systematically crawl and extract content from websites using Tavily's crawl API.
 | `response_time` | number | Time taken for the crawl request in seconds |
 | `request_id` | string | Unique identifier for support reference |
 
-### `tavily_map`
+### Tavily Map
 
 Discover and visualize website structure using Tavily's map API. Maps out all accessible URLs from a base URL with depth control, path filtering, and domain restrictions.
 

--- a/apps/docs/content/docs/en/integrations/telegram.mdx
+++ b/apps/docs/content/docs/en/integrations/telegram.mdx
@@ -59,7 +59,7 @@ Integrate Telegram into the workflow. Send, edit, forward, copy, pin, and delete
 
 ## Actions
 
-### `telegram_message`
+### Telegram Send Message
 
 Send messages to Telegram channels or users through the Telegram Bot API. Enables direct communication and notifications with message tracking and chat confirmation.
 
@@ -91,7 +91,7 @@ Send messages to Telegram channels or users through the Telegram Bot API. Enable
 |   ↳ `date` | number | Unix timestamp when message was sent |
 |   ↳ `text` | string | Text content of the sent message |
 
-### `telegram_delete_message`
+### Telegram Delete Message
 
 Delete messages in Telegram channels or chats through the Telegram Bot API. Requires the message ID of the message to delete.
 
@@ -112,7 +112,7 @@ Delete messages in Telegram channels or chats through the Telegram Bot API. Requ
 |   ↳ `ok` | boolean | API response success status |
 |   ↳ `deleted` | boolean | Whether the message was successfully deleted |
 
-### `telegram_send_photo`
+### Telegram Send Photo
 
 Send photos to Telegram channels or users through the Telegram Bot API.
 
@@ -151,7 +151,7 @@ Send photos to Telegram channels or users through the Telegram Bot API.
 |     ↳ `width` | number | Photo width in pixels |
 |     ↳ `height` | number | Photo height in pixels |
 
-### `telegram_send_video`
+### Telegram Send Video
 
 Send videos to Telegram channels or users through the Telegram Bot API.
 
@@ -223,7 +223,7 @@ Send videos to Telegram channels or users through the Telegram Bot API.
 |     ↳ `file_unique_id` | string | Unique document file identifier |
 |     ↳ `file_size` | number | Size of document file in bytes |
 
-### `telegram_send_audio`
+### Telegram Send Audio
 
 Send audio files to Telegram channels or users through the Telegram Bot API.
 
@@ -265,7 +265,7 @@ Send audio files to Telegram channels or users through the Telegram Bot API.
 |     ↳ `file_unique_id` | string | Unique identifier across different bots for this file |
 |     ↳ `file_size` | number | Size of the audio file in bytes |
 
-### `telegram_send_animation`
+### Telegram Send Animation
 
 Send animations (GIFs) to Telegram channels or users through the Telegram Bot API.
 
@@ -337,7 +337,7 @@ Send animations (GIFs) to Telegram channels or users through the Telegram Bot AP
 |     ↳ `file_unique_id` | string | Unique document file identifier |
 |     ↳ `file_size` | number | Size of document file in bytes |
 
-### `telegram_send_document`
+### Telegram Send Document
 
 Send documents (PDF, ZIP, DOC, etc.) to Telegram channels or users through the Telegram Bot API.
 
@@ -376,7 +376,7 @@ Send documents (PDF, ZIP, DOC, etc.) to Telegram channels or users through the T
 |     ↳ `file_unique_id` | string | Unique document file identifier |
 |     ↳ `file_size` | number | Size of document file in bytes |
 
-### `telegram_edit_message_text`
+### Telegram Edit Message Text
 
 Edit the text of an existing message in a Telegram chat or channel through the Telegram Bot API.
 
@@ -399,7 +399,7 @@ Edit the text of an existing message in a Telegram chat or channel through the T
 |   ↳ `date` | number | Unix timestamp when message was sent |
 |   ↳ `text` | string | Text content of the edited message |
 
-### `telegram_forward_message`
+### Telegram Forward Message
 
 Forward a message from one Telegram chat to another through the Telegram Bot API.
 
@@ -422,7 +422,7 @@ Forward a message from one Telegram chat to another through the Telegram Bot API
 |   ↳ `date` | number | Unix timestamp when message was sent |
 |   ↳ `text` | string | Text content of the forwarded message |
 
-### `telegram_copy_message`
+### Telegram Copy Message
 
 Copy a message to another Telegram chat without a forward header through the Telegram Bot API.
 
@@ -444,7 +444,7 @@ Copy a message to another Telegram chat without a forward header through the Tel
 | `data` | object | Copied message identifier |
 |   ↳ `message_id` | number | Identifier of the new copied message |
 
-### `telegram_send_location`
+### Telegram Send Location
 
 Send a point on the map to a Telegram chat through the Telegram Bot API.
 
@@ -466,7 +466,7 @@ Send a point on the map to a Telegram chat through the Telegram Bot API.
 |   ↳ `message_id` | number | Unique Telegram message identifier |
 |   ↳ `date` | number | Unix timestamp when message was sent |
 
-### `telegram_send_contact`
+### Telegram Send Contact
 
 Send a phone contact to a Telegram chat through the Telegram Bot API.
 
@@ -490,7 +490,7 @@ Send a phone contact to a Telegram chat through the Telegram Bot API.
 |   ↳ `message_id` | number | Unique Telegram message identifier |
 |   ↳ `date` | number | Unix timestamp when message was sent |
 
-### `telegram_send_poll`
+### Telegram Send Poll
 
 Send a native poll to a Telegram chat through the Telegram Bot API.
 
@@ -514,7 +514,7 @@ Send a native poll to a Telegram chat through the Telegram Bot API.
 |   ↳ `message_id` | number | Unique Telegram message identifier |
 |   ↳ `date` | number | Unix timestamp when message was sent |
 
-### `telegram_pin_message`
+### Telegram Pin Message
 
 Pin a message in a Telegram chat through the Telegram Bot API.
 
@@ -536,7 +536,7 @@ Pin a message in a Telegram chat through the Telegram Bot API.
 |   ↳ `ok` | boolean | API response success status |
 |   ↳ `result` | boolean | Whether the message was pinned |
 
-### `telegram_unpin_message`
+### Telegram Unpin Message
 
 Unpin a pinned message in a Telegram chat through the Telegram Bot API. Unpins the most recent pinned message when no message ID is given.
 
@@ -557,7 +557,7 @@ Unpin a pinned message in a Telegram chat through the Telegram Bot API. Unpins t
 |   ↳ `ok` | boolean | API response success status |
 |   ↳ `result` | boolean | Whether the message was unpinned |
 
-### `telegram_set_message_reaction`
+### Telegram Set Message Reaction
 
 Set or remove an emoji reaction on a message in a Telegram chat through the Telegram Bot API.
 
@@ -580,7 +580,7 @@ Set or remove an emoji reaction on a message in a Telegram chat through the Tele
 |   ↳ `ok` | boolean | API response success status |
 |   ↳ `result` | boolean | Whether the reaction was set |
 
-### `telegram_send_chat_action`
+### Telegram Send Chat Action
 
 Show a status action such as a typing indicator in a Telegram chat through the Telegram Bot API.
 
@@ -601,7 +601,7 @@ Show a status action such as a typing indicator in a Telegram chat through the T
 |   ↳ `ok` | boolean | API response success status |
 |   ↳ `result` | boolean | Whether the action was broadcast |
 
-### `telegram_get_chat`
+### Telegram Get Chat
 
 Get up-to-date information about a Telegram chat through the Telegram Bot API.
 
@@ -629,7 +629,7 @@ Get up-to-date information about a Telegram chat through the Telegram Bot API.
 |   ↳ `invite_link` | string | Primary invite link for the chat |
 |   ↳ `linked_chat_id` | number | Linked discussion or channel chat ID |
 
-### `telegram_get_chat_member`
+### Telegram Get Chat Member
 
 Get information about a member of a Telegram chat through the Telegram Bot API.
 

--- a/apps/docs/content/docs/en/integrations/temporal.mdx
+++ b/apps/docs/content/docs/en/integrations/temporal.mdx
@@ -32,7 +32,7 @@ Connect to a Temporal cluster over the server's HTTP API to start workflow execu
 
 ## Actions
 
-### `temporal_start_workflow`
+### Temporal Start Workflow
 
 Start a new workflow execution on a Temporal cluster.
 
@@ -63,7 +63,7 @@ Start a new workflow execution on a Temporal cluster.
 | `runId` | string | Run ID of the started workflow execution |
 | `started` | boolean | Whether a new execution was started \(false when an existing execution was reused\) |
 
-### `temporal_signal_workflow`
+### Temporal Signal Workflow
 
 Send a signal to a running Temporal workflow execution.
 
@@ -86,7 +86,7 @@ Send a signal to a running Temporal workflow execution.
 | `workflowId` | string | Workflow ID of the signaled execution |
 | `signalName` | string | Name of the signal that was sent |
 
-### `temporal_signal_with_start`
+### Temporal Signal With Start
 
 Atomically signal a Temporal workflow, starting it first if it is not already running, so the signal is never lost.
 
@@ -119,7 +119,7 @@ Atomically signal a Temporal workflow, starting it first if it is not already ru
 | `runId` | string | Run ID of the signaled \(or newly started\) execution |
 | `started` | boolean | Whether this call started a new execution \(false when only signaled\) |
 
-### `temporal_query_workflow`
+### Temporal Query Workflow
 
 Run a synchronous query against the state of a Temporal workflow execution and return the result.
 
@@ -143,7 +143,7 @@ Run a synchronous query against the state of a Temporal workflow execution and r
 | `queryType` | string | Name of the query that was run |
 | `result` | json | Decoded query result. A single payload is returned as its JSON value; multiple payloads are returned as an array |
 
-### `temporal_update_workflow`
+### Temporal Update Workflow
 
 Invoke an update handler on a running Temporal workflow and wait for its result. Unlike a signal, an update is validated by the workflow and returns a response.
 
@@ -167,7 +167,7 @@ Invoke an update handler on a running Temporal workflow and wait for its result.
 | `updateName` | string | Name of the update that was invoked |
 | `result` | json | Decoded update result. A single payload is returned as its JSON value; multiple payloads are returned as an array |
 
-### `temporal_describe_workflow`
+### Temporal Describe Workflow
 
 Get the current state of a Temporal workflow execution, including status, timing, memo, search attributes, and pending activities.
 
@@ -203,7 +203,7 @@ Get the current state of a Temporal workflow execution, including status, timing
 |   ↳ `attempt` | number | Current attempt number |
 |   ↳ `lastFailureMessage` | string | Message of the most recent failure, if the activity is retrying |
 
-### `temporal_list_workflows`
+### Temporal List Workflows
 
 List workflow executions in a Temporal namespace, optionally filtered with a visibility query.
 
@@ -234,7 +234,7 @@ List workflow executions in a Temporal namespace, optionally filtered with a vis
 |   ↳ `taskQueue` | string | Task queue of the execution |
 | `nextPageToken` | string | Token for the next page of results, null when no more pages exist |
 
-### `temporal_count_workflows`
+### Temporal Count Workflows
 
 Count workflow executions in a Temporal namespace matching a visibility query, with optional GROUP BY aggregation.
 
@@ -256,7 +256,7 @@ Count workflow executions in a Temporal namespace matching a visibility query, w
 |   ↳ `values` | json | Decoded values of the GROUP BY fields |
 |   ↳ `count` | number | Number of executions in the group |
 
-### `temporal_get_workflow_history`
+### Temporal Get Workflow History
 
 Fetch the event history of a Temporal workflow execution, optionally filtered to just the close event.
 
@@ -284,7 +284,7 @@ Fetch the event history of a Temporal workflow execution, optionally filtered to
 |   ↳ `attributes` | json | The event's type-specific attributes \(payload data is base64-encoded\) |
 | `nextPageToken` | string | Token for the next page of events, null when no more pages exist |
 
-### `temporal_cancel_workflow`
+### Temporal Cancel Workflow
 
 Request cooperative cancellation of a running Temporal workflow execution. The workflow decides how to respond to the request.
 
@@ -305,7 +305,7 @@ Request cooperative cancellation of a running Temporal workflow execution. The w
 | --------- | ---- | ----------- |
 | `workflowId` | string | Workflow ID of the execution whose cancellation was requested |
 
-### `temporal_terminate_workflow`
+### Temporal Terminate Workflow
 
 Forcefully terminate a Temporal workflow execution immediately, without giving the workflow a chance to react.
 
@@ -326,7 +326,7 @@ Forcefully terminate a Temporal workflow execution immediately, without giving t
 | --------- | ---- | ----------- |
 | `workflowId` | string | Workflow ID of the terminated execution |
 
-### `temporal_reset_workflow`
+### Temporal Reset Workflow
 
 Reset a Temporal workflow execution to a past workflow task, terminating the current run and replaying from the reset point in a new run.
 
@@ -349,7 +349,7 @@ Reset a Temporal workflow execution to a past workflow task, terminating the cur
 | `workflowId` | string | Workflow ID of the reset execution |
 | `runId` | string | Run ID of the new run created by the reset |
 
-### `temporal_describe_task_queue`
+### Temporal Describe Task Queue
 
 List the workers currently polling a Temporal task queue, to check whether a workflow or activity has live workers.
 
@@ -373,7 +373,7 @@ List the workers currently polling a Temporal task queue, to check whether a wor
 |   ↳ `lastAccessTime` | string | Last time the worker polled the queue \(RFC 3339\) |
 |   ↳ `ratePerSecond` | number | Poller rate per second |
 
-### `temporal_create_schedule`
+### Temporal Create Schedule
 
 Create a Temporal schedule that starts a workflow on a cron or interval cadence.
 
@@ -402,7 +402,7 @@ Create a Temporal schedule that starts a workflow on a cron or interval cadence.
 | --------- | ---- | ----------- |
 | `scheduleId` | string | ID of the created schedule |
 
-### `temporal_list_schedules`
+### Temporal List Schedules
 
 List schedules in a Temporal namespace.
 
@@ -429,7 +429,7 @@ List schedules in a Temporal namespace.
 |   ↳ `futureActionTimes` | json | Upcoming action times \(RFC 3339\) |
 | `nextPageToken` | string | Token for the next page of results, null when no more pages exist |
 
-### `temporal_describe_schedule`
+### Temporal Describe Schedule
 
 Get the configuration and current state of a Temporal schedule, including its spec, recent actions, and upcoming run times.
 
@@ -460,7 +460,7 @@ Get the configuration and current state of a Temporal schedule, including its sp
 |   ↳ `runId` | string | Run ID of the started execution |
 | `futureActionTimes` | json | Upcoming action times \(RFC 3339\) |
 
-### `temporal_pause_schedule`
+### Temporal Pause Schedule
 
 Pause a Temporal schedule so it stops taking actions until unpaused.
 
@@ -480,7 +480,7 @@ Pause a Temporal schedule so it stops taking actions until unpaused.
 | --------- | ---- | ----------- |
 | `scheduleId` | string | ID of the paused schedule |
 
-### `temporal_unpause_schedule`
+### Temporal Unpause Schedule
 
 Unpause a Temporal schedule so it resumes taking actions.
 
@@ -500,7 +500,7 @@ Unpause a Temporal schedule so it resumes taking actions.
 | --------- | ---- | ----------- |
 | `scheduleId` | string | ID of the unpaused schedule |
 
-### `temporal_trigger_schedule`
+### Temporal Trigger Schedule
 
 Trigger an immediate action of a Temporal schedule, outside its normal spec.
 
@@ -520,7 +520,7 @@ Trigger an immediate action of a Temporal schedule, outside its normal spec.
 | --------- | ---- | ----------- |
 | `scheduleId` | string | ID of the triggered schedule |
 
-### `temporal_delete_schedule`
+### Temporal Delete Schedule
 
 Delete a Temporal schedule. Workflows already started by the schedule keep running.
 

--- a/apps/docs/content/docs/en/integrations/textract.mdx
+++ b/apps/docs/content/docs/en/integrations/textract.mdx
@@ -33,7 +33,7 @@ Integrate AWS Textract into your workflow to extract text, tables, forms, and ke
 
 ## Actions
 
-### `textract_parser`
+### AWS Textract Parser
 
 #### Input
 
@@ -78,7 +78,7 @@ Integrate AWS Textract into your workflow to extract text, tables, forms, and ke
 |   ↳ `pages` | number | Number of pages in the document |
 | `modelVersion` | string | Version of the Textract model used for processing |
 
-### `textract_analyze_expense`
+### AWS Textract Analyze Expense
 
 Extract structured invoice and receipt fields using AWS Textract AnalyzeExpense
 
@@ -109,7 +109,7 @@ Extract structured invoice and receipt fields using AWS Textract AnalyzeExpense
 |   ↳ `pages` | number | Number of pages in the document |
 | `modelVersion` | string | Version of the AnalyzeExpense model used \(multi-page/async only\) |
 
-### `textract_analyze_id`
+### AWS Textract Analyze ID
 
 Extract identity document fields using AWS Textract AnalyzeID
 

--- a/apps/docs/content/docs/en/integrations/thrive.mdx
+++ b/apps/docs/content/docs/en/integrations/thrive.mdx
@@ -33,7 +33,7 @@ Integrate Thrive Learning into the workflow. Manage user lifecycle, audiences an
 
 ## Actions
 
-### `thrive_create_user`
+### Thrive Create User
 
 Create a new user in Thrive.
 
@@ -85,7 +85,7 @@ Create a new user in Thrive.
 |   ↳ `domain` | string | Domain this individual is associated with |
 |   ↳ `additionalFields` | json | Custom field values for this user |
 
-### `thrive_update_user`
+### Thrive Update User
 
 Update an existing user in Thrive by ref. Only the fields provided are changed.
 
@@ -137,7 +137,7 @@ Update an existing user in Thrive by ref. Only the fields provided are changed.
 |   ↳ `domain` | string | Domain this individual is associated with |
 |   ↳ `additionalFields` | json | Custom field values for this user |
 
-### `thrive_delete_user`
+### Thrive Delete User
 
 Permanently delete (obfuscate) a user in Thrive by ref while retaining training history.
 
@@ -156,7 +156,7 @@ Permanently delete (obfuscate) a user in Thrive by ref while retaining training 
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the user was deleted |
 
-### `thrive_suspend_user`
+### Thrive Suspend User
 
 Suspend a user in Thrive by ref, marking the account inactive.
 
@@ -195,7 +195,7 @@ Suspend a user in Thrive by ref, marking the account inactive.
 |   ↳ `domain` | string | Domain this individual is associated with |
 |   ↳ `additionalFields` | json | Custom field values for this user |
 
-### `thrive_search_users`
+### Thrive Search Users
 
 Search users in Thrive and return basic user information with pagination.
 
@@ -253,7 +253,7 @@ Search users in Thrive and return basic user information with pagination.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_get_user_by_id`
+### Thrive Get User by ID
 
 Get a single user in Thrive by their ID and return basic user information.
 
@@ -301,7 +301,7 @@ Get a single user in Thrive by their ID and return basic user information.
 |   ↳ `audiences` | array | Audience IDs the user belongs to |
 |   ↳ `singleSignOn` | boolean | Whether the user uses single sign-on |
 
-### `thrive_get_user_by_ref`
+### Thrive Get User by Ref
 
 Get a single user in Thrive by their ref and return basic user information.
 
@@ -330,7 +330,7 @@ Get a single user in Thrive by their ref and return basic user information.
 |   ↳ `additionalFields` | json | Custom field values |
 |   ↳ `languageCode` | string | The user's language code |
 
-### `thrive_list_audiences`
+### Thrive List Audiences
 
 List audiences and structures in Thrive with pagination.
 
@@ -369,7 +369,7 @@ List audiences and structures in Thrive with pagination.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_create_audience`
+### Thrive Create Audience
 
 Create a new audience or structure in Thrive.
 
@@ -403,7 +403,7 @@ Create a new audience or structure in Thrive.
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
 
-### `thrive_get_audience`
+### Thrive Get Audience
 
 Get a single audience or structure in Thrive by id or reference.
 
@@ -434,7 +434,7 @@ Get a single audience or structure in Thrive by id or reference.
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
 
-### `thrive_update_audience`
+### Thrive Update Audience
 
 Update an audience in Thrive, optionally moving it to a new parent.
 
@@ -468,7 +468,7 @@ Update an audience in Thrive, optionally moving it to a new parent.
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
 
-### `thrive_delete_audience`
+### Thrive Delete Audience
 
 Delete an audience in Thrive (only if it has no child audiences).
 
@@ -487,7 +487,7 @@ Delete an audience in Thrive (only if it has no child audiences).
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the audience was deleted |
 
-### `thrive_list_audience_members`
+### Thrive List Audience Members
 
 List the members of a Thrive audience with pagination.
 
@@ -516,7 +516,7 @@ List the members of a Thrive audience with pagination.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_add_audience_members`
+### Thrive Add Audience Members
 
 Add members to a Thrive audience by email, ref, or id.
 
@@ -545,7 +545,7 @@ Add members to a Thrive audience by email, ref, or id.
 |       ↳ `reason` | string | The reason for the failure |
 |       ↳ `reference` | string | The entity reference |
 
-### `thrive_replace_audience_members`
+### Thrive Replace Audience Members
 
 Replace a Thrive audience's entire members list with the given users (does not support an empty array).
 
@@ -574,7 +574,7 @@ Replace a Thrive audience's entire members list with the given users (does not s
 |       ↳ `reason` | string | The reason for the failure |
 |       ↳ `reference` | string | The entity reference |
 
-### `thrive_remove_audience_member`
+### Thrive Remove Audience Member
 
 Remove a single member from a Thrive audience.
 
@@ -594,7 +594,7 @@ Remove a single member from a Thrive audience.
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the audience member was removed |
 
-### `thrive_list_audience_managers`
+### Thrive List Audience Managers
 
 List the managers of a Thrive audience.
 
@@ -620,7 +620,7 @@ List the managers of a Thrive audience.
 |     ↳ `peopleManager` | json | People manager permissions |
 |     ↳ `administrator` | json | Administrator permissions \(structures only\) |
 
-### `thrive_add_audience_managers`
+### Thrive Add Audience Managers
 
 Add managers to a Thrive audience with their permissions.
 
@@ -649,7 +649,7 @@ Add managers to a Thrive audience with their permissions.
 |       ↳ `reason` | string | The reason for the failure |
 |       ↳ `reference` | string | The entity reference |
 
-### `thrive_replace_audience_managers`
+### Thrive Replace Audience Managers
 
 Replace a Thrive audience's entire manager list with the given managers (does not support an empty array).
 
@@ -678,7 +678,7 @@ Replace a Thrive audience's entire manager list with the given managers (does no
 |       ↳ `reason` | string | The reason for the failure |
 |       ↳ `reference` | string | The entity reference |
 
-### `thrive_remove_audience_manager`
+### Thrive Remove Audience Manager
 
 Remove a single manager from a Thrive audience.
 
@@ -698,7 +698,7 @@ Remove a single manager from a Thrive audience.
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the audience manager was removed |
 
-### `thrive_list_assignments`
+### Thrive List Assignments
 
 List compliance assignments in Thrive, optionally filtered by audience.
 
@@ -732,7 +732,7 @@ List compliance assignments in Thrive, optionally filtered by audience.
 |   ↳ `deletedAt` | string | Deletion timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
 
-### `thrive_create_assignment`
+### Thrive Create Assignment
 
 Create a compliance assignment in Thrive for an audience and content item.
 
@@ -768,7 +768,7 @@ Create a compliance assignment in Thrive for an audience and content item.
 |   ↳ `deletedAt` | string | Deletion timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
 
-### `thrive_get_assignment`
+### Thrive Get Assignment
 
 Get a single compliance assignment in Thrive by its ID.
 
@@ -799,7 +799,7 @@ Get a single compliance assignment in Thrive by its ID.
 |   ↳ `deletedAt` | string | Deletion timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
 
-### `thrive_update_assignment`
+### Thrive Update Assignment
 
 Update a compliance assignment in Thrive.
 
@@ -835,7 +835,7 @@ Update a compliance assignment in Thrive.
 |   ↳ `deletedAt` | string | Deletion timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
 
-### `thrive_delete_assignment`
+### Thrive Delete Assignment
 
 Delete a compliance assignment in Thrive.
 
@@ -855,7 +855,7 @@ Delete a compliance assignment in Thrive.
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the assignment was deleted |
 
-### `thrive_list_enrolments`
+### Thrive List Enrolments
 
 List enrolments for a compliance assignment in Thrive.
 
@@ -896,7 +896,7 @@ List enrolments for a compliance assignment in Thrive.
 |     ↳ `updatedAt` | string | Date the event was last modified |
 |   ↳ `updatedAt` | string | Date the enrolment was last updated |
 
-### `thrive_get_enrolment`
+### Thrive Get Enrolment
 
 Get a single enrolment for a compliance assignment in Thrive.
 
@@ -933,7 +933,7 @@ Get a single enrolment for a compliance assignment in Thrive.
 |     ↳ `updatedAt` | string | Date the event was last modified |
 |   ↳ `updatedAt` | string | Date the enrolment was last updated |
 
-### `thrive_list_completions`
+### Thrive List Completions
 
 List learning completion records in Thrive, optionally filtered by user or content.
 
@@ -968,7 +968,7 @@ List learning completion records in Thrive, optionally filtered by user or conte
 |   ↳ `completedAt` | string | Timestamp when the completion occurred \(ISO 8601\) |
 |   ↳ `activeUntil` | string | Timestamp the completion is valid until \(ISO 8601\) |
 
-### `thrive_get_completion`
+### Thrive Get Completion
 
 Get a single learning completion record in Thrive by its ID.
 
@@ -997,7 +997,7 @@ Get a single learning completion record in Thrive by its ID.
 |   ↳ `completedAt` | string | Timestamp when the completion occurred \(ISO 8601\) |
 |   ↳ `activeUntil` | string | Timestamp the completion is valid until \(ISO 8601\) |
 
-### `thrive_create_completion`
+### Thrive Create Completion
 
 Record a learning completion in Thrive for a user and content item.
 
@@ -1018,7 +1018,7 @@ Record a learning completion in Thrive for a user and content item.
 | --------- | ---- | ----------- |
 | `statementId` | string | The completion statement ID |
 
-### `thrive_get_content`
+### Thrive Get Content
 
 Get a single content record in Thrive by its ID.
 
@@ -1050,7 +1050,7 @@ Get a single content record in Thrive by its ID.
 |     ↳ `unit` | string | The unit of the duration \(always 'minutes'\) |
 |   ↳ `contentHistory` | array | Chronological history of actions on this content |
 
-### `thrive_query_content`
+### Thrive Query Content
 
 Query content records in Thrive with pagination and filtering options.
 
@@ -1091,7 +1091,7 @@ Query content records in Thrive with pagination and filtering options.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_get_activity`
+### Thrive Get Activity
 
 Get a single activity record in Thrive by its ID.
 
@@ -1119,7 +1119,7 @@ Get a single activity record in Thrive by its ID.
 |   ↳ `data` | json | Unstructured activity data; shape varies by type |
 |   ↳ `with` | json | Additional context information |
 
-### `thrive_query_activities`
+### Thrive Query Activities
 
 Query activity records in Thrive with pagination and filtering options.
 
@@ -1159,7 +1159,7 @@ Query activity records in Thrive with pagination and filtering options.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_get_cpd_category`
+### Thrive Get CPD Category
 
 Get a single CPD category in Thrive by its ID.
 
@@ -1180,7 +1180,7 @@ Get a single CPD category in Thrive by its ID.
 |   ↳ `categoryId` | string | Unique ID for this category record |
 |   ↳ `name` | string | Name of the category of CPD activity |
 
-### `thrive_query_cpd_categories`
+### Thrive Query CPD Categories
 
 Query CPD categories in Thrive and return results with pagination.
 
@@ -1208,7 +1208,7 @@ Query CPD categories in Thrive and return results with pagination.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_get_cpd_entry`
+### Thrive Get CPD Entry
 
 Get a single CPD log entry in Thrive by its ID.
 
@@ -1239,7 +1239,7 @@ Get a single CPD log entry in Thrive by its ID.
 |   ↳ `description` | string | Summary or reflective statement |
 |   ↳ `isVerified` | boolean | Whether the activity was generated from verified system activity |
 
-### `thrive_query_cpd_entries`
+### Thrive Query CPD Entries
 
 Query CPD log entries in Thrive and return results with pagination.
 
@@ -1278,7 +1278,7 @@ Query CPD log entries in Thrive and return results with pagination.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_get_cpd_requirement`
+### Thrive Get CPD Requirement
 
 Get a single CPD requirement summary in Thrive by its ID.
 
@@ -1302,7 +1302,7 @@ Get a single CPD requirement summary in Thrive by its ID.
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
 
-### `thrive_query_cpd_requirements`
+### Thrive Query CPD Requirements
 
 Query CPD requirement summaries in Thrive and return results with pagination.
 
@@ -1333,7 +1333,7 @@ Query CPD requirement summaries in Thrive and return results with pagination.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_query_cpd_user_summaries`
+### Thrive Query CPD User Summaries
 
 Query CPD user log summaries in Thrive and return results with pagination.
 
@@ -1363,7 +1363,7 @@ Query CPD user log summaries in Thrive and return results with pagination.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_list_tags`
+### Thrive List Tags
 
 List tags in Thrive and return tag information with pagination.
 
@@ -1395,7 +1395,7 @@ List tags in Thrive and return tag information with pagination.
 |   ↳ `page` | number | Current page number |
 |   ↳ `perPage` | number | Number of results per page |
 
-### `thrive_get_tag`
+### Thrive Get Tag
 
 Get a single tag in Thrive by its ID.
 
@@ -1420,7 +1420,7 @@ Get a single tag in Thrive by its ID.
 |   ↳ `interests` | array | IDs of users interested in this tag |
 |   ↳ `skills` | array | IDs of users skilled in this tag |
 
-### `thrive_add_user_tags`
+### Thrive Add User Tags
 
 Add one or more tags to a learner in Thrive.
 
@@ -1441,7 +1441,7 @@ Add one or more tags to a learner in Thrive.
 | `status` | number | The HTTP status code of the operation |
 | `message` | string | A human-readable result message |
 
-### `thrive_remove_user_tags`
+### Thrive Remove User Tags
 
 Remove one or more tags from a learner in Thrive.
 
@@ -1462,7 +1462,7 @@ Remove one or more tags from a learner in Thrive.
 | `status` | number | The HTTP status code of the operation |
 | `message` | string | A human-readable result message |
 
-### `thrive_update_user_skills`
+### Thrive Update User Skills
 
 Update skills and levels for a learner in Thrive.
 
@@ -1483,7 +1483,7 @@ Update skills and levels for a learner in Thrive.
 | `status` | number | The HTTP status code of the operation |
 | `message` | string | A human-readable result message |
 
-### `thrive_get_skill_levels`
+### Thrive Get Skill Levels
 
 Get the available skill levels configured in Thrive.
 

--- a/apps/docs/content/docs/en/integrations/tiktok.mdx
+++ b/apps/docs/content/docs/en/integrations/tiktok.mdx
@@ -18,7 +18,7 @@ Integrate TikTok into your workflow. Get user profile information including foll
 
 ## Actions
 
-### `tiktok_get_user`
+### TikTok Get User
 
 Get the authenticated TikTok user profile information including display name, avatar, bio, follower count, and video statistics.
 
@@ -45,7 +45,7 @@ Get the authenticated TikTok user profile information including display name, av
 | `videoCount` | number | Total number of public videos |
 | `avatarFile` | file | Downloadable copy of the profile avatar image \(largest available variant\), stored as a workflow file so it can be chained into file-consuming blocks \(e.g. attached to an email\). |
 
-### `tiktok_list_videos`
+### TikTok List Videos
 
 Get a list of the authenticated user's TikTok videos with cover images, titles, and metadata. Supports pagination.
 
@@ -79,7 +79,7 @@ Get a list of the authenticated user's TikTok videos with cover images, titles, 
 | `cursor` | number | Cursor for fetching the next page of results |
 | `hasMore` | boolean | Whether there are more videos to fetch |
 
-### `tiktok_query_videos`
+### TikTok Query Videos
 
 Query specific TikTok videos by their IDs to get fresh metadata including cover images, embed links, and video details.
 
@@ -110,7 +110,7 @@ Query specific TikTok videos by their IDs to get fresh metadata including cover 
 |   ↳ `commentCount` | number | Number of comments |
 |   ↳ `shareCount` | number | Number of shares |
 
-### `tiktok_upload_video_draft`
+### TikTok Upload Video Draft
 
 Send an uploaded video to the authenticated user's TikTok inbox for manual editing and posting. The user must open TikTok and tap the inbox notification to complete the post. Rate limit: 6 requests per minute per user.
 
@@ -126,7 +126,7 @@ Send an uploaded video to the authenticated user's TikTok inbox for manual editi
 | --------- | ---- | ----------- |
 | `publishId` | string | Unique identifier for tracking the draft status. Use this with the Get Post Status tool to check when the user has completed posting from their inbox. |
 
-### `tiktok_get_post_status`
+### TikTok Get Post Status
 
 Check the status of a video draft upload. Use the publishId returned from Upload Video Draft to track progress.
 

--- a/apps/docs/content/docs/en/integrations/tinybird.mdx
+++ b/apps/docs/content/docs/en/integrations/tinybird.mdx
@@ -36,7 +36,7 @@ Interact with Tinybird: stream JSON or NDJSON events with the Events API, run SQ
 
 ## Actions
 
-### `tinybird_events`
+### Tinybird Events
 
 Send events to a Tinybird Data Source using the Events API. Supports JSON and NDJSON formats with optional gzip compression.
 
@@ -59,7 +59,7 @@ Send events to a Tinybird Data Source using the Events API. Supports JSON and ND
 | `successful_rows` | number | Number of rows successfully ingested |
 | `quarantined_rows` | number | Number of rows quarantined \(failed validation\) |
 
-### `tinybird_query`
+### Tinybird Query
 
 Execute SQL queries against Tinybird Pipes and Data Sources using the Query API.
 
@@ -84,7 +84,7 @@ Execute SQL queries against Tinybird Pipes and Data Sources using the Query API.
 | `rows_before_limit_at_least` | number | Minimum number of rows there would be without a LIMIT clause \(only available with FORMAT JSON\) |
 | `statistics` | json | Query execution statistics - elapsed time, rows read, bytes read \(only available with FORMAT JSON\) |
 
-### `tinybird_query_pipe`
+### Tinybird Query Pipe
 
 Call a published Tinybird Pipe API Endpoint by name, passing dynamic parameters and receiving structured JSON results.
 
@@ -113,7 +113,7 @@ Call a published Tinybird Pipe API Endpoint by name, passing dynamic parameters 
 |   ↳ `rows_read` | number | Number of rows processed |
 |   ↳ `bytes_read` | number | Number of bytes processed |
 
-### `tinybird_append_datasource`
+### Tinybird Append Data Source
 
 Append data to a Tinybird Data Source from a remote file URL (CSV, NDJSON, Parquet).
 
@@ -139,7 +139,7 @@ Append data to a Tinybird Data Source from a remote file URL (CSV, NDJSON, Parqu
 | `job` | json | Full import job details \(kind, id, status, created_at, datasource, ...\) |
 | `datasource` | json | Target Data Source metadata \(id, name, ...\) |
 
-### `tinybird_truncate_datasource`
+### Tinybird Truncate Data Source
 
 Delete all rows from a Tinybird Data Source.
 
@@ -158,7 +158,7 @@ Delete all rows from a Tinybird Data Source.
 | `truncated` | boolean | Whether the Data Source was truncated successfully |
 | `result` | json | Raw response body from the truncate endpoint, if any |
 
-### `tinybird_delete_datasource_rows`
+### Tinybird Delete Data Source Rows
 
 Delete rows from a Tinybird Data Source matching a SQL condition.
 
@@ -183,7 +183,7 @@ Delete rows from a Tinybird Data Source matching a SQL condition.
 | `status` | string | Current job status \(e.g., "waiting", "done"\) |
 | `job` | json | Full delete job details \(kind, id, status, delete_condition, rows_affected, ...\) |
 
-### `tinybird_get_job`
+### Tinybird Get Job
 
 Check the status of an asynchronous Tinybird job (import, delete, etc.) by ID.
 

--- a/apps/docs/content/docs/en/integrations/trello.mdx
+++ b/apps/docs/content/docs/en/integrations/trello.mdx
@@ -43,7 +43,7 @@ Integrate with Trello to list, search, create, update, and delete cards and list
 
 ## Actions
 
-### `trello_list_lists`
+### Trello Get Lists
 
 List all lists on a Trello board
 
@@ -66,7 +66,7 @@ List all lists on a Trello board
 |   ↳ `idBoard` | string | Board ID containing the list |
 | `count` | number | Number of lists returned |
 
-### `trello_list_cards`
+### Trello List Cards
 
 List cards from a Trello board or list
 
@@ -99,7 +99,7 @@ List cards from a Trello board or list
 |   ↳ `dueComplete` | boolean | Whether the due date is complete |
 | `count` | number | Number of cards returned |
 
-### `trello_search`
+### Trello Search
 
 Search Trello cards and boards by keyword
 
@@ -133,7 +133,7 @@ Search Trello cards and boards by keyword
 |   ↳ `idOrganization` | string | Workspace/organization ID that owns the board |
 | `count` | number | Total number of cards and boards returned |
 
-### `trello_create_card`
+### Trello Create Card
 
 Create a new card in a Trello list
 
@@ -170,7 +170,7 @@ Create a new card in a Trello list
 |   ↳ `due` | string | Card due date in ISO 8601 format |
 |   ↳ `dueComplete` | boolean | Whether the due date is complete |
 
-### `trello_update_card`
+### Trello Update Card
 
 Update an existing card on Trello
 
@@ -206,7 +206,7 @@ Update an existing card on Trello
 |   ↳ `due` | string | Card due date in ISO 8601 format |
 |   ↳ `dueComplete` | boolean | Whether the due date is complete |
 
-### `trello_delete_card`
+### Trello Delete Card
 
 Permanently delete a Trello card
 
@@ -222,7 +222,7 @@ Permanently delete a Trello card
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the card was deleted |
 
-### `trello_get_actions`
+### Trello Get Actions
 
 Get activity/actions from a board or card
 
@@ -267,7 +267,7 @@ Get activity/actions from a board or card
 |     ↳ `name` | string | List name |
 | `count` | number | Number of actions returned |
 
-### `trello_add_comment`
+### Trello Add Comment
 
 Add a comment to a Trello card
 
@@ -306,7 +306,7 @@ Add a comment to a Trello card
 |     ↳ `id` | string | List ID |
 |     ↳ `name` | string | List name |
 
-### `trello_create_board`
+### Trello Create Board
 
 Create a new Trello board
 
@@ -331,7 +331,7 @@ Create a new Trello board
 |   ↳ `closed` | boolean | Whether the board is closed |
 |   ↳ `idOrganization` | string | ID of the workspace/organization the board belongs to |
 
-### `trello_get_board`
+### Trello Get Board
 
 Retrieve a single Trello board by ID
 
@@ -353,7 +353,7 @@ Retrieve a single Trello board by ID
 |   ↳ `closed` | boolean | Whether the board is closed |
 |   ↳ `idOrganization` | string | ID of the workspace/organization the board belongs to |
 
-### `trello_create_list`
+### Trello Create List
 
 Create a new list on a Trello board
 
@@ -376,7 +376,7 @@ Create a new list on a Trello board
 |   ↳ `pos` | number | List position on the board |
 |   ↳ `idBoard` | string | Board ID containing the list |
 
-### `trello_update_list`
+### Trello Update List
 
 Rename, move, archive, or reopen a Trello list
 
@@ -401,7 +401,7 @@ Rename, move, archive, or reopen a Trello list
 |   ↳ `pos` | number | List position on the board |
 |   ↳ `idBoard` | string | Board ID containing the list |
 
-### `trello_get_card`
+### Trello Get Card
 
 Retrieve a single Trello card by ID
 
@@ -431,7 +431,7 @@ Retrieve a single Trello card by ID
 |   ↳ `due` | string | Card due date in ISO 8601 format |
 |   ↳ `dueComplete` | boolean | Whether the due date is complete |
 
-### `trello_add_checklist`
+### Trello Add Checklist
 
 Add a checklist to a Trello card
 
@@ -454,7 +454,7 @@ Add a checklist to a Trello card
 |   ↳ `idBoard` | string | Board ID containing the checklist |
 |   ↳ `pos` | number | Checklist position on the card |
 
-### `trello_add_checklist_item`
+### Trello Add Checklist Item
 
 Add an item to a Trello checklist
 
@@ -478,7 +478,7 @@ Add an item to a Trello checklist
 |   ↳ `pos` | number | Item position on the checklist |
 |   ↳ `idChecklist` | string | Checklist ID containing the item |
 
-### `trello_update_checklist_item`
+### Trello Update Checklist Item
 
 Check off, uncheck, or rename a Trello checklist item
 
@@ -502,7 +502,7 @@ Check off, uncheck, or rename a Trello checklist item
 |   ↳ `pos` | number | Item position on the checklist |
 |   ↳ `idChecklist` | string | Checklist ID containing the item |
 
-### `trello_add_label`
+### Trello Add Label
 
 Attach an existing label to a Trello card
 
@@ -519,7 +519,7 @@ Attach an existing label to a Trello card
 | --------- | ---- | ----------- |
 | `labelIds` | array | Label IDs now applied to the card |
 
-### `trello_remove_label`
+### Trello Remove Label
 
 Detach a label from a Trello card
 
@@ -536,7 +536,7 @@ Detach a label from a Trello card
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the label was removed from the card |
 
-### `trello_add_member`
+### Trello Add Member
 
 Assign a member to a Trello card
 
@@ -553,7 +553,7 @@ Assign a member to a Trello card
 | --------- | ---- | ----------- |
 | `memberIds` | array | Member IDs now assigned to the card |
 
-### `trello_remove_member`
+### Trello Remove Member
 
 Unassign a member from a Trello card
 
@@ -570,7 +570,7 @@ Unassign a member from a Trello card
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the member was removed from the card |
 
-### `trello_list_members`
+### Trello List Members
 
 List members of a Trello board
 

--- a/apps/docs/content/docs/en/integrations/trigger_dev.mdx
+++ b/apps/docs/content/docs/en/integrations/trigger_dev.mdx
@@ -36,7 +36,7 @@ Integrate Trigger.dev into the workflow. Trigger and batch trigger background ta
 
 ## Actions
 
-### `trigger_dev_trigger_task`
+### Trigger.dev Trigger Task
 
 Trigger a Trigger.dev task by its identifier with an optional JSON payload. Returns the ID of the created run.
 
@@ -61,7 +61,7 @@ Trigger a Trigger.dev task by its identifier with an optional JSON payload. Retu
 | --------- | ---- | ----------- |
 | `id` | string | ID of the run that was triggered \(starts with run_\) |
 
-### `trigger_dev_batch_trigger_task`
+### Trigger.dev Batch Trigger Task
 
 Batch trigger a Trigger.dev task with up to 1,000 payloads. All items in the batch run the same task. Returns the batch ID and the created run IDs.
 
@@ -80,7 +80,7 @@ Batch trigger a Trigger.dev task with up to 1,000 payloads. All items in the bat
 | `batchId` | string | ID of the batch that was triggered |
 | `runIds` | array | IDs of the runs created by the batch |
 
-### `trigger_dev_get_batch`
+### Trigger.dev Get Batch
 
 Retrieve a Trigger.dev batch by its ID, including its status, run IDs, and success and failure counts.
 
@@ -110,7 +110,7 @@ Retrieve a Trigger.dev batch by its ID, including its status, run IDs, and succe
 |   ↳ `error` | json | Error details |
 |   ↳ `errorCode` | string | Optional error code |
 
-### `trigger_dev_get_batch_results`
+### Trigger.dev Get Batch Results
 
 Retrieve the execution results of every run in a Trigger.dev batch, including outputs and error details.
 
@@ -128,7 +128,7 @@ Retrieve the execution results of every run in a Trigger.dev batch, including ou
 | `id` | string | ID of the batch \(starts with batch_\) |
 | `items` | array | Execution results for each run in the batch |
 
-### `trigger_dev_get_run`
+### Trigger.dev Get Run
 
 Retrieve a Trigger.dev run by its ID, including status, payload, output, attempts, and timing details.
 
@@ -205,7 +205,7 @@ Retrieve a Trigger.dev run by its ID, including status, payload, output, attempt
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_get_run_result`
+### Trigger.dev Get Run Result
 
 Retrieve the result of a Trigger.dev run: whether it succeeded, its output, and error details. Lighter than Get Run when only the outcome is needed.
 
@@ -282,7 +282,7 @@ Retrieve the result of a Trigger.dev run: whether it succeeded, its output, and 
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_get_run_events`
+### Trigger.dev Get Run Events
 
 Retrieve the log and span events of a Trigger.dev run, including messages, levels, durations, and error events.
 
@@ -315,7 +315,7 @@ Retrieve the log and span events of a Trigger.dev run, including messages, level
 |     ↳ `name` | string | Event name |
 |     ↳ `time` | string | When the event occurred |
 
-### `trigger_dev_get_run_trace`
+### Trigger.dev Get Run Trace
 
 Retrieve the OpenTelemetry trace of a Trigger.dev run as a tree of spans with timing, errors, and nested children.
 
@@ -333,7 +333,7 @@ Retrieve the OpenTelemetry trace of a Trigger.dev run as a tree of spans with ti
 | `traceId` | string | OpenTelemetry trace ID of the run |
 | `rootSpan` | json | Root span of the trace; each span has id, parentId, runId, data \(message, taskSlug, startTime, duration, isError, level, events\), and recursively nested children spans |
 
-### `trigger_dev_list_runs`
+### Trigger.dev List Runs
 
 List Trigger.dev runs in the environment of the API key, with optional filters for status, task, version, tags, schedule, and creation time.
 
@@ -364,7 +364,7 @@ List Trigger.dev runs in the environment of the API key, with optional filters f
 |   ↳ `next` | string | Run ID to start the next page after |
 |   ↳ `previous` | string | Run ID to start the previous page before |
 
-### `trigger_dev_cancel_run`
+### Trigger.dev Cancel Run
 
 Cancel an in-progress Trigger.dev run. Has no effect if the run is already completed.
 
@@ -381,7 +381,7 @@ Cancel an in-progress Trigger.dev run. Has no effect if the run is already compl
 | --------- | ---- | ----------- |
 | `id` | string | ID of the run that was canceled |
 
-### `trigger_dev_replay_run`
+### Trigger.dev Replay Run
 
 Replay a Trigger.dev run, creating a new run with the same payload and options as the original.
 
@@ -398,7 +398,7 @@ Replay a Trigger.dev run, creating a new run with the same payload and options a
 | --------- | ---- | ----------- |
 | `id` | string | ID of the new run created by the replay |
 
-### `trigger_dev_reschedule_run`
+### Trigger.dev Reschedule Run
 
 Reschedule a delayed Trigger.dev run with a new delay. Only valid while the run is in the DELAYED state.
 
@@ -476,7 +476,7 @@ Reschedule a delayed Trigger.dev run with a new delay. Only valid while the run 
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_add_run_tags`
+### Trigger.dev Add Run Tags
 
 Add tags to an existing Trigger.dev run. Runs can have up to 10 tags.
 
@@ -494,7 +494,7 @@ Add tags to an existing Trigger.dev run. Runs can have up to 10 tags.
 | --------- | ---- | ----------- |
 | `message` | string | Confirmation message for the added tags |
 
-### `trigger_dev_update_run_metadata`
+### Trigger.dev Update Run Metadata
 
 Replace the metadata of a Trigger.dev run with a new JSON object.
 
@@ -512,7 +512,7 @@ Replace the metadata of a Trigger.dev run with a new JSON object.
 | --------- | ---- | ----------- |
 | `metadata` | json | The updated metadata of the run |
 
-### `trigger_dev_create_schedule`
+### Trigger.dev Create Schedule
 
 Create an imperative cron schedule that triggers a Trigger.dev task on a recurring basis.
 
@@ -593,7 +593,7 @@ Create an imperative cron schedule that triggers a Trigger.dev task on a recurri
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_get_schedule`
+### Trigger.dev Get Schedule
 
 Retrieve a Trigger.dev schedule by its ID.
 
@@ -670,7 +670,7 @@ Retrieve a Trigger.dev schedule by its ID.
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_list_schedules`
+### Trigger.dev List Schedules
 
 List Trigger.dev schedules in the project, with page-based pagination.
 
@@ -706,7 +706,7 @@ List Trigger.dev schedules in the project, with page-based pagination.
 |   ↳ `totalPages` | number | Total number of pages |
 |   ↳ `count` | number | Total number of schedules |
 
-### `trigger_dev_update_schedule`
+### Trigger.dev Update Schedule
 
 Update an imperative Trigger.dev schedule by its ID, replacing its task, cron expression, timezone, and external ID.
 
@@ -787,7 +787,7 @@ Update an imperative Trigger.dev schedule by its ID, replacing its task, cron ex
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_delete_schedule`
+### Trigger.dev Delete Schedule
 
 Delete an imperative Trigger.dev schedule by its ID.
 
@@ -805,7 +805,7 @@ Delete an imperative Trigger.dev schedule by its ID.
 | `deleted` | boolean | Whether the schedule was deleted |
 | `scheduleId` | string | ID of the schedule that was deleted |
 
-### `trigger_dev_activate_schedule`
+### Trigger.dev Activate Schedule
 
 Activate an imperative Trigger.dev schedule so it resumes triggering its task.
 
@@ -882,7 +882,7 @@ Activate an imperative Trigger.dev schedule so it resumes triggering its task.
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_deactivate_schedule`
+### Trigger.dev Deactivate Schedule
 
 Deactivate an imperative Trigger.dev schedule so it stops triggering its task.
 
@@ -959,7 +959,7 @@ Deactivate an imperative Trigger.dev schedule so it stops triggering its task.
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_list_env_vars`
+### Trigger.dev List Env Vars
 
 List the environment variables of a Trigger.dev project environment. Values are returned in plaintext and will appear in workflow outputs and run history — scope this operation carefully.
 
@@ -979,7 +979,7 @@ List the environment variables of a Trigger.dev project environment. Values are 
 |   ↳ `name` | string | Name of the environment variable |
 |   ↳ `value` | string | Plaintext value of the environment variable; appears in workflow outputs and run history |
 
-### `trigger_dev_create_env_var`
+### Trigger.dev Create Env Var
 
 Create an environment variable in a Trigger.dev project environment.
 
@@ -1000,7 +1000,7 @@ Create an environment variable in a Trigger.dev project environment.
 | `success` | boolean | Whether the environment variable was created |
 | `name` | string | Name of the environment variable that was created |
 
-### `trigger_dev_get_env_var`
+### Trigger.dev Get Env Var
 
 Retrieve an environment variable from a Trigger.dev project environment. The value is returned in plaintext and will appear in workflow outputs and run history.
 
@@ -1020,7 +1020,7 @@ Retrieve an environment variable from a Trigger.dev project environment. The val
 | `name` | string | Name of the environment variable |
 | `value` | string | Plaintext value of the environment variable; appears in workflow outputs and run history |
 
-### `trigger_dev_update_env_var`
+### Trigger.dev Update Env Var
 
 Update the value of an environment variable in a Trigger.dev project environment.
 
@@ -1041,7 +1041,7 @@ Update the value of an environment variable in a Trigger.dev project environment
 | `success` | boolean | Whether the environment variable was updated |
 | `name` | string | Name of the environment variable that was updated |
 
-### `trigger_dev_delete_env_var`
+### Trigger.dev Delete Env Var
 
 Delete an environment variable from a Trigger.dev project environment.
 
@@ -1061,7 +1061,7 @@ Delete an environment variable from a Trigger.dev project environment.
 | `success` | boolean | Whether the environment variable was deleted |
 | `name` | string | Name of the environment variable that was deleted |
 
-### `trigger_dev_import_env_vars`
+### Trigger.dev Import Env Vars
 
 Upload multiple environment variables to a Trigger.dev project environment in one request.
 
@@ -1082,7 +1082,7 @@ Upload multiple environment variables to a Trigger.dev project environment in on
 | `success` | boolean | Whether the environment variables were uploaded |
 | `count` | number | Number of environment variables submitted |
 
-### `trigger_dev_get_queue`
+### Trigger.dev Get Queue
 
 Retrieve a Trigger.dev queue by ID, task identifier, or custom queue name, including its running and queued counts.
 
@@ -1160,7 +1160,7 @@ Retrieve a Trigger.dev queue by ID, task identifier, or custom queue name, inclu
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_list_queues`
+### Trigger.dev List Queues
 
 List the queues in the environment of the API key, including running and queued counts, with page-based pagination.
 
@@ -1194,7 +1194,7 @@ List the queues in the environment of the API key, including running and queued 
 |   ↳ `totalPages` | number | Total number of pages |
 |   ↳ `count` | number | Total number of queues |
 
-### `trigger_dev_pause_queue`
+### Trigger.dev Pause Queue
 
 Pause a Trigger.dev queue so no new runs start. Runs that are currently executing continue to completion.
 
@@ -1272,7 +1272,7 @@ Pause a Trigger.dev queue so no new runs start. Runs that are currently executin
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_resume_queue`
+### Trigger.dev Resume Queue
 
 Resume a paused Trigger.dev queue so new runs can start again.
 
@@ -1350,7 +1350,7 @@ Resume a paused Trigger.dev queue so new runs can start again.
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_override_queue_concurrency`
+### Trigger.dev Override Queue Concurrency
 
 Override the concurrency limit of a Trigger.dev queue with a new value.
 
@@ -1429,7 +1429,7 @@ Override the concurrency limit of a Trigger.dev queue with a new value.
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_reset_queue_concurrency`
+### Trigger.dev Reset Queue Concurrency
 
 Reset the concurrency limit of a Trigger.dev queue back to its base value, removing any override.
 
@@ -1507,7 +1507,7 @@ Reset the concurrency limit of a Trigger.dev queue back to its base value, remov
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_list_deployments`
+### Trigger.dev List Deployments
 
 List Trigger.dev deployments in the environment of the API key, with optional status and creation-time filters.
 
@@ -1531,7 +1531,7 @@ List Trigger.dev deployments in the environment of the API key, with optional st
 | `pagination` | object | Cursor pagination details |
 |   ↳ `next` | string | Cursor to pass as the page-after parameter for the next page |
 
-### `trigger_dev_get_deployment`
+### Trigger.dev Get Deployment
 
 Retrieve a Trigger.dev deployment by its ID, including its status, version, and registered tasks.
 
@@ -1608,7 +1608,7 @@ Retrieve a Trigger.dev deployment by its ID, including its status, version, and 
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_get_latest_deployment`
+### Trigger.dev Get Latest Deployment
 
 Retrieve the latest Trigger.dev deployment in the environment of the API key.
 
@@ -1684,7 +1684,7 @@ Retrieve the latest Trigger.dev deployment in the environment of the API key.
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_promote_deployment`
+### Trigger.dev Promote Deployment
 
 Promote a Trigger.dev deployment version so new runs execute on it (e.g., to roll back to a previous version).
 
@@ -1703,7 +1703,7 @@ Promote a Trigger.dev deployment version so new runs execute on it (e.g., to rol
 | `version` | string | Version of the promoted deployment |
 | `shortCode` | string | Short code of the promoted deployment |
 
-### `trigger_dev_execute_query`
+### Trigger.dev Execute Query
 
 Execute a TRQL (SQL-like) query against Trigger.dev run data for reporting and analytics.
 
@@ -1726,7 +1726,7 @@ Execute a TRQL (SQL-like) query against Trigger.dev run data for reporting and a
 | `format` | string | Format of the results \(json or csv\) |
 | `results` | json | Query results: an array of row objects for json format, a CSV string for csv |
 
-### `trigger_dev_get_query_schema`
+### Trigger.dev Get Query Schema
 
 Retrieve the TRQL query schema: the tables and columns available for Execute Query, with types and allowed values.
 
@@ -1752,7 +1752,7 @@ Retrieve the TRQL query schema: the tables and columns available for Execute Que
 |     ↳ `allowedValues` | array | Allowed values for enum-like columns |
 |     ↳ `coreColumn` | boolean | Whether the column is included in default queries |
 
-### `trigger_dev_create_waitpoint_token`
+### Trigger.dev Create Waitpoint Token
 
 Create a Trigger.dev waitpoint token that a task can wait on until it is completed from outside (e.g., a human approval).
 
@@ -1774,7 +1774,7 @@ Create a Trigger.dev waitpoint token that a task can wait on until it is complet
 | `isCached` | boolean | Whether an existing token was returned because the same idempotency key was reused |
 | `url` | string | HTTP callback URL; a POST request to this URL completes the waitpoint without an API key |
 
-### `trigger_dev_complete_waitpoint_token`
+### Trigger.dev Complete Waitpoint Token
 
 Complete a Trigger.dev waitpoint token, resuming any task waiting on it and passing it optional JSON data.
 
@@ -1792,7 +1792,7 @@ Complete a Trigger.dev waitpoint token, resuming any task waiting on it and pass
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the waitpoint token was completed |
 
-### `trigger_dev_get_waitpoint_token`
+### Trigger.dev Get Waitpoint Token
 
 Retrieve a Trigger.dev waitpoint token by its ID, including its status, timeout, and completion data.
 
@@ -1869,7 +1869,7 @@ Retrieve a Trigger.dev waitpoint token by its ID, including its status, timeout,
 | `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
 | `timezones` | json | Supported IANA timezones \(List Timezones\) |
 
-### `trigger_dev_list_waitpoint_tokens`
+### Trigger.dev List Waitpoint Tokens
 
 List Trigger.dev waitpoint tokens in the environment of the API key, with optional status, tag, and creation-time filters.
 
@@ -1897,7 +1897,7 @@ List Trigger.dev waitpoint tokens in the environment of the API key, with option
 |   ↳ `next` | string | Waitpoint ID to start the next page after |
 |   ↳ `previous` | string | Waitpoint ID to start the previous page before |
 
-### `trigger_dev_list_timezones`
+### Trigger.dev List Timezones
 
 List the IANA timezones supported by Trigger.dev schedules, for use as the timezone of a cron schedule.
 

--- a/apps/docs/content/docs/en/integrations/twilio_sms.mdx
+++ b/apps/docs/content/docs/en/integrations/twilio_sms.mdx
@@ -33,7 +33,7 @@ Integrate Twilio into the workflow. Can send SMS messages.
 
 ## Actions
 
-### `twilio_send_sms`
+### Twilio Send SMS
 
 Send text messages to single or multiple recipients using the Twilio API.
 

--- a/apps/docs/content/docs/en/integrations/twilio_voice.mdx
+++ b/apps/docs/content/docs/en/integrations/twilio_voice.mdx
@@ -34,7 +34,7 @@ Integrate Twilio Voice into the workflow. Make outbound calls and retrieve call 
 
 ## Actions
 
-### `twilio_voice_make_call`
+### Twilio Voice Make Call
 
 Make an outbound phone call using Twilio Voice API.
 
@@ -70,7 +70,7 @@ Make an outbound phone call using Twilio Voice API.
 | `priceUnit` | string | Currency of the price |
 | `error` | string | Error message if call failed |
 
-### `twilio_voice_list_calls`
+### Twilio Voice List Calls
 
 Retrieve a list of calls made to and from an account.
 
@@ -98,7 +98,7 @@ Retrieve a list of calls made to and from an account.
 | `pageSize` | number | Number of calls per page |
 | `error` | string | Error message if retrieval failed |
 
-### `twilio_voice_get_recording`
+### Twilio Voice Get Recording
 
 Retrieve call recording information and transcription (if enabled via TwiML).
 

--- a/apps/docs/content/docs/en/integrations/typeform.mdx
+++ b/apps/docs/content/docs/en/integrations/typeform.mdx
@@ -32,7 +32,7 @@ Integrate Typeform into the workflow. Can retrieve responses, download files, an
 
 ## Actions
 
-### `typeform_responses`
+### Typeform Responses
 
 Retrieve form responses from Typeform
 
@@ -57,7 +57,7 @@ Retrieve form responses from Typeform
 | `page_count` | number | Total number of pages available |
 | `items` | array | Array of response objects with response_id, submitted_at, answers, and metadata |
 
-### `typeform_files`
+### Typeform Files
 
 Download files uploaded in Typeform responses
 
@@ -81,7 +81,7 @@ Download files uploaded in Typeform responses
 | `contentType` | string | MIME type of the uploaded file |
 | `filename` | string | Original filename of the uploaded file |
 
-### `typeform_insights`
+### Typeform Insights
 
 Retrieve insights and analytics for Typeform forms
 
@@ -119,7 +119,7 @@ Retrieve insights and analytics for Typeform forms
 |     ↳ `total_visits` | number | Total number of visits |
 |     ↳ `unique_visits` | number | Total number of unique visits |
 
-### `typeform_list_forms`
+### Typeform List Forms
 
 Retrieve a list of all forms in your Typeform account
 
@@ -141,7 +141,7 @@ Retrieve a list of all forms in your Typeform account
 | `page_count` | number | Total number of pages available |
 | `items` | array | Array of form objects with id, title, created_at, last_updated_at, settings, theme, and _links |
 
-### `typeform_get_form`
+### Typeform Get Form
 
 Retrieve complete details and structure of a specific form
 
@@ -170,7 +170,7 @@ Retrieve complete details and structure of a specific form
 | `published_at` | string | Form publication timestamp \(ISO 8601 format\) |
 | `_links` | object | Related resource links including public form URL |
 
-### `typeform_create_form`
+### Typeform Create Form
 
 Create a new form with fields and settings
 
@@ -201,7 +201,7 @@ Create a new form with fields and settings
 | `thankyou_screens` | array | Array of thank you screens |
 | `_links` | object | Related resource links including public form URL |
 
-### `typeform_update_form`
+### Typeform Update Form
 
 Update an existing form using JSON Patch operations
 
@@ -219,7 +219,7 @@ Update an existing form using JSON Patch operations
 | --------- | ---- | ----------- |
 | `message` | string | Success confirmation message |
 
-### `typeform_delete_form`
+### Typeform Delete Form
 
 Permanently delete a form and all its responses
 

--- a/apps/docs/content/docs/en/integrations/upstash.mdx
+++ b/apps/docs/content/docs/en/integrations/upstash.mdx
@@ -34,7 +34,7 @@ Connect to Upstash Redis to perform key-value, hash, list, and utility operation
 
 ## Actions
 
-### `upstash_redis_get`
+### Upstash Redis Get
 
 Get the value of a key from Upstash Redis.
 
@@ -53,7 +53,7 @@ Get the value of a key from Upstash Redis.
 | `key` | string | The key that was retrieved |
 | `value` | json | The value of the key \(string\), or null if not found |
 
-### `upstash_redis_set`
+### Upstash Redis Set
 
 Set the value of a key in Upstash Redis with an optional expiration time in seconds.
 
@@ -74,7 +74,7 @@ Set the value of a key in Upstash Redis with an optional expiration time in seco
 | `key` | string | The key that was set |
 | `result` | string | The result of the SET operation \(typically "OK"\) |
 
-### `upstash_redis_delete`
+### Upstash Redis Delete
 
 Delete a key from Upstash Redis.
 
@@ -93,7 +93,7 @@ Delete a key from Upstash Redis.
 | `key` | string | The key that was deleted |
 | `deletedCount` | number | Number of keys deleted \(0 if key did not exist, 1 if deleted\) |
 
-### `upstash_redis_keys`
+### Upstash Redis Keys
 
 List keys matching a pattern in Upstash Redis. Defaults to listing all keys (*).
 
@@ -113,7 +113,7 @@ List keys matching a pattern in Upstash Redis. Defaults to listing all keys (*).
 | `keys` | array | List of keys matching the pattern |
 | `count` | number | Number of keys found |
 
-### `upstash_redis_command`
+### Upstash Redis Command
 
 Execute an arbitrary Redis command against Upstash Redis. Pass the full command as a JSON array (e.g., ["HSET", "myhash", "field1", "value1"]).
 
@@ -132,7 +132,7 @@ Execute an arbitrary Redis command against Upstash Redis. Pass the full command 
 | `command` | string | The command that was executed |
 | `result` | json | The result of the Redis command |
 
-### `upstash_redis_hset`
+### Upstash Redis HSET
 
 Set a field in a hash stored at a key in Upstash Redis.
 
@@ -154,7 +154,7 @@ Set a field in a hash stored at a key in Upstash Redis.
 | `field` | string | The field that was set |
 | `result` | number | Number of new fields added \(0 if field was updated, 1 if new\) |
 
-### `upstash_redis_hget`
+### Upstash Redis HGET
 
 Get the value of a field in a hash stored at a key in Upstash Redis.
 
@@ -175,7 +175,7 @@ Get the value of a field in a hash stored at a key in Upstash Redis.
 | `field` | string | The field that was retrieved |
 | `value` | json | The value of the hash field \(string\), or null if not found |
 
-### `upstash_redis_hgetall`
+### Upstash Redis HGETALL
 
 Get all fields and values of a hash stored at a key in Upstash Redis.
 
@@ -195,7 +195,7 @@ Get all fields and values of a hash stored at a key in Upstash Redis.
 | `fields` | object | All field-value pairs in the hash, keyed by field name |
 | `fieldCount` | number | Number of fields in the hash |
 
-### `upstash_redis_incr`
+### Upstash Redis INCR
 
 Atomically increment the integer value of a key by one in Upstash Redis. If the key does not exist, it is set to 0 before incrementing.
 
@@ -214,7 +214,7 @@ Atomically increment the integer value of a key by one in Upstash Redis. If the 
 | `key` | string | The key that was incremented |
 | `value` | number | The new value after incrementing |
 
-### `upstash_redis_expire`
+### Upstash Redis EXPIRE
 
 Set a timeout on a key in Upstash Redis. After the timeout, the key is deleted.
 
@@ -234,7 +234,7 @@ Set a timeout on a key in Upstash Redis. After the timeout, the key is deleted.
 | `key` | string | The key that expiration was set on |
 | `result` | number | 1 if the timeout was set, 0 if the key does not exist |
 
-### `upstash_redis_ttl`
+### Upstash Redis TTL
 
 Get the remaining time to live of a key in Upstash Redis. Returns -1 if the key has no expiration, -2 if the key does not exist.
 
@@ -253,7 +253,7 @@ Get the remaining time to live of a key in Upstash Redis. Returns -1 if the key 
 | `key` | string | The key checked |
 | `ttl` | number | Remaining TTL in seconds. Positive integer if the key has a TTL set, -1 if the key exists with no expiration, -2 if the key does not exist. |
 
-### `upstash_redis_lpush`
+### Upstash Redis LPUSH
 
 Prepend a value to the beginning of a list in Upstash Redis. Creates the list if it does not exist.
 
@@ -273,7 +273,7 @@ Prepend a value to the beginning of a list in Upstash Redis. Creates the list if
 | `key` | string | The list key |
 | `length` | number | The length of the list after the push |
 
-### `upstash_redis_lrange`
+### Upstash Redis LRANGE
 
 Get a range of elements from a list in Upstash Redis. Use 0 and -1 for start and stop to get all elements.
 
@@ -295,7 +295,7 @@ Get a range of elements from a list in Upstash Redis. Use 0 and -1 for start and
 | `values` | array | List of elements in the specified range |
 | `count` | number | Number of elements returned |
 
-### `upstash_redis_exists`
+### Upstash Redis EXISTS
 
 Check if a key exists in Upstash Redis. Returns true if the key exists, false otherwise.
 
@@ -314,7 +314,7 @@ Check if a key exists in Upstash Redis. Returns true if the key exists, false ot
 | `key` | string | The key that was checked |
 | `exists` | boolean | Whether the key exists \(true\) or not \(false\) |
 
-### `upstash_redis_setnx`
+### Upstash Redis SETNX
 
 Set the value of a key only if it does not already exist. Returns true if the key was set, false if it already existed.
 
@@ -334,7 +334,7 @@ Set the value of a key only if it does not already exist. Returns true if the ke
 | `key` | string | The key that was attempted to set |
 | `wasSet` | boolean | Whether the key was set \(true\) or already existed \(false\) |
 
-### `upstash_redis_incrby`
+### Upstash Redis INCRBY
 
 Increment the integer value of a key by a given amount. Use a negative value to decrement. If the key does not exist, it is set to 0 before the operation.
 

--- a/apps/docs/content/docs/en/integrations/uptimerobot.mdx
+++ b/apps/docs/content/docs/en/integrations/uptimerobot.mdx
@@ -33,7 +33,7 @@ Integrate UptimeRobot into your workflow. Create and manage monitors, inspect in
 
 ## Actions
 
-### `uptimerobot_list_monitors`
+### UptimeRobot List Monitors
 
 List monitors in your UptimeRobot account, with optional filters and pagination
 
@@ -94,7 +94,7 @@ List monitors in your UptimeRobot account, with optional filters and pagination
 |     ↳ `duration` | number | Incident duration in seconds |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
-### `uptimerobot_get_monitor`
+### UptimeRobot Get Monitor
 
 Get the details of a single UptimeRobot monitor by ID
 
@@ -148,7 +148,7 @@ Get the details of a single UptimeRobot monitor by ID
 |     ↳ `startedAt` | string | When the incident started |
 |     ↳ `duration` | number | Incident duration in seconds |
 
-### `uptimerobot_create_monitor`
+### UptimeRobot Create Monitor
 
 Create a new monitor in UptimeRobot
 
@@ -225,7 +225,7 @@ Create a new monitor in UptimeRobot
 |     ↳ `startedAt` | string | When the incident started |
 |     ↳ `duration` | number | Incident duration in seconds |
 
-### `uptimerobot_update_monitor`
+### UptimeRobot Update Monitor
 
 Update an existing UptimeRobot monitor. Only the provided fields are changed.
 
@@ -300,7 +300,7 @@ Update an existing UptimeRobot monitor. Only the provided fields are changed.
 |     ↳ `startedAt` | string | When the incident started |
 |     ↳ `duration` | number | Incident duration in seconds |
 
-### `uptimerobot_delete_monitor`
+### UptimeRobot Delete Monitor
 
 Permanently delete an UptimeRobot monitor by ID
 
@@ -318,7 +318,7 @@ Permanently delete an UptimeRobot monitor by ID
 | `deleted` | boolean | Whether the monitor was deleted |
 | `id` | number | ID of the deleted monitor |
 
-### `uptimerobot_pause_monitor`
+### UptimeRobot Pause Monitor
 
 Pause an UptimeRobot monitor so it stops running checks
 
@@ -372,7 +372,7 @@ Pause an UptimeRobot monitor so it stops running checks
 |     ↳ `startedAt` | string | When the incident started |
 |     ↳ `duration` | number | Incident duration in seconds |
 
-### `uptimerobot_start_monitor`
+### UptimeRobot Start Monitor
 
 Resume a paused UptimeRobot monitor so it starts running checks again
 
@@ -426,7 +426,7 @@ Resume a paused UptimeRobot monitor so it starts running checks again
 |     ↳ `startedAt` | string | When the incident started |
 |     ↳ `duration` | number | Incident duration in seconds |
 
-### `uptimerobot_list_incidents`
+### UptimeRobot List Incidents
 
 List incidents across your UptimeRobot account (last 24 hours by default), with optional filters
 
@@ -460,7 +460,7 @@ List incidents across your UptimeRobot account (last 24 hours by default), with 
 |   ↳ `includeInReports` | boolean | Whether the incident is included in reports |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
-### `uptimerobot_get_incident`
+### UptimeRobot Get Incident
 
 Get the details of a single UptimeRobot incident by ID
 
@@ -488,7 +488,7 @@ Get the details of a single UptimeRobot incident by ID
 |     ↳ `httpResponseCode` | number | HTTP response code observed |
 |     ↳ `responseDownloadUrl` | string | URL to download the captured response body |
 
-### `uptimerobot_list_maintenance_windows`
+### UptimeRobot List Maintenance Windows
 
 List maintenance windows in your UptimeRobot account
 
@@ -518,7 +518,7 @@ List maintenance windows in your UptimeRobot account
 |   ↳ `created` | string | When the maintenance window was created |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
-### `uptimerobot_get_maintenance_window`
+### UptimeRobot Get Maintenance Window
 
 Get the details of a single UptimeRobot maintenance window by ID
 
@@ -547,7 +547,7 @@ Get the details of a single UptimeRobot maintenance window by ID
 |   ↳ `status` | string | Status \(active or paused\) |
 |   ↳ `created` | string | When the maintenance window was created |
 
-### `uptimerobot_create_maintenance_window`
+### UptimeRobot Create Maintenance Window
 
 Create a new maintenance window to suppress alerts during planned downtime
 
@@ -583,7 +583,7 @@ Create a new maintenance window to suppress alerts during planned downtime
 |   ↳ `status` | string | Status \(active or paused\) |
 |   ↳ `created` | string | When the maintenance window was created |
 
-### `uptimerobot_update_maintenance_window`
+### UptimeRobot Update Maintenance Window
 
 Update an existing maintenance window. Only the provided fields are changed.
 
@@ -620,7 +620,7 @@ Update an existing maintenance window. Only the provided fields are changed.
 |   ↳ `status` | string | Status \(active or paused\) |
 |   ↳ `created` | string | When the maintenance window was created |
 
-### `uptimerobot_delete_maintenance_window`
+### UptimeRobot Delete Maintenance Window
 
 Permanently delete an UptimeRobot maintenance window by ID
 
@@ -638,7 +638,7 @@ Permanently delete an UptimeRobot maintenance window by ID
 | `deleted` | boolean | Whether the maintenance window was deleted |
 | `id` | number | ID of the deleted maintenance window |
 
-### `uptimerobot_list_alert_contacts`
+### UptimeRobot List Alert Contacts
 
 List the personal alert contacts in your UptimeRobot account
 
@@ -664,7 +664,7 @@ List the personal alert contacts in your UptimeRobot account
 |   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
-### `uptimerobot_get_alert_contact`
+### UptimeRobot Get Alert Contact
 
 Get the details of a single UptimeRobot alert contact by ID
 
@@ -689,7 +689,7 @@ Get the details of a single UptimeRobot alert contact by ID
 |   ↳ `enableNotificationsFor` | string | Which monitor events trigger notifications |
 |   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
 
-### `uptimerobot_create_alert_contact`
+### UptimeRobot Create Alert Contact
 
 Create an email alert contact in UptimeRobot. The contact must be confirmed via email before it can receive alerts.
 
@@ -716,7 +716,7 @@ Create an email alert contact in UptimeRobot. The contact must be confirmed via 
 |   ↳ `enableNotificationsFor` | string | Which monitor events trigger notifications |
 |   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
 
-### `uptimerobot_delete_alert_contact`
+### UptimeRobot Delete Alert Contact
 
 Permanently delete an UptimeRobot alert contact by ID
 
@@ -734,7 +734,7 @@ Permanently delete an UptimeRobot alert contact by ID
 | `deleted` | boolean | Whether the alert contact was deleted |
 | `id` | number | ID of the deleted alert contact |
 
-### `uptimerobot_list_psps`
+### UptimeRobot List Status Pages
 
 List the public status pages in your UptimeRobot account
 
@@ -768,7 +768,7 @@ List the public status pages in your UptimeRobot account
 |   ↳ `subscription` | boolean | Whether the subscribe feature is enabled |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
-### `uptimerobot_get_psp`
+### UptimeRobot Get Status Page
 
 Get the details of a single UptimeRobot public status page by ID
 
@@ -801,7 +801,7 @@ Get the details of a single UptimeRobot public status page by ID
 |   ↳ `hideUrlLinks` | boolean | Whether the "Powered by" footer link is hidden |
 |   ↳ `subscription` | boolean | Whether the subscribe feature is enabled |
 
-### `uptimerobot_create_psp`
+### UptimeRobot Create Status Page
 
 Create a public status page in UptimeRobot, optionally with a logo and icon image
 
@@ -842,7 +842,7 @@ Create a public status page in UptimeRobot, optionally with a logo and icon imag
 |   ↳ `hideUrlLinks` | boolean | Whether the "Powered by" footer link is hidden |
 |   ↳ `subscription` | boolean | Whether the subscribe feature is enabled |
 
-### `uptimerobot_update_psp`
+### UptimeRobot Update Status Page
 
 Update a public status page in UptimeRobot. Only the provided fields are changed; logo and icon images can be replaced.
 
@@ -884,7 +884,7 @@ Update a public status page in UptimeRobot. Only the provided fields are changed
 |   ↳ `hideUrlLinks` | boolean | Whether the "Powered by" footer link is hidden |
 |   ↳ `subscription` | boolean | Whether the subscribe feature is enabled |
 
-### `uptimerobot_delete_psp`
+### UptimeRobot Delete Status Page
 
 Permanently delete an UptimeRobot public status page by ID
 
@@ -902,7 +902,7 @@ Permanently delete an UptimeRobot public status page by ID
 | `deleted` | boolean | Whether the status page was deleted |
 | `id` | number | ID of the deleted status page |
 
-### `uptimerobot_get_account`
+### UptimeRobot Get Account
 
 Get details about the authenticated UptimeRobot account, including plan and limits
 

--- a/apps/docs/content/docs/en/integrations/vanta.mdx
+++ b/apps/docs/content/docs/en/integrations/vanta.mdx
@@ -36,7 +36,7 @@ Integrate Vanta into the workflow. Monitor compliance frameworks, controls, and 
 
 ## Actions
 
-### `vanta_list_frameworks`
+### Vanta List Frameworks
 
 List the compliance frameworks (e.g., SOC 2, ISO 27001) available in a Vanta account with completion counts
 
@@ -57,7 +57,7 @@ List the compliance frameworks (e.g., SOC 2, ISO 27001) available in a Vanta acc
 | `frameworks` | array | Frameworks in the Vanta account |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_framework`
+### Vanta Get Framework
 
 Get a Vanta compliance framework by ID, including its requirement categories and mapped controls
 
@@ -76,7 +76,7 @@ Get a Vanta compliance framework by ID, including its requirement categories and
 | --------- | ---- | ----------- |
 | `framework` | json | The requested framework with requirement categories |
 
-### `vanta_list_framework_controls`
+### Vanta List Framework Controls
 
 List the controls that belong to a specific Vanta compliance framework
 
@@ -98,7 +98,7 @@ List the controls that belong to a specific Vanta compliance framework
 | `controls` | array | Controls belonging to the framework |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_list_controls`
+### Vanta List Controls
 
 List the security controls in a Vanta account, optionally filtered by framework
 
@@ -120,7 +120,7 @@ List the security controls in a Vanta account, optionally filtered by framework
 | `controls` | array | Controls matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_control`
+### Vanta Get Control
 
 Get a Vanta security control by ID, including its status and evidence pass/fail counts
 
@@ -139,7 +139,7 @@ Get a Vanta security control by ID, including its status and evidence pass/fail 
 | --------- | ---- | ----------- |
 | `control` | json | The requested control with status and evidence counts |
 
-### `vanta_list_control_tests`
+### Vanta List Control Tests
 
 List the automated tests mapped to a specific Vanta control
 
@@ -161,7 +161,7 @@ List the automated tests mapped to a specific Vanta control
 | `tests` | array | Tests mapped to the control |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_list_control_documents`
+### Vanta List Control Documents
 
 List the evidence documents mapped to a specific Vanta control
 
@@ -183,7 +183,7 @@ List the evidence documents mapped to a specific Vanta control
 | `documents` | array | Documents mapped to the control |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_list_tests`
+### Vanta List Tests
 
 List the automated compliance tests in a Vanta account, with filters for status, framework, integration, control, owner, and category
 
@@ -211,7 +211,7 @@ List the automated compliance tests in a Vanta account, with filters for status,
 | `tests` | array | Tests matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_test`
+### Vanta Get Test
 
 Get a Vanta automated compliance test by ID, including its status and remediation info
 
@@ -230,7 +230,7 @@ Get a Vanta automated compliance test by ID, including its status and remediatio
 | --------- | ---- | ----------- |
 | `test` | json | The requested test |
 
-### `vanta_list_test_entities`
+### Vanta List Test Entities
 
 List the failing or deactivated resource entities for a specific Vanta test, useful for finding exactly which resources need remediation
 
@@ -253,7 +253,7 @@ List the failing or deactivated resource entities for a specific Vanta test, use
 | `entities` | array | Resource entities for the test |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_list_documents`
+### Vanta List Documents
 
 List the evidence documents in a Vanta account, optionally filtered by framework or document status
 
@@ -276,7 +276,7 @@ List the evidence documents in a Vanta account, optionally filtered by framework
 | `documents` | array | Documents matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_document`
+### Vanta Get Document
 
 Get a Vanta evidence document by ID, including its renewal schedule and deactivation status
 
@@ -295,7 +295,7 @@ Get a Vanta evidence document by ID, including its renewal schedule and deactiva
 | --------- | ---- | ----------- |
 | `document` | json | The requested document |
 
-### `vanta_list_document_uploads`
+### Vanta List Document Uploads
 
 List the files uploaded to a specific Vanta evidence document
 
@@ -317,7 +317,7 @@ List the files uploaded to a specific Vanta evidence document
 | `uploads` | array | Files uploaded to the document |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_upload_document_file`
+### Vanta Upload Document File
 
 Upload an evidence file to a Vanta document. Requires credentials with the vanta-api.documents:upload scope.
 
@@ -342,7 +342,7 @@ Upload an evidence file to a Vanta document. Requires credentials with the vanta
 | --------- | ---- | ----------- |
 | `upload` | json | Metadata of the uploaded file |
 
-### `vanta_download_document_file`
+### Vanta Download Document File
 
 Download a file previously uploaded to a Vanta evidence document and store it in execution files
 
@@ -365,7 +365,7 @@ Download a file previously uploaded to a Vanta evidence document and store it in
 | `mimeType` | string | MIME type of the downloaded file |
 | `size` | number | Size of the downloaded file in bytes |
 
-### `vanta_submit_document`
+### Vanta Submit Document
 
 Submit a Vanta document collection for review so uploaded evidence becomes visible to auditors. Requires credentials with write access.
 
@@ -385,7 +385,7 @@ Submit a Vanta document collection for review so uploaded evidence becomes visib
 | `documentId` | string | ID of the submitted document |
 | `submitted` | boolean | Whether the document collection was submitted |
 
-### `vanta_list_people`
+### Vanta List People
 
 List the people tracked in a Vanta account with employment status, group membership, and security task completion
 
@@ -412,7 +412,7 @@ List the people tracked in a Vanta account with employment status, group members
 | `people` | array | People matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_person`
+### Vanta Get Person
 
 Get a person tracked in Vanta by ID, including employment, leave, and security task status
 
@@ -431,7 +431,7 @@ Get a person tracked in Vanta by ID, including employment, leave, and security t
 | --------- | ---- | ----------- |
 | `person` | json | The requested person |
 
-### `vanta_list_policies`
+### Vanta List Policies
 
 List the security policies in a Vanta account with approval status and version info
 
@@ -452,7 +452,7 @@ List the security policies in a Vanta account with approval status and version i
 | `policies` | array | Policies in the Vanta account |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_policy`
+### Vanta Get Policy
 
 Get a Vanta security policy by ID, including its approval status and latest approved version documents
 
@@ -471,7 +471,7 @@ Get a Vanta security policy by ID, including its approval status and latest appr
 | --------- | ---- | ----------- |
 | `policy` | json | The requested policy |
 
-### `vanta_list_vendors`
+### Vanta List Vendors
 
 List the vendors tracked in a Vanta account with risk levels, contract dates, and security review schedules
 
@@ -494,7 +494,7 @@ List the vendors tracked in a Vanta account with risk levels, contract dates, an
 | `vendors` | array | Vendors matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_vendor`
+### Vanta Get Vendor
 
 Get a Vanta vendor by ID, including risk levels, contract details, and authentication info
 
@@ -513,7 +513,7 @@ Get a Vanta vendor by ID, including risk levels, contract details, and authentic
 | --------- | ---- | ----------- |
 | `vendor` | json | The requested vendor |
 
-### `vanta_list_monitored_computers`
+### Vanta List Monitored Computers
 
 List the monitored computers in a Vanta account with screenlock, disk encryption, password manager, and antivirus check outcomes
 
@@ -535,7 +535,7 @@ List the monitored computers in a Vanta account with screenlock, disk encryption
 | `computers` | array | Monitored computers matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_list_vulnerabilities`
+### Vanta List Vulnerabilities
 
 List the vulnerabilities detected across a Vanta account with filters for severity, fixability, SLA deadlines, package, and integration
 
@@ -567,7 +567,7 @@ List the vulnerabilities detected across a Vanta account with filters for severi
 | `vulnerabilities` | array | Vulnerabilities matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_list_vulnerability_remediations`
+### Vanta List Vulnerability Remediations
 
 List remediated vulnerabilities in a Vanta account with detection, SLA deadline, and remediation dates
 
@@ -593,7 +593,7 @@ List remediated vulnerabilities in a Vanta account with detection, SLA deadline,
 | `remediations` | array | Vulnerability remediations matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_list_vulnerable_assets`
+### Vanta List Vulnerable Assets
 
 List the assets associated with vulnerabilities in a Vanta account (servers, repositories, workstations, and more)
 
@@ -618,7 +618,7 @@ List the assets associated with vulnerabilities in a Vanta account (servers, rep
 | `assets` | array | Vulnerable assets matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_vulnerable_asset`
+### Vanta Get Vulnerable Asset
 
 Get a vulnerable asset in Vanta by ID, including the scanners reporting it and per-scanner asset details
 
@@ -637,7 +637,7 @@ Get a vulnerable asset in Vanta by ID, including the scanners reporting it and p
 | --------- | ---- | ----------- |
 | `asset` | json | The requested vulnerable asset |
 
-### `vanta_list_risk_scenarios`
+### Vanta List Risk Scenarios
 
 List the risk scenarios in a Vanta risk register with likelihood/impact scores, treatment decisions, and review status
 
@@ -669,7 +669,7 @@ List the risk scenarios in a Vanta risk register with likelihood/impact scores, 
 | `riskScenarios` | array | Risk scenarios matching the filters |
 | `pageInfo` | json | Cursor pagination info for the returned page; pass endCursor as pageCursor to fetch the next page |
 
-### `vanta_get_risk_scenario`
+### Vanta Get Risk Scenario
 
 Get a Vanta risk scenario by ID, including its scores, treatment decision, and review status
 

--- a/apps/docs/content/docs/en/integrations/vercel.mdx
+++ b/apps/docs/content/docs/en/integrations/vercel.mdx
@@ -32,7 +32,7 @@ Integrate with Vercel to manage deployments, projects, domains, DNS records, env
 
 ## Actions
 
-### `vercel_list_deployments`
+### Vercel List Deployments
 
 List deployments for a Vercel project or team
 
@@ -76,7 +76,7 @@ List deployments for a Vercel project or team
 | `count` | number | Number of deployments returned |
 | `hasMore` | boolean | Whether more deployments are available |
 
-### `vercel_get_deployment`
+### Vercel Get Deployment
 
 Get details of a specific Vercel deployment
 
@@ -131,7 +131,7 @@ Get details of a specific Vercel deployment
 | `errorMessage` | string | Deployment error message |
 | `aliasAssigned` | boolean | Whether the alias has been assigned |
 
-### `vercel_create_deployment`
+### Vercel Create Deployment
 
 Create a new deployment or redeploy an existing one
 
@@ -166,7 +166,7 @@ Create a new deployment or redeploy an existing one
 | `errorMessage` | string | Deployment error message |
 | `aliasAssigned` | boolean | Whether the alias has been assigned |
 
-### `vercel_cancel_deployment`
+### Vercel Cancel Deployment
 
 Cancel a running Vercel deployment
 
@@ -191,7 +191,7 @@ Cancel a running Vercel deployment
 | `projectId` | string | Associated project ID |
 | `inspectorUrl` | string | Vercel inspector URL |
 
-### `vercel_delete_deployment`
+### Vercel Delete Deployment
 
 Delete a Vercel deployment
 
@@ -211,7 +211,7 @@ Delete a Vercel deployment
 | `uid` | string | The removed deployment ID |
 | `state` | string | Deployment state after deletion \(DELETED\) |
 
-### `vercel_get_deployment_events`
+### Vercel Get Deployment Events
 
 Get build and runtime events for a Vercel deployment
 
@@ -245,7 +245,7 @@ Get build and runtime events for a Vercel deployment
 |   ↳ `info` | object | Build step info \(type, name, entrypoint, path, step, readyState\) |
 | `count` | number | Number of events returned |
 
-### `vercel_list_deployment_files`
+### Vercel List Deployment Files
 
 List files in a Vercel deployment
 
@@ -274,7 +274,7 @@ List files in a Vercel deployment
 |     ↳ `uid` | string | File identifier |
 | `count` | number | Number of files returned |
 
-### `vercel_promote_deployment`
+### Vercel Promote Deployment
 
 Promote a deployment by pointing the production deployment to the given deployment
 
@@ -294,7 +294,7 @@ Promote a deployment by pointing the production deployment to the given deployme
 | --------- | ---- | ----------- |
 | `promoted` | boolean | Whether the deployment was promoted to production |
 
-### `vercel_list_projects`
+### Vercel List Projects
 
 List all projects in a Vercel team or account
 
@@ -325,7 +325,7 @@ List all projects in a Vercel team or account
 | `hasMore` | boolean | Whether more projects are available |
 | `nextFrom` | string | Continuation token to pass as `from` to fetch the next page |
 
-### `vercel_get_project`
+### Vercel Get Project
 
 Get details of a specific Vercel project
 
@@ -354,7 +354,7 @@ Get details of a specific Vercel project
 |   ↳ `repo` | string | Repository name |
 |   ↳ `org` | string | Organization or owner |
 
-### `vercel_create_project`
+### Vercel Create Project
 
 Create a new Vercel project
 
@@ -385,7 +385,7 @@ Create a new Vercel project
 | `createdAt` | number | Creation timestamp |
 | `updatedAt` | number | Last updated timestamp |
 
-### `vercel_update_project`
+### Vercel Update Project
 
 Update an existing Vercel project
 
@@ -415,7 +415,7 @@ Update an existing Vercel project
 | `framework` | string | Project framework |
 | `updatedAt` | number | Last updated timestamp |
 
-### `vercel_delete_project`
+### Vercel Delete Project
 
 Delete a Vercel project
 
@@ -434,7 +434,7 @@ Delete a Vercel project
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the project was successfully deleted |
 
-### `vercel_pause_project`
+### Vercel Pause Project
 
 Pause a Vercel project
 
@@ -455,7 +455,7 @@ Pause a Vercel project
 | `name` | string | Project name |
 | `paused` | boolean | Whether the project is paused |
 
-### `vercel_unpause_project`
+### Vercel Unpause Project
 
 Unpause a Vercel project
 
@@ -476,7 +476,7 @@ Unpause a Vercel project
 | `name` | string | Project name |
 | `paused` | boolean | Whether the project is paused |
 
-### `vercel_list_project_domains`
+### Vercel List Project Domains
 
 List all domains for a Vercel project
 
@@ -512,7 +512,7 @@ List all domains for a Vercel project
 | `count` | number | Number of domains returned |
 | `hasMore` | boolean | Whether more domains are available |
 
-### `vercel_add_project_domain`
+### Vercel Add Project Domain
 
 Add a domain to a Vercel project
 
@@ -548,7 +548,7 @@ Add a domain to a Vercel project
 | `createdAt` | number | Creation timestamp |
 | `updatedAt` | number | Last updated timestamp |
 
-### `vercel_remove_project_domain`
+### Vercel Remove Project Domain
 
 Remove a domain from a Vercel project
 
@@ -568,7 +568,7 @@ Remove a domain from a Vercel project
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the domain was successfully removed |
 
-### `vercel_update_project_domain`
+### Vercel Update Project Domain
 
 Update a project domain's configuration on Vercel
 
@@ -604,7 +604,7 @@ Update a project domain's configuration on Vercel
 | `createdAt` | number | Creation timestamp |
 | `updatedAt` | number | Last updated timestamp |
 
-### `vercel_verify_project_domain`
+### Vercel Verify Project Domain
 
 Verify a Vercel project domain by checking its verification challenge
 
@@ -632,7 +632,7 @@ Verify a Vercel project domain by checking its verification challenge
 | `createdAt` | number | Creation timestamp |
 | `updatedAt` | number | Last update timestamp |
 
-### `vercel_get_env_vars`
+### Vercel Get Environment Variables
 
 Retrieve environment variables for a Vercel project
 
@@ -663,7 +663,7 @@ Retrieve environment variables for a Vercel project
 |   ↳ `updatedAt` | number | Last update timestamp |
 | `count` | number | Number of environment variables returned |
 
-### `vercel_create_env_var`
+### Vercel Create Environment Variable
 
 Create an environment variable for a Vercel project
 
@@ -696,7 +696,7 @@ Create an environment variable for a Vercel project
 | `createdAt` | number | Creation timestamp |
 | `updatedAt` | number | Last update timestamp |
 
-### `vercel_update_env_var`
+### Vercel Update Environment Variable
 
 Update an environment variable for a Vercel project
 
@@ -730,7 +730,7 @@ Update an environment variable for a Vercel project
 | `createdAt` | number | Creation timestamp |
 | `updatedAt` | number | Last update timestamp |
 
-### `vercel_delete_env_var`
+### Vercel Delete Environment Variable
 
 Delete an environment variable from a Vercel project
 
@@ -750,7 +750,7 @@ Delete an environment variable from a Vercel project
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the environment variable was successfully deleted |
 
-### `vercel_list_domains`
+### Vercel List Domains
 
 List all domains in a Vercel account or team
 
@@ -790,7 +790,7 @@ List all domains in a Vercel account or team
 | `count` | number | Number of domains returned |
 | `hasMore` | boolean | Whether more domains are available |
 
-### `vercel_get_domain`
+### Vercel Get Domain
 
 Get information about a specific domain in a Vercel account
 
@@ -827,7 +827,7 @@ Get information about a specific domain in a Vercel account
 | `teamId` | string | Owner team ID |
 | `transferStartedAt` | number | Transfer start timestamp |
 
-### `vercel_add_domain`
+### Vercel Add Domain
 
 Add a new domain to a Vercel account or team
 
@@ -861,7 +861,7 @@ Add a new domain to a Vercel account or team
 |   ↳ `username` | string | Creator username |
 |   ↳ `email` | string | Creator email |
 
-### `vercel_delete_domain`
+### Vercel Delete Domain
 
 Delete a domain from a Vercel account or team
 
@@ -881,7 +881,7 @@ Delete a domain from a Vercel account or team
 | `uid` | string | The ID of the deleted domain |
 | `deleted` | boolean | Whether the domain was deleted |
 
-### `vercel_get_domain_config`
+### Vercel Get Domain Config
 
 Get the configuration for a domain in a Vercel account
 
@@ -908,7 +908,7 @@ Get the configuration for a domain in a Vercel account
 |   ↳ `rank` | number | Priority rank \(1 is preferred\) |
 |   ↳ `value` | string | CNAME value |
 
-### `vercel_list_dns_records`
+### Vercel List DNS Records
 
 List all DNS records for a domain in a Vercel account
 
@@ -942,7 +942,7 @@ List all DNS records for a domain in a Vercel account
 | `count` | number | Number of records returned |
 | `hasMore` | boolean | Whether more records are available |
 
-### `vercel_create_dns_record`
+### Vercel Create DNS Record
 
 Create a DNS record for a domain in a Vercel account
 
@@ -975,7 +975,7 @@ Create a DNS record for a domain in a Vercel account
 | `uid` | string | The DNS record ID |
 | `updated` | number | Timestamp of the update |
 
-### `vercel_update_dns_record`
+### Vercel Update DNS Record
 
 Update an existing DNS record for a domain in a Vercel account
 
@@ -1016,7 +1016,7 @@ Update an existing DNS record for a domain in a Vercel account
 | `recordType` | string | DNS record type \(A, AAAA, ALIAS, CAA, CNAME, HTTPS, MX, NS, SRV, TXT\) |
 | `createdAt` | number | Timestamp of record creation |
 
-### `vercel_delete_dns_record`
+### Vercel Delete DNS Record
 
 Delete a DNS record for a domain in a Vercel account
 
@@ -1036,7 +1036,7 @@ Delete a DNS record for a domain in a Vercel account
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the record was deleted |
 
-### `vercel_list_aliases`
+### Vercel List Aliases
 
 List aliases for a Vercel project or team
 
@@ -1070,7 +1070,7 @@ List aliases for a Vercel project or team
 | `count` | number | Number of aliases returned |
 | `hasMore` | boolean | Whether more aliases are available |
 
-### `vercel_get_alias`
+### Vercel Get Alias
 
 Get details about a specific alias by ID or hostname
 
@@ -1099,7 +1099,7 @@ Get details about a specific alias by ID or hostname
 |   ↳ `id` | string | Deployment ID |
 |   ↳ `url` | string | Deployment URL |
 
-### `vercel_create_alias`
+### Vercel Create Alias
 
 Assign an alias (domain/subdomain) to a deployment
 
@@ -1123,7 +1123,7 @@ Assign an alias (domain/subdomain) to a deployment
 | `created` | string | Creation timestamp as ISO 8601 date-time string |
 | `oldDeploymentId` | string | ID of the previously aliased deployment, if the alias was reassigned |
 
-### `vercel_delete_alias`
+### Vercel Delete Alias
 
 Delete an alias by its ID
 
@@ -1142,7 +1142,7 @@ Delete an alias by its ID
 | --------- | ---- | ----------- |
 | `status` | string | Deletion status \(SUCCESS\) |
 
-### `vercel_list_edge_configs`
+### Vercel List Edge Configs
 
 List all Edge Config stores for a team
 
@@ -1168,7 +1168,7 @@ List all Edge Config stores for a team
 |   ↳ `sizeInBytes` | number | Size in bytes |
 | `count` | number | Number of Edge Configs returned |
 
-### `vercel_get_edge_config`
+### Vercel Get Edge Config
 
 Get details about a specific Edge Config store
 
@@ -1193,7 +1193,7 @@ Get details about a specific Edge Config store
 | `itemCount` | number | Number of items |
 | `sizeInBytes` | number | Size in bytes |
 
-### `vercel_create_edge_config`
+### Vercel Create Edge Config
 
 Create a new Edge Config store
 
@@ -1218,7 +1218,7 @@ Create a new Edge Config store
 | `itemCount` | number | Number of items |
 | `sizeInBytes` | number | Size in bytes |
 
-### `vercel_get_edge_config_items`
+### Vercel Get Edge Config Items
 
 Get all items in an Edge Config store
 
@@ -1243,7 +1243,7 @@ Get all items in an Edge Config store
 |   ↳ `updatedAt` | number | Last update timestamp |
 | `count` | number | Number of items returned |
 
-### `vercel_update_edge_config_items`
+### Vercel Update Edge Config Items
 
 Create, update, upsert, or delete items in an Edge Config store
 
@@ -1262,7 +1262,7 @@ Create, update, upsert, or delete items in an Edge Config store
 | --------- | ---- | ----------- |
 | `status` | string | Operation status |
 
-### `vercel_delete_edge_config`
+### Vercel Delete Edge Config
 
 Delete an Edge Config store by ID
 
@@ -1280,7 +1280,7 @@ Delete an Edge Config store by ID
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the Edge Config was successfully deleted |
 
-### `vercel_list_webhooks`
+### Vercel List Webhooks
 
 List webhooks for a Vercel project or team
 
@@ -1307,7 +1307,7 @@ List webhooks for a Vercel project or team
 |   ↳ `updatedAt` | number | Last updated timestamp |
 | `count` | number | Number of webhooks returned |
 
-### `vercel_get_webhook`
+### Vercel Get Webhook
 
 Get details about a specific Vercel webhook
 
@@ -1331,7 +1331,7 @@ Get details about a specific Vercel webhook
 | `createdAt` | number | Creation timestamp |
 | `updatedAt` | number | Last updated timestamp |
 
-### `vercel_create_webhook`
+### Vercel Create Webhook
 
 Create a new webhook for a Vercel team
 
@@ -1358,7 +1358,7 @@ Create a new webhook for a Vercel team
 | `createdAt` | number | Creation timestamp |
 | `updatedAt` | number | Last updated timestamp |
 
-### `vercel_delete_webhook`
+### Vercel Delete Webhook
 
 Delete a webhook from a Vercel team
 
@@ -1376,7 +1376,7 @@ Delete a webhook from a Vercel team
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the webhook was successfully deleted |
 
-### `vercel_create_check`
+### Vercel Create Check
 
 Create a new deployment check
 
@@ -1416,7 +1416,7 @@ Create a new deployment check
 | `completedAt` | number | Completion timestamp in milliseconds |
 | `output` | json | Check result output including metrics \(FCP, LCP, CLS, TBT, virtualExperienceScore\) |
 
-### `vercel_get_check`
+### Vercel Get Check
 
 Get details of a specific deployment check
 
@@ -1451,7 +1451,7 @@ Get details of a specific deployment check
 | `completedAt` | number | Completion timestamp in milliseconds |
 | `output` | json | Check result output including metrics \(FCP, LCP, CLS, TBT, virtualExperienceScore\) |
 
-### `vercel_list_checks`
+### Vercel List Checks
 
 List all checks for a deployment
 
@@ -1487,7 +1487,7 @@ List all checks for a deployment
 |   ↳ `output` | json | Check result output including metrics |
 | `count` | number | Total number of checks |
 
-### `vercel_update_check`
+### Vercel Update Check
 
 Update an existing deployment check
 
@@ -1529,7 +1529,7 @@ Update an existing deployment check
 | `completedAt` | number | Completion timestamp in milliseconds |
 | `output` | json | Check result output including metrics \(FCP, LCP, CLS, TBT, virtualExperienceScore\) |
 
-### `vercel_rerequest_check`
+### Vercel Rerequest Check
 
 Rerequest a deployment check
 
@@ -1550,7 +1550,7 @@ Rerequest a deployment check
 | --------- | ---- | ----------- |
 | `rerequested` | boolean | Whether the check was successfully rerequested |
 
-### `vercel_list_teams`
+### Vercel List Teams
 
 List all teams in a Vercel account
 
@@ -1589,7 +1589,7 @@ List all teams in a Vercel account
 |   ↳ `next` | number | Timestamp for next page request |
 |   ↳ `prev` | number | Timestamp for previous page request |
 
-### `vercel_get_team`
+### Vercel Get Team
 
 Get information about a specific Vercel team
 
@@ -1624,7 +1624,7 @@ Get information about a specific Vercel team
 |   ↳ `teamRoles` | array | Team role assignments |
 |   ↳ `teamPermissions` | array | Team permission assignments |
 
-### `vercel_list_team_members`
+### Vercel List Team Members
 
 List all members of a Vercel team
 
@@ -1664,7 +1664,7 @@ List all members of a Vercel team
 |   ↳ `next` | number | Timestamp to request the next page |
 |   ↳ `prev` | number | Timestamp to request the previous page |
 
-### `vercel_get_user`
+### Vercel Get User
 
 Get information about the authenticated Vercel user
 

--- a/apps/docs/content/docs/en/integrations/wealthbox.mdx
+++ b/apps/docs/content/docs/en/integrations/wealthbox.mdx
@@ -34,7 +34,7 @@ Integrate Wealthbox into the workflow. Can read and write notes, read and write 
 
 ## Actions
 
-### `wealthbox_read_note`
+### Read Wealthbox Note
 
 Read content from a Wealthbox note
 
@@ -57,7 +57,7 @@ Read content from a Wealthbox note
 |     ↳ `noteId` | string | ID of the note |
 |     ↳ `itemType` | string | Type of item \(note\) |
 
-### `wealthbox_write_note`
+### Write Wealthbox Note
 
 Create or update a Wealthbox note
 
@@ -81,7 +81,7 @@ Create or update a Wealthbox note
 |     ↳ `noteId` | string | ID of the created/updated note |
 |     ↳ `itemType` | string | Type of item \(note\) |
 
-### `wealthbox_read_contact`
+### Read Wealthbox Contact
 
 Read content from a Wealthbox contact
 
@@ -104,7 +104,7 @@ Read content from a Wealthbox contact
 |     ↳ `contactId` | string | ID of the contact |
 |     ↳ `itemType` | string | Type of item \(contact\) |
 
-### `wealthbox_write_contact`
+### Write Wealthbox Contact
 
 Create a new Wealthbox contact
 
@@ -130,7 +130,7 @@ Create a new Wealthbox contact
 |     ↳ `contactId` | string | ID of the created/updated contact |
 |     ↳ `itemType` | string | Type of item \(contact\) |
 
-### `wealthbox_read_task`
+### Read Wealthbox Task
 
 Read content from a Wealthbox task
 
@@ -153,7 +153,7 @@ Read content from a Wealthbox task
 |     ↳ `taskId` | string | ID of the task |
 |     ↳ `itemType` | string | Type of item \(task\) |
 
-### `wealthbox_write_task`
+### Write Wealthbox Task
 
 Create or update a Wealthbox task
 

--- a/apps/docs/content/docs/en/integrations/webflow.mdx
+++ b/apps/docs/content/docs/en/integrations/webflow.mdx
@@ -34,7 +34,7 @@ Integrates Webflow CMS into the workflow. Can create, get, list, update, or dele
 
 ## Actions
 
-### `webflow_list_items`
+### Webflow List Items
 
 List all items from a Webflow CMS collection
 
@@ -65,7 +65,7 @@ List all items from a Webflow CMS collection
 |   ↳ `offset` | number | Pagination offset |
 |   ↳ `limit` | number | Maximum items per page |
 
-### `webflow_get_item`
+### Webflow Get Item
 
 Get a single item from a Webflow CMS collection
 
@@ -84,7 +84,7 @@ Get a single item from a Webflow CMS collection
 | `item` | json | The retrieved item object |
 | `metadata` | json | Metadata about the retrieved item |
 
-### `webflow_create_item`
+### Webflow Create Item
 
 Create a new item in a Webflow CMS collection
 
@@ -103,7 +103,7 @@ Create a new item in a Webflow CMS collection
 | `item` | json | The created item object |
 | `metadata` | json | Metadata about the created item |
 
-### `webflow_update_item`
+### Webflow Update Item
 
 Update an existing item in a Webflow CMS collection
 
@@ -123,7 +123,7 @@ Update an existing item in a Webflow CMS collection
 | `item` | json | The updated item object |
 | `metadata` | json | Metadata about the updated item |
 
-### `webflow_delete_item`
+### Webflow Delete Item
 
 Delete an item from a Webflow CMS collection
 

--- a/apps/docs/content/docs/en/integrations/whatsapp.mdx
+++ b/apps/docs/content/docs/en/integrations/whatsapp.mdx
@@ -32,7 +32,7 @@ Integrate WhatsApp into the workflow. Send text, template, media, and interactiv
 
 ## Actions
 
-### `whatsapp_send_message`
+### WhatsApp Send Message
 
 Send a free-form text message through the WhatsApp Cloud API. Only works inside the 24-hour customer service window — use Send Template to start a conversation.
 
@@ -83,7 +83,7 @@ Send a free-form text message through the WhatsApp Cloud API. Only works inside 
 | `raw` | json | Full structured WhatsApp webhook payload |
 | `error` | string | Error information if sending fails |
 
-### `whatsapp_send_template`
+### WhatsApp Send Template
 
 Send a pre-approved WhatsApp template message. Required to start a conversation or to message a user outside the 24-hour customer service window.
 
@@ -135,7 +135,7 @@ Send a pre-approved WhatsApp template message. Required to start a conversation 
 | `raw` | json | Full structured WhatsApp webhook payload |
 | `error` | string | Error information if sending fails |
 
-### `whatsapp_send_media`
+### WhatsApp Send Media
 
 Send an image, document, video, audio, or sticker message. Accepts an uploaded file, a media ID, or a public link.
 
@@ -190,7 +190,7 @@ Send an image, document, video, audio, or sticker message. Accepts an uploaded f
 | `raw` | json | Full structured WhatsApp webhook payload |
 | `error` | string | Error information if sending fails |
 
-### `whatsapp_send_interactive`
+### WhatsApp Send Interactive
 
 Send an interactive WhatsApp message with reply buttons or a selectable list.
 
@@ -245,7 +245,7 @@ Send an interactive WhatsApp message with reply buttons or a selectable list.
 | `raw` | json | Full structured WhatsApp webhook payload |
 | `error` | string | Error information if sending fails |
 
-### `whatsapp_send_reaction`
+### WhatsApp Send Reaction
 
 React to a WhatsApp message with an emoji. Send an empty emoji to remove an existing reaction.
 
@@ -296,7 +296,7 @@ React to a WhatsApp message with an emoji. Send an empty emoji to remove an exis
 | `raw` | json | Full structured WhatsApp webhook payload |
 | `error` | string | Error information if sending fails |
 
-### `whatsapp_mark_read`
+### WhatsApp Mark As Read
 
 Mark a received WhatsApp message as read so the sender sees blue checkmarks, optionally showing a typing indicator.
 
@@ -314,7 +314,7 @@ Mark a received WhatsApp message as read so the sender sees blue checkmarks, opt
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the message was successfully marked as read |
 
-### `whatsapp_upload_media`
+### WhatsApp Upload Media
 
 Upload a file to WhatsApp and get a media ID for sending. Uploaded media is retained for 30 days and can back many sends.
 
@@ -334,7 +334,7 @@ Upload a file to WhatsApp and get a media ID for sending. Uploaded media is reta
 | `mimeType` | string | MIME type WhatsApp received the file as |
 | `size` | number | Size of the uploaded file in bytes |
 
-### `whatsapp_get_media`
+### WhatsApp Download Media
 
 Download media a customer sent you. Takes the media ID from an incoming WhatsApp message and stores the file in the workflow.
 

--- a/apps/docs/content/docs/en/integrations/wikipedia.mdx
+++ b/apps/docs/content/docs/en/integrations/wikipedia.mdx
@@ -32,7 +32,7 @@ Integrate Wikipedia into the workflow. Can get page summary, search pages, get p
 
 ## Actions
 
-### `wikipedia_summary`
+### Wikipedia Page Summary
 
 Get a summary and metadata for a specific Wikipedia page.
 
@@ -81,7 +81,7 @@ Get a summary and metadata for a specific Wikipedia page.
 |     ↳ `lat` | number | Latitude |
 |     ↳ `lon` | number | Longitude |
 
-### `wikipedia_search`
+### Wikipedia Search
 
 Search for Wikipedia pages by title or content.
 
@@ -114,7 +114,7 @@ Search for Wikipedia pages by title or content.
 | `totalHits` | number | Total number of search results found |
 | `query` | string | The search query that was executed |
 
-### `wikipedia_content`
+### Wikipedia Page Content
 
 Get the full HTML content of a Wikipedia page.
 
@@ -138,7 +138,7 @@ Get the full HTML content of a Wikipedia page.
 |   ↳ `content_model` | string | Content model \(wikitext\) |
 |   ↳ `content_format` | string | Content format \(text/html\) |
 
-### `wikipedia_random`
+### Wikipedia Random Page
 
 Get a random Wikipedia page.
 

--- a/apps/docs/content/docs/en/integrations/wiza.mdx
+++ b/apps/docs/content/docs/en/integrations/wiza.mdx
@@ -70,7 +70,7 @@ Integrates Wiza into the workflow. Search prospects, enrich companies, reveal ve
 
 ## Actions
 
-### `wiza_prospect_search`
+### Wiza Prospect Search
 
 Search Wiza's database of prospects using person, company, and financial filters
 
@@ -106,7 +106,7 @@ Search Wiza's database of prospects using person, company, and financial filters
 | `total` | number | Total number of matching prospects |
 | `profiles` | array | Sample profiles matching the filter criteria |
 
-### `wiza_company_enrichment`
+### Wiza Company Enrichment
 
 Enrich a company by name, domain, LinkedIn ID, or LinkedIn slug with detailed firmographic data
 
@@ -151,7 +151,7 @@ Enrich a company by name, domain, LinkedIn ID, or LinkedIn slug with detailed fi
 | `company_country` | string | Country |
 | `credits` | json | Credits deducted for this enrichment \(api_credits: \{ total, company_credits \}\) |
 
-### `wiza_individual_reveal`
+### Wiza Individual Reveal
 
 Reveal a contact via LinkedIn URL, name + company/domain, or email. Starts the reveal and polls until it resolves. Uses 2 credits per valid email and 5 credits per phone, charged only on success.
 
@@ -209,7 +209,7 @@ Reveal a contact via LinkedIn URL, name + company/domain, or email. Starts the r
 | `company_description` | string | Company description |
 | `credits` | json | Credits consumed by the reveal |
 
-### `wiza_get_credits`
+### Wiza Get Credits
 
 Retrieve the remaining credits on your Wiza account
 

--- a/apps/docs/content/docs/en/integrations/wordpress.mdx
+++ b/apps/docs/content/docs/en/integrations/wordpress.mdx
@@ -35,7 +35,7 @@ Integrate with WordPress.com to create, update, and manage posts, pages, media, 
 
 ## Actions
 
-### `wordpress_create_post`
+### WordPress Create Post
 
 Create a new blog post in WordPress.com
 
@@ -73,7 +73,7 @@ Create a new blog post in WordPress.com
 |   ↳ `categories` | array | Category IDs |
 |   ↳ `tags` | array | Tag IDs |
 
-### `wordpress_update_post`
+### WordPress Update Post
 
 Update an existing blog post in WordPress.com
 
@@ -112,7 +112,7 @@ Update an existing blog post in WordPress.com
 |   ↳ `categories` | array | Category IDs |
 |   ↳ `tags` | array | Tag IDs |
 
-### `wordpress_delete_post`
+### WordPress Delete Post
 
 Delete a blog post from WordPress.com
 
@@ -145,7 +145,7 @@ Delete a blog post from WordPress.com
 |   ↳ `categories` | array | Category IDs |
 |   ↳ `tags` | array | Tag IDs |
 
-### `wordpress_get_post`
+### WordPress Get Post
 
 Get a single blog post from WordPress.com by ID
 
@@ -176,7 +176,7 @@ Get a single blog post from WordPress.com by ID
 |   ↳ `categories` | array | Category IDs |
 |   ↳ `tags` | array | Tag IDs |
 
-### `wordpress_list_posts`
+### WordPress List Posts
 
 List blog posts from WordPress.com with optional filters
 
@@ -217,7 +217,7 @@ List blog posts from WordPress.com with optional filters
 | `total` | number | Total number of posts |
 | `totalPages` | number | Total number of pages |
 
-### `wordpress_create_page`
+### WordPress Create Page
 
 Create a new page in WordPress.com
 
@@ -255,7 +255,7 @@ Create a new page in WordPress.com
 |   ↳ `parent` | number | Parent page ID |
 |   ↳ `menu_order` | number | Menu order |
 
-### `wordpress_update_page`
+### WordPress Update Page
 
 Update an existing page in WordPress.com
 
@@ -294,7 +294,7 @@ Update an existing page in WordPress.com
 |   ↳ `parent` | number | Parent page ID |
 |   ↳ `menu_order` | number | Menu order |
 
-### `wordpress_delete_page`
+### WordPress Delete Page
 
 Delete a page from WordPress.com
 
@@ -327,7 +327,7 @@ Delete a page from WordPress.com
 |   ↳ `parent` | number | Parent page ID |
 |   ↳ `menu_order` | number | Menu order |
 
-### `wordpress_get_page`
+### WordPress Get Page
 
 Get a single page from WordPress.com by ID
 
@@ -358,7 +358,7 @@ Get a single page from WordPress.com by ID
 |   ↳ `parent` | number | Parent page ID |
 |   ↳ `menu_order` | number | Menu order |
 
-### `wordpress_list_pages`
+### WordPress List Pages
 
 List pages from WordPress.com with optional filters
 
@@ -397,7 +397,7 @@ List pages from WordPress.com with optional filters
 | `total` | number | Total number of pages |
 | `totalPages` | number | Total number of result pages |
 
-### `wordpress_upload_media`
+### WordPress Upload Media
 
 Upload a media file (image, video, document) to WordPress.com
 
@@ -431,7 +431,7 @@ Upload a media file (image, video, document) to WordPress.com
 |   ↳ `source_url` | string | Direct URL to the media file |
 |   ↳ `media_details` | object | Media details \(dimensions, etc.\) |
 
-### `wordpress_get_media`
+### WordPress Get Media
 
 Get a single media item from WordPress.com by ID
 
@@ -460,7 +460,7 @@ Get a single media item from WordPress.com by ID
 |   ↳ `source_url` | string | Direct URL to the media file |
 |   ↳ `media_details` | object | Media details \(dimensions, etc.\) |
 
-### `wordpress_list_media`
+### WordPress List Media
 
 List media items from the WordPress.com media library
 
@@ -497,7 +497,7 @@ List media items from the WordPress.com media library
 | `total` | number | Total number of media items |
 | `totalPages` | number | Total number of result pages |
 
-### `wordpress_delete_media`
+### WordPress Delete Media
 
 Delete a media item from WordPress.com
 
@@ -527,7 +527,7 @@ Delete a media item from WordPress.com
 |   ↳ `source_url` | string | Direct URL to the media file |
 |   ↳ `media_details` | object | Media details \(dimensions, etc.\) |
 
-### `wordpress_create_comment`
+### WordPress Create Comment
 
 Create a new comment on a WordPress.com post
 
@@ -560,7 +560,7 @@ Create a new comment on a WordPress.com post
 |   ↳ `link` | string | Comment permalink |
 |   ↳ `status` | string | Comment status |
 
-### `wordpress_list_comments`
+### WordPress List Comments
 
 List comments from WordPress.com with optional filters
 
@@ -596,7 +596,7 @@ List comments from WordPress.com with optional filters
 | `total` | number | Total number of comments |
 | `totalPages` | number | Total number of result pages |
 
-### `wordpress_update_comment`
+### WordPress Update Comment
 
 Update a comment in WordPress.com (content or status)
 
@@ -626,7 +626,7 @@ Update a comment in WordPress.com (content or status)
 |   ↳ `link` | string | Comment permalink |
 |   ↳ `status` | string | Comment status |
 
-### `wordpress_delete_comment`
+### WordPress Delete Comment
 
 Delete a comment from WordPress.com
 
@@ -656,7 +656,7 @@ Delete a comment from WordPress.com
 |   ↳ `link` | string | Comment permalink |
 |   ↳ `status` | string | Comment status |
 
-### `wordpress_create_category`
+### WordPress Create Category
 
 Create a new category in WordPress.com
 
@@ -684,7 +684,7 @@ Create a new category in WordPress.com
 |   ↳ `taxonomy` | string | Taxonomy name |
 |   ↳ `parent` | number | Parent category ID |
 
-### `wordpress_list_categories`
+### WordPress List Categories
 
 List categories from WordPress.com
 
@@ -714,7 +714,7 @@ List categories from WordPress.com
 | `total` | number | Total number of categories |
 | `totalPages` | number | Total number of result pages |
 
-### `wordpress_get_category`
+### WordPress Get Category
 
 Get a single category from WordPress.com by ID
 
@@ -739,7 +739,7 @@ Get a single category from WordPress.com by ID
 |   ↳ `taxonomy` | string | Taxonomy name |
 |   ↳ `parent` | number | Parent category ID |
 
-### `wordpress_update_category`
+### WordPress Update Category
 
 Update an existing category in WordPress.com
 
@@ -768,7 +768,7 @@ Update an existing category in WordPress.com
 |   ↳ `taxonomy` | string | Taxonomy name |
 |   ↳ `parent` | number | Parent category ID |
 
-### `wordpress_delete_category`
+### WordPress Delete Category
 
 Delete a category from WordPress.com
 
@@ -794,7 +794,7 @@ Delete a category from WordPress.com
 |   ↳ `taxonomy` | string | Taxonomy name |
 |   ↳ `parent` | number | Parent category ID |
 
-### `wordpress_create_tag`
+### WordPress Create Tag
 
 Create a new tag in WordPress.com
 
@@ -820,7 +820,7 @@ Create a new tag in WordPress.com
 |   ↳ `slug` | string | Tag slug |
 |   ↳ `taxonomy` | string | Taxonomy name |
 
-### `wordpress_list_tags`
+### WordPress List Tags
 
 List tags from WordPress.com
 
@@ -849,7 +849,7 @@ List tags from WordPress.com
 | `total` | number | Total number of tags |
 | `totalPages` | number | Total number of result pages |
 
-### `wordpress_get_tag`
+### WordPress Get Tag
 
 Get a single tag from WordPress.com by ID
 
@@ -873,7 +873,7 @@ Get a single tag from WordPress.com by ID
 |   ↳ `slug` | string | Tag slug |
 |   ↳ `taxonomy` | string | Taxonomy name |
 
-### `wordpress_update_tag`
+### WordPress Update Tag
 
 Update an existing tag in WordPress.com
 
@@ -900,7 +900,7 @@ Update an existing tag in WordPress.com
 |   ↳ `slug` | string | Tag slug |
 |   ↳ `taxonomy` | string | Taxonomy name |
 
-### `wordpress_delete_tag`
+### WordPress Delete Tag
 
 Delete a tag from WordPress.com
 
@@ -925,7 +925,7 @@ Delete a tag from WordPress.com
 |   ↳ `slug` | string | Tag slug |
 |   ↳ `taxonomy` | string | Taxonomy name |
 
-### `wordpress_get_current_user`
+### WordPress Get Current User
 
 Get information about the currently authenticated WordPress.com user
 
@@ -953,7 +953,7 @@ Get information about the currently authenticated WordPress.com user
 |   ↳ `roles` | array | User roles |
 |   ↳ `avatar_urls` | object | Avatar URLs at different sizes |
 
-### `wordpress_list_users`
+### WordPress List Users
 
 List users from WordPress.com (requires admin privileges)
 
@@ -988,7 +988,7 @@ List users from WordPress.com (requires admin privileges)
 | `total` | number | Total number of users |
 | `totalPages` | number | Total number of result pages |
 
-### `wordpress_get_user`
+### WordPress Get User
 
 Get a specific user from WordPress.com by ID
 
@@ -1017,7 +1017,7 @@ Get a specific user from WordPress.com by ID
 |   ↳ `roles` | array | User roles |
 |   ↳ `avatar_urls` | object | Avatar URLs at different sizes |
 
-### `wordpress_search_content`
+### WordPress Search Content
 
 Search across all content types in WordPress.com (posts, pages, media)
 

--- a/apps/docs/content/docs/en/integrations/workday.mdx
+++ b/apps/docs/content/docs/en/integrations/workday.mdx
@@ -34,7 +34,7 @@ Integrate Workday HRIS into your workflow. Create pre-hires, hire employees, man
 
 ## Actions
 
-### `workday_get_worker`
+### Get Workday Worker
 
 Retrieve a specific worker profile including personal, employment, and organization data.
 
@@ -54,7 +54,7 @@ Retrieve a specific worker profile including personal, employment, and organizat
 | --------- | ---- | ----------- |
 | `worker` | json | Worker profile with personal, employment, and organization data |
 
-### `workday_list_workers`
+### List Workday Workers
 
 List or search workers with optional filtering and pagination.
 
@@ -76,7 +76,7 @@ List or search workers with optional filtering and pagination.
 | `workers` | array | Array of worker profiles |
 | `total` | number | Total number of matching workers |
 
-### `workday_create_prehire`
+### Create Workday Pre-Hire
 
 Create a new pre-hire (applicant) record in Workday. This is typically the first step before hiring an employee.
 
@@ -101,7 +101,7 @@ Create a new pre-hire (applicant) record in Workday. This is typically the first
 | `preHireId` | string | ID of the created pre-hire record |
 | `descriptor` | string | Display name of the pre-hire |
 
-### `workday_hire_employee`
+### Hire Workday Employee
 
 Hire a pre-hire into an employee position. Converts an applicant into an active employee record with position, start date, and manager assignment.
 
@@ -127,7 +127,7 @@ Hire a pre-hire into an employee position. Converts an applicant into an active 
 | `eventId` | string | Event ID of the hire business process |
 | `hireDate` | string | Effective hire date |
 
-### `workday_update_worker`
+### Update Workday Worker
 
 Update fields on an existing worker record in Workday.
 
@@ -149,7 +149,7 @@ Update fields on an existing worker record in Workday.
 | `eventId` | string | Event ID of the change personal information business process |
 | `workerId` | string | Worker ID that was updated |
 
-### `workday_assign_onboarding`
+### Assign Workday Onboarding Plan
 
 Create or update an onboarding plan assignment for a worker. Sets up onboarding stages and manages the assignment lifecycle.
 
@@ -173,7 +173,7 @@ Create or update an onboarding plan assignment for a worker. Sets up onboarding 
 | `workerId` | string | Worker ID the plan was assigned to |
 | `planId` | string | Onboarding plan ID that was assigned |
 
-### `workday_get_organizations`
+### Get Workday Organizations
 
 Retrieve organizations, departments, and cost centers from Workday.
 
@@ -196,7 +196,7 @@ Retrieve organizations, departments, and cost centers from Workday.
 | `organizations` | array | Array of organization records |
 | `total` | number | Total number of matching organizations |
 
-### `workday_change_job`
+### Change Workday Job
 
 Perform a job change for a worker including transfers, promotions, demotions, and lateral moves.
 
@@ -224,7 +224,7 @@ Perform a job change for a worker including transfers, promotions, demotions, an
 | `workerId` | string | Worker ID the job change was applied to |
 | `effectiveDate` | string | Effective date of the job change |
 
-### `workday_get_compensation`
+### Get Workday Compensation
 
 Retrieve compensation plan details for a specific worker.
 
@@ -249,7 +249,7 @@ Retrieve compensation plan details for a specific worker.
 |   ↳ `currency` | string | Currency code |
 |   ↳ `frequency` | string | Pay frequency |
 
-### `workday_terminate_worker`
+### Terminate Workday Worker
 
 Initiate a worker termination in Workday. Triggers the Terminate Employee business process.
 

--- a/apps/docs/content/docs/en/integrations/x.mdx
+++ b/apps/docs/content/docs/en/integrations/x.mdx
@@ -35,7 +35,7 @@ Integrate X into the workflow. Search tweets, manage bookmarks, follow/block/mut
 
 ## Actions
 
-### `x_create_tweet`
+### X Create Tweet
 
 Create a new tweet, reply, or quote tweet on X
 
@@ -56,7 +56,7 @@ Create a new tweet, reply, or quote tweet on X
 | `id` | string | The ID of the created tweet |
 | `text` | string | The text of the created tweet |
 
-### `x_delete_tweet`
+### X Delete Tweet
 
 Delete a tweet authored by the authenticated user
 
@@ -72,7 +72,7 @@ Delete a tweet authored by the authenticated user
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the tweet was successfully deleted |
 
-### `x_search_tweets`
+### X Search Tweets
 
 Search for recent tweets using keywords, hashtags, or advanced query operators
 
@@ -123,7 +123,7 @@ Search for recent tweets using keywords, hashtags, or advanced query operators
 |   ↳ `oldestId` | string | ID of the oldest tweet |
 |   ↳ `nextToken` | string | Pagination token for next page |
 
-### `x_get_tweets_by_ids`
+### X Get Tweets By IDs
 
 Look up multiple tweets by their IDs (up to 100)
 
@@ -162,7 +162,7 @@ Look up multiple tweets by their IDs (up to 100)
 |       ↳ `followingCount` | number | Number of users following |
 |       ↳ `tweetCount` | number | Total number of tweets |
 
-### `x_get_quote_tweets`
+### X Get Quote Tweets
 
 Get tweets that quote a specific tweet
 
@@ -194,7 +194,7 @@ Get tweets that quote a specific tweet
 |   ↳ `resultCount` | number | Number of results returned |
 |   ↳ `nextToken` | string | Token for next page |
 
-### `x_hide_reply`
+### X Hide Reply
 
 Hide or unhide a reply to a tweet authored by the authenticated user
 
@@ -211,7 +211,7 @@ Hide or unhide a reply to a tweet authored by the authenticated user
 | --------- | ---- | ----------- |
 | `hidden` | boolean | Whether the reply is now hidden |
 
-### `x_get_user_tweets`
+### X Get User Tweets
 
 Get tweets authored by a specific user
 
@@ -263,7 +263,7 @@ Get tweets authored by a specific user
 |   ↳ `nextToken` | string | Token for next page |
 |   ↳ `previousToken` | string | Token for previous page |
 
-### `x_get_user_mentions`
+### X Get User Mentions
 
 Get tweets that mention a specific user
 
@@ -314,7 +314,7 @@ Get tweets that mention a specific user
 |   ↳ `nextToken` | string | Token for next page |
 |   ↳ `previousToken` | string | Token for previous page |
 
-### `x_get_user_timeline`
+### X Get User Timeline
 
 Get the reverse chronological home timeline for the authenticated user
 
@@ -366,7 +366,7 @@ Get the reverse chronological home timeline for the authenticated user
 |   ↳ `nextToken` | string | Token for next page |
 |   ↳ `previousToken` | string | Token for previous page |
 
-### `x_manage_like`
+### X Manage Like
 
 Like or unlike a tweet on X
 
@@ -384,7 +384,7 @@ Like or unlike a tweet on X
 | --------- | ---- | ----------- |
 | `liked` | boolean | Whether the tweet is now liked |
 
-### `x_manage_retweet`
+### X Manage Retweet
 
 Retweet or unretweet a tweet on X
 
@@ -402,7 +402,7 @@ Retweet or unretweet a tweet on X
 | --------- | ---- | ----------- |
 | `retweeted` | boolean | Whether the tweet is now retweeted |
 
-### `x_get_liked_tweets`
+### X Get Liked Tweets
 
 Get tweets liked by a specific user
 
@@ -427,7 +427,7 @@ Get tweets liked by a specific user
 |   ↳ `resultCount` | number | Number of results returned |
 |   ↳ `nextToken` | string | Token for next page |
 
-### `x_get_liking_users`
+### X Get Liking Users
 
 Get the list of users who liked a specific tweet
 
@@ -458,7 +458,7 @@ Get the list of users who liked a specific tweet
 |   ↳ `resultCount` | number | Number of results returned |
 |   ↳ `nextToken` | string | Token for next page |
 
-### `x_get_retweeted_by`
+### X Get Retweeted By
 
 Get the list of users who retweeted a specific tweet
 
@@ -489,7 +489,7 @@ Get the list of users who retweeted a specific tweet
 |   ↳ `resultCount` | number | Number of results returned |
 |   ↳ `nextToken` | string | Token for next page |
 
-### `x_get_bookmarks`
+### X Get Bookmarks
 
 Get bookmarked tweets for the authenticated user
 
@@ -536,7 +536,7 @@ Get bookmarked tweets for the authenticated user
 |   ↳ `nextToken` | string | Token for next page |
 |   ↳ `previousToken` | string | Token for previous page |
 
-### `x_create_bookmark`
+### X Create Bookmark
 
 Bookmark a tweet for the authenticated user
 
@@ -553,7 +553,7 @@ Bookmark a tweet for the authenticated user
 | --------- | ---- | ----------- |
 | `bookmarked` | boolean | Whether the tweet was successfully bookmarked |
 
-### `x_delete_bookmark`
+### X Delete Bookmark
 
 Remove a tweet from the authenticated user's bookmarks
 
@@ -570,7 +570,7 @@ Remove a tweet from the authenticated user's bookmarks
 | --------- | ---- | ----------- |
 | `bookmarked` | boolean | Whether the tweet is still bookmarked \(should be false after deletion\) |
 
-### `x_get_me`
+### X Get Me
 
 Get the authenticated user's profile information
 
@@ -595,7 +595,7 @@ Get the authenticated user's profile information
 |     ↳ `followingCount` | number | Number of users following |
 |     ↳ `tweetCount` | number | Total number of tweets |
 
-### `x_search_users`
+### X Search Users
 
 Search for X users by name, username, or bio
 
@@ -626,7 +626,7 @@ Search for X users by name, username, or bio
 |   ↳ `resultCount` | number | Number of results returned |
 |   ↳ `nextToken` | string | Pagination token for next page |
 
-### `x_get_followers`
+### X Get Followers
 
 Get the list of followers for a user
 
@@ -657,7 +657,7 @@ Get the list of followers for a user
 |   ↳ `resultCount` | number | Number of results returned |
 |   ↳ `nextToken` | string | Token for next page |
 
-### `x_get_following`
+### X Get Following
 
 Get the list of users that a user is following
 
@@ -688,7 +688,7 @@ Get the list of users that a user is following
 |   ↳ `resultCount` | number | Number of results returned |
 |   ↳ `nextToken` | string | Token for next page |
 
-### `x_manage_follow`
+### X Manage Follow
 
 Follow or unfollow a user on X
 
@@ -707,7 +707,7 @@ Follow or unfollow a user on X
 | `following` | boolean | Whether you are now following the user |
 | `pendingFollow` | boolean | Whether the follow request is pending \(for protected accounts\) |
 
-### `x_manage_block`
+### X Manage Block
 
 Block or unblock a user on X
 
@@ -725,7 +725,7 @@ Block or unblock a user on X
 | --------- | ---- | ----------- |
 | `blocking` | boolean | Whether you are now blocking the user |
 
-### `x_get_blocking`
+### X Get Blocking
 
 Get the list of users blocked by the authenticated user
 
@@ -756,7 +756,7 @@ Get the list of users blocked by the authenticated user
 |   ↳ `resultCount` | number | Number of results returned |
 |   ↳ `nextToken` | string | Token for next page |
 
-### `x_manage_mute`
+### X Manage Mute
 
 Mute or unmute a user on X
 
@@ -774,7 +774,7 @@ Mute or unmute a user on X
 | --------- | ---- | ----------- |
 | `muting` | boolean | Whether you are now muting the user |
 
-### `x_get_trends_by_woeid`
+### X Get Trends By WOEID
 
 Get trending topics for a specific location by WOEID (e.g., 1 for worldwide, 23424977 for US)
 
@@ -793,7 +793,7 @@ Get trending topics for a specific location by WOEID (e.g., 1 for worldwide, 234
 |   ↳ `trendName` | string | Name of the trending topic |
 |   ↳ `tweetCount` | number | Number of tweets for this trend |
 
-### `x_get_personalized_trends`
+### X Get Personalized Trends
 
 Get personalized trending topics for the authenticated user
 
@@ -812,7 +812,7 @@ Get personalized trending topics for the authenticated user
 |   ↳ `category` | string | Category of the trend |
 |   ↳ `trendingSince` | string | ISO 8601 timestamp of when the topic started trending |
 
-### `x_get_usage`
+### X Get Usage
 
 Get the API usage data for your X project
 

--- a/apps/docs/content/docs/en/integrations/youtube.mdx
+++ b/apps/docs/content/docs/en/integrations/youtube.mdx
@@ -32,7 +32,7 @@ Integrate YouTube into the workflow. Can search for videos, get trending videos,
 
 ## Actions
 
-### `youtube_channel_info`
+### YouTube Channel Info
 
 Get detailed information about a YouTube channel including statistics, branding, and content details.
 
@@ -62,7 +62,7 @@ Get detailed information about a YouTube channel including statistics, branding,
 | `bannerImageUrl` | string | Channel banner image URL |
 | `hiddenSubscriberCount` | boolean | Whether the subscriber count is hidden |
 
-### `youtube_channel_playlists`
+### YouTube Channel Playlists
 
 Get all public playlists from a specific YouTube channel.
 
@@ -90,7 +90,7 @@ Get all public playlists from a specific YouTube channel.
 | `totalResults` | number | Total number of playlists in the channel |
 | `nextPageToken` | string | Token for accessing the next page of results |
 
-### `youtube_channel_videos`
+### YouTube Channel Videos
 
 Search for videos from a specific YouTube channel with sorting options. For complete channel video list, use channel_info to get uploadsPlaylistId, then use playlist_items.
 
@@ -118,7 +118,7 @@ Search for videos from a specific YouTube channel with sorting options. For comp
 | `totalResults` | number | Total number of videos in the channel |
 | `nextPageToken` | string | Token for accessing the next page of results |
 
-### `youtube_comments`
+### YouTube Video Comments
 
 Get top-level comments from a YouTube video with author details and engagement.
 
@@ -150,7 +150,7 @@ Get top-level comments from a YouTube video with author details and engagement.
 | `totalResults` | number | Total number of comment threads available |
 | `nextPageToken` | string | Token for accessing the next page of results |
 
-### `youtube_playlist_items`
+### YouTube Playlist Items
 
 Get videos from a YouTube playlist. Can be used with a channel uploads playlist to get all channel videos.
 
@@ -180,7 +180,7 @@ Get videos from a YouTube playlist. Can be used with a channel uploads playlist 
 | `totalResults` | number | Total number of items in playlist |
 | `nextPageToken` | string | Token for accessing the next page of results |
 
-### `youtube_search`
+### YouTube Search
 
 Search for videos on YouTube using the YouTube Data API. Supports advanced filtering by channel, date range, duration, category, quality, captions, live streams, and more.
 
@@ -221,7 +221,7 @@ Search for videos on YouTube using the YouTube Data API. Supports advanced filte
 | `totalResults` | number | Total number of search results available |
 | `nextPageToken` | string | Token for accessing the next page of results |
 
-### `youtube_trending`
+### YouTube Trending Videos
 
 Get the most popular/trending videos on YouTube. Can filter by region and video category.
 
@@ -254,7 +254,7 @@ Get the most popular/trending videos on YouTube. Can filter by region and video 
 | `totalResults` | number | Total number of trending videos available |
 | `nextPageToken` | string | Token for accessing the next page of results |
 
-### `youtube_video_categories`
+### YouTube Video Categories
 
 Get a list of video categories available on YouTube. Use this to discover valid category IDs for filtering search and trending results.
 
@@ -276,7 +276,7 @@ Get a list of video categories available on YouTube. Use this to discover valid 
 |   ↳ `assignable` | boolean | Whether videos can be tagged with this category |
 | `totalResults` | number | Total number of categories available |
 
-### `youtube_video_details`
+### YouTube Video Details
 
 Get detailed information about a specific YouTube video including statistics, content details, live streaming info, and metadata.
 

--- a/apps/docs/content/docs/en/integrations/zendesk.mdx
+++ b/apps/docs/content/docs/en/integrations/zendesk.mdx
@@ -51,7 +51,7 @@ Integrate Zendesk into the workflow. Can get tickets, get ticket, create ticket,
 
 ## Actions
 
-### `zendesk_get_tickets`
+### Get Tickets from Zendesk
 
 Retrieve a list of tickets from Zendesk with optional filtering
 
@@ -136,7 +136,7 @@ Retrieve a list of tickets from Zendesk with optional filtering
 |   ↳ `total_returned` | number | Number of items returned in this response |
 |   ↳ `has_more` | boolean | Whether more items are available |
 
-### `zendesk_get_ticket`
+### Get Single Ticket from Zendesk
 
 Get a single ticket by ID from Zendesk
 
@@ -208,7 +208,7 @@ Get a single ticket by ID from Zendesk
 |   ↳ `generated_timestamp` | number | Unix timestamp of the ticket generation |
 | `ticket_id` | number | The ticket ID |
 
-### `zendesk_create_ticket`
+### Create Ticket in Zendesk
 
 Create a new ticket in Zendesk with support for custom fields
 
@@ -289,7 +289,7 @@ Create a new ticket in Zendesk with support for custom fields
 |   ↳ `generated_timestamp` | number | Unix timestamp of the ticket generation |
 | `ticket_id` | number | The created ticket ID |
 
-### `zendesk_create_tickets_bulk`
+### Bulk Create Tickets in Zendesk
 
 Create multiple tickets in Zendesk at once (max 100)
 
@@ -323,7 +323,7 @@ Create multiple tickets in Zendesk at once (max 100)
 |     ↳ `error` | string | Error message if operation failed |
 | `job_id` | string | The bulk operation job ID |
 
-### `zendesk_update_ticket`
+### Update Ticket in Zendesk
 
 Update an existing ticket in Zendesk with support for custom fields
 
@@ -404,7 +404,7 @@ Update an existing ticket in Zendesk with support for custom fields
 |   ↳ `generated_timestamp` | number | Unix timestamp of the ticket generation |
 | `ticket_id` | number | The updated ticket ID |
 
-### `zendesk_update_tickets_bulk`
+### Bulk Update Tickets in Zendesk
 
 Update multiple tickets in Zendesk at once (max 100)
 
@@ -443,7 +443,7 @@ Update multiple tickets in Zendesk at once (max 100)
 |     ↳ `error` | string | Error message if operation failed |
 | `job_id` | string | The bulk operation job ID |
 
-### `zendesk_delete_ticket`
+### Delete Ticket from Zendesk
 
 Delete a ticket from Zendesk
 
@@ -463,7 +463,7 @@ Delete a ticket from Zendesk
 | `deleted` | boolean | Deletion success |
 | `ticket_id` | string | The deleted ticket ID |
 
-### `zendesk_merge_tickets`
+### Merge Tickets in Zendesk
 
 Merge multiple tickets into a target ticket
 
@@ -500,7 +500,7 @@ Merge multiple tickets into a target ticket
 | `job_id` | string | The merge job ID |
 | `target_ticket_id` | string | The target ticket ID that tickets were merged into |
 
-### `zendesk_get_users`
+### Get Users from Zendesk
 
 Retrieve a list of users from Zendesk with optional filtering
 
@@ -570,7 +570,7 @@ Retrieve a list of users from Zendesk with optional filtering
 |   ↳ `total_returned` | number | Number of items returned in this response |
 |   ↳ `has_more` | boolean | Whether more items are available |
 
-### `zendesk_get_user`
+### Get Single User from Zendesk
 
 Get a single user by ID from Zendesk
 
@@ -631,7 +631,7 @@ Get a single user by ID from Zendesk
 |   ↳ `remote_photo_url` | string | URL to a remote photo |
 | `user_id` | number | The user ID |
 
-### `zendesk_get_current_user`
+### Get Current User from Zendesk
 
 Get the currently authenticated user from Zendesk
 
@@ -691,7 +691,7 @@ Get the currently authenticated user from Zendesk
 |   ↳ `remote_photo_url` | string | URL to a remote photo |
 | `user_id` | number | The current user ID |
 
-### `zendesk_search_users`
+### Search Users in Zendesk
 
 Search for users in Zendesk using a query string
 
@@ -761,7 +761,7 @@ Search for users in Zendesk using a query string
 |   ↳ `total_returned` | number | Number of items returned in this response |
 |   ↳ `has_more` | boolean | Whether more items are available |
 
-### `zendesk_create_user`
+### Create User in Zendesk
 
 Create a new user in Zendesk
 
@@ -829,7 +829,7 @@ Create a new user in Zendesk
 |   ↳ `remote_photo_url` | string | URL to a remote photo |
 | `user_id` | number | The created user ID |
 
-### `zendesk_create_users_bulk`
+### Bulk Create Users in Zendesk
 
 Create multiple users in Zendesk using bulk import
 
@@ -863,7 +863,7 @@ Create multiple users in Zendesk using bulk import
 |     ↳ `error` | string | Error message if operation failed |
 | `job_id` | string | The bulk operation job ID |
 
-### `zendesk_update_user`
+### Update User in Zendesk
 
 Update an existing user in Zendesk
 
@@ -932,7 +932,7 @@ Update an existing user in Zendesk
 |   ↳ `remote_photo_url` | string | URL to a remote photo |
 | `user_id` | number | The updated user ID |
 
-### `zendesk_update_users_bulk`
+### Bulk Update Users in Zendesk
 
 Update multiple users in Zendesk using bulk update
 
@@ -966,7 +966,7 @@ Update multiple users in Zendesk using bulk update
 |     ↳ `error` | string | Error message if operation failed |
 | `job_id` | string | The bulk operation job ID |
 
-### `zendesk_delete_user`
+### Delete User from Zendesk
 
 Delete a user from Zendesk
 
@@ -986,7 +986,7 @@ Delete a user from Zendesk
 | `deleted` | boolean | Deletion success |
 | `user_id` | string | The deleted user ID |
 
-### `zendesk_get_organizations`
+### Get Organizations from Zendesk
 
 Retrieve a list of organizations from Zendesk
 
@@ -1027,7 +1027,7 @@ Retrieve a list of organizations from Zendesk
 |   ↳ `total_returned` | number | Number of items returned in this response |
 |   ↳ `has_more` | boolean | Whether more items are available |
 
-### `zendesk_get_organization`
+### Get Single Organization from Zendesk
 
 Get a single organization by ID from Zendesk
 
@@ -1061,7 +1061,7 @@ Get a single organization by ID from Zendesk
 |   ↳ `external_id` | string | External ID for linking to external records |
 | `organization_id` | number | The organization ID |
 
-### `zendesk_autocomplete_organizations`
+### Autocomplete Organizations in Zendesk
 
 Autocomplete organizations in Zendesk by name prefix (for name matching/autocomplete)
 
@@ -1103,7 +1103,7 @@ Autocomplete organizations in Zendesk by name prefix (for name matching/autocomp
 |   ↳ `total_returned` | number | Number of items returned in this response |
 |   ↳ `has_more` | boolean | Whether more items are available |
 
-### `zendesk_create_organization`
+### Create Organization in Zendesk
 
 Create a new organization in Zendesk
 
@@ -1142,7 +1142,7 @@ Create a new organization in Zendesk
 |   ↳ `external_id` | string | External ID for linking to external records |
 | `organization_id` | number | The created organization ID |
 
-### `zendesk_create_organizations_bulk`
+### Bulk Create Organizations in Zendesk
 
 Create multiple organizations in Zendesk using bulk import
 
@@ -1176,7 +1176,7 @@ Create multiple organizations in Zendesk using bulk import
 |     ↳ `error` | string | Error message if operation failed |
 | `job_id` | string | The bulk operation job ID |
 
-### `zendesk_update_organization`
+### Update Organization in Zendesk
 
 Update an existing organization in Zendesk
 
@@ -1216,7 +1216,7 @@ Update an existing organization in Zendesk
 |   ↳ `external_id` | string | External ID for linking to external records |
 | `organization_id` | number | The updated organization ID |
 
-### `zendesk_delete_organization`
+### Delete Organization from Zendesk
 
 Delete an organization from Zendesk
 
@@ -1236,7 +1236,7 @@ Delete an organization from Zendesk
 | `deleted` | boolean | Whether the organization was successfully deleted |
 | `organization_id` | string | The deleted organization ID |
 
-### `zendesk_search`
+### Search Zendesk
 
 Unified search across tickets, users, and organizations in Zendesk
 
@@ -1265,7 +1265,7 @@ Unified search across tickets, users, and organizations in Zendesk
 |   ↳ `has_more` | boolean | Whether more items are available |
 | `results` | array | Array of result objects \(tickets, users, or organizations depending on search query\) |
 
-### `zendesk_search_count`
+### Count Search Results in Zendesk
 
 Count the number of search results matching a query in Zendesk
 

--- a/apps/docs/content/docs/en/integrations/zep.mdx
+++ b/apps/docs/content/docs/en/integrations/zep.mdx
@@ -36,7 +36,7 @@ Integrate Zep for long-term memory management. Create threads, add messages, ret
 
 ## Actions
 
-### `zep_create_thread`
+### Create Thread
 
 Start a new conversation thread in Zep
 
@@ -58,7 +58,7 @@ Start a new conversation thread in Zep
 | `createdAt` | string | Creation timestamp \(ISO 8601\) |
 | `projectUuid` | string | Project UUID |
 
-### `zep_get_threads`
+### Get Threads
 
 List all conversation threads
 
@@ -87,7 +87,7 @@ List all conversation threads
 | `responseCount` | number | Number of items in this response |
 | `totalCount` | number | Total number of items available |
 
-### `zep_delete_thread`
+### Delete Thread
 
 Delete a conversation thread from Zep
 
@@ -104,7 +104,7 @@ Delete a conversation thread from Zep
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the thread was deleted |
 
-### `zep_get_context`
+### Get User Context
 
 Retrieve user context from a thread with summary or basic mode
 
@@ -123,7 +123,7 @@ Retrieve user context from a thread with summary or basic mode
 | --------- | ---- | ----------- |
 | `context` | string | The context string \(summary or basic mode\) |
 
-### `zep_get_messages`
+### Get Messages
 
 Retrieve messages from a thread
 
@@ -153,7 +153,7 @@ Retrieve messages from a thread
 | `rowCount` | number | Number of rows returned |
 | `totalCount` | number | Total number of items available |
 
-### `zep_add_messages`
+### Add Messages
 
 Add messages to an existing thread
 
@@ -173,7 +173,7 @@ Add messages to an existing thread
 | `added` | boolean | Whether messages were added successfully |
 | `messageIds` | array | Array of added message UUIDs |
 
-### `zep_add_user`
+### Add User
 
 Create a new user in Zep
 
@@ -200,7 +200,7 @@ Create a new user in Zep
 | `createdAt` | string | Creation timestamp \(ISO 8601\) |
 | `metadata` | object | User metadata \(dynamic key-value pairs\) |
 
-### `zep_get_user`
+### Get User
 
 Retrieve user information from Zep
 
@@ -224,7 +224,7 @@ Retrieve user information from Zep
 | `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 | `metadata` | object | User metadata \(dynamic key-value pairs\) |
 
-### `zep_get_user_threads`
+### Get User Threads
 
 List all conversation threads for a specific user
 

--- a/apps/docs/content/docs/en/integrations/zerobounce.mdx
+++ b/apps/docs/content/docs/en/integrations/zerobounce.mdx
@@ -23,7 +23,7 @@ Integrate ZeroBounce to validate email deliverability in real time — detect in
 
 ## Actions
 
-### `zerobounce_verify_email`
+### ZeroBounce Verify Email
 
 Validate an email address deliverability in real time. Uses one validation credit.
 
@@ -45,7 +45,7 @@ Validate an email address deliverability in real time. Uses one validation credi
 | `freeEmail` | boolean | Whether the address is on a free email provider |
 | `didYouMean` | string | Suggested correction for a likely typo |
 
-### `zerobounce_get_credits`
+### ZeroBounce Get Credits
 
 Retrieve the remaining validation credits for the authenticated account.
 

--- a/apps/docs/content/docs/en/integrations/zoho_desk.mdx
+++ b/apps/docs/content/docs/en/integrations/zoho_desk.mdx
@@ -43,7 +43,7 @@ Read and update Zoho Desk tickets, manage comments and threads, look up contacts
 
 ## Actions
 
-### `zoho_desk_list_tickets`
+### Zoho Desk List Tickets
 
 List tickets from a Zoho Desk organization with optional filters. Returns a list projection: description, resolution, statusType and classification are only available from Get Ticket.
 
@@ -103,7 +103,7 @@ List tickets from a Zoho Desk organization with optional filters. Returns a list
 |   ↳ `cf` | json | Custom field values, keyed by custom field API name |
 | `count` | number | Number of tickets returned |
 
-### `zoho_desk_get_ticket`
+### Zoho Desk Get Ticket
 
 Retrieve a single Zoho Desk ticket by ID.
 
@@ -154,7 +154,7 @@ Retrieve a single Zoho Desk ticket by ID.
 |   ↳ `isSpam` | boolean | Whether the ticket is marked spam |
 |   ↳ `cf` | json | Custom field values, keyed by custom field API name |
 
-### `zoho_desk_update_ticket`
+### Zoho Desk Update Ticket
 
 Update fields on an existing Zoho Desk ticket.
 
@@ -216,7 +216,7 @@ Update fields on an existing Zoho Desk ticket.
 |   ↳ `isSpam` | boolean | Whether the ticket is marked spam |
 |   ↳ `cf` | json | Custom field values, keyed by custom field API name |
 
-### `zoho_desk_list_comments`
+### Zoho Desk List Comments
 
 List comments on a Zoho Desk ticket.
 
@@ -259,7 +259,7 @@ List comments on a Zoho Desk ticket.
 |     ↳ `href` | string | Download href |
 | `count` | number | Number of comments returned |
 
-### `zoho_desk_add_comment`
+### Zoho Desk Add Comment
 
 Add a comment to a Zoho Desk ticket.
 
@@ -301,7 +301,7 @@ Add a comment to a Zoho Desk ticket.
 |     ↳ `size` | string | File size as reported by Zoho |
 |     ↳ `href` | string | Download href |
 
-### `zoho_desk_list_threads`
+### Zoho Desk List Threads
 
 List conversation threads on a Zoho Desk ticket, newest first (Zoho sorts by sendDateTime descending by default). Returns a list projection: message bodies (content, summary, to/cc/bcc) come back only from Get Thread.
 
@@ -359,7 +359,7 @@ List conversation threads on a Zoho Desk ticket, newest first (Zoho sorts by sen
 |     ↳ `href` | string | Download href |
 | `count` | number | Number of threads returned |
 
-### `zoho_desk_get_thread`
+### Zoho Desk Get Thread
 
 Retrieve the full content of a single Zoho Desk ticket thread.
 
@@ -415,7 +415,7 @@ Retrieve the full content of a single Zoho Desk ticket thread.
 |     ↳ `size` | string | File size as reported by Zoho |
 |     ↳ `href` | string | Download href |
 
-### `zoho_desk_get_contact`
+### Zoho Desk Get Contact
 
 Retrieve a Zoho Desk contact by ID.
 
@@ -452,7 +452,7 @@ Retrieve a Zoho Desk contact by ID.
 |   ↳ `description` | string | Description |
 |   ↳ `cf` | json | Custom field values, keyed by custom field API name |
 
-### `zoho_desk_get_attachment`
+### Zoho Desk Get Attachment
 
 Download a Zoho Desk ticket attachment (from its href) as a file.
 
@@ -471,7 +471,7 @@ Download a Zoho Desk ticket attachment (from its href) as a file.
 | --------- | ---- | ----------- |
 | `file` | file | The downloaded attachment file |
 
-### `zoho_desk_list_organizations`
+### Zoho Desk List Organizations
 
 List the Zoho Desk organizations (portals) the connected account can access.
 

--- a/apps/docs/content/docs/en/integrations/zoom.mdx
+++ b/apps/docs/content/docs/en/integrations/zoom.mdx
@@ -41,7 +41,7 @@ Integrate Zoom into workflows. Create, list, update, and delete Zoom meetings. G
 
 ## Actions
 
-### `zoom_create_meeting`
+### Zoom Create Meeting
 
 Create a new Zoom meeting
 
@@ -113,7 +113,7 @@ Create a new Zoom meeting
 |     ↳ `duration` | number | Duration in minutes |
 |     ↳ `status` | string | Occurrence status |
 
-### `zoom_list_meetings`
+### Zoom List Meetings
 
 List all meetings for a Zoom user
 
@@ -149,7 +149,7 @@ List all meetings for a Zoom user
 |   ↳ `totalRecords` | number | Total number of records |
 |   ↳ `nextPageToken` | string | Token for next page of results |
 
-### `zoom_get_meeting`
+### Zoom Get Meeting
 
 Get details of a specific Zoom meeting
 
@@ -210,7 +210,7 @@ Get details of a specific Zoom meeting
 |     ↳ `duration` | number | Duration in minutes |
 |     ↳ `status` | string | Occurrence status |
 
-### `zoom_update_meeting`
+### Zoom Update Meeting
 
 Update an existing Zoom meeting
 
@@ -239,7 +239,7 @@ Update an existing Zoom meeting
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the meeting was updated successfully |
 
-### `zoom_delete_meeting`
+### Zoom Delete Meeting
 
 Delete or cancel a Zoom meeting
 
@@ -258,7 +258,7 @@ Delete or cancel a Zoom meeting
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the meeting was deleted successfully |
 
-### `zoom_get_meeting_invitation`
+### Zoom Get Meeting Invitation
 
 Get the meeting invitation text for a Zoom meeting
 
@@ -274,7 +274,7 @@ Get the meeting invitation text for a Zoom meeting
 | --------- | ---- | ----------- |
 | `invitation` | string | The meeting invitation text |
 
-### `zoom_list_recordings`
+### Zoom List Recordings
 
 List all cloud recordings for a Zoom user
 
@@ -324,7 +324,7 @@ List all cloud recordings for a Zoom user
 |   ↳ `totalRecords` | number | Total number of records |
 |   ↳ `nextPageToken` | string | Token for next page of results |
 
-### `zoom_get_meeting_recordings`
+### Zoom Get Meeting Recordings
 
 Get all recordings for a specific Zoom meeting
 
@@ -367,7 +367,7 @@ Get all recordings for a specific Zoom meeting
 |     ↳ `recording_type` | string | Type of recording \(shared_screen, audio_only, etc.\) |
 | `files` | file[] | Downloaded recording files |
 
-### `zoom_delete_recording`
+### Zoom Delete Recording
 
 Delete cloud recordings for a Zoom meeting
 
@@ -385,7 +385,7 @@ Delete cloud recordings for a Zoom meeting
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the recording was deleted successfully |
 
-### `zoom_list_past_participants`
+### Zoom List Past Participants
 
 List participants from a past Zoom meeting
 

--- a/apps/docs/content/docs/en/integrations/zoominfo.mdx
+++ b/apps/docs/content/docs/en/integrations/zoominfo.mdx
@@ -42,7 +42,7 @@ Integrates ZoomInfo into the workflow. Search companies and contacts, enrich fir
 
 ## Actions
 
-### `zoominfo_search_companies`
+### ZoomInfo Search Companies
 
 Search the ZoomInfo company database by name, industry, location, and size.
 
@@ -75,7 +75,7 @@ Search the ZoomInfo company database by name, industry, location, and size.
 | --------- | ---- | ----------- |
 | `companies` | array | Matching companies |
 
-### `zoominfo_search_contacts`
+### ZoomInfo Search Contacts
 
 Search ZoomInfo for contacts (people) by name, job title, company, and other filters. Does not return emails or phone numbers — use Enrich Contacts for engagement data.
 
@@ -108,7 +108,7 @@ Search ZoomInfo for contacts (people) by name, job title, company, and other fil
 | --------- | ---- | ----------- |
 | `contacts` | array | Matching contacts \(without emails or phone numbers\) |
 
-### `zoominfo_enrich_companies`
+### ZoomInfo Enrich Companies
 
 Enrich up to 25 companies in one request with detailed firmographics, industry, financials, and more.
 
@@ -127,7 +127,7 @@ Enrich up to 25 companies in one request with detailed firmographics, industry, 
 | --------- | ---- | ----------- |
 | `results` | array | Enrichment results, one per input with match status and attributes |
 
-### `zoominfo_enrich_contacts`
+### ZoomInfo Enrich Contacts
 
 Enrich up to 25 contacts in one request with verified emails, phone numbers, job details, and more.
 
@@ -147,7 +147,7 @@ Enrich up to 25 contacts in one request with verified emails, phone numbers, job
 | --------- | ---- | ----------- |
 | `results` | array | Enrichment results, one per input with match status and attributes |
 
-### `zoominfo_search_intent`
+### ZoomInfo Search Intent
 
 Search for companies showing intent signals on specific topics.
 
@@ -177,7 +177,7 @@ Search for companies showing intent signals on specific topics.
 | --------- | ---- | ----------- |
 | `signals` | array | Intent signals with topic, score, audience strength, and company |
 
-### `zoominfo_search_news`
+### ZoomInfo Search News
 
 Search ZoomInfo news articles by category, URL, or date range.
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -255,6 +255,55 @@ interface TriggerConfigField {
   placeholder?: string
 }
 
+/** The subset of `SubBlockConfig` the generated configuration table reads. */
+interface RegistrySubBlock {
+  id?: string
+  type?: string
+  title?: string
+  description?: string
+  placeholder?: unknown
+  /** `true`, or a condition object making the field required only for some configurations. */
+  required?: unknown
+  readOnly?: boolean
+}
+
+interface RegistryTrigger {
+  subBlocks?: RegistrySubBlock[]
+}
+
+/** Present for the operator, not part of a trigger's configuration surface. */
+const TRIGGER_UI_ONLY_IDS = new Set([
+  'webhookUrlDisplay',
+  'triggerInstructions',
+  'selectedTriggerId',
+])
+
+/**
+ * Loads the evaluated trigger registry.
+ *
+ * Imported by absolute path so Bun resolves the `@/` aliases against `apps/sim`'s tsconfig
+ * rather than this script's.
+ */
+async function loadTriggerRegistry(): Promise<Record<string, RegistryTrigger>> {
+  const module = await import(path.join(rootDir, 'apps/sim/triggers/registry.ts'))
+  return module.TRIGGER_REGISTRY as Record<string, RegistryTrigger>
+}
+
+/** Human-facing tool names, keyed by tool id. Kept in sync with the registry by CI. */
+let toolDisplayNames: Map<string, string> | null = null
+
+async function loadToolDisplayNames(): Promise<Map<string, string>> {
+  if (toolDisplayNames) return toolDisplayNames
+  const module = await import(path.join(rootDir, 'apps/sim/tools/generated/tool-metadata.ts'))
+  const metadata = module.default as Record<string, { name?: string }>
+  toolDisplayNames = new Map(
+    Object.entries(metadata).flatMap(([id, entry]) =>
+      entry?.name ? [[id, entry.name] as const] : []
+    )
+  )
+  return toolDisplayNames
+}
+
 interface TriggerFullInfo {
   id: string
   name: string
@@ -377,7 +426,6 @@ async function generateIconMapping(options: {
       // First, extract the primary icon from the file (usually the legacy block's icon)
       const primaryIcon = extractIconNameFromContent(fileContent)
 
-      // Find all block exports and their types
       const exportRegex = /export\s+const\s+(\w+)Block\s*:\s*BlockConfig[^=]*=\s*\{/g
       let match
 
@@ -385,7 +433,6 @@ async function generateIconMapping(options: {
         const blockName = match[1]
         const startIndex = match.index + match[0].length - 1
 
-        // Extract the block content
         const endIndex = findMatchingClose(fileContent, startIndex)
 
         if (endIndex !== -1) {
@@ -401,18 +448,15 @@ async function generateIconMapping(options: {
             continue
           }
 
-          // Get block type
           const blockType =
             extractStringPropertyFromContent(blockContent, 'type') || blockName.toLowerCase()
 
-          // Get icon - either from this block or inherited from primary
           const iconName = extractIconNameFromContent(blockContent) || primaryIcon
 
           if (!blockType || !iconName) {
             continue
           }
 
-          // Skip trigger/webhook/rss blocks
           if (
             blockType.includes('_trigger') ||
             blockType.includes('_webhook') ||
@@ -421,7 +465,6 @@ async function generateIconMapping(options: {
             continue
           }
 
-          // Get category for additional filtering
           const category = extractStringPropertyFromContent(blockContent, 'category') || 'misc'
 
           // Exclude first-party `blocks`-category primitives (except the native
@@ -542,7 +585,6 @@ function extractOperationsFromContent(blockContent: string): { label: string; id
   const subBlocksMatch = /subBlocks\s*:\s*\[/.exec(blockContent)
   if (!subBlocksMatch) return []
 
-  // Locate the opening '[' of the subBlocks array
   const arrayStart = subBlocksMatch.index + subBlocksMatch[0].length - 1
   const arrayEnd = findMatchingClose(blockContent, arrayStart, '[', ']')
   if (arrayEnd === -1) return []
@@ -565,7 +607,6 @@ function extractOperationsFromContent(blockContent: string): { label: string; id
         if (optArrayEnd === -1) return []
         const optionsContent = objContent.substring(optArrayStart + 1, optArrayEnd - 1)
 
-        // Extract { label, id } pairs from each option object
         const pairs: { label: string; id: string }[] = []
         const optionObjectRegex = /\{[^{}]*\}/g
         let m
@@ -976,7 +1017,6 @@ async function writeIntegrationsJson(iconMapping: Record<string, IconRef>): Prom
             const switchMappedId = switchCaseMap.get(id)
             if (switchMappedId) {
               opDesc = toolDescMap.get(switchMappedId) || ''
-              // Also check versioned variants in tools.access (e.g. gmail_send_v2)
               if (!opDesc) {
                 for (const tId of toolsAccess) {
                   if (tId === switchMappedId || tId.startsWith(`${switchMappedId}_v`)) {
@@ -1046,7 +1086,6 @@ async function writeIntegrationsJson(iconMapping: Record<string, IconRef>): Prom
       }
     }
 
-    // Sort alphabetically by name for a predictable, crawl-friendly order
     integrations.sort((a, b) => a.name.localeCompare(b.name))
 
     const jsonPath = path.join(INTEGRATIONS_DATA_PATH, 'integrations.json')
@@ -1094,7 +1133,6 @@ function extractAllBlockConfigs(fileContent: string): BlockConfig[] {
   // First, extract the primary icon from the file (for V2 blocks that inherit via spread)
   const primaryIcon = extractIconNameFromContent(fileContent)
 
-  // Find all block exports in the file
   const exportRegex = /export\s+const\s+(\w+)Block\s*:\s*BlockConfig[^=]*=\s*\{/g
   let match
 
@@ -1102,13 +1140,11 @@ function extractAllBlockConfigs(fileContent: string): BlockConfig[] {
     const blockName = match[1]
     const startIndex = match.index + match[0].length - 1 // Position of opening brace
 
-    // Extract the block content by matching braces
     const endIndex = findMatchingClose(fileContent, startIndex)
 
     if (endIndex !== -1) {
       const blockContent = fileContent.substring(startIndex, endIndex)
 
-      // Check if this block has hideFromToolbar: true
       const hideFromToolbar = /hideFromToolbar\s*:\s*true/.test(stripSourceComments(blockContent))
       if (hideFromToolbar) {
         console.log(`Skipping ${blockName}Block - hideFromToolbar is true`)
@@ -1162,7 +1198,6 @@ function extractBlockConfigFromContent(
     let baseConfig: BlockConfig | null = null
 
     if (spreadBase && fileContent) {
-      // Extract the base block's content from the file
       const baseBlockRegex = new RegExp(
         `export\\s+const\\s+${spreadBase}\\s*:\\s*BlockConfig[^=]*=\\s*\\{`,
         'g'
@@ -1553,7 +1588,6 @@ function extractToolsAccessFromContent(content: string): string[] {
 function getToolPrefixFromName(toolName: string): string {
   const parts = toolName.split('_')
 
-  // Try to find a valid tool directory
   for (let i = parts.length - 1; i >= 1; i--) {
     const possiblePrefix = parts.slice(0, i).join('_')
     const toolDirPath = path.join(rootDir, `apps/sim/tools/${possiblePrefix}`)
@@ -1592,10 +1626,8 @@ function resolveConstReference(
     return constResolutionCache.get(cacheKey)!
   }
 
-  // Read the types file for this tool
   const typesFilePath = path.join(rootDir, `apps/sim/tools/${toolPrefix}/types.ts`)
   if (!fs.existsSync(typesFilePath)) {
-    // Try to find const in the tool file itself
     return null
   }
 
@@ -1613,7 +1645,6 @@ function resolveConstReference(
     return null
   }
 
-  // Extract the const content
   const startIndex = constMatch.index + constMatch[0].length - 1
   const endIndex = findMatchingClose(typesContent, startIndex)
 
@@ -1661,7 +1692,6 @@ function parseConstProperties(
   while ((spreadMatch = spreadRegex.exec(content)) !== null) {
     const constName = spreadMatch[1]
 
-    // Check if at depth 0
     const beforeMatch = content.substring(0, spreadMatch.index)
     const openBraces = (beforeMatch.match(/\{/g) || []).length
     const closeBraces = (beforeMatch.match(/\}/g) || []).length
@@ -1676,7 +1706,6 @@ function parseConstProperties(
     }
   }
 
-  // Find all top-level property definitions
   const propRegex = /(\w+)\s*:\s*(?:\{|([A-Z][A-Z_0-9]+)(?:\s*,|\s*$))/g
   let match
 
@@ -1684,12 +1713,10 @@ function parseConstProperties(
     const propName = match[1]
     const constRef = match[2]
 
-    // Skip 'items' keyword (always a nested structure, never a field name)
     if (propName === 'items') {
       continue
     }
 
-    // Check if this match is at depth 0 (not inside nested braces)
     const beforeMatch = content.substring(0, match.index)
     const openBraces = (beforeMatch.match(/\{/g) || []).length
     const closeBraces = (beforeMatch.match(/\}/g) || []).length
@@ -1758,7 +1785,6 @@ function resolveConstFromTypesContent(
     return constResolutionCache.get(cacheKey)!
   }
 
-  // Find the const definition in typesContent
   const constRegex = new RegExp(
     `export\\s+const\\s+${constName}\\s*(?::\\s*[^=]+)?\\s*=\\s*\\{`,
     'g'
@@ -2075,7 +2101,6 @@ function extractToolInfo(
       )
       if (inheritedDescMatch) {
         const baseTool = inheritedDescMatch[1]
-        // Try to find the base tool's description in the file
         const baseToolDescRegex = new RegExp(
           `export\\s+const\\s+${baseTool}Tool[^{]*\\{[\\s\\S]*?description\\s*:\\s*(?:'([^']+)'|"([^"]+)"|\`([^\`]+)\`)`,
           'i'
@@ -2116,7 +2141,6 @@ function extractToolInfo(
           const char = content[i]
           const prevChar = i > 0 ? content[i - 1] : ''
 
-          // Skip escaped quotes
           if (prevChar === '\\') continue
 
           if (char === "'" && !inDoubleQuote && !inBacktick) {
@@ -2184,7 +2208,6 @@ function extractToolInfo(
       }
     }
 
-    // Get the tool prefix for resolving const references
     const toolPrefix = getToolPrefixFromName(toolName)
 
     let outputs = extractOutputsFromToolContent(toolContent, toolPrefix)
@@ -2255,16 +2278,7 @@ function formatOutputStructure(outputs: Record<string, any>, indentLevel = 0): s
       }
     }
 
-    const escapedDescription = description
-      .replace(/\|/g, '\\|')
-      .replace(/\{/g, '\\{')
-      .replace(/\}/g, '\\}')
-      .replace(/\(/g, '\\(')
-      .replace(/\)/g, '\\)')
-      .replace(/\[/g, '\\[')
-      .replace(/\]/g, '\\]')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
+    const escapedDescription = escapeMdxCell(description)
 
     // Build prefix based on indent level - each level adds 2 spaces before the arrow
     let prefix = ''
@@ -2311,7 +2325,6 @@ function parseToolOutputsField(outputsContent: string, toolPrefix?: string): Rec
       const propName = constMatch[1]
       const constName = constMatch[2]
 
-      // Check if at depth 0
       const beforeMatch = outputsContent.substring(0, constMatch.index)
       const openBraces = (beforeMatch.match(/\{/g) || []).length
       const closeBraces = (beforeMatch.match(/\}/g) || []).length
@@ -2333,12 +2346,10 @@ function parseToolOutputsField(outputsContent: string, toolPrefix?: string): Rec
       const constName = propAccessMatch[2]
       const accessedProp = propAccessMatch[3]
 
-      // Skip if already resolved
       if (outputs[propName]) {
         continue
       }
 
-      // Check if at depth 0
       const beforeMatch = outputsContent.substring(0, propAccessMatch.index)
       const openBraces = (beforeMatch.match(/\{/g) || []).length
       const closeBraces = (beforeMatch.match(/\}/g) || []).length
@@ -2358,7 +2369,6 @@ function parseToolOutputsField(outputsContent: string, toolPrefix?: string): Rec
     while ((spreadMatch = spreadRegex.exec(outputsContent)) !== null) {
       const constName = spreadMatch[1]
 
-      // Check if at depth 0 (not inside nested braces)
       const beforeMatch = outputsContent.substring(0, spreadMatch.index)
       const openBraces = (beforeMatch.match(/\{/g) || []).length
       const closeBraces = (beforeMatch.match(/\}/g) || []).length
@@ -2402,7 +2412,6 @@ function parseToolOutputsField(outputsContent: string, toolPrefix?: string): Rec
     const fieldName = match[1]
     const bracePos = match.index + match[0].length - 1
 
-    // Skip if already resolved as const reference
     if (outputs[fieldName]) {
       continue
     }
@@ -2614,12 +2623,10 @@ function parsePropertiesContent(
       const propName = constMatch[1]
       const constName = constMatch[2]
 
-      // Skip keywords
       if (propName === 'items' || propName === 'properties' || propName === 'type') {
         continue
       }
 
-      // Check if at depth 0
       const beforeMatch = propertiesContent.substring(0, constMatch.index)
       const openBraces = (beforeMatch.match(/\{/g) || []).length
       const closeBraces = (beforeMatch.match(/\}/g) || []).length
@@ -2641,17 +2648,14 @@ function parsePropertiesContent(
       const constName = propAccessMatch[2]
       const accessedProp = propAccessMatch[3]
 
-      // Skip keywords
       if (propName === 'items' || propName === 'properties' || propName === 'type') {
         continue
       }
 
-      // Skip if already resolved
       if (properties[propName]) {
         continue
       }
 
-      // Check if at depth 0
       const beforeMatch = propertiesContent.substring(0, propAccessMatch.index)
       const openBraces = (beforeMatch.match(/\{/g) || []).length
       const closeBraces = (beforeMatch.match(/\}/g) || []).length
@@ -2671,7 +2675,6 @@ function parsePropertiesContent(
     while ((spreadMatch = spreadRegex.exec(propertiesContent)) !== null) {
       const constName = spreadMatch[1]
 
-      // Check if at depth 0
       const beforeMatch = propertiesContent.substring(0, spreadMatch.index)
       const openBraces = (beforeMatch.match(/\{/g) || []).length
       const closeBraces = (beforeMatch.match(/\}/g) || []).length
@@ -2698,7 +2701,6 @@ function parsePropertiesContent(
       continue
     }
 
-    // Skip if already resolved as const reference
     if (properties[propName]) {
       continue
     }
@@ -2777,7 +2779,6 @@ async function getToolInfo(toolName: string): Promise<{
       toolSuffix = parts.slice(1).join('_')
     }
 
-    // Check if this is a versioned tool (e.g., _v2, _v3)
     const isVersionedTool = isVersionedType(toolSuffix)
     const strippedToolSuffix = stripVersionSuffix(toolSuffix)
 
@@ -2786,7 +2787,6 @@ async function getToolInfo(toolName: string): Promise<{
     // For versioned tools, prioritize the exact versioned file first
     // This handles cases like google_sheets where V2 is in a separate file (read_v2.ts)
     if (isVersionedTool) {
-      // First priority: exact versioned file (e.g., read_v2.ts)
       possibleLocations.push({
         path: path.join(rootDir, `apps/sim/tools/${toolPrefix}/${toolSuffix}.ts`),
         priority: 'exact',
@@ -2804,7 +2804,6 @@ async function getToolInfo(toolName: string): Promise<{
       })
     }
 
-    // Also try camelCase versions
     const camelCaseSuffix = strippedToolSuffix
       .split('_')
       .map((part, i) => (i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
@@ -2824,12 +2823,10 @@ async function getToolInfo(toolName: string): Promise<{
     let foundFile = ''
     let foundExactId = false
 
-    // Try to find a file that contains the exact tool ID
     for (const location of possibleLocations) {
       if (fs.existsSync(location.path)) {
         const content = fs.readFileSync(location.path, 'utf-8')
 
-        // Check if this file contains the exact tool ID we're looking for
         const toolIdRegex = new RegExp(`id:\\s*['"]${toolName}['"]`)
         if (toolIdRegex.test(content)) {
           toolFileContent = content
@@ -3056,16 +3053,7 @@ async function generateMarkdownForBlock(
       const output = outputs[outputKey]
 
       const escapedDescription = output.description
-        ? output.description
-            .replace(/\|/g, '\\|')
-            .replace(/\{/g, '\\{')
-            .replace(/\}/g, '\\}')
-            .replace(/\(/g, '\\(')
-            .replace(/\)/g, '\\)')
-            .replace(/\[/g, '\\[')
-            .replace(/\]/g, '\\]')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
+        ? escapeMdxCell(output.description)
         : `Output from ${outputKey}`
 
       if (typeof output.type === 'string') {
@@ -3088,16 +3076,7 @@ async function generateMarkdownForBlock(
         for (const propName in output.properties) {
           const prop = output.properties[propName]
           const escapedPropertyDescription = prop.description
-            ? prop.description
-                .replace(/\|/g, '\\|')
-                .replace(/\{/g, '\\{')
-                .replace(/\}/g, '\\}')
-                .replace(/\(/g, '\\(')
-                .replace(/\)/g, '\\)')
-                .replace(/\[/g, '\\[')
-                .replace(/\]/g, '\\]')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
+            ? escapeMdxCell(prop.description)
             : `The ${propName} of the ${outputKey}`
 
           outputsSection += `| ↳ \`${propName}\` | ${prop.type} | ${escapedPropertyDescription} |\n`
@@ -3112,19 +3091,21 @@ async function generateMarkdownForBlock(
   if (tools.access?.length) {
     toolsSection = '## Actions\n\n'
 
+    const displayNames = await loadToolDisplayNames()
+
     for (const tool of tools.access) {
-      // Strip version suffix from tool name for display
-      const displayToolName = stripVersionSuffix(tool)
-      toolsSection += `### \`${displayToolName}\`\n\n`
+      // Prefer the tool's own name ("A2A Send Message") over its id — the id is an
+      // implementation detail, and these headings are what the page's table of
+      // contents shows. Falls back to the id for a tool missing from the metadata.
+      const heading = displayNames.get(tool) ?? displayNames.get(stripVersionSuffix(tool))
+      toolsSection += `### ${heading ?? stripVersionSuffix(tool)}\n\n`
 
       console.log(`Getting info for tool: ${tool}`)
       const toolInfo = await getToolInfo(tool)
 
       if (toolInfo) {
         if (toolInfo.description && toolInfo.description !== 'No description available') {
-          const escapedToolDescription = toolInfo.description
-            .replace(/\{/g, '\\{')
-            .replace(/\}/g, '\\}')
+          const escapedToolDescription = escapeMdxProse(toolInfo.description)
           toolsSection += `${escapedToolDescription}\n\n`
         }
 
@@ -3135,16 +3116,7 @@ async function generateMarkdownForBlock(
         if (toolInfo.params.length > 0) {
           for (const param of toolInfo.params) {
             const escapedDescription = param.description
-              ? param.description
-                  .replace(/\|/g, '\\|')
-                  .replace(/\{/g, '\\{')
-                  .replace(/\}/g, '\\}')
-                  .replace(/\(/g, '\\(')
-                  .replace(/\)/g, '\\)')
-                  .replace(/\[/g, '\\[')
-                  .replace(/\]/g, '\\]')
-                  .replace(/</g, '&lt;')
-                  .replace(/>/g, '&gt;')
+              ? escapeMdxCell(param.description)
               : 'No description'
 
             toolsSection += `| \`${param.name}\` | ${param.type} | ${param.required ? 'Yes' : 'No'} | ${escapedDescription} |\n`
@@ -3177,16 +3149,7 @@ async function generateMarkdownForBlock(
               }
             }
 
-            const escapedDescription = description
-              .replace(/\|/g, '\\|')
-              .replace(/\{/g, '\\{')
-              .replace(/\}/g, '\\}')
-              .replace(/\(/g, '\\(')
-              .replace(/\)/g, '\\)')
-              .replace(/\[/g, '\\[')
-              .replace(/\]/g, '\\]')
-              .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;')
+            const escapedDescription = escapeMdxCell(description)
 
             toolsSection += `| \`${key}\` | ${type} | ${escapedDescription} |\n`
           }
@@ -3332,6 +3295,23 @@ function formatTriggerProviderName(provider: string): string {
 /**
  * Escape text for use inside an MDX table cell.
  */
+/**
+ * Escapes MDX-hostile characters in text emitted as a paragraph rather than a table cell.
+ *
+ * MDX reads `{` as an expression and `<` as the start of a JSX tag, so a tool description
+ * like `The copy is named "<original> - copy"` fails the docs build outright with
+ * "Expected a closing tag for `<original>`". Unlike {@link escapeMdxCell} this leaves
+ * pipes, parens and brackets alone — those are legal in prose, and escaping them would
+ * mangle markdown links.
+ */
+function escapeMdxProse(text: string): string {
+  return text
+    .replace(/\{/g, '\\{')
+    .replace(/\}/g, '\\}')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
 function escapeMdxCell(text: string): string {
   return text
     .replace(/\|/g, '\\|')
@@ -3443,7 +3423,6 @@ function resolveTriggerBuilderFunction(
     )
   }
 
-  // Handle `return { ... }` — inline object literal
   const returnMatch = /\breturn\s*\{/.exec(funcBody)
   if (!returnMatch) return {}
 
@@ -3625,237 +3604,35 @@ function matchQuotedProperty(content: string, propName: string): string | undefi
   return match[1] ?? match[2] ?? match[3]
 }
 
-function parseSubBlockObject(
-  obj: string,
-  uiOnlyIds: Set<string>,
-  resolverContent?: string
-): TriggerConfigField | null {
-  let id: string | undefined = matchQuotedProperty(obj, 'id')
-
-  // Handle const-reference ids: `id: SCREAMING_CASE_IDENTIFIER`
-  if (!id) {
-    const constRefMatch = /\bid\s*:\s*([A-Z][A-Z0-9_]+)\b/.exec(obj)
-    if (constRefMatch) {
-      id = resolveConstStringValue(constRefMatch[1], resolverContent ?? '') ?? undefined
-    }
-  }
-
-  if (!id || uiOnlyIds.has(id)) return null
-
-  const type = matchQuotedProperty(obj, 'type')
-  if (type === 'text') return null
-  if (/\breadOnly\s*:\s*true/.test(obj)) return null
-
-  const title = matchQuotedProperty(obj, 'title')
-  const requiredMatch = /\brequired\s*:\s*(true)/.exec(obj)
-  const placeholder = matchQuotedProperty(obj, 'placeholder')
-
-  // Use title as description fallback so oauth-input and other fields without
-  // an explicit description still show something meaningful in the docs table.
-  const description = matchQuotedProperty(obj, 'description') ?? title
-
-  return {
-    id,
-    title: title ?? id,
-    type: type ?? 'short-input',
-    required: Boolean(requiredMatch),
-    placeholder,
-    description,
-  }
-}
-
 /**
- * Resolve a SubBlockConfig builder function to its field definitions.
- * Handles `return [...]`, `return {...}`, and `blocks.push(...)` patterns.
- * Searches `utilsContent` first, then `primaryContent`.
+ * A trigger's user-facing configuration fields, in declaration order.
+ *
+ * Read from the evaluated registry rather than parsed out of source. Static parsing silently
+ * dropped every field whose builder assembled its array imperatively or took a description as
+ * a parameter — that is how all ten Jira triggers lost `webhookSecret` and `jqlFilter` — and
+ * a regex that recovered them also invented `fieldFilters` on the nine triggers that never
+ * declare it. Wrong config is worse than absent config, so this evaluates the real objects.
  */
-function resolveSubBlockBuilderFunction(
-  funcName: string,
-  utilsContent: string,
-  primaryContent?: string
-): TriggerConfigField[] {
-  const UI_ONLY_IDS = new Set(['webhookUrlDisplay', 'triggerInstructions', 'selectedTriggerId'])
-
-  for (const content of [utilsContent, primaryContent ?? '']) {
-    if (!content) continue
-    const funcRegex = new RegExp(`(?:export\\s+)?function\\s+${funcName}\\s*\\(`)
-    const funcMatch = funcRegex.exec(content)
-    if (!funcMatch) continue
-
-    // Find the closing ')' of the parameter list, then the '{' that opens the function body.
-    // Using just indexOf('{') would pick up '{' inside object-type parameters.
-    const openParen = content.indexOf('(', funcMatch.index)
-    if (openParen === -1) continue
-    const closeParen = findMatchingClose(content, openParen, '(', ')')
-    if (closeParen === -1) continue
-    const bodyStart = content.indexOf('{', closeParen)
-    if (bodyStart === -1) continue
-    const bodyEnd = findMatchingClose(content, bodyStart)
-    if (bodyEnd === -1) continue
-
-    const funcBody = content.substring(bodyStart + 1, bodyEnd - 1)
-
-    // Pattern 1: `return [...]`
-    const returnArrayMatch = /\breturn\s*\[/.exec(funcBody)
-    if (returnArrayMatch) {
-      const arrayStart = funcBody.indexOf('[', returnArrayMatch.index)
-      const arrayEnd = findMatchingClose(funcBody, arrayStart, '[', ']')
-      if (arrayEnd !== -1) {
-        return parseSubBlockArrayContent(
-          funcBody.substring(arrayStart + 1, arrayEnd - 1),
-          UI_ONLY_IDS,
-          content
-        )
-      }
-    }
-
-    // Pattern 2: `return { ... }` (single object)
-    const returnObjMatch = /\breturn\s*\{/.exec(funcBody)
-    if (returnObjMatch) {
-      const objStart = funcBody.indexOf('{', returnObjMatch.index)
-      const objEnd = findMatchingClose(funcBody, objStart)
-      if (objEnd !== -1) {
-        const field = parseSubBlockObject(
-          funcBody.substring(objStart, objEnd),
-          UI_ONLY_IDS,
-          content
-        )
-        return field ? [field] : []
-      }
-    }
-
-    // Pattern 3: `blocks.push({...})`
-    const pushFields: TriggerConfigField[] = []
-    const pushRegex = /\bblocks\.push\s*\(/g
-    let pushMatch: RegExpExecArray | null
-    while ((pushMatch = pushRegex.exec(funcBody)) !== null) {
-      const parenStart = pushMatch.index + pushMatch[0].length - 1
-      const parenEnd = findMatchingClose(funcBody, parenStart, '(', ')')
-      if (parenEnd === -1) continue
-      const pushArg = funcBody.substring(parenStart + 1, parenEnd - 1).trim()
-      if (pushArg.startsWith('{')) {
-        const field = parseSubBlockObject(pushArg, UI_ONLY_IDS, content)
-        if (field) pushFields.push(field)
-      }
-    }
-    if (pushFields.length > 0) return pushFields
-  }
-
-  return []
-}
-
-/**
- * Parse SubBlockConfig items from within an array body (between the brackets).
- * Handles inline `{...}` objects and function calls `funcName(...)`.
- */
-function parseSubBlockArrayContent(
-  arrayContent: string,
-  uiOnlyIds: Set<string>,
-  utilsContent: string
-): TriggerConfigField[] {
+function triggerConfigFields(trigger: RegistryTrigger | undefined): TriggerConfigField[] {
   const fields: TriggerConfigField[] = []
-  let i = 0
-
-  while (i < arrayContent.length) {
-    if (arrayContent[i] === '{') {
-      const j = findMatchingClose(arrayContent, i)
-      if (j === -1) break
-      const field = parseSubBlockObject(arrayContent.substring(i, j), uiOnlyIds, utilsContent)
-      if (field) fields.push(field)
-      i = j
-    } else if (/[a-zA-Z_]/.test(arrayContent[i])) {
-      // Possible function call: funcName(args)
-      const funcCallMatch = /^(\w+)\s*\(/.exec(arrayContent.substring(i))
-      if (funcCallMatch && utilsContent) {
-        const funcName = funcCallMatch[1]
-        if (funcName !== 'true' && funcName !== 'false' && funcName !== 'null') {
-          fields.push(...resolveSubBlockBuilderFunction(funcName, utilsContent))
-        }
-        // Advance past the function call's closing paren
-        const openIdx = arrayContent.indexOf('(', i + funcName.length)
-        if (openIdx !== -1) {
-          const closeIdx = findMatchingClose(arrayContent, openIdx, '(', ')')
-          i = closeIdx !== -1 ? closeIdx : openIdx + 1
-        } else {
-          i += funcName.length
-        }
-      } else {
-        i++
-      }
-    } else {
-      i++
-    }
+  for (const subBlock of trigger?.subBlocks ?? []) {
+    if (!subBlock.id || TRIGGER_UI_ONLY_IDS.has(subBlock.id)) continue
+    if (subBlock.type === 'text' || subBlock.readOnly === true) continue
+    fields.push({
+      id: subBlock.id,
+      title: subBlock.title ?? subBlock.id,
+      type: subBlock.type ?? 'short-input',
+      // Only an unconditional `true` counts. `required` is also allowed to be a
+      // condition object (`{ field, value }`), which makes the field required for
+      // some configurations and not others — "No" is the honest summary there.
+      required: subBlock.required === true,
+      placeholder: typeof subBlock.placeholder === 'string' ? subBlock.placeholder : undefined,
+      // Falling back to the title keeps oauth-input and other description-less
+      // fields from rendering an empty cell.
+      description: subBlock.description ?? subBlock.title,
+    })
   }
-
   return fields
-}
-
-/**
- * Extract user-facing configuration fields from a TriggerConfig subBlocks definition.
- * Handles both inline arrays (`subBlocks: [...]`) and builder function calls
- * (`subBlocks: buildXSubBlocks({...})`), resolving them from the trigger file and utils.ts.
- */
-function extractTriggerConfigFields(
-  segment: string,
-  primaryContent?: string,
-  utilsContent?: string
-): TriggerConfigField[] {
-  const UI_ONLY_IDS = new Set(['webhookUrlDisplay', 'triggerInstructions', 'selectedTriggerId'])
-  const allContent = utilsContent || primaryContent || ''
-
-  // Case 1: Inline subBlocks: [...]
-  const subBlocksMatch = /\bsubBlocks\s*:\s*\[/.exec(segment)
-  if (subBlocksMatch) {
-    const arrayStart = subBlocksMatch.index + subBlocksMatch[0].length - 1
-    const arrayEnd = findMatchingClose(segment, arrayStart, '[', ']')
-    if (arrayEnd === -1) return []
-    return parseSubBlockArrayContent(
-      segment.substring(arrayStart + 1, arrayEnd - 1),
-      UI_ONLY_IDS,
-      allContent
-    )
-  }
-
-  // Case 2: Builder function call — subBlocks: buildXFunc(...)
-  if (!allContent) return []
-  const builderCallMatch = /\bsubBlocks\s*:\s*(\w+)\s*\(/.exec(segment)
-  if (!builderCallMatch) return []
-
-  const funcName = builderCallMatch[1]
-
-  // Special case: buildTriggerSubBlocks — user config lives in the `extraFields` parameter
-  if (funcName === 'buildTriggerSubBlocks') {
-    const openParen = builderCallMatch.index + builderCallMatch[0].length - 1
-    const closeParen = findMatchingClose(segment, openParen, '(', ')')
-    if (closeParen === -1) return []
-
-    const argsBody = segment.substring(openParen + 1, closeParen - 1)
-    const extraFieldsMatch = /\bextraFields\s*:\s*/.exec(argsBody)
-    if (!extraFieldsMatch) return []
-
-    // Find first non-whitespace char after "extraFields:"
-    let valuePos = extraFieldsMatch.index + extraFieldsMatch[0].length
-    while (valuePos < argsBody.length && /\s/.test(argsBody[valuePos])) valuePos++
-
-    if (argsBody[valuePos] === '[') {
-      // extraFields: [...] — inline array, may contain function calls
-      const arrayEnd = findMatchingClose(argsBody, valuePos, '[', ']')
-      if (arrayEnd === -1) return []
-      return parseSubBlockArrayContent(
-        argsBody.substring(valuePos + 1, arrayEnd - 1),
-        UI_ONLY_IDS,
-        allContent
-      )
-    }
-
-    // extraFields: buildXFunc(args) — resolve the builder function
-    const extraFuncMatch = /^(\w+)\s*\(/.exec(argsBody.substring(valuePos))
-    if (!extraFuncMatch) return []
-    return resolveSubBlockBuilderFunction(extraFuncMatch[1], allContent)
-  }
-
-  // For all other builders, resolve the function body directly
-  return resolveSubBlockBuilderFunction(funcName, allContent)
 }
 
 /**
@@ -3869,13 +3646,14 @@ async function buildFullTriggerRegistry(): Promise<Map<string, TriggerFullInfo>>
   const triggerFiles = (await glob(`${TRIGGERS_PATH}/**/*.ts`)).filter(
     (f) => !SKIP.has(path.basename(f)) && !f.includes('.test.')
   )
+  const registryTriggers = await loadTriggerRegistry()
 
   for (const file of triggerFiles) {
     try {
       const content = fs.readFileSync(file, 'utf-8')
 
-      // Load sibling modules (utils.ts, shared.ts, …) so builder functions and
-      // shared output/config constants referenced by name still resolve.
+      // Load sibling modules (utils.ts, shared.ts, …) so shared output constants
+      // referenced by name still resolve.
       const utilsContent = readTriggerSiblingModules(file)
 
       const exportRegex = /export\s+const\s+\w+\s*:\s*TriggerConfig\s*=\s*\{/g
@@ -3911,7 +3689,7 @@ async function buildFullTriggerRegistry(): Promise<Map<string, TriggerFullInfo>>
           provider: providerMatch[1],
           polling,
           outputs: extractTriggerOutputs(segment, content, utilsContent),
-          configFields: extractTriggerConfigFields(segment, content, utilsContent),
+          configFields: triggerConfigFields(registryTriggers[idMatch[1]]),
         })
       }
     } catch {
@@ -4036,9 +3814,7 @@ function buildTriggersSection(triggers: TriggerFullInfo[]): string {
     const separator = i < triggers.length - 1 ? '\n---\n\n' : ''
 
     triggersSection += `### ${trigger.name}\n\n`
-    const escapedTriggerDescription = trigger.description
-      .replace(/\{/g, '\\{')
-      .replace(/\}/g, '\\}')
+    const escapedTriggerDescription = escapeMdxProse(trigger.description)
     triggersSection += `${escapedTriggerDescription}\n\n`
     triggersSection += configSection
     triggersSection += outputSection


### PR DESCRIPTION
## Summary

**Unbreaks the docs build.** It has been failing on staging since the Smartlead merge:

```
./apps/docs/content/docs/en/integrations/smartlead.mdx
Expected a closing tag for `<original>` before the end of `paragraph`
```

Tool descriptions are emitted as **prose**, and that path escaped only braces — every table-cell path already escaped angle brackets. MDX reads `<` as the start of a JSX tag, so `The copy is named "<original> - copy"` fails the build outright. `escapeMdxProse` handles the MDX-hostile characters and deliberately leaves pipes/parens/brackets alone, which are legal in prose and whose escaping would mangle markdown links.

**Trigger config now comes from the evaluated registry, not regex over source.** Static parsing silently dropped every field whose builder assembled its array imperatively or took a description as a parameter — all ten Jira triggers lost `webhookSecret` and `jqlFilter`, and Monday lost its config too. Regenerating the docs was *destructive*. Reading real objects also deletes 232 lines of parsing.

**Tool headings show the tool's name, not its id** — `### \`a2a_send_message\`` → `### A2A Send Message`, unformatted, across 241 pages. Names come from `tools/generated/tool-metadata.ts`, which CI keeps in sync. These headings feed each page's table of contents. `a2a.mdx` is hand-written so its headings were updated directly.

**Cleanup:** five hand-inlined copies of the escape chain collapsed into the `escapeMdxCell` that already existed, and 44 comments that restated the line below them removed. **4,306 → 4,069 lines.**

## Type of Change
- [x] Bug fix

## Testing

Every refactor step was verified against a **golden manifest of all 289 generated files**, itself validated in both directions — deterministic across repeated runs, and proven to catch a one-character change. So the only output differences are intended ones.

| Step | Result |
|---|---|
| escape-chain consolidation | byte-identical, 289 files |
| 44 comment removals | byte-identical, 289 files |
| trigger config from registry | diff reviewed line by line |
| post-rebase regen | zero drift |

Two things I built, measured, and **threw away** rather than ship:
- A regex fix for the imperative-array pattern — it "recovered" the Jira config but **invented `fieldFilters` on the 9 triggers that never declare it** and degraded descriptions to placeholder titles. Wrong docs are worse than missing docs.
- Sourcing trigger `outputs` from the registry too — symmetric with the config fix, and it deleted **10,298 lines across 53 files**. Reverted on sight.

Also caught a bug I introduced: `required` may be a condition object (`{ field, value }`), so `Boolean(required)` wrongly rendered "Yes" on 4 HubSpot fields. Only an unconditional `true` counts, matching previous behavior.

## Known gap (please don't read this PR as "the generator is now trustworthy")

`extractTriggerOutputs` still parses source and has the **same** blind spot — it already drops one Jira `#### Output` section on `main`, which I verified predates this change. Regenerating is now safe for trigger **config** but still lossy for trigger **outputs**.

Separately: `openai.mdx` is a stale orphan with no backing block since the multi-provider Embeddings work (#6317) — the generator doesn't rewrite it and the stale-doc cleanup doesn't delete it. Left alone here; it probably just wants deleting.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
