### PR TITLE
improvement(workflow): smooth the running hatch and sit it in the slot's own box

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/action-bar/action-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/action-bar/action-bar.tsx
@@ -98,12 +98,15 @@ const RUNNING_FILL_INSET_PLAIN = 'left-[26px]'
  * inside it at the bottom — the fill visibly ran off the block. The per-slot
  * version never did, because each button's own clip contained it.
  *
- * Same taper, read off that path: the edge sits 16.67px in from the row's right
- * at the overlay's top (y=4) and 3.33px at its bottom (y=20), a slope of 20/24.
- * Changing the end silhouette means changing these two numbers with it.
+ * Same taper, read off that path. Its straight run — (22.4, 2.88) to
+ * (36.59, 19.9) in the slot's own 40×24 box — has a slope of 20/24, so across
+ * the full row it moves from 20px in at the top to flush at the bottom. The
+ * overlay spans the row, so those are its two numbers; they are the slot's own
+ * edge continued, which is what puts the hatch's end exactly where a hovered
+ * slot's fill ends. Changing the end silhouette means changing them with it.
  */
 const RUNNING_FILL_END_TAPER =
-  '[clip-path:polygon(0_0,calc(100%_-_16.67px)_0,calc(100%_-_3.33px)_100%,0_100%)]'
+  '[clip-path:polygon(0_0,calc(100%_-_20px)_0,100%_100%,0_100%)]'
 
 const ICON_SIZE = 'size-[14px]'
 
