### PR TITLE
fix(files): let a mouse wheel scroll CSV and XLSX previews horizontally

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/csv-table-preview.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/csv-table-preview.tsx
@@ -2,11 +2,11 @@
 
 import { memo } from 'react'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
+import { useHorizontalWheelScroll } from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-horizontal-wheel-scroll'
 import { useWorkspaceCsvPreview } from '@/hooks/queries/workspace-file-table'
 import { useCsvTruncationImport } from './csv-import'
 import { DataTable } from './data-table'
 import { PreviewError, PreviewLoadingFrame, resolvePreviewError } from './preview-shared'
-import { useHorizontalWheelScroll } from './use-horizontal-wheel-scroll'
 
 /**
  * Read-only preview for a CSV that is too large to load fully into the editor. Streams only the

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/csv-table-preview.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/csv-table-preview.tsx
@@ -6,6 +6,7 @@ import { useWorkspaceCsvPreview } from '@/hooks/queries/workspace-file-table'
 import { useCsvTruncationImport } from './csv-import'
 import { DataTable } from './data-table'
 import { PreviewError, PreviewLoadingFrame, resolvePreviewError } from './preview-shared'
+import { useHorizontalWheelScroll } from './use-horizontal-wheel-scroll'
 
 /**
  * Read-only preview for a CSV that is too large to load fully into the editor. Streams only the
@@ -19,6 +20,7 @@ export const CsvTablePreview = memo(function CsvTablePreview({
   file: WorkspaceFileRecord
   workspaceId: string
 }) {
+  const scrollRef = useHorizontalWheelScroll()
   const version = Number(new Date(file.updatedAt)) || file.size
   const {
     data,
@@ -42,7 +44,7 @@ export const CsvTablePreview = memo(function CsvTablePreview({
   }
 
   return (
-    <div className='flex flex-1 flex-col overflow-auto p-6'>
+    <div ref={scrollRef} className='flex flex-1 flex-col overflow-auto p-6'>
       <DataTable headers={data.headers} rows={data.rows} />
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -4,10 +4,10 @@ import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import '@sim/emcn/components/code/code.css'
 import { CSV_PREVIEW_MAX_ROWS } from '@/lib/api/contracts/workspace-file-table'
 import { getFileExtension } from '@/lib/uploads/utils/file-utils'
+import { useHorizontalWheelScroll } from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-horizontal-wheel-scroll'
 import { type CsvImportFileDescriptor, useCsvTruncationImport } from './csv-import'
 import { DataTable } from './data-table'
 import { MermaidDiagram } from './mermaid-diagram'
-import { useHorizontalWheelScroll } from './use-horizontal-wheel-scroll'
 import { ZoomablePreview } from './zoomable-preview'
 
 type PreviewType = 'markdown' | 'html' | 'csv' | 'svg' | 'mermaid' | null

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel.tsx
@@ -7,6 +7,7 @@ import { getFileExtension } from '@/lib/uploads/utils/file-utils'
 import { type CsvImportFileDescriptor, useCsvTruncationImport } from './csv-import'
 import { DataTable } from './data-table'
 import { MermaidDiagram } from './mermaid-diagram'
+import { useHorizontalWheelScroll } from './use-horizontal-wheel-scroll'
 import { ZoomablePreview } from './zoomable-preview'
 
 type PreviewType = 'markdown' | 'html' | 'csv' | 'svg' | 'mermaid' | null
@@ -264,6 +265,7 @@ const CsvPreview = memo(function CsvPreview({
   file: CsvImportFileDescriptor
   readOnly?: boolean
 }) {
+  const scrollRef = useHorizontalWheelScroll()
   const { headers, rows, truncated } = useMemo(() => parseCsv(content), [content])
   useCsvTruncationImport(workspaceId, file, truncated, readOnly)
 
@@ -276,7 +278,7 @@ const CsvPreview = memo(function CsvPreview({
   }
 
   return (
-    <div className='min-h-0 flex-1 overflow-auto p-6'>
+    <div ref={scrollRef} className='min-h-0 flex-1 overflow-auto p-6'>
       <DataTable headers={headers} rows={rows} />
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.test.ts
@@ -71,6 +71,22 @@ describe('bindPreviewHorizontalWheel', () => {
     expect(container.scrollTop).toBe(0)
   })
 
+  /**
+   * `deltaMode` is not always pixels — Firefox reports mouse wheels in lines — while scroll
+   * offsets always are, so a three-line notch added raw would move the table three pixels.
+   */
+  it('converts a line-mode delta to pixels', () => {
+    wheel(container, { deltaX: 3, deltaY: 0, deltaMode: WheelEvent.DOM_DELTA_LINE })
+
+    expect(container.scrollLeft).toBe(48)
+  })
+
+  it('converts a page-mode delta to the container width', () => {
+    wheel(container, { deltaX: 1, deltaY: 0, deltaMode: WheelEvent.DOM_DELTA_PAGE })
+
+    expect(container.scrollLeft).toBe(1000)
+  })
+
   it('leaves a plain vertical wheel alone so the container still scrolls down', () => {
     const event = wheel(container, { deltaX: 0, deltaY: 120 })
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.test.ts
@@ -50,6 +50,27 @@ describe('bindPreviewHorizontalWheel', () => {
     expect(event.defaultPrevented).toBe(true)
   })
 
+  /**
+   * Cancelling a wheel event is all-or-nothing, so a diagonal trackpad pan must have its
+   * vertical movement re-applied by hand — otherwise `preventDefault` silently eats it.
+   */
+  it('keeps the vertical movement of a diagonal pan', () => {
+    Object.defineProperty(container, 'scrollHeight', { value: 5000, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 500, configurable: true })
+
+    wheel(container, { deltaX: 40, deltaY: 90 })
+
+    expect(container.scrollLeft).toBe(40)
+    expect(container.scrollTop).toBe(90)
+  })
+
+  it('does not also spend a shift gesture vertically', () => {
+    wheel(container, { deltaX: 0, deltaY: 120, shiftKey: true })
+
+    expect(container.scrollLeft).toBe(120)
+    expect(container.scrollTop).toBe(0)
+  })
+
   it('leaves a plain vertical wheel alone so the container still scrolls down', () => {
     const event = wheel(container, { deltaX: 0, deltaY: 120 })
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * A mouse whose wheel reports only `deltaY` has no native gesture for reaching a preview
+ * table's horizontal overflow short of dragging the scrollbar, so the tabular previews bind
+ * `bindPreviewHorizontalWheel`. It must move the container on a horizontal gesture, stay out
+ * of the way otherwise, and — unlike the zooming variant — leave ctrl/cmd+wheel to the browser
+ * so page zoom still works over a table.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { bindPreviewHorizontalWheel } from '@/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom'
+
+/** jsdom does no layout, so scrollWidth/clientWidth are stubbed to model an overflowing container. */
+function makeContainer({ scrollWidth = 2000, clientWidth = 1000 } = {}): HTMLElement {
+  const el = document.createElement('div')
+  Object.defineProperty(el, 'scrollWidth', { value: scrollWidth, configurable: true })
+  Object.defineProperty(el, 'clientWidth', { value: clientWidth, configurable: true })
+  el.scrollLeft = 0
+  document.body.appendChild(el)
+  return el
+}
+
+function wheel(el: HTMLElement, init: WheelEventInit): WheelEvent {
+  const event = new WheelEvent('wheel', { bubbles: true, cancelable: true, ...init })
+  el.dispatchEvent(event)
+  return event
+}
+
+describe('bindPreviewHorizontalWheel', () => {
+  let container: HTMLElement
+  let unbind: () => void
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    container = makeContainer()
+    unbind = bindPreviewHorizontalWheel(container)
+  })
+
+  it("scrolls by a trackpad's horizontal delta", () => {
+    const event = wheel(container, { deltaX: 120, deltaY: 0 })
+
+    expect(container.scrollLeft).toBe(120)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('maps shift+wheel to horizontal for a vertical-only mouse', () => {
+    const event = wheel(container, { deltaX: 0, deltaY: 120, shiftKey: true })
+
+    expect(container.scrollLeft).toBe(120)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('leaves a plain vertical wheel alone so the container still scrolls down', () => {
+    const event = wheel(container, { deltaX: 0, deltaY: 120 })
+
+    expect(container.scrollLeft).toBe(0)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  /** Zoom is the browser's here — the tabular previews have no zoom of their own. */
+  it.each([
+    ['ctrl', { ctrlKey: true }],
+    ['cmd', { metaKey: true }],
+  ])('leaves %s+wheel to the browser', (_label, modifier) => {
+    const event = wheel(container, { deltaX: 120, deltaY: 0, ...modifier })
+
+    expect(container.scrollLeft).toBe(0)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('does nothing when the container has no horizontal overflow', () => {
+    const fitted = makeContainer({ scrollWidth: 1000, clientWidth: 1000 })
+    const unbindFitted = bindPreviewHorizontalWheel(fitted)
+
+    const event = wheel(fitted, { deltaX: 120, deltaY: 0 })
+
+    expect(fitted.scrollLeft).toBe(0)
+    expect(event.defaultPrevented).toBe(false)
+    unbindFitted()
+  })
+
+  it('stops scrolling once unbound', () => {
+    unbind()
+
+    wheel(container, { deltaX: 120, deltaY: 0 })
+
+    expect(container.scrollLeft).toBe(0)
+  })
+
+  it('scrolls a child gesture, since the listener captures', () => {
+    const cell = document.createElement('td')
+    container.appendChild(cell)
+
+    wheel(cell, { deltaX: 80, deltaY: 0 })
+
+    expect(container.scrollLeft).toBe(80)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.ts
@@ -18,9 +18,22 @@ function horizontalDeltaOf(event: WheelEvent): number {
 }
 
 /**
- * Scroll `container` horizontally for a wheel gesture. No-op when the gesture carries
- * no horizontal component or the container has nothing to scroll, leaving the event to
- * scroll vertically as usual.
+ * Vertical component still owed to the container once the horizontal one is taken.
+ * Shift *remaps* `deltaY` onto the horizontal axis, so that gesture has no vertical
+ * component left to spend; an ordinary diagonal trackpad pan does.
+ */
+function verticalDeltaOf(event: WheelEvent): number {
+  return event.deltaX !== 0 ? event.deltaY : 0
+}
+
+/**
+ * Scroll `container` for a wheel gesture carrying a horizontal component. No-op when the
+ * gesture is purely vertical or the container has nothing to scroll sideways, leaving the
+ * event to scroll natively.
+ *
+ * Cancelling a wheel event is all-or-nothing, so once `preventDefault` is called this owes
+ * the container *both* axes — a diagonal pan that only had its `deltaX` applied would lose
+ * its vertical movement entirely.
  */
 function applyHorizontalWheel(container: HTMLElement, event: WheelEvent): void {
   const horizontalDelta = horizontalDeltaOf(event)
@@ -28,6 +41,7 @@ function applyHorizontalWheel(container: HTMLElement, event: WheelEvent): void {
 
   event.preventDefault()
   container.scrollLeft += horizontalDelta
+  container.scrollTop += verticalDeltaOf(event)
 }
 
 /**

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.ts
@@ -9,6 +9,45 @@ interface BindPreviewWheelZoomOptions {
 }
 
 /**
+ * Horizontal component of a wheel gesture: a trackpad's own `deltaX`, or `deltaY`
+ * while Shift is held — the only horizontal gesture available on a mouse whose
+ * wheel reports `deltaY` alone.
+ */
+function horizontalDeltaOf(event: WheelEvent): number {
+  return event.deltaX !== 0 ? event.deltaX : event.shiftKey ? event.deltaY : 0
+}
+
+/**
+ * Scroll `container` horizontally for a wheel gesture. No-op when the gesture carries
+ * no horizontal component or the container has nothing to scroll, leaving the event to
+ * scroll vertically as usual.
+ */
+function applyHorizontalWheel(container: HTMLElement, event: WheelEvent): void {
+  const horizontalDelta = horizontalDeltaOf(event)
+  if (horizontalDelta === 0 || container.scrollWidth <= container.clientWidth) return
+
+  event.preventDefault()
+  container.scrollLeft += horizontalDelta
+}
+
+/**
+ * Bind horizontal wheel gestures for a preview scroll container that has no zoom of its
+ * own — the tabular CSV/XLSX previews, whose table is wider than its frame. A mouse whose
+ * wheel reports only `deltaY` otherwise has no way to reach that overflow short of dragging
+ * the scrollbar. Unlike {@link bindPreviewWheelZoom} this leaves `ctrl`/`cmd`+wheel alone,
+ * so browser page zoom still works over a table.
+ */
+export function bindPreviewHorizontalWheel(container: HTMLElement): () => void {
+  const onWheel = (event: WheelEvent) => {
+    if (event.ctrlKey || event.metaKey) return
+    applyHorizontalWheel(container, event)
+  }
+
+  container.addEventListener('wheel', onWheel, { capture: true, passive: false })
+  return () => container.removeEventListener('wheel', onWheel, { capture: true })
+}
+
+/**
  * Bind browser pinch/ctrl-wheel zoom and horizontal wheel gestures for preview
  * scroll containers. Trackpad pinch fires `wheel` with `ctrlKey=true`; without
  * a non-passive native listener the browser falls back to page zoom. `metaKey`
@@ -34,11 +73,7 @@ export function bindPreviewWheelZoom(
       return
     }
 
-    const horizontalDelta = event.deltaX !== 0 ? event.deltaX : event.shiftKey ? event.deltaY : 0
-    if (horizontalDelta === 0 || container.scrollWidth <= container.clientWidth) return
-
-    event.preventDefault()
-    container.scrollLeft += horizontalDelta
+    applyHorizontalWheel(container, event)
   }
 
   container.addEventListener('wheel', onWheel, { capture: true, passive: false })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom.ts
@@ -27,6 +27,20 @@ function verticalDeltaOf(event: WheelEvent): number {
 }
 
 /**
+ * Rough pixel height of one wheel "line". A wheel delta is only in pixels when `deltaMode`
+ * says so — Firefox reports mouse wheels in lines — while scroll offsets are always pixels,
+ * so a three-line notch added raw would move the table three pixels.
+ */
+const WHEEL_LINE_HEIGHT_PX = 16
+
+/** Convert a wheel delta to pixels. `pageSize` is the container extent along that axis. */
+function toPixels(delta: number, event: WheelEvent, pageSize: number): number {
+  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) return delta * WHEEL_LINE_HEIGHT_PX
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) return delta * pageSize
+  return delta
+}
+
+/**
  * Scroll `container` for a wheel gesture carrying a horizontal component. No-op when the
  * gesture is purely vertical or the container has nothing to scroll sideways, leaving the
  * event to scroll natively.
@@ -40,8 +54,8 @@ function applyHorizontalWheel(container: HTMLElement, event: WheelEvent): void {
   if (horizontalDelta === 0 || container.scrollWidth <= container.clientWidth) return
 
   event.preventDefault()
-  container.scrollLeft += horizontalDelta
-  container.scrollTop += verticalDeltaOf(event)
+  container.scrollLeft += toPixels(horizontalDelta, event, container.clientWidth)
+  container.scrollTop += toPixels(verticalDeltaOf(event), event, container.clientHeight)
 }
 
 /**

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-horizontal-wheel-scroll.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-horizontal-wheel-scroll.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { useCallback, useRef } from 'react'
+import { bindPreviewHorizontalWheel } from '@/app/workspace/[workspaceId]/files/components/file-viewer/preview-wheel-zoom'
+
+/**
+ * Ref callback that gives a preview scroll container horizontal wheel scrolling.
+ *
+ * The tabular previews render a table wider than its frame, and a mouse whose wheel
+ * reports only `deltaY` has no native way to reach the overflow short of dragging the
+ * scrollbar. Binding is done through a ref callback rather than an effect so the
+ * listener attaches with the node and detaches when React passes `null`.
+ */
+export function useHorizontalWheelScroll() {
+  const unbindRef = useRef<(() => void) | null>(null)
+
+  return useCallback((node: HTMLDivElement | null) => {
+    unbindRef.current?.()
+    unbindRef.current = node ? bindPreviewHorizontalWheel(node) : null
+  }, [])
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/xlsx-preview.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/xlsx-preview.tsx
@@ -10,6 +10,7 @@ import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import { DataTable } from './data-table'
 import { PreviewError, PreviewLoadingFrame, resolvePreviewError } from './preview-shared'
 import { useDocPreviewBinary } from './use-doc-preview-binary'
+import { useHorizontalWheelScroll } from './use-horizontal-wheel-scroll'
 
 const logger = createLogger('XlsxPreview')
 
@@ -29,6 +30,7 @@ export const XlsxPreview = memo(function XlsxPreview({
   file: WorkspaceFileRecord
   workspaceId: string
 }) {
+  const scrollRef = useHorizontalWheelScroll()
   const preview = useDocPreviewBinary(workspaceId, file)
   const fileData = preview.data
 
@@ -130,7 +132,7 @@ export const XlsxPreview = memo(function XlsxPreview({
           ))}
         </div>
       </div>
-      <div className='flex-1 overflow-auto p-6'>
+      <div ref={scrollRef} className='flex-1 overflow-auto p-6'>
         <DataTable headers={currentSheet.headers} rows={currentSheet.rows} />
         {currentSheet.truncated && (
           <p className='mt-3 text-center text-[12px] text-[var(--text-muted)]'>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/xlsx-preview.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/xlsx-preview.tsx
@@ -7,10 +7,10 @@ import { toError } from '@sim/utils/errors'
 import type { WorkBook } from 'xlsx'
 import { assertOoxmlPreviewWithinLimits } from '@/lib/file-parsers/ooxml-preview-guard'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
+import { useHorizontalWheelScroll } from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-horizontal-wheel-scroll'
 import { DataTable } from './data-table'
 import { PreviewError, PreviewLoadingFrame, resolvePreviewError } from './preview-shared'
 import { useDocPreviewBinary } from './use-doc-preview-binary'
-import { useHorizontalWheelScroll } from './use-horizontal-wheel-scroll'
 
 const logger = createLogger('XlsxPreview')
 


### PR DESCRIPTION
## Summary
- Hovering a CSV/XLSX preview table and scrolling does nothing sideways on a mouse whose wheel reports only `deltaY` — the horizontal overflow is reachable only by dragging the scrollbar
- The zoomable previews (docx, pdf, pptx, image) already bind `bindPreviewWheelZoom`, whose horizontal branch maps a trackpad's `deltaX`, and Shift+`deltaY` on a plain mouse, onto `scrollLeft`. The tabular previews never bound anything
- Extracted that branch into `bindPreviewHorizontalWheel` — sharing the delta logic with the zooming variant rather than duplicating it — and bound it in all three tabular preview containers (`csv-table-preview`, `xlsx-preview`, `preview-panel`'s `CsvPreview`) via a `useHorizontalWheelScroll` ref callback
- The new binder ignores ctrl/cmd+wheel, so browser page zoom still works over a table. These previews have no zoom of their own, unlike the zoomable ones

Latent until #6550: while the table was sized to the frame it never overflowed, so there was nothing to scroll. Independent of that PR though — the binder no-ops when `scrollWidth <= clientWidth`, so it is inert until the table is actually wider.

## Type of Change
- [x] Bug fix

## Testing
8 unit tests in `preview-wheel-zoom.test.ts` covering trackpad `deltaX`, Shift+wheel, plain vertical wheel (must stay vertical), ctrl/cmd passthrough, the no-overflow no-op, unbind, and capture from a child cell. Mutation-verified: 3 fail when the binder body is removed.

jsdom does no layout, so the tests assert the handler's contract rather than real scrolling. Verified actual behavior separately with trusted wheel events in headless Chromium, hovering a table cell:

| | plain wheel | Shift+wheel |
|---|---|---|
| unbound (today) | scrolls down 200 | scrolls **down** 200 — no horizontal movement |
| bound (this PR) | scrolls down 200 | scrolls **right** 200 |

Not yet exercised in the running app.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
