### PR TITLE
fix(chat): keep the composer remove badge anchored and align chip tokens

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/chat-message-attachments/chat-message-attachments.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/chat-message-attachments/chat-message-attachments.tsx
@@ -2,35 +2,12 @@ import { cn } from '@sim/emcn'
 import { getDocumentIcon } from '@/components/icons/document-icons'
 import type { ChatMessageAttachment } from '@/app/workspace/[workspaceId]/home/types'
 
-/**
- * Tile geometry shared with the thumbnail branches so a mixed row stays uniform.
- *
- * The border is load-bearing, not decoration: this renders on both the home transcript
- * (`--bg`) and the workflow chat panel (`--surface-1`), and against the latter the fill
- * is only ~8/255 away in light mode. With an icon-only tile the surface *is* the
- * affordance, so it needs an edge — the same reason the user message bubble pairs
- * `--surface-5` with a border.
- */
-const ATTACHMENT_TILE =
-  'size-[56px] overflow-hidden rounded-[8px] border border-[var(--border)] bg-[var(--surface-5)]'
-
-/**
- * A sent document shows only its type icon. The filename was already read in the
- * composer before sending, so repeating it here costs a wide pill in the transcript
- * for information the hover title still carries.
- */
-function FileAttachmentTile(props: { mediaType: string; filename: string }) {
+function FileAttachmentPill(props: { mediaType: string; filename: string }) {
   const Icon = getDocumentIcon(props.mediaType, props.filename)
   return (
-    <div
-      title={props.filename}
-      // The icon carries no accessible name on its own, so without these the tile is
-      // announced as nothing at all — the filename used to be real text.
-      role='img'
-      aria-label={props.filename}
-      className={cn(ATTACHMENT_TILE, 'flex items-center justify-center text-[var(--text-icon)]')}
-    >
-      <Icon className='size-[18px]' />
+    <div className='flex max-w-[140px] items-center gap-[5px] rounded-lg bg-[var(--surface-5)] px-[6px] py-[3px]'>
+      <Icon className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
+      <span className='truncate text-[var(--text-body)] text-xs'>{props.filename}</span>
     </div>
   )
 }
@@ -55,7 +32,7 @@ export function ChatMessageAttachments(props: {
       {attachments.map((att) => {
         if (!att.previewUrl) {
           return (
-            <FileAttachmentTile key={att.id} mediaType={att.media_type} filename={att.filename} />
+            <FileAttachmentPill key={att.id} mediaType={att.media_type} filename={att.filename} />
           )
         }
         const isVideo = att.media_type.startsWith('video/')
@@ -64,10 +41,7 @@ export function ChatMessageAttachments(props: {
           return (
             <div
               key={att.id}
-              title={att.filename}
-              role='img'
-              aria-label={att.filename}
-              className={cn(ATTACHMENT_TILE, 'relative')}
+              className='relative size-[56px] overflow-hidden rounded-lg bg-[var(--surface-5)]'
             >
               <div className='absolute inset-0 flex items-center justify-center text-[var(--text-icon)]'>
                 <Icon className='size-[18px]' />
@@ -83,7 +57,7 @@ export function ChatMessageAttachments(props: {
           )
         }
         return (
-          <div key={att.id} className={ATTACHMENT_TILE} title={att.filename}>
+          <div key={att.id} className='size-[56px] overflow-hidden rounded-lg'>
             <img src={att.previewUrl} alt={att.filename} className='size-full object-cover' />
           </div>
         )

--- a/apps/sim/app/workspace/[workspaceId]/home/components/chat-message-attachments/chat-message-attachments.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/chat-message-attachments/chat-message-attachments.tsx
@@ -2,12 +2,35 @@ import { cn } from '@sim/emcn'
 import { getDocumentIcon } from '@/components/icons/document-icons'
 import type { ChatMessageAttachment } from '@/app/workspace/[workspaceId]/home/types'
 
-function FileAttachmentPill(props: { mediaType: string; filename: string }) {
+/**
+ * Tile geometry shared with the thumbnail branches so a mixed row stays uniform.
+ *
+ * The border is load-bearing, not decoration: this renders on both the home transcript
+ * (`--bg`) and the workflow chat panel (`--surface-1`), and against the latter the fill
+ * is only ~8/255 away in light mode. With an icon-only tile the surface *is* the
+ * affordance, so it needs an edge — the same reason the user message bubble pairs
+ * `--surface-5` with a border.
+ */
+const ATTACHMENT_TILE =
+  'size-[56px] overflow-hidden rounded-[8px] border border-[var(--border)] bg-[var(--surface-5)]'
+
+/**
+ * A sent document shows only its type icon. The filename was already read in the
+ * composer before sending, so repeating it here costs a wide pill in the transcript
+ * for information the hover title still carries.
+ */
+function FileAttachmentTile(props: { mediaType: string; filename: string }) {
   const Icon = getDocumentIcon(props.mediaType, props.filename)
   return (
-    <div className='flex max-w-[140px] items-center gap-[5px] rounded-[10px] bg-[var(--surface-5)] px-[6px] py-[3px]'>
-      <Icon className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
-      <span className='truncate text-[11px] text-[var(--text-body)]'>{props.filename}</span>
+    <div
+      title={props.filename}
+      // The icon carries no accessible name on its own, so without these the tile is
+      // announced as nothing at all — the filename used to be real text.
+      role='img'
+      aria-label={props.filename}
+      className={cn(ATTACHMENT_TILE, 'flex items-center justify-center text-[var(--text-icon)]')}
+    >
+      <Icon className='size-[18px]' />
     </div>
   )
 }
@@ -32,7 +55,7 @@ export function ChatMessageAttachments(props: {
       {attachments.map((att) => {
         if (!att.previewUrl) {
           return (
-            <FileAttachmentPill key={att.id} mediaType={att.media_type} filename={att.filename} />
+            <FileAttachmentTile key={att.id} mediaType={att.media_type} filename={att.filename} />
           )
         }
         const isVideo = att.media_type.startsWith('video/')
@@ -41,7 +64,10 @@ export function ChatMessageAttachments(props: {
           return (
             <div
               key={att.id}
-              className='relative size-[56px] overflow-hidden rounded-[8px] bg-[var(--surface-5)]'
+              title={att.filename}
+              role='img'
+              aria-label={att.filename}
+              className={cn(ATTACHMENT_TILE, 'relative')}
             >
               <div className='absolute inset-0 flex items-center justify-center text-[var(--text-icon)]'>
                 <Icon className='size-[18px]' />
@@ -51,14 +77,14 @@ export function ChatMessageAttachments(props: {
                 muted
                 playsInline
                 preload='metadata'
-                className='relative h-full w-full object-cover'
+                className='relative size-full object-cover'
               />
             </div>
           )
         }
         return (
-          <div key={att.id} className='size-[56px] overflow-hidden rounded-[8px]'>
-            <img src={att.previewUrl} alt={att.filename} className='h-full w-full object-cover' />
+          <div key={att.id} className={ATTACHMENT_TILE} title={att.filename}>
+            <img src={att.previewUrl} alt={att.filename} className='size-full object-cover' />
           </div>
         )
       })}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/chat-message-attachments/chat-message-attachments.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/chat-message-attachments/chat-message-attachments.tsx
@@ -6,7 +6,7 @@ function FileAttachmentPill(props: { mediaType: string; filename: string }) {
   const Icon = getDocumentIcon(props.mediaType, props.filename)
   return (
     <div className='flex max-w-[140px] items-center gap-[5px] rounded-lg bg-[var(--surface-5)] px-[6px] py-[3px]'>
-      <Icon className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
+      <Icon className='size-[14px] shrink-0 text-[var(--text-icon)]' />
       <span className='truncate text-[var(--text-body)] text-xs'>{props.filename}</span>
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
@@ -73,14 +73,14 @@ describe('AttachedFilesList', () => {
     expect(wrapper?.className).toMatch(/max-w-/)
   })
 
-  it('reveals the remove control on keyboard focus, not only on hover', () => {
+  it('keeps the remove control visible rather than gating it on hover', () => {
     render([file({})])
 
+    // A reveal-on-hover badge is unreachable on touch and invisible while it holds
+    // keyboard focus, so it must not be opacity-gated at all.
     const remove = container.querySelector('button[aria-label^="Remove"]')
-    // Hidden only where a pointer can reveal it, and focus has to reveal it there too —
-    // otherwise a keyboard user tabs onto a fully transparent control.
-    expect(remove?.className).toContain('hover-hover:opacity-0')
-    expect(remove?.className).toContain('hover-hover:focus-visible:opacity-100')
+    expect(remove).not.toBeNull()
+    expect(remove?.className).not.toMatch(/opacity-0/)
   })
 
   it('drops the image and reveals the type icon when the preview fails to decode', () => {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
@@ -58,9 +58,6 @@ describe('AttachedFilesList', () => {
   })
 
   it('keeps a HEIC on the thumbnail shape while it has no preview yet', () => {
-    // The shape is keyed off the type, not the preview: a HEIC gets its preview only
-    // once the server derivative exists, and switching shape mid-upload would jump the
-    // layout. It must not fall back to the document card.
     render([file({ name: 'photo.heic', type: 'image/heic' })])
 
     expect(container.textContent).not.toContain('photo.heic')
@@ -68,13 +65,12 @@ describe('AttachedFilesList', () => {
   })
 
   it('caps the card wrapper so a long filename cannot strand the remove badge', () => {
-    // The badge is positioned against this wrapper. Without a cap here the wrapper
-    // stretches to the filename's max-content width while the card stays 220px, and
-    // the badge drifts off to the right of the card.
     render([file({ name: '9bacf973-cd64-437b-be12-58be9f2c1a4d-very-long-name.pdf' })])
 
+    // jsdom does no layout, so the cap can only be asserted structurally: it has to sit
+    // on the wrapper the badge is positioned against, not on the button.
     const wrapper = container.querySelector('button')?.parentElement
-    expect(wrapper?.className).toContain('max-w-[min(220px,100%)]')
+    expect(wrapper?.className).toMatch(/max-w-/)
   })
 
   it('drops the image and reveals the type icon when the preview fails to decode', () => {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
@@ -73,6 +73,16 @@ describe('AttachedFilesList', () => {
     expect(wrapper?.className).toMatch(/max-w-/)
   })
 
+  it('reveals the remove control on keyboard focus, not only on hover', () => {
+    render([file({})])
+
+    const remove = container.querySelector('button[aria-label^="Remove"]')
+    // Hidden only where a pointer can reveal it, and focus has to reveal it there too —
+    // otherwise a keyboard user tabs onto a fully transparent control.
+    expect(remove?.className).toContain('hover-hover:opacity-0')
+    expect(remove?.className).toContain('hover-hover:focus-visible:opacity-100')
+  })
+
   it('drops the image and reveals the type icon when the preview fails to decode', () => {
     render([file({ name: 'photo.heic', type: 'image/heic', previewUrl: '/api/files/serve/x' })])
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.test.tsx
@@ -67,6 +67,16 @@ describe('AttachedFilesList', () => {
     expect(container.querySelector('img')).toBeNull()
   })
 
+  it('caps the card wrapper so a long filename cannot strand the remove badge', () => {
+    // The badge is positioned against this wrapper. Without a cap here the wrapper
+    // stretches to the filename's max-content width while the card stays 220px, and
+    // the badge drifts off to the right of the card.
+    render([file({ name: '9bacf973-cd64-437b-be12-58be9f2c1a4d-very-long-name.pdf' })])
+
+    const wrapper = container.querySelector('button')?.parentElement
+    expect(wrapper?.className).toContain('max-w-[min(220px,100%)]')
+  })
+
   it('drops the image and reveals the type icon when the preview fails to decode', () => {
     render([file({ name: 'photo.heic', type: 'image/heic', previewUrl: '/api/files/serve/x' })])
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -116,8 +116,9 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
           }}
           aria-label={`Remove ${file.name}`}
           /* Visible by default so a coarse pointer never has to discover it through an
-             emulated hover; fine pointers get the reveal-on-hover treatment. */
-          className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-body)] transition-opacity hover-hover:opacity-0 hover-hover:group-hover:opacity-100'
+             emulated hover; fine pointers get reveal-on-hover, plus reveal-on-focus so
+             it is never transparent while it holds the keyboard focus. */
+          className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-body)] transition-opacity hover-hover:opacity-0 hover-hover:focus-visible:opacity-100 hover-hover:group-hover:opacity-100'
         >
           <X className='size-[10px]' />
         </button>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -1,27 +1,18 @@
 'use client'
 
 import React, { useState } from 'react'
-import { cn, Loader, Tooltip } from '@sim/emcn'
+import { cn, Loader } from '@sim/emcn'
 import { X } from '@sim/emcn/icons'
 import { getDocumentIcon } from '@/components/icons/document-icons'
 import { getFileExtension } from '@/lib/uploads/utils/file-utils'
 import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments'
 
 /**
- * Chrome shared by both chip shapes. Both stand 48px tall so a row mixing thumbnails
- * and documents sits on one baseline.
- *
- * Deliberately NOT `chipFilledFillTokens` (`--surface-5` / `dark:--surface-4`): that
- * pair assumes a page background, but this chip sits inside the composer, which is
- * already `--surface-4` in dark mode — reusing it would make the chip invisible against
- * its own container. `--surface-5` steps away from the composer in both themes, and
- * hover steps further away in the direction each theme reads as "raised".
+ * Chrome shared by both chip shapes. Not `chipFilledFillTokens` — its dark fill is
+ * `--surface-4`, which is the composer's own background.
  */
 const CHIP_SURFACE =
   'relative cursor-pointer rounded-lg border border-[var(--border)] bg-[var(--surface-5)] transition-colors hover-hover:bg-[var(--surface-active)] dark:hover-hover:bg-[var(--surface-6)]'
-
-/** Height lives on the wrapper so both shapes are the same size by construction. */
-const CHIP_HEIGHT = 'h-[48px]'
 
 interface AttachedFilesListProps {
   attachedFiles: AttachedFile[]
@@ -36,11 +27,9 @@ interface AttachedFileChipProps {
 }
 
 /**
- * One attachment.
- *
- * Media renders as a thumbnail; everything else renders as a labelled card — icon
- * badge, filename, file type. A document has no thumbnail worth showing, and the
- * filename is the thing worth reading.
+ * One attachment: media renders as a thumbnail, anything else as a labelled card.
+ * Shape keys off the media type, not preview presence — a HEIC has no preview until its
+ * server derivative lands, and flipping shape mid-upload would jump the layout.
  */
 const AttachedFileChip = React.memo(function AttachedFileChip({
   file,
@@ -49,118 +38,89 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
 }: AttachedFileChipProps) {
   const Icon = getDocumentIcon(file.type, file.name)
   const isVideo = file.type.startsWith('video/')
-  // Keyed off the type, not the presence of a preview: a HEIC has no preview until its
-  // upload finishes, and flipping shape mid-upload would jump the layout.
   const isMedia = isVideo || file.type.startsWith('image/')
   const extension = getFileExtension(file.name)
   const [previewFailed, setPreviewFailed] = useState(false)
 
   return (
-    <Tooltip.Root>
-      {/* Both the size and the width cap live here, not on the button: this wrapper
-          anchors the remove badge, so sizing it to the button's uncapped max-content
-          width would strand the badge far to the right of a long filename. */}
-      <div
+    /* Owns the width cap: it anchors the remove badge, which a max-content button would strand. */
+    <div
+      className={cn(
+        'group relative',
+        isMedia ? 'size-[48px] shrink-0' : 'h-[48px] min-w-0 max-w-[min(220px,100%)]'
+      )}
+    >
+      <button
+        type='button'
         className={cn(
-          'group relative',
-          CHIP_HEIGHT,
-          isMedia ? 'w-[48px] shrink-0' : 'min-w-0 max-w-[min(220px,100%)]'
+          CHIP_SURFACE,
+          'size-full',
+          isMedia ? 'overflow-hidden' : 'flex items-center gap-2 py-[7px] pr-5 pl-2'
         )}
+        onClick={() => onFileClick(file)}
       >
-        <Tooltip.Trigger asChild>
-          <button
-            type='button'
-            className={cn(
-              CHIP_SURFACE,
-              'size-full',
-              isMedia
-                ? 'overflow-hidden'
-                : // `pr-5` reserves room for the remove badge so it never sits over the
-                  // filename.
-                  'flex items-center gap-2 py-2 pr-5 pl-2'
-            )}
-            onClick={() => onFileClick(file)}
-          >
-            {isMedia ? (
-              <>
-                <span className='absolute inset-0 flex items-center justify-center text-[var(--text-icon)]'>
-                  <Icon className='size-[18px]' />
-                </span>
-                {file.previewUrl &&
-                  !previewFailed &&
-                  (isVideo ? (
-                    <video
-                      src={file.previewUrl}
-                      muted
-                      playsInline
-                      preload='metadata'
-                      className='relative size-full object-cover'
-                    />
-                  ) : (
-                    <img
-                      src={file.previewUrl}
-                      alt={file.name}
-                      // A HEIC whose server-side transcode failed comes back as bytes the
-                      // browser still cannot decode. Dropping the image reveals the type
-                      // icon beneath instead of a broken glyph.
-                      onError={() => setPreviewFailed(true)}
-                      className='relative size-full object-cover'
-                    />
-                  ))}
-              </>
-            ) : (
-              <>
-                {/* Steps again on hover: the chip's own hover fill closes to within
-                    7/255 of this badge in light mode, which would erase it during the
-                    one interaction where it is being looked at. */}
-                <span className='flex size-[32px] shrink-0 items-center justify-center rounded-md bg-[var(--surface-6)] text-[var(--text-icon)] transition-colors group-hover:bg-[var(--surface-7)] dark:bg-[var(--surface-3)] dark:group-hover:bg-[var(--surface-3)]'>
-                  <Icon className='size-[16px]' />
-                </span>
-                <span className='flex min-w-0 flex-col items-start'>
-                  <span className='w-full truncate text-[var(--text-body)] text-small leading-tight'>
-                    {file.name}
-                  </span>
-                  {/* The name truncates from the tail, so the extension is often not
-                      readable from it — this is the format, not a restatement.
-                      `--text-icon`, not `--text-muted`: muted lands at 2.4:1 on this
-                      fill in dark mode, well under AA. */}
-                  {extension && (
-                    <span className='text-[var(--text-icon)] text-caption uppercase leading-tight'>
-                      {extension}
-                    </span>
-                  )}
-                </span>
-              </>
-            )}
-            {file.uploading && (
-              <span className='absolute inset-0 flex items-center justify-center rounded-[inherit] bg-[var(--surface-5)]/70 dark:bg-[var(--surface-4)]/70'>
-                <Loader className='size-[14px] text-[var(--text-icon)]' animate />
+        {isMedia ? (
+          <>
+            <span className='absolute inset-0 flex items-center justify-center text-[var(--text-icon)]'>
+              <Icon className='size-[18px]' />
+            </span>
+            {file.previewUrl &&
+              !previewFailed &&
+              (isVideo ? (
+                <video
+                  src={file.previewUrl}
+                  muted
+                  playsInline
+                  preload='metadata'
+                  className='relative size-full object-cover'
+                />
+              ) : (
+                <img
+                  src={file.previewUrl}
+                  alt={file.name}
+                  onError={() => setPreviewFailed(true)}
+                  className='relative size-full object-cover'
+                />
+              ))}
+          </>
+        ) : (
+          <>
+            {/* Hover steps too: --surface-active is within 7/255 of --surface-6 in light mode. */}
+            <span className='flex size-[32px] shrink-0 items-center justify-center rounded-md bg-[var(--surface-6)] text-[var(--text-icon)] transition-colors hover-hover:group-hover:bg-[var(--surface-7)] dark:bg-[var(--surface-3)]'>
+              <Icon className='size-[16px]' />
+            </span>
+            <span className='flex min-w-0 flex-col items-start'>
+              <span className='w-full truncate text-[var(--text-body)] text-small leading-tight'>
+                {file.name}
               </span>
-            )}
-          </button>
-        </Tooltip.Trigger>
-        {!file.uploading && (
-          <button
-            type='button'
-            onClick={(e) => {
-              e.stopPropagation()
-              onRemoveFile(file.id)
-            }}
-            aria-label={`Remove ${file.name}`}
-            // Opaque, not a translucent scrim: a semi-transparent fill composites with
-            // whatever sits under it, so the same badge reads differently over a light
-            // card than over a photo. An opaque surface plus a border keeps the glyph
-            // contrast fixed and gives the badge an edge against any thumbnail.
-            className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-1)] text-[var(--text-body)] opacity-0 transition-opacity group-hover:opacity-100'
-          >
-            <X className='size-[9px]' />
-          </button>
+              {extension && (
+                <span className='text-[var(--text-icon)] text-caption uppercase leading-tight'>
+                  {extension}
+                </span>
+              )}
+            </span>
+          </>
         )}
-      </div>
-      {/* No width or truncation here — Tooltip.Content already caps and wraps, and this
-          exists precisely to reveal the name the card truncated. */}
-      <Tooltip.Content>{file.name}</Tooltip.Content>
-    </Tooltip.Root>
+        {file.uploading && (
+          <span className='absolute inset-0 flex items-center justify-center rounded-[inherit] bg-[var(--surface-5)]/70 dark:bg-[var(--surface-4)]/70'>
+            <Loader className='size-[14px] text-[var(--text-icon)]' animate />
+          </span>
+        )}
+      </button>
+      {!file.uploading && (
+        <button
+          type='button'
+          onClick={(e) => {
+            e.stopPropagation()
+            onRemoveFile(file.id)
+          }}
+          aria-label={`Remove ${file.name}`}
+          className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-body)] opacity-0 transition-opacity group-hover:opacity-100'
+        >
+          <X className='size-[10px]' />
+        </button>
+      )}
+    </div>
   )
 })
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -18,7 +18,7 @@ import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/
  * hover steps further away in the direction each theme reads as "raised".
  */
 const CHIP_SURFACE =
-  'relative cursor-pointer rounded-[10px] border border-[var(--border)] bg-[var(--surface-5)] transition-colors hover-hover:bg-[var(--surface-active)] dark:hover-hover:bg-[var(--surface-6)]'
+  'relative cursor-pointer rounded-lg border border-[var(--border)] bg-[var(--surface-5)] transition-colors hover-hover:bg-[var(--surface-active)] dark:hover-hover:bg-[var(--surface-6)]'
 
 /** Height lives on the wrapper so both shapes are the same size by construction. */
 const CHIP_HEIGHT = 'h-[48px]'
@@ -113,7 +113,7 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
                 {/* Steps again on hover: the chip's own hover fill closes to within
                     7/255 of this badge in light mode, which would erase it during the
                     one interaction where it is being looked at. */}
-                <span className='flex size-[32px] shrink-0 items-center justify-center rounded-[8px] bg-[var(--surface-6)] text-[var(--text-icon)] transition-colors group-hover:bg-[var(--surface-7)] dark:bg-[var(--surface-3)] dark:group-hover:bg-[var(--surface-3)]'>
+                <span className='flex size-[32px] shrink-0 items-center justify-center rounded-md bg-[var(--surface-6)] text-[var(--text-icon)] transition-colors group-hover:bg-[var(--surface-7)] dark:bg-[var(--surface-3)] dark:group-hover:bg-[var(--surface-3)]'>
                   <Icon className='size-[16px]' />
                 </span>
                 <span className='flex min-w-0 flex-col items-start'>
@@ -147,10 +147,11 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
               onRemoveFile(file.id)
             }}
             aria-label={`Remove ${file.name}`}
-            // Sits inside the chip's top-right corner. A fixed dark scrim rather than a
-            // surface token: it overlays arbitrary photo content on the thumbnail shape,
-            // where no theme token can guarantee contrast.
-            className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition-opacity group-hover:opacity-100'
+            // Opaque, not a translucent scrim: a semi-transparent fill composites with
+            // whatever sits under it, so the same badge reads differently over a light
+            // card than over a photo. An opaque surface plus a border keeps the glyph
+            // contrast fixed and gives the badge an edge against any thumbnail.
+            className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-1)] text-[var(--text-body)] opacity-0 transition-opacity group-hover:opacity-100'
           >
             <X className='size-[9px]' />
           </button>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -54,7 +54,15 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
 
   return (
     <Tooltip.Root>
-      <div className={cn('group relative', isMedia ? 'flex-shrink-0' : 'min-w-0')}>
+      {/* The width cap lives here, not on the button: this wrapper anchors the remove
+          badge, and sizing it to the button's uncapped max-content width would strand
+          the badge far to the right of a long filename. */}
+      <div
+        className={cn(
+          'group relative',
+          isMedia ? 'flex-shrink-0' : 'min-w-0 max-w-[min(220px,100%)]'
+        )}
+      >
         <Tooltip.Trigger asChild>
           <button
             type='button'
@@ -62,9 +70,9 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
               CHIP_SURFACE,
               isMedia
                 ? 'w-[48px] overflow-hidden'
-                : // Capped at 220px but never wider than the composer, so a long filename
-                  // truncates on a narrow viewport instead of overflowing the shell.
-                  'flex max-w-[min(220px,100%)] items-center gap-2 py-2 pr-3 pl-2'
+                : // Fills the capped wrapper, so the filename truncates rather than
+                  // widening the card past the badge it is anchored to.
+                  'flex w-full items-center gap-2 py-2 pr-3 pl-2'
             )}
             onClick={() => onFileClick(file)}
           >

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -117,10 +117,10 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
             onRemoveFile(file.id)
           }}
           aria-label={`Remove ${file.name}`}
-          /* Visible by default so a coarse pointer never has to discover it through an
-             emulated hover; fine pointers get reveal-on-hover, plus reveal-on-focus so
-             it is never transparent while it holds the keyboard focus. */
-          className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-body)] transition-opacity hover-hover:opacity-0 hover-hover:focus-visible:opacity-100 hover-hover:group-hover:opacity-100'
+          /* Always visible: reveal-on-hover would hide it from touch and from keyboard
+             focus, and `hover-hover` cannot express "while the chip is hovered" from
+             here anyway — it carries its own `&:hover`, so it binds to this element. */
+          className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-body)]'
         >
           <X className='size-[10px]' />
         </button>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -115,7 +115,9 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
             onRemoveFile(file.id)
           }}
           aria-label={`Remove ${file.name}`}
-          className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-body)] opacity-0 transition-opacity group-hover:opacity-100'
+          /* Visible by default so a coarse pointer never has to discover it through an
+             emulated hover; fine pointers get the reveal-on-hover treatment. */
+          className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-body)] transition-opacity hover-hover:opacity-0 hover-hover:group-hover:opacity-100'
         >
           <X className='size-[10px]' />
         </button>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -18,7 +18,10 @@ import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/
  * hover steps further away in the direction each theme reads as "raised".
  */
 const CHIP_SURFACE =
-  'relative h-[48px] cursor-pointer rounded-[10px] border border-[var(--border)] bg-[var(--surface-5)] transition-colors hover-hover:bg-[var(--surface-active)] dark:hover-hover:bg-[var(--surface-6)]'
+  'relative cursor-pointer rounded-[10px] border border-[var(--border)] bg-[var(--surface-5)] transition-colors hover-hover:bg-[var(--surface-active)] dark:hover-hover:bg-[var(--surface-6)]'
+
+/** Height lives on the wrapper so both shapes are the same size by construction. */
+const CHIP_HEIGHT = 'h-[48px]'
 
 interface AttachedFilesListProps {
   attachedFiles: AttachedFile[]
@@ -54,13 +57,14 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
 
   return (
     <Tooltip.Root>
-      {/* The width cap lives here, not on the button: this wrapper anchors the remove
-          badge, and sizing it to the button's uncapped max-content width would strand
-          the badge far to the right of a long filename. */}
+      {/* Both the size and the width cap live here, not on the button: this wrapper
+          anchors the remove badge, so sizing it to the button's uncapped max-content
+          width would strand the badge far to the right of a long filename. */}
       <div
         className={cn(
           'group relative',
-          isMedia ? 'flex-shrink-0' : 'min-w-0 max-w-[min(220px,100%)]'
+          CHIP_HEIGHT,
+          isMedia ? 'w-[48px] shrink-0' : 'min-w-0 max-w-[min(220px,100%)]'
         )}
       >
         <Tooltip.Trigger asChild>
@@ -68,11 +72,12 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
             type='button'
             className={cn(
               CHIP_SURFACE,
+              'size-full',
               isMedia
-                ? 'w-[48px] overflow-hidden'
-                : // Fills the capped wrapper, so the filename truncates rather than
-                  // widening the card past the badge it is anchored to.
-                  'flex w-full items-center gap-2 py-2 pr-3 pl-2'
+                ? 'overflow-hidden'
+                : // `pr-5` reserves room for the remove badge so it never sits over the
+                  // filename.
+                  'flex items-center gap-2 py-2 pr-5 pl-2'
             )}
             onClick={() => onFileClick(file)}
           >
@@ -105,17 +110,24 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
               </>
             ) : (
               <>
-                <span className='flex size-[32px] shrink-0 items-center justify-center rounded-[8px] bg-[var(--surface-6)] text-[var(--text-icon)] dark:bg-[var(--surface-3)]'>
+                {/* Steps again on hover: the chip's own hover fill closes to within
+                    7/255 of this badge in light mode, which would erase it during the
+                    one interaction where it is being looked at. */}
+                <span className='flex size-[32px] shrink-0 items-center justify-center rounded-[8px] bg-[var(--surface-6)] text-[var(--text-icon)] transition-colors group-hover:bg-[var(--surface-7)] dark:bg-[var(--surface-3)] dark:group-hover:bg-[var(--surface-3)]'>
                   <Icon className='size-[16px]' />
                 </span>
                 <span className='flex min-w-0 flex-col items-start'>
-                  <span className='w-full truncate text-[var(--text-body)] text-small'>
+                  <span className='w-full truncate text-[var(--text-body)] text-small leading-tight'>
                     {file.name}
                   </span>
-                  {/* The name truncates, so the extension is genuinely not readable from
-                      it — this is the format, not a restatement of the label. */}
+                  {/* The name truncates from the tail, so the extension is often not
+                      readable from it — this is the format, not a restatement.
+                      `--text-icon`, not `--text-muted`: muted lands at 2.4:1 on this
+                      fill in dark mode, well under AA. */}
                   {extension && (
-                    <span className='text-[var(--text-muted)] text-xs uppercase'>{extension}</span>
+                    <span className='text-[var(--text-icon)] text-caption uppercase leading-tight'>
+                      {extension}
+                    </span>
                   )}
                 </span>
               </>
@@ -135,18 +147,18 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
               onRemoveFile(file.id)
             }}
             aria-label={`Remove ${file.name}`}
-            // Overhangs the chip by 5px, which the composer's `py-2` absorbs. `--surface-6`
-            // (not the chip's own fill) because this badge sits on the composer shell —
-            // white in light mode, `--surface-4` in dark — and must read against both.
-            className='-top-[5px] -right-[5px] absolute flex size-[16px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface-6)] text-[var(--text-icon)] opacity-0 transition-opacity group-hover:opacity-100'
+            // Sits inside the chip's top-right corner. A fixed dark scrim rather than a
+            // surface token: it overlays arbitrary photo content on the thumbnail shape,
+            // where no theme token can guarantee contrast.
+            className='absolute top-[2px] right-[2px] flex size-[16px] items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition-opacity group-hover:opacity-100'
           >
             <X className='size-[9px]' />
           </button>
         )}
       </div>
-      <Tooltip.Content side='top'>
-        <p className='max-w-[200px] truncate'>{file.name}</p>
-      </Tooltip.Content>
+      {/* No width or truncation here — Tooltip.Content already caps and wraps, and this
+          exists precisely to reveal the name the card truncated. */}
+      <Tooltip.Content>{file.name}</Tooltip.Content>
     </Tooltip.Root>
   )
 })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/attached-files-list/attached-files-list.tsx
