### PR TITLE
fix(tables): preserve group auto-run semantics

### DIFF
--- a/apps/sim/lib/table/application/groups.test.ts
+++ b/apps/sim/lib/table/application/groups.test.ts
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   resolveContext: vi.fn(),
   resolvePermission: vi.fn(),
   resolveWorkflowContext: vi.fn(),
+  runDetached: vi.fn(),
+  runWorkflowColumn: vi.fn(),
   signal: vi.fn(),
   updateGroup: vi.fn(),
 }))
@@ -36,7 +38,12 @@ vi.mock('@sim/platform-authz/workspace', () => ({
 }))
 vi.mock('@sim/utils/id', () => ({ generateId: () => 'generated-id' }))
 vi.mock('@/enrichments/registry', () => ({ getEnrichment: mocks.getEnrichment }))
-vi.mock('@/lib/core/utils/background', () => ({ runDetached: vi.fn() }))
+vi.mock('@/lib/core/utils/background', () => ({
+  runDetached: (label: string, work: () => Promise<unknown>) => {
+    mocks.runDetached(label)
+    void work()
+  },
+}))
 vi.mock('@/lib/core/utils/request', () => ({ generateRequestId: () => 'request-1' }))
 vi.mock('@/lib/table/application/context', () => ({
   resolveActiveTableContext: mocks.resolveContext,
@@ -51,7 +58,9 @@ vi.mock('@/lib/table/column-naming', () => ({
   },
 }))
 vi.mock('@/lib/table/events', () => ({ signalTableSchemaChanged: mocks.signal }))
-vi.mock('@/lib/table/workflow-columns', () => ({ runWorkflowColumn: vi.fn() }))
+vi.mock('@/lib/table/workflow-columns', () => ({
+  runWorkflowColumn: mocks.runWorkflowColumn,
+}))
 vi.mock('@/lib/table/workflow-groups/service', () => ({
   addWorkflowGroup: mocks.addGroup,
   addWorkflowGroupOutput: mocks.addOutput,
@@ -145,6 +154,10 @@ describe('workflow and enrichment Table application commands', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.resolvePermission.mockResolvedValue('write')
+    mocks.runWorkflowColumn.mockResolvedValue({
+      dispatchId: 'dispatch-1',
+      shouldSignalRowsChanged: false,
+    })
     mocks.resolveContext.mockResolvedValue({
       tableId: table.id,
       table,
@@ -242,6 +255,30 @@ describe('workflow and enrichment Table application commands', () => {
       }),
       'request-1'
     )
+  })
+
+  it('starts group auto-run without manual rerun semantics', async () => {
+    await createWorkflowTableGroup.execute({
+      principal,
+      input: {
+        tableId: table.id,
+        workspaceId: table.workspaceId,
+        workflowId: 'workflow-1',
+        outputs: [{ blockId: 'block-2', path: 'score' }],
+        autoRun: true,
+      },
+    })
+
+    expect(mocks.runDetached).toHaveBeenCalledWith('table-workflow-group-create-auto-run')
+    expect(mocks.runWorkflowColumn).toHaveBeenCalledWith({
+      tableId: table.id,
+      workspaceId: table.workspaceId,
+      groupIds: ['generated-id'],
+      mode: 'new',
+      isManualRun: false,
+      requestId: 'request-1',
+      triggeredByUserId: 'user-1',
+    })
   })
 
   it('conceals a cross-workspace workflow before group mutation or effects', async () => {

--- a/apps/sim/lib/table/application/groups.ts
+++ b/apps/sim/lib/table/application/groups.ts
@@ -156,7 +156,8 @@ function dispatchGroupAutoRun(params: {
       tableId: params.tableId,
       workspaceId: params.workspaceId,
       groupIds: [params.groupId],
-      mode: 'all',
+      mode: 'new',
+      isManualRun: false,
       requestId: generateRequestId(),
       triggeredByUserId: params.actorUserId,
     })


### PR DESCRIPTION
## Summary
- use non-manual `new` dispatch semantics for group auto-run
- prevent auto-run from cancelling active work or clearing completed cells

## Type of Change
- [x] Bug fix

## Testing
- 23 focused table group application and route tests
- Sim app typecheck
- Full lint
- All 25 repository audits

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)