### PR TITLE
test(table): pin the executor auth pairing on the table read route

### DIFF
--- a/apps/sim/app/api/table/[tableId]/route.test.ts
+++ b/apps/sim/app/api/table/[tableId]/route.test.ts
@@ -164,14 +164,18 @@ describe('PATCH /api/table/[tableId] folder moves', () => {
 })
 
 /**
- * Pins the auth mode this route's executor caller is built against.
+ * Pins which auth path this route hands a Bearer token to.
  *
  * `fetchTableSchema` in `@/tools/schema-enrichers` reaches this route with a legacy
- * `type: 'internal'` token from the deprecated `buildAuthHeaders`. That token is only
- * accepted while GET authenticates through `checkSessionOrInternalAuth`; the delegation
- * policy the sibling table routes use rejects it outright. Migrating this route without
- * moving that caller to `buildExecutorDelegationHeaders` in the same change breaks every
- * table tool attached to an Agent block, so this assertion fails first and says so.
+ * `type: 'internal'` token from the deprecated `buildAuthHeaders`. Only
+ * `checkSessionOrInternalAuth` accepts that token; the delegation policy the sibling
+ * table routes use rejects it outright. Migrating this route without moving that caller
+ * to `buildExecutorDelegationHeaders` in the same change breaks every table tool on an
+ * Agent block, so this fails first and names the caller.
+ *
+ * Scope: this pins the *route's* choice of verifier. That the legacy token is actually
+ * valid for that verifier — and rejected by the delegation one — is pinned separately in
+ * `@/lib/auth/internal.test.ts`. Both halves are needed; neither implies the other.
  */
 describe('GET /api/table/[tableId] executor auth pairing', () => {
   beforeEach(() => {
@@ -185,13 +189,20 @@ describe('GET /api/table/[tableId] executor auth pairing', () => {
     mockGetLimits.mockResolvedValue({ maxRowsPerTable: 1000 })
   })
 
-  it('authenticates a legacy internal token, which is what fetchTableSchema sends', async () => {
-    const response = await GET(
-      new NextRequest('http://localhost:3000/api/table/tbl_1?workspaceId=workspace-1'),
-      routeContext
-    )
+  it('routes a Bearer token to the legacy verifier fetchTableSchema mints for', async () => {
+    const request = new NextRequest('http://localhost:3000/api/table/tbl_1?workspaceId=workspace-1')
+    request.headers.set('authorization', 'Bearer legacy-internal-token')
+
+    const response = await GET(request, routeContext)
 
     expect(response.status).toBe(200)
-    expect(hybridAuthMockFns.mockCheckSessionOrInternalAuth).toHaveBeenCalled()
+    expect(hybridAuthMockFns.mockCheckSessionOrInternalAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({ get: expect.any(Function) }),
+      }),
+      expect.anything()
+    )
+    const [forwarded] = hybridAuthMockFns.mockCheckSessionOrInternalAuth.mock.calls[0]
+    expect(forwarded.headers.get('authorization')).toBe('Bearer legacy-internal-token')
   })
 })

--- a/apps/sim/app/api/table/[tableId]/route.test.ts
+++ b/apps/sim/app/api/table/[tableId]/route.test.ts
@@ -55,7 +55,7 @@ vi.mock('@/app/api/table/utils', () => ({
   tableLockErrorResponse: () => null,
 }))
 
-import { PATCH } from '@/app/api/table/[tableId]/route'
+import { GET, PATCH } from '@/app/api/table/[tableId]/route'
 
 const TABLE = {
   id: 'tbl_1',
@@ -160,5 +160,38 @@ describe('PATCH /api/table/[tableId] folder moves', () => {
     expect(response.status).toBe(400)
     expect(mockMoveTableToFolder).not.toHaveBeenCalled()
     expect(mockRenameTable).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * Pins the auth mode this route's executor caller is built against.
+ *
+ * `fetchTableSchema` in `@/tools/schema-enrichers` reaches this route with a legacy
+ * `type: 'internal'` token from the deprecated `buildAuthHeaders`. That token is only
+ * accepted while GET authenticates through `checkSessionOrInternalAuth`; the delegation
+ * policy the sibling table routes use rejects it outright. Migrating this route without
+ * moving that caller to `buildExecutorDelegationHeaders` in the same change breaks every
+ * table tool attached to an Agent block, so this assertion fails first and says so.
+ */
+describe('GET /api/table/[tableId] executor auth pairing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hybridAuthMockFns.mockCheckSessionOrInternalAuth.mockResolvedValue({
+      success: true,
+      userId: 'user-1',
+      authType: 'internal_jwt',
+    })
+    mockCheckAccess.mockResolvedValue({ ok: true, table: TABLE })
+    mockGetLimits.mockResolvedValue({ maxRowsPerTable: 1000 })
+  })
+
+  it('authenticates a legacy internal token, which is what fetchTableSchema sends', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/api/table/tbl_1?workspaceId=workspace-1'),
+      routeContext
+    )
+
+    expect(response.status).toBe(200)
+    expect(hybridAuthMockFns.mockCheckSessionOrInternalAuth).toHaveBeenCalled()
   })
 })

