### PR TITLE
fix(snowflake): drop the oversized credential modal help text

### DIFF
--- a/apps/sim/lib/credentials/token-service-accounts/descriptors.ts
+++ b/apps/sim/lib/credentials/token-service-accounts/descriptors.ts
@@ -412,8 +412,6 @@ export const TOKEN_SERVICE_ACCOUNT_DESCRIPTORS: Record<
       },
     ],
     docsUrl: 'https://docs.sim.ai/integrations/snowflake-service-account',
-    helpText:
-      'A programmatic access token acts as the Snowflake user that owns it, or as the single role it was restricted to. It always expires — 15 days by default, 365 at most — and every user type except SERVICE_AGENT must be covered by a network policy to authenticate with it, unless an authentication policy waives that.',
     invalidCredentialsHelp:
       'Snowflake rejected this token. Check that it belongs to a user on this exact account host, that it has not expired or been revoked, that a network policy allows Sim to reach the account, and that the SQL API is enabled for the account.',
   },


### PR DESCRIPTION
## Summary
- Removes the help paragraph under the Programmatic access token field in the Snowflake credential modal. It ran 313 characters — 3× the typical provider's and 50% longer than the next worst — and pushed the Account host field down the modal.
- Everything it said (expiry defaults, role restriction, the network-policy requirement per user type) is already on the setup guide the modal links to, and the network-policy cause is repeated in the rejection copy, which is when someone actually needs it.
- Three providers already ship no `helpText` at all, so this matches the existing range rather than inventing a new one.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `type-check`, lint, `check:api-validation` and the credentials suite all pass; the diff is two deleted lines.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)