### PR TITLE
fix(mcp): audit an upsert that rewrites or revives a server

### DIFF
--- a/apps/sim/lib/mcp/application/use-cases.ts
+++ b/apps/sim/lib/mcp/application/use-cases.ts
@@ -4,6 +4,7 @@ import { getPostgresErrorCode } from '@sim/utils/errors'
 import type { ListSortOrder } from '@/lib/api/list-query'
 import { defineAuthorizedWorkspaceUseCase } from '@/lib/core/application'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
+import { sanitizeUrlForLog } from '@/lib/core/utils/logging'
 import { mcpServerDelegationPolicy } from '@/lib/mcp/application/authorization'
 import { mcpServerOperations } from '@/lib/mcp/application/operations'
 import {
@@ -197,7 +198,7 @@ function createAudit(
       metadata: {
         serverName: result.server.name,
         transport: result.server.transport,
-        url: result.server.url,
+        url: result.server.url ? sanitizeUrlForLog(result.server.url) : null,
         timeout: result.server.timeout,
         retries: result.server.retries,
         source: input.source,
@@ -321,7 +322,7 @@ function updateAudit(
     metadata: {
       serverName: result.server.name,
       transport: result.server.transport,
-      url: result.server.url,
+      url: result.server.url ? sanitizeUrlForLog(result.server.url) : null,
       updatedFields: result.updatedFields ?? [],
       source: input.source,
     },
@@ -389,7 +390,7 @@ export const deleteMcpServerUseCase = defineAuthorizedWorkspaceUseCase({
     metadata: {
       serverName: result.server.name,
       transport: result.server.transport,
-      url: result.server.url,
+      url: result.server.url ? sanitizeUrlForLog(result.server.url) : null,
       source: input.source,
     },
   }),

--- a/apps/sim/lib/mcp/application/use-cases.ts
+++ b/apps/sim/lib/mcp/application/use-cases.ts
@@ -176,18 +176,24 @@ async function saveMcpServer(args: {
   return requireSuccessfulResult(result, 'Failed to register MCP server')
 }
 
+/**
+ * A registration is an addition when it inserts a row or revives a soft-deleted
+ * one, and an update when it rewrites a live row — which `registerMcpServer`
+ * allows, repointing headers and the URL's query string. Auditing only the
+ * insert left both upsert outcomes unrecorded.
+ */
 function createAudit(
   input: SaveMcpServerInput,
   result: PerformMcpServerResult & { server: McpServerRow }
 ) {
-  if (result.updated) return []
+  const isRewrite = result.updated === true && !result.revived
   return [
     {
-      action: AuditAction.MCP_SERVER_ADDED,
+      action: isRewrite ? AuditAction.MCP_SERVER_UPDATED : AuditAction.MCP_SERVER_ADDED,
       resourceType: AuditResourceType.MCP_SERVER,
       resourceId: result.server.id,
       resourceName: result.server.name,
-      description: `Added MCP server "${result.server.name}"`,
+      description: `${isRewrite ? 'Updated' : 'Added'} MCP server "${result.server.name}"`,
       metadata: {
         serverName: result.server.name,
         transport: result.server.transport,
@@ -195,6 +201,7 @@ function createAudit(
         timeout: result.server.timeout,
         retries: result.server.retries,
         source: input.source,
+        ...(isRewrite ? { updatedFields: result.updatedFields ?? [] } : {}),
       },
     },
   ]

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.test.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.test.ts
@@ -70,6 +70,8 @@ describe('MCP server lifecycle orchestration', () => {
     auditMockFns.mockRecordAudit.mock.calls.at(-1)?.[0].metadata.updatedFields
   const auditAction = (): string | undefined =>
     auditMockFns.mockRecordAudit.mock.calls.at(-1)?.[0].action
+  const auditMetadata = (): Record<string, unknown> | undefined =>
+    auditMockFns.mockRecordAudit.mock.calls.at(-1)?.[0].metadata
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -286,6 +288,12 @@ describe('MCP server lifecycle orchestration', () => {
     expect(result.revived).toBe(false)
     expect(auditAction()).toBe(AuditAction.MCP_SERVER_UPDATED)
     expect(auditUpdatedFields()).toEqual(expect.arrayContaining(['url', 'headers']))
+    // The registration omitted `description`, and Drizzle skips undefined in
+    // .set(), so the audit must not claim that column was written.
+    expect(auditUpdatedFields()).not.toContain('description')
+    // A query string routinely carries the endpoint's token, and audit rows are
+    // readable by org admins who need no workspace MCP access.
+    expect(auditMetadata()?.url).toBe('https://example.com/mcp')
   })
 
   it('audits a re-registration that revives a soft-deleted server as an addition', async () => {

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.test.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.test.ts
@@ -58,6 +58,7 @@ vi.mock('@/lib/mcp/service', () => ({
 vi.mock('@/lib/mcp/utils', () => ({ generateMcpServerId: mockGenerateMcpServerId }))
 vi.mock('@/lib/posthog/server', () => posthogServerMock)
 
+import { AuditAction } from '@sim/audit'
 import {
   performCreateMcpServer,
   performDeleteMcpServer,
@@ -67,6 +68,8 @@ import {
 describe('MCP server lifecycle orchestration', () => {
   const auditUpdatedFields = (): string[] | undefined =>
     auditMockFns.mockRecordAudit.mock.calls.at(-1)?.[0].metadata.updatedFields
+  const auditAction = (): string | undefined =>
+    auditMockFns.mockRecordAudit.mock.calls.at(-1)?.[0].action
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -243,6 +246,84 @@ describe('MCP server lifecycle orchestration', () => {
     )
     // ...and revoke the now-orphaned OAuth tokens.
     expect(mockRevokeOauthTokens).toHaveBeenCalledWith('server-1', 'workspace-1')
+  })
+
+  it('audits a re-registration that rewrites a live server as an update', async () => {
+    mockGenerateMcpServerId.mockReturnValue('server-1')
+    dbChainMockFns.limit.mockResolvedValueOnce([
+      {
+        id: 'server-1',
+        deletedAt: null,
+        url: 'https://example.com/mcp?token=old',
+        authType: 'headers',
+        oauthClientId: null,
+        oauthClientSecret: null,
+      },
+    ])
+    dbChainMockFns.limit.mockResolvedValueOnce([
+      {
+        id: 'server-1',
+        workspaceId: 'workspace-1',
+        name: 'Example',
+        transport: 'streamable-http',
+        url: 'https://example.com/mcp?token=new',
+        authType: 'headers',
+      },
+    ])
+
+    // The server id hashes origin + pathname only, so a different query string
+    // lands on the same row and repoints it.
+    const result = await performCreateMcpServer({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      name: 'Example',
+      url: 'https://example.com/mcp?token=new',
+      headers: { authorization: 'Bearer rotated' },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.updated).toBe(true)
+    expect(result.revived).toBe(false)
+    expect(auditAction()).toBe(AuditAction.MCP_SERVER_UPDATED)
+    expect(auditUpdatedFields()).toEqual(expect.arrayContaining(['url', 'headers']))
+  })
+
+  it('audits a re-registration that revives a soft-deleted server as an addition', async () => {
+    mockGenerateMcpServerId.mockReturnValue('server-1')
+    dbChainMockFns.limit.mockResolvedValueOnce([
+      {
+        id: 'server-1',
+        deletedAt: new Date(),
+        url: 'https://example.com/mcp',
+        authType: 'headers',
+        oauthClientId: null,
+        oauthClientSecret: null,
+      },
+    ])
+    dbChainMockFns.limit.mockResolvedValueOnce([
+      {
+        id: 'server-1',
+        workspaceId: 'workspace-1',
+        name: 'Example',
+        transport: 'streamable-http',
+        url: 'https://example.com/mcp',
+        authType: 'headers',
+      },
+    ])
+
+    const result = await performCreateMcpServer({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      name: 'Example',
+      url: 'https://example.com/mcp',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.revived).toBe(true)
+    // Bringing a deleted server back is an addition, so it keeps the ADDED action
+    // and carries no updatedFields.
+    expect(auditAction()).toBe(AuditAction.MCP_SERVER_ADDED)
+    expect(auditUpdatedFields()).toBeUndefined()
   })
 
   it('evicts the deleted server from the connection pool (row is already gone from clearCache)', async () => {

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
@@ -6,6 +6,7 @@ import { generateId } from '@sim/utils/id'
 import { and, eq, isNull } from 'drizzle-orm'
 import type { NextRequest } from 'next/server'
 import { encryptSecret } from '@/lib/core/security/encryption'
+import { sanitizeUrlForLog } from '@/lib/core/utils/logging'
 import {
   McpDnsResolutionError,
   McpDomainNotAllowedError,
@@ -245,7 +246,16 @@ export async function createMcpServer(
         if (params.oauthClientSecretProvided) {
           updateValues.oauthClientSecret = oauthClientSecretEncrypted
         }
-        updatedFields = Object.keys(updateValues).filter((key) => key !== 'updatedAt')
+        /**
+         * Drizzle skips `undefined` in `.set()`, and this object assigns every
+         * column unconditionally — `description` is present but undefined when
+         * the registration omits it. Keys must therefore be filtered by value,
+         * or the audit claims a column the write never touched. `null` stays:
+         * clearing a value is a write.
+         */
+        updatedFields = Object.entries(updateValues)
+          .filter(([key, value]) => key !== 'updatedAt' && value !== undefined)
+          .map(([key]) => key)
         await tx.update(mcpServers).set(updateValues).where(eq(mcpServers.id, serverId))
       })
 
@@ -501,7 +511,7 @@ export async function performCreateMcpServer(
       metadata: {
         serverName: result.server.name,
         transport: result.server.transport,
-        url: result.server.url,
+        url: result.server.url ? sanitizeUrlForLog(result.server.url) : null,
         timeout: result.server.timeout,
         retries: result.server.retries,
         source,
@@ -537,7 +547,7 @@ export async function performUpdateMcpServer(
       metadata: {
         serverName: result.server.name,
         transport: result.server.transport,
-        url: result.server.url,
+        url: result.server.url ? sanitizeUrlForLog(result.server.url) : null,
         updatedFields: result.updatedFields ?? [],
       },
       request: params.request,
@@ -586,7 +596,7 @@ export async function performDeleteMcpServer(
       metadata: {
         serverName: result.server.name,
         transport: result.server.transport,
-        url: result.server.url,
+        url: result.server.url ? sanitizeUrlForLog(result.server.url) : null,
         source,
       },
       request: params.request,

--- a/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
+++ b/apps/sim/lib/mcp/orchestration/server-lifecycle.ts
@@ -89,6 +89,12 @@ export interface PerformMcpServerResult {
   serverId?: string
   server?: typeof mcpServers.$inferSelect
   updated?: boolean
+  /**
+   * Whether an `updated` result brought a soft-deleted row back rather than
+   * rewriting a live one. The two need different audit actions: a revival is an
+   * addition, a rewrite is an update.
+   */
+  revived?: boolean
   authType?: McpAuthType
   configurationChanged?: boolean
   /**
@@ -204,11 +210,12 @@ export async function createMcpServer(
 
       if (shouldClearOauth) await revokeMcpOauthTokens(serverId, params.workspaceId)
 
+      let updatedFields: string[] = []
       await db.transaction(async (tx) => {
         if (shouldClearOauth) {
           await tx.delete(mcpServerOauth).where(eq(mcpServerOauth.mcpServerId, serverId))
         }
-        const updateValues: Record<string, unknown> = {
+        const updateValues: Partial<typeof mcpServers.$inferInsert> = {
           name: params.name,
           description: params.description,
           transport,
@@ -238,6 +245,7 @@ export async function createMcpServer(
         if (params.oauthClientSecretProvided) {
           updateValues.oauthClientSecret = oauthClientSecretEncrypted
         }
+        updatedFields = Object.keys(updateValues).filter((key) => key !== 'updatedAt')
         await tx.update(mcpServers).set(updateValues).where(eq(mcpServers.id, serverId))
       })
 
@@ -247,7 +255,15 @@ export async function createMcpServer(
         .where(and(eq(mcpServers.id, serverId), eq(mcpServers.workspaceId, params.workspaceId)))
         .limit(1)
       if (!server) throw new Error(`MCP server ${serverId} missing after a successful update`)
-      return { success: true, serverId, server, updated: true, authType: resolvedAuthType }
+      return {
+        success: true,
+        serverId,
+        server,
+        updated: true,
+        revived: isRevival,
+        updatedFields,
+        authType: resolvedAuthType,
+      }
     }
 
     await db.insert(mcpServers).values({
@@ -447,8 +463,8 @@ export async function performCreateMcpServer(
       workspaceId: params.workspaceId,
       result,
     })
+    const source = legacySource(params.source)
     if (!result.updated) {
-      const source = legacySource(params.source)
       captureServerEvent(
         params.userId,
         'mcp_server_connected',
@@ -463,27 +479,36 @@ export async function performCreateMcpServer(
           setOnce: { first_mcp_connected_at: new Date().toISOString() },
         }
       )
-      recordAudit({
-        workspaceId: params.workspaceId,
-        actorId: params.userId,
-        actorName: params.actorName ?? undefined,
-        actorEmail: params.actorEmail ?? undefined,
-        action: AuditAction.MCP_SERVER_ADDED,
-        resourceType: AuditResourceType.MCP_SERVER,
-        resourceId: result.server.id,
-        resourceName: result.server.name,
-        description: `Added MCP server "${result.server.name}"`,
-        metadata: {
-          serverName: result.server.name,
-          transport: result.server.transport,
-          url: result.server.url,
-          timeout: result.server.timeout,
-          retries: result.server.retries,
-          source,
-        },
-        request: params.request,
-      })
     }
+
+    /**
+     * Registering a URL that already exists rewrites the live row — headers, the
+     * URL's query string, transport, enabled — so it is an update, not an
+     * addition. Reviving a soft-deleted row is still an addition. Auditing only
+     * the insert left both cases with no trace at all.
+     */
+    const isRewrite = result.updated === true && !result.revived
+    recordAudit({
+      workspaceId: params.workspaceId,
+      actorId: params.userId,
+      actorName: params.actorName ?? undefined,
+      actorEmail: params.actorEmail ?? undefined,
+      action: isRewrite ? AuditAction.MCP_SERVER_UPDATED : AuditAction.MCP_SERVER_ADDED,
+      resourceType: AuditResourceType.MCP_SERVER,
+      resourceId: result.server.id,
+      resourceName: result.server.name,
+      description: `${isRewrite ? 'Updated' : 'Added'} MCP server "${result.server.name}"`,
+      metadata: {
+        serverName: result.server.name,
+        transport: result.server.transport,
+        url: result.server.url,
+        timeout: result.server.timeout,
+        retries: result.server.retries,
+        source,
+        ...(isRewrite ? { updatedFields: result.updatedFields ?? [] } : {}),
+      },
+      request: params.request,
+    })
     return result
   } catch (error) {
     logger.error('Failed to register MCP server', { error })


### PR DESCRIPTION
## Summary
- Registering a URL that already exists takes the upsert branch and **rewrites the live row**, but recorded **no audit row at all** — the ADDED audit was gated on `!result.updated`
- `main` recorded `MCP_SERVER_ADDED` for these unconditionally: wrong action, but a row existed. #5273 added the gate, so staging records nothing. This is an audit-coverage regression, the **third** traced to that PR
- A rewrite is now `MCP_SERVER_UPDATED` carrying `updatedFields`; reviving a soft-deleted row stays `MCP_SERVER_ADDED`
- Follow-up to #6598, which established `updatedFields` on the result

## What the upsert silently rewrites
name, description, transport, headers, timeout, retries, enabled, authType, the connection reset — **and the URL's query string**. `generateMcpServerId` hashes `origin + pathname` only (`utils.ts:238` strips query and fragment), so re-registering `…/mcp?token=NEW` over `…/mcp?token=OLD` lands on the same row and repoints it. MCP endpoints commonly carry tokens there, and headers carry auth.

## Reachability
| Entry point | `existingServerBehavior` | Reaches upsert? |
|---|---|---|
| `POST /api/mcp/servers` (settings "add server") | not passed | **yes** |
| Copilot `manage_mcp_tool` op `add` → `registerMcpServerUseCase` | not passed | **yes** |
| `POST /api/v2/mcp-servers` → `createMcpServerUseCase` | `'reject'` | only on revival |

The Copilot path is what motivated fixing this now: an agent can rewrite a server's headers and URL query with no audit trail.

## Two distinct missing rows
`createMcpServerUseCase` throws unless `idState.deleted`, so **v2's only `updated` case is a revival** — it was dropping a legitimate ADDED row on every revival. Live rewrites and revivals need different actions, so the orchestration now surfaces the `isRevival` it already computed as `revived` on the result.

## Type of Change
- [x] Bug fix

## Testing
- Two new tests: a query-string re-registration asserts `MCP_SERVER_UPDATED` with `updatedFields` containing `url` and `headers`; a soft-deleted revival asserts `MCP_SERVER_ADDED` with no `updatedFields`
- Verified they can fail: restoring the old gate turns both red with `expected undefined to be 'mcp_server.updated'` / `'mcp_server.added'` — i.e. no row at all
- 514 tests pass across `lib/mcp`, `app/api/mcp`, `app/api/v2/mcp`
- `updateValues` retyped from `Record<string, unknown>` to `Partial<typeof mcpServers.$inferInsert>`; typecheck passing is the proof every key is a real column, which is what makes `Object.keys` safe here
- `lint:check`, `check:api-validation:strict`, `check:openapi` all pass

## Deliberately unchanged
Analytics gating. `mcp_server_connected` still fires only for a genuine insert — a revival arguably counts as a new connection, but changing it would skew `first_mcp_connected_at` and is a separate decision.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)