### PR TITLE
fix(emails): align the schedule-disabled email with the standard template rhythm

### DIFF
--- a/apps/sim/components/emails/notifications/schedule-disabled-email.tsx
+++ b/apps/sim/components/emails/notifications/schedule-disabled-email.tsx
@@ -45,18 +45,13 @@ export function ScheduleDisabledEmail({
 
       <Text style={baseStyles.paragraph}>
         {brand.name} turned off the schedule for {resourceLabel}. It will not run again until you
-        turn it back on.
+        fix the problem and turn it back on.
       </Text>
 
       <Section style={baseStyles.infoBox}>
         <Text style={baseStyles.infoBoxTitle}>Reason</Text>
         <Text style={baseStyles.infoBoxList}>{reasonCopy}</Text>
       </Section>
-
-      {/* Divider */}
-      <div style={baseStyles.divider} />
-
-      <Text style={baseStyles.paragraph}>Fix the problem, then turn the schedule back on.</Text>
 
       {manageLink ? (
         <Link href={manageLink} style={{ textDecoration: 'none' }}>


### PR DESCRIPTION
## Summary
- The schedule-disabled email was the only template with two dividers — one boxing in a stray "Fix the problem, then turn the schedule back on." line above the CTA. Every other email goes greeting → body → info box → button → one divider → footnote.
- Dropped the extra divider and folded that instruction into the lead paragraph, so it reads "It will not run again until you fix the problem and turn it back on."
- No style/token changes — just the same structure the rest of the emails already use.

## Type of Change
- [x] Bug fix

## Testing
Rendered the template locally and diffed the HTML against `credits-exhausted` / `welcome` — divider count now matches. `render-notifications.test.ts` passes (6/6), type-check clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)