### PR TITLE
fix(sidebar): keep the pin visible on the chat you're viewing

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/collapsed-sidebar-menu/collapsed-sidebar-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/collapsed-sidebar-menu/collapsed-sidebar-menu.tsx
@@ -300,7 +300,7 @@ export function CollapsedChatFlyoutItem({
         <ConversationListItem
           title={chat.name}
           isActive={!!chat.isActive}
-          isUnread={!!chat.isUnread}
+          isUnread={!!chat.isUnread && !isCurrentRoute}
         />
       </Link>
     </DropdownMenuItem>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -195,6 +195,13 @@ const SidebarChatItem = memo(function SidebarChatItem({
 }) {
   const dragGhostRef = useRef<HTMLElement | null>(null)
 
+  /**
+   * The trailing slot fits one glyph, and the dot wins over the pin: it reports
+   * transient state (a run in progress, or an unread reply elsewhere), while pinning
+   * is persistent and already conveyed by the row sorting to the top of the list.
+   */
+  const showStatusDot = isActive || (!isCurrentRoute && isUnread)
+
   function handleDragStart(e: React.DragEvent) {
     e.dataTransfer.effectAllowed = 'copyMove'
     e.dataTransfer.setData(
@@ -238,12 +245,12 @@ const SidebarChatItem = memo(function SidebarChatItem({
       >
         <div className='min-w-0 flex-1 truncate text-[var(--text-body)]'>{chat.name}</div>
         {chat.id !== 'new' && (
-          <div className='relative flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center'>
-            {(isActive || (!isCurrentRoute && isUnread)) && (
+          <div className='relative flex size-[18px] flex-shrink-0 items-center justify-center'>
+            {showStatusDot && (
               <span
                 aria-hidden='true'
                 className={cn(
-                  'h-[6px] w-[6px] rounded-full transition-opacity',
+                  'size-[6px] rounded-full transition-opacity',
                   isMenuOpen ? 'opacity-0' : 'group-hover:opacity-0'
                 )}
                 style={{
@@ -251,10 +258,13 @@ const SidebarChatItem = memo(function SidebarChatItem({
                 }}
               />
             )}
-            {!isActive && !isUnread && isPinned && !isCurrentRoute && !isMenuOpen && (
+            {!showStatusDot && isPinned && (
               <Pin
                 aria-hidden='true'
-                className='absolute size-[12px] text-[var(--text-icon)] group-hover:hidden'
+                className={cn(
+                  'absolute size-[12px] text-[var(--text-icon)] transition-opacity',
+                  isMenuOpen ? 'opacity-0' : 'group-hover:opacity-0'
+                )}
               />
             )}
             <button


### PR DESCRIPTION
## Summary
- Pinned chats lost their pin glyph the moment you opened them. The pin's guard carried a stale `!isCurrentRoute` term, copy-pasted from the status dot's guard back when the dot was also hidden on the current route — #4354 relaxed the dot's guard and left the pin's byte-identical.
- Derive `showStatusDot` once and express the pin as its negation, so the two conditions in that slot can't drift apart again.
- Collapsed rail never forwarded `isCurrentRoute` to `ConversationListItem`, so the chat you were already reading showed an unread dot there but not in the expanded sidebar. Same chat, same data, two answers.
- Pin now hides by the same `transition-opacity` mechanism the dot uses, instead of `group-hover:hidden` plus a mount guard. That asymmetry is what let the guards drift in the first place.

## Behavior
The trailing 18px slot holds one glyph. Precedence is unchanged: status dot > pin, and the `...` button covers both on hover. So a pinned chat that is *currently generating* still shows the yellow dot, and the pin returns once it settles — the dot is transient and time-sensitive, the pin is persistent and already implied by the row sorting to the top.

## Type of Change
- [x] Bug fix

## Testing
`bun run type-check` and `biome check` pass. **Not verified in a browser** — worth a visual pass on the hover/menu-open states, and on the pin's fade, which is new motion.

## Follow-ups (not in this PR)
- `SidebarChatItem` duplicates the dot that `ConversationListItem` already owns for two other call sites, including an identically-named `showStatusDot` const with a *different* formula. Folding them together means teaching the shared component about the stacked slot, absolute positioning, and the overlaid `...` — too big for a 4-line fix.
- `#EAB308` is a raw hex in exactly two files repo-wide (here and `conversation-list-item.tsx`); it wants a real token.
- The collapsed rail renders no pin at all. Feature gap rather than this bug — pinned chats already sort to the head of that list.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)