### PR TITLE
fix(webhooks): drop the AgentMail-specific webhook body cap

### DIFF
--- a/apps/sim/app/api/webhooks/agentmail/route.test.ts
+++ b/apps/sim/app/api/webhooks/agentmail/route.test.ts
@@ -88,7 +88,7 @@ vi.mock('@/lib/mothership/inbox/executor', () => ({
   executeInboxTask: mockExecuteInboxTask,
 }))
 
-import { AGENTMAIL_WEBHOOK_MAX_BODY_BYTES, WEBHOOK_MAX_BODY_BYTES } from '@/lib/webhooks/constants'
+import { WEBHOOK_MAX_BODY_BYTES } from '@/lib/webhooks/constants'
 import { POST } from '@/app/api/webhooks/agentmail/route'
 
 const TARGET_INBOX_ID = 'agent-b@agentmail.to'
@@ -191,13 +191,13 @@ describe('POST /api/webhooks/agentmail', () => {
     expect(mockVerify).not.toHaveBeenCalled()
   })
 
-  it('rejects a body above the AgentMail cap even though it fits the shared webhook cap', async () => {
-    const oversized = AGENTMAIL_WEBHOOK_MAX_BODY_BYTES + 1
-    expect(oversized).toBeLessThan(WEBHOOK_MAX_BODY_BYTES)
+  it('rejects an oversized body before parsing or hashing it', async () => {
+    const oversized = WEBHOOK_MAX_BODY_BYTES + 1
 
     const response = await POST(webhookRequest(envelope(), { 'content-length': String(oversized) }))
 
     expect(response.status).toBe(413)
+    expect(dbChainMockFns.select).not.toHaveBeenCalled()
     expect(mockVerify).not.toHaveBeenCalled()
   })
 

--- a/apps/sim/app/api/webhooks/agentmail/route.ts
+++ b/apps/sim/app/api/webhooks/agentmail/route.ts
@@ -32,7 +32,7 @@ import {
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { executeInboxTask } from '@/lib/mothership/inbox/executor'
 import type { AgentMailWebhookPayload, RejectionReason } from '@/lib/mothership/inbox/types'
-import { AGENTMAIL_WEBHOOK_MAX_BODY_BYTES } from '@/lib/webhooks/constants'
+import { WEBHOOK_MAX_BODY_BYTES } from '@/lib/webhooks/constants'
 
 const logger = createLogger('AgentMailWebhook')
 
@@ -60,13 +60,9 @@ function verifiesAgainst(
  * signature verification, so an oversized payload cannot exhaust pod memory.
  */
 async function readAgentMailBody(req: Request): Promise<string> {
-  assertContentLengthWithinLimit(
-    req.headers,
-    AGENTMAIL_WEBHOOK_MAX_BODY_BYTES,
-    AGENTMAIL_BODY_LABEL
-  )
+  assertContentLengthWithinLimit(req.headers, WEBHOOK_MAX_BODY_BYTES, AGENTMAIL_BODY_LABEL)
   const buffer = await readStreamToBufferWithLimit(req.body, {
-    maxBytes: AGENTMAIL_WEBHOOK_MAX_BODY_BYTES,
+    maxBytes: WEBHOOK_MAX_BODY_BYTES,
     label: AGENTMAIL_BODY_LABEL,
   })
   return new TextDecoder().decode(buffer)
@@ -85,7 +81,7 @@ export const POST = withRouteHandler(async (req: Request) => {
     } catch (bodyError) {
       if (isPayloadSizeLimitError(bodyError)) {
         logger.warn('Rejected oversized AgentMail webhook body', {
-          maxBytes: AGENTMAIL_WEBHOOK_MAX_BODY_BYTES,
+          maxBytes: WEBHOOK_MAX_BODY_BYTES,
           observedBytes: bodyError.observedBytes,
         })
         return NextResponse.json({ error: 'Request body too large' }, { status: 413 })

--- a/apps/sim/lib/api/contracts/webhooks.ts
+++ b/apps/sim/lib/api/contracts/webhooks.ts
@@ -86,10 +86,17 @@ export const agentMailEnvelopeSchema = z
   })
   .passthrough()
 
-/** Unverified view of an AgentMail envelope, read only to pick which secret to check. */
+/**
+ * Unverified view of an AgentMail envelope, read only to pick which secret to
+ * check. An AgentMail inbox id is the inbox's email address, so the bound is
+ * RFC 5321's maximum address length rather than an arbitrary cutoff.
+ */
 export const agentMailRoutingSchema = z.object({
   message: z.object({
-    inbox_id: z.string().min(1, 'message.inbox_id cannot be empty').max(320),
+    inbox_id: z
+      .string()
+      .min(1, 'message.inbox_id cannot be empty')
+      .max(320, 'message.inbox_id exceeds the maximum email address length'),
   }),
 })
 

--- a/apps/sim/lib/webhooks/constants.ts
+++ b/apps/sim/lib/webhooks/constants.ts
@@ -10,11 +10,3 @@ import { env } from '@/lib/core/config/env'
  */
 export const WEBHOOK_MAX_BODY_BYTES =
   Number.parseInt(env.WEBHOOK_MAX_REQUEST_BYTES, 10) || 10 * 1024 * 1024
-
-/**
- * Bounds the body an unauthenticated caller can make the AgentMail receiver
- * buffer, parse and HMAC. AgentMail delivers attachments by reference, so an
- * envelope is headers plus the text/HTML parts; 4 MB still fits rich HTML with
- * inline `data:` images, which a tighter cap would reject as lost mail.
- */
-export const AGENTMAIL_WEBHOOK_MAX_BODY_BYTES = Math.min(WEBHOOK_MAX_BODY_BYTES, 4 * 1024 * 1024)


### PR DESCRIPTION
Follow-up audit of #6431. The receiver carried its own 4 MB body cap, justified on the grounds that it is the only public receiver that parses an unverified body before authenticating.

That justification was wrong. `app/api/webhooks/trigger/[path]/route.ts` calls `parseWebhookBody` (which `JSON.parse`s up to the shared cap) well before `verifyProviderAuth`, on an equally public path. The AgentMail receiver has the same exposure profile as its sibling, so a separate, tighter cap was an inconsistent limit rather than a principled one — and it could reject a large-but-legitimate email outright, which the shared cap would have accepted.

Removing it costs nothing security-wise: the one-signature-check-per-request property comes from the tenant lookup and its unique index, not from the body cap. This also removes the only backwards-incompatible behavior change in #6431 and avoids setting a per-provider-constant precedent in a shared module.

Also documents why the routing id is bounded at 320 characters (RFC 5321 max address length, since an AgentMail inbox id *is* an email address) so it doesn't read as arbitrary.

## Audit findings that needed no change

- **Only two writers of `workspace.inbox_provider_id`** (`enableInbox` sets a freshly minted id, `disableInbox` nulls it), so the unique index cannot be violated by any existing flow.
- **No webhook rows with a null provider id**, so the routing lookup cannot strand an existing tenant.
- **The enable-path race is unchanged.** Between the webhook row insert and the workspace update, the old code verified the signature and then failed its `inboxProviderId` mismatch check; the new code fails the lookup. Both return 401 and both rely on provider retry.
- **The partial index is used for a bare equality predicate** — verified with `EXPLAIN` against an existing `WHERE col IS NOT NULL` partial index on the same server, which plans an index scan without the query restating the predicate.

## Testing

Existing suites pass (620 across webhooks/mothership). The body-cap test now asserts the route rejects an oversized body before reaching either the database or the hash. Type-check, lint, `check:api-validation`, and `check:migrations` pass.