@@ -429,7 +432,11 @@ export const ActionBar = memo(
             <span
               aria-hidden='true'
               className={cn(
-                'pointer-events-none absolute inset-y-[4px] right-0 overflow-hidden',
+                /* Spans the row, so the hatch occupies exactly the box a slot's
+                   hover fill does — same height, and the same padding in from
+                   the swell on every side, since the row already sits inside
+                   the container's own inset. */
+                'pointer-events-none absolute inset-y-0 right-0 overflow-hidden',
                 isSwell ? RUNNING_FILL_INSET_SWELL : RUNNING_FILL_INSET_PLAIN,
                 isSwell && RUNNING_FILL_END_TAPER
               )}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/action-bar/action-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/action-bar/action-bar.tsx
@@ -66,10 +66,24 @@ const ACTION_BUTTON_STYLES = [
  * 25.11px of period. Writing 24/26 directly would render ~3.5% wide and drift
  * out of the squares' rhythm across the row.
  *
+ * Each edge ramps over 0.75px rather than switching colour at a single offset,
+ * which is why the stops come in pairs 0.375px either side of 23.18 and 25.11.
+ * A gradient is sampled once per pixel with no coverage term, so a hard stop on
+ * a 15°-off-vertical edge can only ever land wholly on one side or the other —
+ * the marks came out visibly stepped, which is the one thing a shape this thin
+ * cannot hide. Ramping across roughly a device pixel gives the rasterizer the
+ * intermediate values antialiasing would have produced, and measured edge
+ * deviation drops from 0.28 device px (pure quantization) to 0.05.
+ *
+ * The ramps are centred on the old offsets, so the 50%-coverage line — the edge
+ * the eye actually locates — has not moved and the 24/2 rhythm is untouched.
+ * Widening the feather further would keep smoothing, but the gap is only 1.93px
+ * of stop, so it comes straight out of the mark's dark core.
+ *
  * `--surface-2` is the same fill the slots used; only where it is painted moved.
  */
 const RUNNING_FILL =
-  'bg-[repeating-linear-gradient(75deg,var(--surface-2)_0_23.18px,transparent_23.18px_25.11px)]'
+  'bg-[repeating-linear-gradient(75deg,var(--surface-2)_0_22.805px,transparent_23.555px_24.735px,var(--surface-2)_25.11px)]'
 
 /** Left edge of the fill: clears the run/stop button, which stays live mid-run. */
 const RUNNING_FILL_INSET_SWELL = 'left-[42px]'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/action-bar/action-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/action-bar/action-bar.tsx
@@ -67,23 +67,29 @@ const ACTION_BUTTON_STYLES = [
  * out of the squares' rhythm across the row.
  *
  * Each edge ramps over 0.75px rather than switching colour at a single offset,
- * which is why the stops come in pairs 0.375px either side of 23.18 and 25.11.
- * A gradient is sampled once per pixel with no coverage term, so a hard stop on
- * a 15°-off-vertical edge can only ever land wholly on one side or the other —
- * the marks came out visibly stepped, which is the one thing a shape this thin
- * cannot hide. Ramping across roughly a device pixel gives the rasterizer the
- * intermediate values antialiasing would have produced, and measured edge
- * deviation drops from 0.28 device px (pure quantization) to 0.05.
+ * which is why the stops come in pairs 0.375px either side of the mark's two
+ * edges. A gradient is sampled once per pixel with no coverage term, so a hard
+ * stop on a 15°-off-vertical edge can only ever land wholly on one side or the
+ * other — the marks came out visibly stepped, which is the one thing a shape
+ * this thin cannot hide. Ramping across roughly a device pixel gives the
+ * rasterizer the intermediate values antialiasing would have produced, and
+ * measured edge deviation drops from 0.28 device px (pure quantization) to 0.05.
  *
- * The ramps are centred on the old offsets, so the 50%-coverage line — the edge
- * the eye actually locates — has not moved and the 24/2 rhythm is untouched.
+ * The period runs centre-of-mark to centre-of-mark (11.59 → 36.7) rather than
+ * starting at an edge, because a repeating gradient truncates at its own wrap:
+ * anchored at 0, the ramp leaving the mark would have run 24.735 → 25.485 and
+ * been cut at 25.11, so that edge got half the feather and the gap came out
+ * 1.93 → 1.75px. Both ramps have to sit strictly inside the period. The list
+ * still tiles backwards from its first stop, so the marks land exactly where
+ * anchoring at 0 put them — same 26px pitch, same phase against the squares.
+ *
  * Widening the feather further would keep smoothing, but the gap is only 1.93px
  * of stop, so it comes straight out of the mark's dark core.
  *
  * `--surface-2` is the same fill the slots used; only where it is painted moved.
  */
 const RUNNING_FILL =
-  'bg-[repeating-linear-gradient(75deg,var(--surface-2)_0_22.805px,transparent_23.555px_24.735px,var(--surface-2)_25.11px)]'
+  'bg-[repeating-linear-gradient(75deg,var(--surface-2)_11.59px_22.805px,transparent_23.555px_24.735px,var(--surface-2)_25.485px_36.7px)]'
 
 /** Left edge of the fill: clears the run/stop button, which stays live mid-run. */
 const RUNNING_FILL_INSET_SWELL = 'left-[42px]'
@@ -105,8 +111,7 @@ const RUNNING_FILL_INSET_PLAIN = 'left-[26px]'
  * edge continued, which is what puts the hatch's end exactly where a hovered
  * slot's fill ends. Changing the end silhouette means changing them with it.
  */
-const RUNNING_FILL_END_TAPER =
-  '[clip-path:polygon(0_0,calc(100%_-_20px)_0,100%_100%,0_100%)]'
+const RUNNING_FILL_END_TAPER = '[clip-path:polygon(0_0,calc(100%_-_20px)_0,100%_100%,0_100%)]'
 
 const ICON_SIZE = 'size-[14px]'
 


### PR DESCRIPTION
## Summary

Two things about the running-block hatch, from the Slack thread.

**Slanted edges read as stepped.** A repeating gradient is sampled once per pixel with no coverage term, so a hard colour stop on an edge 15° off vertical can only land wholly on one side or the other. There is no partial value to soften it, and on a mark this thin the staircase *is* the whole edge. Each edge now ramps over 0.75px — roughly a device pixel — which hands the rasterizer the intermediate values antialiasing would have produced.

The period runs centre-of-mark to centre-of-mark (11.59 → 36.7) rather than starting at an edge. A repeating gradient truncates at its own wrap, so anchoring at 0 left the ramp leaving the mark cut in half and pulled its 50%-coverage line 0.19px inward — one side of every stripe stayed sharper and the gap rendered 1.75px instead of 1.93px. Both ramps have to sit strictly inside the period. The list still tiles backwards from its first stop, so the marks land where anchoring at 0 put them: same 26px pitch, same phase against the squares, which matters because the marks are aligned to the slot rhythm.

**The bar did not match the slots.** The hatch was inset 4px into a 24px row, so it stood 16px tall inside a swell whose slots are 24px — a shorter bar floating in the row rather than the slots themselves filling — and its right end stopped short of where a hovered slot's fill ends. It now spans the row. The row already sits inside the container's 2px/3.2px inset, so occupying it outright puts the hatch in exactly the box a slot's hover fill occupies: same height, same padding in from the swell on every side.

The end taper had to move with it. Its two numbers were read off the slot's diagonal at the old overlay's top and bottom (y=4, y=20); continuing that same edge — slope 20/24 — across the full row gives 20px in at the top and flush at the bottom, so the hatch still ends on the slot's own diagonal.

## Type of Change
- [x] Improvement

## Testing
Reproduced the swell faithfully in headless Chromium — real container metrics (`h-[28px]`, `py-0.5`, `px-[0.2rem]`), the real cap `clip-path` values, the composited `will-change: transform` layer — with a hovered slot rendered alongside as ground truth.

**Height and padding**, sampling a column through the stop's hover fill and through the hatch:

| | top | bottom | height |
|---|---|---|---|
| stop hover fill | 2.0px | 26.0px | 24.0px |
| hatch (after) | 2.0px | 26.0px | 24.0px |
| hatch (before) | 6.0px | 22.0px | 16.0px |

**Edge smoothness**, tracking a single stripe and measuring its deviation from its own straight line:

| | 1x | 2x |
|---|---|---|
| hard stops | 0.289 | 0.282 |
| feathered | 0.063 | 0.047 |

0.28 device px is the signature of a fully quantized edge (uniform-over-one-pixel has σ≈0.289). Pixel magnification confirms it: before is binary black/white steps with no intermediate greys, after is a smooth ramp — now symmetric on both sides — with the mark's dark core intact.

**Feather symmetry**, 50%-coverage crossings across three periods (gap nominal 1.93px):

| | measured gap |
|---|---|
| period anchored at the mark's edge | 1.746 / 1.742 / 1.748 |
| period anchored at the mark's centre | 1.932 / 1.931 / 1.930 |

Feather width was chosen by sweeping 0.35/0.5/0.75/1.0px — wider keeps smoothing, but the gap is only 1.93px of stop so it comes straight out of the core.

Also verified: fading to `transparent` produces no dark fringe (premultiplied interpolation — measured 250→253→255 over white), and Tailwind emits every arbitrary value here intact rather than silently dropping it.

Not yet seen on a running block in the app — verified against the isolated swell only.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)