### PR TITLE
fix(knowledge): pluralize the module header and root breadcrumb

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx
@@ -510,7 +510,7 @@ export function Document({
     () =>
       combinedError
         ? [
-            { label: 'Knowledge Base', icon: Database, onClick: handleNavToKB },
+            { label: 'Knowledge bases', icon: Database, onClick: handleNavToKB },
             {
               label: knowledgeBaseCrumbLabel,
               icon: Database,
@@ -519,7 +519,7 @@ export function Document({
             { label: 'Error' },
           ]
         : [
-            { label: 'Knowledge Base', icon: Database, onClick: handleNavToKB },
+            { label: 'Knowledge bases', icon: Database, onClick: handleNavToKB },
             {
               label: knowledgeBaseCrumbLabel,
               icon: Database,
@@ -989,7 +989,7 @@ export function Document({
 
   const editorBreadcrumbBase = useMemo<BreadcrumbItem[]>(
     () => [
-      { label: 'Knowledge Base', icon: Database, onClick: handleNavToKB },
+      { label: 'Knowledge bases', icon: Database, onClick: handleNavToKB },
       {
         label: knowledgeBaseCrumbLabel,
         icon: Database,
@@ -1022,7 +1022,7 @@ export function Document({
 
   const loadingBreadcrumbs = useMemo<BreadcrumbItem[]>(
     () => [
-      { label: 'Knowledge Base', icon: Database, onClick: handleNavToKB },
+      { label: 'Knowledge bases', icon: Database, onClick: handleNavToKB },
       {
         label: knowledgeBaseCrumbLabel,
         icon: Database,

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/loading.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/loading.tsx
@@ -19,7 +19,7 @@ const COLUMNS = [
 const ACTIONS: ChromeActionSpec[] = [{ text: 'New chunk', icon: Plus, variant: 'primary' }]
 
 const BREADCRUMBS: BreadcrumbItem[] = [
-  { label: 'Knowledge Base', icon: Database, onClick: noop },
+  { label: 'Knowledge bases', icon: Database, onClick: noop },
   { label: '…', icon: Database },
   { label: '…', terminal: true },
 ]

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -444,7 +444,7 @@ export function KnowledgeBase({
   /**
    * Breadcrumb leaf label. Falls back to the canonical '…' placeholder while
    * the name loads (mirroring loading.tsx) instead of duplicating the root
-   * "Knowledge Base" crumb.
+   * "Knowledge bases" crumb.
    */
   const knowledgeBaseCrumbLabel = knowledgeBase?.name || passedKnowledgeBaseName || '…'
   const error = knowledgeBaseError || documentsError
@@ -872,7 +872,7 @@ export function KnowledgeBase({
 
   const breadcrumbs: BreadcrumbItem[] = [
     {
-      label: 'Knowledge Base',
+      label: 'Knowledge bases',
       icon: Database,
       onClick: () => router.push(`/workspace/${workspaceId}/knowledge`),
     },
@@ -1182,7 +1182,7 @@ export function KnowledgeBase({
       <Resource onContextMenu={handleEmptyContextMenu}>
         <Resource.Header
           icon={Database}
-          title='Knowledge Base'
+          title='Knowledge bases'
           breadcrumbs={breadcrumbs}
           actions={[
             ...headerActions,

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/loading.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/loading.tsx
@@ -25,7 +25,7 @@ const ACTIONS: ChromeActionSpec[] = [
 ]
 
 const BREADCRUMBS: BreadcrumbItem[] = [
-  { label: 'Knowledge Base', icon: Database, onClick: noop },
+  { label: 'Knowledge bases', icon: Database, onClick: noop },
   { label: '…', icon: Database, terminal: true },
 ]
 

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx
@@ -110,7 +110,7 @@ const CONTENT_FILTER_OPTIONS: ChipDropdownOption[] = [
 
 const FILTER_SECTION_LABEL_CLASS = 'text-[var(--text-muted)] text-small'
 
-const ROOT_BREADCRUMB_LABEL = 'Knowledge Base'
+const ROOT_BREADCRUMB_LABEL = 'Knowledge bases'
 const FOLDER_RESOURCE_TYPE = 'knowledge_base' as const
 
 function connectorCell(connectorTypes?: string[]): ResourceCell {

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/loading.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/loading.tsx
@@ -26,7 +26,7 @@ export default function KnowledgeLoading() {
   return (
     <ResourceChromeFallback
       icon={Database}
-      title='Knowledge Base'
+      title='Knowledge bases'
       columns={COLUMNS}
       actions={ACTIONS}
       searchPlaceholder='Search knowledge bases...'

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/page.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/page.tsx
@@ -7,7 +7,7 @@ import KnowledgeLoading from '@/app/workspace/[workspaceId]/knowledge/loading'
 import { prefetchKnowledgeBases } from '@/app/workspace/[workspaceId]/knowledge/prefetch'
 
 export const metadata: Metadata = {
-  title: 'Knowledge Base',
+  title: 'Knowledge bases',
 }
 
 /**


### PR DESCRIPTION
## Summary
- Follow-up to #6514: rename the Knowledge Base module's page header, browser-tab title, and loading skeleton from "Knowledge Base" to "Knowledge bases" so they match the sidebar nav label
- Apply the same rename to the root breadcrumb in the KB detail and document views (and their loading skeletons), and to the "Move to" root option
- Singular entity copy is untouched ("Create/Edit/Delete Knowledge Base", KB-name fallbacks, "Knowledge base not found")

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)