### PR TITLE
fix(knowledge): retain model input provenance

### DIFF
--- a/apps/sim/lib/api/contracts/knowledge/search.test.ts
+++ b/apps/sim/lib/api/contracts/knowledge/search.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { internalKnowledgeSearchBodySchema } from '@/lib/api/contracts/knowledge/search'
+import { RESOLVED_SECRET_PROVENANCE_FIELD } from '@/lib/execution/private-tool-metadata'
+
+describe('internal Knowledge search contract', () => {
+  it('retains the private model-input provenance envelope for boundary validation', () => {
+    const provenance = {
+      version: 1 as const,
+      complete: true,
+      entries: [{ name: 'QUERY_SECRET', encryptedValue: 'encrypted-query-secret' }],
+      scope: { userId: 'workflow-owner', workspaceId: 'workspace-1' },
+    }
+
+    expect(
+      internalKnowledgeSearchBodySchema.parse({
+        knowledgeBaseIds: ['knowledge-base-1'],
+        query: 'search query',
+        [RESOLVED_SECRET_PROVENANCE_FIELD]: provenance,
+      })
+    ).toMatchObject({ [RESOLVED_SECRET_PROVENANCE_FIELD]: provenance })
+  })
+})

--- a/apps/sim/lib/api/contracts/knowledge/search.ts
+++ b/apps/sim/lib/api/contracts/knowledge/search.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
+import { resolvedSecretTraceProvenanceSchema } from '@/lib/api/contracts/primitives'
 import { defineRouteContract } from '@/lib/api/contracts/types'
+import { RESOLVED_SECRET_PROVENANCE_FIELD } from '@/lib/execution/private-tool-metadata'
 import { DEFAULT_RERANKER_MODEL, rerankerModelSchema } from '@/lib/knowledge/reranker-models'
 
 export const knowledgeSearchTagFilterSchema = z.object({
@@ -92,6 +94,7 @@ export const internalKnowledgeSearchBodySchema = z.intersection(
   z.object({
     workflowId: z.string().optional(),
     skipUsageBilling: z.boolean().optional(),
+    [RESOLVED_SECRET_PROVENANCE_FIELD]: resolvedSecretTraceProvenanceSchema.optional(),
   })
 )
 

--- a/apps/sim/lib/knowledge/model-input-provenance.test.ts
+++ b/apps/sim/lib/knowledge/model-input-provenance.test.ts
@@ -3,6 +3,7 @@
  */
 import { encryptionMockFns, environmentUtilsMockFns, resetEnvironmentUtilsMock } from '@sim/testing'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { internalKnowledgeSearchBodySchema } from '@/lib/api/contracts/knowledge/search'
 import { PRIVATE_MODEL_INPUT_PROVENANCE_HEADER } from '@/lib/execution/model-input-provenance'
 import {
   RESOLVED_SECRET_PROVENANCE_FIELD,
@@ -84,6 +85,25 @@ describe('Knowledge model input provenance', () => {
     expect(result.success).toBe(true)
     expect(result.success && result.registry?.isComplete()).toBe(true)
     expect(environmentUtilsMockFns.mockGetEffectiveEnvironmentSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('accepts a verified envelope after the internal route contract parses it', async () => {
+    const body = internalKnowledgeSearchBodySchema.parse({
+      knowledgeBaseIds: ['knowledge-base-1'],
+      ...verifiedPayload(),
+    })
+
+    const result = await prepareKnowledgeModelInputProvenance({
+      headers: verifiedHeaders(),
+      payload: body,
+      isInternalRequest: true,
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+      modelInput: body.query,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.success && result.registry?.isComplete()).toBe(true)
   })
 
   it('does not activate an authenticated entry absent from the exact model input', async () => {


### PR DESCRIPTION
## Summary
- retain the authenticated private model-input provenance envelope through internal Knowledge Search contract parsing
- add regression coverage spanning transport envelope creation, Zod boundary parsing, and Knowledge provenance verification

## Type of Change
- [x] Bug fix

## Testing
- 17 focused transport, contract, and Knowledge provenance tests passing
- Sim type-check passing
- Lint and all 24 CI audits passing

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)