### PR TITLE
fix(executor): carry child provenance across the workflow agent tool result

### DIFF
--- a/apps/sim/executor/handlers/workflow/workflow-tool-runner.test.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-tool-runner.test.ts
@@ -3,7 +3,11 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockExecute } = vi.hoisted(() => ({ mockExecute: vi.fn() }))
+const { mockExecute, mockDecryptSecret, mockEncryptSecret } = vi.hoisted(() => ({
+  mockExecute: vi.fn(),
+  mockDecryptSecret: vi.fn(),
+  mockEncryptSecret: vi.fn(),
+}))
 
 vi.mock('@/executor/handlers/workflow/workflow-handler', () => ({
   WorkflowBlockHandler: class {
@@ -11,8 +15,19 @@ vi.mock('@/executor/handlers/workflow/workflow-handler', () => ({
   },
 }))
 
+vi.mock('@/lib/core/security/encryption', () => ({
+  decryptSecret: mockDecryptSecret,
+  encryptSecret: mockEncryptSecret,
+}))
+
+import { projectToolResultForCopilot } from '@/lib/copilot/request/tools/resolved-secret-result'
+import type { ToolExecutionResult } from '@/lib/copilot/tool-executor/types'
+import { ExecutionState } from '@/executor/execution/state'
 import type { PiiBlockOutputRedaction } from '@/executor/execution/types'
 import { runWorkflowTool } from '@/executor/handlers/workflow/workflow-tool-runner'
+import type { ExecutionContext } from '@/executor/types'
+import { ResolvedSecretTraceRegistry } from '@/executor/utils/resolved-secret-trace-registry'
+import { EnvResolver } from '@/executor/variables/resolvers/env'
 
 const PII_POLICY: PiiBlockOutputRedaction = {
   enabled: true,
@@ -59,5 +74,167 @@ describe('runWorkflowTool execution context', () => {
 
     const [ctxArg] = mockExecute.mock.calls[0]
     expect(ctxArg.environmentVariables).toEqual({ MY_API_KEY: 'trusted' })
+  })
+})
+
+const CHILD_SECRET = 'sk-live-7f2c9a41d8be4055b6c3'
+const CHILD_SECRET_ENCRYPTED = 'encrypted:CHILD_API_KEY'
+const SHORT_SECRET = 'hunter7'
+const SHORT_SECRET_ENCRYPTED = 'encrypted:SHORT_KEY'
+const SCOPE = { userId: 'user-1', workspaceId: 'ws-1' }
+
+/**
+ * Resolves `{{NAME}}` through the real {@link EnvResolver} against the synthetic child context,
+ * reproducing how a child block records provenance for an environment variable it consumed.
+ */
+function resolveChildEnvReference(
+  ctx: ExecutionContext,
+  reference: string,
+  inputPath: readonly string[]
+): unknown {
+  return new EnvResolver().resolve(reference, {
+    executionContext: ctx,
+    executionState: new ExecutionState(),
+    currentNodeId: 'child-block',
+    inputPath,
+  })
+}
+
+describe('runWorkflowTool model-facing result provenance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDecryptSecret.mockImplementation(async (encryptedValue: string) => {
+      if (encryptedValue === CHILD_SECRET_ENCRYPTED) return { decrypted: CHILD_SECRET }
+      if (encryptedValue === SHORT_SECRET_ENCRYPTED) return { decrypted: SHORT_SECRET }
+      throw new Error(`Unexpected encrypted value: ${encryptedValue}`)
+    })
+  })
+
+  it('keeps a child-resolved environment secret out of the agent-visible tool result', async () => {
+    const registry = new ResolvedSecretTraceRegistry(
+      [
+        {
+          name: 'CHILD_API_KEY',
+          plaintext: CHILD_SECRET,
+          encryptedValue: CHILD_SECRET_ENCRYPTED,
+        },
+      ],
+      SCOPE
+    )
+
+    mockExecute.mockImplementation(async (ctx: ExecutionContext) => {
+      const resolved = resolveChildEnvReference(ctx, '{{CHILD_API_KEY}}', ['child-block', 'apiKey'])
+      return {
+        success: true,
+        childWorkflowName: 'Child',
+        childWorkflowId: 'wf-child',
+        result: { token: resolved },
+        childTraceSpans: [
+          {
+            id: 'span-1',
+            name: 'API',
+            type: 'api',
+            input: { authorization: `Bearer ${resolved}` },
+          },
+        ],
+      }
+    })
+
+    const result = await runWorkflowTool(
+      { workflowId: 'wf-child', _context: { workspaceId: 'ws-1', userId: 'user-1' } },
+      {
+        environmentVariables: { CHILD_API_KEY: CHILD_SECRET },
+        resolvedSecretTraceRegistry: registry,
+      }
+    )
+
+    expect(JSON.stringify(result.output)).toContain(CHILD_SECRET)
+
+    const projected = projectToolResultForCopilot(result as ToolExecutionResult, registry)
+    expect(JSON.stringify(projected)).not.toContain(CHILD_SECRET)
+    expect(projected.output).toEqual({
+      success: true,
+      childWorkflowName: 'Child',
+      childWorkflowId: 'wf-child',
+      result: { token: '{{CHILD_API_KEY}}' },
+      childTraceSpans: [
+        {
+          id: 'span-1',
+          name: 'API',
+          type: 'api',
+          input: { authorization: 'Bearer {{CHILD_API_KEY}}' },
+        },
+      ],
+    })
+  })
+
+  it('keeps a child-resolved environment secret out of a failed tool result', async () => {
+    const registry = new ResolvedSecretTraceRegistry(
+      [{ name: 'CHILD_API_KEY', plaintext: CHILD_SECRET, encryptedValue: CHILD_SECRET_ENCRYPTED }],
+      SCOPE
+    )
+
+    mockExecute.mockImplementation(async (ctx: ExecutionContext) => {
+      const resolved = resolveChildEnvReference(ctx, '{{CHILD_API_KEY}}', ['child-block', 'apiKey'])
+      throw new Error(`Upstream rejected credential ${String(resolved)}`)
+    })
+
+    const result = await runWorkflowTool(
+      { workflowId: 'wf-child', _context: { workspaceId: 'ws-1', userId: 'user-1' } },
+      {
+        environmentVariables: { CHILD_API_KEY: CHILD_SECRET },
+        resolvedSecretTraceRegistry: registry,
+      }
+    )
+
+    const projected = projectToolResultForCopilot(result as ToolExecutionResult, registry)
+    expect(JSON.stringify(projected)).not.toContain(CHILD_SECRET)
+    expect(projected.error).toContain('{{CHILD_API_KEY}}')
+  })
+
+  it('leaves an unrelated configured secret inert in the agent-visible tool result', async () => {
+    const registry = new ResolvedSecretTraceRegistry(
+      [
+        {
+          name: 'CHILD_API_KEY',
+          plaintext: CHILD_SECRET,
+          encryptedValue: CHILD_SECRET_ENCRYPTED,
+        },
+      ],
+      SCOPE
+    )
+
+    mockExecute.mockResolvedValue({ success: true, result: { note: 'no secret here' } })
+
+    const result = await runWorkflowTool(
+      { workflowId: 'wf-child', _context: { workspaceId: 'ws-1', userId: 'user-1' } },
+      {
+        environmentVariables: { CHILD_API_KEY: CHILD_SECRET },
+        resolvedSecretTraceRegistry: registry,
+      }
+    )
+
+    const projected = projectToolResultForCopilot(result as ToolExecutionResult, registry)
+    expect(projected.output).toEqual({ success: true, result: { note: 'no secret here' } })
+  })
+
+  it('cannot redact a child-resolved value below the substitutable literal length', async () => {
+    const registry = new ResolvedSecretTraceRegistry(
+      [{ name: 'SHORT_KEY', plaintext: SHORT_SECRET, encryptedValue: SHORT_SECRET_ENCRYPTED }],
+      SCOPE
+    )
+
+    mockExecute.mockImplementation(async (ctx: ExecutionContext) => {
+      const resolved = resolveChildEnvReference(ctx, '{{SHORT_KEY}}', ['child-block', 'apiKey'])
+      return { success: true, result: { token: resolved } }
+    })
+
+    const result = await runWorkflowTool(
+      { workflowId: 'wf-child', _context: { workspaceId: 'ws-1', userId: 'user-1' } },
+      { environmentVariables: { SHORT_KEY: SHORT_SECRET }, resolvedSecretTraceRegistry: registry }
+    )
+
+    const projected = projectToolResultForCopilot(result as ToolExecutionResult, registry)
+    expect(JSON.stringify(projected)).toContain(SHORT_SECRET)
   })
 })

