### PR TITLE
feat(demo): fire the X conversion event when a demo is booked

### DIFF
--- a/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.tsx
+++ b/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import Cal, { getCalApi } from '@calcom/embed-react'
+import { isHosted } from '@/lib/core/config/env-flags'
 import type { DemoLead } from '@/app/(landing)/demo/components/demo-form'
 
 /** The Cal.com event the demo books - set `NEXT_PUBLIC_CAL_LINK` to override. */
@@ -14,12 +15,34 @@ const CAL_LINK = process.env.NEXT_PUBLIC_CAL_LINK ?? 'team/sim/demo'
  */
 const CAL_BRAND_COLOR = '#6f3dfa'
 
+/**
+ * X (Twitter) conversion event fired when a demo is actually booked, so ad
+ * delivery optimizes toward bookings rather than form submits.
+ */
+const X_DEMO_BOOKED_EVENT_ID = 'tw-q5xbl-q5xbn'
+
 interface DemoSchedulerProps {
   /** The captured lead used to prefill the Cal.com booking. */
   lead: DemoLead
 }
 
 let calEmbedPreloaded = false
+
+/**
+ * Fires the X conversion once the Cal.com booking is confirmed. There is no
+ * standalone confirmation page to drop the pixel snippet into — Cal renders the
+ * "you're booked" state inside its cross-origin iframe — so the embed's
+ * `bookingSuccessfulV2` event is the confirmation.
+ *
+ * Module-scope so the same function identity can be handed to both `on` and
+ * `off`. `window.twq` is only defined where {@link LandingLayout} renders the
+ * pixel base code, so the optional call is a second guard for the window
+ * between mount and `uwt.js` finishing — the stub `twq` queues calls made
+ * before the script loads and replays them.
+ */
+function trackDemoBooked(): void {
+  window.twq?.('event', X_DEMO_BOOKED_EVENT_ID, {})
+}
 
 /**
  * Warm the Cal.com embed before the scheduler mounts. Loads `embed.js` and
@@ -55,12 +78,27 @@ export function preloadCalEmbed(): void {
  */
 export function DemoScheduler({ lead }: DemoSchedulerProps) {
   useEffect(() => {
-    getCalApi({ namespace: CAL_NAMESPACE }).then((cal) => {
-      cal('ui', {
-        hideEventTypeDetails: true,
-        styles: { branding: { brandColor: CAL_BRAND_COLOR } },
+    let cancelled = false
+    const api = getCalApi({ namespace: CAL_NAMESPACE })
+    api
+      .then((cal) => {
+        if (cancelled) return
+        cal('ui', {
+          hideEventTypeDetails: true,
+          styles: { branding: { brandColor: CAL_BRAND_COLOR } },
+        })
+        // Matches the layout's pixel gating - a self-hosted deployment loads no
+        // base pixel, so it must not subscribe an ad-tracking callback either.
+        if (isHosted) cal('on', { action: 'bookingSuccessfulV2', callback: trackDemoBooked })
       })
-    })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+      if (!isHosted) return
+      api
+        .then((cal) => cal('off', { action: 'bookingSuccessfulV2', callback: trackDemoBooked }))
+        .catch(() => {})
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- Fire the X (Twitter) conversion event `tw-q5xbl-q5xbn` when a demo booking is actually confirmed, so ad delivery optimizes toward bookings rather than form submits
- There is no standalone demo confirmation page to drop the pixel snippet into — Cal.com renders the "you're booked" state inside its cross-origin iframe — so the event is wired to the embed's `bookingSuccessfulV2` callback, unsubscribed on unmount
- Gated on `isHosted`, matching how the landing layout gates the pixel base code: a self-hosted deployment loads no pixel and subscribes no ad-tracking callback
- No CSP/COOP/COEP changes needed — `static.ads-twitter.com` (script-src) and `analytics.twitter.com` (connect-src, hosted-only) are already allowed, `/demo` is already exempt from strict COOP and runs COEP `unsafe-none`, and this adds no new origin

## Type of Change
- [x] New feature

## Testing
Type-check and lint clean. Not verified end-to-end in a browser — proving the conversion fires requires completing a real booking on the team calendar, so this should be confirmed on staging via the X Events Manager after deploy.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)