### PR TITLE
fix(skills): only reject a built-in name collision on an actual rename

### DIFF
--- a/apps/sim/lib/skills/orchestration/skill-lifecycle.test.ts
+++ b/apps/sim/lib/skills/orchestration/skill-lifecycle.test.ts
@@ -58,7 +58,7 @@ describe('skill lifecycle built-in name collision', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUpsertSkills.mockResolvedValue({ touched: [{ id: SKILL_ID, name: 'x' }] })
-    mockGetSkillById.mockImplementation(async () => skillRow(BUILTIN_NAME))
+    mockGetSkillById.mockResolvedValue(skillRow(BUILTIN_NAME))
   })
 
   it('allows an update that re-sends an existing built-in-colliding name unchanged', async () => {

--- a/apps/sim/lib/skills/orchestration/skill-lifecycle.test.ts
+++ b/apps/sim/lib/skills/orchestration/skill-lifecycle.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetSkillActorContext, mockUpsertSkills, mockGetSkillById, mockDeleteSkill } =
+  vi.hoisted(() => ({
+    mockGetSkillActorContext: vi.fn(),
+    mockUpsertSkills: vi.fn(),
+    mockGetSkillById: vi.fn(),
+    mockDeleteSkill: vi.fn(),
+  }))
+
+vi.mock('@/lib/skills/access', () => ({
+  getSkillActorContext: mockGetSkillActorContext,
+}))
+
+vi.mock('@/lib/workflows/skills/operations', () => ({
+  upsertSkills: mockUpsertSkills,
+  getSkillById: mockGetSkillById,
+  deleteSkill: mockDeleteSkill,
+}))
+
+vi.mock('@/lib/posthog/server', () => ({
+  captureServerEvent: vi.fn(),
+}))
+
+vi.mock('@sim/audit', () => ({
+  AuditAction: { SKILL_CREATED: 'skill.created', SKILL_UPDATED: 'skill.updated' },
+  AuditResourceType: { SKILL: 'skill' },
+  recordAudit: vi.fn(),
+}))
+
+import { createSkill, updateSkill } from '@/lib/skills/orchestration/skill-lifecycle'
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111'
+const USER_ID = '22222222-2222-4222-8222-222222222222'
+const SKILL_ID = '33333333-3333-4333-8333-333333333333'
+
+/** `research` is one of the shipped built-in skill names. */
+const BUILTIN_NAME = 'research'
+
+function skillRow(name: string) {
+  return {
+    id: SKILL_ID,
+    workspaceId: WORKSPACE_ID,
+    name,
+    description: 'desc',
+    content: 'content',
+  }
+}
+
+function actorOwning(name: string) {
+  return { skill: skillRow(name), hasWorkspaceAccess: true, canEdit: true }
+}
+
+describe('skill lifecycle built-in name collision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpsertSkills.mockResolvedValue({ touched: [{ id: SKILL_ID, name: 'x' }] })
+    mockGetSkillById.mockImplementation(async () => skillRow(BUILTIN_NAME))
+  })
+
+  it('allows an update that re-sends an existing built-in-colliding name unchanged', async () => {
+    mockGetSkillActorContext.mockResolvedValue(actorOwning(BUILTIN_NAME))
+
+    const row = await updateSkill({
+      workspaceId: WORKSPACE_ID,
+      userId: USER_ID,
+      skillId: SKILL_ID,
+      name: BUILTIN_NAME,
+      description: 'updated description',
+      content: 'updated content',
+    })
+
+    expect(row.name).toBe(BUILTIN_NAME)
+    expect(mockUpsertSkills).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects renaming a skill into a built-in name', async () => {
+    mockGetSkillActorContext.mockResolvedValue(actorOwning('my-skill'))
+
+    await expect(
+      updateSkill({
+        workspaceId: WORKSPACE_ID,
+        userId: USER_ID,
+        skillId: SKILL_ID,
+        name: BUILTIN_NAME,
+      })
+    ).rejects.toThrow(`The skill name "${BUILTIN_NAME}" is reserved by a built-in skill`)
+
+    expect(mockUpsertSkills).not.toHaveBeenCalled()
+  })
+
+  it('rejects creating a skill with a built-in name', async () => {
+    await expect(
+      createSkill({
+        workspaceId: WORKSPACE_ID,
+        userId: USER_ID,
+        name: BUILTIN_NAME,
+        description: 'desc',
+        content: 'content',
+      })
+    ).rejects.toThrow(`The skill name "${BUILTIN_NAME}" is reserved by a built-in skill`)
+
+    expect(mockUpsertSkills).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/lib/skills/orchestration/skill-lifecycle.ts
+++ b/apps/sim/lib/skills/orchestration/skill-lifecycle.ts
@@ -337,9 +337,7 @@ export async function updateSkill(
   }
 
   const invalid =
-    (params.name !== undefined
-      ? (fieldError(skillNameSchema, params.name) ?? builtinNameCollision(params.name))
-      : null) ??
+    (params.name !== undefined ? fieldError(skillNameSchema, params.name) : null) ??
     (params.description !== undefined
       ? fieldError(skillDescriptionSchema, params.description)
       : null) ??
@@ -348,6 +346,17 @@ export async function updateSkill(
 
   const resolved = await resolveEditableSkill(params)
   if (!resolved.ok) throwSkillFailure(resolved.result)
+
+  /**
+   * Only a rename can newly shadow a built-in, so the guard runs against the
+   * canonical name rather than the submitted one. Rows predating the guard may
+   * already carry a built-in's name, and the skill modal always submits the
+   * full object — re-sending that unchanged name is not a new collision.
+   */
+  if (params.name !== undefined && params.name !== resolved.skill.name) {
+    const collision = builtinNameCollision(params.name)
+    if (collision) throw new OrchestrationError('validation', collision)
+  }
 
   try {
     await upsertSkills({

--- a/apps/sim/lib/skills/orchestration/skill-lifecycle.ts
+++ b/apps/sim/lib/skills/orchestration/skill-lifecycle.ts
@@ -347,12 +347,9 @@ export async function updateSkill(
   const resolved = await resolveEditableSkill(params)
   if (!resolved.ok) throwSkillFailure(resolved.result)
 
-  /**
-   * Only a rename can newly shadow a built-in, so the guard runs against the
-   * canonical name rather than the submitted one. Rows predating the guard may
-   * already carry a built-in's name, and the skill modal always submits the
-   * full object — re-sending that unchanged name is not a new collision.
-   */
+  // Only a rename can newly shadow a built-in. Rows predating the guard may already carry a
+  // built-in's name, and the modal always resubmits the full object, so compare against the
+  // canonical name rather than rejecting every write that echoes it back.
   if (params.name !== undefined && params.name !== resolved.skill.name) {
     const collision = builtinNameCollision(params.name)
     if (collision) throw new OrchestrationError('validation', collision)


### PR DESCRIPTION
**Stacked on #6569** → #6568 → #6567 → #6565 → #6560. Review only this PR's own commits; merge after its parents.

A skill whose existing name matches a built-in returned **400 on every save**, with no in-product way out except renaming it.

### Cause

`updateSkill` ran `builtinNameCollision(params.name)` in the field-validation block *before* `resolveEditableSkill` loaded the canonical row — so the persisted name was not yet in scope and the guard could not compare against it. It fired on any update carrying a `name`, changed or not.

Reachable from the real client: the skill modal sends `updates: { name, description, content }` — always the full object, including an unchanged name. (The detail page sends only changed fields and was unaffected, so the "skill modal" framing is the accurate one.)

### Not theoretical

Built-in skills shipped in #4923; this guard shipped in #5273. In between, `operations.ts` merged built-ins with `BUILTIN_SKILLS.filter((b) => !dbNames.has(b.name.toLowerCase()))`, so a workspace skill named `research`, `create-table`, `deploy-workflow`, or `connect-integration` was freely creatable and simply shadowed the built-in. Those rows are now stuck.

### Fix

The guard moves to after `resolveEditableSkill` and fires only when `params.name !== resolved.skill.name`. Comparison is exact, so `research` → `Research` still counts as a rename into a collision and is rejected. Error shape is unchanged (`OrchestrationError('validation', …)`, identical to the create path). Creating a new skill with a built-in name still 400s.

**Layer choice:** the shared `updateSkill` orchestration primitive, not `updateSkillUseCase`. The two surfaces diverge today — v2 `PATCH /api/v2/skills/[id]` and Copilot go through the use case, but internal `POST /api/skills` calls `performUpdateSkill` directly. `updateSkill` is the single chokepoint both reach *and* the layer where the canonical row is loaded; placing it in the use case would have left the internal path broken.

Side effect: a non-editor attempting a colliding rename now gets 403 rather than 400 — correct, since authorization should precede business validation.

### Pre-existing issue, not fixed here

`POST /api/skills` bypassing `updateSkillUseCase` skips that use case's authorization and semantic audit — an Application Operation Boundary violation worth its own ticket. This fix is placed so the two surfaces cannot disagree on *this* rule regardless.

Test 1 (unchanged colliding name succeeds) goes red on revert. Tests 2 and 3 are regression guards that pass with and without the fix — proven capable of failing by neutering `builtinNameCollision`. type-check · biome · 44 tests · `check:api-validation` — all pass.