### PR TITLE
fix(ci): include auth package in app Docker prune

### DIFF
--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -106,6 +106,7 @@
     "@react-email/components": "1.0.12",
     "@react-email/render": "2.1.0",
     "@sim/audit": "workspace:*",
+    "@sim/auth": "workspace:*",
     "@sim/browser-protocol": "workspace:*",
     "@sim/desktop-bridge": "workspace:*",
     "@sim/emcn": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -209,6 +209,7 @@
         "@react-email/components": "1.0.12",
         "@react-email/render": "2.1.0",
         "@sim/audit": "workspace:*",
+        "@sim/auth": "workspace:*",
         "@sim/browser-protocol": "workspace:*",
         "@sim/desktop-bridge": "workspace:*",
         "@sim/emcn": "workspace:*",


### PR DESCRIPTION
## Summary

Declare `@sim/auth` as a direct workspace dependency of `apps/sim` and update the lockfile.

## Root cause

The v2 application code imports `@sim/auth/principal`, but `apps/sim/package.json` did not declare `@sim/auth`. Full-monorepo CI installs every workspace and therefore resolved the undeclared package, while `docker/app.Dockerfile` runs `turbo prune sim --docker`. Turbo correctly omitted `packages/auth` from that pruned build graph, causing the staging image build to fail with `Module not found: Can't resolve '@sim/auth/principal'`.

## Impact

The app Docker image can include and resolve `@sim/auth/principal` during the staging build.

## Verification

- Ran `turbo prune sim --docker` from this branch.
- Confirmed the prune output reports `Added @sim/auth`.
- Confirmed the diff contains only the `apps/sim/package.json` and `bun.lock` dependency entries.
