### PR TITLE
fix(executor): copy the env map at the workflow-tool boundary

### DIFF
--- a/apps/sim/tools/index.test.ts
+++ b/apps/sim/tools/index.test.ts
@@ -1550,6 +1550,29 @@ describe('executeTool Function', () => {
     )
   })
 
+  it('copies the env map so a child run cannot corrupt the parent context', async () => {
+    mockRunWorkflowTool.mockResolvedValueOnce({ success: true, output: { ok: true } })
+    const executionContext = createToolExecutionContext({
+      environmentVariables: { MY_API_KEY: 'parent-secret' },
+    })
+
+    await executeTool(
+      'workflow_executor_child-workflow',
+      { workflowId: 'child-workflow' },
+      { executionContext }
+    )
+
+    const forwarded = (mockRunWorkflowTool.mock.calls[0]?.[1] as Record<string, unknown>)
+      .environmentVariables as Record<string, string>
+    expect(forwarded).toEqual({ MY_API_KEY: 'parent-secret' })
+    expect(forwarded).not.toBe(executionContext.environmentVariables)
+
+    forwarded.MY_API_KEY = 'mutated-by-child'
+    forwarded.INJECTED = 'added-by-child'
+
+    expect(executionContext.environmentVariables).toEqual({ MY_API_KEY: 'parent-secret' })
+  })
+
   it('leaves the custom-block runner without the consumer redaction policy', async () => {
     mockRunCustomBlockTool.mockResolvedValueOnce({ success: true, output: { ok: true } })
 

--- a/apps/sim/tools/index.ts
+++ b/apps/sim/tools/index.ts
@@ -1792,7 +1792,11 @@ async function executeToolImplementation(
           // Trusted `executionContext`, never `_context` — that bag spreads
           // model-reachable `contextParams._context` first, so a model could otherwise
           // inject its own env map or disable redaction.
-          environmentVariables: executionContext?.environmentVariables ?? {},
+          // Copied, not aliased: the child holds this map for its whole run, and a
+          // write through it would corrupt the parent's env and every later sibling
+          // tool call. Every other consumer of `ctx.environmentVariables` already
+          // copies (`normalizeStringRecord`); this boundary is the longest-lived one.
+          environmentVariables: { ...executionContext?.environmentVariables },
           piiBlockOutputRedaction: executionContext?.piiBlockOutputRedaction,
         }
       )


### PR DESCRIPTION
## Summary

Follow-up hardening to #6611, which began forwarding the invoking run's environment variables into a workflow executed as an Agent tool.

A full runtime audit of #6611 confirmed that **nothing in the child execution path writes through `ctx.environmentVariables` today** — so this is not a live defect. It closes the one structural gap that audit surfaced.

## Why

`tools/index.ts` was the only consumer that handed the parent's live env map across an execution boundary **by reference**, and it hands it to the longest-lived consumer there is — the child holds that object for its entire run, across `WorkflowBlockHandler.executeCore`'s prologue.

Every other consumer already copies before handing the map on:

| Consumer | Copies via |
|---|---|
| `agent-handler.ts:2496`, `:2576` | `normalizeStringRecord(ctx.environmentVariables)` |
| `function-handler.ts:87` | `normalizeStringRecord(...)` |
| `condition-handler.ts:52` | `normalizeStringRecord(...)` |
| `providers/utils.ts:1629` | `normalizeStringRecord(...)` |
| `tools/index.ts` (workflow tool) | **nothing — the outlier this PR fixes** |

A future write through the child's reference would corrupt the parent's env and every later sibling tool call in the same agent turn — a cross-run bug with no local symptom, and exactly the kind of thing that is invisible in review.

## Why a shallow spread is exact

The value is typed `Record<string, string>`, and the sub-Executor already re-copies it through `normalizeStringRecord` at `executor.ts:73`, so the child receives a byte-identical map either way. The spread also subsumes the previous `?? {}` — spreading `undefined` yields `{}`.

## Type of Change
- [x] Bug fix (hardening)

## Testing
New test mutates the forwarded map and asserts the parent context is unchanged; it fails without the spread. Full `executor/` + `tools/index.test.ts` suite: 2096 passed. Type-check and Biome clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
