### PR TITLE
improvement(audits): skip the sql-date-binding parse for files without drizzle-orm

### DIFF
--- a/scripts/check-sql-date-binding.ts
+++ b/scripts/check-sql-date-binding.ts
@@ -544,6 +544,18 @@ function analyzeSource(source: string, file = 'source.ts'): FileAnalysis {
   return { violations }
 }
 
+/**
+ * Skips the parse for files that cannot bind the tag.
+ *
+ * `collectSqlBindings` and `isDrizzleImportCall` both match the specifier as a string literal,
+ * so a source that never names the module yields no bindings and no violations. That is all but
+ * ~590 of the ~13,900 scanned files, and not parsing them takes the audit from ~4.5s to ~0.8s.
+ * An escaped specifier (`'drizzle\x2dorm'`) would evade the substring; the repo contains none.
+ */
+function mayBindDrizzleSql(source: string): boolean {
+  return source.includes(DRIZZLE_MODULE)
+}
+
 function collectSources(dir: string, found: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (SKIP_DIRS.has(entry.name)) continue
@@ -560,7 +572,9 @@ function main(): void {
   const skipped: { file: string; parseError: string }[] = []
 
   for (const file of files) {
-    const analysis = analyzeSource(readFileSync(file, 'utf8'), file)
+    const source = readFileSync(file, 'utf8')
+    if (!mayBindDrizzleSql(source)) continue
+    const analysis = analyzeSource(source, file)
     if (analysis.parseError) skipped.push({ file, parseError: analysis.parseError })
     violations.push(...analysis.violations)
   }


### PR DESCRIPTION
## Summary
- `check:sql-date-binding` Babel-parsed all 13,941 source files under `apps`, `packages`, and `scripts`. A violation can only come from an `sql` tag resolved through a `drizzle-orm` import, and both the static (`collectSqlBindings`) and dynamic (`isDrizzleImportCall`) resolvers match the specifier as a string literal — so a file that never names the module cannot bind the tag and cannot violate.
- Only ~590 of those files name it. Skip the parse for the other 92% of bytes.
- Audit goes ~4.5s → ~0.8s (5.7x), dropping out of the four slowest audits. `check:audits` goes 6.0s → 5.3s wall, 38.0s → 32.9s serial.
- Output is unchanged.

## Type of Change
- [x] Improvement (performance)

## Testing
Tested manually:
- Clean tree before/after both report `✓ 13941 files bind every sql-template Date through a column encoder`, warm timings 4.38s/4.63s → 0.82s/0.76s.
- Planted a real violation (`sql\`... ${aDate}\`` in a file importing `sql` from `drizzle-orm`) and confirmed it is still reported with exit 1.
- `bun run check:audits` and `bunx biome check` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)