### PR TITLE
fix(mcp): audit the columns an MCP server update wrote, not the params it got

### DIFF
--- a/apps/sim/lib/mcp/application/use-cases.ts
+++ b/apps/sim/lib/mcp/application/use-cases.ts
@@ -315,9 +315,7 @@ function updateAudit(
       serverName: result.server.name,
       transport: result.server.transport,
       url: result.server.url,
-      updatedFields: Object.keys(input).filter(
-        (key) => !['workspaceId', 'serverId', 'source'].includes(key)
-      ),
+      updatedFields: result.updatedFields ?? [],
       source: input.source,
     },
   }

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.test.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.test.ts
@@ -3,6 +3,7 @@
  */
 import {
   auditMock,
+  auditMockFns,
   dbChainMock,
   dbChainMockFns,
   encryptionMock,
@@ -64,6 +65,9 @@ import {
 } from '@/lib/mcp/orchestration/server-lifecycle'
 
 describe('MCP server lifecycle orchestration', () => {
+  const auditUpdatedFields = (): string[] | undefined =>
+    auditMockFns.mockRecordAudit.mock.calls.at(-1)?.[0].metadata.updatedFields
+
   beforeEach(() => {
     vi.clearAllMocks()
     resetDbChainMock()
@@ -151,6 +155,48 @@ describe('MCP server lifecycle orchestration', () => {
     )
     // ...and revoke the now-orphaned OAuth tokens rather than leaving them stored and valid.
     expect(mockRevokeOauthTokens).toHaveBeenCalledWith('server-1', 'workspace-1')
+    // The reset columns are the point of this audit row — an auditor needs to see
+    // that the connection was invalidated, not just that authType was touched.
+    expect(auditUpdatedFields()).toEqual(
+      expect.arrayContaining(['authType', 'connectionStatus', 'lastConnected', 'lastError'])
+    )
+  })
+
+  it('audits only the columns an edit wrote, not the params it was handed', async () => {
+    dbChainMockFns.limit.mockResolvedValueOnce([
+      {
+        url: 'https://example.com/mcp',
+        authType: 'headers',
+        oauthClientId: null,
+        oauthClientSecret: null,
+      },
+    ])
+    dbChainMockFns.returning.mockResolvedValueOnce([
+      {
+        id: 'server-1',
+        workspaceId: 'workspace-1',
+        name: 'Renamed',
+        transport: 'streamable-http',
+        url: 'https://example.com/mcp',
+        authType: 'headers',
+      },
+    ])
+
+    // A rename from the settings modal: the route always sends the OAuth params.
+    const result = await performUpdateMcpServer({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      serverId: 'server-1',
+      name: 'Renamed',
+      oauthClientId: null,
+      oauthClientIdProvided: false,
+      oauthClientSecretProvided: false,
+    })
+
+    expect(result.success).toBe(true)
+    // `updatedAt` is excluded deliberately — it moves on every write, so it would
+    // be noise in every audit row.
+    expect(auditUpdatedFields()).toEqual(['name'])
   })
 
   it('resets to disconnected when a create/upsert flips an existing OAuth server to headers', async () => {

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
@@ -91,6 +91,13 @@ export interface PerformMcpServerResult {
   updated?: boolean
   authType?: McpAuthType
   configurationChanged?: boolean
+  /**
+   * Fields the update's SET clause wrote, minus `updatedAt`, for audit. Only
+   * the writer knows these: a param is not a write, and callers cannot see the
+   * `connectionStatus`/`lastConnected`/`lastError` reset that an auth or
+   * credential change forces. Record this instead of deriving names from input.
+   */
+  updatedFields?: string[]
 }
 
 export type McpServerMutationAction = 'create' | 'update' | 'delete'
@@ -389,7 +396,12 @@ export async function updateMcpServer(
       params.timeout !== undefined ||
       params.retries !== undefined
 
-    return { success: true, server, configurationChanged: shouldClearCache }
+    return {
+      success: true,
+      server,
+      configurationChanged: shouldClearCache,
+      updatedFields: Object.keys(updateData).filter((key) => key !== 'updatedAt'),
+    }
   } catch (error) {
     logger.error('Failed to update MCP server', { error })
     throw error
@@ -501,15 +513,7 @@ export async function performUpdateMcpServer(
         serverName: result.server.name,
         transport: result.server.transport,
         url: result.server.url,
-        updatedFields: Object.entries(params)
-          .filter(
-            ([key, value]) =>
-              value !== undefined &&
-              !['workspaceId', 'userId', 'serverId', 'actorName', 'actorEmail', 'request'].includes(
-                key
-              )
-          )
-          .map(([key]) => key),
+        updatedFields: result.updatedFields ?? [],
       },
       request: params.request,
     })


### PR DESCRIPTION
## Summary
- Every `PATCH /api/mcp/servers/[id]` audit row listed `oauthClientId`, `oauthClientIdProvided` and `oauthClientSecretProvided` — including renames and URL edits that never touched credentials — and omitted the `connectionStatus`/`lastConnected`/`lastError` resets the write actually performed
- The route always sends `oauthClientId: body.oauthClientId || null` and `*Provided: ... !== undefined`, so `null` and `false` both survive the `value !== undefined` filter. All three appear on **every** PATCH regardless of what the client sends — no modal-side condition needed. The two `*Provided` flags aren't even columns; they're control params
- Regression from #5273 (`263e3ca67e`), which split `performUpdateMcpServer` into a writer that owns `updateData` and a thin audit wrapper with no access to it. `main` derived the list from `Object.keys(updateData)`; the wrapper fell back to the params it could see
- Only the writer knows which columns a write touched, so `updateMcpServer` now returns `updatedFields` and both the internal wrapper and the v2 use case record it. Net −9 lines of derivation logic
- Audit fidelity only — `.map(([key]) => key)` records names, never values. No credential value was or is exposed

## Why this shape
This is the pattern the repo already uses: `workflow-mcp-lifecycle.ts:96,552,939` and `credentials/orchestration/index.ts:159,339` both carry `updatedFields?: string[]` on the result and populate it from the writer's `updateData`. This makes `server-lifecycle.ts` the third instance rather than a new convention. The v2 twin shared the flaw in a different form (`Object.keys(input)` with no filter at all) and now reads the same `result.updatedFields`.

## Intentional change to audit output
Rows now include `connectionStatus`/`lastConnected`/`lastError` on an auth or credential change, include `authType` when it is implicitly promoted to `oauth`, and stop including `oauthClientIdProvided`/`oauthClientSecretProvided`. I grepped for downstream consumers keyed on the old strings (EE audit-log UI, v1 export, dashboards) and found none.

## Type of Change
- [x] Bug fix

## Testing
- Two new tests in `server-lifecycle.test.ts`: one asserting a rename records exactly `['name']`, one asserting an auth-type flip records the reset columns
- Verified they can fail: against the old params-derived logic they go red with `expected [ 'name', 'oauthClientId', …(2) ] to deeply equal [ 'name' ]` and `expected [ 'authType' ] to deeply equal ArrayContaining{…}`
- 875 tests pass across `lib/mcp`, `app/api/mcp`, `app/api/v2/mcp`, `lib/credentials`
- `check:openapi` unchanged and `check:api-validation:strict` pass — confirms no `updatedFields` key leaks into a wire response (no caller spreads the result; the v2 projection re-wraps picked fields)

## Follow-ups (not in this PR)
- `performCreateMcpServer`'s upsert branch rewrites an existing server (name, URL, headers, OAuth creds, auth-type flip, same connection reset) but gates its audit on `if (!result.updated)`, so an upsert-rewrite emits **no** `MCP_SERVER_UPDATED` row at all. That's a behavior change, and it needs `updateValues` tightened from `Record<string, unknown>` to `Partial<typeof mcpServers.$inferInsert>` first to be column-safe
- `Object.keys(updateData).filter(k => k !== 'updatedAt')` now appears in 6 places across 4 files (5 predate this PR). Worth one shared helper so the exclusion set is a single edit, but that spans `lib/credentials` and a v1 admin route — its own PR

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)