### PR TITLE
improvement(tables): show a tooltip on truncated column headers

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/column-header-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/column-header-menu.tsx
@@ -4,11 +4,11 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@sim/emcn'
 import { ChevronDown } from '@sim/emcn/icons'
 import type { WorkflowGroup } from '@/lib/table'
+import { HeaderLabel } from '@/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/header-label'
 import type { WorkflowMetadata } from '@/stores/workflows/registry/types'
 import { COL_WIDTH, SELECTION_TINT_BG } from '../constants'
 import type { ColumnSourceInfo, DisplayColumn } from '../types'
 import { ColumnTypeIcon } from './column-type-icon'
-import { HeaderLabel } from './header-label'
 import { ColumnOptionsMenu } from './workflow-group-meta-cell'
 
 interface ColumnHeaderMenuProps {

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/column-header-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/column-header-menu.tsx
@@ -8,6 +8,7 @@ import type { WorkflowMetadata } from '@/stores/workflows/registry/types'
 import { COL_WIDTH, SELECTION_TINT_BG } from '../constants'
 import type { ColumnSourceInfo, DisplayColumn } from '../types'
 import { ColumnTypeIcon } from './column-type-icon'
+import { HeaderLabel } from './header-label'
 import { ColumnOptionsMenu } from './workflow-group-meta-cell'
 
 interface ColumnHeaderMenuProps {
@@ -296,9 +297,10 @@ export const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
             blockIconInfo={sourceInfo?.blockIconInfo}
             blockMissing={blockMissing}
           />
-          <span className='ml-1.5 min-w-0 overflow-clip text-ellipsis whitespace-nowrap text-[var(--text-primary)] text-small'>
-            {column.workflowGroupId ? column.headerLabel : column.name}
-          </span>
+          <HeaderLabel
+            label={column.workflowGroupId ? column.headerLabel : column.name}
+            className='ml-1.5 text-[var(--text-primary)] text-small'
+          />
         </div>
       ) : (
         <div className='flex h-full w-full min-w-0 items-center'>
@@ -314,9 +316,10 @@ export const ColumnHeaderMenu = React.memo(function ColumnHeaderMenu({
               blockIconInfo={sourceInfo?.blockIconInfo}
               blockMissing={blockMissing}
             />
-            <span className='ml-1.5 min-w-0 overflow-clip text-ellipsis whitespace-nowrap text-[var(--text-primary)] text-small'>
-              {column.workflowGroupId ? column.headerLabel : column.name}
-            </span>
+            <HeaderLabel
+              label={column.workflowGroupId ? column.headerLabel : column.name}
+              className='ml-1.5 text-[var(--text-primary)] text-small'
+            />
           </button>
           <button
             type='button'

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/header-label.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/header-label.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { memo } from 'react'
+import { cn, FloatingTooltip, isTextClipped, useFloatingTooltip } from '@sim/emcn'
+
+interface HeaderLabelProps {
+  label: string
+  className?: string
+}
+
+/**
+ * Column header text that clips with an ellipsis and reveals its full value in
+ * a floating tooltip — but only while actually clipped, since an untruncated
+ * header already says everything the tooltip would.
+ */
+export const HeaderLabel = memo(function HeaderLabel({ label, className }: HeaderLabelProps) {
+  const { state, handlers } = useFloatingTooltip(isTextClipped)
+
+  return (
+    <>
+      <span className={cn('min-w-0 truncate', className)} {...handlers}>
+        {label}
+      </span>
+      <FloatingTooltip label={label} state={state} />
+    </>
+  )
+})

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
@@ -31,6 +31,7 @@ import { getEnrichment } from '@/enrichments/registry'
 import type { WorkflowMetadata } from '@/stores/workflows/registry/types'
 import { SELECTION_TINT_BG } from '../constants'
 import type { DisplayColumn } from '../types'
+import { HeaderLabel } from './header-label'
 
 /** Fixed row-cap presets for the "Run N empty rows" shortcuts. Shared by the
  *  group-header options menu and the inline quick-run dropdown so the two
@@ -439,7 +440,7 @@ export function WorkflowGroupMetaCell({
         ) : (
           <Workflow className='size-[12px] shrink-0 text-[var(--text-icon)]' />
         )}
-        <span className='min-w-0 truncate text-[var(--text-secondary)] text-xs'>{name}</span>
+        <HeaderLabel label={name} className='text-[var(--text-secondary)] text-xs' />
         {onRunColumn && (
           <DropdownMenu open={runMenuOpen} onOpenChange={setRunMenuOpen}>
             <DropdownMenuTrigger asChild>

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
@@ -27,11 +27,11 @@ import {
 } from '@sim/emcn/icons'
 import type { RunLimit, RunMode } from '@/lib/api/contracts/tables'
 import type { WorkflowGroupType } from '@/lib/table'
+import { HeaderLabel } from '@/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/header-label'
 import { getEnrichment } from '@/enrichments/registry'
 import type { WorkflowMetadata } from '@/stores/workflows/registry/types'
 import { SELECTION_TINT_BG } from '../constants'
 import type { DisplayColumn } from '../types'
-import { HeaderLabel } from './header-label'
 
 /** Fixed row-cap presets for the "Run N empty rows" shortcuts. Shared by the
  *  group-header options menu and the inline quick-run dropdown so the two


### PR DESCRIPTION
## Summary
- Column headers in the table grid now reveal their full name in an emcn floating tooltip when the text is clipped — gated on `isTextClipped`, so an untruncated header never shows one
- Covers both surfaces: the standalone table page and the embedded table view in the mothership chat page (same `TableGrid`), plus the workflow/enrichment group header
- New `HeaderLabel` component replaces the three hand-rolled truncating spans

## Type of Change
- [x] Improvement

## Testing
Tested manually. `bun run type-check`, `bun run lint`, and `bun run check:audits` (22 audits) pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)