--- a/apps/sim/executor/handlers/workflow/workflow-tool-runner.ts
+++ b/apps/sim/executor/handlers/workflow/workflow-tool-runner.ts
@@ -31,6 +31,40 @@ function aggregateChildCost(childTraceSpans: TraceSpan[]): number {
   return Math.max(0, summary.totalCost - summary.baseExecutionCharge)
 }
 
+/**
+ * Records that the child's result carries provenance for the secrets it resolved, so the
+ * model-facing projection can still find them.
+ *
+ * The child executes against the caller's own tool-call registry object, so nothing has to be
+ * moved between registries — but `EnvResolver` records a resolution without marking it
+ * propagated, and `forkForPropagatedEntries` (the fork every model boundary projects through)
+ * keeps only propagated entries. Without this crossing a value the child resolved from an
+ * environment variable is dropped from the projection registry and reaches the model vendor in
+ * plaintext. Mirrors the custom-block crossing in `workflow-handler`, and fails closed: an
+ * unusable envelope marks the registry incomplete, which reduces the result the model sees.
+ */
+async function markResultProvenanceCrossing(
+  registry: ResolvedSecretTraceRegistry | undefined,
+  result: ToolResponse
+): Promise<void> {
+  if (!registry) return
+  try {
+    const crossingProvenance = registry.exportCommittedProvenanceForValue({
+      output: result.output,
+      error: result.error,
+    })
+    await registry.importProvenance(crossingProvenance, {
+      trusted: true,
+      origin: 'workflowToolRunner.agentResultCrossing',
+    })
+  } catch (error) {
+    logger.error('Workflow tool result provenance could not be carried across', {
+      error: getErrorMessage(error, 'Unknown error'),
+    })
+    registry.markIncomplete('value-provenance-import-failed')
+  }
+}
+
 interface WorkflowToolParams {
   workflowId?: string
   inputMapping?: Record<string, unknown> | string
@@ -93,7 +127,9 @@ export async function runWorkflowTool(
       output && typeof output === 'object' && !Array.isArray(output)
         ? (output as Record<string, unknown>)
         : { result: output }
-    return { success: true, output: normalized }
+    const result: ToolResponse = { success: true, output: normalized }
+    await markResultProvenanceCrossing(options.resolvedSecretTraceRegistry, result)
+    return result
   } catch (error) {
     const message = getErrorMessage(error, 'Workflow execution failed')
     const isChildError = ChildWorkflowError.isChildWorkflowError(error)
@@ -108,7 +144,7 @@ export async function runWorkflowTool(
       message,
       code: structured.code,
     })
-    return {
+    const result: ToolResponse = {
       success: false,
       output: {
         ...(childCost > 0 ? { cost: { total: childCost } } : {}),
@@ -117,5 +153,7 @@ export async function runWorkflowTool(
       },
       error: message,
     }
+    await markResultProvenanceCrossing(options.resolvedSecretTraceRegistry, result)
+    return result
   }
 }


### PR DESCRIPTION
## Summary

A workflow invoked as an agent tool now resolves `{{VAR}}` to the real decrypted value in the child run (#6611). The tool result handed back to the **model vendor** is projected through a registry that had dropped those entries, so the plaintext crosses to the vendor verbatim. This is on `staging` only — the release it belongs to has not been promoted — but it is a **promotion blocker for staging → main**.

**What reaches the vendor today on staging.** For an agent whose tool is a workflow, the tool message serialized into the next model request contains the child's decrypted environment-variable values — in `output.result`, and also inside `output.childTraceSpans`, which carries every child block's inputs and outputs. Reproduced with the real registry, the real `EnvResolver`, and the real model projection: a live `sk-live-…` style token appears in both.

**Mechanism.**
- Model-facing projection (`projectToolResultForCopilot`) forks with `registry.forkForPropagatedEntries()`, which keeps **only** entries a result explicitly carried.
- `EnvResolver` (`executor/variables/resolvers/env.ts`) records the resolution **without** `propagated`, unlike the other boundaries that hand a value onward (`tools/index.ts`, `providers/runtime-context.ts`).
- The child shares the caller's registry **object**, so `blockLogs`, trace spans and error diagnostics still redact correctly — they read the unforked registry. Only the model fork loses the entries.
- The blast radius is larger than the child's final output: `mapChildOutputToParent` puts the full `childTraceSpans` into the returned object, and `postProcessToolOutput` strips only `__`-prefixed keys.

**Why `main` does not have this.** There, `workflow_executor` was an HTTP tool: the execute route emitted `__resolvedSecretTraceProvenance`, the tool imported it as `propagated: true`, and `transformResponse` curated the body so `childTraceSpans` never crossed. The in-process branch returns before any of that runs.

## The fix

`runWorkflowTool` exports committed provenance for the value it is about to return and imports it back with `{ trusted: true }`, which marks those entries propagated. This is the crossing the **custom-block** branch already performs in `workflow-handler.ts`; the non-custom branch skipped it only because the two registries are the same object — exactly the assumption the model fork breaks.

- Output-projection only. The returned result is byte-identical and the child executes exactly as before; only registry metadata changes.
- Applied on both the success and the failure return, so a child error message that embeds a resolved secret is covered too.
- Redacted values render as `{{NAME}}` — the same literal the model saw before the regression.
- Fails closed: an unusable envelope marks the registry incomplete, which reduces (never widens) what the model receives.

**Why not the alternative** (marking `EnvResolver`'s records `propagated`): `propagated` means "this result carries this secret across a boundary", not "a block consumed this secret". `EnvResolver` runs at *input* resolution for the executing block, in every workflow run, into the run-scoped registry — flipping it there would restate an output-crossing fact at an input site and change what crosses at every unrelated boundary in the product, for a defect that exists at exactly one. Smaller diff, much wider reach, and it does not become more correct than the precedent it replaces. Fixing the boundary that is actually broken keeps the canvas workflow block and the custom-block path untouched.

**On `childTraceSpans`.** Curation alone would not have fixed `result`, so it was never a substitute. I also did **not** drop it here: the canvas `workflow_input` block runs through the same `runWorkflowTool`, and `block-executor` lifts `childTraceSpans` off that output into the block log for trace nesting (`span-factory` reads it) before stripping it from block state. Dropping it in the runner would silently break child-run traces in the UI. Child block I/O reaching the vendor is still questionable on its own merits, but it needs a model-facing output projection hook, which does not exist today (tools have `request.modelInput`, no output equivalent) — worth a follow-up, and it is now redacted either way.

**Short-literal caveat, stated plainly.** `MIN_SUBSTITUTABLE_LITERAL_LENGTH = 8` governs detection as well as substitution, so an environment value of 7 characters or fewer is **not** covered by this fix — not in the model result, and not in logs or traces either. That floor is deliberate (it subsumed the per-value exception lists that fixed prior false-positive incidents) and this PR does not touch it. A test pins the behavior so it is documented rather than silent.

## Testing

- New tests in `workflow-tool-runner.test.ts` drive the real `ResolvedSecretTraceRegistry`, the real `EnvResolver`, and the real `projectToolResultForCopilot`. The two leak tests **fail on plain `staging`** (secret present in `result` and in `childTraceSpans`; secret present in the projected error) and pass with the fix.
- A third test asserts an unrelated configured secret stays inert, and a fourth pins the short-literal limitation.
- Green: full `executor/` suite (1947), `tools/index`, resolved-secret registry / projection / refusal suites, `providers/runtime-context`.
- `bun run type-check` clean; biome clean.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
