### PR TITLE
fix(knowledge): return pending status for new documents

### DIFF
--- a/apps/sim/app/api/knowledge/migrated-routes.test.ts
+++ b/apps/sim/app/api/knowledge/migrated-routes.test.ts
@@ -151,7 +151,7 @@ const document = {
   chunkCount: 1,
   tokenCount: 5,
   characterCount: 20,
-  processingStatus: 'completed' as const,
+  processingStatus: 'pending' as const,
   enabled: true,
   uploadedAt: new Date('2026-01-01T00:00:00Z'),
 }
@@ -356,6 +356,10 @@ describe('migrated internal Knowledge routes', () => {
     })
 
     expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { processingStatus: 'pending' },
+    })
     expect(mocks.platformUpload).toHaveBeenCalledOnce()
     expect(mocks.capture).toHaveBeenCalledOnce()
     expect(mocks.createDocuments.mock.invocationCallOrder[0]).toBeLessThan(

--- a/apps/sim/lib/knowledge/documents/service.ts
+++ b/apps/sim/lib/knowledge/documents/service.ts
@@ -1908,6 +1908,7 @@ export async function createSingleDocument(
   chunkCount: number
   tokenCount: number
   characterCount: number
+  processingStatus: 'pending'
   enabled: boolean
   uploadedAt: Date
   tag1: string | null
@@ -1973,6 +1974,7 @@ export async function createSingleDocument(
     chunkCount: 0,
     tokenCount: 0,
     characterCount: 0,
+    processingStatus: 'pending' as const,
     enabled: true,
     uploadedAt: now,
     uploadedBy,
@@ -2126,6 +2128,7 @@ export async function createSingleDocument(
     chunkCount: number
     tokenCount: number
     characterCount: number
+    processingStatus: 'pending'
     enabled: boolean
     uploadedAt: Date
     tag1: string | null
@@ -2143,7 +2146,7 @@ export async function getDocumentByUploadId(
   documentId: string,
   knowledgeBaseId: string
 ): Promise<
-  | (Awaited<ReturnType<typeof createSingleDocument>> & {
+  | (Omit<Awaited<ReturnType<typeof createSingleDocument>>, 'processingStatus'> & {
       processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
     })
   | null

--- a/apps/sim/lib/knowledge/documents/storage-billing.test.ts
+++ b/apps/sim/lib/knowledge/documents/storage-billing.test.ts
@@ -144,6 +144,25 @@ describe('knowledge document storage attribution', () => {
     expect(mockMaybeNotifyStorageLimitForBillingContext).toHaveBeenCalledWith(STORAGE_CONTEXT, 5)
   })
 
+  it('returns the pending processing state persisted for a new document', async () => {
+    const created = await createSingleDocument(
+      {
+        filename: 'note.txt',
+        fileUrl: 'data:text/plain;base64,SGVsbG8=',
+        fileSize: 5,
+        mimeType: 'text/plain',
+      },
+      'knowledge-base-1',
+      'request-1',
+      'external-collaborator'
+    )
+
+    expect(created.processingStatus).toBe('pending')
+    expect(dbChainMockFns.values).toHaveBeenCalledWith(
+      expect.objectContaining({ processingStatus: 'pending' })
+    )
+  })
+
   it('resolves admission before opening the document transaction', async () => {
     let transactionOpen = false
     mockResolveStorageBillingContext.mockImplementationOnce(async () => {

--- a/apps/sim/lib/knowledge/orchestration/documents.ts
+++ b/apps/sim/lib/knowledge/orchestration/documents.ts
@@ -61,9 +61,12 @@ export interface KnowledgeDocumentInput {
  */
 export type KnowledgeDocumentProcessing = 'queue' | 'async'
 
-export type CreatedKnowledgeDocument = Awaited<ReturnType<typeof createSingleDocument>> & {
-  /** Present when an idempotent completion returns an already-processing document. */
-  processingStatus?: 'pending' | 'processing' | 'completed' | 'failed'
+export type CreatedKnowledgeDocument = Omit<
+  Awaited<ReturnType<typeof createSingleDocument>>,
+  'processingStatus'
+> & {
+  /** New documents are pending; idempotent completion may return a later persisted state. */
+  processingStatus: 'pending' | 'processing' | 'completed' | 'failed'
 }
 
 export interface PerformUploadKnowledgeDocumentParams extends KnowledgeOperationContext {


### PR DESCRIPTION
## Summary
- return the persisted pending status for newly created knowledge documents
- keep created-document types and route responses aligned with the response contract

## Type of Change
- [x] Bug fix

## Testing
- 27 focused Vitest tests
- Sim type-check
- lint and repository audits

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)