### PR TITLE
improvement(admin): move user row actions into an overflow menu with confirm modals

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -230,14 +230,6 @@ export function Admin() {
     impersonatingUserId,
   ])
 
-  /** Confirms the send on the menu item itself, since nothing about the user row changes. */
-  const resetPasswordLabel = (userId: string) => {
-    if (sendPasswordReset.variables?.userId !== userId) return 'Reset password'
-    if (sendPasswordReset.isPending) return 'Sending...'
-    if (sendPasswordReset.isSuccess) return 'Reset sent'
-    return 'Reset password'
-  }
-
   const renderUserRow = (u: AdminUser) => (
     <div key={u.id} className='flex items-center gap-3 px-3 py-2 text-small'>
       <span className='w-[170px] truncate text-[var(--text-primary)]'>{u.name || '—'}</span>
@@ -267,7 +259,7 @@ export function Admin() {
               label={`Actions for ${u.email}`}
               actions={[
                 {
-                  label: resetPasswordLabel(u.id),
+                  label: 'Reset password',
                   onSelect: () => {
                     setProvisionWarning(null)
                     sendPasswordReset.reset()
@@ -437,6 +429,15 @@ export function Admin() {
           {provisionWarning && (
             <p className='text-[var(--text-error)] text-small'>{provisionWarning}</p>
           )}
+
+          {sendPasswordReset.variables &&
+            (sendPasswordReset.isPending || sendPasswordReset.isSuccess) && (
+              <p className='text-[var(--text-secondary)] text-small'>
+                {sendPasswordReset.isPending
+                  ? `Sending a password reset email to ${sendPasswordReset.variables.email}...`
+                  : `Password reset email sent to ${sendPasswordReset.variables.email}.`}
+              </p>
+            )}
 
           {searchQuery.length > 0 && usersData ? (
             <>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -56,10 +56,9 @@ const USER_TABLE_HEADER = (
 )
 
 /**
- * The row action awaiting confirmation in {@link ChipConfirmModal}. Carries the
- * id plus, for a role change, the role the admin chose to apply — never the
- * whole user row. A refetch while the modal is open therefore refreshes the
- * name it shows without ever redirecting the action the admin committed to.
+ * The row action awaiting confirmation. Holds ids, never the user row, so a
+ * refetch while the modal is open refreshes the name it shows without
+ * redirecting the action the admin committed to.
  */
 type PendingUserAction =
   | { type: 'ban'; userId: string }
@@ -211,7 +210,6 @@ export function Admin() {
     )
   }
 
-  /** Rows with an action in flight, whose remaining actions stay disabled. */
   const pendingUserIds = new Set<string>()
   for (const mutation of [setUserRole, banUser, unbanUser, impersonateUser, sendPasswordReset]) {
     if (mutation.isPending && mutation.variables?.userId)
@@ -233,6 +231,7 @@ export function Admin() {
         {u.id !== session?.user?.id && (
           <>
             <Chip
+              aria-label={`Impersonate ${u.email}`}
               onClick={() => handleImpersonate(u.id, u.email)}
               disabled={pendingUserIds.has(u.id)}
             >
@@ -249,6 +248,13 @@ export function Admin() {
                       { userId: u.id, email: u.email },
                       {
                         onSuccess: () => toast.success(`Password reset email sent to ${u.email}`),
+                        onError: (error) =>
+                          toast.error(
+                            getErrorMessage(
+                              error,
+                              `Could not send a password reset email to ${u.email}`
+                            )
+                          ),
                       }
                     )
                   },
@@ -399,13 +405,10 @@ export function Admin() {
             </p>
           )}
 
-          {(unbanUser.error ||
-            impersonateUser.error ||
-            sendPasswordReset.error ||
-            impersonationGuardError) && (
+          {(unbanUser.error || impersonateUser.error || impersonationGuardError) && (
             <p className='text-[var(--text-error)] text-small'>
               {impersonationGuardError ||
-                (unbanUser.error || impersonateUser.error || sendPasswordReset.error)?.message ||
+                (unbanUser.error || impersonateUser.error)?.message ||
                 'Action failed. Please try again.'}
             </p>
           )}
@@ -524,14 +527,12 @@ export function Admin() {
           ' ',
           isDemotion
             ? { text: 'revokes their platform admin access.', error: true }
-            : {
-                text: 'grants full platform admin access, including impersonating any user.',
-                error: true,
-              },
+            : 'grants full platform admin access, including impersonating any user.',
         ]}
         confirm={{
           label: isDemotion ? 'Demote' : 'Promote',
           onClick: handleConfirmRoleChange,
+          variant: isDemotion ? 'destructive' : 'primary',
           pending: setUserRole.isPending,
           pendingLabel: isDemotion ? 'Demoting...' : 'Promoting...',
         }}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -7,6 +7,7 @@ import {
   Chip,
   ChipConfirmModal,
   ChipInput,
+  ChipModalError,
   ChipModalField,
   ChipSelect,
   Label,
@@ -269,7 +270,10 @@ export function Admin() {
                 },
                 {
                   label: u.role === 'admin' ? 'Demote' : 'Promote',
-                  onSelect: () => setPendingAction({ type: 'role', user: u }),
+                  onSelect: () => {
+                    setUserRole.reset()
+                    setPendingAction({ type: 'role', user: u })
+                  },
                   disabled: pendingUserIds.has(u.id),
                 },
                 u.banned
@@ -527,6 +531,7 @@ export function Admin() {
           placeholder='Optional'
           disabled={banUser.isPending}
         />
+        <ChipModalError>{banUser.error?.message}</ChipModalError>
       </ChipConfirmModal>
 
       <ChipConfirmModal
@@ -553,7 +558,9 @@ export function Admin() {
           pending: setUserRole.isPending,
           pendingLabel: isDemotion ? 'Demoting...' : 'Promoting...',
         }}
-      />
+      >
+        <ChipModalError>{setUserRole.error?.message}</ChipModalError>
+      </ChipConfirmModal>
 
       <AddUserModal
         open={isAddUserOpen}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -410,6 +410,12 @@ export function Admin() {
             <p className='text-[var(--text-error)] text-small'>{provisionWarning}</p>
           )}
 
+          {sendPasswordReset.isPending && sendPasswordReset.variables && (
+            <p className='text-[var(--text-secondary)] text-small'>
+              Sending a password reset email to {sendPasswordReset.variables.email}...
+            </p>
+          )}
+
           {searchQuery.length > 0 && usersData ? (
             <>
               <div className='flex flex-col gap-0.5'>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -288,6 +288,7 @@ export function Admin() {
                   : {
                       label: 'Ban',
                       onSelect: () => {
+                        banUser.reset()
                         setBanReason('')
                         setPendingAction({ type: 'ban', user: u })
                       },

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -56,14 +56,14 @@ const USER_TABLE_HEADER = (
 )
 
 /**
- * The row action awaiting confirmation in {@link ChipConfirmModal}. Holds only
- * the id so the modal reads the live row — a background refetch while it is
- * open must not leave the confirm acting on a stale role.
+ * The row action awaiting confirmation in {@link ChipConfirmModal}. Carries the
+ * id plus, for a role change, the role the admin chose to apply — never the
+ * whole user row. A refetch while the modal is open therefore refreshes the
+ * name it shows without ever redirecting the action the admin committed to.
  */
-interface PendingUserAction {
-  type: 'ban' | 'role'
-  userId: string
-}
+type PendingUserAction =
+  | { type: 'ban'; userId: string }
+  | { type: 'role'; userId: string; nextRole: 'admin' | 'user' }
 
 const MOTHERSHIP_ENV_OPTIONS: { value: MothershipEnvironment; label: string }[] = [
   { value: 'default', label: 'Default' },
@@ -184,7 +184,7 @@ export function Admin() {
       recentUsers?.find((u) => u.id === pendingAction.userId) ??
       null)
     : null
-  const isDemotion = pendingUser?.role === 'admin'
+  const isDemotion = pendingAction?.type === 'role' && pendingAction.nextRole === 'user'
 
   const closePendingAction = () => {
     setPendingAction(null)
@@ -204,9 +204,9 @@ export function Admin() {
   }
 
   const handleConfirmRoleChange = () => {
-    if (pendingAction?.type !== 'role' || !pendingUser) return
+    if (pendingAction?.type !== 'role') return
     setUserRole.mutate(
-      { userId: pendingUser.id, role: isDemotion ? 'user' : 'admin' },
+      { userId: pendingAction.userId, role: pendingAction.nextRole },
       { onSuccess: closePendingAction }
     )
   }
@@ -258,7 +258,11 @@ export function Admin() {
                   label: u.role === 'admin' ? 'Demote' : 'Promote',
                   onSelect: () => {
                     setUserRole.reset()
-                    setPendingAction({ type: 'role', userId: u.id })
+                    setPendingAction({
+                      type: 'role',
+                      userId: u.id,
+                      nextRole: u.role === 'admin' ? 'user' : 'admin',
+                    })
                   },
                   disabled: pendingUserIds.has(u.id),
                 },

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   Badge,
   Button,
@@ -13,6 +13,7 @@ import {
   Label,
   Search,
   Switch,
+  toast,
 } from '@sim/emcn'
 import { getErrorMessage } from '@sim/utils/errors'
 import { useQueryStates } from 'nuqs'
@@ -54,8 +55,15 @@ const USER_TABLE_HEADER = (
   </div>
 )
 
-/** The row action awaiting confirmation in {@link ChipConfirmModal}. */
-type PendingUserAction = { type: 'ban'; user: AdminUser } | { type: 'role'; user: AdminUser }
+/**
+ * The row action awaiting confirmation in {@link ChipConfirmModal}. Holds only
+ * the id so the modal reads the live row — a background refetch while it is
+ * open must not leave the confirm acting on a stale role.
+ */
+interface PendingUserAction {
+  type: 'ban' | 'role'
+  userId: string
+}
 
 const MOTHERSHIP_ENV_OPTIONS: { value: MothershipEnvironment; label: string }[] = [
   { value: 'default', label: 'Default' },
@@ -171,7 +179,12 @@ export function Admin() {
     )
   }
 
-  const isDemotion = pendingAction?.user.role === 'admin'
+  const pendingUser = pendingAction
+    ? (usersData?.users.find((u) => u.id === pendingAction.userId) ??
+      recentUsers?.find((u) => u.id === pendingAction.userId) ??
+      null)
+    : null
+  const isDemotion = pendingUser?.role === 'admin'
 
   const closePendingAction = () => {
     setPendingAction(null)
@@ -181,10 +194,9 @@ export function Admin() {
   const handleConfirmBan = () => {
     if (pendingAction?.type !== 'ban') return
     const trimmedReason = banReason.trim()
-    banUser.reset()
     banUser.mutate(
       {
-        userId: pendingAction.user.id,
+        userId: pendingAction.userId,
         ...(trimmedReason ? { banReason: trimmedReason } : {}),
       },
       { onSuccess: closePendingAction }
@@ -192,44 +204,20 @@ export function Admin() {
   }
 
   const handleConfirmRoleChange = () => {
-    if (pendingAction?.type !== 'role') return
-    setUserRole.reset()
+    if (pendingAction?.type !== 'role' || !pendingUser) return
     setUserRole.mutate(
-      {
-        userId: pendingAction.user.id,
-        role: pendingAction.user.role === 'admin' ? 'user' : 'admin',
-      },
+      { userId: pendingUser.id, role: isDemotion ? 'user' : 'admin' },
       { onSuccess: closePendingAction }
     )
   }
 
-  const pendingUserIds = useMemo(() => {
-    const ids = new Set<string>()
-    if (setUserRole.isPending && (setUserRole.variables as { userId?: string })?.userId)
-      ids.add((setUserRole.variables as { userId: string }).userId)
-    if (banUser.isPending && (banUser.variables as { userId?: string })?.userId)
-      ids.add((banUser.variables as { userId: string }).userId)
-    if (unbanUser.isPending && (unbanUser.variables as { userId?: string })?.userId)
-      ids.add((unbanUser.variables as { userId: string }).userId)
-    if (impersonateUser.isPending && (impersonateUser.variables as { userId?: string })?.userId)
-      ids.add((impersonateUser.variables as { userId: string }).userId)
-    if (sendPasswordReset.isPending && sendPasswordReset.variables?.userId)
-      ids.add(sendPasswordReset.variables.userId)
-    if (impersonatingUserId) ids.add(impersonatingUserId)
-    return ids
-  }, [
-    setUserRole.isPending,
-    setUserRole.variables,
-    banUser.isPending,
-    banUser.variables,
-    unbanUser.isPending,
-    unbanUser.variables,
-    impersonateUser.isPending,
-    impersonateUser.variables,
-    sendPasswordReset.isPending,
-    sendPasswordReset.variables,
-    impersonatingUserId,
-  ])
+  /** Rows with an action in flight, whose remaining actions stay disabled. */
+  const pendingUserIds = new Set<string>()
+  for (const mutation of [setUserRole, banUser, unbanUser, impersonateUser, sendPasswordReset]) {
+    if (mutation.isPending && mutation.variables?.userId)
+      pendingUserIds.add(mutation.variables.userId)
+  }
+  if (impersonatingUserId) pendingUserIds.add(impersonatingUserId)
 
   const renderUserRow = (u: AdminUser) => (
     <div key={u.id} className='flex items-center gap-3 px-3 py-2 text-small'>
@@ -244,27 +232,25 @@ export function Admin() {
       <span className='flex w-[150px] items-center justify-end gap-1'>
         {u.id !== session?.user?.id && (
           <>
-            <Button
-              variant='active'
-              className='h-[28px] px-2 text-caption'
+            <Chip
               onClick={() => handleImpersonate(u.id, u.email)}
               disabled={pendingUserIds.has(u.id)}
             >
-              {impersonatingUserId === u.id ||
-              (impersonateUser.isPending &&
-                (impersonateUser.variables as { userId?: string } | undefined)?.userId === u.id)
-                ? 'Switching...'
-                : 'Impersonate'}
-            </Button>
+              {impersonatingUserId === u.id ? 'Switching...' : 'Impersonate'}
+            </Chip>
             <RowActionsMenu
-              label={`Actions for ${u.email}`}
+              label={`${u.email} actions`}
               actions={[
                 {
                   label: 'Reset password',
                   onSelect: () => {
                     setProvisionWarning(null)
-                    sendPasswordReset.reset()
-                    sendPasswordReset.mutate({ userId: u.id, email: u.email })
+                    sendPasswordReset.mutate(
+                      { userId: u.id, email: u.email },
+                      {
+                        onSuccess: () => toast.success(`Password reset email sent to ${u.email}`),
+                      }
+                    )
                   },
                   disabled: pendingUserIds.has(u.id),
                 },
@@ -272,17 +258,14 @@ export function Admin() {
                   label: u.role === 'admin' ? 'Demote' : 'Promote',
                   onSelect: () => {
                     setUserRole.reset()
-                    setPendingAction({ type: 'role', user: u })
+                    setPendingAction({ type: 'role', userId: u.id })
                   },
                   disabled: pendingUserIds.has(u.id),
                 },
                 u.banned
                   ? {
                       label: 'Unban',
-                      onSelect: () => {
-                        unbanUser.reset()
-                        unbanUser.mutate({ userId: u.id })
-                      },
+                      onSelect: () => unbanUser.mutate({ userId: u.id }),
                       disabled: pendingUserIds.has(u.id),
                     }
                   : {
@@ -290,7 +273,7 @@ export function Admin() {
                       onSelect: () => {
                         banUser.reset()
                         setBanReason('')
-                        setPendingAction({ type: 'ban', user: u })
+                        setPendingAction({ type: 'ban', userId: u.id })
                       },
                       destructive: true,
                       disabled: pendingUserIds.has(u.id),
@@ -412,21 +395,13 @@ export function Admin() {
             </p>
           )}
 
-          {(setUserRole.error ||
-            banUser.error ||
-            unbanUser.error ||
+          {(unbanUser.error ||
             impersonateUser.error ||
             sendPasswordReset.error ||
             impersonationGuardError) && (
             <p className='text-[var(--text-error)] text-small'>
               {impersonationGuardError ||
-                (
-                  setUserRole.error ||
-                  banUser.error ||
-                  unbanUser.error ||
-                  impersonateUser.error ||
-                  sendPasswordReset.error
-                )?.message ||
+                (unbanUser.error || impersonateUser.error || sendPasswordReset.error)?.message ||
                 'Action failed. Please try again.'}
             </p>
           )}
@@ -434,15 +409,6 @@ export function Admin() {
           {provisionWarning && (
             <p className='text-[var(--text-error)] text-small'>{provisionWarning}</p>
           )}
-
-          {sendPasswordReset.variables &&
-            (sendPasswordReset.isPending || sendPasswordReset.isSuccess) && (
-              <p className='text-[var(--text-secondary)] text-small'>
-                {sendPasswordReset.isPending
-                  ? `Sending a password reset email to ${sendPasswordReset.variables.email}...`
-                  : `Password reset email sent to ${sendPasswordReset.variables.email}.`}
-              </p>
-            )}
 
           {searchQuery.length > 0 && usersData ? (
             <>
@@ -509,7 +475,7 @@ export function Admin() {
         title='Ban user'
         text={[
           'Banning ',
-          { text: pendingAction?.user.email ?? 'this user', bold: true },
+          { text: pendingUser?.email ?? 'this user', bold: true },
           ' ',
           {
             text: 'signs them out everywhere and blocks them from signing back in.',
@@ -544,7 +510,7 @@ export function Admin() {
         title={isDemotion ? 'Demote user' : 'Promote user'}
         text={[
           isDemotion ? 'Demoting ' : 'Promoting ',
-          { text: pendingAction?.user.email ?? 'this user', bold: true },
+          { text: pendingUser?.email ?? 'this user', bold: true },
           ' ',
           isDemotion
             ? { text: 'revokes their platform admin access.', error: true }

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/admin/admin.tsx
@@ -1,7 +1,18 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Badge, Button, Chip, ChipInput, ChipSelect, cn, Label, Search, Switch } from '@sim/emcn'
+import {
+  Badge,
+  Button,
+  Chip,
+  ChipConfirmModal,
+  ChipInput,
+  ChipModalField,
+  ChipSelect,
+  Label,
+  Search,
+  Switch,
+} from '@sim/emcn'
 import { getErrorMessage } from '@sim/utils/errors'
 import { useQueryStates } from 'nuqs'
 import type { MothershipEnvironment } from '@/lib/api/contracts'
@@ -12,6 +23,7 @@ import {
   adminUrlKeys,
 } from '@/app/workspace/[workspaceId]/settings/components/admin/search-params'
 import { useRecentImpersonations } from '@/app/workspace/[workspaceId]/settings/components/admin/use-recent-impersonations'
+import { RowActionsMenu } from '@/app/workspace/[workspaceId]/settings/components/row-actions-menu'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
 import { SettingsSection } from '@/app/workspace/[workspaceId]/settings/components/settings-section/settings-section'
@@ -37,9 +49,12 @@ const USER_TABLE_HEADER = (
     <span className='flex-1'>Email</span>
     <span className='w-[60px]'>Role</span>
     <span className='w-[55px]'>Status</span>
-    <span className='w-[300px] text-right'>Actions</span>
+    <span className='w-[150px] text-right'>Actions</span>
   </div>
 )
+
+/** The row action awaiting confirmation in {@link ChipConfirmModal}. */
+type PendingUserAction = { type: 'ban'; user: AdminUser } | { type: 'role'; user: AdminUser }
 
 const MOTHERSHIP_ENV_OPTIONS: { value: MothershipEnvironment; label: string }[] = [
   { value: 'default', label: 'Default' },
@@ -72,7 +87,7 @@ export function Admin() {
   )
 
   const [searchInput, setSearchInput] = useState(searchQuery)
-  const [banUserId, setBanUserId] = useState<string | null>(null)
+  const [pendingAction, setPendingAction] = useState<PendingUserAction | null>(null)
   const [banReason, setBanReason] = useState('')
   const [impersonatingUserId, setImpersonatingUserId] = useState<string | null>(null)
   const [impersonationGuardError, setImpersonationGuardError] = useState<string | null>(null)
@@ -155,6 +170,38 @@ export function Admin() {
     )
   }
 
+  const isDemotion = pendingAction?.user.role === 'admin'
+
+  const closePendingAction = () => {
+    setPendingAction(null)
+    setBanReason('')
+  }
+
+  const handleConfirmBan = () => {
+    if (pendingAction?.type !== 'ban') return
+    const trimmedReason = banReason.trim()
+    banUser.reset()
+    banUser.mutate(
+      {
+        userId: pendingAction.user.id,
+        ...(trimmedReason ? { banReason: trimmedReason } : {}),
+      },
+      { onSuccess: closePendingAction }
+    )
+  }
+
+  const handleConfirmRoleChange = () => {
+    if (pendingAction?.type !== 'role') return
+    setUserRole.reset()
+    setUserRole.mutate(
+      {
+        userId: pendingAction.user.id,
+        role: pendingAction.user.role === 'admin' ? 'user' : 'admin',
+      },
+      { onSuccess: closePendingAction }
+    )
+  }
+
   const pendingUserIds = useMemo(() => {
     const ids = new Set<string>()
     if (setUserRole.isPending && (setUserRole.variables as { userId?: string })?.userId)
@@ -183,7 +230,7 @@ export function Admin() {
     impersonatingUserId,
   ])
 
-  /** Confirms the send in place, since nothing about the user row changes. */
+  /** Confirms the send on the menu item itself, since nothing about the user row changes. */
   const resetPasswordLabel = (userId: string) => {
     if (sendPasswordReset.variables?.userId !== userId) return 'Reset password'
     if (sendPasswordReset.isPending) return 'Sending...'
@@ -192,126 +239,70 @@ export function Admin() {
   }
 
   const renderUserRow = (u: AdminUser) => (
-    <div key={u.id} className='flex flex-col gap-2 px-3 py-2 text-small'>
-      <div className='flex items-center gap-3'>
-        <span className='w-[170px] truncate text-[var(--text-primary)]'>{u.name || '—'}</span>
-        <span className='flex-1 truncate text-[var(--text-secondary)]'>{u.email}</span>
-        <span className='w-[60px]'>
-          <Badge variant={u.role === 'admin' ? 'blue' : 'gray'}>{u.role || 'user'}</Badge>
-        </span>
-        <span className='w-[55px]'>
-          {u.banned ? <Badge variant='red'>Banned</Badge> : <Badge variant='green'>Active</Badge>}
-        </span>
-        <span className='flex w-[300px] justify-end gap-1'>
-          {u.id !== session?.user?.id && (
-            <>
-              <Button
-                variant='active'
-                className='h-[28px] px-2 text-caption'
-                onClick={() => {
-                  setProvisionWarning(null)
-                  sendPasswordReset.reset()
-                  sendPasswordReset.mutate({ userId: u.id, email: u.email })
-                }}
-                disabled={pendingUserIds.has(u.id)}
-              >
-                {resetPasswordLabel(u.id)}
-              </Button>
-              <Button
-                variant='active'
-                className='h-[28px] px-2 text-caption'
-                onClick={() => handleImpersonate(u.id, u.email)}
-                disabled={pendingUserIds.has(u.id)}
-              >
-                {impersonatingUserId === u.id ||
-                (impersonateUser.isPending &&
-                  (impersonateUser.variables as { userId?: string } | undefined)?.userId === u.id)
-                  ? 'Switching...'
-                  : 'Impersonate'}
-              </Button>
-              <Button
-                variant='active'
-                className='h-[28px] px-2 text-caption'
-                onClick={() => {
-                  setUserRole.reset()
-                  setUserRole.mutate({
-                    userId: u.id,
-                    role: u.role === 'admin' ? 'user' : 'admin',
-                  })
-                }}
-                disabled={pendingUserIds.has(u.id)}
-              >
-                {u.role === 'admin' ? 'Demote' : 'Promote'}
-              </Button>
-              {u.banned ? (
-                <Button
-                  variant='active'
-                  className='h-[28px] px-2 text-caption'
-                  onClick={() => {
-                    unbanUser.reset()
-                    unbanUser.mutate({ userId: u.id })
-                  }}
-                  disabled={pendingUserIds.has(u.id)}
-                >
-                  Unban
-                </Button>
-              ) : (
-                <Button
-                  variant='active'
-                  className={cn(
-                    'h-[28px] px-2 text-caption',
-                    banUserId === u.id ? 'text-[var(--text-primary)]' : 'text-[var(--text-error)]'
-                  )}
-                  onClick={() => {
-                    if (banUserId === u.id) {
-                      setBanUserId(null)
-                      setBanReason('')
-                    } else {
-                      setBanUserId(u.id)
-                      setBanReason('')
-                    }
-                  }}
-                  disabled={pendingUserIds.has(u.id)}
-                >
-                  {banUserId === u.id ? 'Cancel' : 'Ban'}
-                </Button>
-              )}
-            </>
-          )}
-        </span>
-      </div>
-      {banUserId === u.id && !u.banned && (
-        <div className='flex items-center gap-2 pl-[170px]'>
-          <ChipInput
-            value={banReason}
-            onChange={(e) => setBanReason(e.target.value)}
-            placeholder='Reason (optional)'
-            className='flex-1'
-          />
-          <Button
-            variant='primary'
-            className='h-[28px] px-3 text-caption'
-            onClick={() => {
-              banUser.reset()
-              banUser.mutate(
+    <div key={u.id} className='flex items-center gap-3 px-3 py-2 text-small'>
+      <span className='w-[170px] truncate text-[var(--text-primary)]'>{u.name || '—'}</span>
+      <span className='flex-1 truncate text-[var(--text-secondary)]'>{u.email}</span>
+      <span className='w-[60px]'>
+        <Badge variant={u.role === 'admin' ? 'blue' : 'gray'}>{u.role || 'user'}</Badge>
+      </span>
+      <span className='w-[55px]'>
+        {u.banned ? <Badge variant='red'>Banned</Badge> : <Badge variant='green'>Active</Badge>}
+      </span>
+      <span className='flex w-[150px] items-center justify-end gap-1'>
+        {u.id !== session?.user?.id && (
+          <>
+            <Button
+              variant='active'
+              className='h-[28px] px-2 text-caption'
+              onClick={() => handleImpersonate(u.id, u.email)}
+              disabled={pendingUserIds.has(u.id)}
+            >
+              {impersonatingUserId === u.id ||
+              (impersonateUser.isPending &&
+                (impersonateUser.variables as { userId?: string } | undefined)?.userId === u.id)
+                ? 'Switching...'
+                : 'Impersonate'}
+            </Button>
+            <RowActionsMenu
+              label={`Actions for ${u.email}`}
+              actions={[
                 {
-                  userId: u.id,
-                  ...(banReason.trim() ? { banReason: banReason.trim() } : {}),
+                  label: resetPasswordLabel(u.id),
+                  onSelect: () => {
+                    setProvisionWarning(null)
+                    sendPasswordReset.reset()
+                    sendPasswordReset.mutate({ userId: u.id, email: u.email })
+                  },
+                  disabled: pendingUserIds.has(u.id),
                 },
                 {
-                  onSuccess: () => {
-                    setBanUserId(null)
-                    setBanReason('')
-                  },
-                }
-              )
-            }}
-            disabled={pendingUserIds.has(u.id)}
-          >
-            Confirm Ban
-          </Button>
-        </div>
-      )}
+                  label: u.role === 'admin' ? 'Demote' : 'Promote',
+                  onSelect: () => setPendingAction({ type: 'role', user: u }),
+                  disabled: pendingUserIds.has(u.id),
+                },
+                u.banned
+                  ? {
+                      label: 'Unban',
+                      onSelect: () => {
+                        unbanUser.reset()
+                        unbanUser.mutate({ userId: u.id })
+                      },
+                      disabled: pendingUserIds.has(u.id),
+                    }
+                  : {
+                      label: 'Ban',
+                      onSelect: () => {
+                        setBanReason('')
+                        setPendingAction({ type: 'ban', user: u })
+                      },
+                      destructive: true,
+                      disabled: pendingUserIds.has(u.id),
+                    },
+              ]}
+            />
+          </>
+        )}
+      </span>
     </div>
   )
 
@@ -503,6 +494,66 @@ export function Admin() {
           )}
         </div>
       </SettingsSection>
+      <ChipConfirmModal
+        open={pendingAction?.type === 'ban'}
+        onOpenChange={(open) => {
+          if (!open) closePendingAction()
+        }}
+        srTitle='Ban user'
+        title='Ban user'
+        text={[
+          'Banning ',
+          { text: pendingAction?.user.email ?? 'this user', bold: true },
+          ' ',
+          {
+            text: 'signs them out everywhere and blocks them from signing back in.',
+            error: true,
+          },
+          ' You can unban them later.',
+        ]}
+        confirm={{
+          label: 'Ban',
+          onClick: handleConfirmBan,
+          pending: banUser.isPending,
+          pendingLabel: 'Banning...',
+        }}
+      >
+        <ChipModalField
+          type='input'
+          title='Reason'
+          value={banReason}
+          onChange={setBanReason}
+          placeholder='Optional'
+          disabled={banUser.isPending}
+        />
+      </ChipConfirmModal>
+
+      <ChipConfirmModal
+        open={pendingAction?.type === 'role'}
+        onOpenChange={(open) => {
+          if (!open) closePendingAction()
+        }}
+        srTitle={isDemotion ? 'Demote user' : 'Promote user'}
+        title={isDemotion ? 'Demote user' : 'Promote user'}
+        text={[
+          isDemotion ? 'Demoting ' : 'Promoting ',
+          { text: pendingAction?.user.email ?? 'this user', bold: true },
+          ' ',
+          isDemotion
+            ? { text: 'revokes their platform admin access.', error: true }
+            : {
+                text: 'grants full platform admin access, including impersonating any user.',
+                error: true,
+              },
+        ]}
+        confirm={{
+          label: isDemotion ? 'Demote' : 'Promote',
+          onClick: handleConfirmRoleChange,
+          pending: setUserRole.isPending,
+          pendingLabel: isDemotion ? 'Demoting...' : 'Promoting...',
+        }}
+      />
+
       <AddUserModal
         open={isAddUserOpen}
         onOpenChange={setIsAddUserOpen}
@@ -513,7 +564,7 @@ export function Admin() {
           setAdminParams({ q: user.email, offset: null })
           setProvisionWarning(
             resetEmailError
-              ? `Created ${user.email}, but the password reset email failed to send (${resetEmailError}). Use Reset password on their row to try again.`
+              ? `Created ${user.email}, but the password reset email failed to send (${resetEmailError}). Use Reset password in that row's actions menu to try again.`
               : null
           )
         }}


### PR DESCRIPTION
## Summary
- Moved Reset password, Promote/Demote, and Ban/Unban into a `...` overflow menu (`RowActionsMenu`, same as Secrets/API keys) so the actions column stops wrapping to two lines
- Kept Impersonate as the only inline button since it's the action we use most
- Ban now opens a `ChipConfirmModal` (destructive) with the optional reason as a `ChipModalField`, replacing the ad-hoc inline two-step row
- Promote/Demote now opens the same confirm modal instead of firing immediately

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)