### PR TITLE
fix(sdk): make the 0.2.0 SDK release safe to publish

### DIFF
--- a/apps/docs/content/docs/en/api-reference/python.mdx
+++ b/apps/docs/content/docs/en/api-reference/python.mdx
@@ -275,7 +275,10 @@ class WorkflowExecutionResult:
     metadata: Optional[Dict[str, Any]] = None
     trace_spans: Optional[List[Any]] = None
     total_duration: Optional[float] = None
+    status: Optional[str] = None
 ```
+
+`success` is `True` only for the `completed` and `paused` statuses. `status` carries the server's terminal status verbatim, so a cancelled run (`success=False`, `error=None`) is distinguishable from a failed one.
 
 ### AsyncExecutionResult
 

--- a/bun.lock
+++ b/bun.lock
@@ -611,7 +611,7 @@
     },
     "packages/ts-sdk": {
       "name": "simstudio-ts-sdk",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "devDependencies": {
         "@sim/tsconfig": "workspace:*",
         "@types/node": "24.2.1",

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -2,6 +2,22 @@
 
 The official Python SDK for [Sim](https://sim.ai), allowing you to execute workflows programmatically from your Python applications.
 
+## Server compatibility
+
+`0.2.x` talks to the v2 API and has no fallback to the older endpoints, so it requires a Sim deployment that serves `POST /api/v2/workflows/{id}/execute`. That surface is newer than the endpoints `0.1.x` used, and a deployment can also have it switched off — a self-hosted build serves `/api/v2` only when the operator enables `V2_API`. Where it is unavailable every v2 route answers 404, so `execute_workflow` raises `SimStudioError('HTTP 404: Not Found')` — enable or upgrade the v2 API on the server, or pin `simstudio-sdk<0.2`, which keeps using `/api/workflows/{id}/execute` and `/api/jobs/{id}`.
+
+## Upgrading from 0.1.x to 0.2.0
+
+`0.2.0` is a breaking release.
+
+- **Requests move to `/api/v2`.** `execute_workflow` posts to `/api/v2/workflows/{workflow_id}/execute`, sends the workflow input nested under `input`, and carries `async` / `executionTimeoutSeconds` in the body instead of the `X-Execution-Mode` and `X-Execution-Timeout-Seconds` headers.
+- **`AsyncExecutionResult.job_id` is now `run_id`,** and `execution_id` has been removed from that dataclass. Replace `result.job_id` with `result.run_id`.
+- **`get_job_status(job_id)` is legacy.** It still calls `/api/jobs/{job_id}` and only resolves IDs from a `0.1.x` async execution. For runs started by `0.2.x`, use `get_workflow_run(workflow_id, run_id)`, which reads `/api/v2/workflows/{workflow_id}/runs/{run_id}`.
+- **`WorkflowExecutionResult.success` is derived from the run status** rather than read from the response body, and is `True` only for `completed` and `paused` runs — so a run cancelled while it was in flight now reports `success=False`, as it did before the v2 migration. The new `WorkflowExecutionResult.status` field carries the server's terminal status (`'completed'`, `'failed'`, `'paused'` or `'cancelled'`), which is how you tell a cancelled run from a failed one.
+- **`metadata` is now built by the SDK,** with the keys `duration`, `runId`, `startTime` and `endTime`. The v2 response carries no execution logs or trace spans, so `logs` and `trace_spans` are always `None`; the pre-v2 `metadata['executionId']` is now `metadata['runId']`.
+
+Note one deliberate difference from the TypeScript SDK: a failed synchronous run *throws* there, but here it returns normally with `error` set and `status='failed'`.
+
 ## Installation
 
 ```bash
@@ -245,7 +261,10 @@ class WorkflowExecutionResult:
     metadata: Optional[Dict[str, Any]] = None
     trace_spans: Optional[list] = None
     total_duration: Optional[float] = None
