### PR TITLE
improvement(tools): make internal tool routing an explicit tool declaration

### DIFF
--- a/apps/sim/executor/handlers/agent/agent-handler.test.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.test.ts
@@ -91,17 +91,13 @@ vi.mock('@/providers', () => ({
 
 vi.mock('@/executor/utils/http', () => ({
   buildAuthHeaders: vi.fn().mockResolvedValue({ 'Content-Type': 'application/json' }),
-  buildInternalApiUrl: vi.fn((path: string, params?: Record<string, string>) => {
-    const url = new URL(path, 'http://localhost:3000')
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        if (value !== undefined && value !== null) {
-          url.searchParams.set(key, value)
-        }
-      }
-    }
-    return url
-  }),
+  internalApiUrl: vi.fn(
+    (segments: TemplateStringsArray, ...values: unknown[]) =>
+      new URL(
+        String.raw({ raw: segments }, ...values.map((v) => encodeURIComponent(String(v)))),
+        'http://localhost:3000'
+      )
+  ),
   extractAPIErrorMessage: vi.fn(async (response: Response) => {
     const defaultMessage = `API request failed with status ${response.status}`
     try {

--- a/apps/sim/executor/handlers/agent/agent-handler.test.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.test.ts
@@ -91,7 +91,7 @@ vi.mock('@/providers', () => ({
 
 vi.mock('@/executor/utils/http', () => ({
   buildAuthHeaders: vi.fn().mockResolvedValue({ 'Content-Type': 'application/json' }),
-  buildAPIUrl: vi.fn((path: string, params?: Record<string, string>) => {
+  buildInternalApiUrl: vi.fn((path: string, params?: Record<string, string>) => {
     const url = new URL(path, 'http://localhost:3000')
     if (params) {
       for (const [key, value] of Object.entries(params)) {

--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -59,7 +59,7 @@ import type {
 import { parseResponseFormat } from '@/executor/handlers/shared/response-format'
 import type { BlockHandler, ExecutionContext, StreamingExecution } from '@/executor/types'
 import { collectBlockData } from '@/executor/utils/block-data'
-import { buildAuthHeaders, buildInternalApiUrl } from '@/executor/utils/http'
+import { buildAuthHeaders, internalApiUrl } from '@/executor/utils/http'
 import { stringifyJSON } from '@/executor/utils/json'
 import { projectResolvedSecretDiagnosticContent } from '@/executor/utils/resolved-secret-content-projection'
 import { prepareResolvedSecretProjectedInputs } from '@/executor/utils/resolved-secret-input-projection'
@@ -1212,12 +1212,11 @@ export class AgentBlockHandler implements BlockHandler {
     }
 
     const headers = await buildAuthHeaders(ctx.userId)
-    const url = buildInternalApiUrl('/api/mcp/tools/discover', {
-      serverId,
-      workspaceId: ctx.workspaceId,
-      workflowId: ctx.workflowId,
-      ...(ctx.userId ? { userId: ctx.userId } : {}),
-    })
+    const url = internalApiUrl`/api/mcp/tools/discover`
+    url.searchParams.set('serverId', serverId)
+    url.searchParams.set('workspaceId', ctx.workspaceId)
+    url.searchParams.set('workflowId', ctx.workflowId)
+    if (ctx.userId) url.searchParams.set('userId', ctx.userId)
 
     const maxAttempts = 2
     for (let attempt = 0; attempt < maxAttempts; attempt++) {

--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -59,7 +59,7 @@ import type {
 import { parseResponseFormat } from '@/executor/handlers/shared/response-format'
 import type { BlockHandler, ExecutionContext, StreamingExecution } from '@/executor/types'
 import { collectBlockData } from '@/executor/utils/block-data'
-import { buildAPIUrl, buildAuthHeaders } from '@/executor/utils/http'
+import { buildAuthHeaders, buildInternalApiUrl } from '@/executor/utils/http'
 import { stringifyJSON } from '@/executor/utils/json'
 import { projectResolvedSecretDiagnosticContent } from '@/executor/utils/resolved-secret-content-projection'
 import { prepareResolvedSecretProjectedInputs } from '@/executor/utils/resolved-secret-input-projection'
@@ -1212,7 +1212,7 @@ export class AgentBlockHandler implements BlockHandler {
     }
 
     const headers = await buildAuthHeaders(ctx.userId)
-    const url = buildAPIUrl('/api/mcp/tools/discover', {
+    const url = buildInternalApiUrl('/api/mcp/tools/discover', {
       serverId,
       workspaceId: ctx.workspaceId,
       workflowId: ctx.workflowId,

--- a/apps/sim/executor/handlers/evaluator/evaluator-handler.ts
+++ b/apps/sim/executor/handlers/evaluator/evaluator-handler.ts
@@ -15,11 +15,7 @@ import type { BlockOutput } from '@/blocks/types'
 import { validateModelProvider } from '@/ee/access-control/utils/permission-check'
 import { BlockType, DEFAULTS, EVALUATOR } from '@/executor/constants'
 import type { BlockHandler, ExecutionContext } from '@/executor/types'
-import {
-  buildAuthHeaders,
-  buildInternalApiUrl,
-  extractAPIErrorMessage,
-} from '@/executor/utils/http'
+import { buildAuthHeaders, extractAPIErrorMessage, internalApiUrl } from '@/executor/utils/http'
 import { isJSONString, parseJSON, stringifyJSON } from '@/executor/utils/json'
 import { projectResolvedSecretDiagnosticError } from '@/executor/utils/resolved-secret-content-projection'
 import type {
@@ -190,7 +186,8 @@ export class EvaluatorBlockHandler implements BlockHandler {
     }
 
     try {
-      const url = buildInternalApiUrl('/api/providers', ctx.userId ? { userId: ctx.userId } : {})
+      const url = internalApiUrl`/api/providers`
+      if (ctx.userId) url.searchParams.set('userId', ctx.userId)
 
       const providerRequest: ProviderRequest = {
         model,

--- a/apps/sim/executor/handlers/evaluator/evaluator-handler.ts
+++ b/apps/sim/executor/handlers/evaluator/evaluator-handler.ts
@@ -15,7 +15,11 @@ import type { BlockOutput } from '@/blocks/types'
 import { validateModelProvider } from '@/ee/access-control/utils/permission-check'
 import { BlockType, DEFAULTS, EVALUATOR } from '@/executor/constants'
 import type { BlockHandler, ExecutionContext } from '@/executor/types'
-import { buildAPIUrl, buildAuthHeaders, extractAPIErrorMessage } from '@/executor/utils/http'
+import {
+  buildAuthHeaders,
+  buildInternalApiUrl,
+  extractAPIErrorMessage,
+} from '@/executor/utils/http'
 import { isJSONString, parseJSON, stringifyJSON } from '@/executor/utils/json'
 import { projectResolvedSecretDiagnosticError } from '@/executor/utils/resolved-secret-content-projection'
 import type {
@@ -186,7 +190,7 @@ export class EvaluatorBlockHandler implements BlockHandler {
     }
 
     try {
-      const url = buildAPIUrl('/api/providers', ctx.userId ? { userId: ctx.userId } : {})
+      const url = buildInternalApiUrl('/api/providers', ctx.userId ? { userId: ctx.userId } : {})
 
       const providerRequest: ProviderRequest = {
         model,

--- a/apps/sim/executor/handlers/mothership/mothership-handler.test.ts
+++ b/apps/sim/executor/handlers/mothership/mothership-handler.test.ts
@@ -32,7 +32,7 @@ const PRIVATE_PROVENANCE = {
 const {
   mockAreModelSafeWorkspaceFileKeys,
   mockBuildAuthHeaders,
-  mockBuildInternalApiUrl,
+  mockInternalApiUrl,
   mockExtractAPIErrorMessage,
   mockGenerateId,
   mockIsExecutionCancelled,
@@ -41,7 +41,7 @@ const {
 } = vi.hoisted(() => ({
   mockAreModelSafeWorkspaceFileKeys: vi.fn(),
   mockBuildAuthHeaders: vi.fn(),
-  mockBuildInternalApiUrl: vi.fn(),
+  mockInternalApiUrl: vi.fn(),
   mockExtractAPIErrorMessage: vi.fn(),
   mockGenerateId: vi.fn(),
   mockIsExecutionCancelled: vi.fn(),
@@ -57,7 +57,7 @@ vi.mock('@/lib/uploads/contexts/workspace/workspace-file-secret-provenance', () 
 
 vi.mock('@/executor/utils/http', () => ({
   buildAuthHeaders: mockBuildAuthHeaders,
-  buildInternalApiUrl: mockBuildInternalApiUrl,
+  internalApiUrl: mockInternalApiUrl,
   extractAPIErrorMessage: mockExtractAPIErrorMessage,
 }))
 
@@ -155,9 +155,7 @@ describe('MothershipBlockHandler', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     mockBuildAuthHeaders.mockResolvedValue({ Authorization: 'Bearer internal' })
-    mockBuildInternalApiUrl.mockReturnValue(
-      new URL('/api/mothership/execute', 'http://localhost:3000')
-    )
+    mockInternalApiUrl.mockReturnValue(new URL('/api/mothership/execute', 'http://localhost:3000'))
     mockExtractAPIErrorMessage.mockResolvedValue('boom')
     mockGenerateId.mockReset()
     mockIsExecutionCancelled.mockReset()

--- a/apps/sim/executor/handlers/mothership/mothership-handler.test.ts
+++ b/apps/sim/executor/handlers/mothership/mothership-handler.test.ts
@@ -32,7 +32,7 @@ const PRIVATE_PROVENANCE = {
 const {
   mockAreModelSafeWorkspaceFileKeys,
   mockBuildAuthHeaders,
-  mockBuildAPIUrl,
+  mockBuildInternalApiUrl,
   mockExtractAPIErrorMessage,
   mockGenerateId,
   mockIsExecutionCancelled,
@@ -41,7 +41,7 @@ const {
 } = vi.hoisted(() => ({
   mockAreModelSafeWorkspaceFileKeys: vi.fn(),
   mockBuildAuthHeaders: vi.fn(),
-  mockBuildAPIUrl: vi.fn(),
+  mockBuildInternalApiUrl: vi.fn(),
   mockExtractAPIErrorMessage: vi.fn(),
   mockGenerateId: vi.fn(),
   mockIsExecutionCancelled: vi.fn(),
@@ -57,7 +57,7 @@ vi.mock('@/lib/uploads/contexts/workspace/workspace-file-secret-provenance', () 
 
 vi.mock('@/executor/utils/http', () => ({
   buildAuthHeaders: mockBuildAuthHeaders,
-  buildAPIUrl: mockBuildAPIUrl,
+  buildInternalApiUrl: mockBuildInternalApiUrl,
   extractAPIErrorMessage: mockExtractAPIErrorMessage,
 }))
 
@@ -155,7 +155,9 @@ describe('MothershipBlockHandler', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     mockBuildAuthHeaders.mockResolvedValue({ Authorization: 'Bearer internal' })
-    mockBuildAPIUrl.mockReturnValue(new URL('/api/mothership/execute', 'http://localhost:3000'))
+    mockBuildInternalApiUrl.mockReturnValue(
+      new URL('/api/mothership/execute', 'http://localhost:3000')
+    )
     mockExtractAPIErrorMessage.mockResolvedValue('boom')
     mockGenerateId.mockReset()
     mockIsExecutionCancelled.mockReset()

--- a/apps/sim/executor/handlers/mothership/mothership-handler.ts
+++ b/apps/sim/executor/handlers/mothership/mothership-handler.ts
@@ -42,7 +42,11 @@ import type {
   NormalizedBlockOutput,
   StreamingExecution,
 } from '@/executor/types'
-import { buildAPIUrl, buildAuthHeaders, extractAPIErrorMessage } from '@/executor/utils/http'
+import {
+  buildAuthHeaders,
+  buildInternalApiUrl,
+  extractAPIErrorMessage,
+} from '@/executor/utils/http'
 import type {
   ResolvedSecretInputPath,
   ResolvedSecretTraceRegistry,
@@ -796,7 +800,7 @@ export class MothershipBlockHandler implements BlockHandler {
       requestId
     )
 
-    const url = buildAPIUrl('/api/mothership/execute')
+    const url = buildInternalApiUrl('/api/mothership/execute')
     const headers = await buildAuthHeaders(ctx.userId)
     headers.Accept = 'application/x-ndjson'
     headers[MOTHERSHIP_EXECUTE_STREAM_HEADER] = MOTHERSHIP_EXECUTE_STREAM_VALUE

--- a/apps/sim/executor/handlers/mothership/mothership-handler.ts
+++ b/apps/sim/executor/handlers/mothership/mothership-handler.ts
@@ -42,11 +42,7 @@ import type {
   NormalizedBlockOutput,
   StreamingExecution,
 } from '@/executor/types'
-import {
-  buildAuthHeaders,
-  buildInternalApiUrl,
-  extractAPIErrorMessage,
-} from '@/executor/utils/http'
+import { buildAuthHeaders, extractAPIErrorMessage, internalApiUrl } from '@/executor/utils/http'
 import type {
   ResolvedSecretInputPath,
   ResolvedSecretTraceRegistry,
@@ -800,7 +796,7 @@ export class MothershipBlockHandler implements BlockHandler {
       requestId
     )
 
-    const url = buildInternalApiUrl('/api/mothership/execute')
+    const url = internalApiUrl`/api/mothership/execute`
     const headers = await buildAuthHeaders(ctx.userId)
     headers.Accept = 'application/x-ndjson'
     headers[MOTHERSHIP_EXECUTE_STREAM_HEADER] = MOTHERSHIP_EXECUTE_STREAM_VALUE

--- a/apps/sim/executor/handlers/workflow/workflow-handler.test.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-handler.test.ts
@@ -183,7 +183,13 @@ vi.mock('@/lib/auth/internal', () => ({
 
 vi.mock('@/executor/utils/http', () => ({
   buildAuthHeaders: vi.fn().mockResolvedValue({ 'Content-Type': 'application/json' }),
-  buildInternalApiUrl: vi.fn((path: string) => new URL(path, 'http://localhost:3000')),
+  internalApiUrl: vi.fn(
+    (segments: TemplateStringsArray, ...values: unknown[]) =>
+      new URL(
+        String.raw({ raw: segments }, ...values.map((v) => encodeURIComponent(String(v)))),
+        'http://localhost:3000'
+      )
+  ),
   extractAPIErrorMessage: vi.fn(async (response: Response) => {
     const defaultMessage = `API request failed with status ${response.status}`
     try {

--- a/apps/sim/executor/handlers/workflow/workflow-handler.test.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-handler.test.ts
@@ -183,7 +183,7 @@ vi.mock('@/lib/auth/internal', () => ({
 
 vi.mock('@/executor/utils/http', () => ({
   buildAuthHeaders: vi.fn().mockResolvedValue({ 'Content-Type': 'application/json' }),
-  buildAPIUrl: vi.fn((path: string) => new URL(path, 'http://localhost:3000')),
+  buildInternalApiUrl: vi.fn((path: string) => new URL(path, 'http://localhost:3000')),
   extractAPIErrorMessage: vi.fn(async (response: Response) => {
     const defaultMessage = `API request failed with status ${response.status}`
     try {

--- a/apps/sim/executor/handlers/workflow/workflow-handler.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-handler.ts
@@ -42,7 +42,7 @@ import {
   type StreamingExecution,
 } from '@/executor/types'
 import { hasExecutionResult } from '@/executor/utils/errors'
-import { buildAPIUrl, buildAuthHeaders } from '@/executor/utils/http'
+import { buildAuthHeaders, buildInternalApiUrl } from '@/executor/utils/http'
 import { getIterationContext } from '@/executor/utils/iteration-context'
 import { parseJSON } from '@/executor/utils/json'
 import { lazyCleanupInputMapping } from '@/executor/utils/lazy-cleanup'
@@ -952,7 +952,7 @@ export class WorkflowBlockHandler implements BlockHandler {
 
   private async loadChildWorkflow(workflowId: string, userId?: string) {
     const headers = await buildAuthHeaders(userId)
-    const url = buildAPIUrl(`/api/workflows/${workflowId}`)
+    const url = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}`)
 
     const response = await fetch(url.toString(), { headers })
 
@@ -1015,7 +1015,7 @@ export class WorkflowBlockHandler implements BlockHandler {
   private async checkChildDeployment(workflowId: string, userId?: string): Promise<boolean> {
     try {
       const headers = await buildAuthHeaders(userId)
-      const url = buildAPIUrl(`/api/workflows/${workflowId}/deployed`)
+      const url = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}/deployed`)
 
       const response = await fetch(url.toString(), {
         headers,
@@ -1037,7 +1037,9 @@ export class WorkflowBlockHandler implements BlockHandler {
 
   private async loadChildWorkflowDeployed(workflowId: string, userId?: string) {
     const headers = await buildAuthHeaders(userId)
-    const deployedUrl = buildAPIUrl(`/api/workflows/${workflowId}/deployed`)
+    const deployedUrl = buildInternalApiUrl(
+      `/api/workflows/${encodeURIComponent(workflowId)}/deployed`
+    )
 
     const deployedRes = await fetch(deployedUrl.toString(), {
       headers,
@@ -1058,7 +1060,7 @@ export class WorkflowBlockHandler implements BlockHandler {
       throw new Error(`Deployed state missing or invalid for child workflow ${workflowId}`)
     }
 
-    const metaUrl = buildAPIUrl(`/api/workflows/${workflowId}`)
+    const metaUrl = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}`)
     const metaRes = await fetch(metaUrl.toString(), {
       headers,
       cache: 'no-store',

--- a/apps/sim/executor/handlers/workflow/workflow-handler.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-handler.ts
@@ -42,7 +42,7 @@ import {
   type StreamingExecution,
 } from '@/executor/types'
 import { hasExecutionResult } from '@/executor/utils/errors'
-import { buildAuthHeaders, buildInternalApiUrl } from '@/executor/utils/http'
+import { buildAuthHeaders, internalApiUrl } from '@/executor/utils/http'
 import { getIterationContext } from '@/executor/utils/iteration-context'
 import { parseJSON } from '@/executor/utils/json'
 import { lazyCleanupInputMapping } from '@/executor/utils/lazy-cleanup'
@@ -952,7 +952,7 @@ export class WorkflowBlockHandler implements BlockHandler {
 
   private async loadChildWorkflow(workflowId: string, userId?: string) {
     const headers = await buildAuthHeaders(userId)
-    const url = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}`)
+    const url = internalApiUrl`/api/workflows/${workflowId}`
 
     const response = await fetch(url.toString(), { headers })
 
@@ -1015,7 +1015,7 @@ export class WorkflowBlockHandler implements BlockHandler {
   private async checkChildDeployment(workflowId: string, userId?: string): Promise<boolean> {
     try {
       const headers = await buildAuthHeaders(userId)
-      const url = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}/deployed`)
+      const url = internalApiUrl`/api/workflows/${workflowId}/deployed`
 
       const response = await fetch(url.toString(), {
         headers,
@@ -1037,9 +1037,7 @@ export class WorkflowBlockHandler implements BlockHandler {
 
   private async loadChildWorkflowDeployed(workflowId: string, userId?: string) {
     const headers = await buildAuthHeaders(userId)
-    const deployedUrl = buildInternalApiUrl(
-      `/api/workflows/${encodeURIComponent(workflowId)}/deployed`
-    )
+    const deployedUrl = internalApiUrl`/api/workflows/${workflowId}/deployed`
 
     const deployedRes = await fetch(deployedUrl.toString(), {
       headers,
@@ -1060,7 +1058,7 @@ export class WorkflowBlockHandler implements BlockHandler {
       throw new Error(`Deployed state missing or invalid for child workflow ${workflowId}`)
     }
 
-    const metaUrl = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}`)
+    const metaUrl = internalApiUrl`/api/workflows/${workflowId}`
     const metaRes = await fetch(metaUrl.toString(), {
       headers,
       cache: 'no-store',

--- a/apps/sim/executor/utils/http.test.ts
+++ b/apps/sim/executor/utils/http.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetInternalApiBaseUrl } = vi.hoisted(() => ({
+  mockGetInternalApiBaseUrl: vi.fn(),
+}))
+
+vi.mock('@/lib/core/utils/urls', () => ({
+  getInternalApiBaseUrl: mockGetInternalApiBaseUrl,
+}))
+
+vi.mock('@/lib/auth/internal', () => ({
+  generateInternalToken: vi.fn().mockResolvedValue('token'),
+}))
+
+import { buildInternalApiUrl } from '@/executor/utils/http'
+
+describe('buildInternalApiUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetInternalApiBaseUrl.mockReturnValue('http://internal.sim.local')
+  })
+
+  it('resolves an internal path against the internal base URL', () => {
+    const url = buildInternalApiUrl('/api/workflows/wf-1')
+
+    expect(url.toString()).toBe('http://internal.sim.local/api/workflows/wf-1')
+  })
+
+  it('appends query params', () => {
+    const url = buildInternalApiUrl('/api/table/t-1', { workspaceId: 'ws-1' })
+
+    expect(url.searchParams.get('workspaceId')).toBe('ws-1')
+  })
+
+  it('rejects a path that is not an internal API route', () => {
+    expect(() => buildInternalApiUrl('/health')).toThrow(/must start with \/api\//)
+  })
+
+  it('rejects an absolute URL, which would escape the internal base', () => {
+    expect(() => buildInternalApiUrl('https://attacker.example/api/x')).toThrow(
+      /must start with \/api\//
+    )
+  })
+
+  it('keeps a traversal-shaped id inside its own path segment when encoded by the caller', () => {
+    const id = '../../admin/secrets'
+    const url = buildInternalApiUrl(`/api/table/${encodeURIComponent(id)}`)
+
+    expect(url.pathname).toBe('/api/table/..%2F..%2Fadmin%2Fsecrets')
+  })
+})

--- a/apps/sim/executor/utils/http.test.ts
+++ b/apps/sim/executor/utils/http.test.ts
@@ -15,40 +15,40 @@ vi.mock('@/lib/auth/internal', () => ({
   generateInternalToken: vi.fn().mockResolvedValue('token'),
 }))
 
-import { buildInternalApiUrl } from '@/executor/utils/http'
+import { internalApiUrl } from '@/executor/utils/http'
 
-describe('buildInternalApiUrl', () => {
+describe('internalApiUrl', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetInternalApiBaseUrl.mockReturnValue('http://internal.sim.local')
   })
 
-  it('resolves an internal path against the internal base URL', () => {
-    const url = buildInternalApiUrl('/api/workflows/wf-1')
+  it('resolves an internal route against the internal base URL', () => {
+    const url = internalApiUrl`/api/workflows/${'wf-1'}`
 
     expect(url.toString()).toBe('http://internal.sim.local/api/workflows/wf-1')
   })
 
-  it('appends query params', () => {
-    const url = buildInternalApiUrl('/api/table/t-1', { workspaceId: 'ws-1' })
+  it('encodes an interpolated id so it cannot widen the path', () => {
+    const url = internalApiUrl`/api/table/${'../../admin/secrets'}/rows`
 
-    expect(url.searchParams.get('workspaceId')).toBe('ws-1')
+    expect(url.pathname).toBe('/api/table/..%2F..%2Fadmin%2Fsecrets/rows')
   })
 
-  it('rejects a path that is not an internal API route', () => {
-    expect(() => buildInternalApiUrl('/health')).toThrow(/must start with \/api\//)
+  it('encodes a query-shaped id rather than letting it add params', () => {
+    const url = internalApiUrl`/api/table/${'t-1?workspaceId=other'}`
+
+    expect(url.searchParams.get('workspaceId')).toBeNull()
+    expect(url.pathname).toBe('/api/table/t-1%3FworkspaceId%3Dother')
   })
 
-  it('rejects an absolute URL, which would escape the internal base', () => {
-    expect(() => buildInternalApiUrl('https://attacker.example/api/x')).toThrow(
+  it('rejects a route that is not an internal API path', () => {
+    expect(() => internalApiUrl`/health`).toThrow(/must start with \/api\//)
+  })
+
+  it('rejects an interpolated absolute URL, which would escape the internal base', () => {
+    expect(() => internalApiUrl`${'https://attacker.example/api/x'}`).toThrow(
       /must start with \/api\//
     )
-  })
-
-  it('keeps a traversal-shaped id inside its own path segment when encoded by the caller', () => {
-    const id = '../../admin/secrets'
-    const url = buildInternalApiUrl(`/api/table/${encodeURIComponent(id)}`)
-
-    expect(url.pathname).toBe('/api/table/..%2F..%2Fadmin%2Fsecrets')
   })
 })

--- a/apps/sim/executor/utils/http.ts
+++ b/apps/sim/executor/utils/http.ts
@@ -16,29 +16,32 @@ export async function buildAuthHeaders(userId?: string): Promise<Record<string, 
 }
 
 /**
- * Resolves a Sim-internal API path against the internal base URL. Callers pair this with
- * {@link buildAuthHeaders}, so the path must be a fixed internal route the caller chose — never a
- * caller- or model-supplied URL, and never a value interpolated into the path unencoded.
+ * Builds a URL for one of Sim's own API routes, as a tagged template:
  *
- * @throws when `path` is not a relative `/api/` path, which would otherwise send an
+ * ```ts
+ * const url = internalApiUrl`/api/workflows/${workflowId}/deployed`
+ * ```
+ *
+ * Callers pair this with {@link buildAuthHeaders}, so the request carries an internal token for
+ * the executing user — which makes it critical that the *route* comes from this module's source
+ * and only resource ids come from data. The template's literal segments provide that: they are
+ * fixed at author time, and every interpolated value is percent-encoded, so an id can never widen
+ * the path into a different route.
+ *
+ * @throws when the resolved path is not a relative `/api/` path, which would otherwise send an
  * internally-signed request somewhere the caller did not intend.
  */
-export function buildInternalApiUrl(path: string, params?: Record<string, string>): URL {
+export function internalApiUrl(segments: TemplateStringsArray, ...values: unknown[]): URL {
+  let path = segments[0]
+  for (const [index, value] of values.entries()) {
+    path += encodeURIComponent(String(value)) + segments[index + 1]
+  }
+
   if (!path.startsWith('/api/')) {
     throw new Error(`Internal API path must start with /api/: ${path}`)
   }
 
-  const url = new URL(path, getInternalApiBaseUrl())
-
-  if (params) {
-    for (const [key, value] of Object.entries(params)) {
-      if (value !== undefined && value !== null) {
-        url.searchParams.set(key, value)
-      }
-    }
-  }
-
-  return url
+  return new URL(path, getInternalApiBaseUrl())
 }
 
 export async function extractAPIErrorMessage(response: Response): Promise<string> {

--- a/apps/sim/executor/utils/http.ts
+++ b/apps/sim/executor/utils/http.ts
@@ -1,5 +1,5 @@
 import { generateInternalToken } from '@/lib/auth/internal'
-import { getBaseUrl, getInternalApiBaseUrl } from '@/lib/core/utils/urls'
+import { getInternalApiBaseUrl } from '@/lib/core/utils/urls'
 import { HTTP } from '@/executor/constants'
 
 export async function buildAuthHeaders(userId?: string): Promise<Record<string, string>> {
@@ -15,9 +15,20 @@ export async function buildAuthHeaders(userId?: string): Promise<Record<string, 
   return headers
 }
 
-export function buildAPIUrl(path: string, params?: Record<string, string>): URL {
-  const baseUrl = path.startsWith('/api/') ? getInternalApiBaseUrl() : getBaseUrl()
-  const url = new URL(path, baseUrl)
+/**
+ * Resolves a Sim-internal API path against the internal base URL. Callers pair this with
+ * {@link buildAuthHeaders}, so the path must be a fixed internal route the caller chose — never a
+ * caller- or model-supplied URL, and never a value interpolated into the path unencoded.
+ *
+ * @throws when `path` is not a relative `/api/` path, which would otherwise send an
+ * internally-signed request somewhere the caller did not intend.
+ */
+export function buildInternalApiUrl(path: string, params?: Record<string, string>): URL {
+  if (!path.startsWith('/api/')) {
+    throw new Error(`Internal API path must start with /api/: ${path}`)
+  }
+
+  const url = new URL(path, getInternalApiBaseUrl())
 
   if (params) {
     for (const [key, value] of Object.entries(params)) {

--- a/apps/sim/providers/utils.ts
+++ b/apps/sim/providers/utils.ts
@@ -84,10 +84,10 @@ async function fetchWorkflowMetadata(
   workflowId: string
 ): Promise<{ name: string; description: string | null } | null> {
   try {
-    const { buildAuthHeaders, buildInternalApiUrl } = await import('@/executor/utils/http')
+    const { buildAuthHeaders, internalApiUrl } = await import('@/executor/utils/http')
 
     const headers = await buildAuthHeaders()
-    const url = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}`)
+    const url = internalApiUrl`/api/workflows/${workflowId}`
 
     const response = await fetch(url.toString(), { headers })
     if (!response.ok) {

--- a/apps/sim/providers/utils.ts
+++ b/apps/sim/providers/utils.ts
@@ -84,10 +84,10 @@ async function fetchWorkflowMetadata(
   workflowId: string
 ): Promise<{ name: string; description: string | null } | null> {
   try {
-    const { buildAuthHeaders, buildAPIUrl } = await import('@/executor/utils/http')
+    const { buildAuthHeaders, buildInternalApiUrl } = await import('@/executor/utils/http')
 
     const headers = await buildAuthHeaders()
-    const url = buildAPIUrl(`/api/workflows/${workflowId}`)
+    const url = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}`)
 
     const response = await fetch(url.toString(), { headers })
     if (!response.ok) {

--- a/apps/sim/tools/agiloft/attachment_info.ts
+++ b/apps/sim/tools/agiloft/attachment_info.ts
@@ -59,7 +59,7 @@ export const agiloftAttachmentInfoTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/agiloft/attachment_info',
+    url: '/api/tools/agiloft/attachment_info',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/agiloft/create_record.ts
+++ b/apps/sim/tools/agiloft/create_record.ts
@@ -49,7 +49,7 @@ export const agiloftCreateRecordTool: ToolConfig<AgiloftCreateRecordParams, Agil
     },
 
     request: {
-      url: () => '/api/tools/agiloft/create_record',
+      url: '/api/tools/agiloft/create_record',
       method: 'POST',
       headers: () => ({ 'Content-Type': 'application/json' }),
       body: (params) => ({

--- a/apps/sim/tools/agiloft/delete_record.ts
+++ b/apps/sim/tools/agiloft/delete_record.ts
@@ -48,7 +48,7 @@ export const agiloftDeleteRecordTool: ToolConfig<AgiloftDeleteRecordParams, Agil
     },
 
     request: {
-      url: () => '/api/tools/agiloft/delete_record',
+      url: '/api/tools/agiloft/delete_record',
       method: 'POST',
       headers: () => ({ 'Content-Type': 'application/json' }),
       body: (params) => ({

--- a/apps/sim/tools/agiloft/get_choice_line_id.ts
+++ b/apps/sim/tools/agiloft/get_choice_line_id.ts
@@ -60,7 +60,7 @@ export const agiloftGetChoiceLineIdTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/agiloft/get_choice_line_id',
+    url: '/api/tools/agiloft/get_choice_line_id',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/agiloft/lock_record.ts
+++ b/apps/sim/tools/agiloft/lock_record.ts
@@ -53,7 +53,7 @@ export const agiloftLockRecordTool: ToolConfig<AgiloftLockRecordParams, AgiloftL
   },
 
   request: {
-    url: () => '/api/tools/agiloft/lock_record',
+    url: '/api/tools/agiloft/lock_record',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/agiloft/read_record.ts
+++ b/apps/sim/tools/agiloft/read_record.ts
@@ -53,7 +53,7 @@ export const agiloftReadRecordTool: ToolConfig<AgiloftReadRecordParams, AgiloftR
   },
 
   request: {
-    url: () => '/api/tools/agiloft/read_record',
+    url: '/api/tools/agiloft/read_record',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/agiloft/remove_attachment.ts
+++ b/apps/sim/tools/agiloft/remove_attachment.ts
@@ -65,7 +65,7 @@ export const agiloftRemoveAttachmentTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/agiloft/remove_attachment',
+    url: '/api/tools/agiloft/remove_attachment',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/agiloft/saved_search.ts
+++ b/apps/sim/tools/agiloft/saved_search.ts
@@ -44,7 +44,7 @@ export const agiloftSavedSearchTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/agiloft/saved_search',
+    url: '/api/tools/agiloft/saved_search',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/agiloft/search_records.ts
+++ b/apps/sim/tools/agiloft/search_records.ts
@@ -69,7 +69,7 @@ export const agiloftSearchRecordsTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/agiloft/search_records',
+    url: '/api/tools/agiloft/search_records',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/agiloft/select_records.ts
+++ b/apps/sim/tools/agiloft/select_records.ts
@@ -51,7 +51,7 @@ export const agiloftSelectRecordsTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/agiloft/select_records',
+    url: '/api/tools/agiloft/select_records',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/agiloft/update_record.ts
+++ b/apps/sim/tools/agiloft/update_record.ts
@@ -55,7 +55,7 @@ export const agiloftUpdateRecordTool: ToolConfig<AgiloftUpdateRecordParams, Agil
     },
 
     request: {
-      url: () => '/api/tools/agiloft/update_record',
+      url: '/api/tools/agiloft/update_record',
       method: 'POST',
       headers: () => ({ 'Content-Type': 'application/json' }),
       body: (params) => ({

--- a/apps/sim/tools/confluence/add_label.ts
+++ b/apps/sim/tools/confluence/add_label.ts
@@ -75,7 +75,7 @@ export const confluenceAddLabelTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/labels',
+    url: '/api/tools/confluence/labels',
     method: 'POST',
     headers: (params: ConfluenceAddLabelParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/create_blogpost.ts
+++ b/apps/sim/tools/confluence/create_blogpost.ts
@@ -91,7 +91,7 @@ export const confluenceCreateBlogPostTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/blogposts',
+    url: '/api/tools/confluence/blogposts',
     method: 'POST',
     headers: (params: ConfluenceCreateBlogPostParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/create_comment.ts
+++ b/apps/sim/tools/confluence/create_comment.ts
@@ -66,7 +66,7 @@ export const confluenceCreateCommentTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/comments',
+    url: '/api/tools/confluence/comments',
     method: 'POST',
     headers: (params: ConfluenceCreateCommentParams) => {
       return {

--- a/apps/sim/tools/confluence/create_page.ts
+++ b/apps/sim/tools/confluence/create_page.ts
@@ -87,7 +87,7 @@ export const confluenceCreatePageTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/create-page',
+    url: '/api/tools/confluence/create-page',
     method: 'POST',
     headers: (params: ConfluenceCreatePageParams) => {
       return {

--- a/apps/sim/tools/confluence/create_page_property.ts
+++ b/apps/sim/tools/confluence/create_page_property.ts
@@ -79,7 +79,7 @@ export const confluenceCreatePagePropertyTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/page-properties',
+    url: '/api/tools/confluence/page-properties',
     method: 'POST',
     headers: (params: ConfluenceCreatePagePropertyParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/create_space.ts
+++ b/apps/sim/tools/confluence/create_space.ts
@@ -80,7 +80,7 @@ export const confluenceCreateSpaceTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space',
+    url: '/api/tools/confluence/space',
     method: 'POST',
     headers: (params: ConfluenceCreateSpaceParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/create_space_property.ts
+++ b/apps/sim/tools/confluence/create_space_property.ts
@@ -76,7 +76,7 @@ export const confluenceCreateSpacePropertyTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space-properties',
+    url: '/api/tools/confluence/space-properties',
     method: 'POST',
     headers: (params: ConfluenceCreateSpacePropertyParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/delete_attachment.ts
+++ b/apps/sim/tools/confluence/delete_attachment.ts
@@ -59,7 +59,7 @@ export const confluenceDeleteAttachmentTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/attachment',
+    url: '/api/tools/confluence/attachment',
     method: 'DELETE',
     headers: (params: ConfluenceDeleteAttachmentParams) => {
       return {

--- a/apps/sim/tools/confluence/delete_blogpost.ts
+++ b/apps/sim/tools/confluence/delete_blogpost.ts
@@ -60,7 +60,7 @@ export const confluenceDeleteBlogPostTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/blogposts',
+    url: '/api/tools/confluence/blogposts',
     method: 'DELETE',
     headers: (params: ConfluenceDeleteBlogPostParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/delete_comment.ts
+++ b/apps/sim/tools/confluence/delete_comment.ts
@@ -59,7 +59,7 @@ export const confluenceDeleteCommentTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/comment',
+    url: '/api/tools/confluence/comment',
     method: 'DELETE',
     headers: (params: ConfluenceDeleteCommentParams) => {
       return {

--- a/apps/sim/tools/confluence/delete_label.ts
+++ b/apps/sim/tools/confluence/delete_label.ts
@@ -68,7 +68,7 @@ export const confluenceDeleteLabelTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/labels',
+    url: '/api/tools/confluence/labels',
     method: 'DELETE',
     headers: (params: ConfluenceDeleteLabelParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/delete_page.ts
+++ b/apps/sim/tools/confluence/delete_page.ts
@@ -68,7 +68,7 @@ export const confluenceDeletePageTool: ToolConfig<
   },
 
   request: {
-    url: (params: ConfluenceDeletePageParams) => '/api/tools/confluence/page',
+    url: '/api/tools/confluence/page',
     method: 'DELETE',
     headers: (params: ConfluenceDeletePageParams) => {
       return {

--- a/apps/sim/tools/confluence/delete_page_property.ts
+++ b/apps/sim/tools/confluence/delete_page_property.ts
@@ -68,7 +68,7 @@ export const confluenceDeletePagePropertyTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/page-properties',
+    url: '/api/tools/confluence/page-properties',
     method: 'DELETE',
     headers: (params: ConfluenceDeletePagePropertyParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/delete_space.ts
+++ b/apps/sim/tools/confluence/delete_space.ts
@@ -62,7 +62,7 @@ export const confluenceDeleteSpaceTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space',
+    url: '/api/tools/confluence/space',
     method: 'DELETE',
     headers: (params: ConfluenceDeleteSpaceParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/delete_space_property.ts
+++ b/apps/sim/tools/confluence/delete_space_property.ts
@@ -68,7 +68,7 @@ export const confluenceDeleteSpacePropertyTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space-properties',
+    url: '/api/tools/confluence/space-properties',
     method: 'POST',
     headers: (params: ConfluenceDeleteSpacePropertyParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/get_blogpost.ts
+++ b/apps/sim/tools/confluence/get_blogpost.ts
@@ -84,7 +84,7 @@ export const confluenceGetBlogPostTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/blogposts',
+    url: '/api/tools/confluence/blogposts',
     method: 'POST',
     headers: (params: ConfluenceGetBlogPostParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/get_page_ancestors.ts
+++ b/apps/sim/tools/confluence/get_page_ancestors.ts
@@ -74,7 +74,7 @@ export const confluenceGetPageAncestorsTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/page-ancestors',
+    url: '/api/tools/confluence/page-ancestors',
     method: 'POST',
     headers: (params: ConfluenceGetPageAncestorsParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/get_page_children.ts
+++ b/apps/sim/tools/confluence/get_page_children.ts
@@ -83,7 +83,7 @@ export const confluenceGetPageChildrenTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/page-children',
+    url: '/api/tools/confluence/page-children',
     method: 'POST',
     headers: (params: ConfluenceGetPageChildrenParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/get_page_descendants.ts
+++ b/apps/sim/tools/confluence/get_page_descendants.ts
@@ -84,7 +84,7 @@ export const confluenceGetPageDescendantsTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/page-descendants',
+    url: '/api/tools/confluence/page-descendants',
     method: 'POST',
     headers: (params: ConfluenceGetPageDescendantsParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/get_page_version.ts
+++ b/apps/sim/tools/confluence/get_page_version.ts
@@ -89,7 +89,7 @@ export const confluenceGetPageVersionTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/page-versions',
+    url: '/api/tools/confluence/page-versions',
     method: 'POST',
     headers: (params: ConfluenceGetPageVersionParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/get_pages_by_label.ts
+++ b/apps/sim/tools/confluence/get_pages_by_label.ts
@@ -88,6 +88,7 @@ export const confluenceGetPagesByLabelTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceGetPagesByLabelParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/get_space.ts
+++ b/apps/sim/tools/confluence/get_space.ts
@@ -71,6 +71,7 @@ export const confluenceGetSpaceTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceGetSpaceParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/get_task.ts
+++ b/apps/sim/tools/confluence/get_task.ts
@@ -70,7 +70,7 @@ export const confluenceGetTaskTool: ToolConfig<ConfluenceGetTaskParams, Confluen
     },
 
     request: {
-      url: () => '/api/tools/confluence/tasks',
+      url: '/api/tools/confluence/tasks',
       method: 'POST',
       headers: (params: ConfluenceGetTaskParams) => ({
         Accept: 'application/json',

--- a/apps/sim/tools/confluence/get_user.ts
+++ b/apps/sim/tools/confluence/get_user.ts
@@ -62,7 +62,7 @@ export const confluenceGetUserTool: ToolConfig<ConfluenceGetUserParams, Confluen
     },
 
     request: {
-      url: () => '/api/tools/confluence/user',
+      url: '/api/tools/confluence/user',
       method: 'POST',
       headers: (params: ConfluenceGetUserParams) => ({
         Accept: 'application/json',

--- a/apps/sim/tools/confluence/list_attachments.ts
+++ b/apps/sim/tools/confluence/list_attachments.ts
@@ -80,6 +80,7 @@ export const confluenceListAttachmentsTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceListAttachmentsParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/list_blogposts.ts
+++ b/apps/sim/tools/confluence/list_blogposts.ts
@@ -95,6 +95,7 @@ export const confluenceListBlogPostsTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceListBlogPostsParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/list_blogposts_in_space.ts
+++ b/apps/sim/tools/confluence/list_blogposts_in_space.ts
@@ -108,7 +108,7 @@ export const confluenceListBlogPostsInSpaceTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space-blogposts',
+    url: '/api/tools/confluence/space-blogposts',
     method: 'POST',
     headers: (params: ConfluenceListBlogPostsInSpaceParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/list_comments.ts
+++ b/apps/sim/tools/confluence/list_comments.ts
@@ -87,6 +87,7 @@ export const confluenceListCommentsTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceListCommentsParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/list_labels.ts
+++ b/apps/sim/tools/confluence/list_labels.ts
@@ -78,6 +78,7 @@ export const confluenceListLabelsTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceListLabelsParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/list_page_properties.ts
+++ b/apps/sim/tools/confluence/list_page_properties.ts
@@ -84,6 +84,7 @@ export const confluenceListPagePropertiesTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceListPagePropertiesParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/list_page_versions.ts
+++ b/apps/sim/tools/confluence/list_page_versions.ts
@@ -81,7 +81,7 @@ export const confluenceListPageVersionsTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/page-versions',
+    url: '/api/tools/confluence/page-versions',
     method: 'POST',
     headers: (params: ConfluenceListPageVersionsParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/list_pages_in_space.ts
+++ b/apps/sim/tools/confluence/list_pages_in_space.ts
@@ -111,7 +111,7 @@ export const confluenceListPagesInSpaceTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space-pages',
+    url: '/api/tools/confluence/space-pages',
     method: 'POST',
     headers: (params: ConfluenceListPagesInSpaceParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/list_space_labels.ts
+++ b/apps/sim/tools/confluence/list_space_labels.ts
@@ -79,6 +79,7 @@ export const confluenceListSpaceLabelsTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceListSpaceLabelsParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/list_space_permissions.ts
+++ b/apps/sim/tools/confluence/list_space_permissions.ts
@@ -83,7 +83,7 @@ export const confluenceListSpacePermissionsTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space-permissions',
+    url: '/api/tools/confluence/space-permissions',
     method: 'POST',
     headers: (params: ConfluenceListSpacePermissionsParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/list_space_properties.ts
+++ b/apps/sim/tools/confluence/list_space_properties.ts
@@ -79,7 +79,7 @@ export const confluenceListSpacePropertiesTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space-properties',
+    url: '/api/tools/confluence/space-properties',
     method: 'POST',
     headers: (params: ConfluenceListSpacePropertiesParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/list_spaces.ts
+++ b/apps/sim/tools/confluence/list_spaces.ts
@@ -73,6 +73,7 @@ export const confluenceListSpacesTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceListSpacesParams) => {
       const query = new URLSearchParams({
         domain: params.domain,

--- a/apps/sim/tools/confluence/list_tasks.ts
+++ b/apps/sim/tools/confluence/list_tasks.ts
@@ -111,7 +111,7 @@ export const confluenceListTasksTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/tasks',
+    url: '/api/tools/confluence/tasks',
     method: 'POST',
     headers: (params: ConfluenceListTasksParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/retrieve.ts
+++ b/apps/sim/tools/confluence/retrieve.ts
@@ -50,6 +50,7 @@ export const confluenceRetrieveTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceRetrieveParams) => {
       return '/api/tools/confluence/page'
     },

--- a/apps/sim/tools/confluence/search.ts
+++ b/apps/sim/tools/confluence/search.ts
@@ -69,7 +69,7 @@ export const confluenceSearchTool: ToolConfig<ConfluenceSearchParams, Confluence
   },
 
   request: {
-    url: () => '/api/tools/confluence/search',
+    url: '/api/tools/confluence/search',
     method: 'POST',
     headers: (params: ConfluenceSearchParams) => {
       return {

--- a/apps/sim/tools/confluence/search_in_space.ts
+++ b/apps/sim/tools/confluence/search_in_space.ts
@@ -91,7 +91,7 @@ export const confluenceSearchInSpaceTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/search-in-space',
+    url: '/api/tools/confluence/search-in-space',
     method: 'POST',
     headers: (params: ConfluenceSearchInSpaceParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/update.ts
+++ b/apps/sim/tools/confluence/update.ts
@@ -54,6 +54,7 @@ export const confluenceUpdateTool: ToolConfig<ConfluenceUpdateParams, Confluence
   },
 
   request: {
+    internalRoute: true,
     url: (params: ConfluenceUpdateParams) => {
       return '/api/tools/confluence/page'
     },

--- a/apps/sim/tools/confluence/update_blogpost.ts
+++ b/apps/sim/tools/confluence/update_blogpost.ts
@@ -78,7 +78,7 @@ export const confluenceUpdateBlogPostTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/blogposts',
+    url: '/api/tools/confluence/blogposts',
     method: 'PUT',
     headers: (params: ConfluenceUpdateBlogPostParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/update_comment.ts
+++ b/apps/sim/tools/confluence/update_comment.ts
@@ -66,7 +66,7 @@ export const confluenceUpdateCommentTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/comment',
+    url: '/api/tools/confluence/comment',
     method: 'PUT',
     headers: (params: ConfluenceUpdateCommentParams) => {
       return {

--- a/apps/sim/tools/confluence/update_space.ts
+++ b/apps/sim/tools/confluence/update_space.ts
@@ -79,7 +79,7 @@ export const confluenceUpdateSpaceTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/space',
+    url: '/api/tools/confluence/space',
     method: 'PUT',
     headers: (params: ConfluenceUpdateSpaceParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/update_task.ts
+++ b/apps/sim/tools/confluence/update_task.ts
@@ -79,7 +79,7 @@ export const confluenceUpdateTaskTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/tasks',
+    url: '/api/tools/confluence/tasks',
     method: 'POST',
     headers: (params: ConfluenceUpdateTaskParams) => ({
       Accept: 'application/json',

--- a/apps/sim/tools/confluence/upload_attachment.ts
+++ b/apps/sim/tools/confluence/upload_attachment.ts
@@ -84,7 +84,7 @@ export const confluenceUploadAttachmentTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/confluence/upload-attachment',
+    url: '/api/tools/confluence/upload-attachment',
     method: 'POST',
     headers: (params: ConfluenceUploadAttachmentParams) => {
       return {

--- a/apps/sim/tools/deployments/get_version.ts
+++ b/apps/sim/tools/deployments/get_version.ts
@@ -30,6 +30,7 @@ export const deploymentsGetVersionTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/deployments/list_versions.ts
+++ b/apps/sim/tools/deployments/list_versions.ts
@@ -24,6 +24,7 @@ export const deploymentsListVersionsTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/google_drive/upload.ts
+++ b/apps/sim/tools/google_drive/upload.ts
@@ -67,6 +67,7 @@ export const uploadTool: ToolConfig<GoogleDriveToolParams, GoogleDriveUploadResp
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       // Use custom API route if file is provided, otherwise use Google Drive API directly
       if (params.file) {

--- a/apps/sim/tools/grafana/update_alert_rule.ts
+++ b/apps/sim/tools/grafana/update_alert_rule.ts
@@ -131,7 +131,7 @@ export const updateAlertRuleTool: ToolConfig<GrafanaUpdateAlertRuleParams, ToolR
   },
 
   request: {
-    url: () => '/api/tools/grafana/update_alert_rule',
+    url: '/api/tools/grafana/update_alert_rule',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/grafana/update_dashboard.ts
+++ b/apps/sim/tools/grafana/update_dashboard.ts
@@ -85,7 +85,7 @@ export const updateDashboardTool: ToolConfig<GrafanaUpdateDashboardParams, ToolR
   },
 
   request: {
-    url: () => '/api/tools/grafana/update_dashboard',
+    url: '/api/tools/grafana/update_dashboard',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/grafana/update_folder.ts
+++ b/apps/sim/tools/grafana/update_folder.ts
@@ -41,7 +41,7 @@ export const updateFolderTool: ToolConfig<GrafanaUpdateFolderParams, ToolRespons
   },
 
   request: {
-    url: () => '/api/tools/grafana/update_folder',
+    url: '/api/tools/grafana/update_folder',
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params) => ({

--- a/apps/sim/tools/index.test.ts
+++ b/apps/sim/tools/index.test.ts
@@ -4593,6 +4593,32 @@ describe('MCP Tool Execution', () => {
   })
 
   describe('Tool request retries', () => {
+    const internalRetryTool = {
+      id: 'test_internal_retry',
+      name: 'Test Internal Retry Tool',
+      description: 'An internal tool used to exercise retry pacing',
+      version: '1.0.0',
+      params: {},
+      request: {
+        url: '/api/test',
+        method: 'GET',
+        headers: () => ({ 'Content-Type': 'application/json' }),
+        retry: { enabled: true, retryIdempotentOnly: true },
+      },
+      transformResponse: async (response: Response) => ({
+        success: response.ok,
+        output: { status: response.status },
+      }),
+    }
+
+    beforeEach(() => {
+      ;(tools as any).test_internal_retry = internalRetryTool
+    })
+
+    afterEach(() => {
+      ;(tools as any).test_internal_retry = undefined
+    })
+
     function makeJsonResponse(
       status: number,
       body: unknown,
@@ -4611,7 +4637,7 @@ describe('MCP Tool Execution', () => {
       }
     }
 
-    it('retries on 5xx responses for http_request', async () => {
+    it('retries on 5xx responses', async () => {
       global.fetch = Object.assign(
         vi
           .fn()
@@ -4620,8 +4646,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
         retries: 2,
         retryDelayMs: 0,
@@ -4639,8 +4664,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
       })
 
@@ -4648,14 +4672,13 @@ describe('MCP Tool Execution', () => {
       expect(result.success).toBe(false)
     })
 
-    it('stops retrying after max attempts for http_request', async () => {
+    it('stops retrying after max attempts', async () => {
       global.fetch = Object.assign(
         vi.fn().mockResolvedValue(makeJsonResponse(502, { error: 'bad gateway' })),
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
         retries: 2,
         retryDelayMs: 0,
@@ -4666,14 +4689,13 @@ describe('MCP Tool Execution', () => {
       expect(result.success).toBe(false)
     })
 
-    it('does not retry on 4xx responses for http_request', async () => {
+    it('does not retry on 4xx responses', async () => {
       global.fetch = Object.assign(
         vi.fn().mockResolvedValue(makeJsonResponse(400, { error: 'bad request' })),
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
         retries: 5,
         retryDelayMs: 0,
@@ -4693,8 +4715,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'POST',
         retries: 2,
         retryDelayMs: 0,
@@ -4714,8 +4735,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'POST',
         retries: 1,
         retryNonIdempotent: true,
@@ -4728,7 +4748,7 @@ describe('MCP Tool Execution', () => {
       expect((result.output as any).status).toBe(200)
     })
 
-    it('retries on timeout errors for http_request', async () => {
+    it('retries on timeout errors', async () => {
       const abortError = Object.assign(new Error('Aborted'), { name: 'AbortError' })
       global.fetch = Object.assign(
         vi
@@ -4738,8 +4758,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
         retries: 1,
         retryDelayMs: 0,
@@ -4761,8 +4780,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
         retries: 3,
         retryMaxDelayMs: 5000,
@@ -4783,8 +4801,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
         retries: 3,
         retryMaxDelayMs: 40000,
@@ -4805,8 +4822,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
         retries: 2,
         retryDelayMs: 0,
@@ -4817,7 +4833,7 @@ describe('MCP Tool Execution', () => {
       expect(result.success).toBe(true)
     })
 
-    it('retries on ETIMEDOUT errors for http_request', async () => {
+    it('retries on ETIMEDOUT errors', async () => {
       const etimedoutError = Object.assign(new Error('connect ETIMEDOUT 10.0.0.1:443'), {
         code: 'ETIMEDOUT',
       })
@@ -4829,8 +4845,7 @@ describe('MCP Tool Execution', () => {
         { preconnect: vi.fn() }
       ) as typeof fetch
 
-      const result = await executeTool('http_request', {
-        url: '/api/test',
+      const result = await executeTool('test_internal_retry', {
         method: 'GET',
         retries: 1,
         retryDelayMs: 0,

--- a/apps/sim/tools/index.test.ts
+++ b/apps/sim/tools/index.test.ts
@@ -4612,11 +4612,11 @@ describe('MCP Tool Execution', () => {
     }
 
     beforeEach(() => {
-      ;(tools as any).test_internal_retry = internalRetryTool
+      ;(tools as Record<string, unknown>).test_internal_retry = internalRetryTool
     })
 
     afterEach(() => {
-      ;(tools as any).test_internal_retry = undefined
+      ;(tools as Record<string, unknown>).test_internal_retry = undefined
     })
 
     function makeJsonResponse(

--- a/apps/sim/tools/index.test.ts
+++ b/apps/sim/tools/index.test.ts
@@ -3158,6 +3158,7 @@ describe('Automatic Internal Route Detection', () => {
         resourceId: { type: 'string', required: true },
       },
       request: {
+        internalRoute: true,
         url: (params: any) => `/api/resources/${params.resourceId}`,
         method: 'GET',
         headers: () => ({ 'Content-Type': 'application/json' }),
@@ -3196,6 +3197,8 @@ describe('Automatic Internal Route Detection', () => {
     expect(result.success).toBe(true)
     expect(result.output.result).toBe('Dynamic internal route success')
     expect(mockTool.transformResponse).toHaveBeenCalled()
+    expect(global.fetch).toHaveBeenCalled()
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
 
     Object.assign(tools, originalTools)
   })

--- a/apps/sim/tools/knowledge/create_document.ts
+++ b/apps/sim/tools/knowledge/create_document.ts
@@ -48,7 +48,8 @@ export const knowledgeCreateDocumentTool: ToolConfig<any, KnowledgeCreateDocumen
   },
 
   request: {
-    url: (params) => `/api/knowledge/${params.knowledgeBaseId}/documents`,
+    internalRoute: true,
+    url: (params) => `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents`,
     method: 'POST',
     secretProvenance: {
       request: selectKnowledgeDocumentWriteSecretProvenance,

--- a/apps/sim/tools/knowledge/delete_chunk.ts
+++ b/apps/sim/tools/knowledge/delete_chunk.ts
@@ -29,8 +29,9 @@ export const knowledgeDeleteChunkTool: ToolConfig<any, KnowledgeDeleteChunkRespo
   },
 
   request: {
+    internalRoute: true,
     url: (params) =>
-      `/api/knowledge/${params.knowledgeBaseId}/documents/${params.documentId}/chunks/${params.chunkId}`,
+      `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents/${encodeURIComponent(params.documentId)}/chunks/${encodeURIComponent(params.chunkId)}`,
     method: 'DELETE',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/knowledge/delete_document.ts
+++ b/apps/sim/tools/knowledge/delete_document.ts
@@ -23,7 +23,9 @@ export const knowledgeDeleteDocumentTool: ToolConfig<any, KnowledgeDeleteDocumen
   },
 
   request: {
-    url: (params) => `/api/knowledge/${params.knowledgeBaseId}/documents/${params.documentId}`,
+    internalRoute: true,
+    url: (params) =>
+      `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents/${encodeURIComponent(params.documentId)}`,
     method: 'DELETE',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/knowledge/get_connector.ts
+++ b/apps/sim/tools/knowledge/get_connector.ts
@@ -24,7 +24,9 @@ export const knowledgeGetConnectorTool: ToolConfig<any, KnowledgeGetConnectorRes
   },
 
   request: {
-    url: (params) => `/api/knowledge/${params.knowledgeBaseId}/connectors/${params.connectorId}`,
+    internalRoute: true,
+    url: (params) =>
+      `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/connectors/${encodeURIComponent(params.connectorId)}`,
     method: 'GET',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/knowledge/get_document.ts
+++ b/apps/sim/tools/knowledge/get_document.ts
@@ -24,7 +24,9 @@ export const knowledgeGetDocumentTool: ToolConfig<any, KnowledgeGetDocumentRespo
   },
 
   request: {
-    url: (params) => `/api/knowledge/${params.knowledgeBaseId}/documents/${params.documentId}`,
+    internalRoute: true,
+    url: (params) =>
+      `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents/${encodeURIComponent(params.documentId)}`,
     method: 'GET',
     secretProvenance: { response: { incomplete: 'reject' } },
     headers: () => ({

--- a/apps/sim/tools/knowledge/list_chunks.ts
+++ b/apps/sim/tools/knowledge/list_chunks.ts
@@ -48,6 +48,7 @@ export const knowledgeListChunksTool: ToolConfig<any, KnowledgeListChunksRespons
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const queryParams = new URLSearchParams()
       if (params.search) queryParams.set('search', params.search)
@@ -56,7 +57,7 @@ export const knowledgeListChunksTool: ToolConfig<any, KnowledgeListChunksRespons
         queryParams.set('limit', String(Math.max(1, Math.min(100, Number(params.limit)))))
       if (params.offset != null) queryParams.set('offset', String(params.offset))
       const qs = queryParams.toString()
-      return `/api/knowledge/${params.knowledgeBaseId}/documents/${params.documentId}/chunks${qs ? `?${qs}` : ''}`
+      return `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents/${encodeURIComponent(params.documentId)}/chunks${qs ? `?${qs}` : ''}`
     },
     method: 'GET',
     secretProvenance: { response: { incomplete: 'reject' } },

--- a/apps/sim/tools/knowledge/list_connectors.ts
+++ b/apps/sim/tools/knowledge/list_connectors.ts
@@ -18,7 +18,8 @@ export const knowledgeListConnectorsTool: ToolConfig<any, KnowledgeListConnector
   },
 
   request: {
-    url: (params) => `/api/knowledge/${params.knowledgeBaseId}/connectors`,
+    internalRoute: true,
+    url: (params) => `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/connectors`,
     method: 'GET',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/knowledge/list_documents.ts
+++ b/apps/sim/tools/knowledge/list_documents.ts
@@ -41,6 +41,7 @@ export const knowledgeListDocumentsTool: ToolConfig<any, KnowledgeListDocumentsR
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const queryParams = new URLSearchParams()
       if (params.search) queryParams.set('search', params.search)
@@ -48,7 +49,7 @@ export const knowledgeListDocumentsTool: ToolConfig<any, KnowledgeListDocumentsR
       if (params.limit != null) queryParams.set('limit', String(params.limit))
       if (params.offset != null) queryParams.set('offset', String(params.offset))
       const qs = queryParams.toString()
-      return `/api/knowledge/${params.knowledgeBaseId}/documents${qs ? `?${qs}` : ''}`
+      return `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents${qs ? `?${qs}` : ''}`
     },
     method: 'GET',
     secretProvenance: { response: { incomplete: 'reject' } },

--- a/apps/sim/tools/knowledge/list_tags.ts
+++ b/apps/sim/tools/knowledge/list_tags.ts
@@ -17,7 +17,8 @@ export const knowledgeListTagsTool: ToolConfig<any, KnowledgeListTagsResponse> =
   },
 
   request: {
-    url: (params) => `/api/knowledge/${params.knowledgeBaseId}/tag-definitions`,
+    internalRoute: true,
+    url: (params) => `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/tag-definitions`,
     method: 'GET',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/knowledge/search.ts
+++ b/apps/sim/tools/knowledge/search.ts
@@ -85,7 +85,7 @@ export const knowledgeSearchTool: ToolConfig<any, KnowledgeSearchResponse> = {
   },
 
   request: {
-    url: () => '/api/knowledge/search',
+    url: '/api/knowledge/search',
     method: 'POST',
     modelInput: {
       mode: 'private-provenance',

--- a/apps/sim/tools/knowledge/trigger_sync.ts
+++ b/apps/sim/tools/knowledge/trigger_sync.ts
@@ -23,8 +23,9 @@ export const knowledgeTriggerSyncTool: ToolConfig<any, KnowledgeTriggerSyncRespo
   },
 
   request: {
+    internalRoute: true,
     url: (params) =>
-      `/api/knowledge/${params.knowledgeBaseId}/connectors/${params.connectorId}/sync`,
+      `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/connectors/${encodeURIComponent(params.connectorId)}/sync`,
     method: 'POST',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/knowledge/update_chunk.ts
+++ b/apps/sim/tools/knowledge/update_chunk.ts
@@ -41,8 +41,9 @@ export const knowledgeUpdateChunkTool: ToolConfig<any, KnowledgeUpdateChunkRespo
   },
 
   request: {
+    internalRoute: true,
     url: (params) =>
-      `/api/knowledge/${params.knowledgeBaseId}/documents/${params.documentId}/chunks/${params.chunkId}`,
+      `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents/${encodeURIComponent(params.documentId)}/chunks/${encodeURIComponent(params.chunkId)}`,
     method: 'PUT',
     secretProvenance: {
       request: (params) =>

--- a/apps/sim/tools/knowledge/upload_chunk.ts
+++ b/apps/sim/tools/knowledge/upload_chunk.ts
@@ -29,8 +29,9 @@ export const knowledgeUploadChunkTool: ToolConfig<any, KnowledgeUploadChunkRespo
   },
 
   request: {
+    internalRoute: true,
     url: (params) =>
-      `/api/knowledge/${params.knowledgeBaseId}/documents/${params.documentId}/chunks`,
+      `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents/${encodeURIComponent(params.documentId)}/chunks`,
     method: 'POST',
     secretProvenance: {
       request: () => [{ key: 'chunk-content', inputPaths: [['content']] }],

--- a/apps/sim/tools/knowledge/upsert_document.ts
+++ b/apps/sim/tools/knowledge/upsert_document.ts
@@ -60,7 +60,9 @@ export const knowledgeUpsertDocumentTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `/api/knowledge/${params.knowledgeBaseId}/documents/upsert`,
+    internalRoute: true,
+    url: (params) =>
+      `/api/knowledge/${encodeURIComponent(params.knowledgeBaseId)}/documents/upsert`,
     method: 'POST',
     secretProvenance: {
       request: selectKnowledgeDocumentWriteSecretProvenance,

--- a/apps/sim/tools/llm/chat.ts
+++ b/apps/sim/tools/llm/chat.ts
@@ -128,7 +128,7 @@ export const llmChatTool: ToolConfig<LLMChatParams, LLMChatResponse> = {
   },
 
   request: {
-    url: () => '/api/providers',
+    url: '/api/providers',
     method: 'POST',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/logs/get_execution.ts
+++ b/apps/sim/tools/logs/get_execution.ts
@@ -18,6 +18,7 @@ export const logsGetExecutionTool: ToolConfig<LogsGetExecutionParams, LogsGetExe
   },
 
   request: {
+    internalRoute: true,
     url: (params) => `/api/logs/execution/${encodeURIComponent(params.executionId)}`,
     method: 'GET',
     headers: () => ({

--- a/apps/sim/tools/logs/get_log.ts
+++ b/apps/sim/tools/logs/get_log.ts
@@ -17,6 +17,7 @@ export const logsGetTool: ToolConfig<LogsGetParams, LogsGetResponse> = {
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/logs/get_run_details.ts
+++ b/apps/sim/tools/logs/get_run_details.ts
@@ -21,6 +21,7 @@ export const logsGetRunDetailsTool: ToolConfig<LogsGetRunDetailsParams, LogsGetR
     },
 
     request: {
+      internalRoute: true,
       url: (params) => {
         const workspaceId = params._context?.workspaceId
         if (!workspaceId) {

--- a/apps/sim/tools/logs/query.ts
+++ b/apps/sim/tools/logs/query.ts
@@ -78,6 +78,7 @@ export const logsQueryTool: ToolConfig<LogsQueryParams, LogsQueryResponse> = {
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/logs/query_runs.ts
+++ b/apps/sim/tools/logs/query_runs.ts
@@ -99,6 +99,7 @@ export const logsQueryRunsTool: ToolConfig<LogsQueryRunsParams, LogsQueryRunsRes
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/memory/delete.ts
+++ b/apps/sim/tools/memory/delete.ts
@@ -25,6 +25,7 @@ export const memoryDeleteTool: ToolConfig<any, MemoryResponse> = {
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/memory/get.ts
+++ b/apps/sim/tools/memory/get.ts
@@ -25,6 +25,7 @@ export const memoryGetTool: ToolConfig<any, MemoryResponse> = {
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/memory/get_all.ts
+++ b/apps/sim/tools/memory/get_all.ts
@@ -10,6 +10,7 @@ export const memoryGetAllTool: ToolConfig<any, MemoryResponse> = {
   params: {},
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/microsoft_teams/delete_chat_message.ts
+++ b/apps/sim/tools/microsoft_teams/delete_chat_message.ts
@@ -47,6 +47,7 @@ export const deleteChatMessageTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const chatId = params.chatId?.trim()
       const messageId = params.messageId?.trim()

--- a/apps/sim/tools/microsoft_teams/write_channel.ts
+++ b/apps/sim/tools/microsoft_teams/write_channel.ts
@@ -62,6 +62,7 @@ export const writeChannelTool: ToolConfig<MicrosoftTeamsToolParams, MicrosoftTea
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const teamId = params.teamId?.trim()
       if (!teamId) {

--- a/apps/sim/tools/microsoft_teams/write_chat.ts
+++ b/apps/sim/tools/microsoft_teams/write_chat.ts
@@ -54,6 +54,7 @@ export const writeChatTool: ToolConfig<MicrosoftTeamsToolParams, MicrosoftTeamsW
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       // Ensure chatId is valid
       const chatId = params.chatId?.trim()

--- a/apps/sim/tools/onedrive/upload.ts
+++ b/apps/sim/tools/onedrive/upload.ts
@@ -56,6 +56,7 @@ export const uploadTool: ToolConfig<OneDriveToolParams, OneDriveUploadResponse> 
   },
 
   request: {
+    internalRoute: true,
     url: (params) => {
       const isExcelFile =
         params.mimeType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'

--- a/apps/sim/tools/params.ts
+++ b/apps/sim/tools/params.ts
@@ -776,10 +776,10 @@ async function fetchWorkflowInputFields(
   workflowId: string
 ): Promise<Array<{ name: string; type: string; description?: string }>> {
   try {
-    const { buildAuthHeaders, buildInternalApiUrl } = await import('@/executor/utils/http')
+    const { buildAuthHeaders, internalApiUrl } = await import('@/executor/utils/http')
 
     const headers = await buildAuthHeaders()
-    const url = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}`)
+    const url = internalApiUrl`/api/workflows/${workflowId}`
 
     const response = await fetch(url.toString(), { headers })
     if (!response.ok) {

--- a/apps/sim/tools/params.ts
+++ b/apps/sim/tools/params.ts
@@ -776,10 +776,10 @@ async function fetchWorkflowInputFields(
   workflowId: string
 ): Promise<Array<{ name: string; type: string; description?: string }>> {
   try {
-    const { buildAuthHeaders, buildAPIUrl } = await import('@/executor/utils/http')
+    const { buildAuthHeaders, buildInternalApiUrl } = await import('@/executor/utils/http')
 
     const headers = await buildAuthHeaders()
-    const url = buildAPIUrl(`/api/workflows/${workflowId}`)
+    const url = buildInternalApiUrl(`/api/workflows/${encodeURIComponent(workflowId)}`)
 
     const response = await fetch(url.toString(), { headers })
     if (!response.ok) {

--- a/apps/sim/tools/request-transport.test.ts
+++ b/apps/sim/tools/request-transport.test.ts
@@ -60,20 +60,30 @@ describe('private-provenance tool registry invariant', () => {
   )
 })
 
-function buildProbeTool(request: Partial<ToolConfig['request']>): ToolConfig {
+interface ProbeParams {
+  url: string
+  tableId: string
+}
+
+function buildProbeTool(
+  request: Partial<ToolConfig<ProbeParams>['request']>
+): ToolConfig<ProbeParams> {
   return {
     id: 'probe_tool',
     name: 'Probe',
     description: 'probe',
     version: '1.0.0',
-    params: { url: { type: 'string', visibility: 'user-or-llm' } },
+    params: {
+      url: { type: 'string', visibility: 'user-or-llm' },
+      tableId: { type: 'string', visibility: 'user-or-llm' },
+    },
     request: {
       url: '/api/probe',
       method: 'GET',
       headers: () => ({}),
       ...request,
     },
-  } as ToolConfig
+  }
 }
 
 describe('internal transport selection', () => {
@@ -87,7 +97,7 @@ describe('internal transport selection', () => {
     const prepared = prepareToolRequest(
       buildProbeTool({
         internalRoute: true,
-        url: (params: Record<string, any>) => `/api/table/${params.tableId}/rows`,
+        url: (params) => `/api/table/${params.tableId}/rows`,
       }),
       { tableId: 'table-1' }
     )
@@ -106,7 +116,7 @@ describe('internal transport selection', () => {
 
   it('rejects private provenance on an undeclared builder that emits an internal path', () => {
     const tool = buildProbeTool({
-      url: (params: Record<string, any>) => params.url,
+      url: (params) => params.url,
       body: () => ({ probe: true }),
       modelInput: { mode: 'private-provenance', inputPaths: () => [] },
     })

--- a/apps/sim/tools/request-transport.test.ts
+++ b/apps/sim/tools/request-transport.test.ts
@@ -59,3 +59,130 @@ describe('private-provenance tool registry invariant', () => {
     }
   )
 })
+
+function buildProbeTool(request: Partial<ToolConfig['request']>): ToolConfig {
+  return {
+    id: 'probe_tool',
+    name: 'Probe',
+    description: 'probe',
+    version: '1.0.0',
+    params: { url: { type: 'string', visibility: 'user-or-llm' } },
+    request: {
+      url: '/api/probe',
+      method: 'GET',
+      headers: () => ({}),
+      ...request,
+    },
+  } as ToolConfig
+}
+
+describe('internal transport selection', () => {
+  it('trusts a statically configured internal URL', () => {
+    const prepared = prepareToolRequest(buildProbeTool({ url: '/api/probe' }), {})
+
+    expect(prepared.isInternalRoute).toBe(true)
+  })
+
+  it('trusts a URL builder that declares an internal route', () => {
+    const prepared = prepareToolRequest(
+      buildProbeTool({
+        internalRoute: true,
+        url: (params: Record<string, any>) => `/api/table/${params.tableId}/rows`,
+      }),
+      { tableId: 'table-1' }
+    )
+
+    expect(prepared.isInternalRoute).toBe(true)
+  })
+
+  it('does not trust a declared internal tool that resolves to an external URL', () => {
+    const prepared = prepareToolRequest(
+      buildProbeTool({ internalRoute: true, url: () => 'https://attacker.example/x' }),
+      {}
+    )
+
+    expect(prepared.isInternalRoute).toBe(false)
+  })
+
+  it('rejects private provenance on an undeclared builder that emits an internal path', () => {
+    const tool = buildProbeTool({
+      url: (params: Record<string, any>) => params.url,
+      body: () => ({ probe: true }),
+      modelInput: { mode: 'private-provenance', inputPaths: () => [] },
+    })
+
+    expect(() =>
+      prepareToolRequest(tool, { url: '/api/probe' }, new ResolvedSecretTraceRegistry())
+    ).toThrow(/internal routes/)
+  })
+})
+
+describe('caller-supplied tool URLs never reach the internal transport', () => {
+  it.each(['http_request', 'webhook_request'])(
+    '%s cannot mint an internal request from a relative URL',
+    (toolId) => {
+      const prepared = prepareToolRequest(tools[toolId], {
+        url: '/api/auth/oauth/token',
+        method: 'POST',
+        body: { credentialId: 'cred-1' },
+      })
+
+      expect(prepared.isInternalRoute).toBe(false)
+    }
+  )
+
+  it('keeps a self-hosted integration external when its host param is blank', () => {
+    const prepared = prepareToolRequest(tools.grafana_list_folders, {
+      baseUrl: '',
+      serviceAccountToken: 'token',
+    })
+
+    expect(prepared.url).toMatch(/^\/api\//)
+    expect(prepared.isInternalRoute).toBe(false)
+  })
+
+  const workspaceContext = { _context: { workspaceId: 'workspace-1', userId: 'user-1' } }
+
+  it.each([
+    ['function_execute', { code: 'return 1' }],
+    ['knowledge_search', { knowledgeBaseIds: ['kb-1'], query: 'q' }],
+    ['memory_get_all', workspaceContext],
+    ['table_list', workspaceContext],
+    ['workflow_executor', { workflowId: 'workflow-1' }],
+  ])('%s still uses the internal transport', (toolId, params) => {
+    const prepared = prepareToolRequest(tools[toolId], params)
+
+    expect(prepared.isInternalRoute).toBe(true)
+  })
+})
+
+const PROBE_HOST = 'https://internal-route-probe.invalid'
+
+const declaredInternalTools = Object.entries(tools).filter(
+  ([, tool]) => tool.request.internalRoute === true
+)
+
+describe('declared internal tool registry invariant', () => {
+  it('covers at least one registered tool', () => {
+    expect(declaredInternalTools.length).toBeGreaterThan(0)
+  })
+
+  it.each(declaredInternalTools)(
+    '%s keeps its internal path out of reach of its params',
+    (registryId, tool) => {
+      const probeParams: Record<string, unknown> = {
+        _context: { workspaceId: 'workspace-1', userId: 'user-1' },
+      }
+      for (const name of Object.keys(tool.params)) probeParams[name] = PROBE_HOST
+
+      let url: string
+      try {
+        url = (tool.request.url as (params: Record<string, unknown>) => string)(probeParams)
+      } catch {
+        return
+      }
+
+      expect(url, `${registryId} builds its host from a caller-supplied param`).toMatch(/^\/api\//)
+    }
+  )
+})

--- a/apps/sim/tools/request-transport.ts
+++ b/apps/sim/tools/request-transport.ts
@@ -121,6 +121,12 @@ export function projectToolModelInputParams(
   }
 }
 
+/** The pre-authenticated internal transport needs both a declared-internal tool and a resolved internal path. */
+function isInternalToolRoute(tool: ToolConfig, url: string): boolean {
+  if (!url.startsWith('/api/')) return false
+  return typeof tool.request.url === 'string' || tool.request.internalRoute === true
+}
+
 function formatToolRequest(tool: ToolConfig, params: Record<string, any>): PreparedToolRequest {
   const url = typeof tool.request.url === 'function' ? tool.request.url(params) : tool.request.url
   const method =
@@ -169,7 +175,7 @@ function formatToolRequest(tool: ToolConfig, params: Record<string, any>): Prepa
     timeout: validTimeout,
     proxyUrl,
     stripAuthOnRedirect: tool.request.stripAuthOnRedirect,
-    isInternalRoute: url.startsWith('/api/'),
+    isInternalRoute: isInternalToolRoute(tool, url),
   }
 }
 
@@ -187,10 +193,10 @@ export function prepareToolRequest(
     modelInput?.mode === 'private-provenance' ||
     (modelInput?.mode === 'project' && modelInput.privateInputPaths !== undefined)
 
-  if (hasPrivateModelInputProvenance && !configuredUrl.startsWith('/api/')) {
+  if (hasPrivateModelInputProvenance && !isInternalToolRoute(tool, configuredUrl)) {
     throw new Error(PRIVATE_MODEL_INPUT_EXTERNAL_URL_ERROR_MESSAGE)
   }
-  if (secretProvenance && !configuredUrl.startsWith('/api/')) {
+  if (secretProvenance && !isInternalToolRoute(tool, configuredUrl)) {
     throw new Error(PRIVATE_SECRET_PROVENANCE_EXTERNAL_URL_ERROR_MESSAGE)
   }
 

--- a/apps/sim/tools/schema-enrichers.test.ts
+++ b/apps/sim/tools/schema-enrichers.test.ts
@@ -3,20 +3,22 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockBuildAPIUrl, mockBuildAuthHeaders, mockExtractAPIErrorMessage } = vi.hoisted(() => ({
-  mockBuildAPIUrl: vi.fn((path: string, params?: Record<string, string>) => {
-    const url = new URL(path, 'http://localhost:3000')
-    for (const [key, value] of Object.entries(params ?? {})) {
-      url.searchParams.set(key, value)
-    }
-    return url
-  }),
-  mockBuildAuthHeaders: vi.fn(),
-  mockExtractAPIErrorMessage: vi.fn(),
-}))
+const { mockBuildInternalApiUrl, mockBuildAuthHeaders, mockExtractAPIErrorMessage } = vi.hoisted(
+  () => ({
+    mockBuildInternalApiUrl: vi.fn((path: string, params?: Record<string, string>) => {
+      const url = new URL(path, 'http://localhost:3000')
+      for (const [key, value] of Object.entries(params ?? {})) {
+        url.searchParams.set(key, value)
+      }
+      return url
+    }),
+    mockBuildAuthHeaders: vi.fn(),
+    mockExtractAPIErrorMessage: vi.fn(),
+  })
+)
 
 vi.mock('@/executor/utils/http', () => ({
-  buildAPIUrl: mockBuildAPIUrl,
+  buildInternalApiUrl: mockBuildInternalApiUrl,
   buildAuthHeaders: mockBuildAuthHeaders,
   extractAPIErrorMessage: mockExtractAPIErrorMessage,
 }))
@@ -101,6 +103,26 @@ describe('enrichTableToolSchema', () => {
       enrichTableToolSchema('table-1', 'table_query_rows', ORIGINAL_SCHEMA, 'Query rows', {})
     ).rejects.toThrow('Workspace ID is required to enrich table tool schema for table-1')
   })
+
+  it('keeps a traversal-shaped table id inside the table route', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })))
+    mockExtractAPIErrorMessage.mockResolvedValue('Table not found')
+
+    await expect(
+      enrichTableToolSchema(
+        '../../workflows/wf-1',
+        'table_query_rows',
+        ORIGINAL_SCHEMA,
+        'Query rows',
+        { workspaceId: 'workspace-1', userId: 'user-1' }
+      )
+    ).rejects.toThrow()
+
+    expect(mockBuildInternalApiUrl).toHaveBeenCalledWith(
+      '/api/table/..%2F..%2Fworkflows%2Fwf-1',
+      expect.anything()
+    )
+  })
 })
 
 describe('enrichKBTagsSchema', () => {
@@ -138,5 +160,15 @@ describe('enrichKBTagsSchema', () => {
     await expect(enrichKBTagsSchema('kb-1', {})).resolves.toBeNull()
     expect(mockFetch).not.toHaveBeenCalled()
     expect(mockBuildAuthHeaders).not.toHaveBeenCalled()
+  })
+
+  it('keeps a traversal-shaped knowledge base id inside the tag-definitions route', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })))
+
+    await enrichKBTagsSchema('../../workflows/wf-1', { userId: 'user-1' })
+
+    expect(mockBuildInternalApiUrl).toHaveBeenCalledWith(
+      '/api/knowledge/..%2F..%2Fworkflows%2Fwf-1/tag-definitions'
+    )
   })
 })

--- a/apps/sim/tools/schema-enrichers.test.ts
+++ b/apps/sim/tools/schema-enrichers.test.ts
@@ -3,22 +3,20 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockBuildInternalApiUrl, mockBuildAuthHeaders, mockExtractAPIErrorMessage } = vi.hoisted(
-  () => ({
-    mockBuildInternalApiUrl: vi.fn((path: string, params?: Record<string, string>) => {
-      const url = new URL(path, 'http://localhost:3000')
-      for (const [key, value] of Object.entries(params ?? {})) {
-        url.searchParams.set(key, value)
-      }
-      return url
-    }),
-    mockBuildAuthHeaders: vi.fn(),
-    mockExtractAPIErrorMessage: vi.fn(),
-  })
-)
+const { mockInternalApiUrl, mockBuildAuthHeaders, mockExtractAPIErrorMessage } = vi.hoisted(() => ({
+  mockInternalApiUrl: vi.fn(
+    (segments: TemplateStringsArray, ...values: unknown[]) =>
+      new URL(
+        String.raw({ raw: segments }, ...values.map((v) => encodeURIComponent(String(v)))),
+        'http://localhost:3000'
+      )
+  ),
+  mockBuildAuthHeaders: vi.fn(),
+  mockExtractAPIErrorMessage: vi.fn(),
+}))
 
 vi.mock('@/executor/utils/http', () => ({
-  buildInternalApiUrl: mockBuildInternalApiUrl,
+  internalApiUrl: mockInternalApiUrl,
   buildAuthHeaders: mockBuildAuthHeaders,
   extractAPIErrorMessage: mockExtractAPIErrorMessage,
 }))
@@ -105,7 +103,8 @@ describe('enrichTableToolSchema', () => {
   })
 
   it('keeps a traversal-shaped table id inside the table route', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })))
+    const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 404 }))
+    vi.stubGlobal('fetch', mockFetch)
     mockExtractAPIErrorMessage.mockResolvedValue('Table not found')
 
     await expect(
@@ -118,8 +117,8 @@ describe('enrichTableToolSchema', () => {
       )
     ).rejects.toThrow()
 
-    expect(mockBuildInternalApiUrl).toHaveBeenCalledWith(
-      '/api/table/..%2F..%2Fworkflows%2Fwf-1',
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/api/table/..%2F..%2Fworkflows%2Fwf-1?workspaceId=workspace-1',
       expect.anything()
     )
   })
@@ -163,12 +162,14 @@ describe('enrichKBTagsSchema', () => {
   })
 
   it('keeps a traversal-shaped knowledge base id inside the tag-definitions route', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })))
+    const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 404 }))
+    vi.stubGlobal('fetch', mockFetch)
 
     await enrichKBTagsSchema('../../workflows/wf-1', { userId: 'user-1' })
 
-    expect(mockBuildInternalApiUrl).toHaveBeenCalledWith(
-      '/api/knowledge/..%2F..%2Fworkflows%2Fwf-1/tag-definitions'
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/api/knowledge/..%2F..%2Fworkflows%2Fwf-1/tag-definitions',
+      expect.anything()
     )
   })
 })

--- a/apps/sim/tools/schema-enrichers.ts
+++ b/apps/sim/tools/schema-enrichers.ts
@@ -18,12 +18,14 @@ async function fetchTableSchema(
     throw new Error(`User ID is required to enrich table tool schema for ${tableId}`)
   }
 
-  const { buildAuthHeaders, buildAPIUrl, extractAPIErrorMessage } = await import(
+  const { buildAuthHeaders, buildInternalApiUrl, extractAPIErrorMessage } = await import(
     '@/executor/utils/http'
   )
 
   const headers = await buildAuthHeaders(context.userId)
-  const url = buildAPIUrl(`/api/table/${tableId}`, { workspaceId: context.workspaceId })
+  const url = buildInternalApiUrl(`/api/table/${encodeURIComponent(tableId)}`, {
+    workspaceId: context.workspaceId,
+  })
   const response = await fetch(url.toString(), { headers })
 
   if (!response.ok) {
@@ -127,10 +129,12 @@ async function fetchTagDefinitions(
   }
 
   try {
-    const { buildAuthHeaders, buildAPIUrl } = await import('@/executor/utils/http')
+    const { buildAuthHeaders, buildInternalApiUrl } = await import('@/executor/utils/http')
 
     const headers = await buildAuthHeaders(context.userId)
-    const url = buildAPIUrl(`/api/knowledge/${knowledgeBaseId}/tag-definitions`)
+    const url = buildInternalApiUrl(
+      `/api/knowledge/${encodeURIComponent(knowledgeBaseId)}/tag-definitions`
+    )
 
     logger.info(`Fetching tag definitions for KB ${knowledgeBaseId} from ${url.toString()}`)
 

--- a/apps/sim/tools/schema-enrichers.ts
+++ b/apps/sim/tools/schema-enrichers.ts
@@ -18,14 +18,13 @@ async function fetchTableSchema(
     throw new Error(`User ID is required to enrich table tool schema for ${tableId}`)
   }
 
-  const { buildAuthHeaders, buildInternalApiUrl, extractAPIErrorMessage } = await import(
+  const { buildAuthHeaders, internalApiUrl, extractAPIErrorMessage } = await import(
     '@/executor/utils/http'
   )
 
   const headers = await buildAuthHeaders(context.userId)
-  const url = buildInternalApiUrl(`/api/table/${encodeURIComponent(tableId)}`, {
-    workspaceId: context.workspaceId,
-  })
+  const url = internalApiUrl`/api/table/${tableId}`
+  url.searchParams.set('workspaceId', context.workspaceId)
   const response = await fetch(url.toString(), { headers })
 
   if (!response.ok) {
@@ -129,12 +128,10 @@ async function fetchTagDefinitions(
   }
 
   try {
-    const { buildAuthHeaders, buildInternalApiUrl } = await import('@/executor/utils/http')
+    const { buildAuthHeaders, internalApiUrl } = await import('@/executor/utils/http')
 
     const headers = await buildAuthHeaders(context.userId)
-    const url = buildInternalApiUrl(
-      `/api/knowledge/${encodeURIComponent(knowledgeBaseId)}/tag-definitions`
-    )
+    const url = internalApiUrl`/api/knowledge/${knowledgeBaseId}/tag-definitions`
 
     logger.info(`Fetching tag definitions for KB ${knowledgeBaseId} from ${url.toString()}`)
 

--- a/apps/sim/tools/search/tool.ts
+++ b/apps/sim/tools/search/tool.ts
@@ -22,7 +22,7 @@ export const searchTool: ToolConfig<SearchParams, SearchResponse> = {
       mode: 'project',
       select: (params) => ({ query: params.query }),
     },
-    url: () => '/api/tools/search',
+    url: '/api/tools/search',
     method: 'POST',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/table/batch_insert_rows.ts
+++ b/apps/sim/tools/table/batch_insert_rows.ts
@@ -35,11 +35,13 @@ export const tableBatchInsertRowsTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     secretProvenance: {
       request: (params) => selectTableRowSecretProvenance(params.rows, 'rows'),
       response: { incomplete: 'propagate' },
     },
-    url: (params: TableBatchInsertParams) => `/api/table/${params.tableId}/rows`,
+    url: (params: TableBatchInsertParams) =>
+      `/api/table/${encodeURIComponent(params.tableId)}/rows`,
     method: 'POST',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/table/delete_row.ts
+++ b/apps/sim/tools/table/delete_row.ts
@@ -23,7 +23,9 @@ export const tableDeleteRowTool: ToolConfig<TableRowDeleteParams, TableDeleteRes
   },
 
   request: {
-    url: (params: TableRowDeleteParams) => `/api/table/${params.tableId}/rows/${params.rowId}`,
+    internalRoute: true,
+    url: (params: TableRowDeleteParams) =>
+      `/api/table/${encodeURIComponent(params.tableId)}/rows/${encodeURIComponent(params.rowId)}`,
     method: 'DELETE',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/table/delete_rows_by_filter.ts
+++ b/apps/sim/tools/table/delete_rows_by_filter.ts
@@ -42,7 +42,9 @@ export const tableDeleteRowsByFilterTool: ToolConfig<
   },
 
   request: {
-    url: (params: TableDeleteByFilterParams) => `/api/table/${params.tableId}/rows`,
+    internalRoute: true,
+    url: (params: TableDeleteByFilterParams) =>
+      `/api/table/${encodeURIComponent(params.tableId)}/rows`,
     method: 'DELETE',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/table/get_row.ts
+++ b/apps/sim/tools/table/get_row.ts
@@ -23,6 +23,7 @@ export const tableGetRowTool: ToolConfig<TableRowGetParams, TableRowResponse> = 
   },
 
   request: {
+    internalRoute: true,
     secretProvenance: { response: { incomplete: 'propagate' } },
     url: (params: TableRowGetParams) => {
       const workspaceId = params._context?.workspaceId
@@ -30,7 +31,7 @@ export const tableGetRowTool: ToolConfig<TableRowGetParams, TableRowResponse> = 
         throw new Error('Workspace ID is required in execution context')
       }
 
-      return `/api/table/${params.tableId}/rows/${params.rowId}?workspaceId=${encodeURIComponent(workspaceId)}`
+      return `/api/table/${encodeURIComponent(params.tableId)}/rows/${encodeURIComponent(params.rowId)}?workspaceId=${encodeURIComponent(workspaceId)}`
     },
     method: 'GET',
     headers: () => ({

--- a/apps/sim/tools/table/get_schema.ts
+++ b/apps/sim/tools/table/get_schema.ts
@@ -19,13 +19,14 @@ export const tableGetSchemaTool: ToolConfig<TableGetSchemaParams, TableGetSchema
   },
 
   request: {
+    internalRoute: true,
     url: (params: TableGetSchemaParams) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {
         throw new Error('Workspace ID is required in execution context')
       }
 
-      return `/api/table/${params.tableId}?workspaceId=${encodeURIComponent(workspaceId)}`
+      return `/api/table/${encodeURIComponent(params.tableId)}?workspaceId=${encodeURIComponent(workspaceId)}`
     },
     method: 'GET',
     headers: () => ({

--- a/apps/sim/tools/table/insert_row.ts
+++ b/apps/sim/tools/table/insert_row.ts
@@ -32,11 +32,12 @@ export const tableInsertRowTool: ToolConfig<TableRowInsertParams, TableRowRespon
   },
 
   request: {
+    internalRoute: true,
     secretProvenance: {
       request: (params) => selectTableRowSecretProvenance([params.data]),
       response: { incomplete: 'propagate' },
     },
-    url: (params: TableRowInsertParams) => `/api/table/${params.tableId}/rows`,
+    url: (params: TableRowInsertParams) => `/api/table/${encodeURIComponent(params.tableId)}/rows`,
     method: 'POST',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/table/list.ts
+++ b/apps/sim/tools/table/list.ts
@@ -10,6 +10,7 @@ export const tableListTool: ToolConfig<TableListParams, TableListResponse> = {
   params: {},
 
   request: {
+    internalRoute: true,
     url: (params: TableListParams) => {
       const workspaceId = params._context?.workspaceId
       if (!workspaceId) {

--- a/apps/sim/tools/table/query_rows.ts
+++ b/apps/sim/tools/table/query_rows.ts
@@ -50,6 +50,7 @@ export const tableQueryRowsTool: ToolConfig<TableRowQueryParams, TableQueryRespo
   },
 
   request: {
+    internalRoute: true,
     secretProvenance: { response: { incomplete: 'propagate' } },
     url: (params: TableRowQueryParams) => {
       const workspaceId = params._context?.workspaceId
@@ -74,7 +75,7 @@ export const tableQueryRowsTool: ToolConfig<TableRowQueryParams, TableQueryRespo
         searchParams.append('offset', String(params.offset))
       }
 
-      return `/api/table/${params.tableId}/rows?${searchParams.toString()}`
+      return `/api/table/${encodeURIComponent(params.tableId)}/rows?${searchParams.toString()}`
     },
     method: 'GET',
     headers: () => ({

--- a/apps/sim/tools/table/query_rows_v2.ts
+++ b/apps/sim/tools/table/query_rows_v2.ts
@@ -57,8 +57,10 @@ export const tableQueryRowsV2Tool: ToolConfig<TableRowQueryV2Params, TableQueryV
   },
 
   request: {
+    internalRoute: true,
     secretProvenance: { response: { incomplete: 'propagate' } },
-    url: (params: TableRowQueryV2Params) => `/api/table/${params.tableId}/query`,
+    url: (params: TableRowQueryV2Params) =>
+      `/api/table/${encodeURIComponent(params.tableId)}/query`,
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     body: (params: TableRowQueryV2Params) => {

--- a/apps/sim/tools/table/update_row.ts
+++ b/apps/sim/tools/table/update_row.ts
@@ -38,11 +38,13 @@ export const tableUpdateRowTool: ToolConfig<TableRowUpdateParams, TableRowRespon
   },
 
   request: {
+    internalRoute: true,
     secretProvenance: {
       request: (params) => selectTableRowSecretProvenance([params.data]),
       response: { incomplete: 'propagate' },
     },
-    url: (params: TableRowUpdateParams) => `/api/table/${params.tableId}/rows/${params.rowId}`,
+    url: (params: TableRowUpdateParams) =>
+      `/api/table/${encodeURIComponent(params.tableId)}/rows/${encodeURIComponent(params.rowId)}`,
     method: 'PATCH',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/table/update_rows_by_filter.ts
+++ b/apps/sim/tools/table/update_rows_by_filter.ts
@@ -49,10 +49,12 @@ export const tableUpdateRowsByFilterTool: ToolConfig<
   },
 
   request: {
+    internalRoute: true,
     secretProvenance: {
       request: (params) => selectTableRowSecretProvenance([params.data]),
     },
-    url: (params: TableUpdateByFilterParams) => `/api/table/${params.tableId}/rows`,
+    url: (params: TableUpdateByFilterParams) =>
+      `/api/table/${encodeURIComponent(params.tableId)}/rows`,
     method: 'PUT',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/table/upsert_row.ts
+++ b/apps/sim/tools/table/upsert_row.ts
@@ -39,11 +39,13 @@ export const tableUpsertRowTool: ToolConfig<TableRowInsertParams, TableUpsertRes
   },
 
   request: {
+    internalRoute: true,
     secretProvenance: {
       request: (params) => selectTableRowSecretProvenance([params.data]),
       response: { incomplete: 'propagate' },
     },
-    url: (params: TableRowInsertParams) => `/api/table/${params.tableId}/rows/upsert`,
+    url: (params: TableRowInsertParams) =>
+      `/api/table/${encodeURIComponent(params.tableId)}/rows/upsert`,
     method: 'POST',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/tiktok/upload_video_draft.ts
+++ b/apps/sim/tools/tiktok/upload_video_draft.ts
@@ -37,7 +37,7 @@ export const tiktokUploadVideoDraftTool: ToolConfig<
   },
 
   request: {
-    url: () => '/api/tools/tiktok/upload-video-draft',
+    url: '/api/tools/tiktok/upload-video-draft',
     method: 'POST',
     headers: () => ({
       'Content-Type': 'application/json',

--- a/apps/sim/tools/types.ts
+++ b/apps/sim/tools/types.ts
@@ -175,6 +175,15 @@ export interface ToolConfig<P = any, R = any> {
   // Request configuration
   request: {
     url: string | ((params: P) => string)
+    /**
+     * Declares that this tool targets Sim's own API, authorizing the transport to resolve the
+     * request against the internal base URL and sign it for the executing user.
+     *
+     * Required for every tool whose `url` is a builder returning an internal path. A static `url`
+     * string is self-declaring; a builder is not, because params steer its output — a blank host
+     * param collapses `${host}/api/v2/x` to `/api/v2/x`.
+     */
+    internalRoute?: boolean
     method: HttpMethod | ((params: P) => HttpMethod)
     headers: (params: P) => Record<string, string>
     body?: (params: P) => Record<string, any> | string | FormData | undefined

--- a/apps/sim/tools/wordpress/upload_media.ts
+++ b/apps/sim/tools/wordpress/upload_media.ts
@@ -63,7 +63,7 @@ export const uploadMediaTool: ToolConfig<WordPressUploadMediaParams, WordPressUp
     },
 
     request: {
-      url: () => '/api/tools/wordpress/upload',
+      url: '/api/tools/wordpress/upload',
       method: 'POST',
       headers: () => ({
         'Content-Type': 'application/json',

--- a/apps/sim/tools/workflow/executor.ts
+++ b/apps/sim/tools/workflow/executor.ts
@@ -34,7 +34,9 @@ export const workflowExecutorTool: ToolConfig<
     },
   },
   request: {
-    url: (params: WorkflowExecutorParams) => `/api/workflows/${params.workflowId}/execute`,
+    internalRoute: true,
+    url: (params: WorkflowExecutorParams) =>
+      `/api/workflows/${encodeURIComponent(params.workflowId)}/execute`,
     method: 'POST',
     headers: () => ({ 'Content-Type': 'application/json' }),
     secretProvenance: {

--- a/packages/testing/src/mocks/executor.mock.ts
+++ b/packages/testing/src/mocks/executor.mock.ts
@@ -73,7 +73,13 @@ vi.mock('@/executor/resolver', () => ({
 }))
 vi.mock('@/executor/utils/http', () => ({
   buildAuthHeaders: vi.fn().mockResolvedValue({ 'Content-Type': 'application/json' }),
-  buildInternalApiUrl: vi.fn((path: string) => new URL(path, 'http://localhost:3000')),
+  internalApiUrl: vi.fn(
+    (segments: TemplateStringsArray, ...values: unknown[]) =>
+      new URL(
+        String.raw({ raw: segments }, ...values.map((v) => encodeURIComponent(String(v)))),
+        'http://localhost:3000'
+      )
+  ),
   extractAPIErrorMessage: vi.fn(async (response: Response) => {
     const defaultMessage = `API request failed with status ${response.status}`
     try {

--- a/packages/testing/src/mocks/executor.mock.ts
+++ b/packages/testing/src/mocks/executor.mock.ts
@@ -73,7 +73,7 @@ vi.mock('@/executor/resolver', () => ({
 }))
 vi.mock('@/executor/utils/http', () => ({
   buildAuthHeaders: vi.fn().mockResolvedValue({ 'Content-Type': 'application/json' }),
-  buildAPIUrl: vi.fn((path: string) => new URL(path, 'http://localhost:3000')),
+  buildInternalApiUrl: vi.fn((path: string) => new URL(path, 'http://localhost:3000')),
   extractAPIErrorMessage: vi.fn(async (response: Response) => {
     const defaultMessage = `API request failed with status ${response.status}`
     try {


### PR DESCRIPTION
## Summary
- Internal tool routing is now declared by the tool definition instead of inferred from the resolved URL string. A static `url` string self-declares; a `url` builder must set `request.internalRoute`.
- Collapsed constant `url: () => '/api/...'` builders to plain static strings so the declaration and the URL stay coupled.
- Encoded interpolated ids in internal tool paths.
- Added registry invariants covering both directions plus the retry-path test fixture.

## Type of Change
- [x] Improvement

## Testing
`bun run type-check`, `bun run lint`, and the tools/executor/providers/knowledge suites pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)