### PR TITLE
fix(condition): stop shipping all block outputs in every evaluation

### DIFF
--- a/apps/sim/executor/handlers/condition/condition-handler.test.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.test.ts
@@ -179,7 +179,7 @@ describe('ConditionBlockHandler', () => {
         timeout: 5000,
         envVars: mockContext.environmentVariables,
         workflowVariables: mockContext.workflowVariables,
-        blockData: { 'source-block-1': { value: 10, text: 'hello' } },
+        blockData: {},
         blockNameMapping: { sourceblock: 'source-block-1' },
         _context: {
           workflowId: 'test-workflow-id',
@@ -188,6 +188,24 @@ describe('ConditionBlockHandler', () => {
       }),
       { executionContext: mockContext }
     )
+  })
+
+  it('should never forward collected block outputs in the request body', async () => {
+    mockCollectBlockData.mockReturnValueOnce({
+      blockData: { 'huge-block': { payload: 'x'.repeat(1024) } },
+      blockNameMapping: { hugeblock: 'huge-block' },
+    })
+    mockExecuteTool.mockResolvedValueOnce({ success: true, output: { result: true } })
+
+    const conditions = [
+      { id: 'cond1', title: 'if', value: 'true' },
+      { id: 'else1', title: 'else', value: '' },
+    ]
+
+    await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
+
+    const [, toolParams] = mockExecuteTool.mock.calls[0]
+    expect(toolParams.blockData).toEqual({})
   })
 
   it('should select the else path if other conditions fail', async () => {

--- a/apps/sim/executor/handlers/condition/condition-handler.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.ts
@@ -22,6 +22,12 @@ const CONDITION_TIMEOUT_MS = 5000
  * Evaluates a single condition expression.
  * The resolver preserves legacy Condition expression substitution before this function executes the
  * resulting JavaScript through the shared function execution boundary.
+ *
+ * `blockData` is deliberately empty: the resolver already inlines every `<block.field>` reference
+ * into the expression before this runs, so shipping the run's accumulated block outputs would only
+ * inflate the request body. Sending them blew the 10MB body cap on wide subflows, where a single
+ * flat `blockStates` map holds every branch's outputs.
+ *
  * Returns true if condition is met, false otherwise.
  */
 async function evaluateConditionExpression(
@@ -36,7 +42,7 @@ async function evaluateConditionExpression(
     const contextSetup = `const context = ${JSON.stringify(evalContext)};`
     const code = `${contextSetup}\nreturn Boolean(${conditionExpression})`
 
-    const { blockData, blockNameMapping, blockOutputSchemas } = collectBlockData(ctx, currentNodeId)
+    const { blockNameMapping, blockOutputSchemas } = collectBlockData(ctx, currentNodeId)
 
     const result = await executeTool(
       'function_execute',
@@ -45,7 +51,7 @@ async function evaluateConditionExpression(
         timeout: CONDITION_TIMEOUT_MS,
         envVars: normalizeStringRecord(ctx.environmentVariables),
         workflowVariables: normalizeWorkflowVariables(ctx.workflowVariables),
-        blockData,
+        blockData: {},
         blockNameMapping,
         blockOutputSchemas,
         _context: {


### PR DESCRIPTION
## Problem

`ConditionBlockHandler` forwards `collectBlockData`'s full `blockData` — **every block output accumulated so far in the run** — to `function_execute` on each condition evaluation.

That payload is never read. The resolver already inlines every `<block.field>` reference into the expression before the handler runs (`resolver.ts` `resolveInputs` → `resolveTemplateWithoutConditionFormatting`), so by the time the handler builds the request there is nothing left for the server-side `resolveTagVariables` pass to resolve. It only inflates the request body.

Inside a wide subflow this is fatal: one flat `blockStates` map holds every branch's outputs, so branch *N*'s gate carries branches 0…*N*. A 91-branch parallel pushed the body past the 10MB cap and failed with:

```
Evaluation error in condition "If": Request body size limit exceeded (10MB).
```

…even though the expression was just `<someflag.result> === true`.

Per-value large-value offload does not catch this — `LARGE_VALUE_THRESHOLD_BYTES` is 8MB for a *single* value, while this is an aggregate of many medium ones, so nothing ever trips the offload path.

## Fix

Send `blockData: {}`, mirroring `FunctionBlockHandler`, which moved to exactly this in #4560 and left the condition handler on the old path. `blockNameMapping` and `blockOutputSchemas` are kept — they're bounded by workflow size, not run data.

## Why this is behavior-preserving

`blockData` had exactly one server-side consumer: `resolveTagVariables` (`app/api/function/execute/route.ts`), which resolves leftover `<...>` tags. So this can only regress if a `<...>` tag survives the resolver into a condition's code.

It can't:

- `BlockResolver` calls **the same** `resolveBlockReference` the route calls — both import from `@/executor/utils/block-reference`. The server pass was running identical logic over the same data, one step later.
- **Name lookup** — `findBlockIdByName` is `nameToBlockId.get(normalizeName(name))` built from `workflow.blocks`; `collectBlockData`'s `blockNameMapping` is built from the same array with the same `normalizeName`. Identical key set, so "executor can't find it" ⟹ "server can't find it."
- **Output lookup** — the executor's `getBlockOutput` is strictly *richer* (outer-branch index, `parallelBlockMapping`, cloned-subflow ids, suffix-walking in `state.ts`). `collectBlockData` only does a simple base-id alias.
- `<loop.*>` / `<parallel.*>` / `<variable.*>` are handled by dedicated resolvers (`SPECIAL_REFERENCE_PREFIXES`) and were never in `blockNameMapping` anyway.

Verified against the real resolver — every reference is inlined before the handler:

```
<producer.result> === 'hello world'   →   'hello world' === 'hello world'
<producer.items>.length > 1           →   ["a","b"].length > 1
<neverran.result> === true            →   null === true      ← block never executed
<variable.thr> > 3                    →   5 > 3
```

The only case where a tag survives is an unknown block name, and feeding that case the exact `blockData` + `blockNameMapping` the old handler shipped returns `undefined` too — the old path couldn't rescue it either.

## Testing

- `executor/` suite: **1843/1843 pass**
- `biome check`: clean
- `tsc --noEmit`: no errors in changed code
- Added a regression test asserting collected block outputs are never forwarded (the mock returns a non-empty `blockData`; the assertion pins the forwarded value to `{}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)