### PR TITLE
fix(logs): restore narrow v1 detail query

### DIFF
--- a/apps/sim/app/api/v1/logs/[id]/route.ts
+++ b/apps/sim/app/api/v1/logs/[id]/route.ts
@@ -1,11 +1,13 @@
+import { db } from '@sim/db'
+import { workflow, workflowExecutionLogs } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
+import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 import { v1GetLogContract } from '@/lib/api/contracts/v1/logs'
 import { parseRequest } from '@/lib/api/server'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { materializeExecutionDataForDisplay } from '@/lib/logs/execution/trace-store'
-import { getPublicWorkflowLog } from '@/lib/logs/public-queries'
 import { createApiResponse, getUserLimits } from '@/app/api/v1/logs/meta'
 import {
   checkRateLimit,
@@ -36,7 +38,36 @@ export const GET = withRouteHandler(
 
       const { id } = parsed.data.params
 
-      const log = await getPublicWorkflowLog({ column: 'id', value: id })
+      const rows = await db
+        .select({
+          id: workflowExecutionLogs.id,
+          workflowId: workflowExecutionLogs.workflowId,
+          workspaceId: workflowExecutionLogs.workspaceId,
+          executionId: workflowExecutionLogs.executionId,
+          stateSnapshotId: workflowExecutionLogs.stateSnapshotId,
+          level: workflowExecutionLogs.level,
+          trigger: workflowExecutionLogs.trigger,
+          startedAt: workflowExecutionLogs.startedAt,
+          endedAt: workflowExecutionLogs.endedAt,
+          totalDurationMs: workflowExecutionLogs.totalDurationMs,
+          executionData: workflowExecutionLogs.executionData,
+          costTotal: workflowExecutionLogs.costTotal,
+          files: workflowExecutionLogs.files,
+          createdAt: workflowExecutionLogs.createdAt,
+          workflowName: workflow.name,
+          workflowDescription: workflow.description,
+          workflowFolderId: workflow.folderId,
+          workflowUserId: workflow.userId,
+          workflowWorkspaceId: workflow.workspaceId,
+          workflowCreatedAt: workflow.createdAt,
+          workflowUpdatedAt: workflow.updatedAt,
+        })
+        .from(workflowExecutionLogs)
+        .leftJoin(workflow, eq(workflowExecutionLogs.workflowId, workflow.id))
+        .where(eq(workflowExecutionLogs.id, id))
+        .limit(1)
+
+      const log = rows[0]
       if (!log) {
         return NextResponse.json({ error: 'Log not found' }, { status: 404 })
       }


### PR DESCRIPTION
## Summary
- Restore the route-specific v1 log detail query
- Avoid loading unused snapshot, deployment, pause, and owner data

## Type of Change
- [x] Bug fix

## Testing
- `bun run lint`
- `bun run apps/sim/scripts/check-block-registry.ts origin/staging`
- `bun run check:audits`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)