+    status: Optional[str] = None
 ```
+
+`success` is `True` only for the `completed` and `paused` statuses. `status` carries the server's terminal status verbatim, so a cancelled run (`success=False`, `error=None`) is distinguishable from a failed one.
 
 ### WorkflowStatus
 

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simstudio-sdk"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     {name = "Sim", email = "help@sim.ai"},
 ]

--- a/packages/python-sdk/simstudio/__init__.py
+++ b/packages/python-sdk/simstudio/__init__.py
@@ -6,6 +6,7 @@ Official Python SDK for Sim, allowing you to execute workflows programmatically.
 
 from typing import Any, Dict, Optional, Union
 from dataclasses import dataclass
+from datetime import datetime
 import time
 import random
 import os
@@ -14,7 +15,12 @@ import requests
 
 MAX_EXECUTION_TIMEOUT_SECONDS = 604_800
 
-__version__ = "0.1.2"
+# Run statuses that count as a successful synchronous execution. Deliberately a
+# whitelist: a status later added to the API then defaults to "not successful"
+# rather than silently reporting True.
+_SUCCESSFUL_RUN_STATUSES = ('completed', 'paused')
+
+__version__ = "0.2.0"
 __all__ = [
     "SimStudioClient",
     "SimStudioError",
@@ -28,7 +34,14 @@ __all__ = [
 
 @dataclass
 class WorkflowExecutionResult:
-    """Result of a workflow execution."""
+    """
+    Result of a workflow execution.
+
+    ``success`` is True only for the 'completed' and 'paused' statuses, so a
+    run the server cancels and a run that fails both report False. Read
+    ``status`` to tell those apart -- it carries the server's own terminal
+    status ('completed', 'failed', 'paused' or 'cancelled').
+    """
     success: bool
     output: Optional[Any] = None
     error: Optional[str] = None
@@ -36,6 +49,7 @@ class WorkflowExecutionResult:
     metadata: Optional[Dict[str, Any]] = None
     trace_spans: Optional[list] = None
     total_duration: Optional[float] = None
+    status: Optional[str] = None
 
 
 @dataclass
@@ -58,7 +72,13 @@ class AsyncExecutionResult:
 
 @dataclass
 class RateLimitInfo:
-    """Rate limit information from API response headers."""
+    """
+    Rate limit information from API response headers.
+
+    ``reset`` is epoch milliseconds when the server sends the ISO 8601
+    ``X-RateLimit-Reset`` the v2 API uses, and epoch seconds for the bare
+    integer older endpoints sent. ``retry_after`` is milliseconds.
+    """
     limit: int
     remaining: int
     reset: int
@@ -80,6 +100,23 @@ class SimStudioError(Exception):
         super().__init__(message)
         self.code = code
         self.status = status
+
+
+def _parse_reset_header(value: str) -> int:
+    """
+    Parse the ``X-RateLimit-Reset`` header, matching the TypeScript SDK.
+
+    The v2 API sends an ISO 8601 timestamp, which yields epoch milliseconds;
+    older endpoints sent an epoch integer, which is kept as-is. A quota hint
+    must never take down the call it rode in on, so an unrecognised value
+    degrades to 0 rather than raising.
+    """
+    if value.isdecimal():
+        return int(value)
+    try:
+        return int(datetime.fromisoformat(value.replace('Z', '+00:00')).timestamp() * 1000)
+    except ValueError:
+        return 0
 
 
 class SimStudioClient:
@@ -166,9 +203,11 @@ class SimStudioClient:
 
         Args:
             workflow_id: The ID of the workflow to execute
-            input: Input data to pass to the workflow. Can be a dict (spread at root level),
-                   primitive value (string, number, bool), or list (wrapped in 'input' field).
-                   File-like objects within dicts are automatically converted to base64.
+            input: Input data to pass to the workflow, sent nested under the request
+                   body's 'input' field. A dict becomes the workflow input as-is; any
+                   other value (string, number, bool, list) is wrapped as
+                   {'input': value}. File-like objects within it are automatically
+                   converted to base64.
             timeout: Timeout in seconds (default: 30.0)
             stream: Enable streaming responses (default: None)
             selected_outputs: Block outputs to stream (e.g., ["agent1.content"])
@@ -270,15 +309,19 @@ class SimStudioClient:
                 )
 
             execution_error = result_data.get('error')
+            status = result_data.get('status')
             return WorkflowExecutionResult(
-                success=result_data.get('status') != 'failed',
+                success=status in _SUCCESSFUL_RUN_STATUSES,
                 output=result_data.get('output'),
                 error=execution_error.get('message') if execution_error else None,
                 metadata={
                     'duration': result_data.get('durationMs'),
-                    'runId': result_data['runId']
+                    'runId': result_data['runId'],
+                    'startTime': result_data.get('startedAt'),
+                    'endTime': result_data.get('endedAt')
                 },
-                total_duration=result_data.get('durationMs')
+                total_duration=result_data.get('durationMs'),
+                status=status
             )
 
         except requests.Timeout:
@@ -593,7 +636,7 @@ class SimStudioClient:
             self._rate_limit_info = RateLimitInfo(
                 limit=int(limit) if limit else 0,
                 remaining=int(remaining) if remaining else 0,
-                reset=int(reset) if reset else 0,
+                reset=_parse_reset_header(reset) if reset else 0,
                 retry_after=int(retry_after) * 1000 if retry_after else None
             )
 

--- a/packages/python-sdk/tests/test_client.py
+++ b/packages/python-sdk/tests/test_client.py
@@ -7,17 +7,30 @@ from unittest.mock import Mock, patch
 from simstudio import SimStudioClient, SimStudioError, WorkflowExecutionResult, WorkflowStatus
 
 
-def v2_execution_response(output=None):
+def v2_execution_response(output=None, status="completed", error=None):
     return {
         "data": {
             "runId": "execution-123",
             "workflowId": "workflow-id",
-            "status": "completed",
+            "status": status,
             "output": {} if output is None else output,
-            "error": None,
+            "error": error,
+            "startedAt": "2026-08-11T12:00:00.000Z",
+            "endedAt": "2026-08-11T12:00:00.010Z",
             "durationMs": 10
         }
     }
+
+
+def mock_execution_post(mock_post, status="completed", error=None, headers=None):
+    """Wire a mocked 200 v2 execution response with the given terminal status."""
+    mock_response = Mock()
+    mock_response.ok = True
+    mock_response.status_code = 200
+    mock_response.json.return_value = v2_execution_response(status=status, error=error)
+    mock_response.headers.get.side_effect = lambda h: (headers or {}).get(h)
+    mock_post.return_value = mock_response
+    return mock_response
 
 
 def test_simstudio_client_initialization():
@@ -161,8 +174,56 @@ def test_sync_execution_returns_result(mock_post):
     )
 
     assert result.success is True
+    assert result.status == "completed"
     assert result.output == {"result": "completed"}
+    assert result.metadata == {
+        "duration": 10,
+        "runId": "execution-123",
+        "startTime": "2026-08-11T12:00:00.000Z",
+        "endTime": "2026-08-11T12:00:00.010Z"
+    }
     assert not hasattr(result, 'task_id')
+
+
+@patch('simstudio.requests.Session.post')
+def test_sync_execution_cancelled_is_not_success(mock_post):
+    """A run cancelled out of band is not a success, matching the TypeScript SDK."""
+    mock_execution_post(mock_post, status="cancelled")
+
+    client = SimStudioClient(api_key="test-api-key")
+    result = client.execute_workflow("workflow-id", {})
+
+    assert result.success is False
+    assert result.status == "cancelled"
+
+
+@patch('simstudio.requests.Session.post')
+def test_sync_execution_failed_is_not_success(mock_post):
+    """A failed run is not a success and surfaces the server's error message."""
+    mock_execution_post(
+        mock_post,
+        status="failed",
+        error={"code": "BLOCK_EXECUTION_FAILED", "message": "Invalid credentials"}
+    )
+
+    client = SimStudioClient(api_key="test-api-key")
+    result = client.execute_workflow("workflow-id", {})
+
+    assert result.success is False
+    assert result.status == "failed"
+    assert result.error == "Invalid credentials"
+
+
+@patch('simstudio.requests.Session.post')
+def test_sync_execution_paused_is_success(mock_post):
+    """A paused run is still a success -- it is waiting, not broken."""
+    mock_execution_post(mock_post, status="paused")
+
+    client = SimStudioClient(api_key="test-api-key")
+    result = client.execute_workflow("workflow-id", {})
+
+    assert result.success is True
+    assert result.status == "paused"
 
 
 @patch('simstudio.requests.Session.post')
@@ -495,6 +556,48 @@ def test_get_rate_limit_info_after_api_call(mock_post):
     assert info.limit == 100
     assert info.remaining == 95
     assert info.reset == 1704067200
+
+
+@patch('simstudio.requests.Session.post')
+def test_rate_limit_reset_accepts_iso_timestamp(mock_post):
+    """The v2 API sends X-RateLimit-Reset as an ISO 8601 timestamp, not an epoch int."""
+    mock_execution_post(mock_post, headers={
+        'x-ratelimit-limit': '100',
+        'x-ratelimit-remaining': '99',
+        'x-ratelimit-reset': '2024-01-01T00:00:00.000Z'
+    })
+
+    client = SimStudioClient(api_key="test-api-key")
+    result = client.execute_workflow("workflow-id", {})
+
+    assert result.success is True
+    info = client.get_rate_limit_info()
+    assert info is not None
+    assert info.reset == 1704067200000
+
+
+@pytest.mark.parametrize('reset_header', ['not-a-timestamp', '²'])
+@patch('simstudio.requests.Session.post')
+def test_rate_limit_reset_tolerates_unparseable_value(mock_post, reset_header):
+    """
+    An unrecognised quota hint reports 0 rather than failing the execution.
+
+    '²' covers the digit-like characters str.isdigit() accepts but int()
+    rejects.
+    """
+    mock_execution_post(mock_post, headers={
+        'x-ratelimit-limit': '100',
+        'x-ratelimit-remaining': '99',
+        'x-ratelimit-reset': reset_header
+    })
+
+    client = SimStudioClient(api_key="test-api-key")
+    result = client.execute_workflow("workflow-id", {})
+
+    assert result.success is True
+    info = client.get_rate_limit_info()
+    assert info is not None
+    assert info.reset == 0
 
 
 @patch('simstudio.requests.Session.get')

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -2,6 +2,20 @@
 
 The official TypeScript/JavaScript SDK for [Sim](https://sim.ai), allowing you to execute workflows programmatically from your applications.
 
+## Server compatibility
+
+`0.2.x` talks to the v2 API and has no fallback to the older endpoints, so it requires a Sim deployment that serves `POST /api/v2/workflows/{id}/execute`. That surface is newer than the endpoints `0.1.x` used, and a deployment can also have it switched off — a self-hosted build serves `/api/v2` only when the operator enables `V2_API`. Where it is unavailable every v2 route answers 404, so `executeWorkflow` fails with `HTTP 404: Not Found` — enable or upgrade the v2 API on the server, or stay on `simstudio-ts-sdk@0.1.x`, which keeps using `/api/workflows/{id}/execute` and `/api/jobs/{id}`.
+
+## Upgrading from 0.1.x to 0.2.0
+
+`0.2.0` is a breaking release. It is a minor bump rather than a patch precisely so that `^0.1.2` does not pick it up — you upgrade when you choose to.
+
+- **Requests move to `/api/v2`.** `executeWorkflow` posts to `/api/v2/workflows/{id}/execute`, sends the workflow input nested under `input`, and carries `async` / `executionTimeoutSeconds` in the body instead of the `X-Execution-Mode` and `X-Execution-Timeout-Seconds` headers.
+- **`AsyncExecutionResult.jobId` is now `runId`,** and `executionId` has been removed from that interface. Replace `result.jobId` with `result.runId`.
+- **`getJobStatus(taskId)` is legacy.** It still calls `/api/jobs/{taskId}` and only resolves IDs from a `0.1.x` async execution. For runs started by `0.2.x`, use `getWorkflowRun(workflowId, runId)`, which reads `/api/v2/workflows/{id}/runs/{runId}` and returns a typed `WorkflowRunStatus`.
+- **A failed synchronous run now throws.** Previously it resolved with `{ success: false }`; it now rejects with a `SimStudioError` carrying the server's `error.code` and `error.message`. Any `if (!result.success)` branch that handled failures must move into a `catch`.
+- **`success` is derived from the run status.** It is `true` for `completed` and `paused` runs only, so a run cancelled while it was in flight resolves with `success: false` rather than throwing. Combined with the point above: a rejection means the run failed, and a resolved `success: false` means it was cancelled.
+
 ## Installation
 
 ```bash

