### PR TITLE
improvement(ci): run the CodeQL cron weekly and cancel superseded scans

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,13 +41,12 @@ on:
     # Safety net behind the push trigger, and the thing that keeps the
     # default-branch alert view fresh when main is quiet. Only fires once this
     # file is on the default branch — schedule events ignore other branches.
-    - cron: '17 8 * * *'
+    - cron: '17 8 * * 1'
   workflow_dispatch:
 
-# Scheduled main scans must run to completion — only PR pushes supersede.
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- CodeQL cron goes daily -> weekly (Mondays). Main is already fully scanned on every merge (~2/day), so a nightly run re-scanned a tree that was scanned hours earlier at ~50 runner-minutes each. Every upstream repo that pairs a cron with push+PR triggers uses a weekly cron (TypeScript, codeql-action, immich, novu, nestjs, langflow), and GitHub's starter workflow ships `$cron-weekly`. Daily crons upstream belong to repos where the cron is the *only* trigger.
- `cancel-in-progress` is now unconditional instead of PR-only. Main pushes were serializing: run 31089722455 finished at 11:29:21 and the next run's jobs were created at exactly 11:29:21, so a merge sat queued ~31 min before its ~50 min scan even started. Only the newest analysis of a ref feeds the alert view, so superseded runs are safe to drop. Upstream repos that set concurrency at all use a plain `true`.

Kept the `push: [main]` trigger — it's what the PR scans diff against, and dropping it would degrade the PR analyses, not just staleten the dashboard. Left the PR-side `paths` filter alone.

## Type of Change
- [x] Improvement

## Testing
Verified the YAML parses and the triggers resolve as intended (`push: [main]`, `pull_request: [main, staging]` with the paths filter intact, single weekly cron, `cancel-in-progress: true`). Trigger behavior itself only exercises once this is on the default branch.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
