### PR TITLE
fix(v2): give the keyset cursor's timestamp an explicit SQL type

### DIFF
--- a/.agents/skills/v2-api-conventions/SKILL.md
+++ b/.agents/skills/v2-api-conventions/SKILL.md
@@ -16,12 +16,13 @@ failure (always)      { "error": { "code": "...", "message": "...", "details"?: 
 
 Nothing else at the top level. No `success: true`, no bare `{ "error": "string" }`, no HTML.
 
-That promise is worth stating as a rule because it has been broken four separate ways, each time by a route or a builder taking a shortcut that looked local:
+That promise is worth stating as a rule because it has been broken five separate ways, each time by a route or a builder taking a shortcut that looked local:
 
 - `GET /workflows?limit=1.5` returned **500**. The contract was copied from a sibling and lost its `.int()`, so a fractional limit passed validation and reached Postgres as `LIMIT 2.5`.
 - A malformed JSON body returned **`{"error":"Request body must be valid JSON"}`** — a bare string. The envelope was a per-route opt-in that only 8 of 77 routes remembered.
 - `GET /api/v2/nonexistent` returned a **full HTML 404 document**, because no route file matched and the request fell through to the app's global not-found page.
 - Four collections returned `nextCursor` while **silently discarding** any `limit` the caller sent, because Zod strips unknown keys unless the schema is `.strict()`.
+- Handing back a `nextCursor` from any timestamp-sorted list and passing it straight in returned **500**. The value was validated and bound — but bound with no SQL type, into `date_trunc`, which is overloaded, so Postgres could resolve no overload. Validation was never the missing half; the type was.
 
 Each was one line. The rules below are the generalisations.
 
@@ -62,7 +63,11 @@ Two of these carry real design weight:
 
 **404 is deliberately overloaded.** A workspace the caller cannot reach answers `404 "Workspace not found"`, never 403 — a 403 would confirm the resource exists. `createV2ResourceConcealmentPolicy` does this by mapping a cross-tenant authorization failure to `v2Error('NOT_FOUND', ...)`. The rollout gate answers the same way for the same reason (`gate.ts`: "an ungated caller cannot distinguish 'not in the rollout cohort' from 'no such endpoint'"), and so does the unknown-path catch-all at `app/api/v2/[[...segments]]/route.ts` — its body is byte-identical to the gate's on purpose.
 
-**500 is never caller-reachable.** Any input a caller can send must be rejected at the contract boundary with a 400. If you can construct a query string or body that produces a 500, that is a bug in the contract, not something to wrap in a `try`/`catch`. `v2ErrorForOrchestration` also replaces the message on an unclassified failure with a generic one, so internal detail never leaks. A caller-reachable 500 has shipped twice — a fractional `limit` reaching `LIMIT 2.5`, and a plain `HEAD` tripping the builder's method guard — so treat "a well-formed request produced a 500" as the highest-severity class of defect on this surface.
+**500 is never caller-reachable.** Any input a caller can send must be rejected at the contract boundary with a 400. If you can construct a query string or body that produces a 500, that is a bug in the contract, not something to wrap in a `try`/`catch`. `v2ErrorForOrchestration` also replaces the message on an unclassified failure with a generic one, so internal detail never leaks. A caller-reachable 500 has shipped three times — a fractional `limit` reaching `LIMIT 2.5`, a plain `HEAD` tripping the builder's method guard, and a keyset cursor's timestamp reaching `date_trunc` as an untyped placeholder — so treat "a well-formed request produced a 500" as the highest-severity class of defect on this surface.
+
+**Validating a value is only half of it; the value also has to reach SQL with a type.** A bound parameter arrives as `unknown` and takes its type from context. Against a typed column (`sort_order > $1`) that inference always succeeds, which is why the gap stays invisible almost everywhere — but as an argument to an overloaded function it can resolve to nothing at all. So: **if a bound value is an argument to a SQL function rather than one side of a comparison, write its type down** (`lib/api/list-query.ts`, `timestampKey`, casts from the column).
+
+And this class survives a green test suite — `keysetAfter` returned well-formed SQL and every assertion passed; only Postgres's parser rejected it. When a change alters the *shape* of generated SQL rather than its values, execute it somewhere before believing the suite.
 
 **Which of 403 and 404 an operation documents follows from its authorization, not from whether it is a read.** `requirePermission` throws two different failures: no workspace access at all is `NoWorkspaceAccessError`, which `createV2ResourceConcealmentPolicy` conceals as 404; access below the operation's `minimumRole` is `InsufficientWorkspacePermissionsError`, which stays a 403. So:
 
@@ -182,7 +187,7 @@ Run this against any new or changed v2 endpoint.
 - [ ] Success body is exactly `{data}` or `{data, nextCursor}`; failures are exactly `{error:{code,message,details?}}`.
 - [ ] Route uses a shared builder; no hand-built `NextResponse.json`.
 - [ ] Query and body schemas are `.strict()`.
-- [ ] No caller-supplied value can produce a 500 — check every numeric param reaches SQL as a validated integer.
+- [ ] No caller-supplied value can produce a 500 — check every numeric param reaches SQL as a validated integer, and that any bound value passed as an argument to a SQL function carries an explicit type.
 - [ ] `limit` comes from `v2PaginationFields`, not a hand-written `z.coerce.number()`.
 - [ ] If the response carries `nextCursor`, the query accepts `limit` + `cursor` and the query actually applies them.
 - [ ] Keyset sorts end in a unique `id` key.

--- a/.claude/commands/v2-api-conventions.md
+++ b/.claude/commands/v2-api-conventions.md
@@ -15,12 +15,13 @@ failure (always)      { "error": { "code": "...", "message": "...", "details"?: 
 
 Nothing else at the top level. No `success: true`, no bare `{ "error": "string" }`, no HTML.
 
-That promise is worth stating as a rule because it has been broken four separate ways, each time by a route or a builder taking a shortcut that looked local:
+That promise is worth stating as a rule because it has been broken five separate ways, each time by a route or a builder taking a shortcut that looked local:
 
 - `GET /workflows?limit=1.5` returned **500**. The contract was copied from a sibling and lost its `.int()`, so a fractional limit passed validation and reached Postgres as `LIMIT 2.5`.
 - A malformed JSON body returned **`{"error":"Request body must be valid JSON"}`** — a bare string. The envelope was a per-route opt-in that only 8 of 77 routes remembered.
 - `GET /api/v2/nonexistent` returned a **full HTML 404 document**, because no route file matched and the request fell through to the app's global not-found page.
 - Four collections returned `nextCursor` while **silently discarding** any `limit` the caller sent, because Zod strips unknown keys unless the schema is `.strict()`.
+- Handing back a `nextCursor` from any timestamp-sorted list and passing it straight in returned **500**. The value was validated and bound — but bound with no SQL type, into `date_trunc`, which is overloaded, so Postgres could resolve no overload. Validation was never the missing half; the type was.
 
 Each was one line. The rules below are the generalisations.
 
@@ -61,7 +62,11 @@ Two of these carry real design weight:
 
 **404 is deliberately overloaded.** A workspace the caller cannot reach answers `404 "Workspace not found"`, never 403 — a 403 would confirm the resource exists. `createV2ResourceConcealmentPolicy` does this by mapping a cross-tenant authorization failure to `v2Error('NOT_FOUND', ...)`. The rollout gate answers the same way for the same reason (`gate.ts`: "an ungated caller cannot distinguish 'not in the rollout cohort' from 'no such endpoint'"), and so does the unknown-path catch-all at `app/api/v2/[[...segments]]/route.ts` — its body is byte-identical to the gate's on purpose.
 
-**500 is never caller-reachable.** Any input a caller can send must be rejected at the contract boundary with a 400. If you can construct a query string or body that produces a 500, that is a bug in the contract, not something to wrap in a `try`/`catch`. `v2ErrorForOrchestration` also replaces the message on an unclassified failure with a generic one, so internal detail never leaks. A caller-reachable 500 has shipped twice — a fractional `limit` reaching `LIMIT 2.5`, and a plain `HEAD` tripping the builder's method guard — so treat "a well-formed request produced a 500" as the highest-severity class of defect on this surface.
+**500 is never caller-reachable.** Any input a caller can send must be rejected at the contract boundary with a 400. If you can construct a query string or body that produces a 500, that is a bug in the contract, not something to wrap in a `try`/`catch`. `v2ErrorForOrchestration` also replaces the message on an unclassified failure with a generic one, so internal detail never leaks. A caller-reachable 500 has shipped three times — a fractional `limit` reaching `LIMIT 2.5`, a plain `HEAD` tripping the builder's method guard, and a keyset cursor's timestamp reaching `date_trunc` as an untyped placeholder — so treat "a well-formed request produced a 500" as the highest-severity class of defect on this surface.
+
+**Validating a value is only half of it; the value also has to reach SQL with a type.** A bound parameter arrives as `unknown` and takes its type from context. Against a typed column (`sort_order > $1`) that inference always succeeds, which is why the gap stays invisible almost everywhere — but as an argument to an overloaded function it can resolve to nothing at all. So: **if a bound value is an argument to a SQL function rather than one side of a comparison, write its type down** (`lib/api/list-query.ts`, `timestampKey`, casts from the column).
+
+And this class survives a green test suite — `keysetAfter` returned well-formed SQL and every assertion passed; only Postgres's parser rejected it. When a change alters the *shape* of generated SQL rather than its values, execute it somewhere before believing the suite.
 
 **Which of 403 and 404 an operation documents follows from its authorization, not from whether it is a read.** `requirePermission` throws two different failures: no workspace access at all is `NoWorkspaceAccessError`, which `createV2ResourceConcealmentPolicy` conceals as 404; access below the operation's `minimumRole` is `InsufficientWorkspacePermissionsError`, which stays a 403. So:
 
@@ -181,7 +186,7 @@ Run this against any new or changed v2 endpoint.
 - [ ] Success body is exactly `{data}` or `{data, nextCursor}`; failures are exactly `{error:{code,message,details?}}`.
 - [ ] Route uses a shared builder; no hand-built `NextResponse.json`.
 - [ ] Query and body schemas are `.strict()`.
-- [ ] No caller-supplied value can produce a 500 — check every numeric param reaches SQL as a validated integer.
+- [ ] No caller-supplied value can produce a 500 — check every numeric param reaches SQL as a validated integer, and that any bound value passed as an argument to a SQL function carries an explicit type.
 - [ ] `limit` comes from `v2PaginationFields`, not a hand-written `z.coerce.number()`.
 - [ ] If the response carries `nextCursor`, the query accepts `limit` + `cursor` and the query actually applies them.
 - [ ] Keyset sorts end in a unique `id` key.

--- a/.cursor/commands/v2-api-conventions.md
+++ b/.cursor/commands/v2-api-conventions.md
@@ -10,12 +10,13 @@ failure (always)      { "error": { "code": "...", "message": "...", "details"?: 
 
 Nothing else at the top level. No `success: true`, no bare `{ "error": "string" }`, no HTML.
 
-That promise is worth stating as a rule because it has been broken four separate ways, each time by a route or a builder taking a shortcut that looked local:
+That promise is worth stating as a rule because it has been broken five separate ways, each time by a route or a builder taking a shortcut that looked local:
 
 - `GET /workflows?limit=1.5` returned **500**. The contract was copied from a sibling and lost its `.int()`, so a fractional limit passed validation and reached Postgres as `LIMIT 2.5`.
 - A malformed JSON body returned **`{"error":"Request body must be valid JSON"}`** — a bare string. The envelope was a per-route opt-in that only 8 of 77 routes remembered.
 - `GET /api/v2/nonexistent` returned a **full HTML 404 document**, because no route file matched and the request fell through to the app's global not-found page.
 - Four collections returned `nextCursor` while **silently discarding** any `limit` the caller sent, because Zod strips unknown keys unless the schema is `.strict()`.
+- Handing back a `nextCursor` from any timestamp-sorted list and passing it straight in returned **500**. The value was validated and bound — but bound with no SQL type, into `date_trunc`, which is overloaded, so Postgres could resolve no overload. Validation was never the missing half; the type was.
 
 Each was one line. The rules below are the generalisations.
 
@@ -56,7 +57,11 @@ Two of these carry real design weight:
 
 **404 is deliberately overloaded.** A workspace the caller cannot reach answers `404 "Workspace not found"`, never 403 — a 403 would confirm the resource exists. `createV2ResourceConcealmentPolicy` does this by mapping a cross-tenant authorization failure to `v2Error('NOT_FOUND', ...)`. The rollout gate answers the same way for the same reason (`gate.ts`: "an ungated caller cannot distinguish 'not in the rollout cohort' from 'no such endpoint'"), and so does the unknown-path catch-all at `app/api/v2/[[...segments]]/route.ts` — its body is byte-identical to the gate's on purpose.
 
-**500 is never caller-reachable.** Any input a caller can send must be rejected at the contract boundary with a 400. If you can construct a query string or body that produces a 500, that is a bug in the contract, not something to wrap in a `try`/`catch`. `v2ErrorForOrchestration` also replaces the message on an unclassified failure with a generic one, so internal detail never leaks. A caller-reachable 500 has shipped twice — a fractional `limit` reaching `LIMIT 2.5`, and a plain `HEAD` tripping the builder's method guard — so treat "a well-formed request produced a 500" as the highest-severity class of defect on this surface.
+**500 is never caller-reachable.** Any input a caller can send must be rejected at the contract boundary with a 400. If you can construct a query string or body that produces a 500, that is a bug in the contract, not something to wrap in a `try`/`catch`. `v2ErrorForOrchestration` also replaces the message on an unclassified failure with a generic one, so internal detail never leaks. A caller-reachable 500 has shipped three times — a fractional `limit` reaching `LIMIT 2.5`, a plain `HEAD` tripping the builder's method guard, and a keyset cursor's timestamp reaching `date_trunc` as an untyped placeholder — so treat "a well-formed request produced a 500" as the highest-severity class of defect on this surface.
+
+**Validating a value is only half of it; the value also has to reach SQL with a type.** A bound parameter arrives as `unknown` and takes its type from context. Against a typed column (`sort_order > $1`) that inference always succeeds, which is why the gap stays invisible almost everywhere — but as an argument to an overloaded function it can resolve to nothing at all. So: **if a bound value is an argument to a SQL function rather than one side of a comparison, write its type down** (`lib/api/list-query.ts`, `timestampKey`, casts from the column).
+
+And this class survives a green test suite — `keysetAfter` returned well-formed SQL and every assertion passed; only Postgres's parser rejected it. When a change alters the *shape* of generated SQL rather than its values, execute it somewhere before believing the suite.
 
 **Which of 403 and 404 an operation documents follows from its authorization, not from whether it is a read.** `requirePermission` throws two different failures: no workspace access at all is `NoWorkspaceAccessError`, which `createV2ResourceConcealmentPolicy` conceals as 404; access below the operation's `minimumRole` is `InsufficientWorkspacePermissionsError`, which stays a 403. So:
 
@@ -176,7 +181,7 @@ Run this against any new or changed v2 endpoint.
 - [ ] Success body is exactly `{data}` or `{data, nextCursor}`; failures are exactly `{error:{code,message,details?}}`.
 - [ ] Route uses a shared builder; no hand-built `NextResponse.json`.
 - [ ] Query and body schemas are `.strict()`.
-- [ ] No caller-supplied value can produce a 500 — check every numeric param reaches SQL as a validated integer.
+- [ ] No caller-supplied value can produce a 500 — check every numeric param reaches SQL as a validated integer, and that any bound value passed as an argument to a SQL function carries an explicit type.
 - [ ] `limit` comes from `v2PaginationFields`, not a hand-written `z.coerce.number()`.
 - [ ] If the response carries `nextCursor`, the query accepts `limit` + `cursor` and the query actually applies them.
 - [ ] Keyset sorts end in a unique `id` key.

--- a/apps/sim/lib/api/list-query.test.ts
+++ b/apps/sim/lib/api/list-query.test.ts
@@ -105,11 +105,22 @@ describe('timestampKey', () => {
     )
   })
 
-  it('truncates the bound cursor value to match, binding it through the column encoder', () => {
+  it('casts the bound cursor value so date_trunc has a resolvable overload', () => {
     const { sql: text, params } = render(createdKey.bind('2024-01-01T00:00:00.123Z')!)
 
-    expect(text).toBe(`date_trunc('milliseconds', $1)`)
+    expect(text).toBe(`date_trunc('milliseconds', cast($1 as timestamp))`)
     expect(params).toEqual(['2024-01-01T00:00:00.123Z'])
+  })
+
+  it('takes the cast from the column, so a timestamptz column keeps its offset', () => {
+    const zoned = pgTable('zoned', {
+      at: timestamp('at', { withTimezone: true }).notNull(),
+    })
+    const zonedKey = timestampKey<{ at: Date }>(zoned.at, (r) => r.at)
+
+    expect(render(zonedKey.bind('2024-01-01T00:00:00.123Z')!).sql).toBe(
+      `date_trunc('milliseconds', cast($1 as timestamp with time zone))`
+    )
   })
 
   it('rejects a cursor value that is not a parseable timestamp', () => {
@@ -173,11 +184,27 @@ describe('keysetAfter', () => {
     )
 
     expect(text).toBe(
-      `(date_trunc('milliseconds', "thing"."created_at") > date_trunc('milliseconds', $1) or ` +
-        `(date_trunc('milliseconds', "thing"."created_at") = date_trunc('milliseconds', $2) and ` +
+      `(date_trunc('milliseconds', "thing"."created_at") > date_trunc('milliseconds', cast($1 as timestamp)) or ` +
+        `(date_trunc('milliseconds', "thing"."created_at") = date_trunc('milliseconds', cast($2 as timestamp)) and ` +
         `"thing"."id" > $3))`
     )
     expect(params).toEqual(['2024-01-01T00:00:00.123Z', '2024-01-01T00:00:00.123Z', 'file-7'])
+  })
+
+  /**
+   * Pins the class, not the instance: `date_trunc` is today's only wrapping, so
+   * what this catches is a future key that wraps its bound value untyped.
+   */
+  it('leaves no bound value bare inside a function call', () => {
+    const { sql: text } = render(
+      keysetAfter(
+        [numberKey<Row>(thing.size, () => 0), createdKey, idKey],
+        [7, '2024-01-01T00:00:00.123Z', 'file-7'],
+        'asc'
+      )!
+    )
+
+    expect(text).not.toMatch(/[a-z_]+\((?:[^()]*,)?\s*\$\d+\s*\)/i)
   })
 
   /** A caller controls the cursor's contents, so a bad value is a 400, not a 500 from SQL. */

--- a/apps/sim/lib/api/list-query.ts
+++ b/apps/sim/lib/api/list-query.ts
@@ -109,6 +109,15 @@ export function numberKey<Row>(column: SQLWrapper, read: (row: Row) => number): 
  * `date_trunc` rules out an index-ordered scan, but none of the timestamp
  * columns sorted here are indexed, so it costs nothing today. Adding an index
  * to serve one of these sorts means indexing this same expression.
+ *
+ * The column serializes the `Date` (drizzle's own timestamp encoder) and also
+ * supplies the cast. A bare placeholder arrives as `unknown` and `date_trunc` is
+ * overloaded (`timestamp`, `timestamptz`, `interval`), so it resolves to no
+ * overload and 500s on page two — this is the only key whose placeholder sits
+ * inside a function rather than against a typed column. Taking the type from the
+ * column rather than a literal keeps a `timestamptz` correct, and reading it
+ * inside `bind` keeps the module-scope sort maps from touching the column at
+ * import time.
  */
 export function timestampKey<Row>(column: Column, read: (row: Row) => Date): KeysetKey<Row> {
   return {
@@ -118,8 +127,7 @@ export function timestampKey<Row>(column: Column, read: (row: Row) => Date): Key
       if (typeof value !== 'string') return null
       const date = new Date(value)
       if (Number.isNaN(date.getTime())) return null
-      // Bound through the column so drizzle's own timestamp encoder serializes it.
-      return sql`date_trunc('milliseconds', ${sql.param(date, column)})`
+      return sql`date_trunc('milliseconds', cast(${sql.param(date, column)} as ${sql.raw(column.getSQLType())}))`
     },
   }
 }


### PR DESCRIPTION
## The defect

Every v2 collection hands back a `nextCursor`. Passing that cursor straight back returned **500 `INTERNAL_ERROR`** on every list whose sort includes a timestamp key — which is the *default* sort on five of them.

The keyset compares millisecond-truncated timestamps on both sides:

```
date_trunc('milliseconds', "created_at") > date_trunc('milliseconds', $n)
```

`$n` went out as a bare placeholder, which Postgres types as `unknown`. `date_trunc` is overloaded across `timestamp`, `timestamptz`, and `interval`, so `date_trunc(unknown, unknown)` matches no single candidate and the statement fails with `function date_trunc(unknown, unknown) is not unique`.

The cursor value was never unvalidated — a non-string or unparseable date is already rejected as a 400 by `KeysetKey.bind`. It simply reached SQL with no type. The old TSDoc claimed `sql.param(date, column)` bound it "through the column so drizzle's own timestamp encoder serializes it"; the encoder does run, but drizzle still emits an untyped `$n`, and nothing about a placeholder tells Postgres what it is. The file's own unit test asserted the untyped form and passed.

## Not a regression from the recent v2 work

`git log -S"date_trunc" -- apps/sim/lib/api/list-query.ts`, and the same for `sql.param(date, column)`, both point at a single commit: **#5273**, the original v2 PR. v2 keyset pagination has never worked past page one on a timestamp-sorted list. **#6620** made it reachable and uniform — it gave four previously-unpaginated collections working cursors — which is how it surfaced, but it did not introduce it.

## The fix

Cast the bound value to the column's own SQL type, inside `timestampKey`, so all twelve call sites across six modules inherit it rather than each patching itself:

```ts
sql`date_trunc('milliseconds', cast(${sql.param(date, column)} as ${sql.raw(column.getSQLType())}))`
```

Derived from the column rather than hardcoded `timestamp`: every column reaching this today is `timestamp` without time zone, but a `timestamptz` column would need its `Z` offset honoured rather than ignored, and the derivation keeps that correct for free. It is read inside `bind` rather than at construction because every caller builds its sort map at module scope.

**The millisecond truncation is unchanged.** It is load-bearing: Postgres stores microseconds, a cursor value round-trips through a millisecond-only JS `Date`, and comparing the raw column against the truncated value re-admits the page's own last row. Verified against a real database that a row stored at `…568999` is still correctly excluded by a cursor stamped `…568`.

## Affected sorts

Every keyset containing a timestamp key — 7 collections, 15 sorts. Default sorts in **bold**.

| Collection | Broken | Unaffected |
|---|---|---|
| `workflows` | **`position`**, `createdAt`, `updatedAt` | `name`, `runCount` |
| `tables` | **`createdAt`**, `updatedAt` | `name` |
| `files` | **`uploadedAt`**, `updatedAt` | `name`, `size` |
| `credentials` | **`createdAt`**, `updatedAt` | `displayName` |
| `secrets` (shares the credentials keyset) | `createdAt`, `updatedAt` | **`name`** |
| `knowledge` | **`createdAt`**, `updatedAt` | `name` |
| `custom-tools` | **`createdAt`**, `updatedAt` | `title` |

Not affected at all: `logs`, `skills`, `billing-logs`, `mcp-servers`, `audit-logs` — none of them build a keyset over a truncated timestamp.

`numberKey` and `textKey` carry no equivalent exposure. Their bound values only ever sit as one side of a comparison against a typed column or expression (`sort_order > $1`, `coalesce(size_bytes, size) > $1`), where Postgres infers the type from the comparison. `date_trunc` is the only place a keyset passes a bound value *into* a function — which is exactly why this stayed invisible everywhere else.

I swept every `sql.param(` call site and every SQL-function call with an interpolated operand across `apps/` and `packages/`. The others either already carry an explicit cast by hand (`::jsonb`, `::text`, `::vector` — seven sites, each author having hit the same wall independently) or are single-candidate and resolve fine (`websearch_to_tsquery(regconfig, text)`, `lower`, `make_interval`). This was the only live instance.

## Verification

- **Reproduced against a real Postgres 17.9** before the fix, rendering the actual `keysetAfter` SQL through `PgDialect` and executing it: 4 of 5 sort shapes failed with `function date_trunc(unknown, unknown) is not unique`; the `name` (text-key) control passed. After the fix, 5/5 pass and return the correct rows, including the microsecond-truncation case above.
- New unit tests fail before the fix and pass after. Three added/changed: the cast is emitted; the cast is taken from the column (a `timestamptz` fixture renders `cast($1 as timestamp with time zone)`); and a class guard asserting no bound value is left bare inside any function call, so a future key that wraps its value is caught.
- `bun run type-check`, `bunx turbo run lint:check`, `bun run check:api-validation:strict`, `bun run check:openapi` all pass. `lib/api` suites: 723 tests green; the six modules that call `timestampKey` plus their dependents: 4,470 green.

## Skill

`.agents/skills/v2-api-conventions/SKILL.md` states "500 is never caller-reachable" and keeps an incident log against it. This class is added, along with the generalisation it produces — *if a bound value is an argument to a SQL function rather than one side of a comparison, write its type down* — and the reason it survived review: the generated SQL was well-formed and every assertion passed, so only a database could reject it. Projections regenerated with `scripts/sync-skills.ts`.

## Note for a follow-up (not in this PR)

`lib/data-drains/sources/cursor.ts` (`timeCursorPredicate`) applies `date_trunc('milliseconds', …)` to the column but **not** to the bound cursor value. It does not hit this bug — a row-constructor comparison types the parameter from the left-hand element — but that asymmetry is the same one `timestampKey`'s TSDoc argues re-admits the page's own last row. Worth a look separately.