--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simstudio-ts-sdk",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Sim SDK - Execute workflows programmatically",
   "type": "module",
   "exports": {

--- a/packages/ts-sdk/src/index.test.ts
+++ b/packages/ts-sdk/src/index.test.ts
@@ -4,12 +4,12 @@ import { SimStudioClient, SimStudioError } from './index'
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
-function v2ExecutionResponse(output: unknown = {}) {
+function v2ExecutionResponse(output: unknown = {}, status = 'completed') {
   return {
     data: {
       runId: 'execution-123',
       workflowId: 'workflow-id',
-      status: 'completed',
+      status,
       output,
       error: null,
       startedAt: '2026-08-11T12:00:00.000Z',
@@ -193,6 +193,32 @@ describe('SimStudioClient', () => {
         code: 'BLOCK_EXECUTION_FAILED',
         message: 'Invalid credentials',
       })
+    })
+
+    it('reports a cancelled sync run as unsuccessful', async () => {
+      vi.mocked(mockFetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(v2ExecutionResponse({}, 'cancelled')),
+        headers: { get: vi.fn().mockReturnValue(null) },
+      })
+
+      const result = await client.executeWorkflow('workflow-id', {})
+
+      expect(result).toHaveProperty('success', false)
+    })
+
+    it('reports a paused sync run as successful', async () => {
+      vi.mocked(mockFetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(v2ExecutionResponse({}, 'paused')),
+        headers: { get: vi.fn().mockReturnValue(null) },
+      })
+
+      const result = await client.executeWorkflow('workflow-id', {})
+
+      expect(result).toHaveProperty('success', true)
     })
 
     it('should not set X-Execution-Mode header when async is undefined', async () => {
@@ -511,6 +537,28 @@ describe('SimStudioClient', () => {
       expect(info?.limit).toBe(100)
       expect(info?.remaining).toBe(95)
       expect(info?.reset).toBe(1704067200)
+    })
+
+    it('parses an ISO x-ratelimit-reset, the format the v2 API sends', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(v2ExecutionResponse()),
+        headers: {
+          get: vi.fn((header: string) => {
+            if (header === 'x-ratelimit-limit') return '100'
+            if (header === 'x-ratelimit-remaining') return '99'
+            if (header === 'x-ratelimit-reset') return '2024-01-01T00:00:00.000Z'
+            return null
+          }),
+        },
+      }
+
+      vi.mocked(mockFetch).mockResolvedValue(mockResponse as any)
+
+      await client.executeWorkflow('workflow-id', {})
+
+      expect(client.getRateLimitInfo()?.reset).toBe(1704067200000)
     })
   })
 


