### PR TITLE
fix(chat): render HEIC attachments and restyle composer file chips

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
@@ -4,8 +4,8 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { AttachedFilesList } from '@/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list'
 import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments'
-import { AttachedFilesList } from './attached-files-list'
 
 function file(overrides: Partial<AttachedFile>): AttachedFile {
   return {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments'
+import { AttachedFilesList } from './attached-files-list'
+
+function file(overrides: Partial<AttachedFile>): AttachedFile {
+  return {
+    id: 'f1',
+    name: 'report.pdf',
+    size: 1024,
+    type: 'application/pdf',
+    path: '',
+    uploading: false,
+    ...overrides,
+  }
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function render(files: AttachedFile[]) {
+  act(() => {
+    root.render(
+      <AttachedFilesList attachedFiles={files} onFileClick={() => {}} onRemoveFile={() => {}} />
+    )
+  })
+}
+
+describe('AttachedFilesList', () => {
+  it('renders a document as a labelled card showing the filename', () => {
+    render([file({})])
+
+    expect(container.textContent).toContain('report.pdf')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('renders an image with a preview as a thumbnail, not a filename card', () => {
+    render([file({ name: 'photo.png', type: 'image/png', previewUrl: 'blob:xyz' })])
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:xyz')
+    expect(container.textContent).not.toContain('photo.png')
+  })
+
+  it('keeps a HEIC on the thumbnail shape while it has no preview yet', () => {
+    // The shape is keyed off the type, not the preview: a HEIC gets its preview only
+    // once the server derivative exists, and switching shape mid-upload would jump the
+    // layout. It must not fall back to the document card.
+    render([file({ name: 'photo.heic', type: 'image/heic' })])
+
+    expect(container.textContent).not.toContain('photo.heic')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('drops the image and reveals the type icon when the preview fails to decode', () => {
+    render([file({ name: 'photo.heic', type: 'image/heic', previewUrl: '/api/files/serve/x' })])
+
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+
+    act(() => {
+      img?.dispatchEvent(new Event('error'))
+    })
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -8,12 +8,17 @@ import { getFileExtension } from '@/lib/uploads/utils/file-utils'
 import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments'
 
 /**
- * Chrome shared by both chip shapes, borrowed from the chip family's filled field so a
- * hand-rolled card still reads as part of the system. Both shapes stand 48px tall, so a
- * row mixing thumbnails and documents sits on one baseline.
+ * Chrome shared by both chip shapes. Both stand 48px tall so a row mixing thumbnails
+ * and documents sits on one baseline.
+ *
+ * Deliberately NOT `chipFilledFillTokens` (`--surface-5` / `dark:--surface-4`): that
+ * pair assumes a page background, but this chip sits inside the composer, which is
+ * already `--surface-4` in dark mode — reusing it would make the chip invisible against
+ * its own container. `--surface-5` steps away from the composer in both themes, and
+ * hover steps further away in the direction each theme reads as "raised".
  */
 const CHIP_SURFACE =
-  'relative h-[48px] cursor-pointer rounded-[10px] border border-[var(--border)] bg-[var(--surface-5)] transition-colors dark:bg-[var(--surface-4)] hover-hover:bg-[var(--surface-active)]'
+  'relative h-[48px] cursor-pointer rounded-[10px] border border-[var(--border)] bg-[var(--surface-5)] transition-colors hover-hover:bg-[var(--surface-active)] dark:hover-hover:bg-[var(--surface-6)]'
 
 interface AttachedFilesListProps {
   attachedFiles: AttachedFile[]
@@ -49,7 +54,7 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
 
   return (
     <Tooltip.Root>
-      <div className='group relative flex-shrink-0'>
+      <div className={cn('group relative', isMedia ? 'flex-shrink-0' : 'min-w-0')}>
         <Tooltip.Trigger asChild>
           <button
             type='button'
@@ -57,7 +62,9 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
               CHIP_SURFACE,
               isMedia
                 ? 'w-[48px] overflow-hidden'
-                : 'flex max-w-[220px] items-center gap-2 py-2 pr-3 pl-2'
+                : // Capped at 220px but never wider than the composer, so a long filename
+                  // truncates on a narrow viewport instead of overflowing the shell.
+                  'flex max-w-[min(220px,100%)] items-center gap-2 py-2 pr-3 pl-2'
             )}
             onClick={() => onFileClick(file)}
           >
@@ -120,7 +127,10 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
               onRemoveFile(file.id)
             }}
             aria-label={`Remove ${file.name}`}
-            className='-top-[5px] -right-[5px] absolute flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-6)] text-[var(--text-icon)] opacity-0 transition-opacity group-hover:opacity-100 dark:bg-[var(--surface-3)]'
+            // Overhangs the chip by 5px, which the composer's `py-2` absorbs. `--surface-6`
+            // (not the chip's own fill) because this badge sits on the composer shell —
+            // white in light mode, `--surface-4` in dark — and must read against both.
+            className='-top-[5px] -right-[5px] absolute flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-6)] text-[var(--text-icon)] opacity-0 transition-opacity group-hover:opacity-100'
           >
             <X className='size-[9px]' />
           </button>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -1,16 +1,137 @@
 'use client'
 
-import React from 'react'
-import { Loader, Tooltip } from '@sim/emcn'
+import React, { useState } from 'react'
+import { cn, Loader, Tooltip } from '@sim/emcn'
 import { X } from '@sim/emcn/icons'
 import { getDocumentIcon } from '@/components/icons/document-icons'
+import { getFileExtension } from '@/lib/uploads/utils/file-utils'
 import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments'
+
+/**
+ * Chrome shared by both chip shapes, borrowed from the chip family's filled field so a
+ * hand-rolled card still reads as part of the system. Both shapes stand 48px tall, so a
+ * row mixing thumbnails and documents sits on one baseline.
+ */
+const CHIP_SURFACE =
+  'relative h-[48px] cursor-pointer rounded-[10px] border border-[var(--border)] bg-[var(--surface-5)] transition-colors dark:bg-[var(--surface-4)] hover-hover:bg-[var(--surface-active)]'
 
 interface AttachedFilesListProps {
   attachedFiles: AttachedFile[]
   onFileClick: (file: AttachedFile) => void
   onRemoveFile: (id: string) => void
 }
+
+interface AttachedFileChipProps {
+  file: AttachedFile
+  onFileClick: (file: AttachedFile) => void
+  onRemoveFile: (id: string) => void
+}
+
+/**
+ * One attachment.
+ *
+ * Media renders as a thumbnail; everything else renders as a labelled card — icon
+ * badge, filename, file type. A document has no thumbnail worth showing, and the
+ * filename is the thing worth reading.
+ */
+const AttachedFileChip = React.memo(function AttachedFileChip({
+  file,
+  onFileClick,
+  onRemoveFile,
+}: AttachedFileChipProps) {
+  const Icon = getDocumentIcon(file.type, file.name)
+  const isVideo = file.type.startsWith('video/')
+  // Keyed off the type, not the presence of a preview: a HEIC has no preview until its
+  // upload finishes, and flipping shape mid-upload would jump the layout.
+  const isMedia = isVideo || file.type.startsWith('image/')
+  const extension = getFileExtension(file.name)
+  const [previewFailed, setPreviewFailed] = useState(false)
+
+  return (
+    <Tooltip.Root>
+      <div className='group relative flex-shrink-0'>
+        <Tooltip.Trigger asChild>
+          <button
+            type='button'
+            className={cn(
+              CHIP_SURFACE,
+              isMedia
+                ? 'w-[48px] overflow-hidden'
+                : 'flex max-w-[220px] items-center gap-2 py-2 pr-3 pl-2'
+            )}
+            onClick={() => onFileClick(file)}
+          >
+            {isMedia ? (
+              <>
+                <span className='absolute inset-0 flex items-center justify-center text-[var(--text-icon)]'>
+                  <Icon className='size-[18px]' />
+                </span>
+                {file.previewUrl &&
+                  !previewFailed &&
+                  (isVideo ? (
+                    <video
+                      src={file.previewUrl}
+                      muted
+                      playsInline
+                      preload='metadata'
+                      className='relative size-full object-cover'
+                    />
+                  ) : (
+                    <img
+                      src={file.previewUrl}
+                      alt={file.name}
+                      // A HEIC whose server-side transcode failed comes back as bytes the
+                      // browser still cannot decode. Dropping the image reveals the type
+                      // icon beneath instead of a broken glyph.
+                      onError={() => setPreviewFailed(true)}
+                      className='relative size-full object-cover'
+                    />
+                  ))}
+              </>
+            ) : (
+              <>
+                <span className='flex size-[32px] shrink-0 items-center justify-center rounded-[8px] bg-[var(--surface-6)] text-[var(--text-icon)] dark:bg-[var(--surface-3)]'>
+                  <Icon className='size-[16px]' />
+                </span>
+                <span className='flex min-w-0 flex-col items-start'>
+                  <span className='w-full truncate text-[var(--text-body)] text-small'>
+                    {file.name}
+                  </span>
+                  {/* The name truncates, so the extension is genuinely not readable from
+                      it — this is the format, not a restatement of the label. */}
+                  {extension && (
+                    <span className='text-[var(--text-muted)] text-xs uppercase'>{extension}</span>
+                  )}
+                </span>
+              </>
+            )}
+            {file.uploading && (
+              <span className='absolute inset-0 flex items-center justify-center rounded-[inherit] bg-[var(--surface-5)]/70 dark:bg-[var(--surface-4)]/70'>
+                <Loader className='size-[14px] text-[var(--text-icon)]' animate />
+              </span>
+            )}
+          </button>
+        </Tooltip.Trigger>
+        {!file.uploading && (
+          <button
+            type='button'
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemoveFile(file.id)
+            }}
+            aria-label={`Remove ${file.name}`}
+            className='-top-[5px] -right-[5px] absolute flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-6)] text-[var(--text-icon)] opacity-0 transition-opacity group-hover:opacity-100 dark:bg-[var(--surface-3)]'
+          >
+            <X className='size-[9px]' />
+          </button>
+        )}
+      </div>
+      <Tooltip.Content side='top'>
+        <p className='max-w-[200px] truncate'>{file.name}</p>
+      </Tooltip.Content>
+    </Tooltip.Root>
+  )
+})
 
 export const AttachedFilesList = React.memo(function AttachedFilesList({
   attachedFiles,
@@ -20,78 +141,15 @@ export const AttachedFilesList = React.memo(function AttachedFilesList({
   if (attachedFiles.length === 0) return null
 
   return (
-    <div className='mb-1.5 flex flex-wrap gap-1.5'>
-      {attachedFiles.map((file) => {
-        const isVideo = file.type.startsWith('video/')
-        const hasPreview = Boolean(file.previewUrl)
-        return (
-          <Tooltip.Root key={file.id}>
-            <div className='group relative size-[56px] flex-shrink-0'>
-              <Tooltip.Trigger asChild>
-                <button
-                  type='button'
-                  className='relative h-full w-full cursor-pointer overflow-hidden rounded-[8px] border border-[var(--border-1)] bg-[var(--surface-5)] p-0 hover:bg-[var(--surface-4)]'
-                  onClick={() => onFileClick(file)}
-                >
-                  {hasPreview && isVideo ? (
-                    <>
-                      <div className='absolute inset-0 flex items-center justify-center text-[var(--text-icon)]'>
-                        {(() => {
-                          const Icon = getDocumentIcon(file.type, file.name)
-                          return <Icon className='size-[18px]' />
-                        })()}
-                      </div>
-                      <video
-                        src={file.previewUrl}
-                        muted
-                        playsInline
-                        preload='metadata'
-                        className='relative h-full w-full object-cover'
-                      />
-                    </>
-                  ) : hasPreview ? (
-                    <img
-                      src={file.previewUrl}
-                      alt={file.name}
-                      className='h-full w-full object-cover'
-                    />
-                  ) : (
-                    <div className='flex h-full w-full flex-col items-center justify-center gap-0.5 text-[var(--text-icon)]'>
-                      {(() => {
-                        const Icon = getDocumentIcon(file.type, file.name)
-                        return <Icon className='size-[18px]' />
-                      })()}
-                      <span className='max-w-[48px] truncate px-[2px] text-[9px] text-[var(--text-muted)]'>
-                        {file.name.split('.').pop()}
-                      </span>
-                    </div>
-                  )}
-                  {file.uploading && (
-                    <div className='absolute inset-0 flex items-center justify-center bg-black/50'>
-                      <Loader className='size-[14px] text-white' animate />
-                    </div>
-                  )}
-                </button>
-              </Tooltip.Trigger>
-              {!file.uploading && (
-                <button
-                  type='button'
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onRemoveFile(file.id)
-                  }}
-                  className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full bg-black/60 opacity-0 group-hover:opacity-100'
-                >
-                  <X className='size-[10px] text-white' />
-                </button>
-              )}
-            </div>
-            <Tooltip.Content side='top'>
-              <p className='max-w-[200px] truncate'>{file.name}</p>
-            </Tooltip.Content>
-          </Tooltip.Root>
-        )
-      })}
+    <div className='mb-1.5 flex flex-wrap items-center gap-1.5'>
+      {attachedFiles.map((file) => (
+        <AttachedFileChip
+          key={file.id}
+          file={file}
+          onFileClick={onFileClick}
+          onRemoveFile={onRemoveFile}
+        />
+      ))}
     </div>
   )
 })

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments.ts
@@ -5,11 +5,38 @@ import { toast } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { generateId } from '@sim/utils/id'
+import { getMothershipAttachmentPreviewUrl } from '@/lib/copilot/chat/attachment-preview'
 import { uploadViaApiFallback } from '@/lib/uploads/client/api-fallback'
 import { DirectUploadError, runUploadStrategy } from '@/lib/uploads/client/direct-upload'
 import { resolveFileType } from '@/lib/uploads/utils/file-utils'
 
 const logger = createLogger('useFileAttachments')
+
+/**
+ * Image formats no browser decodes in an `<img>`. A blob URL of these bytes renders
+ * broken, so their preview has to come from the serve route, which substitutes a
+ * JPEG derivative once the file is uploaded.
+ *
+ * Matched as prefixes so the `-sequence` variants Safari reports for Live Photos and
+ * burst captures are covered too. The server decides for real by sniffing the
+ * container — see `isHevcHeifContainer` in `@/lib/uploads/server/heic`; keep the two
+ * in step when adding a format.
+ */
+const SERVER_RENDERED_IMAGE_PREFIXES = ['image/heic', 'image/heif'] as const
+
+/** Whether the browser can decode these bytes itself, making a blob URL worth creating. */
+function rendersFromBlobUrl(mediaType: string): boolean {
+  if (SERVER_RENDERED_IMAGE_PREFIXES.some((prefix) => mediaType.startsWith(prefix))) return false
+  return mediaType.startsWith('image/') || mediaType.startsWith('video/')
+}
+
+/**
+ * Revokes a preview URL only when it is one we minted. A preview can also be a serve
+ * URL, which owns no object-URL handle.
+ */
+function revokePreviewUrl(previewUrl?: string): void {
+  if (previewUrl?.startsWith('blob:')) URL.revokeObjectURL(previewUrl)
+}
 
 /**
  * File size units for formatting
@@ -69,15 +96,21 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   /**
+   * Mirrors the current attachments so the unmount cleanup below can reach them. The
+   * cleanup runs once, so reading state directly would close over the empty first
+   * render and revoke nothing.
+   */
+  const attachedFilesRef = useRef<AttachedFile[]>(attachedFiles)
+  useEffect(() => {
+    attachedFilesRef.current = attachedFiles
+  }, [attachedFiles])
+
+  /**
    * Cleanup preview URLs on unmount
    */
   useEffect(() => {
     return () => {
-      attachedFiles.forEach((f) => {
-        if (f.previewUrl) {
-          URL.revokeObjectURL(f.previewUrl)
-        }
-      })
+      attachedFilesRef.current.forEach((f) => revokePreviewUrl(f.previewUrl))
     }
   }, [])
 
@@ -125,18 +158,20 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
       const files = Array.from(fileList)
       if (files.length === 0) return
 
-      const placeholders: AttachedFile[] = files.map((file) => ({
-        id: generateId(),
-        name: file.name,
-        size: file.size,
-        type: resolveFileType(file),
-        path: '',
-        uploading: true,
-        previewUrl:
-          file.type.startsWith('image/') || file.type.startsWith('video/')
-            ? URL.createObjectURL(file)
-            : undefined,
-      }))
+      const placeholders: AttachedFile[] = files.map((file) => {
+        // Resolve once: the browser reports `application/octet-stream` (or nothing) for
+        // plenty of files, and both the chip and the preview decision key off the type.
+        const type = resolveFileType(file)
+        return {
+          id: generateId(),
+          name: file.name,
+          size: file.size,
+          type,
+          path: '',
+          uploading: true,
+          previewUrl: rendersFromBlobUrl(type) ? URL.createObjectURL(file) : undefined,
+        }
+      })
 
       setAttachedFiles((prev) => [...prev, ...placeholders])
 
@@ -171,7 +206,22 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
             setAttachedFiles((prev) =>
               prev.map((f) =>
                 f.id === placeholder.id
-                  ? { ...f, path: result.path, key: result.key, uploading: false }
+                  ? {
+                      ...f,
+                      path: result.path,
+                      key: result.key,
+                      uploading: false,
+                      // A format the browser cannot decode has no local preview; now that
+                      // the bytes are stored, the serve route can hand back a renderable
+                      // derivative. Anything already previewing keeps its blob URL rather
+                      // than paying a round trip for a thumbnail it can draw locally.
+                      previewUrl:
+                        f.previewUrl ??
+                        getMothershipAttachmentPreviewUrl({
+                          key: result.key,
+                          media_type: f.type,
+                        }),
+                    }
                   : f
               )
             )
@@ -180,7 +230,7 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
             toast.error(`Couldn't upload "${file.name}"`, {
               description: toError(error).message,
             })
-            if (placeholder.previewUrl) URL.revokeObjectURL(placeholder.previewUrl)
+            revokePreviewUrl(placeholder.previewUrl)
             setAttachedFiles((prev) => prev.filter((f) => f.id !== placeholder.id))
           }
         })
@@ -220,16 +270,10 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
    * Removes a file from attachments
    * @param fileId - ID of the file to remove
    */
-  const removeFile = useCallback(
-    (fileId: string) => {
-      const file = attachedFiles.find((f) => f.id === fileId)
-      if (file?.previewUrl) {
-        URL.revokeObjectURL(file.previewUrl)
-      }
-      setAttachedFiles((prev) => prev.filter((f) => f.id !== fileId))
-    },
-    [attachedFiles]
-  )
+  const removeFile = useCallback((fileId: string) => {
+    revokePreviewUrl(attachedFilesRef.current.find((f) => f.id === fileId)?.previewUrl)
+    setAttachedFiles((prev) => prev.filter((f) => f.id !== fileId))
+  }, [])
 
   /**
    * Opens file in new tab (for preview)
@@ -303,25 +347,19 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
    * Clears all attached files and cleanup preview URLs
    */
   const clearAttachedFiles = useCallback(() => {
-    attachedFiles.forEach((f) => {
-      if (f.previewUrl) {
-        URL.revokeObjectURL(f.previewUrl)
-      }
-    })
+    attachedFilesRef.current.forEach((f) => revokePreviewUrl(f.previewUrl))
     setAttachedFiles([])
-  }, [attachedFiles])
+  }, [])
 
   /**
    * Replaces the current attached files with a given set.
    * Cleans up preview URLs from the prior set before replacing.
    */
   const restoreAttachedFiles = useCallback((files: AttachedFile[]) => {
-    setAttachedFiles((prev) => {
-      prev.forEach((f) => {
-        if (f.previewUrl) URL.revokeObjectURL(f.previewUrl)
-      })
-      return files
-    })
+    // Revoked outside the updater: React double-invokes updaters in StrictMode and may
+    // replay them, so they have to stay pure.
+    attachedFilesRef.current.forEach((f) => revokePreviewUrl(f.previewUrl))
+    setAttachedFiles(files)
   }, [])
 
   return {


### PR DESCRIPTION
## Summary
- Composer previewed every attachment via `URL.createObjectURL` of the raw bytes. No browser decodes HEVC-coded HEIF, so a HEIC rendered a broken glyph — and since the upload-completion handler never replaced that blob URL, it stayed broken even once a server derivative existed.
- HEIC/HEIF now skip the blob and pick up the serve URL (`preview=1`) once the upload lands, so the JPEG derivative renders. Other images keep their blob URL — no extra round trip for a thumbnail the browser can already draw.
- Added an `onError` fallback: if the image still fails (transcode unavailable, 401/409), the type icon shows instead of a broken glyph.
- Documents now render as labelled cards — icon badge, filename, type — instead of a 9px extension caption. Media keeps the thumbnail. Both are 48px so a mixed row shares a baseline.
- Fixed a blob-URL leak: the unmount cleanup had `[]` deps closing over the first render's empty array, so it revoked nothing, ever.

## Type of Change
- [x] Bug fix

## Testing
`tsc --noEmit`, `lint`, `check:api-validation` clean. 1013 tests pass. Four new tests on the chip; verified the two behavioral ones fail without their fix.

Not yet verified in a browser — pill proportions against the 48px tiles and the overlapping remove badge need a visual check.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)