### PR TITLE
fix(docker): ship libvips so sharp can actually load at runtime

### DIFF
--- a/apps/sim/lib/content/registry-factory.test.ts
+++ b/apps/sim/lib/content/registry-factory.test.ts
@@ -6,15 +6,7 @@ import os from 'os'
 import path from 'path'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
-/**
- * `sharp` resolves a platform-specific `@img/sharp-*` native binary that the
- * standalone file tracer cannot follow, so a deployment can ship without it. It
- * must therefore be loaded lazily and its failure contained: an unreadable OG
- * dimension is optional metadata, not a reason to take down `/blog`, `/library`,
- * and every tag, author, slug, and RSS route that reads the registry.
- *
- * This mock makes `import('sharp')` fail the way a missing native binary does.
- */
+/** Fails `import('sharp')` the way an unloadable native binary does. */
 vi.mock('sharp', () => {
   throw new Error('Could not load the sharp module using the linux-x64 runtime')
 })

--- a/apps/sim/lib/content/registry-factory.ts
+++ b/apps/sim/lib/content/registry-factory.ts
@@ -103,12 +103,9 @@ export function createContentRegistry(config: ContentRegistryConfig): ContentReg
    * `image-size` package, archived upstream with unpatched DoS advisories in
    * its ICNS/JXL/HEIF parsers (GHSA-w3rx-r6r6-pgpr, GHSA-5p2g-fcmc-qvqq).
    *
