### PR TITLE
fix(inbox): disable the inbox atomically and simplify its webhook tests

### DIFF
--- a/apps/sim/app/api/webhooks/agentmail/route.test.ts
+++ b/apps/sim/app/api/webhooks/agentmail/route.test.ts
@@ -1,53 +1,24 @@
 /**
  * @vitest-environment node
  */
-import { dbChainMock, dbChainMockFns, queueTableRows, resetDbChainMock } from '@sim/testing'
+import {
+  dbChainMock,
+  dbChainMockFns,
+  queueTableRows,
+  resetDbChainMock,
+  schemaMock,
+} from '@sim/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockVerify, mockTryAdmit, mockRelease, mockEq, mockExecuteInboxTask, tables } = vi.hoisted(
-  () => ({
-    mockVerify: vi.fn(),
-    mockTryAdmit: vi.fn(),
-    mockRelease: vi.fn(),
-    mockEq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
-    mockExecuteInboxTask: vi.fn(),
-    /** Table-qualified column names keep the eq assertions unambiguous. */
-    tables: {
-      workspace: {
-        id: 'workspace.id',
-        inboxEnabled: 'workspace.inboxEnabled',
-        inboxAddress: 'workspace.inboxAddress',
-        inboxProviderId: 'workspace.inboxProviderId',
-      },
-      mothershipInboxWebhook: {
-        workspaceId: 'mothershipInboxWebhook.workspaceId',
-        secret: 'mothershipInboxWebhook.secret',
-      },
-      mothershipInboxTask: {
-        id: 'mothershipInboxTask.id',
-        chatId: 'mothershipInboxTask.chatId',
-        emailMessageId: 'mothershipInboxTask.emailMessageId',
-        responseMessageId: 'mothershipInboxTask.responseMessageId',
-        workspaceId: 'mothershipInboxTask.workspaceId',
-        createdAt: 'mothershipInboxTask.createdAt',
-        status: 'mothershipInboxTask.status',
-      },
-      mothershipInboxAllowedSender: {
-        id: 'mothershipInboxAllowedSender.id',
-        workspaceId: 'mothershipInboxAllowedSender.workspaceId',
-        email: 'mothershipInboxAllowedSender.email',
-      },
-      permissions: {
-        userId: 'permissions.userId',
-        entityType: 'permissions.entityType',
-        entityId: 'permissions.entityId',
-      },
-      user: { id: 'user.id', email: 'user.email' },
-    },
-  })
-)
+const { mockVerify, mockTryAdmit, mockRelease, mockEq, mockExecuteInboxTask } = vi.hoisted(() => ({
+  mockVerify: vi.fn(),
+  mockTryAdmit: vi.fn(),
+  mockRelease: vi.fn(),
+  mockEq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+  mockExecuteInboxTask: vi.fn(),
+}))
 
-vi.mock('@sim/db', () => ({ ...dbChainMock, ...tables }))
+vi.mock('@sim/db', () => ({ ...dbChainMock, ...schemaMock }))
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...conditions: unknown[]) => conditions),
@@ -100,18 +71,6 @@ const ROUTED_WORKSPACE = {
   webhookSecret: 'whsec_b',
 }
 
