### PR TITLE
fix(mcp): stop refusing tool results authored by another workspace member

### DIFF
--- a/apps/sim/app/api/mcp/serve/[serverId]/route.test.ts
+++ b/apps/sim/app/api/mcp/serve/[serverId]/route.test.ts
@@ -5,6 +5,8 @@
  */
 import {
   dbChainMockFns,
+  encryptionMock,
+  encryptionMockFns,
   hybridAuthMockFns,
   permissionsMock,
   permissionsMockFns,
@@ -30,6 +32,8 @@ const {
   mockSerializeBillingAttributionHeader: vi.fn(),
   fetchMock: vi.fn(),
 }))
+
+vi.mock('@/lib/core/security/encryption', () => encryptionMock)
 
 vi.mock('@/lib/billing/core/billing-attribution', () => ({
   BILLING_ATTRIBUTION_HEADER: 'x-sim-billing-attribution',
@@ -99,6 +103,9 @@ describe('MCP Serve Route', () => {
     )
     mockAssertBillingAttributionSnapshot.mockImplementation((value: unknown) => value)
     mockSerializeBillingAttributionHeader.mockReturnValue('serialized-attribution')
+    encryptionMockFns.mockDecryptSecret.mockImplementation(async (encryptedValue: string) => ({
+      decrypted: `decrypted:${encryptedValue}`,
+    }))
   })
 
   afterEach(() => {
@@ -1119,6 +1126,232 @@ describe('MCP Serve Route', () => {
 
     expect(response.status).toBe(200)
     expect(JSON.parse(body.result.content[0].text)).toEqual(['a', 'b'])
+  })
+
+  it('serves a public tool whose workflow was authored by someone other than the actor', async () => {
+    dbChainMockFns.limit
+      .mockResolvedValueOnce([
+        {
+          id: 'server-1',
+          name: 'Public Server',
+          workspaceId: 'ws-1',
+          isPublic: true,
+          createdBy: 'owner-1',
+        },
+      ])
+      .mockResolvedValueOnce([{ toolName: 'tool_a', workflowId: 'wf-1' }])
+      .mockResolvedValueOnce([{ workspaceId: 'ws-1', deploymentVersionId: 'deployment-1' }])
+    mockExecuteWorkflowService.mockResolvedValueOnce({
+      ok: true,
+      executionId: 'exec-1',
+      workflowId: 'wf-1',
+      status: 'completed',
+      aborted: null,
+      output: { ok: true },
+      error: null,
+      hasResponseBlock: false,
+      resolvedSecretTraceProvenance: createResolvedSecretTraceProvenance('author-2'),
+    })
+
+    const req = new NextRequest('http://localhost:3000/api/mcp/serve/server-1', {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'tool_a', arguments: { q: 'test' } },
+      }),
+    })
+    const response = await POST(req, { params: Promise.resolve({ serverId: 'server-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(JSON.parse(body.result.content[0].text)).toEqual({ ok: true })
+  })
+
+  it('serves a private tool whose workflow was authored by someone other than the caller', async () => {
+    dbChainMockFns.limit
+      .mockResolvedValueOnce([
+        {
+          id: 'server-1',
+          name: 'Private Server',
+          workspaceId: 'ws-1',
+          isPublic: false,
+          createdBy: 'owner-1',
+        },
+      ])
+      .mockResolvedValueOnce([{ toolName: 'tool_a', workflowId: 'wf-1' }])
+      .mockResolvedValueOnce([{ workspaceId: 'ws-1', deploymentVersionId: 'deployment-1' }])
+    /**
+     * `vi.clearAllMocks()` does not drain `mockResolvedValueOnce` queues, and a public-server
+     * test never reaches `checkHybridAuth`, so an earlier queued auth would be consumed here.
+     */
+    hybridAuthMockFns.mockCheckHybridAuth.mockReset()
+    hybridAuthMockFns.mockCheckHybridAuth.mockResolvedValueOnce({
+      success: true,
+      userId: 'user-1',
+      authType: 'api_key',
+      apiKeyType: 'workspace',
+      workspaceId: 'ws-1',
+    })
+    mockGetUserEntityPermissions.mockResolvedValueOnce('write')
+    mockExecuteWorkflowService.mockResolvedValueOnce({
+      ok: true,
+      executionId: 'exec-1',
+      workflowId: 'wf-1',
+      status: 'completed',
+      aborted: null,
+      output: { ok: true },
+      error: null,
+      hasResponseBlock: false,
+      resolvedSecretTraceProvenance: createResolvedSecretTraceProvenance('author-2'),
+    })
+
+    const req = new NextRequest('http://localhost:3000/api/mcp/serve/server-1', {
+      method: 'POST',
+      headers: { 'X-API-Key': 'wsk_test_123' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'tool_a', arguments: { q: 'test' } },
+      }),
+    })
+    const response = await POST(req, { params: Promise.resolve({ serverId: 'server-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(JSON.parse(body.result.content[0].text)).toEqual({ ok: true })
+  })
+
+  it('anonymizes an author-scoped secret label when the actor is not the author', async () => {
+    dbChainMockFns.limit
+      .mockResolvedValueOnce([
+        {
+          id: 'server-1',
+          name: 'Public Server',
+          workspaceId: 'ws-1',
+          isPublic: true,
+          createdBy: 'owner-1',
+        },
+      ])
+      .mockResolvedValueOnce([{ toolName: 'tool_a', workflowId: 'wf-1' }])
+      .mockResolvedValueOnce([{ workspaceId: 'ws-1', deploymentVersionId: 'deployment-1' }])
+    mockExecuteWorkflowService.mockResolvedValueOnce({
+      ok: true,
+      executionId: 'exec-1',
+      workflowId: 'wf-1',
+      status: 'completed',
+      aborted: null,
+      output: { leaked: 'decrypted:author-ciphertext' },
+      error: null,
+      hasResponseBlock: false,
+      resolvedSecretTraceProvenance: {
+        ...createResolvedSecretTraceProvenance('author-2'),
+        entries: [{ name: 'AUTHOR_TOKEN', encryptedValue: 'author-ciphertext' }],
+      },
+    })
+
+    const req = new NextRequest('http://localhost:3000/api/mcp/serve/server-1', {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'tool_a', arguments: { q: 'test' } },
+      }),
+    })
+    const response = await POST(req, { params: Promise.resolve({ serverId: 'server-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(JSON.parse(body.result.content[0].text)).toEqual({ leaked: '[REDACTED_SECRET]' })
+    expect(body.result.content[0].text).not.toContain('AUTHOR_TOKEN')
+  })
+
+  it('keeps the author-scoped secret label when the actor is the author', async () => {
+    dbChainMockFns.limit
+      .mockResolvedValueOnce([
+        {
+          id: 'server-1',
+          name: 'Public Server',
+          workspaceId: 'ws-1',
+          isPublic: true,
+          createdBy: 'owner-1',
+        },
+      ])
+      .mockResolvedValueOnce([{ toolName: 'tool_a', workflowId: 'wf-1' }])
+      .mockResolvedValueOnce([{ workspaceId: 'ws-1', deploymentVersionId: 'deployment-1' }])
+    mockExecuteWorkflowService.mockResolvedValueOnce({
+      ok: true,
+      executionId: 'exec-1',
+      workflowId: 'wf-1',
+      status: 'completed',
+      aborted: null,
+      output: { leaked: 'decrypted:owner-ciphertext' },
+      error: null,
+      hasResponseBlock: false,
+      resolvedSecretTraceProvenance: {
+        ...createResolvedSecretTraceProvenance('owner-1'),
+        entries: [{ name: 'OWNER_TOKEN', encryptedValue: 'owner-ciphertext' }],
+      },
+    })
+
+    const req = new NextRequest('http://localhost:3000/api/mcp/serve/server-1', {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'tool_a', arguments: { q: 'test' } },
+      }),
+    })
+    const response = await POST(req, { params: Promise.resolve({ serverId: 'server-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(JSON.parse(body.result.content[0].text)).toEqual({ leaked: '{{OWNER_TOKEN}}' })
+  })
+
+  it('refuses a tool result whose provenance was stamped for another workspace', async () => {
+    dbChainMockFns.limit
+      .mockResolvedValueOnce([
+        {
+          id: 'server-1',
+          name: 'Public Server',
+          workspaceId: 'ws-1',
+          isPublic: true,
+          createdBy: 'owner-1',
+        },
+      ])
+      .mockResolvedValueOnce([{ toolName: 'tool_a', workflowId: 'wf-1' }])
+      .mockResolvedValueOnce([{ workspaceId: 'ws-1', deploymentVersionId: 'deployment-1' }])
+    mockExecuteWorkflowService.mockResolvedValueOnce({
+      ok: true,
+      executionId: 'exec-1',
+      workflowId: 'wf-1',
+      status: 'completed',
+      aborted: null,
+      output: { ok: true },
+      error: null,
+      hasResponseBlock: false,
+      resolvedSecretTraceProvenance: createResolvedSecretTraceProvenance('owner-1', 'ws-other'),
+    })
+
+    const req = new NextRequest('http://localhost:3000/api/mcp/serve/server-1', {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'tool_a', arguments: { q: 'test' } },
+      }),
+    })
+    const response = await POST(req, { params: Promise.resolve({ serverId: 'server-1' }) })
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body.error.code).toBe(-32603)
   })
 
   it('rejects duplicate tool names instead of choosing an arbitrary workflow', async () => {

--- a/apps/sim/app/api/mcp/serve/[serverId]/route.ts
+++ b/apps/sim/app/api/mcp/serve/[serverId]/route.ts
@@ -205,11 +205,20 @@ async function projectWorkflowToolOutput(
   provenance: unknown,
   scope: { userId: string; workspaceId: string }
 ): Promise<unknown> {
+  /**
+   * Deliberately compares the tenant only, never the user. The executor stamps provenance with
+   * the workflow AUTHOR (`personalEnvUserId` falls back to `metadata.workflowUserId` on this
+   * non-session path) while `scope` here is the ACTING caller, and a caller who did not author
+   * the workflow is the ordinary team configuration — demanding they match refuses every such
+   * call after the workflow has already run and been billed. Restoring a user comparison here
+   * is not hardening: the registry compares both scope fields itself and marks every entry
+   * imported from another user anonymous, so a non-author already sees the opaque redaction
+   * placeholder rather than the author's secret names.
+   */
   if (
     !isResolvedSecretTraceProvenanceV1(provenance) ||
     !provenance.complete ||
-    provenance.scope?.userId !== scope.userId ||
-    provenance.scope.workspaceId !== scope.workspaceId
+    provenance.scope?.workspaceId !== scope.workspaceId
   ) {
     throw new Error('MCP workflow execution provenance is unavailable')
   }


### PR DESCRIPTION
## Summary
- `tools/call` on an MCP server returned HTTP 500 / JSON-RPC `-32603` whenever the caller was not the person who authored the workflow behind the tool. The provenance precondition in `apps/sim/app/api/mcp/serve/[serverId]/route.ts` compared `provenance.scope?.userId !== scope.userId`, but the executor stamps provenance with the workflow AUTHOR (`personalEnvUserId`, falling back to `metadata.workflowUserId` on this non-session path) while `scope` here is the ACTING caller. Owner != actor is the ordinary team configuration, so the check refused normal traffic.
- The refusal happened AFTER the workflow had already executed and been billed, and MCP clients retry 500s — so every retry re-ran and re-charged the workflow while still failing.
- Public servers amplified this: the actor is pinned to `server.createdBy`, so any server whose creator differs from a tool's workflow author was permanently broken for every caller, including anonymous ones.
- Fix drops only the `userId` arm and keeps the `workspaceId` arm, so cross-tenant provenance is still refused. A TSDoc records why `userId` is deliberately not compared, so the check is not "restored" later as hardening.
- Anonymization still protects the author: `ResolvedSecretTraceRegistry` compares both scope fields itself and marks every entry imported from another user anonymous, so a non-author sees `[REDACTED_SECRET]` rather than the author's secret name. That is covered by a test.

## Type of Change
- [x] Bug fix

## Testing
`bunx vitest run "app/api/mcp/serve/[serverId]/route.test.ts"` — 41/41 pass. Reverting only `route.ts` to staging makes exactly 3 fail (both non-author paths plus the anonymization projection), so the tests provably fail without the fix. `bun run type-check` in `apps/sim` is clean; biome is clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
