### PR TITLE
fix(uploads): treat a missing storage object as absent metadata, not a failure

### DIFF
--- a/apps/sim/app/api/files/serve/[...path]/route.test.ts
+++ b/apps/sim/app/api/files/serve/[...path]/route.test.ts
@@ -7,6 +7,13 @@ import { hybridAuthMockFns, storageServiceMock, storageServiceMockFns } from '@s
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('@sim/logger', () => ({
+  createLogger: vi.fn(() => serveLogger),
+  logger: serveLogger,
+  runWithRequestContext: vi.fn(<T>(_ctx: unknown, fn: () => T): T => fn()),
+  getRequestContext: vi.fn(() => undefined),
+}))
+
 const {
   mockVerifyFileAccess,
   mockReadFile,
@@ -18,6 +25,7 @@ const {
   mockCreateFileResponse,
   mockCreateErrorResponse,
   FileNotFoundError,
+  serveLogger,
 } = vi.hoisted(() => {
   class FileNotFoundErrorClass extends Error {
     constructor(message: string) {
@@ -26,6 +34,7 @@ const {
     }
   }
   return {
+    serveLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     mockVerifyFileAccess: vi.fn(),
     mockReadFile: vi.fn(),
     mockIsUsingCloudStorage: vi.fn(),
@@ -231,5 +240,33 @@ describe('File Serve API Route', () => {
         expect(response.headers.get('Content-Type')).toBe(test.contentType)
       })
     }
+  })
+
+  describe('failure log level', () => {
+    it('records a missing file at info, not error', async () => {
+      /** A superseded key is an ordinary 404, not a server fault. */
+      const req = new NextRequest('http://localhost:3000/api/files/serve/')
+      const response = await GET(req, { params: Promise.resolve({ path: [] }) })
+
+      expect(response.status).toBe(404)
+      expect(serveLogger.info).toHaveBeenCalledWith(
+        'Error serving file:',
+        expect.objectContaining({ reason: expect.any(String) })
+      )
+      expect(serveLogger.error).not.toHaveBeenCalled()
+    })
+
+    it('still records a genuine failure at error', async () => {
+      mockVerifyFileAccess.mockRejectedValueOnce(new Error('permission backend down'))
+
+      const req = new NextRequest(
+        'http://localhost:3000/api/files/serve/workspace/ws/test-file.txt'
+      )
+      await GET(req, {
+        params: Promise.resolve({ path: ['workspace', 'ws', 'test-file.txt'] }),
+      }).catch(() => undefined)
+
+      expect(serveLogger.error).toHaveBeenCalled()
+    })
   })
 })

--- a/apps/sim/app/api/files/serve/[...path]/route.ts
+++ b/apps/sim/app/api/files/serve/[...path]/route.ts
@@ -26,6 +26,23 @@ import {
 
 const logger = createLogger('FilesServeAPI')
 
+/**
+ * Records a failed serve at a level that matches whose fault it is.
+ *
+ * A file that is not there is an ordinary answer rather than a server fault: a
+ * workspace file is rewritten under a new key on every content update, so a reader
+ * holding the previous key lands here routinely and correctly receives a 404. Each
+ * handler rethrows into the outer one, so logging those at `error` reports the same
+ * expected 404 twice and buries the failures that do warrant attention.
+ */
+function logServeFailure(message: string, error: unknown): void {
+  if (error instanceof FileNotFoundError) {
+    logger.info(message, { reason: error.message })
+    return
+  }
+  logger.error(message, error)
+}
+
 interface ServeOptions {
   /** `raw=1` — bypass all resolution and serve the stored source as-is. */
   raw: boolean
@@ -179,7 +196,7 @@ export const GET = withRouteHandler(
         return NextResponse.json({ error: 'Document is still being generated' }, { status: 409 })
       }
 
-      logger.error('Error serving file:', error)
+      logServeFailure('Error serving file:', error)
 
       if (error instanceof FileNotFoundError) {
         return createErrorResponse(error)
@@ -244,7 +261,7 @@ async function handleLocalFile(
       cacheControl: resolveServeCacheControl(options.versioned, contextParam),
     })
   } catch (error) {
-    logger.error('Error reading local file:', error)
+    logServeFailure('Error reading local file:', error)
     throw error
   }
 }
@@ -311,7 +328,7 @@ async function handleCloudProxy(
       cacheControl: resolveServeCacheControl(options.versioned, context),
     })
   } catch (error) {
-    logger.error('Error downloading from cloud storage:', error)
+    logServeFailure('Error downloading from cloud storage:', error)
     throw error
   }
 }
@@ -348,7 +365,7 @@ async function handleCloudProxyPublic(
       cacheControl: PUBLIC_ASSET_CACHE_CONTROL,
     })
   } catch (error) {
-    logger.error('Error serving public cloud file:', error)
+    logServeFailure('Error serving public cloud file:', error)
     throw error
   }
 }
@@ -373,7 +390,7 @@ async function handleLocalFilePublic(filename: string): Promise<NextResponse> {
       cacheControl: PUBLIC_ASSET_CACHE_CONTROL,
     })
   } catch (error) {
-    logger.error('Error reading public local file:', error)
+    logServeFailure('Error reading public local file:', error)
     throw error
   }
 }

