### PR TITLE
fix(files): stop validating .jsonl as single-document JSON

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -264,7 +264,12 @@ const MONACO_LANGUAGE_BY_EXTENSION: Partial<Record<string, string>> = {
   graphql: 'graphql',
   gql: 'graphql',
   json: 'json',
-  jsonl: 'json',
+  /**
+   * Not `json`: JSON Lines holds one value per line, which Monaco's
+   * single-document parser flags as invalid. Validation is global
+   * (`jsonDefaults`), so opting JSONL out is the only per-file lever.
+   */
+  jsonl: 'plaintext',
   yaml: 'yaml',
   yml: 'yaml',
   toml: 'toml',


### PR DESCRIPTION
## Summary
- `.jsonl` was mapped to Monaco's `json` language in the Files editor. JSON Lines holds one independent JSON value per line, so Monaco's single-document parser flags every line after the first as invalid — a wall of false errors on a well-formed file.
- Map `.jsonl` to `plaintext` instead. JSON validation can't be scoped to a single model (`jsonDefaults` is global), so opting JSONL out of the JSON language is the only per-file lever short of shipping a custom grammar.
- Trade-off: `.jsonl` loses syntax coloring but no longer reports false errors. A proper `jsonl` Monarch grammar would keep both; that's a larger change and not worth it at current usage.
- Behaviorally identical to deleting the key (no `.jsonl` MIME is in the MIME map, so the lookup already falls through to `plaintext`). Keeping the explicit entry plus the comment stops it from being "restored" to `json` later.

Found while investigating an unrelated editor report — the root cause of that report is still unconfirmed, and this does not claim to address it.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `MONACO_LANGUAGE_BY_EXTENSION` and `resolveMonacoLanguage` are module-private with a single consumer, so the change only affects the `language` prop for `.jsonl` files — no persisted state, wire format, or contract is involved. `plaintext` is a Monaco built-in and already the fallback, so nothing new is registered. Typecheck and biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)