### PR TITLE
fix(copilot): clamp the legacy int4 size when materializing a chat upload

### DIFF
--- a/apps/sim/lib/copilot/tools/handlers/materialize-file.test.ts
+++ b/apps/sim/lib/copilot/tools/handlers/materialize-file.test.ts
@@ -155,6 +155,9 @@ const STORAGE_CONTEXT = {
   customStorageLimitGB: null,
 }
 
+const POSTGRES_INT4_MAX = 2_147_483_647
+const OVERSIZED_BYTES = 3 * 1024 * 1024 * 1024
+
 const mothershipRow = {
   id: 'file-1',
   key: 'mothership/file-1',
@@ -336,6 +339,58 @@ describe('executeMaterializeFile - save storage transition', () => {
     expect(mockMaybeNotifyStorageLimitForBillingContext).toHaveBeenCalledWith(
       STORAGE_CONTEXT,
       1_250
+    )
+  })
+
+  it('writes an int4-representable legacy size and the exact byte count above the int4 ceiling', async () => {
+    // A row above the int4 ceiling must not be written raw to `size`: Postgres
+    // raises 22003 and the save becomes unrecoverable.
+    mockHeadObject.mockResolvedValue({ size: OVERSIZED_BYTES, contentType: 'text/plain' })
+
+    const result = await executeMaterializeFile(
+      { fileNames: ['report.txt'], operation: 'save' },
+      context
+    )
+
+    expect(result.success).toBe(true)
+    const [updateSet] = dbChainMockFns.set.mock.calls.at(-1) as [Record<string, unknown>]
+    expect(updateSet.size).toBe(POSTGRES_INT4_MAX)
+    expect(updateSet.sizeBytes).toBe(OVERSIZED_BYTES)
+    expect(mockCheckStorageQuotaForBillingContext).toHaveBeenCalledWith(
+      STORAGE_CONTEXT,
+      OVERSIZED_BYTES
+    )
+    expect(mockIncrementStorageUsageForBillingContextInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      STORAGE_CONTEXT,
+      OVERSIZED_BYTES
+    )
+  })
+
+  it('falls back to the exact stored byte count, not the clamped legacy size', async () => {
+    // Without cloud storage a missing object does not short-circuit, so the row is
+    // the only size source — and its `size` is already clamped.
+    mockHeadObject.mockResolvedValue(null)
+    mockHasCloudStorage.mockReturnValue(false)
+    mockFindUpload.mockResolvedValue({
+      ...mothershipRow,
+      size: POSTGRES_INT4_MAX,
+      sizeBytes: OVERSIZED_BYTES,
+    })
+
+    const result = await executeMaterializeFile(
+      { fileNames: ['report.txt'], operation: 'save' },
+      context
+    )
+
+    expect(result.success).toBe(true)
+    const [updateSet] = dbChainMockFns.set.mock.calls.at(-1) as [Record<string, unknown>]
+    expect(updateSet.sizeBytes).toBe(OVERSIZED_BYTES)
+    expect(updateSet.size).toBe(POSTGRES_INT4_MAX)
+    expect(mockIncrementStorageUsageForBillingContextInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      STORAGE_CONTEXT,
+      OVERSIZED_BYTES
     )
   })
 

--- a/apps/sim/lib/copilot/tools/handlers/materialize-file.ts
+++ b/apps/sim/lib/copilot/tools/handlers/materialize-file.ts
@@ -36,6 +36,7 @@ import {
 } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
 import { getBoundWorkspaceFileSecretProvenance } from '@/lib/uploads/contexts/workspace/workspace-file-secret-provenance'
 import { hasCloudStorage, headObject } from '@/lib/uploads/core/storage-service'
+import { toLegacyWorkspaceFileSize } from '@/lib/uploads/shared/types'
 import { isArchiveFileName } from '@/lib/uploads/utils/file-utils'
 import { parseWorkflowJson } from '@/lib/workflows/operations/import-export'
 import { saveWorkflowToNormalizedTables } from '@/lib/workflows/persistence/utils'
@@ -109,7 +110,12 @@ async function executeSave(
   if (!head && hasCloudStorage()) {
     return { success: false, error: `Upload object not found: "${fileName}".` }
   }
-  const verifiedSize = head?.size ?? row.size
+  /**
+   * The true byte count can exceed the legacy int4 `size` column, so read the exact
+   * `sizeBytes` first and clamp back down for the legacy projection.
+   */
+  const verifiedSize = head?.size ?? row.sizeBytes ?? row.size
+  const legacySize = toLegacyWorkspaceFileSize(verifiedSize)
   const billingContext = await resolveStorageBillingContext(workspaceId)
   const quotaCheck = await checkStorageQuotaForBillingContext(billingContext, verifiedSize)
   if (!quotaCheck.allowed) {
@@ -145,7 +151,8 @@ async function executeSave(
             messageId: null,
             originalName: materializedName,
             displayName: materializedName,
-            size: verifiedSize,
+            size: legacySize,
+            sizeBytes: verifiedSize,
           })
           .where(
             and(


### PR DESCRIPTION
## Summary
- `materialize_file(operation: 'save')` wrote the HEADed object size straight into `workspace_files.size`, which is still `integer NOT NULL`. A mothership chat attachment may be up to `MAX_WORKSPACE_FILE_SIZE` (5 GiB), so saving one issued `SET size = <bytes > 2^31-1>` against int4. Postgres raises **22003**; the retry filter matches only 23505, so it rethrows, the transaction rolls back, and the tool returns `success: false` with no way for the user to complete the save. No corruption — int4 overflows loudly, it never truncates — but the file could never be saved.
- Fix: clamp the legacy projection with the existing `toLegacyWorkspaceFileSize()` and dual-write the exact count to `sizeBytes`, which is what every other `workspace_files` size writer already does (`server/metadata.ts` x4, `workspace-file-manager.ts:243`/`:1706`, `finalizers.ts:367`). This call site was simply missed when the widening landed — the change converges it with the other six rather than inventing a third shape.
- The size source had to widen too. `head?.size ?? row.size` fell back to the clamped int4 column; now that the write also sets `sizeBytes`, that fallback would have overwritten an exact `size_bytes` with the clamp — and since the object is gone in that branch, nothing could recover it. `row.sizeBytes ?? row.size` is the same coalescing precedence the readers already use (`workspace-file-manager.ts:227`, `finalizers.ts:399`, `metadata.ts:46`). This branch is live whenever `hasCloudStorage()` is false, since the early return at the HEAD miss is cloud-only.
- Storage accounting keeps using the exact `verifiedSize`, so quota checks and usage increments are unaffected — only the legacy int4 projection is clamped.

## Severity — not release-blocking
`size_bytes` is introduced by migration 0289 in this same release, and the legacy `size` column is `integer NOT NULL`, so an oversized row was never physically creatable. **No backfill is needed and no existing row is affected** — the original premise that legacy rows need one is inverted.

The oversized path is not reachable today given the upload limits elsewhere in the stack, so this is correctness hardening landing before the column ships, not a fix for an active failure. It is a small change (13 source lines) that removes an unrecoverable failure mode at the point the ceiling would otherwise be hit.

## Follow-ups (deliberately out of scope)
- **`workspace-file-manager.ts:963`** (`trackChatUpload`, insert branch) writes a caller-supplied `size` with no clamp and no `sizeBytes`. It is the next instance of this bug and sits upstream of the row this PR repairs. Converting loose external input from a DB error into a JS throw (the helper validates and throws on non-safe-integer/negative input) is a behavior change that deserves its own review rather than riding along here.
- **A shared `workspaceFileSizeColumns(bytes)` helper returning `{ size, sizeBytes }`, plus a lint guard** so the dual-write cannot be half-applied. The two columns must always agree and are currently kept in sync by convention across independent call sites. That belongs with the contract phase — `size` cannot safely be dropped while unconverged writers exist.
- **`ee/workspace-forking/lib/copy/copy-files.ts:266`/`:312`** copies `meta.size` (already int4-valid, so no overflow risk) but drops `sizeBytes`, so a forked large file lands with `size_bytes = NULL` and bills the clamped value. Read-side fix is `coalesce(sizeBytes, size)` at the select.
- **Rollback note:** once rows above 2 GiB exist, rolling back to a build without the coalescing readers makes them read as 2 GiB and corrupts storage counters.

## Type of Change
- [x] Bug fix

## Testing
`bunx vitest run lib/copilot/tools/handlers/materialize-file.test.ts` — 26 passed. Both new tests were proven red against the unfixed source: the clamp test fails with `expected 3221225472 to be 2147483647`, the fallback test with `expected undefined to be 3221225472`. `bun run type-check` clean; biome clean on both changed files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
