### PR TITLE
fix(tables): prevent legacy group auto-run dispatch

### DIFF
--- a/apps/sim/lib/table/application/groups.test.ts
+++ b/apps/sim/lib/table/application/groups.test.ts
@@ -378,6 +378,28 @@ describe('workflow and enrichment Table application commands', () => {
     )
   })
 
+  it('does not start auto-run when the generic update saves a legacy enabled group', async () => {
+    await updateTableGroupUseCase.execute({
+      principal,
+      input: {
+        tableId: table.id,
+        workspaceId: table.workspaceId,
+        groupId: group.id,
+        autoRun: true,
+      },
+    })
+
+    expect(mocks.updateGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoRun: true,
+        suppressAutoRunDispatch: true,
+      }),
+      'request-1'
+    )
+    expect(mocks.runDetached).not.toHaveBeenCalled()
+    expect(mocks.runWorkflowColumn).not.toHaveBeenCalled()
+  })
+
   it('rejects an invalid output before constructing or mutating the group', async () => {
     await expect(
       createWorkflowTableGroup.execute({
@@ -511,6 +533,28 @@ describe('workflow and enrichment Table application commands', () => {
     expect(result.changed).toBe(false)
     expect(mocks.audit).not.toHaveBeenCalled()
     expect(mocks.signal).not.toHaveBeenCalled()
+  })
+
+  it('does not start auto-run when the workflow update saves a legacy enabled group', async () => {
+    await updateWorkflowTableGroup.execute({
+      principal,
+      input: {
+        tableId: table.id,
+        workspaceId: table.workspaceId,
+        groupId: group.id,
+        autoRun: true,
+      },
+    })
+
+    expect(mocks.updateGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoRun: true,
+        suppressAutoRunDispatch: true,
+      }),
+      'request-1'
+    )
+    expect(mocks.runDetached).not.toHaveBeenCalled()
+    expect(mocks.runWorkflowColumn).not.toHaveBeenCalled()
   })
 
   it('passes authorized output type and ordering to the add-output mutation', async () => {

--- a/apps/sim/lib/table/application/groups.ts
+++ b/apps/sim/lib/table/application/groups.ts
@@ -635,7 +635,7 @@ export const updateTableGroupUseCase = defineAuthorizedTableUseCase({
       changed:
         JSON.stringify(context.table.schema) !== JSON.stringify(table.schema) ||
         JSON.stringify(context.table.metadata) !== JSON.stringify(table.metadata),
-      startAutoRun: previousGroup?.autoRun !== true && input.autoRun === true,
+      startAutoRun: previousGroup?.autoRun === false && input.autoRun === true,
       actorUserId,
     }
   },
@@ -824,7 +824,7 @@ export const updateWorkflowTableGroup = defineAuthorizedTableUseCase({
       changed:
         JSON.stringify(context.table.schema) !== JSON.stringify(table.schema) ||
         JSON.stringify(context.table.metadata) !== JSON.stringify(table.metadata),
-      startAutoRun: previousGroup.autoRun !== true && input.autoRun === true,
+      startAutoRun: previousGroup.autoRun === false && input.autoRun === true,
       actorUserId,
     }
   },


### PR DESCRIPTION
## Summary
- only dispatch table group auto-run on an explicit false-to-true transition
- add regression coverage for legacy groups without a persisted autoRun value

## Type of Change
- [x] Bug fix

## Testing
- targeted Vitest suite
- TypeScript type-check
- lint and full audit suite

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)