### PR TITLE
fix(files): order file folders in SQL like every other folder list

### DIFF
--- a/apps/sim/lib/api/contracts/v2/shared.ts
+++ b/apps/sim/lib/api/contracts/v2/shared.ts
@@ -72,9 +72,9 @@ import { FolderPathError, parseFolderPath, requireNonRootFolderPath } from '@/li
  *
  * Every one of these is pushed into SQL, except on `GET /skills` (which merges
  * the static builtin registry into the DB rows, then re-filters and re-sorts the
- * merged array) and `GET /files/folders` (which applies `parentPath`, `search`,
- * and the sort in JS). Both read a full result set to produce a page; neither is
- * a pattern to copy.
+ * merged array) and `GET /files/folders` (which applies `parentPath` and `search`
+ * in JS; its sort is pushed into SQL like every other folder list). Both read a
+ * full result set to produce a page; neither is a pattern to copy.
  *
  * ## Which lists are paged
  *

--- a/apps/sim/lib/folders/queries.ts
+++ b/apps/sim/lib/folders/queries.ts
@@ -149,7 +149,7 @@ export async function resolveRestoredFolderId(
  * enum by `satisfies`. Each ends in `createdAt` so folders sharing a name or a
  * `sortOrder` still come back in a stable order.
  */
-const FOLDER_SORTS = {
+export const FOLDER_SORTS = {
   position: [folder.sortOrder, folder.createdAt],
   name: [folder.name, folder.createdAt],
   createdAt: [folder.createdAt],

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-folder-manager.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-folder-manager.ts
@@ -3,7 +3,8 @@ import { folder as folderTable, workspaceFiles, workspace as workspaceTable } fr
 import { createLogger } from '@sim/logger'
 import { getErrorMessage, getPostgresErrorCode } from '@sim/utils/errors'
 import { generateId } from '@sim/utils/id'
-import { and, asc, eq, inArray, isNull, min, sql } from 'drizzle-orm'
+import { and, eq, inArray, isNull, min, sql } from 'drizzle-orm'
+import { type ListSortOrder, listOrderBy } from '@/lib/api/list-query'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 import type { DbOrTx } from '@/lib/db/types'
 import { acquireFolderMutationLock } from '@/lib/folders/locks'
@@ -17,6 +18,7 @@ import {
   parseFolderPath,
   requireNonRootFolderPath,
 } from '@/lib/folders/paths'
+import { FOLDER_SORTS, type FolderSortBy } from '@/lib/folders/queries'
 import { collectDescendantFolderIds } from '@/lib/folders/subtree'
 import { encodeWorkspaceFileFolderDisplaySegment } from '@/lib/workspace-files/folder-display-path'
 import { MAX_WORKSPACE_FILE_BULK_AFFECTED_ITEMS } from '@/lib/workspace-files/limits'
@@ -383,11 +385,21 @@ export async function findWorkspaceFileFolderIdByPath(
   return parentId
 }
 
+/**
+ * Lists a workspace's file folders, ordered in the database like every other folder
+ * list so a name sort uses the same collation and the same `createdAt` tiebreak.
+ * Defaults to `position` — `sortOrder ASC, createdAt ASC` — which honours a user's
+ * manual ordering and is what surfaces reading the payload positionally expect.
+ */
 export async function listWorkspaceFileFolders(
   workspaceId: string,
-  options?: { scope?: WorkspaceFileFolderScope }
+  options?: {
+    scope?: WorkspaceFileFolderScope
+    sortBy?: FolderSortBy
+    sortOrder?: ListSortOrder
+  }
 ): Promise<WorkspaceFileFolderRecord[]> {
-  const { scope = 'active' } = options ?? {}
+  const { scope = 'active', sortBy = 'position', sortOrder = 'asc' } = options ?? {}
   const rows = await db
     .select()
     .from(folderTable)
@@ -406,7 +418,7 @@ export async function listWorkspaceFileFolders(
               isNull(folderTable.deletedAt)
             )
     )
-    .orderBy(asc(folderTable.sortOrder), asc(folderTable.createdAt))
+    .orderBy(...listOrderBy(FOLDER_SORTS[sortBy], sortOrder))
 
   const paths = buildWorkspaceFileFolderPathMap(rows)
   return rows.map((row) => mapFolder(row, paths))

--- a/apps/sim/lib/workspace-files/application/workspace-file-folders.test.ts
+++ b/apps/sim/lib/workspace-files/application/workspace-file-folders.test.ts
@@ -121,6 +121,38 @@ describe('workspace file folder operations', () => {
     expect(mockNotify).toHaveBeenCalledOnce()
   })
 
+  it.each([
+    ['leaves the sort unset so the repository keeps its position ordering', {}, undefined],
+    ['delegates an explicit sort', { sortBy: 'name', sortOrder: 'desc' } as const, 'name'],
+  ])('%s', async (_label, sortInput, expectedSortBy) => {
+    mockList.mockResolvedValue([folder])
+
+    await listWorkspaceFileFoldersOperation.execute({
+      principal: { kind: 'session', userId: 'user-1', sessionId: 'session-1' },
+      input: { workspaceId: 'ws-1', ...sortInput },
+    })
+
+    expect(mockList).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({ sortBy: expectedSortBy })
+    )
+  })
+
+  it('preserves the order the repository returned rather than re-sorting in memory', async () => {
+    mockList.mockResolvedValue([
+      { ...folder, id: 'newest', name: 'zeta' },
+      { ...folder, id: 'middle', name: 'Alpha' },
+      { ...folder, id: 'oldest', name: 'beta' },
+    ])
+
+    const result = await listWorkspaceFileFoldersOperation.execute({
+      principal: { kind: 'session', userId: 'user-1', sessionId: 'session-1' },
+      input: { workspaceId: 'ws-1' },
+    })
+
+    expect(result.folders.map((item) => item.id)).toEqual(['newest', 'middle', 'oldest'])
+  })
+
   it('matches a canonical encoded parent path against decoded stored folder paths', async () => {
     mockList.mockResolvedValue([
       { ...folder, id: 'child-1', name: 'Q1', path: 'Reports & Plans/Q1' },

--- a/apps/sim/lib/workspace-files/application/workspace-file-folders.ts
+++ b/apps/sim/lib/workspace-files/application/workspace-file-folders.ts
@@ -1,8 +1,10 @@
 import { AuditAction, AuditResourceType } from '@sim/audit'
 import { resolvePrincipalAttribution } from '@sim/auth/principal'
 import { createLogger } from '@sim/logger'
+import type { ListSortOrder } from '@/lib/api/list-query'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 import { parseFolderPath } from '@/lib/folders/paths'
+import type { FolderSortBy } from '@/lib/folders/queries'
 import { notifyWorkspaceFilesChanged } from '@/lib/realtime/notify'
 import {
   assertWorkspaceFileItemsBelongToWorkspace,
@@ -30,8 +32,14 @@ export interface ListWorkspaceFileFoldersInput {
   scope?: 'active' | 'archived' | 'all'
   parentPath?: string
   search?: string
-  sortBy?: 'name' | 'createdAt' | 'updatedAt'
-  sortOrder?: 'asc' | 'desc'
+  /**
+   * Only v2 sends a sort; the internal route, Copilot, and the VFS do not, and some of
+   * their consumers render the payload in the order it arrives. So this stays optional
+   * and undefined means "leave the repository's `position` ordering alone" — a default
+   * applied here would silently reorder those surfaces.
+   */
+  sortBy?: Exclude<FolderSortBy, 'position'>
+  sortOrder?: ListSortOrder
 }
 
 export interface ListWorkspaceFileFoldersResult {
@@ -115,6 +123,8 @@ async function executeListWorkspaceFileFolders(args: {
 }): Promise<ListWorkspaceFileFoldersResult> {
   let folders = await listWorkspaceFileFolders(args.context.workspaceId, {
     scope: args.input.scope,
+    sortBy: args.input.sortBy,
+    sortOrder: args.input.sortOrder,
   })
   if (args.input.parentPath !== undefined) {
     const parentSegments = parseFolderPath(args.input.parentPath)
@@ -128,14 +138,6 @@ async function executeListWorkspaceFileFolders(args: {
     const search = args.input.search.toLowerCase()
     folders = folders.filter((folder) => folder.name.toLowerCase().includes(search))
   }
-  const sortBy = args.input.sortBy ?? 'name'
-  const sortOrder = args.input.sortOrder ?? 'asc'
-  folders.sort((left, right) => {
-    const leftValue = left[sortBy]
-    const rightValue = right[sortBy]
-    const comparison = leftValue < rightValue ? -1 : leftValue > rightValue ? 1 : 0
-    return sortOrder === 'asc' ? comparison : -comparison
-  })
   return { folders }
 }
 


### PR DESCRIPTION
## Summary
- `executeListWorkspaceFileFolders` defaulted to `sortBy ?? 'name'` — defaults written for the new v2 contract — and sorted in JS. The internal contract (`workspace-file-folders.ts`) exposes only `scope`, so the repository's `sortOrder ASC, createdAt ASC` ordering became unreachable.
- That ordering is meaningful: a new folder takes `sortOrder = minSortOrder - 1`, so it is deliberately newest-first, and it is user-modifiable.
- Pushed the sort into the query like the workflow, knowledge, and table folder lists already do, reusing the shared `FOLDER_SORTS` map. Omitting `sortBy` keeps `position`; v2 always sends one from its contract defaults.

## Impact this fixes
Surfaces that render the payload in arrival order and had flipped newest-first → alphabetical:
- `@`-mention **Folders** group — no sort, `MAX_PER_GROUP = 8`, so a workspace with >8 folders showed the 8 alphabetically-first instead of the 8 most recent, making a just-created folder unreachable without typing.
- Add-resource dropdown **search results** — filters, never sorts.
- Copilot `list_file_folders`.

Also removes a real SSR mismatch: `files/prefetch.ts` hydrates `workspaceFileFolderKeys.list(workspaceId, 'active')` by calling the data layer directly (repository order) while the client hook fetches the same key through the route (name-sorted). Its TSDoc asserts a *"correctly-ordered first frame"* and that a *"hydrated entry matches a client fetch"* — true again now.

Unaffected either way (they re-sort client-side): the Files browser (`files.tsx` sorts by `sortOrder` then `localeCompare`), Recently Deleted, and the add-resource submenu tree.

## Secondary correctness win
A `sortBy=name` request previously compared with raw `<`/`>` on UTF-16 code units, so `"Zebra"` sorted before `"apple"` — a third ordering matching neither the old one nor the `localeCompare` every client surface uses, with no tiebreak for equal names. It now uses the database collation and the shared `createdAt` tiebreak, consistent with the other folder lists.

## Type of Change
- [x] Bug fix

## Testing
- New tests assert the sort is delegated (not applied in memory) and that omitting `sortBy` leaves it unset. Verified all three fail against the pre-fix code.
- `bunx vitest run lib/ app/api/` — 15,141 passing.
- Repo-wide `lint:check` and `type-check` (23/23 each), plus `check:api-validation` and monorepo-boundary gates.
- Audited every caller of the use case (internal route, v2 route, Copilot tool, Copilot VFS ×2, function-execute mounts); the VFS and function-execute paths consume results by path lookup, so ordering is immaterial there.
- Confirmed no sibling sweep is needed: `listActiveFolderRows`' `?? 'name'` is a dead default — its only callers are v2 use cases that always receive a defaulted `sortBy`.
- Not exercised against a live workspace.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)