### PR TITLE
fix(cmdk): update search-modal assertions to the renamed New chat label

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.test.tsx
@@ -149,7 +149,7 @@ describe('SearchModal', () => {
 
     const askRow = document.querySelector<HTMLElement>('[cmdk-item]')
     expect(document.querySelectorAll('[cmdk-item]')).toHaveLength(1)
-    expect(askRow?.textContent).toBe('New Chat: plan our Slack launch week')
+    expect(askRow?.textContent).toBe('New chat: plan our Slack launch week')
     expect(askRow?.getAttribute('aria-selected')).toBe('true')
 
     act(() => {
@@ -192,7 +192,7 @@ describe('SearchModal', () => {
         new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
       )
     })
-    expect(document.querySelector('[cmdk-item]')?.textContent).toBe('New Chat: rainbow')
+    expect(document.querySelector('[cmdk-item]')?.textContent).toBe('New chat: rainbow')
 
     act(() => {
       document


### PR DESCRIPTION
## Summary
- #6543 renamed the cmdk ask-Sim label to sentence case (`New chat: ${query}`, `search-modal.tsx:1094`) but left `search-modal.test.tsx:152` and `:195` asserting `New Chat`
- Those two assertions have been failing `Test and Build / Lint and Test` on staging for every PR since, unrelated to whatever that PR changed
- Test was stale, source is correct — updated the assertions to match

## Type of Change
- [x] Bug fix

## Testing
`search-modal.test.tsx` 19/19 pass. Confirmed the same 2 failures reproduce on clean `origin/staging` without this change.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)