### PR TITLE
fix(idempotency): use compatible PostgreSQL JSON operations

### DIFF
--- a/apps/sim/lib/core/idempotency/service.test.ts
+++ b/apps/sim/lib/core/idempotency/service.test.ts
@@ -154,6 +154,8 @@ describe('IdempotencyService in-progress deadlines', () => {
 
     const conflictOptions = dbChainMockFns.onConflictDoUpdate.mock.calls[0]?.[0]
     const setWhere = JSON.stringify(conflictOptions?.setWhere)
+    expect(setWhere).toContain('json_typeof')
+    expect(setWhere).not.toContain('jsonb_typeof')
     expect(setWhere).toContain('IS DISTINCT FROM')
     expect(setWhere).toContain('in-progress')
   })
@@ -229,7 +231,8 @@ describe('IdempotencyService in-progress deadlines', () => {
       service.executeWithIdempotency('provider', 'delivery-retry-db', vi.fn())
     ).resolves.toBe('new-owner-result')
 
-    const condition = dbChainMockFns.where.mock.calls.at(-1)?.[0]
-    expect(JSON.stringify(condition)).toContain('retry me')
+    const condition = JSON.stringify(dbChainMockFns.where.mock.calls.at(-1)?.[0])
+    expect(condition).toContain('retry me')
+    expect(condition.match(/::jsonb/g)).toHaveLength(2)
   })
 })

--- a/apps/sim/lib/core/idempotency/service.ts
+++ b/apps/sim/lib/core/idempotency/service.ts
@@ -327,7 +327,7 @@ export class IdempotencyService {
     const expiredBefore = new Date(now.getTime() - this.config.ttlSeconds * 1000)
     const inProgressClaimExpired = sql`COALESCE(
       CASE
-        WHEN jsonb_typeof(${idempotencyKey.result} -> 'inProgressExpiresAt') = 'number'
+        WHEN json_typeof(${idempotencyKey.result} -> 'inProgressExpiresAt') = 'number'
           THEN (${idempotencyKey.result} ->> 'inProgressExpiresAt')::double precision
       END,
       EXTRACT(EPOCH FROM ${idempotencyKey.createdAt}) * 1000 + ${this.config.inProgressTtlSeconds * 1000}
@@ -548,7 +548,7 @@ export class IdempotencyService {
       : fence?.observedResult
         ? and(
             eq(idempotencyKey.key, normalizedKey),
-            sql`${idempotencyKey.result} = ${JSON.stringify(fence.observedResult)}::jsonb`
+            sql`${idempotencyKey.result}::jsonb = ${JSON.stringify(fence.observedResult)}::jsonb`
           )
         : eq(idempotencyKey.key, normalizedKey)
     const deleted = await db


### PR DESCRIPTION
## Summary
- use PostgreSQL json_typeof for the JSON-backed idempotency lease expiry check
- cast both retry-fence operands to jsonb and add regression coverage for both mismatches

## Type of Change
- [x] Bug fix

## Testing
- bun run lint
- bun run apps/sim/scripts/check-block-registry.ts origin/staging
- bun run check:audits
- bun run test lib/core/idempotency/service.test.ts (from apps/sim)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)