### PR TITLE
chore(ci): declare least-privilege permissions on the desktop e2e workflow

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -10,6 +10,9 @@ name: Desktop E2E
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: desktop-e2e-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add a top-level `permissions: contents: read` block to `.github/workflows/desktop-e2e.yml` — it was the only workflow in the repo without one, so both its jobs inherited the repo-default `GITHUB_TOKEN` scope
- Closes CodeQL alerts #474 and #475 ("Workflow does not contain permissions", Medium)
- Matters most for the `latest` canary leg, which runs `bun add -d electron@latest` and pulls an unpinned dependency tree onto the runner

## Type of Change
- [x] Chore / CI hardening

## Testing
Tested manually — the workflow is `workflow_dispatch`-only and neither job reads `secrets.GITHUB_TOKEN` beyond checkout, so read-only is sufficient

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)