### PR DESCRIPTION
## Summary

Three release-correctness defects in the two SDK packages, all of which would have shipped badly on the next publish.

**1. The TypeScript SDK carried five breaking changes but was versioned `0.1.3`.**

The v2 migration already landed on this branch's base. It changed, in the published API:

- `executeWorkflow` moved to `POST /api/v2/workflows/{id}/execute`, with the workflow input nested under `input` and `async` / `executionTimeoutSeconds` moved from the `X-Execution-Mode` / `X-Execution-Timeout-Seconds` headers into the body
- `AsyncExecutionResult.jobId` renamed to `runId`
- `executionId` removed from `AsyncExecutionResult`
- `getJobStatus` superseded by `getWorkflowRun(workflowId, runId)`
- a failed synchronous run now **throws** instead of resolving with `{ success: false }`

At `0.1.3` every existing consumer would have taken all five automatically: npm expands `^0.1.2` to `>=0.1.2 <0.2.0-0`, so `0.1.3` is in range and `0.2.0` is not. Verified with the resolver rather than by eye:

```
semver.satisfies('0.1.3', '^0.1.2') === true
semver.satisfies('0.2.0', '^0.1.2') === false
```

Now `0.2.0`. Minor rather than major because the package is pre-1.0 and 0.x minors are where breaking changes belong under semver — `1.0.0` would additionally assert a stability commitment the package has not made. `0.1.3` was never published (npm has `0.1.0`, `0.1.1`, `0.1.2`), so nothing is being reused or overwritten.

