### PR TITLE
perf(ci): scope the Docker layer cache per image and platform

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -25,9 +25,28 @@ inputs:
 runs:
   using: composite
   steps:
+    # One sticky disk per Dockerfile per platform. v1 keyed it on the repo name
+    # alone, so every image shared one disk: matrix jobs all clone the same
+    # parent snapshot and only the first to finish becomes the next parent, so
+    # the app image's `deps` layer was written and discarded every run (~300-465s
+    # rebuilt each time). Platform is in the key because amd64 and arm64 build
+    # the same Dockerfiles concurrently on main and share no layers. Ref is
+    # deliberately not: cross-ref reuse is the point, and an occasional overlap
+    # costs one rebuild.
+    - name: Resolve Docker layer cache key
+      id: cache-key
+      if: inputs.provider == '' || inputs.provider == 'blacksmith'
+      shell: bash
+      env:
+        FILE: ${{ inputs.file }}
+        PLATFORMS: ${{ inputs.platforms }}
+      run: echo "value=${GITHUB_REPOSITORY##*/}/${FILE#./}/${PLATFORMS//\//-}" >> "$GITHUB_OUTPUT"
+
     - name: Set up Blacksmith builder
       if: inputs.provider == '' || inputs.provider == 'blacksmith'
-      uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
+      uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2
+      with:
+        cache-key: ${{ steps.cache-key.outputs.value }}
 
     - name: Build and push (Blacksmith)
       if: inputs.provider == '' || inputs.provider == 'blacksmith'


### PR DESCRIPTION
`app.Dockerfile`'s `deps` stage rebuilds on every build (~300-465s, the longest step in CI) even when no dependency changed. The cause is not the Dockerfile: it is that `setup-docker-builder@v1` keys the Blacksmith sticky disk on the repository name alone (`stickyDiskKey = GITHUB_REPO_NAME`), so every Docker build in the repo shares one disk.

What that means in practice, from the job logs: all five matrix jobs clone the *same* parent snapshot (`Sticky disk parent snapshot: commit-01KZP43K…`, byte-identical across the app/db/realtime/pii/cron jobs of run `31416995583`), and at most one commit per wave becomes the next parent. Matching the 11 snapshot heads minted over 08-07/08-08 against job completion times, 9 of them landed within 2-4s of the *fastest* job finishing (`pii`, ~23s; `cron`, ~18s) and only 2 came from an app build. It is first-writer-wins against the parent generation, not last-writer-wins, which is exactly why the app build (637-919s) essentially never survives. Run `31416995583` cloned a head minted at 15:19:23 by a `pii` job, discarding the app builds that finished at 15:29, 15:59, 16:37 and 17:41 in between.

The fix derives a distinct `cache-key` per Dockerfile per platform and moves to `setup-docker-builder@v2`, where `cache-key` exists as a required input:

```yaml
- name: Resolve Docker layer cache key
  id: cache-key
  if: inputs.provider == '' || inputs.provider == 'blacksmith'
  shell: bash
  env:
    FILE: ${{ inputs.file }}
    PLATFORMS: ${{ inputs.platforms }}
  run: echo "value=${GITHUB_REPOSITORY##*/}/${FILE#./}/${PLATFORMS//\//-}" >> "$GITHUB_OUTPUT"

- name: Set up Blacksmith builder
  if: inputs.provider == '' || inputs.provider == 'blacksmith'
  uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2
  with:
    cache-key: ${{ steps.cache-key.outputs.value }}
```

That yields `sim/docker/app.Dockerfile/linux-amd64`, `sim/docker/db.Dockerfile/linux-amd64`, `sim/docker/app.Dockerfile/linux-arm64`, and so on: ten keys, one per concurrent builder, so no two jobs that run at the same time ever contend for the same snapshot lineage again. Computing it inside the composite means all three call sites (`build-dev`, `build-amd64`, `build-ghcr-arm64`) are covered with no caller changes and no way for a new call site to drift.

Platform is part of the key deliberately. On `main`, `build-amd64` and `build-ghcr-arm64` build the same Dockerfiles concurrently; keying only by Dockerfile would reproduce the identical clobbering between them, and amd64/arm64 share no layers, so splitting costs nothing.

The `deps` layer is genuinely cacheable, which is what makes this worth fixing: re-running `turbo prune sim --docker` at both reference commits (`156ee3eb` -> `5da48d01`) produces byte-identical `out/json` and `bun.lock`, so the only reason `#11 COPY --from=pruner /app/out/json/ ./` misses is that the previous app build's records are not in the snapshot this build cloned.

Nothing was evicting, so this is not a pruning problem: the teardown log reports `Skipping BuildKit cache pruning (max-cache-size-mb not set)` with 91.77 GB retained and fully reclaimable, including five separate ~2.8 GB `deps` layers from five earlier app builds, each with `USAGE COUNT 1`. `max-cache-size-mb` no longer exists on v2; the cache is garbage-collected automatically (layers unused for 8 days). Worth watching separately: org sticky disk usage is currently 942 GB against a 500 GB allowance.

The first build on each new key is cold, and there are ten of them. Everything after that hits a cache that only its own image writes to.

The other Blacksmith runners on `blacksmith-*` labels and the `docker/*` fallback path for `CI_PROVIDER != blacksmith` are untouched; the new step carries the same predicate as the builder step it feeds.
