### PR TITLE
fix(auth): let Microsoft sign-in link via Entra's domain-verified email claim

### DIFF
--- a/apps/sim/app/oauth-error/page.tsx
+++ b/apps/sim/app/oauth-error/page.tsx
@@ -33,6 +33,21 @@ const FRIENDLY: Record<string, string> = {
    */
   signup_disabled:
     'Account creation is disabled on this instance. Ask your admin to create an account for you.',
+  /**
+   * An account already exists for this email but the provider doesn't assert a
+   * verified email, so Better Auth refuses to link (see
+   * `accountLinking.trustedProviders`). Retrying reproduces it exactly, so the
+   * generic "try again" strands the user — name the recovery path instead.
+   */
+  account_not_linked:
+    'An account already exists for this email address. Sign in using the method you originally signed up with.',
+  /**
+   * The provider returned no email claim — for Microsoft work accounts, the
+   * directory's mail attribute is unset or the `email` optional claim isn't
+   * configured on the app registration.
+   */
+  email_not_found:
+    'Your identity provider didn’t share an email address with us, so we couldn’t complete sign-in. Please contact your administrator.',
 }
 
 function messageForError(code: string | undefined): string {

--- a/apps/sim/app/oauth-error/page.tsx
+++ b/apps/sim/app/oauth-error/page.tsx
@@ -34,18 +34,13 @@ const FRIENDLY: Record<string, string> = {
   signup_disabled:
     'Account creation is disabled on this instance. Ask your admin to create an account for you.',
   /**
-   * An account already exists for this email but the provider doesn't assert a
-   * verified email, so Better Auth refuses to link (see
-   * `accountLinking.trustedProviders`). Retrying reproduces it exactly, so the
+   * Better Auth refuses to link an untrusted provider onto an existing account
+   * (`accountLinking.trustedProviders`). Retrying reproduces it exactly, so the
    * generic "try again" strands the user — name the recovery path instead.
    */
   account_not_linked:
     'An account already exists for this email address. Sign in using the method you originally signed up with.',
-  /**
-   * The provider returned no email claim — for Microsoft work accounts, the
-   * directory's mail attribute is unset or the `email` optional claim isn't
-   * configured on the app registration.
-   */
+  /** The provider returned no email claim, so there is nothing to sign in as. */
   email_not_found:
     'Your identity provider didn’t share an email address with us, so we couldn’t complete sign-in. Please contact your administrator.',
 }

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -761,10 +761,9 @@ export const auth = betterAuth({
             clientSecret: env.MICROSOFT_CLIENT_SECRET,
             scope: ['openid', 'profile', 'email'],
             /**
-             * Without this, `/common/` silently reuses whichever Microsoft
-             * session the browser already holds, so someone signed into a
-             * personal account never gets to pick their work account — and
-             * lands on an orphan Sim account under the wrong address.
+             * `/common/` otherwise silently reuses whichever Microsoft session
+             * the browser holds, stranding the user on an orphan Sim account
+             * under their personal address.
              */
             prompt: 'select_account' as const,
             mapProfileToUser: mapMicrosoftProfileToUser,

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -760,7 +760,6 @@ export const auth = betterAuth({
             clientId: env.MICROSOFT_CLIENT_ID,
             clientSecret: env.MICROSOFT_CLIENT_SECRET,
             scope: ['openid', 'profile', 'email'],
-            ...(env.MICROSOFT_TENANT_ID ? { tenantId: env.MICROSOFT_TENANT_ID } : {}),
             /**
              * Without this, `/common/` silently reuses whichever Microsoft
              * session the browser already holds, so someone signed into a

--- a/apps/sim/lib/auth/auth.ts
+++ b/apps/sim/lib/auth/auth.ts
@@ -96,7 +96,11 @@ import { quickValidateEmail } from '@/lib/messaging/email/validation'
 import { validateSignupEmailMx } from '@/lib/messaging/email/validation.server'
 import { isEmailVerificationEffectivelyEnabled } from '@/lib/messaging/email/verification'
 import { scheduleLifecycleEmail } from '@/lib/messaging/lifecycle'
-import { getMicrosoftRefreshTokenExpiry, isMicrosoftProvider } from '@/lib/oauth/microsoft'
+import {
+  getMicrosoftRefreshTokenExpiry,
+  isMicrosoftProvider,
+  mapMicrosoftProfileToUser,
+} from '@/lib/oauth/microsoft'
 import {
   isSalesforceLoginOrigin,
   isSalesforceOAuthProviderId,
@@ -756,6 +760,15 @@ export const auth = betterAuth({
             clientId: env.MICROSOFT_CLIENT_ID,
             clientSecret: env.MICROSOFT_CLIENT_SECRET,
             scope: ['openid', 'profile', 'email'],
+            ...(env.MICROSOFT_TENANT_ID ? { tenantId: env.MICROSOFT_TENANT_ID } : {}),
+            /**
+             * Without this, `/common/` silently reuses whichever Microsoft
+             * session the browser already holds, so someone signed into a
+             * personal account never gets to pick their work account — and
+             * lands on an orphan Sim account under the wrong address.
+             */
+            prompt: 'select_account' as const,
+            mapProfileToUser: mapMicrosoftProfileToUser,
           },
         }),
     },

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -440,7 +440,6 @@ export const env = createEnv({
     DOCUSIGN_CLIENT_SECRET:                z.string().optional(),                  // DocuSign OAuth client secret
     MICROSOFT_CLIENT_ID:                   z.string().optional(),                  // Microsoft OAuth client ID for Office 365/Teams
     MICROSOFT_CLIENT_SECRET:               z.string().optional(),                  // Microsoft OAuth client secret
-    MICROSOFT_TENANT_ID:                   z.string().optional(),                  // Microsoft sign-in tenant: a GUID, 'organizations' (work/school only), or 'common' (default)
     HUBSPOT_CLIENT_ID:                     z.string().optional(),                  // HubSpot OAuth client ID
     HUBSPOT_CLIENT_SECRET:                 z.string().optional(),                  // HubSpot OAuth client secret
     SALESFORCE_CLIENT_ID:                  z.string().optional(),                  // Salesforce OAuth client ID

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -440,6 +440,7 @@ export const env = createEnv({
     DOCUSIGN_CLIENT_SECRET:                z.string().optional(),                  // DocuSign OAuth client secret
     MICROSOFT_CLIENT_ID:                   z.string().optional(),                  // Microsoft OAuth client ID for Office 365/Teams
     MICROSOFT_CLIENT_SECRET:               z.string().optional(),                  // Microsoft OAuth client secret
+    MICROSOFT_TENANT_ID:                   z.string().optional(),                  // Microsoft sign-in tenant: a GUID, 'organizations' (work/school only), or 'common' (default)
     HUBSPOT_CLIENT_ID:                     z.string().optional(),                  // HubSpot OAuth client ID
     HUBSPOT_CLIENT_SECRET:                 z.string().optional(),                  // HubSpot OAuth client secret
     SALESFORCE_CLIENT_ID:                  z.string().optional(),                  // Salesforce OAuth client ID

--- a/apps/sim/lib/oauth/microsoft.test.ts
+++ b/apps/sim/lib/oauth/microsoft.test.ts
@@ -25,20 +25,14 @@ describe('mapMicrosoftProfileToUser', () => {
     }
   })
 
-  /**
-   * The nOAuth case: a hostile tenant sets `email` to a victim's address but
-   * cannot verify that domain, so `xms_edov` is absent or false.
-   */
+  /** nOAuth: a hostile tenant can set `email` but cannot verify the domain. */
   it('does not vouch for an email the tenant has not verified', () => {
     expect(mapMicrosoftProfileToUser({ email: 'victim@target.com' })).toEqual({})
     expect(mapMicrosoftProfileToUser({ email: 'victim@target.com', xms_edov: false })).toEqual({})
     expect(mapMicrosoftProfileToUser({ email: 'victim@target.com', xms_edov: '0' })).toEqual({})
   })
 
-  /**
-   * Better Auth spreads this over its own derived profile, so an empty object
-   * must leave `emailVerified` alone rather than forcing it to `false`.
-   */
+  /** The spread must leave `emailVerified` alone, not force it to `false`. */
   it('returns no key at all when unverified, so it can never downgrade', () => {
     expect('emailVerified' in mapMicrosoftProfileToUser({ email: EMAIL })).toBe(false)
   })

--- a/apps/sim/lib/oauth/microsoft.test.ts
+++ b/apps/sim/lib/oauth/microsoft.test.ts
@@ -2,9 +2,47 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { deriveMicrosoftEmailVerified, isMicrosoftProvider } from '@/lib/oauth/microsoft'
+import {
+  deriveMicrosoftEmailVerified,
+  isMicrosoftProvider,
+  mapMicrosoftProfileToUser,
+} from '@/lib/oauth/microsoft'
 
 const EMAIL = 'user@contoso.com'
+
+describe('mapMicrosoftProfileToUser', () => {
+  it('marks the email verified when Entra asserts domain ownership', () => {
+    expect(mapMicrosoftProfileToUser({ email: EMAIL, xms_edov: true })).toEqual({
+      emailVerified: true,
+    })
+  })
+
+  it('accepts the string and numeric encodings Entra uses for xms_edov', () => {
+    for (const edov of ['true', '1', 1]) {
+      expect(mapMicrosoftProfileToUser({ email: EMAIL, xms_edov: edov })).toEqual({
+        emailVerified: true,
+      })
+    }
+  })
+
+  /**
+   * The nOAuth case: a hostile tenant sets `email` to a victim's address but
+   * cannot verify that domain, so `xms_edov` is absent or false.
+   */
+  it('does not vouch for an email the tenant has not verified', () => {
+    expect(mapMicrosoftProfileToUser({ email: 'victim@target.com' })).toEqual({})
+    expect(mapMicrosoftProfileToUser({ email: 'victim@target.com', xms_edov: false })).toEqual({})
+    expect(mapMicrosoftProfileToUser({ email: 'victim@target.com', xms_edov: '0' })).toEqual({})
+  })
+
+  /**
+   * Better Auth spreads this over its own derived profile, so an empty object
+   * must leave `emailVerified` alone rather than forcing it to `false`.
+   */
+  it('returns no key at all when unverified, so it can never downgrade', () => {
+    expect('emailVerified' in mapMicrosoftProfileToUser({ email: EMAIL })).toBe(false)
+  })
+})
 
 describe('deriveMicrosoftEmailVerified', () => {
   it('honors an explicit email_verified=true claim', () => {

--- a/apps/sim/lib/oauth/microsoft.ts
+++ b/apps/sim/lib/oauth/microsoft.ts
@@ -55,6 +55,45 @@ export function deriveMicrosoftEmailVerified(
 }
 
 /**
+ * True when Entra asserts the token's email is domain-verified via the
+ * `xms_edov` optional claim — emitted only when the email's domain belongs to
+ * the user's own tenant and a tenant admin verified that domain. This is the
+ * one email signal a hostile tenant cannot forge (the nOAuth attack turns on
+ * `email` being freely settable), and Microsoft's documented mitigation.
+ *
+ * The claim requires `xms_edov` and `email` to be configured as optional
+ * claims on the app registration; when absent this returns `false` and callers
+ * fall back to the prior behavior unchanged.
+ *
+ * @see https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference
+ */
+function isMicrosoftEmailDomainVerified(claims: Record<string, unknown>): boolean {
+  const edov = claims.xms_edov
+  return edov === true || edov === 'true' || edov === 1 || edov === '1'
+}
+
+/**
+ * Raises `emailVerified` for Microsoft *sign-in* when — and only when — Entra
+ * asserts domain ownership. Better Auth spreads this result over its own
+ * derived profile, so returning an empty object leaves its computation
+ * untouched: this can promote an unverified email to verified, never the
+ * reverse.
+ *
+ * Why it matters: `microsoft` is deliberately absent from
+ * `accountLinking.trustedProviders`, so Better Auth refuses to link a Microsoft
+ * identity onto an existing user row unless the IdP asserts a verified email.
+ * Entra never emits `email_verified` for work/school accounts, so without this
+ * every user who already has a Sim account is permanently locked out of the
+ * Microsoft button with an `account_not_linked` error. `xms_edov` is what lets
+ * the honest case through while still refusing the forged one.
+ */
+export function mapMicrosoftProfileToUser(
+  profile: Record<string, unknown>
+): { emailVerified: true } | Record<string, never> {
+  return isMicrosoftEmailDomainVerified(profile) ? { emailVerified: true } : {}
+}
+
+/**
  * Extracts user info from a Microsoft ID token JWT instead of calling Graph API /me.
  * This avoids 403 errors for external tenant users whose admin hasn't consented to Graph API scopes.
  * The ID token is always returned when the openid scope is requested.

--- a/apps/sim/lib/oauth/microsoft.ts
+++ b/apps/sim/lib/oauth/microsoft.ts
@@ -55,15 +55,10 @@ export function deriveMicrosoftEmailVerified(
 }
 
 /**
- * True when Entra asserts the token's email is domain-verified via the
- * `xms_edov` optional claim — emitted only when the email's domain belongs to
- * the user's own tenant and a tenant admin verified that domain. This is the
- * one email signal a hostile tenant cannot forge (the nOAuth attack turns on
- * `email` being freely settable), and Microsoft's documented mitigation.
- *
- * The claim requires `xms_edov` and `email` to be configured as optional
- * claims on the app registration; when absent this returns `false` and callers
- * fall back to the prior behavior unchanged.
+ * True when Entra's `xms_edov` optional claim asserts the email's domain is
+ * owned by the user's own tenant and admin-verified — the one email signal a
+ * hostile tenant cannot forge, and Microsoft's documented nOAuth mitigation.
+ * Requires `xms_edov` and `email` as optional claims on the app registration.
  *
  * @see https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference
  */
@@ -73,19 +68,14 @@ function isMicrosoftEmailDomainVerified(claims: Record<string, unknown>): boolea
 }
 
 /**
- * Raises `emailVerified` for Microsoft *sign-in* when — and only when — Entra
- * asserts domain ownership. Better Auth spreads this result over its own
- * derived profile, so returning an empty object leaves its computation
- * untouched: this can promote an unverified email to verified, never the
- * reverse.
+ * Raises `emailVerified` for Microsoft sign-in only when Entra asserts domain
+ * ownership. Better Auth spreads this over its own derived profile, so the
+ * empty object leaves that computation untouched — this can promote unverified
+ * to verified, never the reverse.
  *
- * Why it matters: `microsoft` is deliberately absent from
- * `accountLinking.trustedProviders`, so Better Auth refuses to link a Microsoft
- * identity onto an existing user row unless the IdP asserts a verified email.
- * Entra never emits `email_verified` for work/school accounts, so without this
- * every user who already has a Sim account is permanently locked out of the
- * Microsoft button with an `account_not_linked` error. `xms_edov` is what lets
- * the honest case through while still refusing the forged one.
+ * Without it, `microsoft` being absent from `accountLinking.trustedProviders`
+ * (and Entra never emitting `email_verified` for work accounts) permanently
+ * locks anyone with an existing Sim account out of the Microsoft button.
  */
 export function mapMicrosoftProfileToUser(
   profile: Record<string, unknown>


### PR DESCRIPTION
## Summary
- `microsoft` is excluded from `accountLinking.trustedProviders` because the email claim is attacker-controllable on `/common/` (nOAuth). Entra never emits `email_verified` for work/school accounts, so Better Auth refused to link a Microsoft identity onto any existing user row — those users hit `account_not_linked` permanently, with no recovery path
- Derive `emailVerified` from Entra's `xms_edov` optional claim, emitted only when the email's domain belongs to the user's tenant and an admin verified that domain. It's the one email signal a hostile tenant cannot forge, and it's Microsoft's documented nOAuth mitigation. `microsoft` stays untrusted — the linking guard now passes on its own merits
- The mapper returns `{}` when unverified, so it only ever promotes unverified → verified, never downgrades. With the claim absent, Better Auth's computation is byte-identical to today
- Add `prompt=select_account`, so `/common/` stops silently reusing whichever Microsoft session the browser already holds
- Add `/oauth-error` copy for `account_not_linked` and `email_not_found`, which currently dead-end on "Please try again" — advice that can never succeed

## Requires an Entra change to take effect
Inert until `xms_edov` **and** `email` are added as optional claims on the ID token for the app registration (`xms_edov` requires `email` to be present). Until then the mapper returns `{}` and behavior is unchanged.

Known limitation: `xms_edov` is `false` for SAML/WS-Fed federated domains and for B2B guests, so those tenants remain unlinkable and should use Entra SSO, which is trusted for linking.

## Verified against the Better Auth source
- `callback.mjs:140-152` passes `getUserInfo`'s result into `handleOAuthUserInfo`; `microsoft-entra-id.mjs:91-107` builds it from `decodeJwt(idToken)`, so `xms_edov` is visible to `mapProfileToUser`, whose result is spread last (`:116`)
- `overrideUserInfoOnSignIn` is unset, so the branch that rewrites `email`/`emailVerified` on every sign-in (`link-account.mjs:67-77`) never runs
- Existing Microsoft users get `emailVerified` upgraded on next sign-in (`link-account.mjs:49,65`), guarded on exact email match — an upgrade, never a downgrade
- Welcome email fires exactly once: today Microsoft users get none (`auth.ts:348` gates on `emailVerified`); after this they get one at creation. `afterEmailVerification` only runs in the verification flow, which OAuth signups don't enter — no duplicate
- The OAuth verification-email branch (`link-account.mjs:105`) needs both `sendOnSignUp` and `sendVerificationEmail`; we set neither, so it stays dead
- Integration connectors are untouched — they're `genericOAuth` entries with their own `providerId` and `getUserInfo`

## Type of Change
- [x] Bug fix

## Testing
`bun run type-check` clean; 297 tests across 18 files in `lib/auth` + `lib/oauth` pass; verified the new tests fail when the mapper is stubbed out.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)