**2. The Python SDK was rewritten onto `/api/v2` with no version bump, so it was silently unpublishable.**

`pyproject.toml` still said `0.1.2` and PyPI already has `0.1.2`. The publish job's existence check therefore matched, the job skipped, and it skipped **green** — so the repo and PyPI diverged with no failing signal. Every v2 change made since has been sitting unpublished. Now `0.2.0`.

**3. A cancelled run reported `success=True` in Python and `False` in TypeScript.**

Python derived `success = status != 'failed'`, which counts `cancelled` as a success. TypeScript derives `status === 'completed' || status === 'paused'`. Python was the wrong side and now matches. The predicate is a whitelist on purpose: a status added to the API later defaults to "not successful" rather than silently reporting `True`.

A new `WorkflowExecutionResult.status` field carries the server's terminal status verbatim, so a caller can tell a cancelled run from a failed one — both report `success=False`. The two SDKs now agree on the predicate for all four terminal states and differ only in delivery, which is documented on both sides:

| status | TypeScript | Python |
|---|---|---|
| `completed` | `success: true` | `success=True` |
| `paused` | `success: true` | `success=True` |
| `cancelled` | `success: false` | `success=False` |
| `failed` | throws `SimStudioError` | returns `success=False`, `status='failed'`, `error` set |