-   * `sharp` is loaded lazily, never as a top-level import. It resolves a
-   * platform-specific `@img/sharp-*` native binary that the standalone file
-   * tracer cannot follow, so a deployment that ships without it makes
-   * `import 'sharp'` throw at module scope — which would take down every route
-   * that touches this registry (`/blog`, `/library`, their tag, author, slug,
-   * and RSS routes) rather than degrading one optional OG dimension.
+   * Imported lazily, never at module scope: sharp resolves a native binary, and a
+   * top-level import that fails to load would take down every route reading this
+   * registry instead of dropping one optional dimension.
    */
   async function readOgImageDimensions(
     ogImage: string

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -168,11 +168,9 @@ const nextConfig: NextConfig = {
     '/api/internal/file-doc/seed': ['./node_modules/jsdom/**/*'],
     '/api/internal/file-doc/merge': ['./node_modules/jsdom/**/*'],
     '/api/internal/file-doc/persist': ['./node_modules/jsdom/**/*'],
-    '/*': [
-      './node_modules/sharp/**/*',
-      './node_modules/@img/**/*',
-      './lib/execution/sandbox/bundles/*.cjs',
-    ],
+    // No `sharp`/`@img` entries: these globs resolve against apps/sim while both hoist to the
+    // monorepo root, so they matched nothing. docker/app.Dockerfile copies them instead.
+    '/*': ['./lib/execution/sandbox/bundles/*.cjs'],
   },
   experimental: {
     /**

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -168,8 +168,10 @@ const nextConfig: NextConfig = {
     '/api/internal/file-doc/seed': ['./node_modules/jsdom/**/*'],
     '/api/internal/file-doc/merge': ['./node_modules/jsdom/**/*'],
     '/api/internal/file-doc/persist': ['./node_modules/jsdom/**/*'],
-    // No `sharp`/`@img` entries: these globs resolve against apps/sim while both hoist to the
-    // monorepo root, so they matched nothing. docker/app.Dockerfile copies them instead.
+    /**
+     * No `sharp`/`@img` entries: these globs resolve against apps/sim while both hoist to the
+     * monorepo root, so they matched nothing. docker/app.Dockerfile copies them instead.
+     */
     '/*': ['./lib/execution/sandbox/bundles/*.cjs'],
   },
   experimental: {

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -130,6 +130,15 @@ COPY --from=deps --chown=nextjs:nodejs /app/node_modules/lib0 ./node_modules/lib
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/yjs ./node_modules/yjs
 COPY --from=deps --chown=nextjs:nodejs /app/node_modules/y-protocols ./node_modules/y-protocols
 
+# `@img/sharp-<platform>` loads libvips from `@img/sharp-libvips-<platform>` through the dynamic
+# linker, not a JS require, so the tracer copies the binding but not the library and sharp dies with
+# "ERR_DLOPEN_FAILED: libvips-cpp.so: cannot open shared object file". Same hoisting reason as the Yjs
+# stack above. Copying whole directories keeps these arch-agnostic (each build's deps stage holds only
+# its own platform's packages) and keeps sharp and its binding on the same install. Must stay below
+# the standalone COPY, which ships its own partial node_modules that would otherwise win.
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/sharp ./node_modules/sharp
+COPY --from=deps --chown=nextjs:nodejs /app/node_modules/@img ./node_modules/@img
+
 # Copy the isolated-vm worker script
 COPY --from=builder --chown=nextjs:nodejs /app/apps/sim/lib/execution/isolated-vm-worker.cjs ./apps/sim/lib/execution/isolated-vm-worker.cjs
 


### PR DESCRIPTION
## Summary
- sharp has never been able to load in the deployed image. The runtime error is `ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.3: cannot open shared object file` — not a missing module. `@img/sharp-<platform>` (the `.node` binding) gets traced in; `@img/sharp-libvips-<platform>` (which ships libvips) does not, because the binding loads it through the dynamic linker rather than a JS require.
- Copy `sharp` and `@img` into the runner stage, mirroring the `lib0`/`yjs`/`y-protocols` lines directly above that solve the identical hoisting problem.
- Drop the `./node_modules/sharp/**/*` and `./node_modules/@img/**/*` entries from `outputFileTracingIncludes`. They were added in #2458 (2025-12-18) to do exactly this job and never worked: the globs resolve against `apps/sim` while both packages hoist to the monorepo root. Verified empty in the real `deps` image.
- This is the root cause behind #6496. That PR contained the blast radius (a top-level `import sharp` in the content registry was 500ing `/blog`, `/library`, `/sitemap.xml` and every route beneath them); this one makes sharp work. It also restores copilot VFS image preparation, which has been silently degrading on the same failure — `file-reader.ts` guards its import and logs `Failed to load sharp for image preparation`.
- Trims the over-explained comments #6496 left behind, now that the Dockerfile owns the packaging rationale.

## Type of Change
- [x] Bug fix

## Testing
- Built the `deps` stage (`docker build --target deps`) and confirmed the COPY sources exist and carry the missing file: `@img/sharp-libvips-linux-arm64/lib/libvips-cpp.so.8.18.3`, plus `sharp`, `@img/colour`, and the platform binding.
- Confirmed `/app/apps/sim/node_modules` is **empty** in that image, which is what makes the deleted globs provably dead rather than merely suspicious.
- No new JS deps needed: the deployed image already resolves sharp's `detect-libc`/`semver` — proven by the error reaching `ERR_DLOPEN_FAILED` at all, which only happens after sharp's JS loads. A missing JS dep would be `MODULE_NOT_FOUND`.
- `bun run type-check`, `bun run lint`, `bunx vitest run lib/content` (44 passed).

## Notes
Two things deliberately not done here:
- The `COPY` lines must stay **below** the `.next/standalone` copy. Standalone ships its own partial `node_modules`; hoisting these up would let it clobber them and reintroduce the bug.
- Copying all of `@img` includes the musl variants (~18 MB) that a Debian/glibc image can't load. A wildcard `COPY @img/sharp-linux-*` would trim it, but Docker copies matched *directories' contents* into the destination, flattening them and breaking resolution — not worth 0.5% of a 3.6 GB image.

Follow-up worth its own PR: the `ws` and `jsdom` entries in the same `outputFileTracingIncludes` block are dead for the identical reason, and carry a comment confidently explaining a mechanism that doesn't work. Left alone here to keep an outage fix narrow.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
