### PR TITLE
fix(emcn): drop the brand highlight from popover menus

### DIFF
--- a/apps/sim/app/playground/page.tsx
+++ b/apps/sim/app/playground/page.tsx
@@ -868,10 +868,10 @@ export default function PlaygroundPage() {
                   </PopoverContent>
                 </Popover>
               </VariantRow>
-              <VariantRow label='secondary variant'>
-                <Popover variant='secondary'>
+              <VariantRow label='inverted color scheme'>
+                <Popover colorScheme='inverted'>
                   <PopoverTrigger asChild>
-                    <Button variant='secondary'>Secondary Popover</Button>
+                    <Button variant='secondary'>Inverted Popover</Button>
                   </PopoverTrigger>
                   <PopoverContent>
                     <PopoverItem>Item 1</PopoverItem>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/block-menu/block-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/block-menu/block-menu.tsx
@@ -130,13 +130,7 @@ export function BlockMenu({
   }
 
   return (
-    <Popover
-      open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
-      variant='secondary'
-      size='sm'
-      colorScheme='inverted'
-    >
+    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()} size='sm'>
       <PopoverAnchor
         style={{
           position: 'fixed',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/canvas-menu/canvas-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/canvas-menu/canvas-menu.tsx
@@ -70,13 +70,7 @@ export function CanvasMenu({
   hasBlocks = false,
 }: CanvasMenuProps) {
   return (
-    <Popover
-      open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
-      variant='secondary'
-      size='sm'
-      colorScheme='inverted'
-    >
+    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()} size='sm'>
       <PopoverAnchor
         style={{
           position: 'fixed',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/chat.tsx
@@ -947,7 +947,7 @@ export function Chat() {
 
         <div className='flex flex-shrink-0 items-center gap-2'>
           {/* More menu with actions */}
-          <Popover variant='default' size='sm' open={moreMenuOpen} onOpenChange={setMoreMenuOpen}>
+          <Popover size='sm' open={moreMenuOpen} onOpenChange={setMoreMenuOpen}>
             <PopoverTrigger asChild>
               <Button
                 variant='ghost'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/toolbar/components/toolbar-item-context-menu/toolbar-item-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/toolbar/components/toolbar-item-context-menu/toolbar-item-context-menu.tsx
@@ -47,13 +47,7 @@ export function ToolbarItemContextMenu({
   showViewDocumentation = false,
 }: ToolbarItemContextMenuProps) {
   return (
-    <Popover
-      open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
-      variant='secondary'
-      size='sm'
-      colorScheme='inverted'
-    >
+    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()} size='sm'>
       <PopoverAnchor
         style={{
           position: 'fixed',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/log-row-context-menu/log-row-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/log-row-context-menu/log-row-context-menu.tsx
@@ -47,13 +47,7 @@ export const LogRowContextMenu = memo(function LogRowContextMenu({
   const isStatusFiltered = entry ? filters.statuses.has(entryStatus) : false
 
   return (
-    <Popover
-      open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
-      variant='secondary'
-      size='sm'
-      colorScheme='inverted'
-    >
+    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()} size='sm'>
       <PopoverAnchor
         style={{
           position: 'fixed',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/output-panel/components/output-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/output-panel/components/output-context-menu.tsx
@@ -44,13 +44,7 @@ export const OutputContextMenu = memo(function OutputContextMenu({
   hasSelection,
 }: OutputContextMenuProps) {
   return (
-    <Popover
-      open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
-      variant='secondary'
-      size='sm'
-      colorScheme='inverted'
-    >
+    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()} size='sm'>
       <PopoverAnchor
         style={{
           position: 'fixed',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-controls/workflow-controls.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-controls/workflow-controls.tsx
@@ -93,12 +93,7 @@ export const WorkflowControls = memo(function WorkflowControls() {
         onContextMenu={handleContextMenu}
       >
         {/* Canvas Mode Selector */}
-        <Popover
-          open={isCanvasModeOpen}
-          onOpenChange={setIsCanvasModeOpen}
-          variant='secondary'
-          size='sm'
-        >
+        <Popover open={isCanvasModeOpen} onOpenChange={setIsCanvasModeOpen} size='sm'>
           <Tooltip.Root>
             <PopoverTrigger asChild>
               <div className='flex cursor-pointer items-center gap-1'>
@@ -197,9 +192,7 @@ export const WorkflowControls = memo(function WorkflowControls() {
       <Popover
         open={contextMenu !== null}
         onOpenChange={(open) => !open && setContextMenu(null)}
-        variant='secondary'
         size='sm'
-        colorScheme='inverted'
       >
         <PopoverAnchor
           style={{

--- a/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-context-menu/preview-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-context-menu/preview-context-menu.tsx
@@ -36,13 +36,7 @@ export function PreviewContextMenu({
   if (typeof document === 'undefined') return null
 
   return createPortal(
-    <Popover
-      open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
-      variant='secondary'
-      size='sm'
-      colorScheme='inverted'
-    >
+    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()} size='sm'>
       <PopoverAnchor
         style={{
           position: 'fixed',

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/empty-area-context-menu/empty-area-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/empty-area-context-menu/empty-area-context-menu.tsx
@@ -52,13 +52,7 @@ export function EmptyAreaContextMenu({
   disableCreateFolder = false,
 }: EmptyAreaContextMenuProps) {
   return (
-    <Popover
-      open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
-      variant='secondary'
-      size='sm'
-      colorScheme='inverted'
-    >
+    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()} size='sm'>
       <PopoverAnchor
         style={{
           position: 'fixed',

--- a/packages/emcn/src/components/popover/popover.tsx
+++ b/packages/emcn/src/components/popover/popover.tsx
@@ -58,7 +58,6 @@ import { cn } from '../../lib/cn'
 
 type PopoverSize = 'sm' | 'md'
 type PopoverColorScheme = 'default' | 'inverted'
-type PopoverVariant = 'default' | 'secondary'
 
 /**
  * Style constants for popover components.
@@ -113,16 +112,11 @@ const STYLES = {
     }
   >,
 
-  /** Interactive state styles: default, secondary (brand), inverted (dark bg in light mode) */
+  /** Interactive state styles: default, and inverted (dark bg in light mode) */
   states: {
     default: {
       active: 'bg-[var(--surface-active)]',
       hover: 'hover-hover:bg-[var(--surface-active)]',
-    },
-    secondary: {
-      active: 'bg-[var(--brand-secondary)] text-white [&_svg]:text-white',
-      hover:
-        'hover-hover:bg-[var(--brand-secondary)] hover-hover:text-white hover-hover:[&_svg]:text-white',
     },
     inverted: {
       active:
@@ -133,21 +127,9 @@ const STYLES = {
   },
 } as const
 
-/**
- * Gets the active/hover classes for a popover item.
- * Uses variant for secondary, otherwise colorScheme determines default vs inverted.
- */
-function getItemStateClasses(
-  variant: PopoverVariant,
-  colorScheme: PopoverColorScheme,
-  isActive: boolean
-): string {
+/** Gets the active/hover classes for a popover item, keyed by colour scheme. */
+function getItemStateClasses(colorScheme: PopoverColorScheme, isActive: boolean): string {
   const state = isActive ? 'active' : 'hover'
-
-  if (variant === 'secondary') {
-    return STYLES.states.secondary[state]
-  }
-
   return colorScheme === 'inverted' ? STYLES.states.inverted[state] : STYLES.states.default[state]
 }
 
@@ -163,7 +145,6 @@ interface PopoverContextValue {
   isInFolder: boolean
   folderTitle: string | null
   onFolderSelect: (() => void) | null
-  variant: PopoverVariant
   size: PopoverSize
   colorScheme: PopoverColorScheme
   searchQuery: string
@@ -197,11 +178,6 @@ const usePopoverContext = () => {
 
 export interface PopoverProps extends PopoverPrimitive.PopoverProps {
   /**
-   * Visual variant of the popover
-   * @default 'default'
-   */
-  variant?: PopoverVariant
-  /**
    * Size variant of the popover
    * - sm: 11px text, compact spacing (for logs, notifications, context menus)
    * - md: 13px text, default spacing
@@ -222,7 +198,6 @@ export interface PopoverProps extends PopoverPrimitive.PopoverProps {
  */
 const Popover: React.FC<PopoverProps> = ({
   children,
-  variant = 'default',
   size = 'md',
   colorScheme = 'default',
   open,
@@ -312,7 +287,6 @@ const Popover: React.FC<PopoverProps> = ({
       isInFolder: currentFolder !== null,
       folderTitle,
       onFolderSelect,
-      variant,
       size,
       colorScheme,
       searchQuery,
@@ -333,7 +307,6 @@ const Popover: React.FC<PopoverProps> = ({
       currentFolder,
       folderTitle,
       onFolderSelect,
-      variant,
       size,
       colorScheme,
       searchQuery,
@@ -732,7 +705,6 @@ const PopoverItem = React.forwardRef<HTMLDivElement, PopoverItemProps>(
     ref
   ) => {
     const context = React.useContext(PopoverContext)
-    const variant = context?.variant || 'default'
     const size = context?.size || 'md'
     const colorScheme = context?.colorScheme || 'default'
     const itemRef = React.useRef<HTMLDivElement>(null)
@@ -794,7 +766,7 @@ const PopoverItem = React.forwardRef<HTMLDivElement, PopoverItemProps>(
           STYLES.itemBase,
           STYLES.colorScheme[colorScheme].text,
           STYLES.size[size].item,
-          getItemStateClasses(variant, colorScheme, !!isActive),
+          getItemStateClasses(colorScheme, !!isActive),
           suppressHover && 'hover-hover:!bg-transparent',
           disabled && 'pointer-events-none cursor-not-allowed opacity-50',
           className
@@ -901,7 +873,6 @@ const PopoverFolder = React.forwardRef<HTMLDivElement, PopoverFolderProps>(
       openFolder,
       currentFolder,
       isInFolder,
-      variant,
       size,
       colorScheme,
       lastHoveredItem,
@@ -991,7 +962,7 @@ const PopoverFolder = React.forwardRef<HTMLDivElement, PopoverFolderProps>(
             STYLES.itemBase,
             STYLES.colorScheme[colorScheme].text,
             STYLES.size[size].item,
-            getItemStateClasses(variant, colorScheme, isActive || isHoverOpen),
+            getItemStateClasses(colorScheme, isActive || isHoverOpen),
             suppressHover && 'hover-hover:!bg-transparent',
             className
           )}
@@ -1054,7 +1025,7 @@ interface PopoverBackButtonProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 const PopoverBackButton = React.forwardRef<HTMLDivElement, PopoverBackButtonProps>(
   ({ className, folderTitleRef, folderTitleActive, onFolderTitleMouseEnter, ...props }, ref) => {
-    const { isInFolder, closeFolder, folderTitle, onFolderSelect, variant, size, colorScheme } =
+    const { isInFolder, closeFolder, folderTitle, onFolderSelect, size, colorScheme } =
       usePopoverContext()
 
     if (!isInFolder) return null
@@ -1068,7 +1039,7 @@ const PopoverBackButton = React.forwardRef<HTMLDivElement, PopoverBackButtonProp
             STYLES.itemBase,
             STYLES.colorScheme[colorScheme].text,
             STYLES.size[size].item,
-            getItemStateClasses(variant, colorScheme, false),
+            getItemStateClasses(colorScheme, false),
             className
           )}
           role='button'
@@ -1094,7 +1065,7 @@ const PopoverBackButton = React.forwardRef<HTMLDivElement, PopoverBackButtonProp
               STYLES.itemBase,
               STYLES.colorScheme[colorScheme].text,
               STYLES.size[size].item,
-              getItemStateClasses(variant, colorScheme, !!folderTitleActive),
+              getItemStateClasses(colorScheme, !!folderTitleActive),
               'peer-hover:!bg-transparent'
             )}
             role='button'


### PR DESCRIPTION
Stacked on #6458 — base is `workflow-updates-v2`. Sibling of #6505; the two don't overlap.

## Problem

Context menus opted into a palette of their own:

```tsx
<Popover variant='secondary' size='sm' colorScheme='inverted'>
```

- `variant='secondary'` → row highlight of `--brand-secondary` (bright blue) with `text-white`
- `colorScheme='inverted'` → `--surface-inverted` card with `--border-inverted`

So right-clicking the canvas gave a dark card with a blue selected row, while every other menu in the product — the terminal's overflow menu, for instance — uses `--surface-active` on the standard surface. Two menu languages for the same interaction.

## Change

Removes both overrides from the eight menus that carried them, so they inherit the canonical treatment:

- canvas right-click menu
- block right-click menu
- toolbar item context menu
- workflow controls (canvas mode selector + its context menu)
- terminal output + log-row context menus
- sidebar empty-area context menu
- preview context menu

Then removes the brand state from `Popover` itself, along with the `variant` prop that only ever selected it — `getItemStateClasses` now keys off `colorScheme` alone. `--brand-secondary` no longer appears anywhere in the popover system, so the divergence can't be reintroduced by passing a prop.

`colorScheme='inverted'` stays available and is still used by the inline pickers (tag dropdown, env-var dropdown, tool input), which are a different surface and were left alone.

## Notes

- The two remaining `variant='default'` hits in the playground are `Button` variants, not `Popover`.
- One straggler consumer in `chat.tsx` passed `variant='default'` to a Popover; dropped, since it was already the default.
- The playground's "secondary variant" demo now demonstrates the inverted colour scheme instead.

## Verification

- `bun run type-check` clean for `apps/sim` and `@sim/emcn`
- Purely presentational: no behaviour, props-with-meaning, or state changes beyond removing a dead prop

## Not verified

Not visually confirmed — browser automation was unavailable. Worth an eyeball on the canvas right-click menu in both light and dark mode before merge.