### PR TITLE
fix(sidebar): pluralize the Knowledge bases nav label

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -180,7 +180,7 @@ export function SearchModal({
         },
         {
           id: 'knowledge-base',
-          name: 'Knowledge base',
+          name: 'Knowledge bases',
           icon: Database,
           href: `/workspace/${workspaceId}/knowledge`,
           hidden: permissionConfig.hideKnowledgeBaseTab,

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -819,7 +819,7 @@ export const Sidebar = memo(function Sidebar({
         },
         {
           id: 'knowledge-base',
-          label: 'Knowledge base',
+          label: 'Knowledge bases',
           icon: Database,
           href: `/workspace/${workspaceId}/knowledge`,
           hidden: permissionConfig.hideKnowledgeBaseTab,


### PR DESCRIPTION
## Summary
- Rename the sidebar Workspace nav item from "Knowledge base" to "Knowledge bases" so it matches the plural style of Tables, Files, and Logs
- Apply the same rename to the search modal's Pages list, which mirrors the sidebar nav

## Type of Change
- [x] Bug fix

## Testing
Tested manually; lint and the full audit suite (`check:audits`, 22 audits incl. `check:api-validation:strict`) pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)