**Also fixed, found while verifying the above:** Python parsed `X-RateLimit-Reset` with a bare `int()`. The v2 API sends that header as an ISO 8601 timestamp (`resetAt.toISOString()`), so **every** `execute_workflow` call against v2 would have raised `ValueError` out of the rate-limit bookkeeping — the Python `0.2.0` would have been dead on arrival. It now mirrors the TypeScript parser exactly (all-digit kept as-is, otherwise parsed to epoch ms, otherwise 0) and degrades rather than raising, because a quota hint must never take down the call it rode in on.

Both READMEs get a migration guide. A breaking major without one is the actual defect.

## Publish implications — read before merging

This is a breaking release of two packages to two registries that cannot be un-published cleanly. Versions can never be reused.

- **Nothing publishes on merge to staging.** Both `publish-ts-sdk.yml` and `publish-python-sdk.yml` trigger on `push` to `main` only, path-filtered to their package. The publish fires when staging is promoted to main, not on this merge.
- **Each job reads exactly one version file.** The npm job reads `packages/ts-sdk/package.json`; the PyPI job reads `[project].version` from `packages/python-sdk/pyproject.toml`. Both are `0.2.0` here, and neither version exists on its registry, so both existence checks miss and both will publish. Each also cuts a GitHub release tag.
- **`packages/python-sdk/setup.py` still says `0.1.1` and is dead.** The publish job does not read it, and because `[project].version` is static, setuptools ignores the `version=` kwarg passed to `setup()`. It does not affect this release. Left alone deliberately — see follow-ups.
- **Consumers are not auto-upgraded.** That is the entire point of `0.2.0`: `^0.1.2` and `simstudio-sdk<0.2` both stay on the old line, and upgrading becomes a deliberate act.