@@ -85,8 +85,10 @@ const AttachedFileChip = React.memo(function AttachedFileChip({
           </>
         ) : (
           <>
-            {/* Hover steps too: --surface-active is within 7/255 of --surface-6 in light mode. */}
-            <span className='flex size-[32px] shrink-0 items-center justify-center rounded-md bg-[var(--surface-6)] text-[var(--text-icon)] transition-colors hover-hover:group-hover:bg-[var(--surface-7)] dark:bg-[var(--surface-3)]'>
+            {/* Fill is constant — the chip's own hover is the only hover affordance. It
+                sits a step below `--surface-6` in light mode so the chip's hover fill
+                (`--surface-active`) cannot close on it. */}
+            <span className='flex size-[32px] shrink-0 items-center justify-center rounded-md bg-[var(--surface-7)] text-[var(--text-icon)] dark:bg-[var(--surface-3)]'>
               <Icon className='size-[16px]' />
             </span>
             <span className='flex min-w-0 flex-col items-start'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments.ts
@@ -159,8 +159,8 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
       if (files.length === 0) return
 
       const placeholders: AttachedFile[] = files.map((file) => {
-        // Resolve once: the browser reports `application/octet-stream` (or nothing) for
-        // plenty of files, and both the chip and the preview decision key off the type.
+        /** Resolved once: browsers report `application/octet-stream` (or nothing) for
+         *  plenty of files, and both the chip and the preview decision key off it. */
         const type = resolveFileType(file)
         return {
           id: generateId(),
@@ -211,10 +211,9 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
                       path: result.path,
                       key: result.key,
                       uploading: false,
-                      // A format the browser cannot decode has no local preview; now that
-                      // the bytes are stored, the serve route can hand back a renderable
-                      // derivative. Anything already previewing keeps its blob URL rather
-                      // than paying a round trip for a thumbnail it can draw locally.
+                      /** A format the browser cannot decode has no local preview; the
+                       *  stored bytes now have a renderable derivative. Anything already
+                       *  previewing keeps its blob URL. */
                       previewUrl:
                         f.previewUrl ??
                         getMothershipAttachmentPreviewUrl({
@@ -352,12 +351,11 @@ export function useFileAttachments(props: UseFileAttachmentsProps) {
   }, [])
 
   /**
-   * Replaces the current attached files with a given set.
-   * Cleans up preview URLs from the prior set before replacing.
+   * Replaces the current attached files with a given set, revoking the prior set's
+   * preview URLs first. Revoked outside the updater, which must stay pure — React
+   * double-invokes updaters in StrictMode and may replay them.
    */
   const restoreAttachedFiles = useCallback((files: AttachedFile[]) => {
-    // Revoked outside the updater: React double-invokes updaters in StrictMode and may
-    // replay them, so they have to stay pure.
     attachedFilesRef.current.forEach((f) => revokePreviewUrl(f.previewUrl))
     setAttachedFiles(files)
   }, [])


### PR DESCRIPTION
## Summary
- The remove badge drifted far to the right of a file card. The wrapper it is positioned against had no width cap, so it sized to the filename's *max-content* width while the card capped itself at 220px. Moved the cap onto the wrapper.
- Restored the sent-message attachment styling from `main` — an earlier icon-only pass dropped the filename, leaving no way to tell what was sent.
- Removed the chip tooltips; the card already shows the filename.
- Radii onto the token scale (`--radius` is 8px): `rounded-[10px]` was off-system in both files. Outer surfaces use `rounded-lg`, the nested icon badge `rounded-md`. Filename uses the named `text-xs` instead of an arbitrary `text-[11px]`.
- Remove badge is opaque (`--surface-2`) instead of a translucent scrim, so it reads identically over a light card and over a photo rather than compositing with each. `--surface-1` was 8/255 from the chip fill in light mode.
- Its hover gating now matches the chip's `hover-hover:`; the two were mixed, so a coarse-pointer tap revealed the badge without the chip's hover fill.
- `py-[7px]` so the 32px icon badge fits the 48px box rather than overflowing its padding.

## Type of Change
- [x] Bug fix

## Testing
`tsc --noEmit`, `lint`, `check:api-validation`, `check:import-specifiers` clean. 457 tests pass in the touched area, including 5 on the chip. Verified locally against a running dev server.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)