-/**
- * The two `mothershipInboxTask` lookups race inside one `Promise.all` and the
- * shared mock dequeues on resolution, so both sets must be queued empty — the
- * hourly count falls back to zero on an empty result either way.
- */
-function queueAcceptedDeliveryLookups(): void {
-  queueTableRows(tables.mothershipInboxTask, [])
-  queueTableRows(tables.mothershipInboxTask, [])
-  queueTableRows(tables.mothershipInboxAllowedSender, [{ id: 'allowed-1' }])
-  queueTableRows(tables.permissions, [])
-}
-
 function envelope(messageOverrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
     event_type: 'message.received',
@@ -156,19 +115,19 @@ describe('POST /api/webhooks/agentmail', () => {
   })
 
   it('checks the signature against only the secret the payload routes to', async () => {
-    queueTableRows(tables.workspace, [ROUTED_WORKSPACE])
+    queueTableRows(schemaMock.workspace, [ROUTED_WORKSPACE])
 
     const response = await POST(webhookRequest(envelope()))
 
     expect(response.status).toBe(401)
-    expect(mockEq).toHaveBeenCalledWith(tables.workspace.inboxProviderId, TARGET_INBOX_ID)
+    expect(mockEq).toHaveBeenCalledWith(schemaMock.workspace.inboxProviderId, TARGET_INBOX_ID)
     expect(dbChainMockFns.limit).toHaveBeenCalledWith(1)
     expect(mockVerify).toHaveBeenCalledTimes(1)
     expect(mockVerify).toHaveBeenCalledWith('whsec_b', expect.any(String), expect.any(Object))
   })
 
   it('rejects a payload naming an inbox no workspace owns, without hashing it', async () => {
-    queueTableRows(tables.workspace, [])
+    queueTableRows(schemaMock.workspace, [])
     mockVerify.mockReturnValue(undefined)
 
     const response = await POST(
@@ -177,6 +136,10 @@ describe('POST /api/webhooks/agentmail', () => {
 
     expect(response.status).toBe(401)
     expect(mockVerify).not.toHaveBeenCalled()
+    expect(mockEq).toHaveBeenCalledWith(
+      schemaMock.workspace.inboxProviderId,
+      'agent-unknown@agentmail.to'
+    )
   })
 
   it('rejects an unroutable body before it reaches the database or the hash', async () => {
@@ -212,7 +175,7 @@ describe('POST /api/webhooks/agentmail', () => {
   })
 
   it('releases the admission ticket once the request settles', async () => {
-    queueTableRows(tables.workspace, [ROUTED_WORKSPACE])
+    queueTableRows(schemaMock.workspace, [ROUTED_WORKSPACE])
 
     await POST(webhookRequest(envelope()))
 
@@ -221,8 +184,8 @@ describe('POST /api/webhooks/agentmail', () => {
 
   it('accepts a delivery whose signature verifies against the routed secret', async () => {
     mockVerify.mockReturnValue(undefined)
-    queueTableRows(tables.workspace, [ROUTED_WORKSPACE])
-    queueAcceptedDeliveryLookups()
+    queueTableRows(schemaMock.workspace, [ROUTED_WORKSPACE])
+    queueTableRows(schemaMock.mothershipInboxAllowedSender, [{ id: 'allowed-1' }])
 
     const response = await POST(webhookRequest(envelope()))
 

--- a/apps/sim/lib/mothership/inbox/lifecycle.ts
+++ b/apps/sim/lib/mothership/inbox/lifecycle.ts
@@ -119,9 +119,17 @@ export async function disableInbox(workspaceId: string): Promise<void> {
   }
   await Promise.all(deletePromises)
 
-  await Promise.all([
-    db.delete(mothershipInboxWebhook).where(eq(mothershipInboxWebhook.workspaceId, workspaceId)),
-    db
+  /**
+   * Atomic so the two rows cannot disagree. `workspace.inboxProviderId` is
+   * uniquely indexed, so a half-applied disable would strand the id of an
+   * AgentMail inbox that no longer exists — and the next workspace to claim that
+   * same address would then fail to enable at all.
+   */
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(mothershipInboxWebhook)
+      .where(eq(mothershipInboxWebhook.workspaceId, workspaceId))
+    await tx
       .update(workspace)
       .set({
         inboxEnabled: false,
@@ -129,8 +137,8 @@ export async function disableInbox(workspaceId: string): Promise<void> {
         inboxProviderId: null,
         updatedAt: new Date(),
       })
-      .where(eq(workspace.id, workspaceId)),
-  ])
+      .where(eq(workspace.id, workspaceId))
+  })
 
   logger.info('Inbox disabled', { workspaceId })
 }


### PR DESCRIPTION
Follow-up audit of #6431 and #6436. Two findings, one behavioral and one test-quality.

## Atomic disable

`disableInbox` deleted the webhook row and cleared the workspace inbox columns as two independent statements in a `Promise.all`. That was tolerable before, but `workspace.inbox_provider_id` is now uniquely indexed, which turns a half-applied disable into a fatal state: the workspace keeps the id of an AgentMail inbox that has already been deleted, that address becomes free at the provider, and the next workspace to claim the same username gets the same id back — so its `enableInbox` fails on the unique constraint and surfaces a raw Postgres error to the admin.

Narrow (needs a partial failure *plus* username reuse) and self-inflicted, but it is a state the index newly makes unrecoverable, so both writes now run in one transaction. The AgentMail API deletes still happen before it, so no external I/O is held inside the transaction.

## Test simplification

- Dropped a ~35-line hand-rolled table fixture that `schemaMock` from `@sim/testing` already provides; the file now uses the repo idiom `vi.mock('@sim/db', () => ({ ...dbChainMock, ...schemaMock }))`.
- Dropped a helper whose four `queueTableRows` calls were three-quarters no-ops — the shared chain mock already resolves unqueued chains to an empty array — along with its TSDoc, which was wrong about why the calls were needed.
- The unknown-inbox test previously queued an empty workspace result, which made it pass against the pre-fix code too. It now asserts the routed inbox id reaches the lookup, so it discriminates.

Verified by checking out the pre-fix route from `main` and running the suite against it: 6 of 7 tests fail. The seventh is the oversized-body test, which guards the shared body cap that predates all of this and correctly passes on both.

## Audit findings that needed no change

Recorded so they are on file rather than re-derived later:

- **No legitimate delivery that previously succeeded now fails.** Traced enable, rename, entitlement lapse, and both partial-write windows. In the one window that looked like a regression (webhook row written, workspace row not yet updated) the old code verified the signature and then failed its `inboxProviderId` mismatch check — same 401, same provider retry.
- **The unverified inbox id influences nothing but secret selection.** After the verification gate it is never read again; every downstream field comes from the post-verification parse. All 401 paths return an identical status and body, and both branches pay the same indexed round-trip, so there is no enumeration oracle.
- **Removing the old post-verification mismatch check is provably redundant** — there is now a single `JSON.parse`, so the routing id and the message id are the same object property.
- **Every writer of `inbox_provider_id` audited**: only `enableInbox` and `disableInbox`. Workspace creation and forking both omit the column, and no script-migration touches it.