### PR TITLE
feat(models): add grok-4.6 and make it the xAI flagship

### DIFF
--- a/apps/sim/content/blog/secret-provenance/index.mdx
+++ b/apps/sim/content/blog/secret-provenance/index.mdx
@@ -13,7 +13,7 @@ ogAlt: 'Sim secret provenance technical overview'
 about: ['Security', 'Execution']
 timeRequired: PT12M
 canonical: https://www.sim.ai/blog/secret-provenance
-featured: false
+featured: true
 draft: false
 faq:
   - q: "How does Sim keep API keys out of workflow execution logs?"

--- a/apps/sim/providers/models.test.ts
+++ b/apps/sim/providers/models.test.ts
@@ -362,13 +362,14 @@ describe('kimi provider definition', () => {
 describe('xai provider definition', () => {
   const xai = PROVIDER_DEFINITIONS.xai
 
-  it('is registered with grok-4.5 as the default model', () => {
+  it('is registered with grok-4.6 as the default model', () => {
     expect(xai).toBeDefined()
     expect(xai.id).toBe('xai')
-    expect(xai.defaultModel).toBe('grok-4.5')
+    expect(xai.defaultModel).toBe('grok-4.6')
   })
 
   it('is included in getHostedModels since Sim provides the xAI key server-side', () => {
+    expect(getHostedModels()).toContain('grok-4.6')
     expect(getHostedModels()).toContain('grok-4.5')
   })
 })

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -2135,7 +2135,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     fileAttachment: { maxBytes: 20 * 1024 * 1024, strategy: 'remote-url' },
     name: 'xAI',
     description: "xAI's Grok models",
-    defaultModel: 'grok-4.5',
+    defaultModel: 'grok-4.6',
     modelPatterns: [/^grok/],
     icon: xAIIcon,
     color: '#555555',
@@ -2143,6 +2143,21 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
       toolUsageControl: true,
     },
     models: [
+      {
+        id: 'grok-4.6',
+        pricing: {
+          input: 2.0,
+          cachedInput: 0.5,
+          output: 6.0,
+          updatedAt: '2026-08-12',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 2 },
+        },
+        contextWindow: 500000,
+        releaseDate: '2026-08-12',
+        recommended: true,
+      },
       {
         id: 'grok-4.5',
         pricing: {
@@ -2155,7 +2170,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 500000,
         releaseDate: '2026-07-08',
-        recommended: true,
       },
       {
         id: 'grok-4.3',


### PR DESCRIPTION
## Summary
- Add `grok-4.6` to the xAI catalog: 500k context, \$2.00 in / \$0.50 cached / \$6.00 out per 1M
- Promote it to the xAI flagship — `recommended: true` and `defaultModel`, both moved off `grok-4.5`
- Feature the latest blog post on the index

## Verification
Every field was checked against xAI's live API using the staging hosted key, not just the docs:

- `GET /v1/models/grok-4.6` → `context_length: 500000`, `prompt_text_token_price: 20000`, `cached_prompt_text_token_price: 5000`, `completion_text_token_price: 60000` (units are USD cents per 100M tokens, so \$2.00 / \$0.50 / \$6.00 per 1M) — exact match with the entry
- `temperature: 2` accepted, `temperature: 2.5` rejected with `Temperature must be less than 2` → `{ min: 0, max: 2 }` is right
- `max_completion_tokens` (the only other param `providers/xai/index.ts` sends) accepted
- Tool calling returns a well-formed `tool_calls` array
- 400k-token prompt accepted, confirming the long-context path

`reasoningEffort` is deliberately **not** set. xAI documents `low/medium/high/xhigh` for this model, but `providers/xai/` never reads the flag, so setting it would be a silent no-op. Worth wiring up separately.

Priced at the `<200k` tier, matching every existing grok entry. xAI doubles rates at the 200k threshold; Sim's schema holds one price pair, so long prompts under-bill — pre-existing across the whole provider, not new here.

`grok-4.6` is hosted and billed automatically, since `getHostedModels()` already includes all of `xai`. The staging key pool has access to it today.

## Type of Change
- [x] New feature

## Testing
`models.test.ts`, `utils.test.ts`, `pi-providers.test.ts`, and the content/landing suites all pass (256 tests). Lint, `type-check`, and `agent-stream-docs:check` clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)