### PR TITLE
improvement(ui): unbold the app, align the folder chevron, tidy the feedback modal

### DIFF
--- a/apps/sim/app/(auth)/components/auth-button-classes.ts
+++ b/apps/sim/app/(auth)/components/auth-button-classes.ts
@@ -1,3 +1,3 @@
 /** Shared className for inline auth action links. */
 export const AUTH_TEXT_LINK =
-  'font-medium text-[var(--brand-accent)] underline-offset-4 transition hover:text-[var(--brand-accent-hover)] hover:underline disabled:cursor-not-allowed disabled:opacity-50' as const
+  'text-[var(--brand-accent)] underline-offset-4 transition hover:text-[var(--brand-accent-hover)] hover:underline disabled:cursor-not-allowed disabled:opacity-50' as const

--- a/apps/sim/app/(interfaces)/chat/components/auth/email/email-auth.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/auth/email/email-auth.tsx
@@ -217,8 +217,7 @@ export default function EmailAuth({ identifier }: EmailAuthProps) {
                     Didn't receive a code?{' '}
                     {countdown > 0 ? (
                       <span>
-                        Resend in{' '}
-                        <span className='font-medium text-[var(--text-primary)]'>{countdown}s</span>
+                        Resend in <span className='text-[var(--text-primary)]'>{countdown}s</span>
                       </span>
                     ) : (
                       <button

--- a/apps/sim/app/(interfaces)/chat/components/header/header.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/header/header.tsx
@@ -40,7 +40,7 @@ export function ChatHeader({ chatConfig, starCount }: ChatHeaderProps) {
               className='size-6 rounded-md object-cover'
             />
           )}
-          <h2 className='font-medium text-[var(--text-primary)] text-lg'>
+          <h2 className='text-[var(--text-primary)] text-lg'>
             {chatConfig?.customizations?.headerText || chatConfig?.title || 'Chat'}
           </h2>
         </div>

--- a/apps/sim/app/(interfaces)/chat/components/message-container/message-container.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/message-container/message-container.tsx
@@ -39,9 +39,7 @@ export function ChatMessageContainer({
           {messages.length === 0 ? (
             <div className='flex flex-col items-center justify-center py-10'>
               <div className='space-y-2 text-center'>
-                <h3 className='font-medium text-[var(--text-primary)] text-lg'>
-                  How can I help you today?
-                </h3>
+                <h3 className='text-[var(--text-primary)] text-lg'>How can I help you today?</h3>
                 <p className='text-[var(--text-muted)] text-sm'>
                   {chatConfig?.description || 'Ask me anything.'}
                 </p>

--- a/apps/sim/app/(interfaces)/chat/components/message/components/markdown-renderer.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/message/components/markdown-renderer.tsx
@@ -18,7 +18,7 @@ function LinkWithPreview({ href, children }: { href: string; children: React.Rea
         </a>
       </Tooltip.Trigger>
       <Tooltip.Content side='top' align='center' sideOffset={5} className='max-w-sm'>
-        <span className='truncate font-medium text-xs'>{href}</span>
+        <span className='truncate text-xs'>{href}</span>
       </Tooltip.Content>
     </Tooltip.Root>
   )

--- a/apps/sim/app/(interfaces)/chat/components/message/message.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/message/message.tsx
@@ -187,7 +187,7 @@ export const ClientChatMessage = memo(function ClientChatMessage({
                             {getFileIcon(attachment.type)}
                           </div>
                           <div className='min-w-0 flex-1'>
-                            <div className='truncate font-medium text-[var(--text-primary)] text-xs md:text-sm'>
+                            <div className='truncate text-[var(--text-primary)] text-xs md:text-sm'>
                               {attachment.name}
                             </div>
                             {attachment.size && (

--- a/apps/sim/app/(interfaces)/resume/[workflowId]/[executionId]/resume-page-client.tsx
+++ b/apps/sim/app/(interfaces)/resume/[workflowId]/[executionId]/resume-page-client.tsx
@@ -705,9 +705,7 @@ export default function ResumeExecutionPage({
       <Tooltip.Provider>
         <div className='flex flex-1 items-center justify-center p-6'>
           <div className='max-w-[400px] text-center'>
-            <h1 className='mb-2 font-medium text-[20px] text-[var(--text-primary)]'>
-              Execution Not Found
-            </h1>
+            <h1 className='mb-2 text-[20px] text-[var(--text-primary)]'>Execution Not Found</h1>
             <p className='mb-6 text-[14px] text-[var(--text-secondary)]'>
               This execution could not be located or has already completed.
             </p>
@@ -726,7 +724,7 @@ export default function ResumeExecutionPage({
         {/* Header */}
         <div className='mb-8 flex items-center justify-between'>
           <div>
-            <h1 className='font-medium text-[20px] text-[var(--text-primary)]'>Paused Execution</h1>
+            <h1 className='text-[20px] text-[var(--text-primary)]'>Paused Execution</h1>
             <p className='mt-1 text-[14px] text-[var(--text-secondary)]'>
               Select a pause point to review and resume
             </p>

--- a/apps/sim/app/_shell/desktop-update-gate.tsx
+++ b/apps/sim/app/_shell/desktop-update-gate.tsx
@@ -87,7 +87,7 @@ export function DesktopUpdateGate() {
       data-native-surface-occlusion='takeover'
     >
       <div className='flex max-w-sm flex-col gap-2'>
-        <h1 className='font-medium text-[var(--text-primary)] text-lg'>Update Sim to continue</h1>
+        <h1 className='text-[var(--text-primary)] text-lg'>Update Sim to continue</h1>
         <p className='text-[var(--text-secondary)] text-sm'>
           This version of the Sim desktop app is no longer compatible with the latest Sim. Install
           the update to keep going.

--- a/apps/sim/app/f/[token]/public-file-email-auth.tsx
+++ b/apps/sim/app/f/[token]/public-file-email-auth.tsx
@@ -173,8 +173,7 @@ export function PublicFileEmailAuth({ token }: PublicFileEmailAuthProps) {
             Didn't receive a code?{' '}
             {countdown > 0 ? (
               <span>
-                Resend in{' '}
-                <span className='font-medium text-[var(--text-primary)]'>{countdown}s</span>
+                Resend in <span className='text-[var(--text-primary)]'>{countdown}s</span>
               </span>
             ) : (
               <button

--- a/apps/sim/app/f/[token]/public-file-view.tsx
+++ b/apps/sim/app/f/[token]/public-file-view.tsx
@@ -85,7 +85,7 @@ export function PublicFileView({
             </>
           )}
           <div className='flex min-w-0 flex-col'>
-            <span className='truncate font-medium text-[14px] text-[var(--text-body)]'>{name}</span>
+            <span className='truncate text-[14px] text-[var(--text-body)]'>{name}</span>
             {provenance ? (
               <span className='truncate text-[12px] text-[var(--text-muted)]'>{provenance}</span>
             ) : null}

--- a/apps/sim/app/invite/components/status-card.tsx
+++ b/apps/sim/app/invite/components/status-card.tsx
@@ -34,9 +34,7 @@ export function InviteStatusCard({
     return (
       <>
         <div className='space-y-1 text-center'>
-          <h1 className='font-medium text-[32px] text-[var(--text-primary)] tracking-tight'>
-            Loading
-          </h1>
+          <h1 className='text-[32px] text-[var(--text-primary)] tracking-tight'>Loading</h1>
           <p className='text-[var(--text-muted)]'>{description}</p>
         </div>
         <div className='mt-8 flex w-full items-center justify-center py-8'>
@@ -49,9 +47,7 @@ export function InviteStatusCard({
   return (
     <>
       <div className='space-y-1 text-center'>
-        <h1 className='font-medium text-[32px] text-[var(--text-primary)] tracking-tight'>
-          {title}
-        </h1>
+        <h1 className='text-[32px] text-[var(--text-primary)] tracking-tight'>{title}</h1>
         <p className='text-[var(--text-muted)]'>{description}</p>
       </div>
 

--- a/apps/sim/app/oauth-error/page.tsx
+++ b/apps/sim/app/oauth-error/page.tsx
@@ -40,7 +40,7 @@ export default async function OAuthErrorPage({ searchParams }: OAuthErrorPagePro
     <main className='desktop-title-bar-page flex items-center justify-center px-6'>
       <DesktopTitleBarLane />
       <div className='max-w-sm text-center'>
-        <h1 className='font-semibold text-foreground text-lg'>Couldn’t complete that</h1>
+        <h1 className='text-foreground text-lg'>Couldn’t complete that</h1>
         <p className='mt-2 text-muted-foreground text-sm'>{messageForError(code)}</p>
         <p className='mt-4 text-muted-foreground text-sm'>
           You can close this tab and try again from Sim.

--- a/apps/sim/app/playground/page.tsx
+++ b/apps/sim/app/playground/page.tsx
@@ -90,7 +90,7 @@ import { env, isTruthy } from '@/lib/core/config/env'
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className='space-y-4'>
-      <h2 className='border-[var(--border)] border-b pb-2 font-medium text-[var(--text-primary)] text-lg'>
+      <h2 className='border-[var(--border)] border-b pb-2 text-[var(--text-primary)] text-lg'>
         {title}
       </h2>
       <div className='space-y-4'>{children}</div>
@@ -188,9 +188,7 @@ export default function PlaygroundPage() {
           </div>
           <div className='mx-auto max-w-4xl space-y-12'>
             <div>
-              <h1 className='font-semibold text-2xl text-[var(--text-primary)]'>
-                EMCN Component Playground
-              </h1>
+              <h1 className='text-2xl text-[var(--text-primary)]'>EMCN Component Playground</h1>
               <p className='mt-2 text-[var(--text-secondary)]'>
                 All emcn UI components and their variants
               </p>

--- a/apps/sim/app/unsubscribe/unsubscribe.tsx
+++ b/apps/sim/app/unsubscribe/unsubscribe.tsx
@@ -40,9 +40,7 @@ function UnsubscribeContent() {
     return (
       <InviteLayout>
         <div className='space-y-1 text-center'>
-          <h1 className={'font-medium text-[32px] text-[var(--text-primary)] tracking-tight'}>
-            Loading
-          </h1>
+          <h1 className={'text-[32px] text-[var(--text-primary)] tracking-tight'}>Loading</h1>
           <p className={'text-[var(--text-muted)] text-md'}>Validating your unsubscribe link…</p>
         </div>
         <div className={'mt-8 flex w-full items-center justify-center py-8'}>
@@ -56,7 +54,7 @@ function UnsubscribeContent() {
     return (
       <InviteLayout>
         <div className='space-y-1 text-center'>
-          <h1 className={'font-medium text-[32px] text-[var(--text-primary)] tracking-tight'}>
+          <h1 className={'text-[32px] text-[var(--text-primary)] tracking-tight'}>
             Invalid Unsubscribe Link
           </h1>
           <p className={'text-[var(--text-muted)] text-md'}>{error}</p>
@@ -75,7 +73,7 @@ function UnsubscribeContent() {
     return (
       <InviteLayout>
         <div className='space-y-1 text-center'>
-          <h1 className={'font-medium text-[32px] text-[var(--text-primary)] tracking-tight'}>
+          <h1 className={'text-[32px] text-[var(--text-primary)] tracking-tight'}>
             Important Account Emails
           </h1>
           <p className={'text-[var(--text-muted)] text-md'}>
@@ -97,7 +95,7 @@ function UnsubscribeContent() {
     return (
       <InviteLayout>
         <div className='space-y-1 text-center'>
-          <h1 className={'font-medium text-[32px] text-[var(--text-primary)] tracking-tight'}>
+          <h1 className={'text-[32px] text-[var(--text-primary)] tracking-tight'}>
             Successfully Unsubscribed
           </h1>
           <p className={'text-[var(--text-muted)] text-md'}>
@@ -120,7 +118,7 @@ function UnsubscribeContent() {
   return (
     <InviteLayout>
       <div className='space-y-1 text-center'>
-        <h1 className={'font-medium text-[32px] text-[var(--text-primary)] tracking-tight'}>
+        <h1 className={'text-[32px] text-[var(--text-primary)] tracking-tight'}>
           Email Preferences
         </h1>
         <p className={'text-[var(--text-muted)] text-md'}>
@@ -208,9 +206,7 @@ export default function Unsubscribe() {
       fallback={
         <InviteLayout>
           <div className='space-y-1 text-center'>
-            <h1 className={'font-medium text-[32px] text-[var(--text-primary)] tracking-tight'}>
-              Loading
-            </h1>
+            <h1 className={'text-[32px] text-[var(--text-primary)] tracking-tight'}>Loading</h1>
             <p className={'text-[var(--text-muted)] text-md'}>Validating your unsubscribe link…</p>
           </div>
           <div className={'mt-8 flex w-full items-center justify-center py-8'}>

--- a/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
@@ -249,32 +249,6 @@ export const MessageActions = memo(function MessageActions({
       >
         <ChipModalHeader onClose={() => handleModalClose(false)}>Give feedback</ChipModalHeader>
         <ChipModalBody>
-          <div className='flex items-start justify-between gap-2 px-2'>
-            <p className='font-medium text-[var(--text-secondary)] text-sm'>
-              {pendingFeedback === 'up' ? 'What did you like?' : 'What could be improved?'}
-            </p>
-            {pendingFeedback === 'down' && requestId && (
-              <Tooltip.Root>
-                <Tooltip.Trigger asChild>
-                  <button
-                    type='button'
-                    aria-label='Copy request ID'
-                    onClick={copyRequestId}
-                    className='flex size-[22px] shrink-0 items-center justify-center rounded-full text-[var(--text-icon)] transition-colors hover-hover:bg-[var(--surface-hover)] focus-visible:outline-none'
-                  >
-                    {copiedRequestId ? (
-                      <Check className='size-[14px]' />
-                    ) : (
-                      <Duplicate className='size-[14px]' />
-                    )}
-                  </button>
-                </Tooltip.Trigger>
-                <Tooltip.Content side='top'>
-                  {copiedRequestId ? 'Copied request ID' : 'Copy request ID'}
-                </Tooltip.Content>
-              </Tooltip.Root>
-            )}
-          </div>
           <ChipModalField
             type='textarea'
             title='Feedback'
@@ -292,6 +266,11 @@ export const MessageActions = memo(function MessageActions({
         </ChipModalBody>
         <ChipModalFooter
           onCancel={() => handleModalClose(false)}
+          secondaryActions={
+            pendingFeedback === 'down' && requestId
+              ? [{ label: copiedRequestId ? 'Copied' : 'Copy ID', onClick: copyRequestId }]
+              : undefined
+          }
           primaryAction={{
             label: 'Submit',
             onClick: handleSubmitFeedback,

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
@@ -307,9 +307,8 @@ const BreadcrumbSegment = memo(function BreadcrumbSegment({
   )
   /**
    * Interactive crumbs use a plain `<button>` with bare-chip geometry — NEVER
-   * the Button component, whose buttonVariants inject font-medium /
-   * rounded-[5px] / justify-center and break chip parity with the static/title
-   * crumbs.
+   * the Button component, whose buttonVariants inject rounded-[5px] /
+   * justify-center and break chip parity with the static/title crumbs.
    */
   const triggerClassName = cn(chipVariants(), 'group min-w-0 max-w-full justify-start')
 

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/resource.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/resource.tsx
@@ -471,7 +471,7 @@ const Pagination = memo(function Pagination({
                 variant='ghost'
                 onClick={() => onPageChange(page)}
                 className={cn(
-                  'h-auto p-0 font-medium text-sm transition-colors hover-hover:bg-transparent hover-hover:text-[var(--text-body)]',
+                  'h-auto p-0 text-sm transition-colors hover-hover:bg-transparent hover-hover:text-[var(--text-body)]',
                   page === currentPage ? 'text-[var(--text-body)]' : 'text-[var(--text-secondary)]'
                 )}
               >

--- a/apps/sim/app/workspace/[workspaceId]/components/workspace-access-denied.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/workspace-access-denied.tsx
@@ -11,9 +11,7 @@ export function WorkspaceAccessDenied() {
           <CircleAlert className='size-[18px] text-[var(--text-icon)]' aria-hidden />
         </div>
         <div className='space-y-1'>
-          <h1 className='font-medium text-[var(--text-primary)] text-lg'>
-            Workspace access denied
-          </h1>
+          <h1 className='text-[var(--text-primary)] text-lg'>Workspace access denied</h1>
           <p className='text-[var(--text-muted)] text-sm'>
             You do not have access to this workspace. Ask a workspace administrator for access or
             choose another workspace.

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx
@@ -407,7 +407,7 @@ const MediaPreview = memo(function MediaPreview({
       <div className='flex h-full flex-col items-center justify-center gap-4 bg-[var(--surface-1)] p-8'>
         <div className='flex flex-col items-center gap-2 text-center'>
           <Music className='size-[32px] text-[var(--text-muted)]' />
-          <p className='font-medium text-[14px] text-[var(--text-primary)]'>{file.name}</p>
+          <p className='text-[14px] text-[var(--text-primary)]'>{file.name}</p>
         </div>
         {blobUrl && (
           // biome-ignore lint/a11y/useMediaCaption: audio from workspace files

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/pdf-viewer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/pdf-viewer.tsx
@@ -43,7 +43,7 @@ interface PdfViewerCoreProps {
 function PdfError({ error }: { error: string }) {
   return (
     <div className='flex flex-1 flex-col items-center justify-center gap-[8px]'>
-      <p className='font-medium text-[14px] text-[var(--text-body)]'>Failed to preview PDF</p>
+      <p className='text-[14px] text-[var(--text-body)]'>Failed to preview PDF</p>
       <p className='text-[13px] text-[var(--text-muted)]'>{error}</p>
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared.tsx
@@ -18,7 +18,7 @@ export const UnsupportedPreview = memo(function UnsupportedPreview({ name }: { n
 
   return (
     <div className='flex flex-1 flex-col items-center justify-center gap-[8px]'>
-      <p className='font-medium text-[14px] text-[var(--text-primary)]'>
+      <p className='text-[14px] text-[var(--text-primary)]'>
         Preview not available{ext ? ` for .${ext} files` : ' for this file'}
       </p>
       <p className='text-[13px] text-[var(--text-muted)]'>
@@ -31,9 +31,7 @@ export const UnsupportedPreview = memo(function UnsupportedPreview({ name }: { n
 export function PreviewError({ label, error }: { label: string; error: string }) {
   return (
     <div className='flex flex-1 flex-col items-center justify-center gap-[8px]'>
-      <p className='font-medium text-[14px] text-[var(--text-primary)]'>
-        Failed to preview {label}
-      </p>
+      <p className='text-[14px] text-[var(--text-primary)]'>Failed to preview {label}</p>
       <p className='text-[13px] text-[var(--text-muted)]'>{error}</p>
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-menu-chrome.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-menu-chrome.ts
@@ -17,7 +17,7 @@ export const SUGGESTION_SCROLL_CLASS = 'max-h-[240px] scroll-py-1.5 overflow-y-a
 /** A selectable row: icon + label, 14px icon in `--text-icon`, truncating label. The `img` rules
  * size custom-block image icons (rendered as `<img>`, so the `svg` rules never reach them). */
 export const SUGGESTION_ITEM_CLASS =
-  'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left font-medium text-[var(--text-body)] text-caption outline-none transition-colors [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)] [&_img]:pointer-events-none [&_img]:size-[14px] [&_img]:shrink-0'
+  'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)] [&_img]:pointer-events-none [&_img]:size-[14px] [&_img]:shrink-0'
 
 /** A group heading above a run of rows. */
 export const SUGGESTION_GROUP_LABEL_CLASS =

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -1923,7 +1923,7 @@ export function Files() {
     return (
       <div className='flex w-[240px] flex-col gap-3 p-3'>
         <div className='flex flex-col gap-1.5'>
-          <span className='font-medium text-[var(--text-secondary)] text-caption'>File Type</span>
+          <span className='text-[var(--text-secondary)] text-caption'>File Type</span>
           <ChipCombobox
             options={[
               { value: 'document', label: 'Documents' },
@@ -1943,7 +1943,7 @@ export function Files() {
           />
         </div>
         <div className='flex flex-col gap-1.5'>
-          <span className='font-medium text-[var(--text-secondary)] text-caption'>Size</span>
+          <span className='text-[var(--text-secondary)] text-caption'>Size</span>
           <ChipCombobox
             options={[
               { value: 'small', label: 'Small (< 1 MB)' },
@@ -1963,9 +1963,7 @@ export function Files() {
         </div>
         {memberOptions.length > 0 && (
           <div className='flex flex-col gap-1.5'>
-            <span className='font-medium text-[var(--text-secondary)] text-caption'>
-              Uploaded By
-            </span>
+            <span className='text-[var(--text-secondary)] text-caption'>Uploaded By</span>
             <ChipCombobox
               options={memberOptions}
               multiSelect
@@ -2159,9 +2157,7 @@ export function Files() {
                 <div className='pointer-events-none absolute inset-0 z-[var(--z-dropdown)] flex flex-col items-center justify-center gap-2 border border-[var(--brand-secondary)] border-dashed bg-[var(--surface-4)] transition-colors'>
                   <Upload className='size-5 text-[var(--brand-secondary)]' />
                   <div className='flex flex-col gap-0.5 text-center'>
-                    <p className='font-medium text-[14px] text-[var(--brand-secondary)]'>
-                      Drop to upload
-                    </p>
+                    <p className='text-[14px] text-[var(--brand-secondary)]'>Drop to upload</p>
                     <p className='text-[11px] text-[var(--text-tertiary)]'>
                       Release files here to add them to this workspace
                     </p>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/tool-permission-card.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/tool-permission-card.tsx
@@ -157,7 +157,7 @@ export function ToolPermissionCard({
             </Tooltip.Trigger>
             <Tooltip.Content>
               <div className='max-w-[320px]'>
-                <div className='mb-1 font-medium text-xs'>{toolName}</div>
+                <div className='mb-1 text-xs'>{toolName}</div>
                 <pre className='whitespace-pre-wrap break-all font-mono text-xs'>{preview}</pre>
               </div>
             </Tooltip.Content>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/external-link.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/external-link.tsx
@@ -79,7 +79,7 @@ export function ExternalLink({ href, hostname, children }: ExternalLinkProps) {
       <Tooltip.Content>
         {preview ? (
           <span className='flex flex-col gap-0.5'>
-            {preview.title && <span className='font-medium'>{preview.title}</span>}
+            {preview.title && <span>{preview.title}</span>}
             {preview.description && (
               <span className='line-clamp-2 text-[var(--text-muted)]'>{preview.description}</span>
             )}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/special-tags/special-tags.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/special-tags/special-tags.tsx
@@ -2591,7 +2591,7 @@ function UsageUpgradeDisplay({ data }: { data: UsageUpgradeTagData }) {
           <path d='M8 6.5v3' stroke='currentColor' strokeWidth='1.3' strokeLinecap='round' />
           <circle cx='8' cy='11.5' r='0.75' fill='currentColor' />
         </svg>
-        <span className='font-medium text-amber-800 text-sm leading-5 dark:text-amber-300'>
+        <span className='text-amber-800 text-sm leading-5 dark:text-amber-300'>
           Usage Limit Reached
         </span>
       </div>
@@ -2604,15 +2604,13 @@ function UsageUpgradeDisplay({ data }: { data: UsageUpgradeTagData }) {
           target={isHosted ? undefined : '_blank'}
           rel={isHosted ? undefined : 'noopener noreferrer'}
           aria-label={isHosted ? undefined : `${buttonLabel} (opens in a new tab)`}
-          className='mt-2 inline-flex items-center gap-1 font-medium text-amber-700 text-small underline decoration-dashed underline-offset-2 transition-colors hover-hover:text-amber-900 dark:text-amber-300 dark:hover-hover:text-amber-200'
+          className='mt-2 inline-flex items-center gap-1 text-amber-700 text-small underline decoration-dashed underline-offset-2 transition-colors hover-hover:text-amber-900 dark:text-amber-300 dark:hover-hover:text-amber-200'
         >
           {buttonLabel}
           {isHosted ? <ArrowRight className='size-3' /> : <SquareArrowUpRight className='size-3' />}
         </a>
       ) : (
-        <p className='mt-2 font-medium text-amber-700 text-small dark:text-amber-300'>
-          {unavailableMessage}
-        </p>
+        <p className='mt-2 text-amber-700 text-small dark:text-amber-300'>{unavailableMessage}</p>
       )}
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -645,7 +645,7 @@ export function AddResourceDropdown({
                 )
               })
             ) : (
-              <div className='px-2 py-1.5 text-center font-medium text-[var(--text-tertiary)] text-caption'>
+              <div className='px-2 py-1.5 text-center text-[var(--text-tertiary)] text-caption'>
                 No results
               </div>
             )

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-session.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-session.tsx
@@ -963,7 +963,7 @@ export function BrowserSession({
                     )}
                     {suggestion.name ? (
                       <>
-                        <span className='flex-shrink-0 font-medium'>{suggestion.name}</span>
+                        <span className='flex-shrink-0'>{suggestion.name}</span>
                         <span className='truncate text-[var(--text-muted)]'>
                           — {suggestion.hostname}
                         </span>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/generic-resource-content/generic-resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/generic-resource-content/generic-resource-content.tsx
@@ -40,7 +40,7 @@ export function GenericResourceContent({ data }: GenericResourceContentProps) {
                 animate
               />
             )}
-            <span className='font-medium text-[13px] text-[var(--text-primary)]'>
+            <span className='text-[13px] text-[var(--text-primary)]'>
               {getToolStatusDisplayTitle(entry.displayTitle, entry.status)}
             </span>
             {entry.status === 'error' && (

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
@@ -638,7 +638,7 @@ function EmbeddedWorkflow({ workspaceId, workflowId }: EmbeddedWorkflowProps) {
       <div className='flex h-full flex-col items-center justify-center gap-3'>
         <WorkflowX className='size-[32px] text-[var(--text-icon)]' />
         <div className='flex flex-col items-center gap-1'>
-          <h2 className='font-medium text-[20px] text-[var(--text-primary)]'>Workflow not found</h2>
+          <h2 className='text-[20px] text-[var(--text-primary)]'>Workflow not found</h2>
           <p className='text-[var(--text-body)] text-small'>
             This workflow may have been deleted or moved
           </p>
@@ -699,7 +699,7 @@ function EmbeddedFile({
       <div className='flex h-full flex-col items-center justify-center gap-3'>
         <FileX className='size-[32px] text-[var(--text-icon)]' />
         <div className='flex flex-col items-center gap-1'>
-          <h2 className='font-medium text-[20px] text-[var(--text-primary)]'>File not found</h2>
+          <h2 className='text-[20px] text-[var(--text-primary)]'>File not found</h2>
           <p className='text-[var(--text-body)] text-small'>
             This file may have been deleted or moved
           </p>
@@ -747,7 +747,7 @@ function EmbeddedFolder({ workspaceId, folderId }: EmbeddedFolderProps) {
       <div className='flex h-full flex-col items-center justify-center gap-3'>
         <FolderIcon className='size-[32px] text-[var(--text-icon)]' />
         <div className='flex flex-col items-center gap-1'>
-          <h2 className='font-medium text-[20px] text-[var(--text-primary)]'>Folder not found</h2>
+          <h2 className='text-[20px] text-[var(--text-primary)]'>Folder not found</h2>
           <p className='text-[var(--text-body)] text-small'>
             This folder may have been deleted or moved
           </p>
@@ -758,7 +758,7 @@ function EmbeddedFolder({ workspaceId, folderId }: EmbeddedFolderProps) {
 
   return (
     <div className='flex h-full flex-col overflow-y-auto p-6'>
-      <h2 className='mb-4 font-medium text-[16px] text-[var(--text-primary)]'>{folder.name}</h2>
+      <h2 className='mb-4 text-[16px] text-[var(--text-primary)]'>{folder.name}</h2>
       {folderWorkflows.length === 0 ? (
         <p className='text-[13px] text-[var(--text-muted)]'>No workflows in this folder</p>
       ) : (
@@ -805,7 +805,7 @@ function EmbeddedLog({ workspaceId, logId, onNotFound }: EmbeddedLogProps) {
       <div className='flex h-full flex-col items-center justify-center gap-3'>
         <Library className='size-[32px] text-[var(--text-icon)]' />
         <div className='flex flex-col items-center gap-1'>
-          <h2 className='font-medium text-[20px] text-[var(--text-primary)]'>Log not found</h2>
+          <h2 className='text-[20px] text-[var(--text-primary)]'>Log not found</h2>
           <p className='text-[var(--text-body)] text-small'>
             This log may have been deleted or is no longer available
           </p>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/queued-messages/queued-messages.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/queued-messages/queued-messages.tsx
@@ -61,7 +61,7 @@ export function QueuedMessages({
         ) : (
           <ChevronRight className='size-[14px] text-[var(--text-icon)]' />
         )}
-        <span className='font-medium text-[var(--text-secondary)] text-small'>
+        <span className='text-[var(--text-secondary)] text-small'>
           {messageQueue.length} Queued
         </span>
       </button>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/drop-overlay/drop-overlay.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/drop-overlay/drop-overlay.tsx
@@ -29,7 +29,7 @@ export const DropOverlay = memo(function DropOverlay() {
   return (
     <div className='pointer-events-none absolute inset-[6px] z-10 flex items-center justify-center rounded-[14px] border-[1.5px] border-[var(--border-1)] border-dashed bg-[var(--white)] dark:bg-[var(--surface-4)]'>
       <div className='flex flex-col items-center gap-2'>
-        <span className='font-medium text-[13px] text-[var(--text-secondary)]'>Drop files</span>
+        <span className='text-[13px] text-[var(--text-secondary)]'>Drop files</span>
         <div className='flex items-center gap-2 text-[var(--text-icon)]'>
           {DROP_OVERLAY_ICONS.map((Icon, i) => (
             <Icon key={i} className='size-[14px]' />

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -356,7 +356,7 @@ export const PlusMenuDropdown = React.memo(
                         handleSelect({ type, id: item.id, title: item.name })
                       }}
                       className={cn(
-                        'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left font-medium text-[var(--text-body)] text-caption outline-none transition-colors [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
+                        'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
                         isActive && 'bg-[var(--surface-active)]'
                       )}
                     >
@@ -365,7 +365,7 @@ export const PlusMenuDropdown = React.memo(
                   )
                 })
               ) : (
-                <div className='px-2 py-1.5 text-center font-medium text-[var(--text-tertiary)] text-caption'>
+                <div className='px-2 py-1.5 text-center text-[var(--text-tertiary)] text-caption'>
                   No results
                 </div>
               ))}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/skills-menu-dropdown/skills-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/skills-menu-dropdown/skills-menu-dropdown.tsx
@@ -210,7 +210,7 @@ export const SkillsMenuDropdown = React.memo(
                     onMouseEnter={() => setActiveIndex(index)}
                     onClick={() => handleSelect(target)}
                     className={cn(
-                      'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left font-medium text-[var(--text-body)] text-caption outline-none transition-colors [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
+                      'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
                       isActive && 'bg-[var(--surface-active)]'
                     )}
                   >
@@ -220,7 +220,7 @@ export const SkillsMenuDropdown = React.memo(
                 )
               })
             ) : (
-              <div className='px-2 py-1.5 text-center font-medium text-[var(--text-tertiary)] text-caption'>
+              <div className='px-2 py-1.5 text-center text-[var(--text-tertiary)] text-caption'>
                 No skills or MCP servers
               </div>
             )}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-message-content/user-message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-message-content/user-message-content.tsx
@@ -147,10 +147,7 @@ export function UserMessageContent({
 
     if (plainMentions) {
       elements.push(
-        <span
-          key={`mention-${i}-${range.start}`}
-          className='font-medium text-[var(--text-primary)]'
-        >
+        <span key={`mention-${i}-${range.start}`} className='text-[var(--text-primary)]'>
           {content.slice(range.start, range.end)}
         </span>
       )

--- a/apps/sim/app/workspace/[workspaceId]/integrations/[block]/integration-block-detail.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/[block]/integration-block-detail.tsx
@@ -244,7 +244,7 @@ export function IntegrationBlockDetail({ integration, workspaceId }: Integration
               </div>
             )}
             <div className='flex flex-col gap-1'>
-              <h1 className='font-medium text-[var(--text-body)] text-lg'>{integration.name}</h1>
+              <h1 className='text-[var(--text-body)] text-lg'>{integration.name}</h1>
               <p className='text-[var(--text-muted)] text-md'>{integration.description}</p>
             </div>
           </div>

--- a/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-slack-bot-modal/connect-slack-bot-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-slack-bot-modal/connect-slack-bot-modal.tsx
@@ -243,7 +243,7 @@ interface SubStepProps {
 function SubStep({ n, children }: SubStepProps) {
   return (
     <li className='flex gap-2.5'>
-      <span className='mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--surface-5)] font-medium text-[var(--text-secondary)] text-xs tabular-nums'>
+      <span className='mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-[var(--surface-5)] text-[var(--text-secondary)] text-xs tabular-nums'>
         {n}
       </span>
       <div className='min-w-0 flex-1 text-[var(--text-secondary)] text-sm leading-relaxed'>
@@ -450,7 +450,7 @@ function StepDone({ pending, created, error, onRetry }: StepDoneProps) {
     return (
       <div className='flex flex-col items-center gap-4 py-10 text-center'>
         <div className='space-y-1'>
-          <p className='font-medium text-[var(--text-primary)] text-base'>Bot connected</p>
+          <p className='text-[var(--text-primary)] text-base'>Bot connected</p>
           <p className='max-w-sm text-[var(--text-secondary)] text-sm leading-relaxed'>
             It's now selectable in Slack triggers and actions across this workspace. Click Done to
             finish.

--- a/apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx
@@ -248,7 +248,7 @@ export function ConnectedCredentialDetail({
               <IntegrationTile blockType={integrationBlockType} icon={display.icon} />
             ) : (
               <div className={cn(RESOURCE_TILE_BASE, RESOURCE_TILE_PLAIN)}>
-                <span className='font-medium text-[var(--text-tertiary)] text-small'>
+                <span className='text-[var(--text-tertiary)] text-small'>
                   {resolveProviderLabel(credential.providerId).slice(0, 1) || '?'}
                 </span>
               </div>

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
@@ -641,7 +641,7 @@ export function Document({
     () => (
       <div className='flex w-[240px] flex-col gap-3 p-3'>
         <div className='flex flex-col gap-1.5'>
-          <span className='font-medium text-[var(--text-secondary)] text-caption'>Status</span>
+          <span className='text-[var(--text-secondary)] text-caption'>Status</span>
           <ChipCombobox
             options={[
               { value: 'enabled', label: 'Enabled' },

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -1145,7 +1145,7 @@ export function KnowledgeBase({
               content: (
                 <Tooltip.Root>
                   <Tooltip.Trigger asChild>
-                    <span className='font-medium text-[var(--text-secondary)] text-sm'>
+                    <span className='text-[var(--text-secondary)] text-sm'>
                       {format(new Date(doc.uploadedAt), 'MMM d')}
                     </span>
                   </Tooltip.Trigger>
@@ -1168,9 +1168,7 @@ export function KnowledgeBase({
       <div className='flex h-full flex-col items-center justify-center gap-3'>
         <DatabaseX className='size-[32px] text-[var(--text-muted)]' />
         <div className='flex flex-col items-center gap-1'>
-          <h2 className='font-medium text-[20px] text-[var(--text-secondary)]'>
-            Knowledge base not found
-          </h2>
+          <h2 className='text-[20px] text-[var(--text-secondary)]'>Knowledge base not found</h2>
           <p className='text-[var(--text-muted)] text-small'>
             This knowledge base may have been deleted or moved
           </p>

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field.tsx
@@ -135,7 +135,7 @@ export function ConnectorSelectorField({
 
   if (isLoading && isEnabled) {
     return (
-      <div className='flex h-[30px] items-center gap-2 rounded-lg border border-[var(--border-1)] bg-[var(--surface-5)] px-2 font-medium text-[var(--text-muted)] text-small dark:bg-[var(--surface-4)]'>
+      <div className='flex h-[30px] items-center gap-2 rounded-lg border border-[var(--border-1)] bg-[var(--surface-5)] px-2 text-[var(--text-muted)] text-small dark:bg-[var(--surface-4)]'>
         <Loader className='size-3.5' animate />
         Loading…
       </div>

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connectors-section/connectors-section.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connectors-section/connectors-section.tsx
@@ -383,7 +383,7 @@ function ConnectorCard({
           </div>
           <div className='flex min-w-0 flex-col gap-0.5'>
             <div className='flex min-w-0 items-center gap-2'>
-              <span className='flex min-w-0 items-center gap-1.5 font-medium text-[var(--text-primary)] text-small'>
+              <span className='flex min-w-0 items-center gap-1.5 text-[var(--text-primary)] text-small'>
                 <span className='truncate'>{connectorDef?.name || connector.connectorType}</span>
                 {(isSyncPending || connector.status === 'syncing') && (
                   <Loader className='size-3 text-[var(--text-muted)]' animate />
@@ -556,7 +556,7 @@ function ConnectorCard({
       {connector.status === 'disabled' && (
         <div className='border-[var(--border-muted)] border-t px-2 py-2'>
           <div className='flex flex-col gap-2 rounded-md border border-[var(--border-muted)] bg-[var(--surface-3)] px-2.5 py-2'>
-            <div className='flex items-center gap-1.5 font-medium text-[var(--text-primary)] text-caption'>
+            <div className='flex items-center gap-1.5 text-[var(--text-primary)] text-caption'>
               <TriangleAlert className='size-3 flex-shrink-0 text-[var(--caution)]' />
               Connector disabled after repeated sync failures
             </div>
@@ -596,7 +596,7 @@ function ConnectorCard({
       {missingScopes.length > 0 && connector.status !== 'disabled' && (
         <div className='border-[var(--border-muted)] border-t px-2 py-2'>
           <div className='flex flex-col gap-2 rounded-md border border-[var(--border-muted)] bg-[var(--surface-3)] px-2.5 py-2'>
-            <div className='flex items-center font-medium text-[var(--text-primary)] text-caption'>
+            <div className='flex items-center text-[var(--text-primary)] text-caption'>
               <span className='mr-1.5 inline-block size-[6px] rounded-xs bg-[var(--caution)]' />
               Additional permissions required
             </div>

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/max-badge.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/max-badge.tsx
@@ -1,6 +1,6 @@
 export function MaxBadge() {
   return (
-    <span className='ml-1 shrink-0 rounded-[3px] bg-[var(--surface-5)] px-1 py-[1px] font-medium text-[9px] text-[var(--text-icon)] uppercase tracking-wide'>
+    <span className='ml-1 shrink-0 rounded-[3px] bg-[var(--surface-5)] px-1 py-[1px] text-[9px] text-[var(--text-icon)] uppercase tracking-wide'>
       Max
     </span>
   )

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/edit-knowledge-base-modal/edit-knowledge-base-modal.tsx
@@ -138,7 +138,7 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
             <div className='grid grid-cols-3 gap-2'>
               <div className='rounded-sm border border-[var(--border-1)] bg-[var(--surface-2)] px-2.5 py-2'>
                 <p className='text-[11px] text-[var(--text-tertiary)] leading-tight'>Max Size</p>
-                <p className='font-medium text-[var(--text-primary)] text-sm'>
+                <p className='text-[var(--text-primary)] text-sm'>
                   {chunkingConfig.maxSize.toLocaleString()}
                   <span className='ml-0.5 font-normal text-[11px] text-[var(--text-tertiary)]'>
                     tokens
@@ -147,7 +147,7 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
               </div>
               <div className='rounded-sm border border-[var(--border-1)] bg-[var(--surface-2)] px-2.5 py-2'>
                 <p className='text-[11px] text-[var(--text-tertiary)] leading-tight'>Min Size</p>
-                <p className='font-medium text-[var(--text-primary)] text-sm'>
+                <p className='text-[var(--text-primary)] text-sm'>
                   {chunkingConfig.minSize.toLocaleString()}
                   <span className='ml-0.5 font-normal text-[11px] text-[var(--text-tertiary)]'>
                     chars
@@ -156,7 +156,7 @@ export const EditKnowledgeBaseModal = memo(function EditKnowledgeBaseModal({
               </div>
               <div className='rounded-sm border border-[var(--border-1)] bg-[var(--surface-2)] px-2.5 py-2'>
                 <p className='text-[11px] text-[var(--text-tertiary)] leading-tight'>Overlap</p>
-                <p className='font-medium text-[var(--text-primary)] text-sm'>
+                <p className='text-[var(--text-primary)] text-sm'>
                   {chunkingConfig.overlap.toLocaleString()}
                   <span className='ml-0.5 font-normal text-[11px] text-[var(--text-tertiary)]'>
                     tokens

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/line-chart/line-chart.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/line-chart/line-chart.tsx
@@ -257,7 +257,7 @@ function LineChartComponent({
     >
       {!hasExternalWrapper && (
         <div className='mb-3 flex items-center gap-3'>
-          <h4 className='font-medium text-[var(--text-primary)] text-sm'>{label}</h4>
+          <h4 className='text-[var(--text-primary)] text-sm'>{label}</h4>
           {allSeries.length > 1 && (
             <div className='flex items-center gap-2'>
               {scaledSeries.slice(1).map((s) => {
@@ -671,7 +671,7 @@ function LineChartComponent({
             const top = Math.min(Math.max(anchorY - 26, padding.top), height - padding.bottom - 18)
             return (
               <div
-                className='pointer-events-none absolute rounded-lg border border-[var(--border-1)] bg-[var(--surface-1)] px-2 py-1.5 font-medium text-xs shadow-lg'
+                className='pointer-events-none absolute rounded-lg border border-[var(--border-1)] bg-[var(--surface-1)] px-2 py-1.5 text-xs shadow-lg'
                 style={{ left, top }}
               >
                 {currentHoverDate && (

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/status-bar/status-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/status-bar/status-bar.tsx
@@ -123,9 +123,7 @@ function StatusBarInner({
         >
           {segments[hoverIndex].hasExecutions ? (
             <div>
-              <div className='font-semibold text-[var(--text-primary)]'>
-                {labels[hoverIndex].successLabel}
-              </div>
+              <div className='text-[var(--text-primary)]'>{labels[hoverIndex].successLabel}</div>
               <div className='text-[var(--text-secondary)]'>{labels[hoverIndex].countsLabel}</div>
               {labels[hoverIndex].rangeLabel && (
                 <div className='mt-0.5 text-[var(--text-tertiary)]'>

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/workflows-list/workflows-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/workflows-list/workflows-list.tsx
@@ -30,11 +30,11 @@ function WorkflowsListInner({
       {/* Table header */}
       <div className='flex-shrink-0 rounded-t-[6px] bg-[var(--surface-3)] px-6 py-2.5 dark:bg-[var(--surface-3)]'>
         <div className='flex items-center gap-4'>
-          <span className='w-[160px] flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption'>
+          <span className='w-[160px] flex-shrink-0 text-[var(--text-tertiary)] text-caption'>
             Workflow
           </span>
-          <span className='flex-1 font-medium text-[var(--text-tertiary)] text-caption'>Logs</span>
-          <span className='w-[100px] flex-shrink-0 pl-4 font-medium text-[var(--text-tertiary)] text-caption'>
+          <span className='flex-1 text-[var(--text-tertiary)] text-caption'>Logs</span>
+          <span className='w-[100px] flex-shrink-0 pl-4 text-[var(--text-tertiary)] text-caption'>
             Success Rate
           </span>
         </div>
@@ -81,7 +81,7 @@ function WorkflowsListInner({
                     <Workflow className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
                     <FloatingOverflowText
                       label={workflow.workflowName}
-                      className='block truncate font-medium text-[var(--text-primary)] text-caption'
+                      className='block truncate text-[var(--text-primary)] text-caption'
                     />
                   </div>
 
@@ -95,7 +95,7 @@ function WorkflowsListInner({
                   </div>
 
                   {/* Success rate */}
-                  <span className='w-[100px] flex-shrink-0 pl-4 font-medium text-[var(--text-primary)] text-caption'>
+                  <span className='w-[100px] flex-shrink-0 pl-4 text-[var(--text-primary)] text-caption'>
                     {workflow.overallSuccessRate.toFixed(1)}%
                   </span>
                 </div>

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/dashboard.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/dashboard.tsx
@@ -377,7 +377,7 @@ function DashboardInner({ stats, isLoading, error, searchQuery }: DashboardProps
     return (
       <div className='mt-6 flex flex-1 items-center justify-center'>
         <div className='text-[var(--text-error)]'>
-          <p className='font-medium text-small'>Error loading data</p>
+          <p className='text-small'>Error loading data</p>
           <p className='text-caption'>{error.message}</p>
         </div>
       </div>
@@ -388,7 +388,7 @@ function DashboardInner({ stats, isLoading, error, searchQuery }: DashboardProps
     return (
       <div className='mt-6 flex flex-1 items-center justify-center'>
         <div className='text-center text-[var(--text-secondary)]'>
-          <p className='font-medium text-small'>No workflows</p>
+          <p className='text-small'>No workflows</p>
           <p className='mt-1 text-caption'>Create a workflow to see its execution history here</p>
         </div>
       </div>
@@ -401,11 +401,9 @@ function DashboardInner({ stats, isLoading, error, searchQuery }: DashboardProps
         <div className='grid grid-cols-1 gap-4 md:grid-cols-3'>
           <div className='flex flex-col overflow-hidden rounded-md bg-[var(--surface-2)] dark:bg-[var(--surface-2)]'>
             <div className='flex min-w-0 items-center justify-between gap-2 bg-[var(--surface-3)] px-4 py-[9px] dark:bg-[var(--surface-3)]'>
-              <span className='min-w-0 truncate font-medium text-[var(--text-primary)] text-sm'>
-                Runs
-              </span>
+              <span className='min-w-0 truncate text-[var(--text-primary)] text-sm'>Runs</span>
               {globalDetails && (
-                <span className='flex-shrink-0 font-medium text-[var(--text-secondary)] text-sm'>
+                <span className='flex-shrink-0 text-[var(--text-secondary)] text-sm'>
                   {globalDetails.totalRuns}
                 </span>
               )}
@@ -428,11 +426,9 @@ function DashboardInner({ stats, isLoading, error, searchQuery }: DashboardProps
 
           <div className='flex flex-col overflow-hidden rounded-md bg-[var(--surface-2)] dark:bg-[var(--surface-2)]'>
             <div className='flex min-w-0 items-center justify-between gap-2 bg-[var(--surface-3)] px-4 py-[9px] dark:bg-[var(--surface-3)]'>
-              <span className='min-w-0 truncate font-medium text-[var(--text-primary)] text-sm'>
-                Errors
-              </span>
+              <span className='min-w-0 truncate text-[var(--text-primary)] text-sm'>Errors</span>
               {globalDetails && (
-                <span className='flex-shrink-0 font-medium text-[var(--text-secondary)] text-sm'>
+                <span className='flex-shrink-0 text-[var(--text-secondary)] text-sm'>
                   {globalDetails.totalErrors}
                 </span>
               )}
@@ -455,11 +451,9 @@ function DashboardInner({ stats, isLoading, error, searchQuery }: DashboardProps
 
           <div className='flex flex-col overflow-hidden rounded-md bg-[var(--surface-2)] dark:bg-[var(--surface-2)]'>
             <div className='flex min-w-0 items-center justify-between gap-2 bg-[var(--surface-3)] px-4 py-[9px] dark:bg-[var(--surface-3)]'>
-              <span className='min-w-0 truncate font-medium text-[var(--text-primary)] text-sm'>
-                Latency
-              </span>
+              <span className='min-w-0 truncate text-[var(--text-primary)] text-sm'>Latency</span>
               {globalDetails && (
-                <span className='flex-shrink-0 font-medium text-[var(--text-secondary)] text-sm'>
+                <span className='flex-shrink-0 text-[var(--text-secondary)] text-sm'>
                   {formatLatency(globalDetails.avgLatency)}
                 </span>
               )}

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/execution-snapshot/execution-snapshot.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/execution-snapshot/execution-snapshot.tsx
@@ -138,7 +138,7 @@ export function ExecutionSnapshot({
         >
           <div className='flex items-center gap-3 text-[var(--text-warning)]'>
             <CircleAlert className='size-[20px]' />
-            <span className='font-medium text-base'>Logged State Not Found</span>
+            <span className='text-base'>Logged State Not Found</span>
           </div>
           <div className='max-w-md text-center text-[var(--text-secondary)] text-small'>
             This log was migrated from the old logging system. The workflow state at the time of

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
@@ -91,16 +91,16 @@ function FileCard({ file, isExecutionFile = false, workspaceId }: FileCardProps)
   return (
     <div className='flex flex-col gap-1 rounded-md bg-[var(--surface-1)] px-2 py-1.5'>
       <div className='flex min-w-0 items-center justify-between gap-2'>
-        <span className='min-w-0 flex-1 truncate font-medium text-[var(--text-secondary)] text-caption'>
+        <span className='min-w-0 flex-1 truncate text-[var(--text-secondary)] text-caption'>
           {file.name}
         </span>
-        <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption'>
+        <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption'>
           {formatFileSize(file.size)}
         </span>
       </div>
 
       <div className='flex items-center justify-between'>
-        <span className='font-medium text-[var(--text-subtle)] text-xs'>{file.type}</span>
+        <span className='text-[var(--text-subtle)] text-xs'>{file.type}</span>
         <Button
           variant='ghost'
           className='!h-[20px] !px-1.5 !py-0 text-xs'
@@ -121,9 +121,7 @@ export function FileCards({ files, isExecutionFile = false, workspaceId }: FileC
 
   return (
     <div className='mt-1 flex flex-col gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2.5 py-2 dark:bg-transparent'>
-      <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-        Files ({files.length})
-      </span>
+      <span className='text-[var(--text-tertiary)] text-caption'>Files ({files.length})</span>
       {files.map((file, index) => (
         <FileCard
           key={file.id || `file-${index}`}

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/trace-view/trace-view.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/trace-view/trace-view.tsx
@@ -342,7 +342,7 @@ const TraceTreeRow = memo(function TraceTreeRow({
           <Tooltip.Trigger asChild>
             <span
               className={cn(
-                'min-w-0 flex-1 truncate font-medium text-caption',
+                'min-w-0 flex-1 truncate text-caption',
                 hasError ? 'text-[var(--text-error)]' : 'text-[var(--text-secondary)]',
                 nameMatches && 'text-[var(--text-primary)]'
               )}
@@ -352,7 +352,7 @@ const TraceTreeRow = memo(function TraceTreeRow({
           </Tooltip.Trigger>
           <Tooltip.Content side='right' className='max-w-[320px]'>
             <div className='flex flex-col gap-0.5'>
-              <span className='font-medium'>{getDisplayName(span)}</span>
+              <span>{getDisplayName(span)}</span>
               <span className='text-[var(--text-tertiary)] text-caption'>
                 {formatDuration(duration, { precision: 2 }) || '—'}
                 {offsetMs > 0 && ` · +${formatDuration(offsetMs, { precision: 2 })}`}
@@ -368,7 +368,7 @@ const TraceTreeRow = memo(function TraceTreeRow({
             </div>
           </Tooltip.Content>
         </Tooltip.Root>
-        <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption tabular-nums'>
+        <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption tabular-nums'>
           {formatDuration(duration, { precision: 2 })}
         </span>
       </div>
@@ -463,7 +463,7 @@ function DetailCodeSection({
       >
         <span
           className={cn(
-            'font-medium text-caption transition-colors',
+            'text-caption transition-colors',
             isError
               ? 'text-[var(--text-error)]'
               : 'text-[var(--text-tertiary)] group-hover:text-[var(--text-primary)]'
@@ -632,7 +632,7 @@ function DetailCodeSection({
  */
 function MetaRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className='flex items-center justify-between gap-2 font-medium text-caption'>
+    <div className='flex items-center justify-between gap-2 text-caption'>
       <span className='flex-shrink-0 text-[var(--text-tertiary)]'>{label}</span>
       <span className='min-w-0 truncate text-right text-[var(--text-secondary)]'>{value}</span>
     </div>
@@ -716,13 +716,13 @@ const TraceDetailPane = memo(function TraceDetailPane({ span }: { span: TraceSpa
         <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
           <h3
             className={cn(
-              'min-w-0 truncate font-medium text-sm',
+              'min-w-0 truncate text-sm',
               hasError ? 'text-[var(--text-error)]' : 'text-[var(--text-primary)]'
             )}
           >
             {getDisplayName(span)}
           </h3>
-          <div className='flex items-center gap-1.5 font-medium text-[var(--text-tertiary)] text-caption'>
+          <div className='flex items-center gap-1.5 text-[var(--text-tertiary)] text-caption'>
             <Badge variant={hasError ? 'red' : 'green'} size='sm'>
               {statusLabel}
             </Badge>
@@ -777,7 +777,7 @@ const TraceDetailPane = memo(function TraceDetailPane({ span }: { span: TraceSpa
       )}
 
       {Number.isFinite(startedAt) && Number.isFinite(endedAt) && startedAt > 0 && endedAt > 0 && (
-        <div className='flex items-center justify-between font-medium text-[var(--text-tertiary)] text-caption'>
+        <div className='flex items-center justify-between text-[var(--text-tertiary)] text-caption'>
           <span title={new Date(startedAt).toISOString()} suppressHydrationWarning>
             Started {new Date(startedAt).toLocaleTimeString()}
           </span>
@@ -999,16 +999,16 @@ export const TraceView = memo(function TraceView({ traceSpans, runCostDollars }:
             Jump to error
           </Button>
         )}
-        <span className='flex-shrink-0 font-medium text-[var(--text-secondary)] text-caption tabular-nums'>
+        <span className='flex-shrink-0 text-[var(--text-secondary)] text-caption tabular-nums'>
           {formatDuration(totalDuration, { precision: 2 }) || '—'}
         </span>
-        <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption'>
+        <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption'>
           {blockCount} {blockCount === 1 ? 'span' : 'spans'}
         </span>
         {(() => {
           const rootCost = formatCostAmount(runCostDollars ?? normalizedSpans[0]?.cost?.total)
           return rootCost ? (
-            <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption tabular-nums'>
+            <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption tabular-nums'>
               {rootCost}
             </span>
           ) : null

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/log-details.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/log-details.tsx
@@ -469,17 +469,15 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
               {/* Timestamp + Workflow header */}
               <div className='grid grid-cols-2 gap-x-3 pb-0.5'>
                 <div className='flex min-w-0 flex-col gap-0.5'>
-                  <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                    Timestamp
-                  </span>
-                  <span className='font-medium text-[var(--text-secondary)] text-sm tabular-nums'>
+                  <span className='text-[var(--text-tertiary)] text-caption'>Timestamp</span>
+                  <span className='text-[var(--text-secondary)] text-sm tabular-nums'>
                     {formattedTimestamp
                       ? `${formattedTimestamp.compactDate} ${formattedTimestamp.compactTime}`
                       : '—'}
                   </span>
                 </div>
                 <div className='flex min-w-0 flex-col gap-0.5'>
-                  <span className='font-medium text-[var(--text-tertiary)] text-caption'>
+                  <span className='text-[var(--text-tertiary)] text-caption'>
                     {log.trigger === 'mothership' ? 'Job' : 'Workflow'}
                   </span>
                   {openableWorkflowId ? (
@@ -494,7 +492,7 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
                         <Workflow className='col-start-1 row-start-1 size-[14px] text-[var(--text-icon)] opacity-100 blur-0 transition-[opacity,filter,transform] duration-200 ease-in-out group-hover:scale-[0.25] group-hover:opacity-0 group-hover:blur-[2px] group-focus-visible:scale-[0.25] group-focus-visible:opacity-0 group-focus-visible:blur-[2px] motion-reduce:transition-none' />
                         <SquareArrowUpRight className='col-start-1 row-start-1 size-[14px] scale-[0.25] text-[var(--text-icon)] opacity-0 blur-[2px] transition-[opacity,filter,transform] duration-200 ease-in-out group-hover:scale-100 group-hover:opacity-100 group-hover:blur-0 group-focus-visible:scale-100 group-focus-visible:opacity-100 group-focus-visible:blur-0 motion-reduce:transition-none' />
                       </span>
-                      <span className='min-w-0 truncate font-medium text-[var(--text-secondary)] text-sm transition-colors group-hover:text-[var(--text-primary)] group-focus-visible:text-[var(--text-primary)]'>
+                      <span className='min-w-0 truncate text-[var(--text-secondary)] text-sm transition-colors group-hover:text-[var(--text-primary)] group-focus-visible:text-[var(--text-primary)]'>
                         {workflowLabel}
                       </span>
                       <span className='sr-only'>(opens in a new tab)</span>
@@ -502,7 +500,7 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
                   ) : (
                     <div className='flex min-w-0 items-center gap-1.5'>
                       <Workflow className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
-                      <span className='min-w-0 truncate font-medium text-[var(--text-secondary)] text-sm'>
+                      <span className='min-w-0 truncate text-[var(--text-secondary)] text-sm'>
                         {workflowLabel}
                       </span>
                     </div>
@@ -524,10 +522,10 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
                       handleKeyboardActivation(event, () => copyRunId(log.executionId!))
                     }
                   >
-                    <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption'>
+                    <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption'>
                       Run ID
                     </span>
-                    <span className='min-w-0 truncate font-medium text-[var(--text-secondary)] text-caption tabular-nums'>
+                    <span className='min-w-0 truncate text-[var(--text-secondary)] text-caption tabular-nums'>
                       {copiedRunId ? 'Copied!' : log.executionId}
                     </span>
                   </div>
@@ -535,32 +533,24 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
 
                 {/* Level */}
                 <div className='flex h-10 items-center justify-between px-3'>
-                  <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                    Level
-                  </span>
+                  <span className='text-[var(--text-tertiary)] text-caption'>Level</span>
                   <StatusBadge status={logStatus} />
                 </div>
 
                 {/* Trigger */}
                 <div className='flex h-10 items-center justify-between px-3'>
-                  <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                    Trigger
-                  </span>
+                  <span className='text-[var(--text-tertiary)] text-caption'>Trigger</span>
                   {log.trigger ? (
                     <TriggerBadge trigger={log.trigger} />
                   ) : (
-                    <span className='font-medium text-[var(--text-secondary)] text-caption'>
-                      None
-                    </span>
+                    <span className='text-[var(--text-secondary)] text-caption'>None</span>
                   )}
                 </div>
 
                 {/* Duration */}
                 <div className='flex h-10 items-center justify-between px-3'>
-                  <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                    Duration
-                  </span>
-                  <span className='font-medium text-[var(--text-secondary)] text-caption tabular-nums'>
+                  <span className='text-[var(--text-tertiary)] text-caption'>Duration</span>
+                  <span className='text-[var(--text-secondary)] text-caption tabular-nums'>
                     {formatDuration(log.duration, { precision: 2 }) || '—'}
                   </span>
                 </div>
@@ -568,7 +558,7 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
                 {/* Version */}
                 {log.deploymentVersion && (
                   <div className='flex h-10 items-center gap-2 px-3'>
-                    <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption'>
+                    <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption'>
                       Version
                     </span>
                     <div className='flex w-0 flex-1 justify-end'>
@@ -582,9 +572,7 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
                 {/* Snapshot */}
                 {showWorkflowState && (
                   <div className='flex h-10 items-center justify-between px-3'>
-                    <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                      Snapshot
-                    </span>
+                    <span className='text-[var(--text-tertiary)] text-caption'>Snapshot</span>
                     <Chip leftIcon={Eye} onClick={() => setIsExecutionSnapshotOpen(true)}>
                       View Snapshot
                     </Chip>
@@ -594,9 +582,7 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
                 {/* Troubleshoot */}
                 {canTroubleshoot && (
                   <div className='flex h-10 items-center justify-between px-3'>
-                    <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                      Troubleshoot
-                    </span>
+                    <span className='text-[var(--text-tertiary)] text-caption'>Troubleshoot</span>
                     <Chip leftIcon={Wrench} onClick={handleTroubleshoot}>
                       Troubleshoot in Chat
                     </Chip>
@@ -607,9 +593,7 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
               {/* Workflow Input */}
               {isWorkflowExecutionLog && workflowInput && !permissionConfig.hideTraceSpans && (
                 <div className='flex flex-col gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2.5 py-2 dark:bg-transparent'>
-                  <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                    Workflow Input
-                  </span>
+                  <span className='text-[var(--text-tertiary)] text-caption'>Workflow Input</span>
                   <WorkflowOutputSection output={workflowInput} />
                 </div>
               )}
@@ -619,7 +603,7 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
                 <div className='flex flex-col gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2.5 py-2 dark:bg-transparent'>
                   <span
                     className={cn(
-                      'font-medium text-caption',
+                      'text-caption',
                       workflowOutput.error
                         ? 'text-[var(--text-error)]'
                         : 'text-[var(--text-tertiary)]'
@@ -639,34 +623,30 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
                 <div className='divide-y divide-[var(--border)] overflow-hidden rounded-md border border-[var(--border)] bg-[var(--surface-2)] dark:bg-transparent'>
                   {costBreakdown.rows.map((row) => (
                     <div key={row.key} className='flex h-10 items-center justify-between px-3'>
-                      <span className='min-w-0 truncate font-medium text-[var(--text-tertiary)] text-caption'>
+                      <span className='min-w-0 truncate text-[var(--text-tertiary)] text-caption'>
                         {row.label}
                       </span>
-                      <span className='flex-shrink-0 font-medium text-[var(--text-secondary)] text-caption tabular-nums'>
+                      <span className='flex-shrink-0 text-[var(--text-secondary)] text-caption tabular-nums'>
                         {creditLabel(row.credits, row.dollars)}
                       </span>
                     </div>
                   ))}
                   <div className='flex h-10 items-center justify-between px-3'>
-                    <span className='font-medium text-[var(--text-secondary)] text-caption'>
-                      Total
-                    </span>
-                    <span className='font-semibold text-[var(--text-primary)] text-caption tabular-nums'>
+                    <span className='text-[var(--text-secondary)] text-caption'>Total</span>
+                    <span className='text-[var(--text-primary)] text-caption tabular-nums'>
                       {creditLabel(costBreakdown.totalCredits, costBreakdown.totalDollars)}
                     </span>
                   </div>
                   {(costBreakdown.tokens.input > 0 || costBreakdown.tokens.output > 0) && (
                     <div className='flex h-10 items-center justify-between px-3'>
-                      <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                        Tokens
-                      </span>
-                      <span className='font-medium text-[var(--text-secondary)] text-caption tabular-nums'>
+                      <span className='text-[var(--text-tertiary)] text-caption'>Tokens</span>
+                      <span className='text-[var(--text-secondary)] text-caption tabular-nums'>
                         {costBreakdown.tokens.input} in · {costBreakdown.tokens.output} out
                       </span>
                     </div>
                   )}
                   <div className='px-3 py-2'>
-                    <p className='font-medium text-[var(--text-tertiary)] text-xs'>
+                    <p className='text-[var(--text-tertiary)] text-xs'>
                       Total includes a {formatCost(BASE_EXECUTION_CHARGE)} base charge plus model
                       and tool usage.
                     </p>
@@ -684,15 +664,13 @@ export function LogDetailsContent({ log, onActiveTabChange }: LogDetailsContentP
               <TraceView traceSpans={traceSpans} runCostDollars={log.cost?.total} />
             ) : log.executionData ? (
               <div className='flex h-full items-center justify-center px-4 text-center'>
-                <span className='font-medium text-[var(--text-tertiary)] text-sm'>
+                <span className='text-[var(--text-tertiary)] text-sm'>
                   No trace data available for this run
                 </span>
               </div>
             ) : (
               <div className='flex h-full items-center justify-center px-4 text-center'>
-                <span className='font-medium text-[var(--text-tertiary)] text-sm'>
-                  Loading trace…
-                </span>
+                <span className='text-[var(--text-tertiary)] text-sm'>Loading trace…</span>
               </div>
             )}
           </div>
@@ -806,7 +784,7 @@ export const LogDetails = memo(function LogDetails({
           <div className='flex h-full flex-col px-3.5 pt-3'>
             {/* Header */}
             <div className='flex items-center justify-between'>
-              <h2 className='font-medium text-[var(--text-primary)] text-sm'>Log Details</h2>
+              <h2 className='text-[var(--text-primary)] text-sm'>Log Details</h2>
               <div className='flex items-center gap-[1px]'>
                 {log.status === 'failed' &&
                   (log.workflow?.id || log.workflowId) &&

--- a/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/logs.tsx
@@ -995,7 +995,7 @@ export default function Logs() {
             )}
             {sections.map((section) => (
               <div key={section.title}>
-                <div className='px-3 py-1.5 font-medium text-[var(--text-tertiary)] text-caption uppercase tracking-wide'>
+                <div className='px-3 py-1.5 text-[var(--text-tertiary)] text-caption uppercase tracking-wide'>
                   {section.title}
                 </div>
                 {section.suggestions.map((suggestion) => {
@@ -1019,7 +1019,7 @@ export default function Logs() {
         ) : (
           <div className='py-1'>
             {suggestionType === 'filters' && (
-              <div className='px-3 py-1.5 font-medium text-[var(--text-tertiary)] text-caption uppercase tracking-wide'>
+              <div className='px-3 py-1.5 text-[var(--text-tertiary)] text-caption uppercase tracking-wide'>
                 SUGGESTED FILTERS
               </div>
             )}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
@@ -306,7 +306,7 @@ export function General() {
                       )
                     }
                     return (
-                      <span className='font-medium text-[var(--text-primary)] text-base'>
+                      <span className='text-[var(--text-primary)] text-base'>
                         {getInitials(profile?.name) || ''}
                       </span>
                     )
@@ -339,10 +339,7 @@ export function General() {
                   {isEditingName ? (
                     <>
                       <div className='relative inline-flex'>
-                        <span
-                          className='invisible whitespace-pre font-medium text-base'
-                          aria-hidden='true'
-                        >
+                        <span className='invisible whitespace-pre text-base' aria-hidden='true'>
                           {name || ' '}
                         </span>
                         <input
@@ -352,7 +349,7 @@ export function General() {
                           onChange={(e) => setName(e.target.value)}
                           onKeyDown={handleKeyDown}
                           onBlur={handleInputBlur}
-                          className='absolute top-0 left-0 h-full w-full border-0 bg-transparent p-0 font-medium text-base outline-none focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0'
+                          className='absolute top-0 left-0 h-full w-full border-0 bg-transparent p-0 text-base outline-none focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0'
                           maxLength={100}
                           disabled={updateProfile.isPending}
                           autoComplete='off'
@@ -373,7 +370,7 @@ export function General() {
                     </>
                   ) : (
                     <>
-                      <h3 className='font-medium text-base'>{profile?.name || ''}</h3>
+                      <h3 className='text-base'>{profile?.name || ''}</h3>
                       <Button
                         variant='ghost'
                         className='size-[10.5px] flex-shrink-0 p-0'
@@ -552,8 +549,8 @@ export function General() {
         <ChipModalBody>
           <p className='px-2 text-[var(--text-secondary)] text-sm'>
             A password reset link will be sent to{' '}
-            <span className='font-medium text-[var(--text-primary)]'>{profile?.email}</span>. Click
-            the link in the email to create a new password.
+            <span className='text-[var(--text-primary)]'>{profile?.email}</span>. Click the link in
+            the email to create a new password.
           </p>
           <ChipModalError>{resetPassword.error?.message}</ChipModalError>
         </ChipModalBody>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/inbox/components/inbox-settings-tab/inbox-settings-tab.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/inbox/components/inbox-settings-tab/inbox-settings-tab.tsx
@@ -350,7 +350,7 @@ export function InboxSettingsTab() {
         <ChipModalBody>
           <p className='px-2 text-[var(--text-secondary)] text-sm'>
             Changing your email address will create a new inbox.{' '}
-            <span className='font-medium text-[var(--text-primary)]'>
+            <span className='text-[var(--text-primary)]'>
               The old address will stop receiving emails immediately.
             </span>
           </p>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
@@ -157,9 +157,9 @@ function FormattedInput({
         onChange={onChange}
         onScroll={handleScroll}
         onInput={handleScroll}
-        inputClassName='font-medium font-sans text-transparent caret-[var(--text-primary)]'
+        inputClassName='font-sans text-transparent caret-[var(--text-primary)]'
       />
-      <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden px-2 py-1.5 font-medium font-sans text-sm'>
+      <div className='pointer-events-none absolute inset-0 flex items-center overflow-hidden px-2 py-1.5 font-sans text-sm'>
         <div className='whitespace-nowrap' style={{ transform: `translateX(-${scrollLeft}px)` }}>
           {formatDisplayText(value, { availableEnvVars })}
         </div>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -527,7 +527,7 @@ export function MCP() {
                     >
                       <div className='flex-1'>
                         <div className='flex h-[16px] items-center gap-1.5'>
-                          <p className='font-medium text-[var(--text-primary)] text-sm leading-none'>
+                          <p className='text-[var(--text-primary)] text-sm leading-none'>
                             {tool.name}
                           </p>
                           {issues.length > 0 && (
@@ -563,7 +563,7 @@ export function MCP() {
 
                     {isExpanded && hasParams && (
                       <div className='border-[var(--border-1)] border-t bg-[var(--surface-2)] px-2.5 py-2'>
-                        <p className='mb-1.5 font-medium text-[var(--text-muted)] text-caption uppercase tracking-wide'>
+                        <p className='mb-1.5 text-[var(--text-muted)] text-caption uppercase tracking-wide'>
                           Parameters
                         </p>
                         <div className='flex flex-col gap-1.5'>
@@ -585,7 +585,7 @@ export function MCP() {
                                   className='rounded-sm border border-[var(--border-1)] bg-[var(--surface-3)] px-2 py-1.5'
                                 >
                                   <div className='flex items-center gap-1.5'>
-                                    <span className='font-medium text-[var(--text-primary)] text-small'>
+                                    <span className='text-[var(--text-primary)] text-small'>
                                       {paramName}
                                     </span>
                                     <Badge variant='outline' size='sm'>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mothership/mothership.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mothership/mothership.tsx
@@ -97,7 +97,7 @@ function Divider() {
 }
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
-  return <p className='font-medium text-[var(--text-muted)] text-small'>{children}</p>
+  return <p className='text-[var(--text-muted)] text-small'>{children}</p>
 }
 
 export function Mothership() {
@@ -525,7 +525,7 @@ function StatCard({
       {loading ? (
         <Skeleton className='mt-1 h-[24px] w-[80px] rounded-sm' />
       ) : (
-        <p className='mt-1 font-medium text-[var(--text-primary)] text-lg'>{value ?? '—'}</p>
+        <p className='mt-1 text-[var(--text-primary)] text-lg'>{value ?? '—'}</p>
       )}
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/settings-upgrade-notice/settings-upgrade-notice.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/settings-upgrade-notice/settings-upgrade-notice.tsx
@@ -41,7 +41,7 @@ export function SettingsUpgradeNotice({
       className={cn('flex flex-col items-center justify-center gap-4', compact ? 'py-10' : 'py-20')}
     >
       <div className='text-center'>
-        <h3 className='font-medium text-[var(--text-primary)] text-md'>{title}</h3>
+        <h3 className='text-[var(--text-primary)] text-md'>{title}</h3>
         <p className='mt-1.5 text-[var(--text-muted)] text-sm'>{description}</p>
       </div>
       {canUpgrade && (

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/team-management/components/no-organization-view/no-organization-view.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/team-management/components/no-organization-view/no-organization-view.tsx
@@ -45,9 +45,7 @@ export function NoOrganizationView({
       <div>
         <div className='flex flex-col gap-5'>
           <div>
-            <h4 className='font-medium text-[var(--text-primary)] text-base'>
-              Create Your Team Workspace
-            </h4>
+            <h4 className='text-[var(--text-primary)] text-base'>Create Your Team Workspace</h4>
             <p className='mt-1 text-[var(--text-muted)] text-small'>
               You're subscribed to a {hasEnterprisePlan ? 'enterprise' : 'team'} plan. Create your
               workspace to start collaborating with your team.
@@ -176,7 +174,7 @@ export function NoOrganizationView({
   return (
     <div className='flex flex-col gap-5'>
       <div className='flex flex-col gap-2'>
-        <h3 className='font-medium text-[var(--text-primary)] text-base'>No Team Workspace</h3>
+        <h3 className='text-[var(--text-primary)] text-base'>No Team Workspace</h3>
         <p className='text-[var(--text-secondary)] text-small'>
           You don't have a team workspace yet. To collaborate with others, first upgrade to a team
           or enterprise plan.

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/team-management/components/transfer-ownership-dialog/transfer-ownership-dialog.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/team-management/components/transfer-ownership-dialog/transfer-ownership-dialog.tsx
@@ -130,9 +130,7 @@ export function TransferOwnershipDialog({
                 onAction={onOpenBillingPortal}
                 text={
                   <>
-                    <span className='block font-medium'>
-                      Your payment method stays on this organization
-                    </span>
+                    <span className='block'>Your payment method stays on this organization</span>
                     <span className='block text-[var(--text-secondary)]'>
                       Future charges will keep hitting the card you added. Open the Stripe billing
                       portal to remove it before you leave.
@@ -183,7 +181,7 @@ export function TransferOwnershipDialog({
                           </Avatar>
                           <div className='min-w-0 flex-1'>
                             <div className='flex items-center gap-2'>
-                              <span className='truncate font-medium text-[var(--text-primary)] text-small'>
+                              <span className='truncate text-[var(--text-primary)] text-small'>
                                 {m.name}
                               </span>
                               {m.role === 'admin' && (

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/workflow-mcp-servers/workflow-mcp-servers.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/workflow-mcp-servers/workflow-mcp-servers.tsx
@@ -570,7 +570,7 @@ function ServerDetailView({
                 ) : (
                   <div>
                     <div className='mb-[6.5px] flex items-center justify-between'>
-                      <span className='block pl-0.5 font-medium text-[var(--text-primary)] text-sm'>
+                      <span className='block pl-0.5 text-[var(--text-primary)] text-sm'>
                         Configuration
                       </span>
                       <Button
@@ -690,7 +690,7 @@ function ServerDetailView({
                       >
                         <div className='flex items-center justify-between bg-[var(--surface-4)] px-2.5 py-[5px]'>
                           <div className='flex min-w-0 flex-1 items-center gap-2'>
-                            <span className='block truncate font-medium text-[var(--text-tertiary)] text-base'>
+                            <span className='block truncate text-[var(--text-tertiary)] text-base'>
                               {name}
                             </span>
                             <Badge variant='type' size='sm'>

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-config-sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-config-sidebar.tsx
@@ -237,7 +237,7 @@ function ColumnConfigBody({
   return (
     <div className='flex h-full flex-col'>
       <div className='flex min-h-[48px] items-center justify-between border-[var(--border)] border-b px-3 py-[8.5px]'>
-        <h2 className='font-medium text-[var(--text-primary)] text-small'>Configure column</h2>
+        <h2 className='text-[var(--text-primary)] text-small'>Configure column</h2>
         <Button
           variant='ghost'
           size='sm'

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/enrichment-details/enrichment-details.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/enrichment-details/enrichment-details.tsx
@@ -98,10 +98,8 @@ interface DetailRowProps {
 function DetailRow({ label, children }: DetailRowProps) {
   return (
     <div className='flex h-10 items-center justify-between gap-4 px-3 transition-colors hover-hover:bg-[var(--surface-2)]'>
-      <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption'>
-        {label}
-      </span>
-      <span className='min-w-0 truncate text-right font-medium text-[var(--text-secondary)] text-caption tabular-nums'>
+      <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption'>{label}</span>
+      <span className='min-w-0 truncate text-right text-[var(--text-secondary)] text-caption tabular-nums'>
         {children}
       </span>
     </div>
@@ -159,11 +157,11 @@ function EnrichmentDetailsContent({
 
       {isLoading ? (
         <div className='flex h-full items-center justify-center px-4 text-center'>
-          <span className='font-medium text-[var(--text-tertiary)] text-sm'>Loading…</span>
+          <span className='text-[var(--text-tertiary)] text-sm'>Loading…</span>
         </div>
       ) : !detail ? (
         <div className='flex h-full items-center justify-center px-4 text-center'>
-          <span className='font-medium text-[var(--text-tertiary)] text-sm'>
+          <span className='text-[var(--text-tertiary)] text-sm'>
             No enrichment details for this run
           </span>
         </div>
@@ -172,18 +170,14 @@ function EnrichmentDetailsContent({
           <div className='flex flex-col gap-2.5 pb-4'>
             <div className='grid grid-cols-2 gap-x-3 pb-0.5'>
               <div className='flex min-w-0 flex-col gap-0.5'>
-                <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                  Timestamp
-                </span>
-                <span className='font-medium text-[var(--text-secondary)] text-sm tabular-nums'>
+                <span className='text-[var(--text-tertiary)] text-caption'>Timestamp</span>
+                <span className='text-[var(--text-secondary)] text-sm tabular-nums'>
                   {timestamp ? `${timestamp.compactDate} ${timestamp.compactTime}` : '—'}
                 </span>
               </div>
               <div className='flex min-w-0 flex-col gap-0.5'>
-                <span className='font-medium text-[var(--text-tertiary)] text-caption'>
-                  Enrichment
-                </span>
-                <span className='min-w-0 truncate font-medium text-[var(--text-secondary)] text-sm'>
+                <span className='text-[var(--text-tertiary)] text-caption'>Enrichment</span>
+                <span className='min-w-0 truncate text-[var(--text-secondary)] text-sm'>
                   {groupName || 'Enrichment'}
                 </span>
               </div>
@@ -209,7 +203,7 @@ function EnrichmentDetailsContent({
 
             {lastError && (
               <div className='flex flex-col gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2.5 py-2 dark:bg-transparent'>
-                <span className='font-medium text-[var(--text-error)] text-caption'>Error</span>
+                <span className='text-[var(--text-error)] text-caption'>Error</span>
                 <p className='break-words text-[var(--text-secondary)] text-caption'>{lastError}</p>
               </div>
             )}
@@ -222,14 +216,14 @@ function EnrichmentDetailsContent({
             <Badge variant={RESULT_STATUS_CONFIG[deriveResultStatus(detail)].variant} dot size='sm'>
               {RESULT_STATUS_CONFIG[deriveResultStatus(detail)].label}
             </Badge>
-            <span className='font-medium text-[var(--text-secondary)] text-caption tabular-nums'>
+            <span className='text-[var(--text-secondary)] text-caption tabular-nums'>
               {formatDuration(detail.durationMs, { precision: 2 }) || '—'}
             </span>
-            <span className='font-medium text-[var(--text-tertiary)] text-caption'>
+            <span className='text-[var(--text-tertiary)] text-caption'>
               {ranCount} {ranCount === 1 ? 'provider' : 'providers'}
             </span>
             {detail.totalCost > 0 && (
-              <span className='font-medium text-[var(--text-tertiary)] text-caption tabular-nums'>
+              <span className='text-[var(--text-tertiary)] text-caption tabular-nums'>
                 {formatCost(detail.totalCost)}
               </span>
             )}
@@ -264,19 +258,19 @@ function EnrichmentDetailsContent({
                         <ProviderIcon className={cn('size-[11px]', iconColorClass(bgColor))} />
                       )}
                     </div>
-                    <span className='min-w-0 flex-1 truncate font-medium text-[var(--text-secondary)] text-caption'>
+                    <span className='min-w-0 flex-1 truncate text-[var(--text-secondary)] text-caption'>
                       {outcome.label}
                     </span>
-                    <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption'>
+                    <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption'>
                       {PROVIDER_STATUS_LABEL[outcome.status]}
                     </span>
                     {outcome.cost > 0 && (
-                      <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-xs tabular-nums'>
+                      <span className='flex-shrink-0 text-[var(--text-tertiary)] text-xs tabular-nums'>
                         {formatCost(outcome.cost)}
                       </span>
                     )}
                     {ran && (
-                      <span className='flex-shrink-0 font-medium text-[var(--text-tertiary)] text-caption tabular-nums'>
+                      <span className='flex-shrink-0 text-[var(--text-tertiary)] text-caption tabular-nums'>
                         {formatDuration(outcome.durationMs, { precision: 2 }) || '—'}
                       </span>
                     )}
@@ -367,7 +361,7 @@ export function EnrichmentDetails({
         {rowId && groupId && (
           <div className='flex h-full flex-col px-3.5 pt-3'>
             <div className='flex items-center justify-between'>
-              <h2 className='font-medium text-[var(--text-primary)] text-sm'>Enrichment Details</h2>
+              <h2 className='text-[var(--text-primary)] text-sm'>Enrichment Details</h2>
               <Button variant='ghost' className='!p-1' onClick={onClose} aria-label='Close'>
                 <X className='size-[14px]' />
               </Button>

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/enrichments-sidebar/enrichment-config.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/enrichments-sidebar/enrichment-config.tsx
@@ -242,9 +242,7 @@ export function EnrichmentConfig({
           >
             <ArrowLeft className='size-[14px]' />
           </Button>
-          <h2 className='truncate font-medium text-[var(--text-primary)] text-small'>
-            {enrichment.name}
-          </h2>
+          <h2 className='truncate text-[var(--text-primary)] text-small'>{enrichment.name}</h2>
         </div>
         <Button
           variant='ghost'

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/enrichments-sidebar/enrichments-sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/enrichments-sidebar/enrichments-sidebar.tsx
@@ -72,7 +72,7 @@ function EnrichmentsSidebarBody({
     return (
       <div className='flex h-full flex-col'>
         <div className='flex min-h-[48px] items-center justify-between border-[var(--border)] border-b px-3 py-[8.5px]'>
-          <h2 className='font-medium text-[var(--text-primary)] text-small'>Enrichment</h2>
+          <h2 className='text-[var(--text-primary)] text-small'>Enrichment</h2>
           <Button
             variant='ghost'
             size='sm'
@@ -118,7 +118,7 @@ function EnrichmentsSidebarBody({
   return (
     <div className='flex h-full flex-col'>
       <div className='flex min-h-[48px] items-center justify-between border-[var(--border)] border-b px-3 py-[8.5px]'>
-        <h2 className='font-medium text-[var(--text-primary)] text-small'>Enrichments</h2>
+        <h2 className='text-[var(--text-primary)] text-small'>Enrichments</h2>
         <Button
           variant='ghost'
           size='sm'
@@ -157,7 +157,7 @@ function EnrichmentsSidebarBody({
                   >
                     <Icon className='mt-0.5 size-[14px] flex-none text-[var(--text-icon)]' />
                     <span className='flex min-w-0 flex-col gap-0.5'>
-                      <span className='truncate font-medium text-[var(--text-primary)] text-small'>
+                      <span className='truncate text-[var(--text-primary)] text-small'>
                         {enrichment.name}
                       </span>
                       <span className='whitespace-normal break-words text-[var(--text-tertiary)] text-caption'>

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-filter/table-filter.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-filter/table-filter.tsx
@@ -228,7 +228,7 @@ const FilterRuleRow = memo(function FilterRuleRow({
       ) : (
         <button
           onClick={() => onToggleLogical(rule.id)}
-          className='w-[42px] shrink-0 rounded-full py-0.5 text-right font-medium text-[10px] text-[var(--text-muted)] uppercase tracking-wide transition-colors hover:text-[var(--text-secondary)]'
+          className='w-[42px] shrink-0 rounded-full py-0.5 text-right text-[10px] text-[var(--text-muted)] uppercase tracking-wide transition-colors hover:text-[var(--text-secondary)]'
         >
           {rule.logicalOperator}
         </button>

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/remote-selection-overlay.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/remote-selection-overlay.tsx
@@ -359,7 +359,7 @@ export function RemoteSelectionOverlay({
           // `rounded-bl-none` tabs the label's bottom-left corner onto the selection's
           // top-left, the one deviation from the free-floating canvas cursor tag.
           <div
-            className='pointer-events-none fixed z-[60] max-w-[160px] truncate whitespace-nowrap rounded-xs rounded-bl-none px-1.5 py-0.5 font-medium text-[var(--surface-1)] text-xs'
+            className='pointer-events-none fixed z-[60] max-w-[160px] truncate whitespace-nowrap rounded-xs rounded-bl-none px-1.5 py-0.5 text-[var(--surface-1)] text-xs'
             style={{
               top: hoveredBox.viewportTop,
               left: hoveredBox.viewportLeft,

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -4174,7 +4174,7 @@ export function TableGrid({
       <div className='flex h-full flex-col items-center justify-center gap-3'>
         <TableX className='size-[32px] text-[var(--text-muted)]' />
         <div className='flex flex-col items-center gap-1'>
-          <h2 className='font-medium text-[20px] text-[var(--text-secondary)]'>Table not found</h2>
+          <h2 className='text-[20px] text-[var(--text-secondary)]'>Table not found</h2>
           <p className='text-[var(--text-muted)] text-small'>
             This table may have been deleted or moved
           </p>

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-primitives.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-primitives.tsx
@@ -69,7 +69,7 @@ export const AddRowButton = React.memo(function AddRowButton({ onClick }: { onCl
         onClick={onClick}
       >
         <Plus className='size-[14px] shrink-0 text-[var(--text-icon)]' />
-        <span className='font-medium text-small'>New row</span>
+        <span className='text-small'>New row</span>
       </Button>
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/workflow-sidebar/workflow-sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/workflow-sidebar/workflow-sidebar.tsx
@@ -505,9 +505,7 @@ export function WorkflowSidebarBody({
         sectionElement: (
           <div className='flex items-center gap-1.5 px-1.5 pt-1.5 pb-1'>
             <TagIcon icon={group.blockIcon} color={group.blockColor} />
-            <span className='font-medium text-[var(--text-secondary)] text-caption'>
-              {group.blockName}
-            </span>
+            <span className='text-[var(--text-secondary)] text-caption'>{group.blockName}</span>
           </div>
         ),
         items: group.paths.map((path) => ({
@@ -794,7 +792,7 @@ export function WorkflowSidebarBody({
               <ArrowLeft className='size-[14px]' />
             </Button>
           )}
-          <h2 className='truncate font-medium text-[var(--text-primary)] text-small'>{title}</h2>
+          <h2 className='truncate text-[var(--text-primary)] text-small'>{title}</h2>
         </div>
         <Button
           variant='ghost'
@@ -1007,7 +1005,7 @@ export function WorkflowSidebarBody({
                   <button
                     type='button'
                     onClick={() => setShowAdvanced((v) => !v)}
-                    className='flex items-center gap-1.5 whitespace-nowrap font-medium text-[var(--text-secondary)] text-small hover-hover:text-[var(--text-primary)]'
+                    className='flex items-center gap-1.5 whitespace-nowrap text-[var(--text-secondary)] text-small hover-hover:text-[var(--text-primary)]'
                   >
                     {showAdvanced ? 'Hide additional fields' : 'Show additional fields'}
                     <ChevronDown

--- a/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
@@ -592,7 +592,7 @@ export function Tables() {
     () => (
       <div className='flex w-[240px] flex-col gap-3 p-3'>
         <div className='flex flex-col gap-1.5'>
-          <span className='font-medium text-[var(--text-secondary)] text-caption'>Row Count</span>
+          <span className='text-[var(--text-secondary)] text-caption'>Row Count</span>
           <ChipCombobox
             options={[
               { value: 'empty', label: 'Empty' },
@@ -612,7 +612,7 @@ export function Tables() {
         </div>
         {memberOptions.length > 0 && (
           <div className='flex flex-col gap-1.5'>
-            <span className='font-medium text-[var(--text-secondary)] text-caption'>Owner</span>
+            <span className='text-[var(--text-secondary)] text-caption'>Owner</span>
             <ChipCombobox
               options={memberOptions}
               multiSelect

--- a/apps/sim/app/workspace/[workspaceId]/upgrade/components/comparison-table/comparison-table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/upgrade/components/comparison-table/comparison-table.tsx
@@ -150,7 +150,7 @@ export function ComparisonTable({
         {/* Top-left cell: title, subtitle, and billing toggle */}
         <div className='flex h-full flex-col justify-between gap-3 border-[var(--border)] border-r bg-[var(--surface-1)] px-4 py-4'>
           <div className='flex flex-col gap-0.5'>
-            <span className='font-medium text-[var(--text-primary)] text-base'>Compare plans</span>
+            <span className='text-[var(--text-primary)] text-base'>Compare plans</span>
             <span className='text-[var(--text-muted)] text-small'>Find the right plan for you</span>
           </div>
           <BillingPeriodToggle isAnnual={isAnnual} onChange={onIsAnnualChange} />
@@ -165,10 +165,8 @@ export function ComparisonTable({
               key={col.name}
               className='flex flex-col items-center gap-1 bg-[var(--surface-2)] px-3 py-4 text-center'
             >
-              <span className='font-medium text-[var(--text-primary)] text-base'>{col.name}</span>
-              <span className='font-medium text-[var(--text-primary)] text-md tabular-nums'>
-                {price}
-              </span>
+              <span className='text-[var(--text-primary)] text-base'>{col.name}</span>
+              <span className='text-[var(--text-primary)] text-md tabular-nums'>{price}</span>
               {cta && (
                 <button
                   type='button'
@@ -197,9 +195,7 @@ export function ComparisonTable({
                 sectionIdx > 0 && 'border-[var(--border-1)] border-t'
               )}
             >
-              <span className='font-medium text-[var(--text-primary)] text-small'>
-                {section.title}
-              </span>
+              <span className='text-[var(--text-primary)] text-small'>{section.title}</span>
             </div>
             <div
               className={cn(

--- a/apps/sim/app/workspace/[workspaceId]/upgrade/components/plan-card/plan-card.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/upgrade/components/plan-card/plan-card.tsx
@@ -78,15 +78,13 @@ export function UpgradePlanCard({
     >
       <div className='flex flex-col gap-4'>
         <div className='flex items-start justify-between gap-2'>
-          <h3 className='font-medium text-[24px] text-[var(--text-primary)]'>{name}</h3>
+          <h3 className='text-[24px] text-[var(--text-primary)]'>{name}</h3>
           {bannerText && <ChipTag variant='gray'>{bannerText}</ChipTag>}
         </div>
 
         <div className='flex flex-col'>
           <div className='flex items-center gap-2'>
-            <span className='font-medium text-[20px] text-[var(--text-primary)] tabular-nums'>
-              {price}
-            </span>
+            <span className='text-[20px] text-[var(--text-primary)] tabular-nums'>{price}</span>
             {discountLabel && <ChipTag variant='mono'>{discountLabel}</ChipTag>}
           </div>
           <p className='text-[var(--text-muted)] text-base'>{priceSubtext ?? '\u00A0'}</p>

--- a/apps/sim/app/workspace/[workspaceId]/upgrade/upgrade.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/upgrade/upgrade.tsx
@@ -99,9 +99,7 @@ export function Upgrade({ workspaceId }: UpgradeProps) {
         </div>
         <div className='flex min-h-0 flex-1 items-center justify-center px-6'>
           <div className='flex max-w-md flex-col items-center gap-3 text-center'>
-            <h1 className='font-medium text-[var(--text-body)] text-lg'>
-              Workspace plans unavailable
-            </h1>
+            <h1 className='text-[var(--text-body)] text-lg'>Workspace plans unavailable</h1>
             <p className='text-[var(--text-muted)] text-sm'>{description}</p>
           </div>
         </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/chat.tsx
@@ -912,9 +912,7 @@ export function Chat() {
         className='flex h-[32px] flex-shrink-0 cursor-grab items-center justify-between gap-2.5 bg-[var(--surface-1)] p-0 active:cursor-grabbing'
         onMouseDown={handleMouseDown}
       >
-        <span className='flex-shrink-0 pr-0.5 font-medium text-[var(--text-primary)] text-sm'>
-          Chat
-        </span>
+        <span className='flex-shrink-0 pr-0.5 text-[var(--text-primary)] text-sm'>Chat</span>
 
         {/* Start inputs button and output selector - with max-width to prevent overflow */}
         <div
@@ -924,7 +922,7 @@ export function Chat() {
           {shouldShowConfigureStartInputsButton && (
             <button
               type='button'
-              className='flex flex-none cursor-pointer items-center whitespace-nowrap rounded-md border border-[var(--border-1)] bg-[var(--surface-5)] px-2.5 py-0.5 font-medium font-sans text-[var(--text-primary)] text-caption hover-hover:bg-[var(--surface-active)]'
+              className='flex flex-none cursor-pointer items-center whitespace-nowrap rounded-md border border-[var(--border-1)] bg-[var(--surface-5)] px-2.5 py-0.5 font-sans text-[var(--text-primary)] text-caption hover-hover:bg-[var(--surface-active)]'
               title='Add chat inputs to Start block'
               onMouseDown={(e) => e.stopPropagation()}
               onClick={(e) => {
@@ -1032,7 +1030,7 @@ export function Chat() {
                 <div className='flex items-start gap-2'>
                   <CircleAlert className='mt-0.5 size-3 shrink-0 text-[var(--text-error)]' />
                   <div className='flex-1'>
-                    <div className='mb-1 font-medium text-[var(--text-error)] text-caption'>
+                    <div className='mb-1 text-[var(--text-error)] text-caption'>
                       File upload error
                     </div>
                     <div className='space-y-1'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/chat-message/chat-message.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/chat-message/chat-message.tsx
@@ -80,7 +80,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
 
         {formattedContent && !formattedContent.startsWith('Uploaded') && (
           <div className='rounded-[4px] border border-[var(--border-1)] bg-[var(--surface-5)] px-[8px] py-[6px] transition-all duration-200'>
-            <div className='whitespace-pre-wrap break-words font-medium font-sans text-[var(--text-primary)] text-sm leading-[1.25rem]'>
+            <div className='whitespace-pre-wrap break-words font-sans text-[var(--text-primary)] text-sm leading-[1.25rem]'>
               <WordWrap text={formattedContent} />
             </div>
           </div>
@@ -91,7 +91,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
 
   return (
     <div className='w-full max-w-full overflow-hidden pl-[2px] opacity-100 transition-opacity duration-200'>
-      <div className='whitespace-pre-wrap break-words font-medium font-season text-[var(--text-primary)] text-sm leading-[1.25rem]'>
+      <div className='whitespace-pre-wrap break-words font-season text-[var(--text-primary)] text-sm leading-[1.25rem]'>
         <WordWrap text={formattedContent} />
         {message.isStreaming && <StreamingIndicator />}
       </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/output-select/output-select.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/output-select/output-select.tsx
@@ -280,7 +280,7 @@ export function OutputSelect({
         sectionElement: (
           <div className='flex items-center gap-1.5 px-1.5 py-1'>
             <TagIcon icon={blockIcon} color={blockColor} />
-            <span className='font-medium text-small'>{blockName}</span>
+            <span className='text-small'>{blockName}</span>
           </div>
         ),
         items: outputs.map((output) => ({

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/command-list/command-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/command-list/command-list.tsx
@@ -200,7 +200,7 @@ export function CommandList() {
               {/* Left side: Icon and Label */}
               <div className='flex items-center gap-2'>
                 <Icon className='size-[14px] text-[var(--text-tertiary)] group-hover:text-[var(--text-primary)]' />
-                <span className='font-medium text-[var(--text-tertiary)] text-sm group-hover:text-[var(--text-primary)]'>
+                <span className='text-[var(--text-tertiary)] text-sm group-hover:text-[var(--text-primary)]'>
                   {command.label}
                 </span>
               </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/cursors/cursors.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/cursors/cursors.tsx
@@ -73,7 +73,7 @@ const CursorsComponent = () => {
 
               {/* Name tag to the right, background tightly wrapping text */}
               <div
-                className='ml-[-4px] inline-flex max-w-[160px] truncate whitespace-nowrap rounded-xs px-1.5 py-0.5 font-medium text-[var(--surface-1)] text-xs'
+                className='ml-[-4px] inline-flex max-w-[160px] truncate whitespace-nowrap rounded-xs px-1.5 py-0.5 text-[var(--surface-1)] text-xs'
                 style={{ backgroundColor: color }}
               >
                 {name}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/diff-controls/diff-controls.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/diff-controls/diff-controls.tsx
@@ -65,7 +65,7 @@ export const DiffControls = memo(function DiffControls() {
         <button
           onClick={handleReject}
           title='Reject changes'
-          className='relative flex h-full items-center border border-[var(--border)] bg-[var(--surface-4)] pr-5 pl-3 font-medium text-[var(--text-secondary)] text-small transition-colors hover-hover:border-[var(--border-1)] hover-hover:bg-[var(--surface-6)] hover-hover:text-[var(--text-primary)] dark:hover-hover:bg-[var(--surface-5)]'
+          className='relative flex h-full items-center border border-[var(--border)] bg-[var(--surface-4)] pr-5 pl-3 text-[var(--text-secondary)] text-small transition-colors hover-hover:border-[var(--border-1)] hover-hover:bg-[var(--surface-6)] hover-hover:text-[var(--text-primary)] dark:hover-hover:bg-[var(--surface-5)]'
           style={{
             clipPath: 'polygon(0 0, calc(100% + 10px) 0, 100% 100%, 0 100%)',
             borderRadius: '4px 0 0 4px',
@@ -88,7 +88,7 @@ export const DiffControls = memo(function DiffControls() {
         <button
           onClick={handleAccept}
           title='Accept changes (⇧⌘⏎)'
-          className='-ml-2.5 relative flex h-full items-center border border-[rgba(0,0,0,0.15)] bg-[var(--brand-accent)] pr-3 pl-5 font-medium text-[var(--text-inverse)] text-small transition-[background-color,border-color,fill,stroke] hover-hover:brightness-110 dark:border-[rgba(255,255,255,0.1)]'
+          className='-ml-2.5 relative flex h-full items-center border border-[rgba(0,0,0,0.15)] bg-[var(--brand-accent)] pr-3 pl-5 text-[var(--text-inverse)] text-small transition-[background-color,border-color,fill,stroke] hover-hover:brightness-110 dark:border-[rgba(255,255,255,0.1)]'
           style={{
             clipPath: 'polygon(10px 0, 100% 0, 100% 100%, 0 100%)',
             borderRadius: '0 4px 4px 0',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/error/index.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/error/index.tsx
@@ -35,7 +35,7 @@ export function ErrorUI({
       <div className='flex h-full flex-1 items-center justify-center'>
         <div className='flex flex-col items-center gap-4 text-center'>
           <div className='flex flex-col gap-2'>
-            <h2 className='font-semibold text-[var(--text-primary)] text-md'>{title}</h2>
+            <h2 className='text-[var(--text-primary)] text-md'>{title}</h2>
             <p className='max-w-[300px] text-[var(--text-tertiary)] text-small'>{message}</p>
           </div>
           <Button variant='default' size='sm' onClick={onReset ?? (() => window.location.reload())}>
@@ -54,10 +54,8 @@ export function ErrorUI({
       <div className='relative flex flex-1'>
         <div className='pointer-events-none absolute inset-0 flex items-center justify-center'>
           <div className='pointer-events-none flex flex-col items-center gap-4'>
-            <h3 className='font-semibold text-[var(--text-primary)] text-md'>{title}</h3>
-            <p className='max-w-sm text-center font-medium text-[var(--text-tertiary)] text-sm'>
-              {message}
-            </p>
+            <h3 className='text-[var(--text-primary)] text-md'>{title}</h3>
+            <p className='max-w-sm text-center text-[var(--text-tertiary)] text-sm'>{message}</p>
           </div>
         </div>
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/api/api.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/api/api.tsx
@@ -456,9 +456,7 @@ console.log(limits);`
     <div className='space-y-4'>
       <div>
         <div className='mb-[6.5px] flex items-center justify-between'>
-          <Label className='block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
-            Language
-          </Label>
+          <Label className='block pl-0.5 text-[var(--text-primary)] text-small'>Language</Label>
         </div>
         <ButtonGroup value={language} onValueChange={(val) => setLanguage(val as CodeLanguage)}>
           {(Object.keys(LANGUAGE_LABELS) as CodeLanguage[]).map((lang) => (
@@ -471,9 +469,7 @@ console.log(limits);`
 
       <div>
         <div className='mb-[6.5px] flex items-center justify-between'>
-          <Label className='block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
-            Run workflow
-          </Label>
+          <Label className='block pl-0.5 text-[var(--text-primary)] text-small'>Run workflow</Label>
           <Tooltip.Root>
             <Tooltip.Trigger asChild>
               <Button
@@ -500,7 +496,7 @@ console.log(limits);`
 
       <div>
         <div className='mb-[6.5px] flex items-center justify-between'>
-          <Label className='block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+          <Label className='block pl-0.5 text-[var(--text-primary)] text-small'>
             Run workflow (stream response)
           </Label>
           <div className='flex items-center gap-1.5'>
@@ -539,7 +535,7 @@ console.log(limits);`
 
       <div>
         <div className='mb-[6.5px] flex items-center justify-between'>
-          <Label className='block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+          <Label className='block pl-0.5 text-[var(--text-primary)] text-small'>
             Run workflow (async)
           </Label>
           <div className='flex items-center gap-1.5'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/chat/chat.tsx
@@ -359,7 +359,7 @@ export function ChatDeploy({
           <div>
             <Label
               htmlFor='title'
-              className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'
+              className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'
             >
               Title
             </Label>
@@ -377,7 +377,7 @@ export function ChatDeploy({
           </div>
 
           <div>
-            <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+            <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
               Output
             </Label>
             <OutputSelect
@@ -398,7 +398,7 @@ export function ChatDeploy({
 
           <div className='flex items-center justify-between gap-3'>
             <div className='min-w-0'>
-              <Label className='block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+              <Label className='block pl-0.5 text-[var(--text-primary)] text-small'>
                 Include thinking
               </Label>
             </div>
@@ -412,7 +412,7 @@ export function ChatDeploy({
 
           <div className='flex items-center justify-between gap-3'>
             <div className='min-w-0'>
-              <Label className='block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+              <Label className='block pl-0.5 text-[var(--text-primary)] text-small'>
                 Include tool calls
               </Label>
             </div>
@@ -442,7 +442,7 @@ export function ChatDeploy({
           <div>
             <Label
               htmlFor='welcomeMessage'
-              className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'
+              className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'
             >
               Welcome message
             </Label>
@@ -585,7 +585,7 @@ function IdentifierInput({
     <div>
       <Label
         htmlFor='chat-url'
-        className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'
+        className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'
       >
         URL
       </Label>
@@ -595,7 +595,7 @@ function IdentifierInput({
           error && 'border-[var(--text-error)]'
         )}
       >
-        <div className='flex items-center whitespace-nowrap bg-[var(--surface-5)] pr-1.5 pl-2 font-medium text-[var(--text-secondary)] text-sm'>
+        <div className='flex items-center whitespace-nowrap bg-[var(--surface-5)] pr-1.5 pl-2 text-[var(--text-secondary)] text-sm'>
           {getDomainPrefix()}
         </div>
         <div className='relative flex-1'>
@@ -726,7 +726,7 @@ function AuthSelector({
   return (
     <div className='space-y-4'>
       <div>
-        <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+        <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
           Access control
         </Label>
         <ButtonGroup
@@ -744,7 +744,7 @@ function AuthSelector({
 
       {authType === 'password' && (
         <div>
-          <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+          <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
             Password
           </Label>
           <GeneratedPasswordInput
@@ -772,7 +772,7 @@ function AuthSelector({
 
       {(authType === 'email' || authType === 'sso') && (
         <div>
-          <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+          <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
             {authType === 'email' ? 'Allowed emails' : 'Allowed SSO emails'}
           </Label>
           <ChipEmailsInput

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/api-info-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/api-info-modal.tsx
@@ -243,7 +243,7 @@ export function ApiInfoModal({ open, onOpenChange, workflowId }: ApiInfoModalPro
                   >
                     <div className='flex items-center justify-between bg-[var(--surface-4)] px-2.5 py-[5px]'>
                       <div className='flex min-w-0 flex-1 items-center gap-2'>
-                        <span className='block truncate font-medium text-[var(--text-tertiary)] text-sm'>
+                        <span className='block truncate text-[var(--text-tertiary)] text-sm'>
                           {field.name}
                         </span>
                         <Badge variant='type' size='sm'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/version-description-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/version-description-modal.tsx
@@ -133,7 +133,7 @@ export function VersionDescriptionModal({
             title={
               <span>
                 {currentDescription ? 'Edit the' : 'Add a'} description for{' '}
-                <span className='font-medium text-[var(--text-primary)]'>{versionName}</span>
+                <span className='text-[var(--text-primary)]'>{versionName}</span>
               </span>
             }
             error={

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/versions.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/versions.tsx
@@ -19,8 +19,8 @@ import { formatVersionLabel } from '@/app/workspace/[workspaceId]/w/[workflowId]
 import { useUpdateDeploymentVersion } from '@/hooks/queries/deployments'
 import { VersionDescriptionModal } from './version-description-modal'
 
-const HEADER_TEXT_CLASS = 'font-medium text-[var(--text-tertiary)] text-caption'
-const ROW_TEXT_CLASS = 'font-medium text-[var(--text-primary)] text-caption'
+const HEADER_TEXT_CLASS = 'text-[var(--text-tertiary)] text-caption'
+const ROW_TEXT_CLASS = 'text-[var(--text-primary)] text-caption'
 const COLUMN_BASE_CLASS = 'flex-shrink-0'
 
 const COLUMN_WIDTHS = {
@@ -282,7 +282,7 @@ export function Versions({
                       onClick={(e) => e.stopPropagation()}
                       onBlur={() => handleSaveRename(v.version)}
                       className={cn(
-                        'h-auto w-full border-0 bg-transparent p-0 font-medium text-[var(--text-primary)] text-caption leading-5 shadow-none outline-none focus:outline-none focus-visible:ring-0'
+                        'h-auto w-full border-0 bg-transparent p-0 text-[var(--text-primary)] text-caption leading-5 shadow-none outline-none focus:outline-none focus-visible:ring-0'
                       )}
                       maxLength={100}
                       disabled={renameMutation.isPending}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/general.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/general.tsx
@@ -197,7 +197,7 @@ export function GeneralDeploy({
       <div className='space-y-3'>
         <div>
           <div className='relative mb-[6.5px]'>
-            <Label className='block truncate pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+            <Label className='block truncate pl-0.5 text-[var(--text-primary)] text-small'>
               {previewMode === 'selected' && selectedVersionInfo
                 ? formatVersionLabel(selectedVersionInfo.version, selectedVersionInfo.name)
                 : 'Live Workflow'}
@@ -261,7 +261,7 @@ export function GeneralDeploy({
         </div>
 
         <div>
-          <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+          <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
             Versions
           </Label>
           <Versions

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/mcp/mcp.tsx
@@ -541,7 +541,7 @@ export function McpDeploy({
       ))}
 
       <div>
-        <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+        <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
           Tool name
         </Label>
         <ChipInput
@@ -562,7 +562,7 @@ export function McpDeploy({
       </div>
 
       <div>
-        <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+        <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
           Description
         </Label>
         <Textarea
@@ -579,7 +579,7 @@ export function McpDeploy({
 
       {inputFormat.length > 0 && (
         <div>
-          <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+          <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
             Parameters ({inputFormat.length})
           </Label>
           <p className='mb-[6.5px] pl-0.5 text-[var(--text-secondary)] text-xs'>
@@ -593,7 +593,7 @@ export function McpDeploy({
               >
                 <div className='flex items-center justify-between bg-[var(--surface-4)] px-2.5 py-[5px]'>
                   <div className='flex min-w-0 flex-1 items-center gap-2'>
-                    <span className='block truncate font-medium text-[var(--text-tertiary)] text-sm'>
+                    <span className='block truncate text-[var(--text-tertiary)] text-sm'>
                       {field.name}
                     </span>
                     <Badge variant='type' size='sm'>
@@ -627,7 +627,7 @@ export function McpDeploy({
       )}
 
       <div>
-        <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+        <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
           Servers
         </Label>
         <ChipCombobox

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/grouped-checkbox-list/grouped-checkbox-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/grouped-checkbox-list/grouped-checkbox-list.tsx
@@ -175,7 +175,7 @@ export function GroupedCheckboxList({
             <div className='flex flex-col gap-6'>
               {Object.entries(groupedOptions).map(([groupName, groupOptions]) => (
                 <div key={groupName}>
-                  <h3 className='mb-3 font-semibold text-muted-foreground text-xs uppercase tracking-wider'>
+                  <h3 className='mb-3 text-muted-foreground text-xs uppercase tracking-wider'>
                     {groupName}
                   </h3>
                   <div className='flex flex-col gap-3'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/search-replace/workflow-search-replace.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/search-replace/workflow-search-replace.tsx
@@ -565,7 +565,7 @@ export function WorkflowSearchReplace() {
         onMouseDown={handleMouseDown}
       >
         <div className='flex min-w-0 items-center'>
-          <span className='truncate font-medium text-[13px] text-[var(--text-primary)]'>
+          <span className='truncate text-[13px] text-[var(--text-primary)]'>
             Search and replace
           </span>
         </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/output-panel/output-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/output-panel/output-panel.tsx
@@ -504,7 +504,7 @@ export const OutputPanel = React.memo(function OutputPanel({
             />
             <span
               className={clsx(
-                'w-[58px] font-medium text-xs',
+                'w-[58px] text-xs',
                 matchCount > 0 ? 'text-[var(--text-secondary)]' : 'text-[var(--text-tertiary)]'
               )}
             >

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/variables/variables.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/variables/variables.tsx
@@ -118,7 +118,7 @@ function VariableHeader({
       aria-controls={`variable-content-${variable.id}`}
     >
       <div className='flex min-w-0 flex-1 items-center gap-2'>
-        <span className='block truncate font-medium text-[var(--text-tertiary)] text-sm'>
+        <span className='block truncate text-[var(--text-tertiary)] text-sm'>
           {variable.name || `Variable ${index + 1}`}
         </span>
         {variable.name && (
@@ -170,7 +170,7 @@ function VariableValueInput({ variable, onUpdate, readOnly }: VariableValueInput
           {Array.from({ length: lineCount }, (_, i) => (
             <div
               key={i}
-              className='font-medium font-mono text-[var(--text-muted)] text-xs'
+              className='font-mono text-[var(--text-muted)] text-xs'
               style={{ height: `${LINE_HEIGHT}px`, lineHeight: `${LINE_HEIGHT}px` }}
             >
               {i + 1}
@@ -453,9 +453,7 @@ export function Variables({ readOnly = false }: VariablesProps) {
         onMouseDown={handleMouseDown}
       >
         <div className='flex items-center'>
-          <span className='flex-shrink-0 font-medium text-[var(--text-primary)] text-sm'>
-            Variables
-          </span>
+          <span className='flex-shrink-0 text-[var(--text-primary)] text-sm'>Variables</span>
         </div>
         <div className='flex items-center gap-2'>
           <Button

--- a/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-editor/preview-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-editor/preview-editor.tsx
@@ -210,7 +210,7 @@ function CollapsibleSection({
       >
         <span
           className={cn(
-            'font-medium text-caption transition-colors',
+            'text-caption transition-colors',
             isError
               ? 'text-[var(--text-error)]'
               : 'text-[var(--text-tertiary)] group-hover:text-[var(--text-primary)]'
@@ -350,7 +350,7 @@ function ConnectionsSection({
         <ChevronUp
           className={cn('size-[14px] transition-transform', !isAtMinHeight && 'rotate-180')}
         />
-        <div className='font-medium text-[var(--text-primary)] text-small'>Connections</div>
+        <div className='text-[var(--text-primary)] text-small'>Connections</div>
       </div>
 
       {/* Content - styled like ConnectionBlocks */}
@@ -396,7 +396,7 @@ function ConnectionsSection({
                 </div>
                 <span
                   className={cn(
-                    'truncate font-medium',
+                    'truncate',
                     'text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]'
                   )}
                 >
@@ -425,7 +425,7 @@ function ConnectionsSection({
                     >
                       <span
                         className={cn(
-                          'flex-shrink-0 font-medium',
+                          'flex-shrink-0',
                           'text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]'
                         )}
                       >
@@ -456,11 +456,11 @@ function ConnectionsSection({
               }
             >
               <div className='relative flex size-[14px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm bg-[#8B5CF6]'>
-                <span className='font-bold text-[9px] text-white'>V</span>
+                <span className='text-[9px] text-white'>V</span>
               </div>
               <span
                 className={cn(
-                  'truncate font-medium',
+                  'truncate',
                   'text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]'
                 )}
               >
@@ -483,7 +483,7 @@ function ConnectionsSection({
                     className='group flex min-h-[26px] flex-wrap items-baseline gap-x-2 gap-y-0.5 rounded-lg px-1.5 py-1 text-sm hover-hover:bg-[var(--surface-6)] dark:hover-hover:bg-[var(--surface-5)]'
                     onContextMenu={(e) => handleValueContextMenu(e, v.value)}
                   >
-                    <span className='flex-shrink-0 font-medium text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]'>
+                    <span className='flex-shrink-0 text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]'>
                       {v.name}
                     </span>
                     <span className='min-w-0 break-all text-[var(--text-tertiary)]'>{v.value}</span>
@@ -508,11 +508,11 @@ function ConnectionsSection({
               }
             >
               <div className='relative flex size-[14px] flex-shrink-0 items-center justify-center overflow-hidden rounded-sm bg-[#6B7280]'>
-                <span className='font-bold text-[9px] text-white'>E</span>
+                <span className='text-[9px] text-white'>E</span>
               </div>
               <span
                 className={cn(
-                  'truncate font-medium',
+                  'truncate',
                   'text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]'
                 )}
               >
@@ -534,7 +534,7 @@ function ConnectionsSection({
                     key={v.ref}
                     className='group flex min-h-[26px] flex-wrap items-baseline gap-x-2 gap-y-0.5 rounded-lg px-1.5 py-1 text-sm hover-hover:bg-[var(--surface-6)] dark:hover-hover:bg-[var(--surface-5)]'
                   >
-                    <span className='flex-shrink-0 font-medium text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]'>
+                    <span className='flex-shrink-0 text-[var(--text-secondary)] group-hover:text-[var(--text-primary)]'>
                       {v.name}
                     </span>
                     <span className='min-w-0 break-all text-[var(--text-tertiary)]'>{v.value}</span>
@@ -646,7 +646,7 @@ function SubflowConfigDisplay({ block, loop, parallel }: SubflowConfigDisplayPro
     <div className='flex-1 overflow-y-auto overflow-x-hidden pt-2 pb-2'>
       {/* Type Selection - matches SubflowEditor */}
       <div>
-        <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+        <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
           {isLoop ? 'Loop Type' : 'Parallel Type'}
         </Label>
         <Combobox
@@ -663,7 +663,7 @@ function SubflowConfigDisplay({ block, loop, parallel }: SubflowConfigDisplayPro
 
       {/* Configuration - matches SubflowEditor */}
       <div>
-        <Label className='mb-[6.5px] block pl-0.5 font-medium text-[var(--text-primary)] text-small'>
+        <Label className='mb-[6.5px] block pl-0.5 text-[var(--text-primary)] text-small'>
           {getConfigLabel()}
         </Label>
 
@@ -1113,7 +1113,7 @@ function PreviewEditorContent({
           >
             <SubflowIcon className={cn('size-[12px]', getTileIconColorClass(subflowBgColor))} />
           </div>
-          <span className='min-w-0 flex-1 truncate font-medium text-[var(--text-primary)] text-sm'>
+          <span className='min-w-0 flex-1 truncate text-[var(--text-primary)] text-sm'>
             {subflowName}
           </span>
           {onClose && (
@@ -1141,7 +1141,7 @@ function PreviewEditorContent({
       <div className='flex h-full w-full flex-col overflow-hidden border-[var(--border)] border-l bg-[var(--surface-1)]'>
         <div className='mx-[-1px] flex items-center gap-2 rounded-b-[4px] border-[var(--border)] border-x border-b bg-[var(--surface-4)] px-3 py-1.5'>
           <div className='flex size-[18px] items-center justify-center rounded-sm bg-[var(--surface-3)]' />
-          <span className='font-medium text-[var(--text-primary)] text-sm'>
+          <span className='text-[var(--text-primary)] text-sm'>
             {block.name || 'Unknown Block'}
           </span>
         </div>
@@ -1210,7 +1210,7 @@ function PreviewEditorContent({
             />
           </div>
         )}
-        <span className='min-w-0 flex-1 truncate font-medium text-[var(--text-primary)] text-sm'>
+        <span className='min-w-0 flex-1 truncate text-[var(--text-primary)] text-sm'>
           {block.name || blockConfig.name}
         </span>
         {onClose && (
@@ -1245,7 +1245,7 @@ function PreviewEditorContent({
                   </Badge>
                 )}
                 {executionData.durationMs !== undefined && (
-                  <span className='font-medium text-[var(--text-tertiary)] text-caption'>
+                  <span className='text-[var(--text-tertiary)] text-caption'>
                     {formatDuration(executionData.durationMs, { precision: 2 })}
                   </span>
                 )}
@@ -1400,7 +1400,7 @@ function PreviewEditorContent({
             {isWorkflowBlock && childWorkflowId && (
               <div className='px-2 pt-3'>
                 <div className='subblock-content flex flex-col gap-[9.5px]'>
-                  <div className='pl-0.5 font-medium text-[var(--text-primary)] text-small leading-none'>
+                  <div className='pl-0.5 text-[var(--text-primary)] text-small leading-none'>
                     Workflow Preview
                   </div>
                   <div className='relative h-[160px] overflow-hidden rounded-sm border border-[var(--border)]'>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-workflow/components/block/block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-workflow/components/block/block.tsx
@@ -386,7 +386,7 @@ function WorkflowPreviewBlockInner({ data }: NodeProps<WorkflowPreviewBlockData>
             </div>
           )}
           <span
-            className={`truncate font-medium text-md ${!enabled ? 'text-[var(--text-muted)]' : ''}`}
+            className={`truncate text-md ${!enabled ? 'text-[var(--text-muted)]' : ''}`}
             title={name}
           >
             {name}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-workflow/components/subflow/subflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-workflow/components/subflow/subflow.tsx
@@ -106,7 +106,7 @@ function WorkflowPreviewSubflowInner({ data }: NodeProps<WorkflowPreviewSubflowD
             />
           </div>
           <span
-            className={cn('truncate font-medium text-md', !enabled && 'text-[var(--text-muted)]')}
+            className={cn('truncate text-md', !enabled && 'text-[var(--text-muted)]')}
             title={blockName}
           >
             {blockName}
@@ -122,7 +122,7 @@ function WorkflowPreviewSubflowInner({ data }: NodeProps<WorkflowPreviewSubflowD
       >
         {/* Subflow Start - connects to first block in subflow */}
         <div className='absolute top-4 left-[16px] flex items-center justify-center rounded-lg border border-[var(--border-1)] bg-[var(--surface-2)] px-3 py-1.5'>
-          <span className='font-medium text-[var(--text-primary)] text-sm'>Start</span>
+          <span className='text-[var(--text-primary)] text-sm'>Start</span>
           <Handle
             type='source'
             position={Position.Right}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-workflow/preview-workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-workflow/preview-workflow.tsx
@@ -560,7 +560,7 @@ export function PreviewWorkflow({
         className='flex items-center justify-center rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900'
       >
         <div className='text-center text-gray-500 dark:text-gray-400'>
-          <div className='mb-2 font-medium text-lg'>⚠️ Logged State Not Found</div>
+          <div className='mb-2 text-lg'>⚠️ Logged State Not Found</div>
           <div className='text-sm'>
             This log was migrated from the old system and doesn't contain workflow state data.
           </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/preview/preview.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/preview/preview.tsx
@@ -301,14 +301,14 @@ export function Preview({
                 className='flex h-[28px] items-center gap-[5px] rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2.5 text-[var(--text-secondary)] shadow-sm hover-hover:bg-[var(--surface-4)] hover-hover:text-[var(--text-primary)]'
               >
                 <ArrowLeft className='size-[12px]' />
-                <span className='font-medium text-caption'>Back</span>
+                <span className='text-caption'>Back</span>
               </Button>
             </Tooltip.Trigger>
             <Tooltip.Content side='bottom'>Go back to parent workflow</Tooltip.Content>
           </Tooltip.Root>
           {currentWorkflowName && (
             <div className='flex h-[28px] max-w-[200px] items-center rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2.5 shadow-sm'>
-              <span className='truncate font-medium text-[var(--text-secondary)] text-caption'>
+              <span className='truncate text-[var(--text-secondary)] text-caption'>
                 {currentWorkflowName}
               </span>
             </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-sidebar/settings-sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/settings-sidebar/settings-sidebar.tsx
@@ -352,7 +352,7 @@ export function SettingsSidebar({
                           {item.label}
                         </span>
                         {isLocked && (
-                          <span className='sidebar-collapse-hide ml-auto shrink-0 rounded-[3px] bg-[var(--surface-5)] px-1 py-[1px] font-medium text-[9px] text-[var(--text-icon)] uppercase tracking-wide'>
+                          <span className='sidebar-collapse-hide ml-auto shrink-0 rounded-[3px] bg-[var(--surface-5)] px-1 py-[1px] text-[9px] text-[var(--text-icon)] uppercase tracking-wide'>
                             Max
                           </span>
                         )}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-footer/sidebar-footer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-footer/sidebar-footer.tsx
@@ -138,7 +138,7 @@ export function SidebarFooter({
     />
   ) : (
     <div
-      className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-full font-medium text-[9px] text-white leading-none'
+      className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-full text-[9px] text-white leading-none'
       style={{ backgroundColor: getUserColor(profile.id) }}
     >
       {name.charAt(0).toUpperCase()}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/delete-modal/delete-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/delete-modal/delete-modal.tsx
@@ -221,7 +221,7 @@ export function DeleteModal({
           title={
             <span>
               Type&nbsp;
-              <span className='font-medium text-[var(--text-primary)]'>{workspaceName}</span>
+              <span className='text-[var(--text-primary)]'>{workspaceName}</span>
               &nbsp;to confirm
             </span>
           }

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -502,7 +502,7 @@ export const FolderItem = memo(function FolderItem({ workspaceId, folder }: Fold
       >
         <ChevronRight
           className={clsx(
-            'size-[16px] flex-shrink-0 text-[var(--text-icon)] transition-transform duration-100',
+            'size-[14px] flex-shrink-0 text-[var(--text-icon)] transition-transform duration-150',
             isExpanded && 'rotate-90'
           )}
           aria-hidden='true'

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
@@ -425,7 +425,7 @@ function WorkspaceHeaderImpl({
                   />
                 ) : (
                   <div
-                    className='flex size-[16px] items-center justify-center rounded-sm font-medium text-[9px] text-white leading-none group-hover:invisible'
+                    className='flex size-[16px] items-center justify-center rounded-sm text-[9px] text-white leading-none group-hover:invisible'
                     style={{
                       backgroundColor: activeWorkspaceFull.color ?? 'var(--brand-accent)',
                     }}
@@ -486,7 +486,7 @@ function WorkspaceHeaderImpl({
                   />
                 ) : (
                   <div
-                    className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-sm font-medium text-[9px] text-white leading-none'
+                    className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-sm text-[9px] text-white leading-none'
                     style={{
                       backgroundColor: activeWorkspaceFull.color ?? 'var(--brand-accent)',
                     }}
@@ -517,7 +517,7 @@ function WorkspaceHeaderImpl({
             onCloseAutoFocus={(e) => e.preventDefault()}
           >
             {isWorkspacesLoading ? (
-              <div className='px-2 py-[5px] font-medium text-[var(--text-secondary)] text-caption'>
+              <div className='px-2 py-[5px] text-[var(--text-secondary)] text-caption'>
                 Loading workspaces...
               </div>
             ) : (
@@ -608,7 +608,7 @@ function WorkspaceHeaderImpl({
                               />
                             ) : (
                               <div
-                                className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-sm font-medium text-[9px] text-white leading-none'
+                                className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-sm text-[9px] text-white leading-none'
                                 style={{
                                   backgroundColor: workspace.color ?? 'var(--brand-accent)',
                                 }}
@@ -700,7 +700,7 @@ function WorkspaceHeaderImpl({
                               />
                             ) : (
                               <div
-                                className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-sm font-medium text-[9px] text-white leading-none'
+                                className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-sm text-[9px] text-white leading-none'
                                 style={{
                                   backgroundColor: workspace.color ?? 'var(--brand-accent)',
                                 }}
@@ -809,7 +809,7 @@ function WorkspaceHeaderImpl({
               />
             ) : (
               <div
-                className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-sm font-medium text-[9px] text-white leading-none'
+                className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-sm text-[9px] text-white leading-none'
                 style={{ backgroundColor: activeWorkspaceFull.color ?? 'var(--brand-accent)' }}
               >
                 {workspaceInitial}

--- a/apps/sim/app/workspace/[workspaceId]/w/page.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/page.tsx
@@ -73,7 +73,7 @@ export default function WorkflowsPage() {
             // otherwise spin forever with nothing but a log line.
             <div className='flex flex-col items-center gap-3 text-center text-[var(--text-secondary)]'>
               <div>
-                <p className='font-medium text-small'>Couldn't load workflows</p>
+                <p className='text-small'>Couldn't load workflows</p>
                 <p className='mt-1 text-caption'>Check your connection and try again.</p>
               </div>
               <Chip variant='primary' onClick={() => router.refresh()}>
@@ -83,7 +83,7 @@ export default function WorkflowsPage() {
           ) : isEmpty ? (
             <div className='flex flex-col items-center gap-3 text-center text-[var(--text-secondary)]'>
               <div>
-                <p className='font-medium text-small'>No workflows yet</p>
+                <p className='text-small'>No workflows yet</p>
                 <p className='mt-1 text-caption'>
                   {canCreate
                     ? 'Create one to start building.'

--- a/apps/sim/app/workspace/page.tsx
+++ b/apps/sim/app/workspace/page.tsx
@@ -57,7 +57,7 @@ function WorkspaceStatusCard({
           <CircleAlert className='size-[18px] text-[var(--text-icon)]' aria-hidden />
         </div>
         <div className='space-y-1'>
-          <h1 className='font-medium text-[var(--text-primary)] text-lg'>{title}</h1>
+          <h1 className='text-[var(--text-primary)] text-lg'>{title}</h1>
           <p className='text-[var(--text-muted)] text-sm'>{description}</p>
         </div>
         <div className='flex items-center gap-2'>

--- a/apps/sim/components/settings/settings-header.tsx
+++ b/apps/sim/components/settings/settings-header.tsx
@@ -282,7 +282,7 @@ export function SettingsHeaderShell({ children }: { children: ReactNode }) {
         <div className='mx-auto flex w-full max-w-[48rem] flex-col gap-7 pb-6'>
           {(title || description) && (
             <div className='flex flex-col gap-1'>
-              {title && <h1 className='font-medium text-[var(--text-body)] text-lg'>{title}</h1>}
+              {title && <h1 className='text-[var(--text-body)] text-lg'>{title}</h1>}
               {description && <p className='text-[var(--text-muted)] text-md'>{description}</p>}
             </div>
           )}

--- a/apps/sim/components/settings/settings-unavailable.tsx
+++ b/apps/sim/components/settings/settings-unavailable.tsx
@@ -19,7 +19,7 @@ export function SettingsUnavailable({
       )}
     >
       <div className='flex max-w-md flex-col items-center gap-3 text-center'>
-        <h1 className='font-medium text-[var(--text-body)] text-lg'>{title}</h1>
+        <h1 className='text-[var(--text-body)] text-lg'>{title}</h1>
         <p className='text-[var(--text-muted)] text-sm'>{description}</p>
         <ChipLink href='/workspace'>Back to workspaces</ChipLink>
       </div>

--- a/apps/sim/components/ui/button.tsx
+++ b/apps/sim/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cn } from '@sim/emcn'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/apps/sim/components/ui/select.tsx
+++ b/apps/sim/components/ui/select.tsx
@@ -104,7 +104,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn('py-1.5 pr-2 pl-8 font-semibold text-sm', className)}
+    className={cn('py-1.5 pr-2 pl-8 text-sm', className)}
     {...props}
   />
 ))

--- a/apps/sim/ee/access-control/components/group-detail.tsx
+++ b/apps/sim/ee/access-control/components/group-detail.tsx
@@ -668,7 +668,7 @@ function ProviderRow({
             isProviderAllowed ? 'cursor-pointer' : 'cursor-default opacity-60'
           )}
         >
-          <span className='truncate font-medium text-sm'>{providerName}</span>
+          <span className='truncate text-sm'>{providerName}</span>
           {isProviderAllowed && deniedCount > 0 && (
             <ChipTag variant='gray' className='flex-shrink-0'>
               {deniedCount} blocked
@@ -755,7 +755,7 @@ function BlockToolRow({
             !isBlockAllowed && 'opacity-60'
           )}
         >
-          <span className='truncate font-medium text-sm'>{block.name}</span>
+          <span className='truncate text-sm'>{block.name}</span>
           {isBlockAllowed && deniedCount > 0 && (
             <ChipTag variant='gray' className='flex-shrink-0'>
               {deniedCount} blocked
@@ -1786,7 +1786,7 @@ export function GroupDetail({
                           >
                             {BlockIcon && <BlockIcon className='!size-[9px] text-white' />}
                           </div>
-                          <span className='truncate font-medium text-sm'>{block.name}</span>
+                          <span className='truncate text-sm'>{block.name}</span>
                         </label>
                         {block.description && (
                           <Info side='top' className='flex-shrink-0'>

--- a/apps/sim/ee/custom-blocks/components/custom-block-detail.tsx
+++ b/apps/sim/ee/custom-blocks/components/custom-block-detail.tsx
@@ -618,7 +618,7 @@ export function CustomBlockDetail({ blockId, workspaceId, onBack }: CustomBlockD
                         }}
                       >
                         <div className='flex min-w-0 flex-1 items-center gap-2'>
-                          <span className='block truncate font-medium text-[var(--text-tertiary)] text-sm'>
+                          <span className='block truncate text-[var(--text-tertiary)] text-sm'>
                             {i.name}
                           </span>
                           <Badge variant='type' size='sm'>
@@ -764,7 +764,7 @@ export function CustomBlockDetail({ blockId, workspaceId, onBack }: CustomBlockD
           title={
             <span>
               Type&nbsp;
-              <span className='font-medium text-[var(--text-primary)]'>{existing?.name}</span>
+              <span className='text-[var(--text-primary)]'>{existing?.name}</span>
               &nbsp;to confirm
             </span>
           }

--- a/apps/sim/ee/sso/components/sso-form.tsx
+++ b/apps/sim/ee/sso/components/sso-form.tsx
@@ -220,7 +220,7 @@ export default function SSOForm() {
           <span className='font-normal'>Don't have an account? </span>
           <Link
             href={`/signup${callbackUrl ? `?callbackUrl=${encodeURIComponent(callbackUrl)}` : ''}`}
-            className='font-medium text-[var(--text-primary)] underline-offset-4 transition hover:underline'
+            className='text-[var(--text-primary)] underline-offset-4 transition hover:underline'
           >
             Sign up
           </Link>

--- a/apps/sim/ee/workspace-forking/components/fork-sync/dependent-field-selector.tsx
+++ b/apps/sim/ee/workspace-forking/components/fork-sync/dependent-field-selector.tsx
@@ -48,7 +48,7 @@ export function DependentFieldSelector({
 
   if (isLoading && enabled) {
     return (
-      <div className='flex h-[30px] items-center gap-2 rounded-lg border border-[var(--border-1)] bg-[var(--surface-5)] px-2 font-medium text-[var(--text-muted)] text-small dark:bg-[var(--surface-4)]'>
+      <div className='flex h-[30px] items-center gap-2 rounded-lg border border-[var(--border-1)] bg-[var(--surface-5)] px-2 text-[var(--text-muted)] text-small dark:bg-[var(--surface-4)]'>
         <Loader className='size-3.5' animate />
         Loading…
       </div>

--- a/apps/sim/ee/workspace-forking/components/forks.tsx
+++ b/apps/sim/ee/workspace-forking/components/forks.tsx
@@ -205,8 +205,7 @@ function ForkSyncDetailView({
         {controller.archivedWorkflowNames.length > 0 ? (
           <div className='flex flex-col gap-1 px-2'>
             <p className='break-words text-[var(--text-primary)] text-sm'>
-              Will be archived in <span className='font-medium'>{targetWorkspaceName}</span>{' '}
-              (deleted in the source):
+              Will be archived in <span>{targetWorkspaceName}</span> (deleted in the source):
             </p>
             {controller.archivedWorkflowNames
               .slice(0, ARCHIVED_PREVIEW_LIMIT)
@@ -231,9 +230,9 @@ function ForkSyncDetailView({
           <div className='flex flex-col gap-1 px-2'>
             <p className='break-words text-[var(--text-primary)] text-sm'>
               {controller.triggerUrlChanges.length === 1 ? 'A webhook URL' : 'Webhook URLs'} in{' '}
-              <span className='font-medium'>{targetWorkspaceName}</span> will stop being served —
-              anything calling {controller.triggerUrlChanges.length === 1 ? 'it' : 'them'} breaks
-              until you re-register:
+              <span>{targetWorkspaceName}</span> will stop being served — anything calling{' '}
+              {controller.triggerUrlChanges.length === 1 ? 'it' : 'them'} breaks until you
+              re-register:
             </p>
             {controller.triggerUrlChanges.slice(0, ARCHIVED_PREVIEW_LIMIT).map((change) => (
               // Naming the URL, not just its workflow: several URLs in one workflow would render

--- a/packages/workflow-renderer/src/note/note-block-view.tsx
+++ b/packages/workflow-renderer/src/note/note-block-view.tsx
@@ -21,22 +21,22 @@ const NOTE_COMPONENTS = {
     </p>
   ),
   h1: ({ children }: { children?: ReactNode }) => (
-    <h1 className='mt-3 mb-3 break-words font-semibold text-[var(--text-primary)] text-lg first:mt-0'>
+    <h1 className='mt-3 mb-3 break-words text-[var(--text-primary)] text-lg first:mt-0'>
       {children}
     </h1>
   ),
   h2: ({ children }: { children?: ReactNode }) => (
-    <h2 className='mt-2.5 mb-2.5 break-words font-semibold text-[var(--text-primary)] text-base first:mt-0'>
+    <h2 className='mt-2.5 mb-2.5 break-words text-[var(--text-primary)] text-base first:mt-0'>
       {children}
     </h2>
   ),
   h3: ({ children }: { children?: ReactNode }) => (
-    <h3 className='mt-2 mb-2 break-words font-semibold text-[var(--text-primary)] text-sm first:mt-0'>
+    <h3 className='mt-2 mb-2 break-words text-[var(--text-primary)] text-sm first:mt-0'>
       {children}
     </h3>
   ),
   h4: ({ children }: { children?: ReactNode }) => (
-    <h4 className='mt-2 mb-2 break-words font-semibold text-[var(--text-primary)] text-xs first:mt-0'>
+    <h4 className='mt-2 mb-2 break-words text-[var(--text-primary)] text-xs first:mt-0'>
       {children}
     </h4>
   ),
@@ -155,7 +155,7 @@ const NOTE_COMPONENTS = {
     <tr className='border-[var(--border)] border-b last:border-b-0'>{children}</tr>
   ),
   th: ({ children }: { children?: ReactNode }) => (
-    <th className='px-2 py-1 text-left font-semibold text-[var(--text-primary)]'>{children}</th>
+    <th className='px-2 py-1 text-left text-[var(--text-primary)]'>{children}</th>
   ),
   td: ({ children }: { children?: ReactNode }) => (
     <td className='px-2 py-1 text-[var(--text-secondary)]'>{children}</td>
@@ -220,10 +220,7 @@ export function NoteBlockView({
           <div className='flex min-w-0 flex-1 items-center'>
             <OverflowSpan
               value={name ?? ''}
-              className={cn(
-                'truncate font-medium text-md',
-                !isEnabled && 'text-[var(--text-muted)]'
-              )}
+              className={cn('truncate text-md', !isEnabled && 'text-[var(--text-muted)]')}
             />
           </div>
         </div>

--- a/packages/workflow-renderer/src/subflow/subflow-node-view.tsx
+++ b/packages/workflow-renderer/src/subflow/subflow-node-view.tsx
@@ -174,10 +174,7 @@ export function SubflowNodeView({
             </div>
             <OverflowSpan
               value={blockName}
-              className={cn(
-                'truncate font-medium text-md',
-                !isEnabled && 'text-[var(--text-muted)]'
-              )}
+              className={cn('truncate text-md', !isEnabled && 'text-[var(--text-muted)]')}
             />
           </div>
           <div className='flex items-center gap-1'>
@@ -224,7 +221,7 @@ export function SubflowNodeView({
             data-node-role={`${data.kind}-start`}
             data-extent='parent'
           >
-            <span className='font-medium text-[var(--text-primary)] text-sm'>Start</span>
+            <span className='text-[var(--text-primary)] text-sm'>Start</span>
 
             <Handle
               type='source'

--- a/packages/workflow-renderer/src/workflow-block/workflow-block-view.tsx
+++ b/packages/workflow-renderer/src/workflow-block/workflow-block-view.tsx
@@ -227,7 +227,7 @@ export function WorkflowBlockView({
             <OverflowSpan
               value={name}
               className={cn(
-                'truncate font-medium text-md',
+                'truncate text-md',
                 !isEnabled && runPathStatus !== 'success' && 'text-[var(--text-muted)]'
               )}
             />


### PR DESCRIPTION
## Summary
- Fixes the widespread unintended bolding. #6241 deleted the `--font-weight-*` scale from `globals.css` and its `fontWeight` mapping from `tailwind.config.ts`, so `font-medium` jumped 440/480 → 500, `font-semibold` 500/550 → 600, and body dropped 420 → 400. Nothing was restyled — the utility's meaning changed under ~300 call sites at once. #6291 fixed `packages/emcn` only; every product call site was left behind
- Strips the weight class from body, label, row, and heading text across `app/workspace`, `ee`, `workflow-renderer`, the `unsubscribe`/`invite`/`f/[token]`/`oauth-error`/`_shell`/`playground`/`(interfaces)` route groups, and `components/ui/button.tsx` — whose `buttonVariants` injected `font-medium` into every consumer, the single widest source
- Keeps weight only where it steps up per `.claude/rules/sim-styling.md`: markdown/prose bold (`<strong>`, `prose-strong:`, `[&_strong]:`, markdown headings and `<th>`) and micro avatar initials / tile glyphs at `text-[7px]`/`[8px]`/`micro`
- Aligns the workflow-tree folder chevron to the sidebar section header — `size-[16px]`/`duration-100` → `size-[14px]`/`duration-150`. The files-tree chevron was already on spec, so both trees now agree
- Feedback modal: drops the "What did you like?" / "What could be improved?" line above the Feedback field on both variants, and re-homes Copy ID from an icon button to a footer `secondaryActions` chip. That also removes a hand-rolled field row from `ChipModalBody`, which CLAUDE.md prohibits — it sat at `px-2` instead of the field's effective `px-4`, misaligned with the header and footer gutters

## Type of Change
- [x] Bug fix

## Testing
Tested manually.

Verification beyond that:
- `bunx turbo run type-check` — 23/23 pass; `biome check` clean across `apps` + `packages` (11 pre-existing warnings, all in untouched files)
- **No state affordance lost:** `git grep` for a weight class inside a conditional on the base commit returns zero — there was no `isActive && 'font-medium'` anywhere — so unconditional stripping cannot have erased a selected/hover distinction
- No test or snapshot asserts on a weight class
- Paired elements verified stripped in matched pairs (the invisible width-measuring span in settings `general.tsx`, the transparent-input + overlay in the MCP form modal), since those drift visibly if only one half changes

Not covered, deliberately: `app/(landing)/**`, `apps/docs`, `lib/content/mdx.tsx` and `faq.tsx` carry the same regression — separate design surface, separate PR.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)