### PR TITLE
test(export): pin the table and tool-param loss the sanitized export accepts

### DIFF
--- a/apps/sim/app/api/v1/admin/folders/[id]/export/route.ts
+++ b/apps/sim/app/api/v1/admin/folders/[id]/export/route.ts
@@ -1,10 +1,15 @@
 /**
  * GET /api/v1/admin/folders/[id]/export
  *
- * Export a folder and all its contents (workflows + subfolders) as a ZIP file or JSON (raw, unsanitized for admin backup/restore).
+ * Export a folder and all its contents (workflows + subfolders) as a ZIP file or JSON.
+ *
+ * The two formats are NOT equivalent. `json` emits the raw stored state for admin
+ * backup/restore. `zip` runs every workflow through `sanitizeForExport`, which withholds
+ * credentials and several other classes of sub-block value, so a ZIP does not restore
+ * faithfully — use `json` when the export has to.
  *
  * Query Parameters:
- *   - format: 'zip' (default) or 'json'
+ *   - format: 'zip' (default, sanitized) or 'json' (raw)
  *
  * Response:
  *   - ZIP file download (Content-Type: application/zip)

--- a/apps/sim/app/api/v1/workflows/[id]/export/route.ts
+++ b/apps/sim/app/api/v1/workflows/[id]/export/route.ts
@@ -24,8 +24,10 @@ export const revalidate = 0
  * GET /api/v1/workflows/[id]/export
  *
  * Exports a workflow as a portable JSON envelope that
- * `POST /api/v1/workflows/import` accepts verbatim. Payload assembly and the
- * sanitization guarantees are documented on the shared
+ * `POST /api/v1/workflows/import` accepts without further editing. It is not a
+ * byte-for-byte clone: the envelope is secret-sanitized, so several classes of
+ * sub-block value import as empty and must be re-entered. Payload assembly and
+ * the authoritative list of what is withheld are documented on the shared
  * {@link buildWorkflowExportPayload}; this route authenticates and renders the
  * v1 envelope.
  */

--- a/apps/sim/lib/workflows/credentials/credential-extractor.test.ts
+++ b/apps/sim/lib/workflows/credentials/credential-extractor.test.ts
@@ -4,7 +4,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   EXPORT_PRESERVED_RESOURCE_TYPES,
-  sanitizeForExport,
   sanitizeWorkflowForSharing,
 } from '@/lib/workflows/credentials/credential-extractor'
 import { WORKFLOW_SEARCH_SUBBLOCK_RESOURCE_TYPES } from '@/lib/workflows/search-replace/resources/registry'
@@ -46,6 +45,17 @@ function stateWithSubBlock(type: string, value: unknown): Partial<WorkflowState>
   } as unknown as Partial<WorkflowState>
 }
 
