### PR TITLE
improvement(files): share bubble-menu chrome and stabilize shouldShow

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu-chrome.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu-chrome.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared chrome for the editor's selection-driven bubble toolbars — the text formatting bar and the
+ * table bar. Single source of truth so the two read identically; never re-derive this class string
+ * per consumer.
+ */
+
+/** The floating toolbar: bordered card, popover layer, with the enter animation. */
+export const BUBBLE_MENU_CLASS =
+  'fade-in-0 z-[var(--z-popover)] flex animate-in items-center gap-0.5 rounded-lg border border-[var(--border)] bg-[var(--bg)] p-1 shadow-sm duration-150 ease-out motion-reduce:animate-none'

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Blimp,
   Bold,
@@ -20,6 +20,7 @@ import { PluginKey } from '@tiptap/pm/state'
 import type { Editor } from '@tiptap/react'
 import { useEditorState } from '@tiptap/react'
 import { BubbleMenu } from '@tiptap/react/menus'
+import { BUBBLE_MENU_CLASS } from './bubble-menu-chrome'
 import { applyLink, LinkUrlInput } from './link-editing'
 import { ToolbarButton, ToolbarDivider } from './toolbar-button'
 import { useBubbleMenuFloating } from './use-bubble-menu-floating'
@@ -181,6 +182,18 @@ export function EditorBubbleMenu({
 
   const { resolveAnchor, appendTo } = useBubbleMenuFloating(editor, scrollContainerRef)
 
+  const shouldShow = useCallback(
+    ({ editor: e, from, to }: { editor: Editor; from: number; to: number }) => {
+      // Read-only never shows the menu — even mid-link-edit (e.g. a stream starting) — so a link
+      // can't be applied to a doc that must not mutate.
+      if (!e.isEditable) return false
+      if (isEditingLink) return true
+      if (isPointerDownRef.current) return false
+      return hasFormattableSelection(e, from, to)
+    },
+    [isEditingLink]
+  )
+
   return (
     <BubbleMenu
       editor={editor}
@@ -190,15 +203,8 @@ export function EditorBubbleMenu({
       role='toolbar'
       aria-label='Text formatting'
       updateDelay={0}
-      shouldShow={({ editor: e, from, to }) => {
-        // Read-only never shows the menu — even mid-link-edit (e.g. a stream starting) — so a link
-        // can't be applied to a doc that must not mutate.
-        if (!e.isEditable) return false
-        if (isEditingLink) return true
-        if (isPointerDownRef.current) return false
-        return hasFormattableSelection(e, from, to)
-      }}
-      className='fade-in-0 z-[var(--z-popover)] flex animate-in items-center gap-0.5 rounded-lg border border-[var(--border)] bg-[var(--bg)] p-1 shadow-sm duration-150 ease-out motion-reduce:animate-none'
+      shouldShow={shouldShow}
+      className={BUBBLE_MENU_CLASS}
     >
       {isEditingLink ? (
         <>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu.tsx
@@ -13,6 +13,7 @@ import { PluginKey } from '@tiptap/pm/state'
 import type { Editor } from '@tiptap/react'
 import { useEditorState } from '@tiptap/react'
 import { BubbleMenu } from '@tiptap/react/menus'
+import { BUBBLE_MENU_CLASS } from './bubble-menu-chrome'
 import { ToolbarButton, ToolbarDivider } from './toolbar-button'
 import { useBubbleMenuFloating } from './use-bubble-menu-floating'
 
@@ -21,6 +22,9 @@ interface TableBubbleMenuProps {
   /** The editor's scrollable viewport, so the toolbar repositions with the cell as the pane scrolls. */
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
+
+const shouldShowTableMenu = ({ editor }: { editor: Editor }) =>
+  editor.isEditable && editor.isActive('table')
 
 /**
  * Floating toolbar shown whenever the selection is inside a table: row/column insert-before/after,
@@ -49,8 +53,8 @@ export function TableBubbleMenu({ editor, scrollContainerRef }: TableBubbleMenuP
       role='toolbar'
       aria-label='Table editing'
       updateDelay={0}
-      shouldShow={({ editor: e }) => e.isEditable && e.isActive('table')}
-      className='fade-in-0 z-[var(--z-popover)] flex animate-in items-center gap-0.5 rounded-lg border border-[var(--border)] bg-[var(--bg)] p-1 shadow-sm duration-150 ease-out motion-reduce:animate-none'
+      shouldShow={shouldShowTableMenu}
+      className={BUBBLE_MENU_CLASS}
     >
       <ToolbarButton
         icon={ArrowUp}


### PR DESCRIPTION
## Summary
Final cleanup pass over the pinned bubble menus (follow-up to #6419/#6434/#6435). A multi-agent review (simplify + correctness/backwards-compat + hooks) confirmed the merged fix is correct, backwards-compatible, and free of positioning side effects. Two genuine cleanups remained:

- **Shared chrome**: the text and table toolbars carried a byte-identical `className` chrome string. Extracted to `BUBBLE_MENU_CLASS` in a new `bubble-menu-chrome.ts`, matching the sibling `suggestion-menu-chrome.ts` pattern, so the two can't visually drift.
- **Stable `shouldShow`**: the hook's memoized `getReferencedVirtualElement`/`appendTo` were being defeated by an inline `shouldShow` in the same TipTap `updateOptions` dep array. The table predicate is closure-free → hoisted to module scope; the text predicate is wrapped in `useCallback` keyed on its only reactive input. Now redundant `updateOptions` dispatches are actually avoided.

Deliberately **not** done (avoiding over-engineering / reintroducing removed complexity): no `<BubbleToolbar>` wrapper component (only two consumers), and the old over-tall-selection viewport-clamp stays removed (the native-pin clip-on-scroll-out is intended). Shared-limits review: N/A — z-index is already a token, the `offset:8` match is convention.

## Type of Change
- [x] Refactor / improvement (no behavior change)

## Testing
521 rich-markdown-editor tests pass; type-check + biome clean. Pure refactor — className string is byte-identical via the const, and `shouldShow` logic is unchanged.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)