--- a/apps/sim/tools/schema-enrichers.ts
+++ b/apps/sim/tools/schema-enrichers.ts
@@ -7,6 +7,19 @@ import type { WorkflowToolExecutionContext } from '@/tools/types'
 
 const logger = createLogger('SchemaEnrichers')
 
+/**
+ * Reads a table's schema as the acting user.
+ *
+ * Deliberately still on the deprecated `buildAuthHeaders`, unlike its siblings in this
+ * file: `GET /api/table/[tableId]` authenticates through `checkSessionOrInternalAuth`,
+ * which accepts a legacy `type: 'internal'` token and rejects an executor delegation.
+ * Swapping this to `buildExecutorDelegationHeaders` before that route migrates would
+ * break every table tool on an Agent block. The route's own test pins the pairing.
+ *
+ * Unlike the workflow and knowledge enrichers, a failure here is loud — this runs as a
+ * tool-level `toolEnrichment`, so `createLLMToolSchema` surfaces it as a
+ * `ToolSchemaEnrichmentError` naming the tool rather than degrading the schema silently.
+ */
 async function fetchTableSchema(
   tableId: string,
   context: WorkflowToolExecutionContext


### PR DESCRIPTION
## Summary
Follow-up to #6593. `fetchTableSchema` is the last enricher still calling the deprecated `buildAuthHeaders`, and after #6593 migrated its two siblings in the same file it now reads like a missed migration. It isn't — and "fixing" it today would break table tools.

- `GET /api/table/[tableId]` authenticates through `checkSessionOrInternalAuth` → `verifyInternalToken`, which requires `type: 'internal'`. An executor delegation carries `type: 'internal_delegation'` and is rejected, then falls through to session auth the executor doesn't have.
- The sibling table routes (`[tableId]/groups`, `[tableId]/exports`, `imports/*`) are already on `internalTableSessionOrExecutorAuth`, so this route is the straggler and a plausible next migration target.
- `tables.read` also declares `delegatedServices: ['copilot']`, so an executor delegation would be refused at the operation layer even if the route accepted it.

So: assert the route still authenticates through the legacy path, and record on the caller why it is deliberately not migrated. The migration that flips this route now fails on a test that names the caller, instead of shipping and breaking table tools.

## Why not migrate the route here
`readTableUseCase` exists, but this GET returns an 18-field payload including `maxRows` from `getWorkspaceTableLimits`, which the use case does not supply, and the response is consumed by the Tables UI. Doing it properly means a new contract matched field-by-field against the current output plus widening `tables.read`'s principal policy — a scoped migration of its own, not a follow-up rider on something that isn't broken.

## Correction to how this was previously described
I earlier called this a latent copy of the #6593 bug. The *auth coupling* is the same; the *failure mode is the opposite*. `enrichTableToolSchema` is wired as a tool-level `toolEnrichment`, and `createLLMToolSchema` wraps those in `ToolSchemaEnrichmentError` naming the tool — so a break here fails the Agent block loudly rather than silently degrading the schema the way the workflow and knowledge enrichers did. That is why this is a guard rather than a fix.

## Type of Change
- [x] Test / maintainability

## Testing
- Verified the guard actually trips: stubbed out the route's `checkSessionOrInternalAuth` call and the new test failed while the existing PATCH tests stayed green, so it is targeted rather than incidental.
- `bunx vitest run app/api/table/ tools/` — 2,746 passing.
- Repo-wide `lint:check`, `type-check`, and `check:api-validation`.
- No runtime behavior change.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)