### PR TITLE
fix(workflow): allow dual-mode blocks inside loop/parallel subflows

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -2020,11 +2020,11 @@ const WorkflowContent = React.memo(
           const name = getUniqueBlockName(baseName, blocks)
 
           if (containerInfo) {
-            // Check if this is a trigger block or has trigger mode enabled
+            // Only reject blocks that will actually be triggers: pure trigger blocks
+            // and explicit trigger-mode drops. A dual-mode block (e.g. Gmail) added
+            // without trigger mode is an ordinary block and is valid in a subflow.
             const isTriggerBlock =
-              blockConfig.category === 'triggers' ||
-              blockConfig.triggers?.enabled ||
-              data.enableTriggerMode === true
+              blockConfig.category === 'triggers' || data.enableTriggerMode === true
 
             if (isTriggerBlock) {
               toast.error('Triggers cannot be placed inside loop or parallel subflows.')


### PR DESCRIPTION
## Summary
- Fixes the block picker rejecting dual-mode blocks (Gmail, Slack, etc.) with "Triggers cannot be placed inside loop or parallel subflows" when adding them inside a loop/parallel via a dragged connection
- The drop-path guard treated the config capability flag (`triggers.enabled`) as if the block were a trigger; it now only rejects blocks that will actually be triggers — pure trigger blocks (`category === 'triggers'`) and explicit trigger-mode drops (`enableTriggerMode`)
- Matches the semantics every other guard already uses (`TriggerUtils.isTriggerBlock` checks the actual `triggerMode` state)

## Type of Change
- [x] Bug fix

## Testing
Traced the full picker → `add-block-from-toolbar` → `handleToolbarDrop` path; type-check, lint, and the full audit suite pass. Pure trigger blocks and trigger-mode drags are still rejected from subflows.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)