### PR TITLE
fix(files): stop the file-viewer image reshift on open

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
@@ -131,7 +131,10 @@ interface FileViewerProps {
 
 export function FileViewer(props: FileViewerProps) {
   const { contentSource, workspaceId } = props
-  const imageDimensions = useWorkspaceImageDimensionsAdapter(workspaceId)
+  // A caller-supplied contentSource means the adapter is unused (and its `workspaceId` may be a share token).
+  const imageDimensions = useWorkspaceImageDimensionsAdapter(workspaceId, {
+    enabled: !contentSource,
+  })
   const source = useMemo(
     () => contentSource ?? createWorkspaceFileContentSource(workspaceId, imageDimensions),
     [contentSource, workspaceId, imageDimensions]

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-chip.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-chip.test.tsx
@@ -26,7 +26,7 @@ function fakeNode(attrs: Record<string, unknown>) {
 }
 
 function fakeEditor(): Editor {
-  return { storage: { mention: { navigable: false } } } as unknown as Editor
+  return { storage: { mentionMenu: { navigable: false } } } as unknown as Editor
 }
 
 let container: HTMLDivElement | null = null

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-chip.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-chip.tsx
@@ -38,7 +38,7 @@ export function MentionChipView({ node, editor }: ReactNodeViewProps) {
   const { kind, id, label } = node.attrs as MentionAttrs
   const Icon = mentionIcon(kind, id, label) as StyleableIcon | undefined
   const iconStyle = Icon ? getBareIconStyle(Icon) : undefined
-  const navigable = editor.storage.mention?.navigable === true
+  const navigable = editor.storage.mentionMenu?.navigable === true
   const workspaceId = typeof params.workspaceId === 'string' ? params.workspaceId : undefined
   const path = navigable && workspaceId ? simLinkPath(workspaceId, kind, id) : null
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention.ts
@@ -25,7 +25,7 @@ export interface MentionStorage {
 
 declare module '@tiptap/core' {
   interface Storage {
-    mention: MentionStorage
+    mentionMenu: MentionStorage
   }
 }
 
@@ -35,10 +35,10 @@ declare module '@tiptap/core' {
  * entity inserts it as a portable `sim:<kind>/<id>` markdown link (same wire format as the chat
  * composer's `chip-clipboard-codec`), so it round-trips natively through the editor's link + markdown
  * machinery. The plugin's `items` is an empty gate; the real list is sourced reactively from the store
- * inside {@link MentionList}, populated by the host via the extension's `mention` storage.
+ * inside {@link MentionList}, populated by the host via the extension's `mentionMenu` storage.
  */
 export const Mention = Extension.create<Record<string, never>, MentionStorage>({
-  name: 'mention',
+  name: 'mentionMenu',
 
   addStorage() {
     return { store: createMentionStore(), onOpen: null, enabled: true, navigable: false }
@@ -53,7 +53,7 @@ export const Mention = Extension.create<Record<string, never>, MentionStorage>({
         allowSpaces: false,
         startOfLine: false,
         allow: ({ editor, range }) => {
-          if (!editor.storage.mention.enabled) return false
+          if (!editor.storage.mentionMenu.enabled) return false
           if (editor.isActive('codeBlock') || editor.isActive('link') || editor.isActive('code')) {
             return false
           }
@@ -78,10 +78,10 @@ export const Mention = Extension.create<Record<string, never>, MentionStorage>({
           mapProps: (props) => ({
             query: props.query,
             command: props.command,
-            store: props.editor.storage.mention.store,
+            store: props.editor.storage.mentionMenu.store,
             editor: props.editor,
           }),
-          onOpen: (props) => props.editor.storage.mention?.onOpen?.(),
+          onOpen: (props) => props.editor.storage.mentionMenu?.onOpen?.(),
         }),
       }),
     ]

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/use-editor-mentions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/use-editor-mentions.ts
@@ -27,15 +27,15 @@ export function useEditorMentions(
   useEffect(() => {
     if (!editor) return
     const taggingOn = Boolean(workspaceId) && !disableTagging
-    editor.storage.mention.enabled = taggingOn
-    editor.storage.mention.navigable = navigable
-    editor.storage.mention.onOpen = taggingOn ? () => setActive(true) : null
+    editor.storage.mentionMenu.enabled = taggingOn
+    editor.storage.mentionMenu.navigable = navigable
+    editor.storage.mentionMenu.onOpen = taggingOn ? () => setActive(true) : null
     return () => {
-      editor.storage.mention.onOpen = null
+      editor.storage.mentionMenu.onOpen = null
     }
   }, [editor, workspaceId, navigable, disableTagging])
 
   useEffect(() => {
-    editor?.storage.mention.store.set(items)
+    editor?.storage.mentionMenu.store.set(items)
   }, [editor, items])
 }

--- a/apps/sim/hooks/queries/workspace-files.ts
+++ b/apps/sim/hooks/queries/workspace-files.ts
@@ -142,20 +142,28 @@ export function useWorkspaceFiles(
 }
 
 /**
- * Back the file content source's image-dimension capability with workspace file metadata. Reads intrinsic
- * dimensions synchronously from the already-loaded active file list (so a stored image reserves its box on
- * the first render), and persists the browser's measured dimensions when they're absent or disagree with
- * what's stored — an overwrite, so a stale value (left over after a content swap, or a non-EXIF-corrected
- * one) self-corrects rather than sticking. The write is fire-and-forget and de-duped (an exact-match cache
- * check plus mismatch-only reporting from the caller), so it never storms, never blocks render, and never
- * touches the collaborative document.
+ * Back the file content source's image-dimension capability with workspace file metadata. Subscribes to
+ * the active file list ({@link useWorkspaceFiles}) and reads each image's stored intrinsic dimensions from
+ * it, so a stored image reserves its box before it downloads. A reactive read (not a one-shot
+ * `getQueryData`), so it also works on a cold direct file-view load where the list isn't cached until after
+ * the image first renders: the subscription re-runs the node view's dimension read once the list resolves.
+ * Persists the browser's measured dimensions when they're absent or disagree with what's stored — an
+ * overwrite, so a stale value (left over after a content swap, or a non-EXIF-corrected one) self-corrects
+ * rather than sticking. The write is fire-and-forget and de-duped (an exact-match cache check plus
+ * mismatch-only reporting from the caller), so it never storms, never blocks render, and never touches the
+ * collaborative document. `options.enabled` turns the subscription off for callers that supply their own
+ * content source (the public share page, whose `workspaceId` is a share token that would 404).
  */
-export function useWorkspaceImageDimensionsAdapter(workspaceId: string): ImageDimensionsSource {
+export function useWorkspaceImageDimensionsAdapter(
+  workspaceId: string,
+  options?: { enabled?: boolean }
+): ImageDimensionsSource {
   const queryClient = useQueryClient()
+  const { data: files } = useWorkspaceFiles(workspaceId, 'active', options)
   return useMemo<ImageDimensionsSource>(() => {
     const listKey = workspaceFilesKeys.list(workspaceId, 'active')
     const findRecord = (src: string | undefined): WorkspaceFileRecord | undefined =>
-      findWorkspaceFileBySrc(queryClient.getQueryData<WorkspaceFileRecord[]>(listKey), src)
+      findWorkspaceFileBySrc(files, src)
     return {
       getImageDimensions: (src) => {
         const record = findRecord(src)
@@ -194,7 +202,7 @@ export function useWorkspaceImageDimensionsAdapter(workspaceId: string): ImageDi
           .catch(() => {})
       },
     }
-  }, [queryClient, workspaceId])
+  }, [files, queryClient, workspaceId])
 }
 
 /**


### PR DESCRIPTION
## Summary
- Embedded images in a markdown file reshifted on **every** open: the image loaded ~2.3s in with no reserved box and shoved everything below it down (CLS ~0.17). The `untitled.md` mention itself never moved — the image just popped in nearby.
- Root cause: the intrinsic dimensions **are** stored server-side, but `useWorkspaceImageDimensionsAdapter` read the files list via `queryClient.getQueryData` **non-reactively**. On a cold file-view load the list isn't cached when the image renders, so it returned null; and with a stable adapter identity it never re-checked when the list resolved → no reservation → reflow.
- Fix: read the list via a **reactive `useWorkspaceFiles` subscription**. The adapter re-identifies when the list arrives, re-running the image node view's memoized dimension read so it reserves the box from the stored dims **before** the slower image download finishes. Query key is shared (dedupes with surrounding views). Gated behind `enabled: !contentSource` so the public share page (which passes a share token as `workspaceId`) doesn't fire a 404.
- Also fixes a pre-existing warning surfaced during investigation: the `@`-menu extension and the mention node were both named `mention` (`Duplicate extension names found: ['mention']`). Renamed the menu extension to `mentionMenu` (node keeps `mention`, its persisted doc type) + moved its storage key.

## Type of Change
- [x] Bug fix

## Testing
- Reproduced + verified in a Playwright CLS harness that drives the real collaborative load path (placeholder→live swap seeded via the same converter the realtime server uses): **dims present → 0 shift; dims absent → 0.20**.
- 521 rich-markdown-editor unit tests pass; type-check clean; duplicate-`mention` warning confirmed gone.
- ⚠️ Not yet confirmed on deployed staging — the reserve depends on the list fetch (~100–300ms) resolving before the image download (~2.3s), which it should comfortably; a post-deploy re-run of the CLS probe on the staging file page is the final confirmation.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)