### PR TITLE
docs(self-hosting): note the Railway ENCRYPTION_KEY must be 64-char hex

### DIFF
--- a/apps/docs/content/docs/en/platform/self-hosting/platforms.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/platforms.mdx
@@ -21,6 +21,10 @@ After deployment, set in the Railway dashboard:
 - Your custom domain under **Settings → Networking**, then `NEXT_PUBLIC_APP_URL` to match
 
 <Callout type="warn">
+  The template auto-generates `ENCRYPTION_KEY` as a URL-safe secret, but Sim requires a 64-character hex string. If saving Workspace Secrets fails with `ENCRYPTION_KEY must be set to a 64-character hex string` (HTTP 500), regenerate it with `openssl rand -hex 32` and update the variable in the Railway dashboard.
+</Callout>
+
+<Callout type="warn">
   The Railway template deploys the app services but not the `cron` service, so scheduled workflows and polling triggers stay idle. Add a Railway cron service calling the endpoints in [Background Jobs](/platform/self-hosting/background-jobs), or deploy with Docker Compose instead.
 </Callout>
 

--- a/apps/docs/content/docs/en/platform/self-hosting/platforms.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/platforms.mdx
@@ -53,4 +53,4 @@ Recommended for any production deployment. The requirement is **pgvector**.
 DATABASE_URL="postgresql://user:pass@host:5432/simstudio?sslmode=require"
 ```
 
-For the Helm chart, disable the bundled Postgres and use `externalDatabase` — see [Kubernetes](/platform/self-hosting/kubernetes#external-database). 
+For the Helm chart, disable the bundled Postgres and use `externalDatabase` — see [Kubernetes](/platform/self-hosting/kubernetes#external-database).


### PR DESCRIPTION
## What

Adds a troubleshooting note to the Railway self-hosting docs (`platforms.mdx`) for `ENCRYPTION_KEY`.

## Why

The Railway template auto-generates `ENCRYPTION_KEY` as a URL-safe secret, but Sim validates it as a 64-character hex string. So on a fresh Railway deploy, saving Workspace Secrets fails with:

```
ENCRYPTION_KEY must be set to a 64-character hex string
```

and an HTTP 500 (reported in #6246). The Docker self-hosting docs already generate this correctly with `openssl rand -hex 32` (`self-hosting/index.mdx`); only the Railway path was missing the guidance.

## Change

A `<Callout type="warn">` next to the "auto-generated by the template" line, telling users to regenerate the key with `openssl rand -hex 32` and set it in the Railway dashboard if they hit that error. Docs-only, no code change.

Re #6246.