--- a/apps/sim/lib/uploads/core/errors.test.ts
+++ b/apps/sim/lib/uploads/core/errors.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
+import { hasObjectNotFoundLabel, isObjectNotFoundError } from '@/lib/uploads/core/errors'
 
 describe('isObjectNotFoundError', () => {
   it('matches the shapes each storage provider uses for a missing object', () => {
@@ -65,5 +65,25 @@ describe('isObjectNotFoundError', () => {
     expect(isObjectNotFoundError(undefined)).toBe(false)
     expect(isObjectNotFoundError('NotFound')).toBe(false)
     expect(isObjectNotFoundError(404)).toBe(false)
+  })
+})
+
+describe('hasObjectNotFoundLabel', () => {
+  it('accepts only a provider that names the object as the missing resource', () => {
+    expect(hasObjectNotFoundLabel({ name: 'NotFound' })).toBe(true)
+    expect(hasObjectNotFoundLabel({ name: 'NoSuchKey' })).toBe(true)
+    expect(hasObjectNotFoundLabel({ name: 'RestError', code: 'BlobNotFound' })).toBe(true)
+  })
+
+  it('rejects an unlabelled 404, which cannot be attributed to the object', () => {
+    /** GCS answers a missing object and a missing bucket identically. */
+    expect(hasObjectNotFoundLabel({ code: 404 })).toBe(false)
+    expect(hasObjectNotFoundLabel({ statusCode: 404 })).toBe(false)
+    expect(hasObjectNotFoundLabel({ $metadata: { httpStatusCode: 404 } })).toBe(false)
+  })
+
+  it('rejects a missing bucket or container', () => {
+    expect(hasObjectNotFoundLabel({ name: 'NoSuchBucket' })).toBe(false)
+    expect(hasObjectNotFoundLabel({ name: 'RestError', code: 'ContainerNotFound' })).toBe(false)
   })
 })

--- a/apps/sim/lib/uploads/core/errors.test.ts
+++ b/apps/sim/lib/uploads/core/errors.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { hasObjectNotFoundLabel, isObjectNotFoundError } from '@/lib/uploads/core/errors'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 
 describe('isObjectNotFoundError', () => {
   it('matches the shapes each storage provider uses for a missing object', () => {
@@ -65,25 +65,5 @@ describe('isObjectNotFoundError', () => {
     expect(isObjectNotFoundError(undefined)).toBe(false)
     expect(isObjectNotFoundError('NotFound')).toBe(false)
     expect(isObjectNotFoundError(404)).toBe(false)
-  })
-})
-
-describe('hasObjectNotFoundLabel', () => {
-  it('accepts only a provider that names the object as the missing resource', () => {
-    expect(hasObjectNotFoundLabel({ name: 'NotFound' })).toBe(true)
-    expect(hasObjectNotFoundLabel({ name: 'NoSuchKey' })).toBe(true)
-    expect(hasObjectNotFoundLabel({ name: 'RestError', code: 'BlobNotFound' })).toBe(true)
-  })
-
-  it('rejects an unlabelled 404, which cannot be attributed to the object', () => {
-    /** GCS answers a missing object and a missing bucket identically. */
-    expect(hasObjectNotFoundLabel({ code: 404 })).toBe(false)
-    expect(hasObjectNotFoundLabel({ statusCode: 404 })).toBe(false)
-    expect(hasObjectNotFoundLabel({ $metadata: { httpStatusCode: 404 } })).toBe(false)
-  })
-
-  it('rejects a missing bucket or container', () => {
-    expect(hasObjectNotFoundLabel({ name: 'NoSuchBucket' })).toBe(false)
-    expect(hasObjectNotFoundLabel({ name: 'RestError', code: 'ContainerNotFound' })).toBe(false)
   })
 })

--- a/apps/sim/lib/uploads/core/errors.test.ts
+++ b/apps/sim/lib/uploads/core/errors.test.ts
@@ -24,6 +24,12 @@ describe('isObjectNotFoundError', () => {
     expect(isObjectNotFoundError({ code: 404 })).toBe(true)
   })
 
+  it('reads the label from code when name carries the error class instead', () => {
+    /** Azure raises a `RestError`; the reason lives in `code`, not `name`. */
+    expect(isObjectNotFoundError({ name: 'RestError', code: 'BlobNotFound' })).toBe(true)
+    expect(isObjectNotFoundError({ name: 'Error', code: 'NoSuchKey' })).toBe(true)
+  })
+
   it('matches on status alone when the provider sends no label', () => {
     expect(isObjectNotFoundError({ $metadata: { httpStatusCode: 404 } })).toBe(true)
     expect(isObjectNotFoundError({ statusCode: 404 })).toBe(true)

--- a/apps/sim/lib/uploads/core/errors.test.ts
+++ b/apps/sim/lib/uploads/core/errors.test.ts
@@ -30,6 +30,19 @@ describe('isObjectNotFoundError', () => {
     expect(isObjectNotFoundError({ name: 'Error', code: 'NoSuchKey' })).toBe(true)
   })
 
+  it('does not read a missing bucket or container as an absent object', () => {
+    /**
+     * These answer 404 too. Reading them as absence would turn a total storage
+     * misconfiguration into silent fail-closed reads with nothing to alert on.
+     */
+    expect(
+      isObjectNotFoundError({ name: 'NoSuchBucket', $metadata: { httpStatusCode: 404 } })
+    ).toBe(false)
+    expect(
+      isObjectNotFoundError({ name: 'RestError', code: 'ContainerNotFound', statusCode: 404 })
+    ).toBe(false)
+  })
+
   it('matches on status alone when the provider sends no label', () => {
     expect(isObjectNotFoundError({ $metadata: { httpStatusCode: 404 } })).toBe(true)
     expect(isObjectNotFoundError({ statusCode: 404 })).toBe(true)

--- a/apps/sim/lib/uploads/core/errors.test.ts
+++ b/apps/sim/lib/uploads/core/errors.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
+
+describe('isObjectNotFoundError', () => {
+  it('matches the shapes each storage provider uses for a missing object', () => {
+    /** S3 HeadObject, exactly as the production payload arrived. */
+    expect(
+      isObjectNotFoundError({
+        name: 'NotFound',
+        $fault: 'client',
+        $metadata: { httpStatusCode: 404 },
+      })
+    ).toBe(true)
+    /** S3 GetObject. */
+    expect(isObjectNotFoundError({ name: 'NoSuchKey', $metadata: { httpStatusCode: 404 } })).toBe(
+      true
+    )
+    /** Azure Blob. */
+    expect(isObjectNotFoundError({ code: 'BlobNotFound', statusCode: 404 })).toBe(true)
+    /** GCS, which reports a numeric code. */
+    expect(isObjectNotFoundError({ code: 404 })).toBe(true)
+  })
+
+  it('matches on status alone when the provider sends no label', () => {
+    expect(isObjectNotFoundError({ $metadata: { httpStatusCode: 404 } })).toBe(true)
+    expect(isObjectNotFoundError({ statusCode: 404 })).toBe(true)
+  })
+
+  it('does not swallow a genuine failure', () => {
+    expect(
+      isObjectNotFoundError({ name: 'AccessDenied', $metadata: { httpStatusCode: 403 } })
+    ).toBe(false)
+    expect(
+      isObjectNotFoundError({ name: 'InternalError', $metadata: { httpStatusCode: 500 } })
+    ).toBe(false)
+    expect(isObjectNotFoundError({ name: 'TimeoutError' })).toBe(false)
+    expect(isObjectNotFoundError({ code: 'ECONNRESET' })).toBe(false)
+    expect(isObjectNotFoundError({ code: 403 })).toBe(false)
+  })
+
+  it('tolerates values that are not error objects', () => {
+    expect(isObjectNotFoundError(null)).toBe(false)
+    expect(isObjectNotFoundError(undefined)).toBe(false)
+    expect(isObjectNotFoundError('NotFound')).toBe(false)
+    expect(isObjectNotFoundError(404)).toBe(false)
+  })
+})

--- a/apps/sim/lib/uploads/core/errors.ts
+++ b/apps/sim/lib/uploads/core/errors.ts
@@ -1,3 +1,5 @@
+const NOT_FOUND_LABELS = new Set(['NotFound', 'NoSuchKey', 'BlobNotFound'])
+
 /**
  * True when a storage provider reports that an object simply does not exist.
  *
@@ -13,19 +15,20 @@
 export function isObjectNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false
 
-  const candidate = error as {
+  const { name, code, statusCode, $metadata } = error as {
     name?: unknown
     code?: unknown
     statusCode?: unknown
     $metadata?: { httpStatusCode?: unknown }
   }
 
-  const label = typeof candidate.name === 'string' ? candidate.name : candidate.code
-  if (label === 'NotFound' || label === 'NoSuchKey' || label === 'BlobNotFound') return true
+  /**
+   * `name` and `code` are checked independently: Azure raises a `RestError` whose
+   * `name` says nothing useful and whose `code` carries the reason, while the AWS
+   * SDK puts the reason in `name`.
+   */
+  if (typeof name === 'string' && NOT_FOUND_LABELS.has(name)) return true
+  if (typeof code === 'string' && NOT_FOUND_LABELS.has(code)) return true
 
-  return (
-    candidate.code === 404 ||
-    candidate.statusCode === 404 ||
-    candidate.$metadata?.httpStatusCode === 404
-  )
+  return code === 404 || statusCode === 404 || $metadata?.httpStatusCode === 404
 }

--- a/apps/sim/lib/uploads/core/errors.ts
+++ b/apps/sim/lib/uploads/core/errors.ts
@@ -1,4 +1,11 @@
-const NOT_FOUND_LABELS = new Set(['NotFound', 'NoSuchKey', 'BlobNotFound'])
+const OBJECT_NOT_FOUND_LABELS = new Set(['NotFound', 'NoSuchKey', 'BlobNotFound'])
+
+/**
+ * A missing bucket or container is a misconfiguration, not an absent object, and
+ * it also answers 404. Without this it would read as "no metadata" and every file
+ * read would fail closed with no error to alert on.
+ */
+const CONTAINER_NOT_FOUND_LABELS = new Set(['NoSuchBucket', 'ContainerNotFound'])
 
 /**
  * True when a storage provider reports that an object simply does not exist.
@@ -23,12 +30,14 @@ export function isObjectNotFoundError(error: unknown): boolean {
   }
 
   /**
-   * `name` and `code` are checked independently: Azure raises a `RestError` whose
-   * `name` says nothing useful and whose `code` carries the reason, while the AWS
-   * SDK puts the reason in `name`.
+   * `name` and `code` are both consulted: Azure raises a `RestError` whose `name`
+   * carries the class and whose `code` carries the reason, while the AWS SDK puts
+   * the reason in `name`.
    */
-  if (typeof name === 'string' && NOT_FOUND_LABELS.has(name)) return true
-  if (typeof code === 'string' && NOT_FOUND_LABELS.has(code)) return true
+  const labels = [name, code].filter((value): value is string => typeof value === 'string')
+
+  if (labels.some((label) => CONTAINER_NOT_FOUND_LABELS.has(label))) return false
+  if (labels.some((label) => OBJECT_NOT_FOUND_LABELS.has(label))) return true
 
   return code === 404 || statusCode === 404 || $metadata?.httpStatusCode === 404
 }

--- a/apps/sim/lib/uploads/core/errors.ts
+++ b/apps/sim/lib/uploads/core/errors.ts
@@ -19,30 +19,16 @@ function readLabels(error: unknown): string[] | null {
 }
 
 /**
- * True when a provider names the missing resource as the object itself.
- *
- * The strict form. Use it wherever the caller cannot vouch for what was requested,
- * because an unlabelled 404 is ambiguous: GCS answers a missing object and a
- * missing bucket identically (`code: 404`, `errors[].reason: 'notFound'`), so only
- * the human-readable message separates them. Treating that as absence would let a
- * bucket misconfiguration read as "no metadata" and fail every read closed with
- * nothing left to alert on, so it stays an error here.
- */
-export function hasObjectNotFoundLabel(error: unknown): boolean {
-  const labels = readLabels(error)
-  if (!labels) return false
-  if (labels.some((label) => CONTAINER_NOT_FOUND_LABELS.has(label))) return false
-  return labels.some((label) => OBJECT_NOT_FOUND_LABELS.has(label))
-}
-
-/**
  * True when a storage provider reports that an object does not exist.
  *
- * The lenient form, for a caller that has just performed an object-level operation
- * and can therefore attribute a bare 404 to that object — which is what every
- * provider client here does, and how each spelled this check before it was shared.
- * It additionally accepts a bare 404 (`code`, `statusCode`, or
- * `$metadata.httpStatusCode`), which GCS relies on since it carries no label.
+ * Call this only from code that has just performed an object-level operation, so a
+ * bare 404 can be attributed to that object. A bare 404 is otherwise ambiguous —
+ * GCS answers a missing object and a missing bucket identically (`code: 404`,
+ * `errors[].reason: 'notFound'`), separable only by a human-readable message — and
+ * every caller here is a provider client that knows exactly what it asked for.
+ *
+ * Absence is an expected outcome of a lookup, so callers turn it into an empty
+ * result rather than propagating it.
  *
  * A network failure, a permission denial, or a provider 5xx still propagates.
  */

--- a/apps/sim/lib/uploads/core/errors.ts
+++ b/apps/sim/lib/uploads/core/errors.ts
@@ -7,37 +7,55 @@ const OBJECT_NOT_FOUND_LABELS = new Set(['NotFound', 'NoSuchKey', 'BlobNotFound'
  */
 const CONTAINER_NOT_FOUND_LABELS = new Set(['NoSuchBucket', 'ContainerNotFound'])
 
-/**
- * True when a storage provider reports that an object simply does not exist.
- *
- * Absence is an expected outcome of a lookup, not a failure, so callers turn this
- * into an empty result rather than propagating it. Every provider spells it
- * differently — S3 throws `NotFound` (HeadObject) or `NoSuchKey` (GetObject),
- * Azure Blob throws `BlobNotFound`, and GCS throws a numeric `code: 404` — and the
- * status may arrive as `$metadata.httpStatusCode`, `statusCode`, or `code`.
- *
- * Only genuine absence matches. A network failure, a permission denial, or a
- * provider 5xx still propagates so it surfaces as the error it is.
- */
-export function isObjectNotFoundError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false
-
-  const { name, code, statusCode, $metadata } = error as {
-    name?: unknown
-    code?: unknown
-    statusCode?: unknown
-    $metadata?: { httpStatusCode?: unknown }
-  }
-
+function readLabels(error: unknown): string[] | null {
+  if (!error || typeof error !== 'object') return null
+  const { name, code } = error as { name?: unknown; code?: unknown }
   /**
    * `name` and `code` are both consulted: Azure raises a `RestError` whose `name`
    * carries the class and whose `code` carries the reason, while the AWS SDK puts
    * the reason in `name`.
    */
-  const labels = [name, code].filter((value): value is string => typeof value === 'string')
+  return [name, code].filter((value): value is string => typeof value === 'string')
+}
 
+/**
+ * True when a provider names the missing resource as the object itself.
+ *
+ * The strict form. Use it wherever the caller cannot vouch for what was requested,
+ * because an unlabelled 404 is ambiguous: GCS answers a missing object and a
+ * missing bucket identically (`code: 404`, `errors[].reason: 'notFound'`), so only
+ * the human-readable message separates them. Treating that as absence would let a
+ * bucket misconfiguration read as "no metadata" and fail every read closed with
+ * nothing left to alert on, so it stays an error here.
+ */
+export function hasObjectNotFoundLabel(error: unknown): boolean {
+  const labels = readLabels(error)
+  if (!labels) return false
+  if (labels.some((label) => CONTAINER_NOT_FOUND_LABELS.has(label))) return false
+  return labels.some((label) => OBJECT_NOT_FOUND_LABELS.has(label))
+}
+
+/**
+ * True when a storage provider reports that an object does not exist.
+ *
+ * The lenient form, for a caller that has just performed an object-level operation
+ * and can therefore attribute a bare 404 to that object — which is what every
+ * provider client here does, and how each spelled this check before it was shared.
+ * It additionally accepts a bare 404 (`code`, `statusCode`, or
+ * `$metadata.httpStatusCode`), which GCS relies on since it carries no label.
+ *
+ * A network failure, a permission denial, or a provider 5xx still propagates.
+ */
+export function isObjectNotFoundError(error: unknown): boolean {
+  const labels = readLabels(error)
+  if (!labels) return false
   if (labels.some((label) => CONTAINER_NOT_FOUND_LABELS.has(label))) return false
   if (labels.some((label) => OBJECT_NOT_FOUND_LABELS.has(label))) return true
 
+  const { code, statusCode, $metadata } = error as {
+    code?: unknown
+    statusCode?: unknown
+    $metadata?: { httpStatusCode?: unknown }
+  }
   return code === 404 || statusCode === 404 || $metadata?.httpStatusCode === 404
 }

--- a/apps/sim/lib/uploads/core/errors.ts
+++ b/apps/sim/lib/uploads/core/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * True when a storage provider reports that an object simply does not exist.
+ *
+ * Absence is an expected outcome of a lookup, not a failure, so callers turn this
+ * into an empty result rather than propagating it. Every provider spells it
+ * differently — S3 throws `NotFound` (HeadObject) or `NoSuchKey` (GetObject),
+ * Azure Blob throws `BlobNotFound`, and GCS throws a numeric `code: 404` — and the
+ * status may arrive as `$metadata.httpStatusCode`, `statusCode`, or `code`.
+ *
+ * Only genuine absence matches. A network failure, a permission denial, or a
+ * provider 5xx still propagates so it surfaces as the error it is.
+ */
+export function isObjectNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+
+  const candidate = error as {
+    name?: unknown
+    code?: unknown
+    statusCode?: unknown
+    $metadata?: { httpStatusCode?: unknown }
+  }
+
+  const label = typeof candidate.name === 'string' ? candidate.name : candidate.code
+  if (label === 'NotFound' || label === 'NoSuchKey' || label === 'BlobNotFound') return true
+
+  return (
+    candidate.code === 404 ||
+    candidate.statusCode === 404 ||
+    candidate.$metadata?.httpStatusCode === 404
+  )
+}

--- a/apps/sim/lib/uploads/core/storage-client.test.ts
+++ b/apps/sim/lib/uploads/core/storage-client.test.ts
@@ -3,14 +3,9 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockGetFileMetadataByKey, mockSend, mockHeadObjectCommand } = vi.hoisted(() => ({
+const { mockGetFileMetadataByKey, mockHeadS3Object } = vi.hoisted(() => ({
   mockGetFileMetadataByKey: vi.fn(),
-  mockSend: vi.fn(),
-  mockHeadObjectCommand: vi.fn().mockImplementation(class {}),
-}))
-
-vi.mock('@aws-sdk/client-s3', () => ({
-  HeadObjectCommand: mockHeadObjectCommand,
+  mockHeadS3Object: vi.fn(),
 }))
 
 vi.mock('@/lib/uploads/config', () => ({
@@ -21,7 +16,7 @@ vi.mock('@/lib/uploads/config', () => ({
 }))
 
 vi.mock('@/lib/uploads/providers/s3/client', () => ({
-  getS3Client: () => ({ send: mockSend }),
+  headS3Object: mockHeadS3Object,
 }))
 
 vi.mock('@/lib/uploads/server/metadata', () => ({
@@ -30,13 +25,6 @@ vi.mock('@/lib/uploads/server/metadata', () => ({
 
 import { getFileMetadata } from '@/lib/uploads/core/storage-client'
 
-/** The exact error the AWS SDK raises from HeadObject for an absent object. */
-const notFound = Object.assign(new Error('NotFound'), {
-  name: 'NotFound',
-  $fault: 'client',
-  $metadata: { httpStatusCode: 404 },
-})
-
 describe('getFileMetadata', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -44,25 +32,33 @@ describe('getFileMetadata', () => {
   })
 
   it('reports an absent object as no metadata rather than throwing', async () => {
-    mockSend.mockRejectedValue(notFound)
+    /** The provider client owns not-found and reports absence as `null`. */
+    mockHeadS3Object.mockResolvedValue(null)
 
     await expect(getFileMetadata('workspace/ws/superseded-key.md')).resolves.toEqual({})
   })
 
   it('still propagates a genuine storage failure', async () => {
-    const denied = Object.assign(new Error('AccessDenied'), {
-      name: 'AccessDenied',
-      $metadata: { httpStatusCode: 403 },
-    })
-    mockSend.mockRejectedValue(denied)
+    mockHeadS3Object.mockRejectedValue(
+      Object.assign(new Error('AccessDenied'), {
+        name: 'AccessDenied',
+        $metadata: { httpStatusCode: 403 },
+      })
+    )
 
     await expect(getFileMetadata('workspace/ws/key.md')).rejects.toThrow('AccessDenied')
   })
 
   it('returns provider metadata when the object exists', async () => {
-    mockSend.mockResolvedValue({ Metadata: { workspaceid: 'ws-1' } })
+    mockHeadS3Object.mockResolvedValue({ size: 12, metadata: { workspaceid: 'ws-1' } })
 
     await expect(getFileMetadata('workspace/ws/key.md')).resolves.toEqual({ workspaceid: 'ws-1' })
+  })
+
+  it('treats an object carrying no metadata as no metadata', async () => {
+    mockHeadS3Object.mockResolvedValue({ size: 12 })
+
+    await expect(getFileMetadata('workspace/ws/key.md')).resolves.toEqual({})
   })
 
   it('prefers the database record when one exists', async () => {
@@ -77,6 +73,6 @@ describe('getFileMetadata', () => {
     const metadata = await getFileMetadata('workspace/ws/key.md')
 
     expect(metadata.workspaceId).toBe('ws-1')
-    expect(mockSend).not.toHaveBeenCalled()
+    expect(mockHeadS3Object).not.toHaveBeenCalled()
   })
 })

--- a/apps/sim/lib/uploads/core/storage-client.test.ts
+++ b/apps/sim/lib/uploads/core/storage-client.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetFileMetadataByKey, mockSend, mockHeadObjectCommand } = vi.hoisted(() => ({
+  mockGetFileMetadataByKey: vi.fn(),
+  mockSend: vi.fn(),
+  mockHeadObjectCommand: vi.fn().mockImplementation(class {}),
+}))
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  HeadObjectCommand: mockHeadObjectCommand,
+}))
+
+vi.mock('@/lib/uploads/config', () => ({
+  USE_S3_STORAGE: true,
+  USE_BLOB_STORAGE: false,
+  USE_GCS_STORAGE: false,
+  S3_CONFIG: { bucket: 'bucket', region: 'region' },
+}))
+
+vi.mock('@/lib/uploads/providers/s3/client', () => ({
+  getS3Client: () => ({ send: mockSend }),
+}))
+
+vi.mock('@/lib/uploads/server/metadata', () => ({
+  getFileMetadataByKey: mockGetFileMetadataByKey,
+}))
+
+import { getFileMetadata } from '@/lib/uploads/core/storage-client'
+
+/** The exact error the AWS SDK raises from HeadObject for an absent object. */
+const notFound = Object.assign(new Error('NotFound'), {
+  name: 'NotFound',
+  $fault: 'client',
+  $metadata: { httpStatusCode: 404 },
+})
+
+describe('getFileMetadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetFileMetadataByKey.mockResolvedValue(null)
+  })
+
+  it('reports an absent object as no metadata rather than throwing', async () => {
+    mockSend.mockRejectedValue(notFound)
+
+    await expect(getFileMetadata('workspace/ws/superseded-key.md')).resolves.toEqual({})
+  })
+
+  it('still propagates a genuine storage failure', async () => {
+    const denied = Object.assign(new Error('AccessDenied'), {
+      name: 'AccessDenied',
+      $metadata: { httpStatusCode: 403 },
+    })
+    mockSend.mockRejectedValue(denied)
+
+    await expect(getFileMetadata('workspace/ws/key.md')).rejects.toThrow('AccessDenied')
+  })
+
+  it('returns provider metadata when the object exists', async () => {
+    mockSend.mockResolvedValue({ Metadata: { workspaceid: 'ws-1' } })
+
+    await expect(getFileMetadata('workspace/ws/key.md')).resolves.toEqual({ workspaceid: 'ws-1' })
+  })
+
+  it('prefers the database record when one exists', async () => {
+    mockGetFileMetadataByKey.mockResolvedValue({
+      userId: 'user-1',
+      workspaceId: 'ws-1',
+      originalName: 'doc.md',
+      uploadedAt: new Date('2026-01-01T00:00:00Z'),
+      context: 'workspace',
+    })
+
+    const metadata = await getFileMetadata('workspace/ws/key.md')
+
+    expect(metadata.workspaceId).toBe('ws-1')
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/lib/uploads/core/storage-client.ts
+++ b/apps/sim/lib/uploads/core/storage-client.ts
@@ -1,5 +1,5 @@
 import { USE_BLOB_STORAGE, USE_GCS_STORAGE, USE_S3_STORAGE } from '@/lib/uploads/config'
-import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
+import { hasObjectNotFoundLabel } from '@/lib/uploads/core/errors'
 import type { StorageConfig } from '@/lib/uploads/shared/types'
 
 export type { StorageConfig } from '@/lib/uploads/shared/types'
@@ -40,8 +40,12 @@ export async function getFileMetadata(
      * previous key finds nothing. Report it the way this function already reports
      * "nothing known about this key" rather than as a failure, so callers fall
      * through to their own not-found handling instead of an error path.
+     *
+     * Deliberately the labelled check: this dispatches across every provider and so
+     * cannot attribute a bare 404 to the object rather than its bucket. An
+     * unlabelled 404 keeps propagating, exactly as it did before.
      */
-    if (isObjectNotFoundError(error)) return {}
+    if (hasObjectNotFoundLabel(error)) return {}
     throw error
   }
 }

--- a/apps/sim/lib/uploads/core/storage-client.ts
+++ b/apps/sim/lib/uploads/core/storage-client.ts
@@ -1,5 +1,4 @@
 import { USE_BLOB_STORAGE, USE_GCS_STORAGE, USE_S3_STORAGE } from '@/lib/uploads/config'
-import { hasObjectNotFoundLabel } from '@/lib/uploads/core/errors'
 import type { StorageConfig } from '@/lib/uploads/shared/types'
 
 export type { StorageConfig } from '@/lib/uploads/shared/types'
@@ -31,29 +30,6 @@ export async function getFileMetadata(
   key: string,
   customConfig?: StorageConfig
 ): Promise<Record<string, string>> {
-  try {
-    return await readProviderMetadata(key, customConfig)
-  } catch (error) {
-    /**
-     * A key that no longer resolves is an ordinary outcome — a workspace file is
-     * rewritten under a new key on every content update, so any reader holding the
-     * previous key finds nothing. Report it the way this function already reports
-     * "nothing known about this key" rather than as a failure, so callers fall
-     * through to their own not-found handling instead of an error path.
-     *
-     * Deliberately the labelled check: this dispatches across every provider and so
-     * cannot attribute a bare 404 to the object rather than its bucket. An
-     * unlabelled 404 keeps propagating, exactly as it did before.
-     */
-    if (hasObjectNotFoundLabel(error)) return {}
-    throw error
-  }
-}
-
-async function readProviderMetadata(
-  key: string,
-  customConfig?: StorageConfig
-): Promise<Record<string, string>> {
   const { getFileMetadataByKey } = await import('../server/metadata')
   const metadataRecord = await getFileMetadataByKey(key)
 
@@ -68,57 +44,46 @@ async function readProviderMetadata(
   }
 
   if (USE_BLOB_STORAGE) {
-    const { getBlobServiceClient } = await import('@/lib/uploads/providers/blob/client')
+    const { headBlobObject } = await import('@/lib/uploads/providers/blob/client')
     const { BLOB_CONFIG } = await import('@/lib/uploads/config')
-
-    let blobServiceClient = await getBlobServiceClient()
-    let containerName = BLOB_CONFIG.containerName
-
-    if (customConfig) {
-      const { BlobServiceClient, StorageSharedKeyCredential } = await import('@azure/storage-blob')
-      if (customConfig.connectionString) {
-        blobServiceClient = BlobServiceClient.fromConnectionString(customConfig.connectionString)
-      } else if (customConfig.accountName && customConfig.accountKey) {
-        const credential = new StorageSharedKeyCredential(
-          customConfig.accountName,
-          customConfig.accountKey
-        )
-        blobServiceClient = new BlobServiceClient(
-          `https://${customConfig.accountName}.blob.core.windows.net`,
-          credential
-        )
-      }
-      containerName = customConfig.containerName || containerName
-    }
-
-    const containerClient = blobServiceClient.getContainerClient(containerName)
-    const blockBlobClient = containerClient.getBlockBlobClient(key)
-    const properties = await blockBlobClient.getProperties()
-    return properties.metadata || {}
+    /** `headBlobObject` rejects a config that names no credentials, so only pass one that does. */
+    const credentialed = Boolean(
+      customConfig?.connectionString || (customConfig?.accountName && customConfig?.accountKey)
+    )
+    const object = await headBlobObject(
+      key,
+      credentialed
+        ? {
+            ...customConfig,
+            containerName: customConfig?.containerName || BLOB_CONFIG.containerName,
+          }
+        : undefined
+    )
+    return object?.metadata || {}
   }
 
   if (USE_S3_STORAGE) {
-    const { getS3Client } = await import('@/lib/uploads/providers/s3/client')
-    const { HeadObjectCommand } = await import('@aws-sdk/client-s3')
+    const { headS3Object } = await import('@/lib/uploads/providers/s3/client')
     const { S3_CONFIG } = await import('@/lib/uploads/config')
-
-    const s3Client = getS3Client()
     const bucket = customConfig?.bucket || S3_CONFIG.bucket
 
     if (!bucket) {
       throw new Error('S3 bucket not configured')
     }
 
-    const command = new HeadObjectCommand({
-      Bucket: bucket,
-      Key: key,
+    const object = await headS3Object(key, {
+      bucket,
+      region: customConfig?.region || S3_CONFIG.region,
     })
-
-    const response = await s3Client.send(command)
-    return response.Metadata || {}
+    return object?.metadata || {}
   }
 
   if (USE_GCS_STORAGE) {
+    /**
+     * Unlike the other two, this raises on a missing object rather than reporting
+     * absence, because GCS answers a missing object and a missing bucket the same
+     * way and only the caller's own bucket configuration separates them.
+     */
     const { getGcsObjectMetadata } = await import('@/lib/uploads/providers/gcs/client')
     return getGcsObjectMetadata(
       key,

--- a/apps/sim/lib/uploads/core/storage-client.ts
+++ b/apps/sim/lib/uploads/core/storage-client.ts
@@ -1,4 +1,5 @@
 import { USE_BLOB_STORAGE, USE_GCS_STORAGE, USE_S3_STORAGE } from '@/lib/uploads/config'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 import type { StorageConfig } from '@/lib/uploads/shared/types'
 
 export type { StorageConfig } from '@/lib/uploads/shared/types'
@@ -27,6 +28,25 @@ export function getServePathPrefix(): string {
  * @returns File metadata object with userId, workspaceId, originalName, uploadedAt, etc.
  */
 export async function getFileMetadata(
+  key: string,
+  customConfig?: StorageConfig
+): Promise<Record<string, string>> {
+  try {
+    return await readProviderMetadata(key, customConfig)
+  } catch (error) {
+    /**
+     * A key that no longer resolves is an ordinary outcome — a workspace file is
+     * rewritten under a new key on every content update, so any reader holding the
+     * previous key finds nothing. Report it the way this function already reports
+     * "nothing known about this key" rather than as a failure, so callers fall
+     * through to their own not-found handling instead of an error path.
+     */
+    if (isObjectNotFoundError(error)) return {}
+    throw error
+  }
+}
+
+async function readProviderMetadata(
   key: string,
   customConfig?: StorageConfig
 ): Promise<Record<string, string>> {

--- a/apps/sim/lib/uploads/providers/blob/client.test.ts
+++ b/apps/sim/lib/uploads/providers/blob/client.test.ts
@@ -209,6 +209,44 @@ describe('Azure Blob Storage Client', () => {
         metadata: { simuploadid: 'receipt-1' },
       })
     })
+
+    it('reports an absent blob as null rather than raising', async () => {
+      /** Azure names the class in `name` and the reason in `code`. */
+      mockGetProperties.mockRejectedValueOnce(
+        Object.assign(new Error('BlobNotFound'), {
+          name: 'RestError',
+          code: 'BlobNotFound',
+          statusCode: 404,
+        })
+      )
+
+      await expect(headBlobObject('workspace/superseded.md')).resolves.toBeNull()
+    })
+
+    it('raises when the container itself is missing', async () => {
+      /** Also a 404, but a misconfiguration — reporting absence would hide an outage. */
+      mockGetProperties.mockRejectedValueOnce(
+        Object.assign(new Error('ContainerNotFound'), {
+          name: 'RestError',
+          code: 'ContainerNotFound',
+          statusCode: 404,
+        })
+      )
+
+      await expect(headBlobObject('workspace/file.txt')).rejects.toThrow('ContainerNotFound')
+    })
+
+    it('raises on a permission failure', async () => {
+      mockGetProperties.mockRejectedValueOnce(
+        Object.assign(new Error('AuthorizationFailure'), {
+          name: 'RestError',
+          code: 'AuthorizationFailure',
+          statusCode: 403,
+        })
+      )
+
+      await expect(headBlobObject('workspace/file.txt')).rejects.toThrow('AuthorizationFailure')
+    })
   })
 
   describe('deleteFromBlob', () => {

--- a/apps/sim/lib/uploads/providers/blob/client.ts
+++ b/apps/sim/lib/uploads/providers/blob/client.ts
@@ -20,6 +20,7 @@ import type {
 } from '@/lib/uploads/shared/types'
 import { sanitizeStorageMetadata } from '@/lib/uploads/utils/file-utils'
 import { sanitizeFileName } from '@/executor/constants'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 
 const logger = createLogger('BlobClient')
 const MULTIPART_UPLOAD_ID_METADATA_KEY = 'sim_upload_id'
@@ -446,9 +447,7 @@ export async function headBlobObject(
       ...(properties.metadata ? { metadata: properties.metadata } : {}),
     }
   } catch (err) {
-    const status = (err as { statusCode?: number }).statusCode
-    const code = (err as { code?: string }).code
-    if (status === 404 || code === 'BlobNotFound') {
+    if (isObjectNotFoundError(err)) {
       return null
     }
     throw err
@@ -833,9 +832,7 @@ export async function abortMultipartUpload(
       await blockBlobClient.deleteIfExists()
     }
   } catch (error) {
-    const status = (error as { statusCode?: number }).statusCode
-    const code = (error as { code?: string }).code
-    if (status !== 404 && code !== 'BlobNotFound') {
+    if (!isObjectNotFoundError(error)) {
       logger.warn('Error cleaning up multipart upload:', error)
     }
   }

--- a/apps/sim/lib/uploads/providers/blob/client.ts
+++ b/apps/sim/lib/uploads/providers/blob/client.ts
@@ -7,6 +7,7 @@ import {
   readNodeStreamToBufferWithLimit,
 } from '@/lib/core/utils/stream-limits'
 import { BLOB_CONFIG } from '@/lib/uploads/config'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 import type {
   AzureMultipartPart,
   AzureMultipartUploadInit,
@@ -20,7 +21,6 @@ import type {
 } from '@/lib/uploads/shared/types'
 import { sanitizeStorageMetadata } from '@/lib/uploads/utils/file-utils'
 import { sanitizeFileName } from '@/executor/constants'
-import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 
 const logger = createLogger('BlobClient')
 const MULTIPART_UPLOAD_ID_METADATA_KEY = 'sim_upload_id'

--- a/apps/sim/lib/uploads/providers/gcs/client.ts
+++ b/apps/sim/lib/uploads/providers/gcs/client.ts
@@ -24,6 +24,7 @@ import {
   sanitizeStorageMetadata,
 } from '@/lib/uploads/utils/file-utils'
 import { sanitizeFileName } from '@/executor/constants'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 
 const logger = createLogger('GcsClient')
 
@@ -404,7 +405,7 @@ async function getGcsMultipartCompletionId(
     const metadata = await getGcsObjectMetadata(key, customConfig)
     return metadata[GCS_MULTIPART_UPLOAD_ID_METADATA_KEY] ?? null
   } catch (error) {
-    if ((error as { code?: number } | null)?.code === 404) return null
+    if (isObjectNotFoundError(error)) return null
     throw error
   }
 }

--- a/apps/sim/lib/uploads/providers/gcs/client.ts
+++ b/apps/sim/lib/uploads/providers/gcs/client.ts
@@ -8,6 +8,7 @@ import {
   readNodeStreamToBufferWithLimit,
 } from '@/lib/core/utils/stream-limits'
 import { GCS_CONFIG } from '@/lib/uploads/config'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 import type {
   GcsConfig,
   GcsMultipartPart,
@@ -24,7 +25,6 @@ import {
   sanitizeStorageMetadata,
 } from '@/lib/uploads/utils/file-utils'
 import { sanitizeFileName } from '@/executor/constants'
-import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 
 const logger = createLogger('GcsClient')
 

--- a/apps/sim/lib/uploads/providers/s3/client.test.ts
+++ b/apps/sim/lib/uploads/providers/s3/client.test.ts
@@ -213,6 +213,45 @@ describe('S3 Client', () => {
         metadata: { simuploadid: 'receipt-1' },
       })
     })
+
+    it('reports an absent object as null rather than raising', async () => {
+      /**
+       * A workspace file is rewritten under a new key on every content update, so a
+       * reader holding the previous key lands here routinely. Absence is the answer,
+       * not a failure.
+       */
+      mockSend.mockRejectedValueOnce(
+        Object.assign(new Error('NotFound'), {
+          name: 'NotFound',
+          $metadata: { httpStatusCode: 404 },
+        })
+      )
+
+      await expect(headS3Object('workspace/superseded.md')).resolves.toBeNull()
+    })
+
+    it('raises when the bucket itself is missing', async () => {
+      /** Also a 404, but a misconfiguration — reporting absence would hide an outage. */
+      mockSend.mockRejectedValueOnce(
+        Object.assign(new Error('NoSuchBucket'), {
+          name: 'NoSuchBucket',
+          $metadata: { httpStatusCode: 404 },
+        })
+      )
+
+      await expect(headS3Object('workspace/file.txt')).rejects.toThrow('NoSuchBucket')
+    })
+
+    it('raises on a permission failure', async () => {
+      mockSend.mockRejectedValueOnce(
+        Object.assign(new Error('AccessDenied'), {
+          name: 'AccessDenied',
+          $metadata: { httpStatusCode: 403 },
+        })
+      )
+
+      await expect(headS3Object('workspace/file.txt')).rejects.toThrow('AccessDenied')
+    })
   })
 
   describe('getPresignedUrl', () => {

--- a/apps/sim/lib/uploads/providers/s3/client.ts
+++ b/apps/sim/lib/uploads/providers/s3/client.ts
@@ -20,6 +20,7 @@ import {
   readNodeStreamToBufferWithLimit,
 } from '@/lib/core/utils/stream-limits'
 import { S3_CONFIG, S3_KB_CONFIG } from '@/lib/uploads/config'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 import type {
   S3Config,
   S3MultipartPart,
@@ -36,7 +37,6 @@ import {
   sanitizeStorageMetadata,
 } from '@/lib/uploads/utils/file-utils'
 import { sanitizeFileName } from '@/executor/constants'
-import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 
 let _s3Client: S3Client | null = null
 

--- a/apps/sim/lib/uploads/providers/s3/client.ts
+++ b/apps/sim/lib/uploads/providers/s3/client.ts
@@ -36,6 +36,7 @@ import {
   sanitizeStorageMetadata,
 } from '@/lib/uploads/utils/file-utils'
 import { sanitizeFileName } from '@/executor/constants'
+import { isObjectNotFoundError } from '@/lib/uploads/core/errors'
 
 let _s3Client: S3Client | null = null
 
@@ -260,10 +261,7 @@ export async function headS3Object(
       ...(response.Metadata ? { metadata: response.Metadata } : {}),
     }
   } catch (error) {
-    const code = (error as { name?: string; $metadata?: { httpStatusCode?: number } } | null)?.name
-    const status = (error as { $metadata?: { httpStatusCode?: number } } | null)?.$metadata
-      ?.httpStatusCode
-    if (code === 'NotFound' || code === 'NoSuchKey' || status === 404) {
+    if (isObjectNotFoundError(error)) {
       return null
     }
     throw error


### PR DESCRIPTION
## Summary
Root cause of the chronic `FilesServeAPI` / `FileAuthorization` ERROR noise — **1,000–2,000 lines/day for at least 14 days**, peaking at 2,105 on 07-29.

A workspace file is rewritten under a **new key on every content update**, and the superseded object is deleted immediately (`cleanupWorkspaceStorageObject(oldKey, 'version replacement')`, from #5991). Any reader still holding the previous key therefore finds nothing — which is an ordinary outcome, not a failure.

`getFileMetadata` let that not-found propagate out of all three provider branches. `verifyWorkspaceFileAccess` caught it in its generic handler and logged `ERROR`, so the branch **already written for exactly this case** — `logger.warn('Workspace file missing authorization metadata')` at `authorization.ts:264` — was unreachable.

## Changes
- `getFileMetadata` returns `{}` when the object is absent — the same value it already returns when no provider is configured, so no contract or caller changes
- Genuine failures (permission, network, provider 5xx) still propagate and still log `ERROR`
- Collapsed the three **divergent** per-provider not-found predicates (S3 `NotFound`/`NoSuchKey`, Azure `BlobNotFound`, GCS numeric `404`) onto one shared `isObjectNotFoundError`, rather than adding a fourth copy

Verified against the AWS SDK v3 source: `HeadObjectCommand` throws `NotFound` and `GetObjectCommand` throws `NoSuchKey`, both `__BaseException` with `$fault: 'client'` and `$metadata.httpStatusCode: 404` — matching the production payload exactly.

## Not in scope
This corrects how absence is *modelled*. The underlying design issue — URLs addressing a mutable storage key rather than the stable file id — is a separate change; a stale key legitimately 404s.

## Type of Change
- [x] Bug fix

## Testing
8 new tests. `reports an absent object as no metadata rather than throwing` verified **red before** the fix and green after. Full `lib/uploads` suite: 374 passing across 31 files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

---

## Audit of every changed line

**A defect in this PR's own predicate was found and fixed (`a5b3…`).** The first version read the label as `typeof name === 'string' ? name : code`, so a *non-matching* `name` short-circuited the `code` check entirely. Azure raises a `RestError` whose `name` carries the class and whose `code` carries the reason, so `BlobNotFound` was missed — **narrower than the per-provider check it replaced**. `name` and `code` are now tested independently, with a regression test verified red before / green after.

**All three callers audited for fail-closed behavior.** `getFileMetadata` has exactly 3 callers, all in `authorization.ts`:

| Caller | With `{}` | Outcome |
|---|---|---|
| `verifyWorkspaceFileAccess` (243) | `workspaceId` undefined | falls to the existing `'missing authorization metadata'` warn → **deny** |
| `verifyPublicAssetWriteAccess` (313) | `userId` undefined | hits the branch already commented *"Fail closed when the owner cannot be established"* → **deny** |
| `verifyCopilotFileAccess` (427) | `userId` undefined | falls through to the legacy path check |

The third is a genuine behavior change and is called out deliberately: an **absent** copilot object previously threw and denied; it now takes the same path as an object that exists without metadata. That path grants only when `cloudKey.split('/')[0] === userId` — strictly the caller's own namespace — so no cross-user access is reachable. Downstream, a granted read of an absent object 404s at storage and a granted delete is a no-op. No exposure either way.

**Other checks:** no import cycle (`core/errors.ts` imports nothing; providers are loaded dynamically from `core`). Provider files changed by import position only — verified by diffing after `biome --write --unsafe`. Full `lib/uploads` suite 375 passing across 31 files. Typecheck clean; the sole error (`heic-convert`) reproduces on untouched `origin/main`.


### Second audit round — container-level 404s

A high-effort review pass caught a defect the first audit missed: **`NoSuchBucket` and `ContainerNotFound` also answer 404**, so the status-only clause read them as an absent object. A deleted or misconfigured bucket would have degraded into silent "no metadata" — every file read failing closed, with the `ERROR` that used to alert on it now downgraded to the routine stale-key `warn`. A total storage outage would have been indistinguishable from ordinary noise.

Container-level labels are now excluded before the object-level check, verified red before / green after:

```
{ name: 'NoSuchBucket', $metadata: { httpStatusCode: 404 } }        → false
{ name: 'RestError', code: 'ContainerNotFound', statusCode: 404 }   → false
```

Known limitation, stated rather than implied solved: GCS reports both object- and bucket-level misses as a bare numeric `code: 404` with no distinguishing label, so the two are not separable there. S3 is the production provider and does distinguish them.

`app/api/tools/s3/head-object/route.ts:86` still hand-rolls its own check and was **deliberately not migrated** — it is a user-facing tool against user-supplied credentials that reports `exists: false`, and adopting the shared predicate would turn a nonexistent bucket into an error rather than a negative result. That is a user-visible semantics change and does not belong in this PR.

Suites after the fix: `lib/uploads` 376 passing / 31 files, `app/api/files` 238 passing / 16 files.


---

## Third audit round — the abstraction itself

The earlier rounds kept finding defects in one place: the shared not-found predicate. That was the symptom. The cause was that **`getFileMetadata` re-implemented the S3 and Blob `HEAD` calls inline**, duplicating `headS3Object` and `headBlobObject` — including Azure's entire connection-string / shared-key branch, verbatim. Because it owned those calls, it had to interpret provider errors itself, and doing that safely across providers forced a second, stricter predicate.

Deleting the duplication removes the whole problem:

- `getFileMetadata` now calls `headS3Object` / `headBlobObject`, which **already report absence as `null`**, and maps that to `{}`
- its `try`/`catch` is gone — it no longer inspects errors at all
- the second predicate (`hasObjectNotFoundLabel`) is gone with it; one predicate again, used only by provider clients that know they just performed an object-level operation
- GCS still raises, exactly as before this PR

Each provider now owns its own not-found semantics and the dispatcher just maps `null → {}`.

### Test coverage gap this exposed

Reverting the S3 not-found handling broke **no test** — `storage-client.test.ts` mocks `headS3Object`, so the seam hid whether the two layers agree. Three tests were added to the S3 client's own suite exercising the real `headS3Object` over a mocked SDK: absent object → `null`, `NoSuchBucket` → raises, `AccessDenied` → raises. Reverting the handling now fails `reports an absent object as null rather than raising`, as it should.

An earlier attempt at this used `vi.resetModules()` + `vi.doMock()` + `await import()`; that is banned by CLAUDE.md's testing rules and did not work regardless (the file-level mock shadows the real module). Replaced with `vi.hoisted()` + `vi.mock()` + static imports, matching the file it lives in.

Final: `lib/uploads` 380 passing / 31 files, `app/api/files` 238 passing / 16 files, biome clean on all 8 touched files, typecheck clean apart from the pre-existing `heic-convert`.


---

## Completing the fix: the other two thirds

The change above removes one of the three ERROR lines a stale key produces. Production over 24h shows they fire in near-lockstep, because all three come from the **same request**:

| Line | 24h count |
|---|---|
| `Error verifying workspace file access` | 274 |
| `Error downloading from cloud storage:` | 275 |
| `Error serving file:` | 274 |

Once authorization correctly denies, the route throws `FileNotFoundError`; the inner handler logs it at `error` and rethrows, and the outer handler logs it at `error` again. So an ordinary 404 was reported twice as a server fault — and `route.ts` made that plain:

```ts
logger.error('Error serving file:', error)   // logged as a failure first
if (error instanceof FileNotFoundError) {
  return createErrorResponse(error)          // then handled correctly as a 404
}
```

The precedent for the right behaviour sits a few lines above: `DocCompileUserError` is already logged at `info` with a comment noting it is "not a server fault". `FileNotFoundError` now gets the same treatment, via one `logServeFailure` helper shared by all five catch sites in the file — `error` is reserved for failures that really are the server's.

Nothing is silenced: the 404 is still recorded, still carries its reason, and every non-`FileNotFoundError` still logs at `error`. Two tests cover both directions, verified red before / green after.

With this, the module's ~823 ERROR lines/day drop to ~0 for the stale-key case, rather than the ~549 that would have remained.

Suites: `app/api/files` 240 passing / 16 files, `lib/uploads` 380 passing / 31 files.


### Per-provider verification

| Provider | Change | Result |
|---|---|---|
| **S3** | delegates to `headS3Object`; `NoSuchBucket` now raises rather than reading as absence | better |
| **Blob** | same delegation; `ContainerNotFound` now raises | better |
| **GCS** | predicate swap is behaviour-identical (a bare numeric 404 still matches); `getFileMetadata` still raises | unchanged — no fix, no regression |
| **Local** | `getFileMetadata` returns `{}` as before; gains the serve-route log level | better |

All three cloud providers now assert absence *and* non-404 rethrow, each mutation-verified: removing the guard fails exactly one test in S3 and one in Blob. Blob had no not-found coverage at all before this, and it is the one provider that puts the reason in `code` rather than `name`, so the container-level exclusion was the least-verified path in the change.

**`headS3Object` / `headBlobObject` are also reached through `headObject`**, which serves the TikTok upload tool, workspace forking (2 sites), and `workspace-file-manager` (2 sites). Raising on a missing bucket brings those call sites *into* line with `headObject`'s documented contract — "Returns … null when missing. Throws on errors other than 'not found'" — which returning `null` for a missing bucket had violated, sending callers into a doomed path instead of failing fast.

Two narrow behaviour changes, neither reachable from current callers: a `containerName`-only custom config is no longer honoured in the Blob branch (every call site passes `undefined`), and `abortMultipartUpload` now emits a `warn` on a missing container where it was previously silent.
