### PR TITLE
fix(files): make the rich-markdown-field container a positioning context

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
@@ -182,7 +182,9 @@ function LoadedRichMarkdownField({
     <div
       ref={containerRef}
       className={cn(
-        'flex flex-col px-3 py-2',
+        // `relative` makes this the positioning context for the bubble menu, which is
+        // appended here and absolutely positioned so it tracks the selection through scroll.
+        'relative flex flex-col px-3 py-2',
         // Only a capped box scrolls itself. Uncapped, the box grows and the page
         // scrolls — making it a scroll container anyway would clip the bubble
         // menu against an edge that never moves.


### PR DESCRIPTION
## Summary
- Follow-up to #6434 (native-pin bubble menus). That PR appended the menus into their scroll container using TipTap's default `absolute` strategy and made `rich-markdown-editor`'s container a positioning context (`relative`) — but `rich-markdown-field` **also** mounts `EditorBubbleMenu` with its own container ref and was missed.
- Without `relative` there, the absolutely-positioned toolbar resolves against the wrong offset parent, so scroll tracking breaks in the field. Caught by Cursor Bugbot on #6434 after it merged.
- Adds `relative` to the field container. Safe in both modes: it adds no offset and no clipping, including the uncapped (page-scrolls) box.

## Type of Change
- [x] Bug fix

## Testing
Empirically verified in a harness against the real menu component: in the field's **uncapped/page-scroll** mode the toolbar pins to the cursor with **0 px** drift on window scroll (the previously untested path). Capped mode uses the same mechanism already verified on #6434. 521 editor tests pass; type-check + biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)