### PR TITLE
fix(invite): hold the loading state until the stored token resolves

### DIFF
--- a/apps/sim/app/invite/[id]/invite.tsx
+++ b/apps/sim/app/invite/[id]/invite.tsx
@@ -286,7 +286,8 @@ export default function Invite({ registrationDisabled }: InviteProps) {
   const isNewUser = searchParams.get('new') === 'true'
   const errorReason = searchParams.get('error')
   const urlError = errorReason ? getInviteError(errorReason) : null
-  const tokenFromQuery = searchParams.get('token')
+  /** `|| null` so an empty `?token=` falls back to storage rather than querying with ''. */
+  const tokenFromQuery = searchParams.get('token') || null
   /**
    * Derived during render so the invitation query key is correct on the first
    * commit; an effect-set token refetches under a second key whenever the
@@ -308,7 +309,7 @@ export default function Invite({ registrationDisabled }: InviteProps) {
   })
   const invitation = invitationQuery.data?.invitation ?? null
   const joinPreview = invitationQuery.data?.joinPreview ?? null
-  const isLoading = Boolean(session?.user) && invitationQuery.isPending
+  const isLoading = Boolean(session?.user) && (!isTokenResolved || invitationQuery.isPending)
 
   const fetchError = invitationQuery.error
     ? getInviteError(


### PR DESCRIPTION
## Summary
Closes two gaps left by #6486, both in `apps/sim/app/invite/[id]/invite.tsx`.

**Loading state didn't follow the query gate.** #6486 gated the invitation query on `isTokenResolved` but left `isLoading` reading only `invitationQuery.isPending`. With `enabled: false` React Query still reports `success` when the key already holds data, so a cached null-token entry makes `isPending` false — the accept UI renders for one frame before the effect applies the stored token. Now `!isTokenResolved || invitationQuery.isPending`.

**Empty `?token=` stopped falling back to storage.** `searchParams.get('token')` returns `''`, which is not `null`, so `token` became `''` where the pre-#6486 truthiness check (`if (tokenFromQuery)`) had read `sessionStorage`. Normalized with `|| null` at the source, restoring the original behavior.

Found by Cursor Bugbot on #6487 (the release PR), plus a re-check of my own change while verifying its claim.

## Type of Change
- [x] Bug fix

## Testing
`bun run type-check`, `bun run lint:check` (23/23), `vitest run app/invite` (6 tests) all pass.

Behavior is unchanged on every reachable path except the two defects:

| Path | Before | After |
|---|---|---|
| Cold load, no `?token=` | skeleton (`isPending` true, empty cache) | skeleton (`!isTokenResolved`) — same |
| `?token=xyz` | `isTokenResolved` true → `isPending` | unchanged |
| Signed out | `isLoading` false | unchanged |
| Remount w/ cached null-token entry | **stale accept UI for one frame** | skeleton — fixed |
| `?token=` (empty) | **queried with `''`** | falls back to storage — restored |

No permanent-skeleton risk: the effect always runs on mount and `sessionStorage.getItem` returns `string | null`, never `undefined`, so `isTokenResolved` always becomes true.

Not browser-tested — the changed paths are a loading frame and an empty-param edge case.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
