### PR TITLE
fix(knowledge): validate tag slots and share the tag-name length limit

### DIFF
--- a/apps/sim/app/api/knowledge/[id]/tag-definitions/route.ts
+++ b/apps/sim/app/api/knowledge/[id]/tag-definitions/route.ts
@@ -76,6 +76,11 @@ export const POST = withRouteHandler(
       if (!parsed.success) return parsed.response
 
       const validatedData = parsed.data.body
+      /**
+       * Defense-in-depth runtime check: the contract types `fieldType` as a plain
+       * string because tightening to the field-type enum cascades into UI form
+       * state types. Cast here to allow `includes` to accept the wider input.
+       */
       if (!(SUPPORTED_FIELD_TYPES as readonly string[]).includes(validatedData.fieldType)) {
         return NextResponse.json(
           { error: 'Invalid request data', details: 'Invalid field type' },


### PR DESCRIPTION
## Summary
- Validate the tag slot on write: it reached the DB unchecked (the contract types it as a plain string, the column is `text` with a types-only Drizzle `enum`, and the service casts before inserting), so an unknown slot inserted a row nothing can read
- Create route checks the slot against its declared field type using the existing `isValidSlotForFieldType`, which also closes a slot/field-type mismatch
- Bulk document route checks slot validity only — that route also renames existing definitions, which resend whatever pair is already stored, so a legacy mismatched row stays fixable
- Promote the tag display-name cap to a shared constant and apply it on every write path: both contracts, both modals, and the copilot create/update tools (model-generated names bypassed the contract entirely)
- Drop two local copies of `FIELD_TYPE_LABELS` in favour of the shared one two other components already import

## Notes
- The display-name cap was already `100` on the bulk document route; this shares that number rather than inventing one. The internal create route previously had no cap, so a >100-char name posted there now 400s
- No new helper: the slot checks reuse `isValidSlotForFieldType` / `getFieldTypeForSlot` from `lib/knowledge/constants`

## Type of Change
- [x] Bug fix

## Testing
Added route tests for unknown slot, slot/field-type mismatch, unsupported field type, and the display-name cap; verified each fails without its guard. `app/api/knowledge` + tools + copilot knowledge suites pass, `type-check`, `lint:check`, and `check:api-validation:strict` clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)