### PR TITLE
fix(cli): generate per-install secrets instead of using fixed values

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { execSync, spawn } from 'child_process'
 import { randomBytes } from 'crypto'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 import { createInterface } from 'readline'
@@ -27,6 +27,10 @@ const AES_KEY_PATTERN = /^[0-9a-f]{64}$/i
  * Postgres volume under `~/.simstudio/data`, so minting a fresh one each launch would
  * leave that data permanently unreadable. Any value that is not a 32-byte hex key is
  * replaced.
+ *
+ * Permissions are reasserted on every run: `writeFileSync`'s `mode` applies only when it
+ * creates the file, so a file left by an earlier run — or one the user created — would
+ * otherwise keep whatever mode it already had and stay readable by other local accounts.
  */
 function resolveSecrets(): Record<string, string> {
   const configDir = join(homedir(), '.simstudio')
@@ -49,6 +53,8 @@ function resolveSecrets(): Record<string, string> {
     writeFileSync(secretsPath, `${contents}\n`, { mode: 0o600 })
     console.log(chalk.gray(`🔑 Generated local secrets in ${secretsPath}`))
   }
+
+  chmodSync(secretsPath, 0o600)
 
   return secrets
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { execSync, spawn } from 'child_process'
-import { existsSync, mkdirSync } from 'fs'
+import { randomBytes } from 'crypto'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 import { createInterface } from 'readline'
@@ -14,6 +15,43 @@ const MIGRATIONS_CONTAINER = 'simstudio-migrations'
 const REALTIME_CONTAINER = 'simstudio-realtime'
 const APP_CONTAINER = 'simstudio-app'
 const DEFAULT_PORT = '3000'
+
+const SECRET_KEYS = ['BETTER_AUTH_SECRET', 'ENCRYPTION_KEY', 'INTERNAL_API_SECRET'] as const
+
+const AES_KEY_PATTERN = /^[0-9a-f]{64}$/i
+
+/**
+ * Per-install secrets, generated on first run and reused afterwards.
+ *
+ * They have to persist: `ENCRYPTION_KEY` decrypts credentials already stored in the
+ * Postgres volume under `~/.simstudio/data`, so minting a fresh one each launch would
+ * leave that data permanently unreadable. Any value that is not a 32-byte hex key is
+ * replaced.
+ */
+function resolveSecrets(): Record<string, string> {
+  const configDir = join(homedir(), '.simstudio')
+  const secretsPath = join(configDir, 'secrets.env')
+  const secrets: Record<string, string> = {}
+
+  if (existsSync(secretsPath)) {
+    for (const line of readFileSync(secretsPath, 'utf8').split('\n')) {
+      const separator = line.indexOf('=')
+      if (separator > 0) secrets[line.slice(0, separator).trim()] = line.slice(separator + 1).trim()
+    }
+  }
+
+  const missing = SECRET_KEYS.filter((key) => !AES_KEY_PATTERN.test(secrets[key] ?? ''))
+  for (const key of missing) secrets[key] = randomBytes(32).toString('hex')
+
+  if (missing.length > 0) {
+    mkdirSync(configDir, { recursive: true })
+    const contents = SECRET_KEYS.map((key) => `${key}=${secrets[key]}`).join('\n')
+    writeFileSync(secretsPath, `${contents}\n`, { mode: 0o600 })
+    console.log(chalk.gray(`🔑 Generated local secrets in ${secretsPath}`))
+  }
+
+  return secrets
+}
 
 const program = new Command()
 
@@ -196,6 +234,8 @@ async function main() {
     process.exit(1)
   }
 
+  const secrets = resolveSecrets()
+
   // Start the realtime server
   console.log(chalk.blue('🔄 Starting Realtime Server...'))
   const realtimeSuccess = await runCommand([
@@ -215,7 +255,9 @@ async function main() {
     '-e',
     `NEXT_PUBLIC_APP_URL=http://localhost:${port}`,
     '-e',
-    'BETTER_AUTH_SECRET=your_auth_secret_here',
+    `BETTER_AUTH_SECRET=${secrets.BETTER_AUTH_SECRET}`,
+    '-e',
+    `INTERNAL_API_SECRET=${secrets.INTERNAL_API_SECRET}`,
     'ghcr.io/simstudioai/realtime:latest',
   ])
 
@@ -243,9 +285,11 @@ async function main() {
     '-e',
     `NEXT_PUBLIC_APP_URL=http://localhost:${port}`,
     '-e',
-    'BETTER_AUTH_SECRET=your_auth_secret_here',
+    `BETTER_AUTH_SECRET=${secrets.BETTER_AUTH_SECRET}`,
     '-e',
-    'ENCRYPTION_KEY=your_encryption_key_here',
+    `ENCRYPTION_KEY=${secrets.ENCRYPTION_KEY}`,
+    '-e',
+    `INTERNAL_API_SECRET=${secrets.INTERNAL_API_SECRET}`,
     'ghcr.io/simstudioai/simstudio:latest',
   ])
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { execSync, spawn } from 'child_process'
 import { randomBytes } from 'crypto'
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 import { createInterface } from 'readline'
@@ -28,6 +28,10 @@ const AES_KEY_PATTERN = /^[0-9a-f]{64}$/i
  * leave that data permanently unreadable. Any value that is not a 32-byte hex key is
  * replaced.
  *
+ * Regenerating one key rewrites the whole file, so the write goes to a temp file and is
+ * renamed into place: a plain write truncates first, and a crash mid-write would strand a
+ * still-valid `ENCRYPTION_KEY` and orphan the data it protects.
+ *
  * Permissions are reasserted on every run: `writeFileSync`'s `mode` applies only when it
  * creates the file, so a file left by an earlier run — or one the user created — would
  * otherwise keep whatever mode it already had and stay readable by other local accounts.
@@ -50,7 +54,9 @@ function resolveSecrets(): Record<string, string> {
   if (missing.length > 0) {
     mkdirSync(configDir, { recursive: true })
     const contents = SECRET_KEYS.map((key) => `${key}=${secrets[key]}`).join('\n')
-    writeFileSync(secretsPath, `${contents}\n`, { mode: 0o600 })
+    const pending = `${secretsPath}.tmp`
+    writeFileSync(pending, `${contents}\n`, { mode: 0o600 })
+    renameSync(pending, secretsPath)
     console.log(chalk.gray(`🔑 Generated local secrets in ${secretsPath}`))
   }
 


### PR DESCRIPTION
## Summary
- The launcher passed the same built-in values for `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` to every install. It now generates them once per install and reuses them.
- Secrets persist at `~/.simstudio/secrets.env` (written `0600`). Reuse matters: `ENCRYPTION_KEY` decrypts data already in the Postgres volume under `~/.simstudio/data`, so a fresh key each launch would orphan it.
- Also passes `INTERNAL_API_SECRET`, which the realtime container requires and never received.

## Type of Change
- [x] Bug fix

## Testing
Exercised the secret resolution directly: values are 64-hex and distinct per key, stable across repeated runs, a non-conforming stored value is replaced, a valid uppercase hex key is preserved rather than rotated, and the file is written `0600`. Typecheck and lint clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)