### PR TITLE
fix(enrichment): require work email company domain

### DIFF
--- a/apps/sim/background/workflow-column-execution.ts
+++ b/apps/sim/background/workflow-column-execution.ts
@@ -582,7 +582,7 @@ async function runWorkflowAndWriteTerminal(
           await enrichmentRegistry.importCrossingProvenance(inputProvenance, enrichInputs, {
             trusted: true,
           })
-          const { result, cost, error, detail } = await runEnrichment(enrichment, enrichInputs, {
+          const { result, cost, detail } = await runEnrichment(enrichment, enrichInputs, {
             tableId,
             rowId,
             workspaceId,
@@ -599,20 +599,6 @@ async function runWorkflowAndWriteTerminal(
                 timedOut: timeoutController.isTimedOut(),
                 timeoutMs: timeoutController.timeoutMs,
               }),
-              enrichmentDetails: detail,
-            })
-            return 'error'
-          }
-
-          // Every provider that ran errored (auth / rate-limit / outage) — surface
-          // it rather than writing a blank cell that looks like "no data found".
-          if (error) {
-            await writeState({
-              status: 'error',
-              executionId,
-              jobId: null,
-              workflowId: statusId,
-              error,
               enrichmentDetails: detail,
             })
             return 'error'

--- a/apps/sim/enrichments/work-email/work-email.ts
+++ b/apps/sim/enrichments/work-email/work-email.ts
@@ -20,7 +20,7 @@ export const workEmailEnrichment: EnrichmentConfig = {
   icon: Mail,
   inputs: [
     { id: 'fullName', name: 'Full name', type: 'string', required: true },
-    { id: 'companyDomain', name: 'Company domain', type: 'string' },
+    { id: 'companyDomain', name: 'Company domain', type: 'string', required: true },
     { id: 'linkedinUrl', name: 'LinkedIn URL', type: 'string' },
   ],
   outputs: [{ id: 'email', name: 'email', type: 'string' }],


### PR DESCRIPTION
## Summary
- require a mapped, non-empty Company domain for Work Email configuration and execution; a LinkedIn URL alone no longer qualifies
- show Not found when a table enrichment cascade produces no match, even when every attempted provider errored; retain provider failures in logs and enrichment details
- keep existing saved groups loadable; runs without a mapped/domain value skip before calling providers, and the next edit requires a domain mapping

## Type of Change
- [x] Bug fix

## Testing
- focused Vitest suites: 24 tests passed
- bun run lint
- bun run check:audits

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests are passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the Contributor License Agreement (CONTRIBUTING.md)