### PR TITLE
fix(files): render HTML files shared via a public file link

### DIFF
--- a/apps/sim/app/f/[token]/public-file-view.tsx
+++ b/apps/sim/app/f/[token]/public-file-view.tsx
@@ -66,9 +66,9 @@ export function PublicFileView({
   )
 
   return (
-    <div className='light desktop-title-bar-page flex flex-col bg-[var(--bg)]'>
+    <div className='light desktop-title-bar-page flex h-screen flex-col overflow-hidden bg-[var(--bg)]'>
       <DesktopTitleBarLane />
-      <header className='sticky top-[var(--desktop-title-bar-height)] z-10 flex items-center justify-between gap-4 border-[var(--border)] border-b bg-[var(--bg)] px-4 py-3'>
+      <header className='z-10 flex shrink-0 items-center justify-between gap-4 border-[var(--border)] border-b bg-[var(--bg)] px-4 py-3'>
         <div className='flex min-w-0 items-center gap-3'>
           {!brand.logoUrl && (
             <>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
@@ -284,11 +284,12 @@ const ReadOnlyTextPreview = memo(function ReadOnlyTextPreview({
 
   const resolvedError = resolvePreviewError((error as Error | null) ?? null, null)
   if (resolvedError) return <PreviewError label='file' error={resolvedError} />
-  if (isLoading || content == null) return <PreviewLoadingFrame className='h-full' tone='surface' />
+  if (isLoading || content == null)
+    return <PreviewLoadingFrame className='min-h-0 flex-1' tone='surface' />
 
   if (resolvePreviewType(file.type, file.name)) {
     return (
-      <div className='h-full min-h-0 w-full overflow-auto'>
+      <div className='flex min-h-0 w-full flex-1 flex-col overflow-auto'>
         <PreviewPanel
           content={content}
           mimeType={file.type}
@@ -302,7 +303,7 @@ const ReadOnlyTextPreview = memo(function ReadOnlyTextPreview({
   }
 
   return (
-    <div className='h-full min-h-0 w-full overflow-auto bg-[var(--surface-1)] p-4'>
+    <div className='min-h-0 w-full flex-1 overflow-auto bg-[var(--surface-1)] p-4'>
       <pre className='whitespace-pre-wrap break-words font-mono text-[13px] text-[var(--text-body)]'>
         {content}
       </pre>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -200,7 +200,7 @@ const HtmlPreview = memo(function HtmlPreview({ content }: { content: string }) 
   }, [])
 
   return (
-    <div ref={containerRef} className='h-full overflow-hidden'>
+    <div ref={containerRef} className='flex min-h-0 flex-1 overflow-hidden'>
       {isRenderable && (
         <iframe
           key={resumeNonce}
@@ -225,7 +225,7 @@ function SvgPreview({ content }: { content: string }) {
   }, [content])
 
   return (
-    <ZoomablePreview className='h-full' contentClassName='h-full w-full'>
+    <ZoomablePreview className='min-h-0 flex-1' contentClassName='h-full w-full'>
       {blobUrl && (
         <img
           src={blobUrl}
@@ -240,7 +240,7 @@ function SvgPreview({ content }: { content: string }) {
 
 function MermaidFilePreview({ content, isStreaming }: { content: string; isStreaming?: boolean }) {
   return (
-    <div className='h-full overflow-auto p-6'>
+    <div className='min-h-0 flex-1 overflow-auto p-6'>
       <MermaidDiagram
         definition={content}
         isStreaming={isStreaming}
@@ -267,14 +267,14 @@ const CsvPreview = memo(function CsvPreview({
 
   if (headers.length === 0) {
     return (
-      <div className='flex h-full items-center justify-center p-6'>
+      <div className='flex min-h-0 flex-1 items-center justify-center p-6'>
         <p className='text-[13px] text-[var(--text-muted)]'>No data to display</p>
       </div>
     )
   }
 
   return (
-    <div className='h-full overflow-auto p-6'>
+    <div className='min-h-0 flex-1 overflow-auto p-6'>
       <DataTable headers={headers} rows={rows} />
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -672,7 +672,10 @@ export const TextEditor = memo(function TextEditor({
             </div>
           )}
           <div
-            className={cn('min-w-0 flex-1 overflow-hidden', isResizing && 'pointer-events-none')}
+            className={cn(
+              'flex min-w-0 flex-1 flex-col overflow-hidden',
+              isResizing && 'pointer-events-none'
+            )}
           >
             <PreviewPanel
               key={previewContextKey ? `${file.id}:${previewContextKey}` : file.id}


### PR DESCRIPTION
## Summary
- HTML files shared via `/f/<token>` rendered a blank area under the header. The page root (`.desktop-title-bar-page`) sets only `min-height: 100vh`, so `h-full` on every descendant of `<main>` resolved to `auto` → 0. `HtmlPreview` only mounts its sandboxed iframe once its container measures non-zero, so it silently never mounted
- Gave the public share page root a definite height (`h-screen`, `overflow-hidden`) so the whole `/f/<token>` surface behaves like the in-app viewer; the header's now-dead `sticky` becomes `shrink-0`
- Made the read-only preview chain flex-based (`min-h-0 flex-1`) instead of `h-full`, so it fills its parent rather than depending on an ancestor's definite height — covers the HTML, CSV, SVG, and mermaid branches plus the plain-text and loading frames
- `text-editor`'s preview pane becomes a flex column — it's `HtmlPreview`'s other parent, so `flex-1` would have been inert there

Markdown, plain text, CSV, and image shares were unaffected before (their content has intrinsic height) and are unchanged after.

## Type of Change
- [x] Bug fix

## Testing
Tested manually against a real local public share, driven headless at 1280x800.

Before (patch reverted on disk), on `/f/<token>` for a `text/html` file:

```
main      1280x736  flex min-h-0 flex-1 flex-col
wrap      1280x0    h-full min-h-0 w-full overflow-auto
container 1280x0    h-full overflow-hidden
iframeCount: 0
```

After: `wrap` and `container` are `1280x736`, `iframeCount: 1`, inline `<style>` applied, inline script ran under `sandbox='allow-scripts'`, tall content scrolls inside the iframe.

Also confirmed unchanged: CSV, markdown, plain-text, and PNG shares; and the in-app viewer (the other `HtmlPreview` consumer) — preview mode 1192x834, split mode 595x834 alongside Monaco.

`bun run lint`, `bun run check:audits` (22/22), `bun run type-check` (23/23), and `bunx vitest run app/_shell/desktop-title-bar-surfaces.test.ts app/workspace/[workspaceId]/files/components/file-viewer/` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)