## Server compatibility claim

The branch originally asserted a minimum server version of "Sim v0.7.69 or later" in both READMEs. **I removed that number rather than shipping it**, because a published README cannot be corrected without cutting another release and the claim did not hold up:

- No stable `v0.7.69` tag exists — only `-beta` / `-staging` prereleases. The latest stable tag is `v0.7.68`.
- The commit that added the v2 execute route (#5273) is on `staging` and not on `main`, so `v0.7.68` does not contain it and a stable `v0.7.69` cut before that promotion would not either.
- More fundamentally, **a version number cannot express the requirement at all.** The whole `/api/v2` surface sits behind the `v2-api` gate, which answers 404 when off. A self-hosted deployment serves it only when the operator enables `V2_API`, regardless of which version it runs.

The READMEs now describe the requirement in terms the reader can actually check — the endpoint, the `V2_API` setting, and the 404 they will see — with no version number to go stale.

## Type of Change
- [x] Bug fix

## Testing

- `packages/python-sdk`: 40 passed. Run with `PYTHONPATH=. python -m pytest tests/test_client.py -q`. Note that PR CI does **not** cover this suite — the Python SDK is not a JS workspace, so `turbo run test` skips it and the tests run only inside the publish job on main. Run locally when reviewing.
- `packages/ts-sdk`: 38 passed (`bunx vitest run src/index.test.ts`). This one *is* covered by PR CI via `turbo run test`.
- Re-proved the cancelled-run test fails without the fix: reverting `success` to `status != 'failed'` turns `test_sync_execution_cancelled_is_not_success` red, and restoring it turns it green with a clean tree. Same for the ISO reset parser — reverting to `int(reset)` fails three tests with `ValueError`.
- `bun run type-check` and biome clean on the changed TypeScript.
- `bun.lock` changed by exactly one line: the `packages/ts-sdk` workspace version propagating. No dependency, resolution, or integrity change.

## Explicitly out of scope

A 404-fallback / dual-endpoint compatibility shim was considered and rejected. The legacy 202 body's `statusUrl` points at `/api/jobs/{jobId}`, so mapping `jobId` onto `runId` would hand the caller a `runId` that this SDK's own `getWorkflowRun` cannot resolve — a silently broken poll is worse than an honest 404.

## Follow-ups, not this PR

- `RateLimitInfo.reset` carries epoch **seconds** for the legacy integer header and epoch **milliseconds** for the ISO one, in both SDKs. That inconsistency is faithfully mirrored from TypeScript rather than fixed here; normalizing both to milliseconds is a separate breaking change to a separate field.
- The non-English SDK doc pages still document the `0.1.x` API (`job_id` / `jobId` / `get_job_status` / `getJobStatus`) and become wrong the moment `0.2.0` publishes. This is broader than it first looks: **20 pages across 5 locales** — `{de,es,fr,ja,zh}` × `{api-reference,sdks}` × `{python,typescript}`. The English `api-reference` pages are already current. Separately, there is no `en/sdks/` directory at all, so the ten `*/sdks/*.mdx` pages are orphaned translations of a source page that no longer exists and no English-side edit will ever propagate to them.
- `packages/python-sdk/setup.py` should probably be deleted outright rather than bumped. It is a wholly redundant second metadata declaration — name, description, classifiers, `install_requires`, `python_requires` all duplicated from `pyproject.toml` and none of it consulted. Bumping it to `0.2.0` would make it look live and guarantee the same drift recurs at `0.3.0`. Deleting it removes the trap: if `version` were ever moved to `dynamic`, setup.py's stale value would silently become authoritative.
- The TypeScript `WorkflowExecutionResult` has no `status` field, so "a resolved `success: false` means it was cancelled" is an inference the caller cannot verify from the type. It holds today only because `failed` throws. Python fixed exactly this; adding `status` to TypeScript would be another breaking-ish change and belongs on its own.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