+/**
+ * The exact option set `json-sanitizer`'s `sanitizeForExport` passes, copied rather than imported
+ * so this suite keeps testing `credential-extractor` without pulling in its own consumer.
+ *
+ * The copy cannot drift unnoticed: `import-export-roundtrip` calls the real `sanitizeForExport`
+ * and asserts the same withholding, so dropping an option there turns that suite red. Every
+ * export-shaped assertion below must use this constant — one that quietly omitted
+ * `redactOpaqueCredentialInputs` would describe a configuration no export surface runs.
+ */
+const EXPORT_OPTIONS = { preserveEnvVars: true, redactOpaqueCredentialInputs: true } as const
+
 function sanitizedValue(type: string, value: unknown): unknown {
   vi.mocked(getBlock).mockReturnValue({
     name: 'Test',
@@ -53,7 +63,7 @@ function sanitizedValue(type: string, value: unknown): unknown {
     subBlocks: [{ id: 'field', title: 'Field', type }],
     outputs: {},
   } as never)
-  const sanitized = sanitizeForExport(stateWithSubBlock(type, value))
+  const sanitized = sanitizeWorkflowForSharing(stateWithSubBlock(type, value), EXPORT_OPTIONS)
   return sanitized.blocks?.b1?.subBlocks?.field?.value
 }
 
@@ -98,19 +108,22 @@ describe('export sanitizer resource coverage', () => {
 
   it('clears tableId by key on a block with no registry config', () => {
     vi.mocked(getBlock).mockReturnValue(undefined as never)
-    const sanitized = sanitizeForExport({
-      blocks: {
-        b1: {
-          id: 'b1',
-          type: 'unknown-block',
-          name: 'Test',
-          position: { x: 0, y: 0 },
-          subBlocks: { tableId: { id: 'tableId', type: 'short-input', value: 'tbl_abc' } },
-          outputs: {},
-          enabled: true,
+    const sanitized = sanitizeWorkflowForSharing(
+      {
+        blocks: {
+          b1: {
+            id: 'b1',
+            type: 'unknown-block',
+            name: 'Test',
+            position: { x: 0, y: 0 },
+            subBlocks: { tableId: { id: 'tableId', type: 'short-input', value: 'tbl_abc' } },
+            outputs: {},
+            enabled: true,
+          },
         },
-      },
-    } as unknown as Partial<WorkflowState>)
+      } as unknown as Partial<WorkflowState>,
+      EXPORT_OPTIONS
+    )
     expect(sanitized.blocks?.b1?.subBlocks?.tableId?.value).toBeNull()
   })
 
@@ -133,10 +146,10 @@ describe('export sanitizer resource coverage', () => {
       outputs: {},
     } as never)
 
-    const sanitized = sanitizeWorkflowForSharing(stateWithSubBlock('tool-input', value), {
-      preserveEnvVars: true,
-      redactOpaqueCredentialInputs: true,
-    })
+    const sanitized = sanitizeWorkflowForSharing(
+      stateWithSubBlock('tool-input', value),
+      EXPORT_OPTIONS
+    )
 
     expect(sanitized.blocks?.b1?.subBlocks?.field?.value).toEqual([
       {
@@ -167,10 +180,10 @@ describe('export sanitizer resource coverage', () => {
       outputs: {},
     } as never)
 
-    const sanitized = sanitizeWorkflowForSharing(stateWithSubBlock('tool-input', value), {
-      preserveEnvVars: true,
-      redactOpaqueCredentialInputs: true,
-    })
+    const sanitized = sanitizeWorkflowForSharing(
+      stateWithSubBlock('tool-input', value),
+      EXPORT_OPTIONS
+    )
 
     expect(sanitized.blocks?.b1?.subBlocks?.field?.value).toEqual([
       {
@@ -182,7 +195,7 @@ describe('export sanitizer resource coverage', () => {
     ])
   })
 
-  it('withholds opaque table values from public snapshots', () => {
+  it('withholds opaque table values from public snapshots and exports', () => {
     const value = [
       { Key: 'Authorization', Value: 'Bearer plaintext-secret' },
       { Key: 'API_TOKEN', Value: '{{API_TOKEN}}' },
@@ -194,10 +207,7 @@ describe('export sanitizer resource coverage', () => {
       outputs: {},
     } as never)
 
-    const sanitized = sanitizeWorkflowForSharing(stateWithSubBlock('table', value), {
-      preserveEnvVars: true,
-      redactOpaqueCredentialInputs: true,
-    })
+    const sanitized = sanitizeWorkflowForSharing(stateWithSubBlock('table', value), EXPORT_OPTIONS)
 
     expect(sanitized.blocks?.b1?.subBlocks?.field?.value).toBeNull()
   })

--- a/apps/sim/lib/workflows/credentials/credential-extractor.ts
+++ b/apps/sim/lib/workflows/credentials/credential-extractor.ts
@@ -84,11 +84,17 @@ const WORKSPACE_SPECIFIC_FIELDS = new Set([
 ])
 
 /**
- * Sub-block values whose interior cannot be projected safely for a read-only snapshot API.
+ * Sub-block values whose interior cannot be projected safely once the payload leaves the
+ * workspace.
  *
  * Tables are arbitrary key/value rows used for authorization headers and sandbox environment
- * variables. Their cells carry no password metadata, so public snapshots must withhold the whole
- * value. Tool inputs are handled separately through the search-replace parameter codecs.
+ * variables. Their cells carry no password metadata — nothing distinguishes
+ * `Authorization: Bearer sk-…` from `Content-Type: application/json` — so the whole value is
+ * withheld. Tool inputs are handled separately through the search-replace parameter codecs.
+ *
+ * Which surfaces withhold these values, what that costs, and the shape a future relaxation must
+ * take are recorded on {@link WorkflowSanitizationOptions.redactOpaqueCredentialInputs}, the flag
+ * that governs both this set and the tool-input branch.
  */
 const OPAQUE_CREDENTIAL_BEARING_TYPES: ReadonlySet<string> = new Set(['table'])
 
@@ -269,6 +275,26 @@ interface SanitizedWorkflowState {
 
 interface WorkflowSanitizationOptions {
   preserveEnvVars?: boolean
+  /**
+   * Withhold values whose interior cannot be projected safely once the payload leaves the
+   * workspace — whole `table` values (see {@link OPAQUE_CREDENTIAL_BEARING_TYPES}) and every
+   * `tool-input` parameter with no authoritative codec metadata.
+   *
+   * Governed surfaces are every caller that passes this flag: the public execution-snapshot
+   * projection, the pinned deployment-version read, and — since #6591 — workflow export, which
+   * reaches the in-app Export as JSON button, the folder and multi-select ZIPs, and the v1/v2
+   * export APIs.
+   *
+   * The accepted cost on the export surface is that an export is lossy for tables and does not
+   * round-trip: non-secret configuration (api `params`, cloudwatch dimensions, response `headers`,
+   * sts `tags`) is withheld alongside the secrets, and a whole-`{{ENV_VAR}}` reference inside a
+   * cell is withheld too, unlike the same reference in a `password: true` field. Withholding was
+   * chosen over per-cell heuristics because the sub-blocks that motivate the loss — every header
+   * table and the `browser_use`/`stagehand`/`daytona` variable tables — are exactly the ones a
+   * pasted bearer token lands in, and an export file leaves the trust boundary. Relaxing this
+   * needs a per-sub-block opt-in that fails closed for tables added later, not a wider default;
+   * `import-export-roundtrip` pins the current loss so the trade cannot be reversed silently.
+   */
   redactOpaqueCredentialInputs?: boolean
 }
 
@@ -435,14 +461,4 @@ export function sanitizeCredentials(
   state: Partial<WorkflowState> | null | undefined
 ): SanitizedWorkflowState {
   return sanitizeWorkflowForSharing(state, { preserveEnvVars: false })
-}
-
-/**
- * Sanitize workflow state for export (preserves env vars)
- * Convenience wrapper for workflow export
- */
-export function sanitizeForExport(
-  state: Partial<WorkflowState> | null | undefined
-): SanitizedWorkflowState {
-  return sanitizeWorkflowForSharing(state, { preserveEnvVars: true })
 }

--- a/apps/sim/lib/workflows/operations/export-workflow.ts
+++ b/apps/sim/lib/workflows/operations/export-workflow.ts
@@ -6,33 +6,6 @@ import {
 } from '@/lib/workflows/sanitization/json-sanitizer'
 import { parseWorkflowVariables } from '@/lib/workflows/variables/parse'
 
-/**
- * Server-only assembly of the public workflow-export payload, shared by the v1
- * and v2 export routes so both surfaces emit byte-identical envelopes.
- *
- * Unlike the admin export (`/api/v1/admin/workflows/[id]/export`), which emits
- * the raw state for backup/restore, this runs the payload through
- * `sanitizeForExport`, which nulls five classes of sub-block value:
- * - `password: true` fields, unless the value is a whole `{{ENV_VAR}}`
- *   reference, which is preserved so the import resolves it in the target
- *   workspace;
- * - `oauth-input` credentials;
- * - sensitive nested `tool-input` params and params without authoritative metadata;
- * - opaque credential-bearing values such as arbitrary table cells;
- * - **workspace-scoped bindings** — selector fields and id-keyed fields that
- *   point at rows that do not exist in another workspace, cleared rather than
- *   carried across as dangling ids.
- *
- * The last class means an export is **not** a byte-for-byte clone even when
- * re-imported into the same workspace: those bindings come back empty and must
- * be re-selected. This matches the in-app export.
- *
- * Workflow **variables** are emitted as stored: they are plaintext workflow
- * configuration readable by anyone with workspace read (the same permission the
- * export routes require); secrets belong in environment variables, which travel
- * as unresolved `{{ENV_VAR}}` references.
- */
-
 /** The subset of the workflow record the export payload reads. */
 export interface ExportableWorkflowRecord {
   id: string
@@ -111,6 +84,31 @@ function toExportedEdge(edge: Edge): WorkflowExportEdge {
  * Loads the workflow's normalized state, sanitizes it, and assembles the
  * portable export envelope. Returns `null` when the workflow has no persisted
  * normalized state (the caller renders its own 404).
+ *
+ * Server-only assembly of the public workflow-export payload, shared by the v1
+ * and v2 export routes so both surfaces emit byte-identical envelopes.
+ *
+ * Unlike the admin export (`/api/v1/admin/workflows/[id]/export`), which emits
+ * the raw state for backup/restore, this runs the payload through
+ * `sanitizeForExport`, which nulls five classes of sub-block value:
+ * - `password: true` fields, unless the value is a whole `{{ENV_VAR}}`
+ *   reference, which is preserved so the import resolves it in the target
+ *   workspace;
+ * - `oauth-input` credentials;
+ * - sensitive nested `tool-input` params and params without authoritative metadata;
+ * - opaque credential-bearing values such as arbitrary table cells;
+ * - **workspace-scoped bindings** — selector fields and id-keyed fields that
+ *   point at rows that do not exist in another workspace, cleared rather than
+ *   carried across as dangling ids.
+ *
+ * The last two classes mean an export is **not** a byte-for-byte clone even when
+ * re-imported into the same workspace: those bindings and every table come back
+ * empty and must be re-entered. This matches the in-app export.
+ *
+ * Workflow **variables** are emitted as stored: they are plaintext workflow
+ * configuration readable by anyone with workspace read (the same permission the
+ * export routes require); secrets belong in environment variables, which travel
+ * as unresolved `{{ENV_VAR}}` references.
  */
 export async function buildWorkflowExportPayload(
   workflowData: ExportableWorkflowRecord

--- a/apps/sim/lib/workflows/operations/import-export-roundtrip.test.ts
+++ b/apps/sim/lib/workflows/operations/import-export-roundtrip.test.ts
@@ -67,6 +67,51 @@ function makeSourceState() {
         enabled: true,
         data: { parentId: 'par1', extent: 'parent' },
       },
+      apiCall: {
+        id: 'apiCall',
+        type: 'api',
+        name: 'Call',
+        position: { x: 400, y: 200 },
+        subBlocks: {
+          url: { id: 'url', type: 'short-input', value: 'https://example.com/v1/items' },
+          headers: {
+            id: 'headers',
+            type: 'table',
+            value: [
+              { id: 'r1', cells: { Key: 'Content-Type', Value: 'application/json' } },
+              { id: 'r2', cells: { Key: 'Authorization', Value: '{{TABLE_ONLY_TOKEN}}' } },
+            ],
+          },
+          params: {
+            id: 'params',
+            type: 'table',
+            value: [{ id: 'r3', cells: { Key: 'limit', Value: '10' } }],
+          },
+        },
+        outputs: {},
+        enabled: true,
+      },
+      agent: {
+        id: 'agent',
+        type: 'agent',
+        name: 'Agent',
+        position: { x: 600, y: 200 },
+        subBlocks: {
+          tools: {
+            id: 'tools',
+            type: 'tool-input',
+            value: [
+              {
+                type: 'custom-tool',
+                title: 'My Tool',
+                params: { endpoint: 'https://example.com/hook', greeting: 'hi' },
+              },
+            ],
+          },
+        },
+        outputs: {},
+        enabled: true,
+      },
     } as Record<string, any>,
     edges: [
       { id: 'e1', source: 'starter', target: 'loop1', sourceHandle: 'source', targetHandle: null },
@@ -87,7 +132,8 @@ function makeSourceState() {
 
 describe('workflow export -> import round trip', () => {
   const exported = sanitizeForExport(makeSourceState() as any)
-  const { data: reimported, errors } = parseWorkflowJson(JSON.stringify(exported))
+  const exportedJson = JSON.stringify(exported)
+  const { data: reimported, errors } = parseWorkflowJson(exportedJson)
 
   it('re-imports without validation errors', () => {
     expect(errors).toEqual([])
@@ -96,13 +142,15 @@ describe('workflow export -> import round trip', () => {
 
   it('preserves every block, including children inside loop and parallel containers', () => {
     expect(Object.keys(exported.state.blocks).sort()).toEqual([
+      'agent',
+      'apiCall',
       'childInLoop',
       'childInPar',
       'loop1',
       'par1',
       'starter',
     ])
-    expect(Object.keys(reimported!.blocks)).toHaveLength(5)
+    expect(Object.keys(reimported!.blocks)).toHaveLength(7)
   })
 
   it('preserves every edge', () => {
@@ -135,6 +183,44 @@ describe('workflow export -> import round trip', () => {
     expect(reimported!.variables).toMatchObject({
       v1: { id: 'v1', name: 'apiHost', type: 'string', value: 'https://example.com' },
     })
+  })
+
+  /**
+   * The round trip is deliberately NOT lossless, and these assertions exist so that stops being a
+   * surprise. `sanitizeForExport` passes `redactOpaqueCredentialInputs`, which withholds whole
+   * `table` values and every parameter of a tool with no authoritative codec metadata — see the
+   * trade recorded on `OPAQUE_CREDENTIAL_BEARING_TYPES` in `credential-extractor`.
+   *
+   * Both classes carry secrets no per-field rule can find (a bearer token pasted into a header
+   * cell, a key in a custom tool's params) and both also carry ordinary configuration, which goes
+   * with them. Whoever revisits that trade has to edit these expectations, which is the point: the
+   * absence of a `table` fixture here is why the change reached a release unnoticed.
+   */
+  it('withholds table values, including whole {{ENV_VAR}} cells, on the way out', () => {
+    const subBlocks = exported.state.blocks.apiCall.subBlocks as Record<string, { value: unknown }>
+
+    expect(subBlocks.headers.value).toBeNull()
+    expect(subBlocks.params.value).toBeNull()
+    expect(subBlocks.url.value).toBe('https://example.com/v1/items')
+    expect(exportedJson).not.toContain('{{API_TOKEN}}')
+  })
+
+  it('withholds every parameter of a tool with no authoritative codec metadata', () => {
+    const tools = exported.state.blocks.agent.subBlocks.tools.value as {
+      params: Record<string, unknown>
+    }[]
+
+    expect(tools[0].params).toEqual({ endpoint: null, greeting: null })
+    expect(tools[0].title).toBe('My Tool')
+  })
+
+  it('re-imports the withheld sub-blocks as empty rather than dropping or corrupting them', () => {
+    const reimportedApi = Object.values(reimported!.blocks).find(
+      (b: any) => b.type === 'api'
+    ) as any
+
+    expect(reimportedApi.subBlocks.headers.value).toBeNull()
+    expect(reimportedApi.subBlocks.url.value).toBe('https://example.com/v1/items')
   })
 
   it('does not hang on a block name containing regex metacharacters', () => {

--- a/apps/sim/lib/workflows/operations/import-export-roundtrip.test.ts
+++ b/apps/sim/lib/workflows/operations/import-export-roundtrip.test.ts
@@ -15,6 +15,14 @@ import { describe, expect, it } from 'vitest'
 import { parseWorkflowJson } from '@/lib/workflows/operations/import-export'
 import { sanitizeForExport } from '@/lib/workflows/sanitization/json-sanitizer'
 
+/**
+ * A whole-`{{ENV_VAR}}` reference that appears in exactly one place: a table cell. The leak sweep
+ * below greps the serialized envelope for it, so it has to be a value no other fixture uses and
+ * the same symbol has to feed both the fixture and the assertion — spelling the string twice is
+ * how that sweep silently starts passing vacuously.
+ */
+const TABLE_ONLY_ENV_REF = '{{TABLE_ONLY_TOKEN}}'
+
 function makeSourceState() {
   return {
     blocks: {
@@ -79,7 +87,7 @@ function makeSourceState() {
             type: 'table',
             value: [
               { id: 'r1', cells: { Key: 'Content-Type', Value: 'application/json' } },
-              { id: 'r2', cells: { Key: 'Authorization', Value: '{{TABLE_ONLY_TOKEN}}' } },
+              { id: 'r2', cells: { Key: 'Authorization', Value: TABLE_ONLY_ENV_REF } },
             ],
           },
           params: {
@@ -202,7 +210,7 @@ describe('workflow export -> import round trip', () => {
     expect(subBlocks.headers.value).toBeNull()
     expect(subBlocks.params.value).toBeNull()
     expect(subBlocks.url.value).toBe('https://example.com/v1/items')
-    expect(exportedJson).not.toContain('{{API_TOKEN}}')
+    expect(exportedJson).not.toContain(TABLE_ONLY_ENV_REF)
   })
 
   it('withholds every parameter of a tool with no authoritative codec metadata', () => {
@@ -215,12 +223,11 @@ describe('workflow export -> import round trip', () => {
   })
 
   it('re-imports the withheld sub-blocks as empty rather than dropping or corrupting them', () => {
-    const reimportedApi = Object.values(reimported!.blocks).find(
-      (b: any) => b.type === 'api'
-    ) as any
+    const reimportedApi = Object.values(reimported!.blocks).find((b) => b.type === 'api')
 
-    expect(reimportedApi.subBlocks.headers.value).toBeNull()
-    expect(reimportedApi.subBlocks.url.value).toBe('https://example.com/v1/items')
+    expect(reimportedApi).toBeDefined()
+    expect(reimportedApi?.subBlocks.headers.value).toBeNull()
+    expect(reimportedApi?.subBlocks.url.value).toBe('https://example.com/v1/items')
   })
 
   it('does not hang on a block name containing regex metacharacters', () => {


### PR DESCRIPTION
## Summary

**This PR intentionally changes no behavior.** It pins an existing trade-off in place, documents it, and removes a footgun. No redaction logic is touched.

#6591 turned on `redactOpaqueCredentialInputs` for the workflow export path. That closed a real leak: a bearer token pasted into an API block's Headers cell, and secrets in custom tool params, were reaching the v1/v2 export APIs and the in-app Export as JSON in plaintext.

Its unpriced cost shipped with it. An export/import round trip now returns API blocks with empty Headers and Query Params, and drops `{{ENV_VAR}}` references inside table cells even though the same reference in a `password` field survives. Nothing in the test suite described either side of that trade, so it could be flipped in either direction without anyone noticing — and an earlier audit did recommend reverting the flag.

- adds round-trip fixtures (an api block with two table sub-blocks, an agent block with a custom tool) plus assertions pinning the current loss
- records the trade on `redactOpaqueCredentialInputs` — which surfaces it governs, what is lost, why withholding beat per-cell heuristics, and the shape a future relaxation must take
- deletes a duplicate `sanitizeForExport` in `credential-extractor.ts`
- corrects two route TSDocs that misdescribed what the code does, and moves the canonical sanitization doc onto the symbol those docs link to

## The tests guard in both directions

Not just "redaction still works" — reverting the flag now fails loudly. Setting `redactOpaqueCredentialInputs: false` in `json-sanitizer.ts` produces exactly 4 failures:

```
× redacts nested tool credentials from the public export payload
× withholds table values, including whole {{ENV_VAR}} cells, on the way out
× withholds every parameter of a tool with no authoritative codec metadata
× re-imports the withheld sub-blocks as empty rather than dropping or corrupting them
```

The first one is the point: it is executable proof that reverting the flag re-opens a secret leak. The other three pin the accepted cost, so anyone who decides the loss is unacceptable has to edit those expectations deliberately rather than delete the flag and ship.

## The deleted duplicate was a real footgun

`credential-extractor.ts` exported its own `sanitizeForExport` that called `sanitizeWorkflowForSharing` with `preserveEnvVars: true` and **not** `redactOpaqueCredentialInputs`. It had zero production importers — every real caller uses the same-named but different function in `@/lib/workflows/sanitization/json-sanitizer`, which does pass the flag and returns a full envelope.

Its only consumer was a test suite, which therefore described a configuration nothing runs. Two identically-named exports where one silently omits a redaction flag is exactly the shape of a future leak. The suite now passes the real option set explicitly, and `import-export-roundtrip` exercises the genuine `sanitizeForExport`, so the copy cannot drift unnoticed.

## Open question for the owner

This PR does not resolve the underlying tension, because it is a product decision, not an engineering one:

**Is workflow export a faithful backup format, or a share-safe projection?**

Those two goals conflict here and the answer decides any future change. Today the export path tries to be both and lands as a share-safe projection that people reasonably expect to be a backup. If it is a backup, the fix is a per-sub-block opt-in that fails closed for tables added later — never a wider default. If it is a share-safe projection, the current loss is correct and the gap is discoverability: nothing in the product or the logs tells a user their tables came back empty; they find out by re-importing.

Worth noting the first relaxation candidates are already visible in the new fixture — `api.params` (query params) and response-shaping header tables are not credential sinks.

## Recommended next action: discoverability, not relaxation

Independent of how that question is answered, the concrete follow-up I'd recommend is **telling the user what was withheld** — surface a warning on export (and on import) that table sub-blocks and unauthoritative tool params came back empty and must be re-entered.

That is the right next step because it is the only option with no security trade: it does not widen what is exported by a single byte, so it cannot re-open the leak #6591 closed, and it works whichever answer the product question gets. It converts a silent loss into an informed one. Today a user discovers the loss by re-importing a workflow and finding empty Headers — which is also why this reached a release unnoticed.

Relaxing the redaction (a per-sub-block opt-in that fails closed) is the larger, riskier change and should wait on the product decision. Discoverability should not.

## Type of Change
- [x] Chore / test + docs (no behavior change)

## Testing
35/35 passing across `import-export-roundtrip`, `credential-extractor`, and `export-workflow`. Bidirectional guard verified by flipping the flag and confirming 4 failures, then restoring. `bun run type-check` clean, biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

