### PR TITLE
fix(workflow): stop subflows resizing themselves after every load

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
@@ -25,20 +25,67 @@ export function useNodeUtilities(blocks: Record<string, any>) {
   }, [])
 
   /**
-   * A block's dimensions as the block itself reported them, or null if it has
-   * not reported yet.
+   * A block's dimensions as reported during this session, or null if nothing
+   * has reported them yet.
    *
-   * {@link getBlockDimensions} without the estimate fallback — a rough box is
-   * fine for clamping a drag or placing a paste; see
-   * {@link calculateLoopDimensions} for why a container cannot size from one.
+   * Reads `layout`, not `height`. `layout` is in-memory only — a card writes it
+   * through `updateBlockLayoutMetrics` once it knows what it renders, and a
+   * container through `updateNodeDimensions` once it has been sized from its
+   * children. `height` is a persisted column, so it can still hold last
+   * session's value for a block that has not reported yet, and `data.width` /
+   * `data.height` likewise persist a container's last size. Sizing a container
+   * from those is the same guess-then-correct this gate exists to prevent, just
+   * closer to the truth and harder to reproduce.
    *
-   * A container's own size is already derived from its children, so it counts
-   * as reported once it has one; an empty container reports its default.
+   * Reading `layout` also settles nesting: an inner container that is still
+   * waiting on its own children has nothing in `layout`, so it reports null and
+   * the outer container waits with it, rather than sizing to the inner one's
+   * default and resizing again once it fills out.
    */
   const getReportedBlockDimensions = useCallback(
     (blockId: string): { width: number; height: number } | null => {
       const block = blocks[blockId]
-      if (!block) return null
+      const reportedHeight = block?.layout?.measuredHeight
+      if (!block || !reportedHeight) return null
+
+      if (isContainerType(block.type)) {
+        return {
+          width: Math.max(
+            block.layout?.measuredWidth || CONTAINER_DIMENSIONS.DEFAULT_WIDTH,
+            CONTAINER_DIMENSIONS.MIN_WIDTH
+          ),
+          height: Math.max(reportedHeight, CONTAINER_DIMENSIONS.MIN_HEIGHT),
+        }
+      }
+
+      return {
+        width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
+        height:
+          block.type === 'note'
+            ? reportedHeight
+            : Math.max(reportedHeight, BLOCK_DIMENSIONS.MIN_HEIGHT),
+      }
+    },
+    [blocks, isContainerType]
+  )
+
+  /**
+   * Get the dimensions of a block, falling back to its persisted height and
+   * then to an estimate from its type.
+   *
+   * The callers here only need a rough box — clamping a drag, placing a paste —
+   * so a stale height beats a guess and a guess beats nothing. A container
+   * sizing itself cannot use either; see {@link calculateLoopDimensions}.
+   */
+  const getBlockDimensions = useCallback(
+    (blockId: string): { width: number; height: number } => {
+      const reported = getReportedBlockDimensions(blockId)
+      if (reported) return reported
+
+      const block = blocks[blockId]
+      if (!block) {
+        return { width: BLOCK_DIMENSIONS.FIXED_WIDTH, height: BLOCK_DIMENSIONS.MIN_HEIGHT }
+      }
 
       if (isContainerType(block.type)) {
         return {
@@ -53,36 +100,19 @@ export function useNodeUtilities(blocks: Record<string, any>) {
         }
       }
 
-      if (!block.height) return null
-
-      return {
-        width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
-        height:
-          block.type === 'note'
-            ? block.height
-            : Math.max(block.height, BLOCK_DIMENSIONS.MIN_HEIGHT),
-      }
-    },
-    [blocks, isContainerType]
-  )
-
-  /**
-   * Get the dimensions of a block, estimating from its type when it has not
-   * reported a height yet.
-   */
-  const getBlockDimensions = useCallback(
-    (blockId: string): { width: number; height: number } => {
-      const reported = getReportedBlockDimensions(blockId)
-      if (reported) return reported
-
-      const block = blocks[blockId]
-      if (!block) {
-        return { width: BLOCK_DIMENSIONS.FIXED_WIDTH, height: BLOCK_DIMENSIONS.MIN_HEIGHT }
+      if (block.height) {
+        return {
+          width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
+          height:
+            block.type === 'note'
+              ? block.height
+              : Math.max(block.height, BLOCK_DIMENSIONS.MIN_HEIGHT),
+        }
       }
 
       return estimateBlockDimensions(block.type)
     },
-    [blocks, getReportedBlockDimensions]
+    [blocks, isContainerType, getReportedBlockDimensions]
   )
 
   /**

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { createLogger } from '@sim/logger'
-import { BLOCK_DIMENSIONS, CONTAINER_DIMENSIONS } from '@sim/workflow-renderer'
+import { BLOCK_DIMENSIONS, CONTAINER_DIMENSIONS, getNoteBlockHeight } from '@sim/workflow-renderer'
 import { useReactFlow } from 'reactflow'
 import { getBlockMetrics } from '@/lib/workflows/autolayout/utils'
 import {
@@ -59,11 +59,17 @@ export function useNodeUtilities(blocks: Record<string, any>) {
         }
       }
 
-      const metrics = getBlockMetrics(block)
-      return {
-        width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : metrics.width,
-        height: block.type === 'note' && block.height ? block.height : metrics.height,
+      /* A note is not a card: it has no sub-block rows and no error row, so the
+         card estimate does not describe it. Its own height is what it was
+         measured at, or the height an empty one paints. */
+      if (block.type === 'note') {
+        return {
+          width: BLOCK_DIMENSIONS.NOTE_WIDTH,
+          height: block.height || getNoteBlockHeight(true),
+        }
       }
+
+      return getBlockMetrics(block)
     },
     [isContainerType]
   )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
@@ -25,67 +25,20 @@ export function useNodeUtilities(blocks: Record<string, any>) {
   }, [])
 
   /**
-   * A block's dimensions as reported during this session, or null if nothing
-   * has reported them yet.
+   * A block's dimensions as the block itself reported them, or null if it has
+   * not reported yet.
    *
-   * Reads `layout`, not `height`. `layout` is in-memory only — a card writes it
-   * through `updateBlockLayoutMetrics` once it knows what it renders, and a
-   * container through `updateNodeDimensions` once it has been sized from its
-   * children. `height` is a persisted column, so it can still hold last
-   * session's value for a block that has not reported yet, and `data.width` /
-   * `data.height` likewise persist a container's last size. Sizing a container
-   * from those is the same guess-then-correct this gate exists to prevent, just
-   * closer to the truth and harder to reproduce.
+   * {@link getBlockDimensions} without the estimate fallback — a rough box is
+   * fine for clamping a drag or placing a paste; see
+   * {@link calculateLoopDimensions} for why a container cannot size from one.
    *
-   * Reading `layout` also settles nesting: an inner container that is still
-   * waiting on its own children has nothing in `layout`, so it reports null and
-   * the outer container waits with it, rather than sizing to the inner one's
-   * default and resizing again once it fills out.
+   * A container's own size is already derived from its children, so it counts
+   * as reported once it has one; an empty container reports its default.
    */
   const getReportedBlockDimensions = useCallback(
     (blockId: string): { width: number; height: number } | null => {
       const block = blocks[blockId]
-      const reportedHeight = block?.layout?.measuredHeight
-      if (!block || !reportedHeight) return null
-
-      if (isContainerType(block.type)) {
-        return {
-          width: Math.max(
-            block.layout?.measuredWidth || CONTAINER_DIMENSIONS.DEFAULT_WIDTH,
-            CONTAINER_DIMENSIONS.MIN_WIDTH
-          ),
-          height: Math.max(reportedHeight, CONTAINER_DIMENSIONS.MIN_HEIGHT),
-        }
-      }
-
-      return {
-        width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
-        height:
-          block.type === 'note'
-            ? reportedHeight
-            : Math.max(reportedHeight, BLOCK_DIMENSIONS.MIN_HEIGHT),
-      }
-    },
-    [blocks, isContainerType]
-  )
-
-  /**
-   * Get the dimensions of a block, falling back to its persisted height and
-   * then to an estimate from its type.
-   *
-   * The callers here only need a rough box — clamping a drag, placing a paste —
-   * so a stale height beats a guess and a guess beats nothing. A container
-   * sizing itself cannot use either; see {@link calculateLoopDimensions}.
-   */
-  const getBlockDimensions = useCallback(
-    (blockId: string): { width: number; height: number } => {
-      const reported = getReportedBlockDimensions(blockId)
-      if (reported) return reported
-
-      const block = blocks[blockId]
-      if (!block) {
-        return { width: BLOCK_DIMENSIONS.FIXED_WIDTH, height: BLOCK_DIMENSIONS.MIN_HEIGHT }
-      }
+      if (!block) return null
 
       if (isContainerType(block.type)) {
         return {
@@ -100,19 +53,36 @@ export function useNodeUtilities(blocks: Record<string, any>) {
         }
       }
 
-      if (block.height) {
-        return {
-          width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
-          height:
-            block.type === 'note'
-              ? block.height
-              : Math.max(block.height, BLOCK_DIMENSIONS.MIN_HEIGHT),
-        }
+      if (!block.height) return null
+
+      return {
+        width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
+        height:
+          block.type === 'note'
+            ? block.height
+            : Math.max(block.height, BLOCK_DIMENSIONS.MIN_HEIGHT),
+      }
+    },
+    [blocks, isContainerType]
+  )
+
+  /**
+   * Get the dimensions of a block, estimating from its type when it has not
+   * reported a height yet.
+   */
+  const getBlockDimensions = useCallback(
+    (blockId: string): { width: number; height: number } => {
+      const reported = getReportedBlockDimensions(blockId)
+      if (reported) return reported
+
+      const block = blocks[blockId]
+      if (!block) {
+        return { width: BLOCK_DIMENSIONS.FIXED_WIDTH, height: BLOCK_DIMENSIONS.MIN_HEIGHT }
       }
 
       return estimateBlockDimensions(block.type)
     },
-    [blocks, isContainerType, getReportedBlockDimensions]
+    [blocks, getReportedBlockDimensions]
   )
 
   /**

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
@@ -2,10 +2,10 @@ import { useCallback } from 'react'
 import { createLogger } from '@sim/logger'
 import { BLOCK_DIMENSIONS, CONTAINER_DIMENSIONS } from '@sim/workflow-renderer'
 import { useReactFlow } from 'reactflow'
+import { getBlockMetrics } from '@/lib/workflows/autolayout/utils'
 import {
   calculateContainerDimensions,
   clampPositionToContainer,
-  estimateBlockDimensions,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/utils/node-position-utils'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
@@ -25,20 +25,27 @@ export function useNodeUtilities(blocks: Record<string, any>) {
   }, [])
 
   /**
-   * A block's dimensions as the block itself reported them, or null if it has
-   * not reported yet.
+   * Get the dimensions of a block.
    *
-   * {@link getBlockDimensions} without the estimate fallback — a rough box is
-   * fine for clamping a drag or placing a paste; see
-   * {@link calculateLoopDimensions} for why a container cannot size from one.
+   * Before a card mounts there is no measurement, so the height comes from
+   * {@link getBlockMetrics}, which estimates it from the block's own state —
+   * the sub-blocks its values leave visible, the summary sentence it will draw,
+   * the error row — through the same `calculateWorkflowBlockDimensions` the
+   * card itself calls. It lands on the height the card goes on to render.
    *
-   * A container's own size is already derived from its children, so it counts
-   * as reported once it has one; an empty container reports its default.
+   * The old estimate read the block's *type* alone and assumed
+   * `ceil(subBlockCount / 2)` rows, which put a 39-field Gmail card at 276px
+   * against the 112px it draws. A container sized from that, painted it, then
+   * got the real height a frame later and visibly resized — on every load,
+   * because measurements are not persisted. Estimating from state removes the
+   * gap rather than waiting it out: both passes now produce the same number.
    */
-  const getReportedBlockDimensions = useCallback(
-    (blockId: string): { width: number; height: number } | null => {
+  const getBlockDimensions = useCallback(
+    (blockId: string): { width: number; height: number } => {
       const block = blocks[blockId]
-      if (!block) return null
+      if (!block) {
+        return { width: BLOCK_DIMENSIONS.FIXED_WIDTH, height: BLOCK_DIMENSIONS.MIN_HEIGHT }
+      }
 
       if (isContainerType(block.type)) {
         return {
@@ -53,36 +60,13 @@ export function useNodeUtilities(blocks: Record<string, any>) {
         }
       }
 
-      if (!block.height) return null
-
+      const metrics = getBlockMetrics(block)
       return {
-        width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
-        height:
-          block.type === 'note'
-            ? block.height
-            : Math.max(block.height, BLOCK_DIMENSIONS.MIN_HEIGHT),
+        width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : metrics.width,
+        height: block.type === 'note' && block.height ? block.height : metrics.height,
       }
     },
     [blocks, isContainerType]
-  )
-
-  /**
-   * Get the dimensions of a block, estimating from its type when it has not
-   * reported a height yet.
-   */
-  const getBlockDimensions = useCallback(
-    (blockId: string): { width: number; height: number } => {
-      const reported = getReportedBlockDimensions(blockId)
-      if (reported) return reported
-
-      const block = blocks[blockId]
-      if (!block) {
-        return { width: BLOCK_DIMENSIONS.FIXED_WIDTH, height: BLOCK_DIMENSIONS.MIN_HEIGHT }
-      }
-
-      return estimateBlockDimensions(block.type)
-    },
-    [blocks, getReportedBlockDimensions]
   )
 
   /**
@@ -295,43 +279,33 @@ export function useNodeUtilities(blocks: Record<string, any>) {
   /**
    * Calculates appropriate dimensions for a loop or parallel node based on its children
    *
-   * Sizes only from heights the children have themselves reported. A card's
-   * height depends on what it actually renders — which rows survive its
-   * conditions, whether it draws a summary sentence, and for a reactive field
-   * even a credential it has to fetch — so the card is the only thing that can
-   * know it, and it publishes it once it does.
-   *
-   * Guessing in the meantime is what made a container resize on every load:
-   * `estimateBlockDimensions` assumes `ceil(subBlockCount / 2)` rows, so it read
-   * a 39-field Gmail card as 276px tall against the 112px it draws. The
-   * container painted that, then the real height arrived a frame later and it
-   * visibly resized. Returning null holds the container at the size it already
-   * has, so it moves once, to the right answer.
+   * Child heights come from {@link getBlockDimensions}, which estimates from
+   * block state when a card has not mounted yet and lands on the height it will
+   * render — so the size computed before the cards report matches the one after,
+   * and the container does not resize behind the user.
    *
    * @param nodeId ID of the container node
-   * @returns Calculated dimensions, or null while any child is still unmeasured
+   * @returns Calculated width and height for the container
    */
   const calculateLoopDimensions = useCallback(
-    (nodeId: string): { width: number; height: number } | null => {
+    (nodeId: string): { width: number; height: number } => {
       const currentBlocks = useWorkflowStore.getState().blocks
       const childBlockIds = Object.keys(currentBlocks).filter(
         (id) => currentBlocks[id]?.data?.parentId === nodeId
       )
 
-      const childPositions: Array<{ x: number; y: number; width: number; height: number }> = []
-      for (const childId of childBlockIds) {
-        const child = currentBlocks[childId]
-        if (!child?.position) continue
-
-        const reported = getReportedBlockDimensions(childId)
-        if (!reported) return null
-
-        childPositions.push({ x: child.position.x, y: child.position.y, ...reported })
-      }
+      const childPositions = childBlockIds
+        .map((childId) => {
+          const child = currentBlocks[childId]
+          if (!child?.position) return null
+          const { width, height } = getBlockDimensions(childId)
+          return { x: child.position.x, y: child.position.y, width, height }
+        })
+        .filter((position): position is NonNullable<typeof position> => position !== null)
 
       return calculateContainerDimensions(childPositions)
     },
-    [getReportedBlockDimensions]
+    [getBlockDimensions]
   )
 
   /**
@@ -352,8 +326,6 @@ export function useNodeUtilities(blocks: Record<string, any>) {
 
       for (const { id, block } of containerBlocks) {
         const dimensions = calculateLoopDimensions(id)
-        if (!dimensions) continue
-
         const currentWidth = block?.data?.width
         const currentHeight = block?.data?.height
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
@@ -40,9 +40,8 @@ export function useNodeUtilities(blocks: Record<string, any>) {
    * because measurements are not persisted. Estimating from state removes the
    * gap rather than waiting it out: both passes now produce the same number.
    */
-  const getBlockDimensions = useCallback(
-    (blockId: string): { width: number; height: number } => {
-      const block = blocks[blockId]
+  const dimensionsOfBlock = useCallback(
+    (block: any): { width: number; height: number } => {
       if (!block) {
         return { width: BLOCK_DIMENSIONS.FIXED_WIDTH, height: BLOCK_DIMENSIONS.MIN_HEIGHT }
       }
@@ -66,7 +65,12 @@ export function useNodeUtilities(blocks: Record<string, any>) {
         height: block.type === 'note' && block.height ? block.height : metrics.height,
       }
     },
-    [blocks, isContainerType]
+    [isContainerType]
+  )
+
+  const getBlockDimensions = useCallback(
+    (blockId: string): { width: number; height: number } => dimensionsOfBlock(blocks[blockId]),
+    [blocks, dimensionsOfBlock]
   )
 
   /**
@@ -298,14 +302,21 @@ export function useNodeUtilities(blocks: Record<string, any>) {
         .map((childId) => {
           const child = currentBlocks[childId]
           if (!child?.position) return null
-          const { width, height } = getBlockDimensions(childId)
+          /* Sized from `currentBlocks`, the same snapshot the position came
+             from. Reading dimensions off the hook's render snapshot instead
+             mixed two ages of the same store: `resizeLoopNodes` walks
+             deepest-first, so an inner container resized earlier in the pass
+             was already updated here but still old there, and the parent sized
+             against a stale inner box — leaving nested containers to converge
+             over a second pass. */
+          const { width, height } = dimensionsOfBlock(child)
           return { x: child.position.x, y: child.position.y, width, height }
         })
         .filter((position): position is NonNullable<typeof position> => position !== null)
 
       return calculateContainerDimensions(childPositions)
     },
-    [getBlockDimensions]
+    [dimensionsOfBlock]
   )
 
   /**

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-node-utilities.ts
@@ -25,40 +25,64 @@ export function useNodeUtilities(blocks: Record<string, any>) {
   }, [])
 
   /**
-   * Get the dimensions of a block.
-   * For regular blocks, uses stored height or estimates based on block config.
+   * A block's dimensions as the block itself reported them, or null if it has
+   * not reported yet.
+   *
+   * {@link getBlockDimensions} without the estimate fallback — a rough box is
+   * fine for clamping a drag or placing a paste; see
+   * {@link calculateLoopDimensions} for why a container cannot size from one.
+   *
+   * A container's own size is already derived from its children, so it counts
+   * as reported once it has one; an empty container reports its default.
+   */
+  const getReportedBlockDimensions = useCallback(
+    (blockId: string): { width: number; height: number } | null => {
+      const block = blocks[blockId]
+      if (!block) return null
+
+      if (isContainerType(block.type)) {
+        return {
+          width: Math.max(
+            block.data?.width || CONTAINER_DIMENSIONS.DEFAULT_WIDTH,
+            CONTAINER_DIMENSIONS.MIN_WIDTH
+          ),
+          height: Math.max(
+            block.data?.height || CONTAINER_DIMENSIONS.DEFAULT_HEIGHT,
+            CONTAINER_DIMENSIONS.MIN_HEIGHT
+          ),
+        }
+      }
+
+      if (!block.height) return null
+
+      return {
+        width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
+        height:
+          block.type === 'note'
+            ? block.height
+            : Math.max(block.height, BLOCK_DIMENSIONS.MIN_HEIGHT),
+      }
+    },
+    [blocks, isContainerType]
+  )
+
+  /**
+   * Get the dimensions of a block, estimating from its type when it has not
+   * reported a height yet.
    */
   const getBlockDimensions = useCallback(
     (blockId: string): { width: number; height: number } => {
+      const reported = getReportedBlockDimensions(blockId)
+      if (reported) return reported
+
       const block = blocks[blockId]
       if (!block) {
         return { width: BLOCK_DIMENSIONS.FIXED_WIDTH, height: BLOCK_DIMENSIONS.MIN_HEIGHT }
       }
 
-      if (isContainerType(block.type)) {
-        return {
-          width: block.data?.width
-            ? Math.max(block.data.width, CONTAINER_DIMENSIONS.MIN_WIDTH)
-            : CONTAINER_DIMENSIONS.DEFAULT_WIDTH,
-          height: block.data?.height
-            ? Math.max(block.data.height, CONTAINER_DIMENSIONS.MIN_HEIGHT)
-            : CONTAINER_DIMENSIONS.DEFAULT_HEIGHT,
-        }
-      }
-
-      if (block.height) {
-        return {
-          width: block.type === 'note' ? BLOCK_DIMENSIONS.NOTE_WIDTH : BLOCK_DIMENSIONS.FIXED_WIDTH,
-          height:
-            block.type === 'note'
-              ? block.height
-              : Math.max(block.height, BLOCK_DIMENSIONS.MIN_HEIGHT),
-        }
-      }
-
       return estimateBlockDimensions(block.type)
     },
-    [blocks, isContainerType]
+    [blocks, getReportedBlockDimensions]
   )
 
   /**
@@ -270,28 +294,44 @@ export function useNodeUtilities(blocks: Record<string, any>) {
 
   /**
    * Calculates appropriate dimensions for a loop or parallel node based on its children
+   *
+   * Sizes only from heights the children have themselves reported. A card's
+   * height depends on what it actually renders — which rows survive its
+   * conditions, whether it draws a summary sentence, and for a reactive field
+   * even a credential it has to fetch — so the card is the only thing that can
+   * know it, and it publishes it once it does.
+   *
+   * Guessing in the meantime is what made a container resize on every load:
+   * `estimateBlockDimensions` assumes `ceil(subBlockCount / 2)` rows, so it read
+   * a 39-field Gmail card as 276px tall against the 112px it draws. The
+   * container painted that, then the real height arrived a frame later and it
+   * visibly resized. Returning null holds the container at the size it already
+   * has, so it moves once, to the right answer.
+   *
    * @param nodeId ID of the container node
-   * @returns Calculated width and height for the container
+   * @returns Calculated dimensions, or null while any child is still unmeasured
    */
   const calculateLoopDimensions = useCallback(
-    (nodeId: string): { width: number; height: number } => {
+    (nodeId: string): { width: number; height: number } | null => {
       const currentBlocks = useWorkflowStore.getState().blocks
       const childBlockIds = Object.keys(currentBlocks).filter(
         (id) => currentBlocks[id]?.data?.parentId === nodeId
       )
 
-      const childPositions = childBlockIds
-        .map((childId) => {
-          const child = currentBlocks[childId]
-          if (!child?.position) return null
-          const { width, height } = getBlockDimensions(childId)
-          return { x: child.position.x, y: child.position.y, width, height }
-        })
-        .filter((p): p is NonNullable<typeof p> => p !== null)
+      const childPositions: Array<{ x: number; y: number; width: number; height: number }> = []
+      for (const childId of childBlockIds) {
+        const child = currentBlocks[childId]
+        if (!child?.position) continue
+
+        const reported = getReportedBlockDimensions(childId)
+        if (!reported) return null
+
+        childPositions.push({ x: child.position.x, y: child.position.y, ...reported })
+      }
 
       return calculateContainerDimensions(childPositions)
     },
-    [getBlockDimensions]
+    [getReportedBlockDimensions]
   )
 
   /**
@@ -312,6 +352,8 @@ export function useNodeUtilities(blocks: Record<string, any>) {
 
       for (const { id, block } of containerBlocks) {
         const dimensions = calculateLoopDimensions(id)
+        if (!dimensions) continue
+
         const currentWidth = block?.data?.width
         const currentHeight = block?.data?.height
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/node-position-utils.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/node-position-utils.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment node
+ */
+import { CONTAINER_DIMENSIONS } from '@sim/workflow-renderer'
+import { describe, expect, it } from 'vitest'
+import {
+  calculateContainerDimensions,
+  clampPositionToContainer,
+} from '@/app/workspace/[workspaceId]/w/[workflowId]/utils/node-position-utils'
+
+describe('calculateContainerDimensions', () => {
+  it('covers the child it holds plus one trailing padding', () => {
+    /* Child coordinates are relative to the container's own origin, so their
+       far edge is already the distance to cover. */
+    const child = { x: 273, y: 207.5, width: 250, height: 112 }
+
+    expect(calculateContainerDimensions([child])).toEqual({
+      width: child.x + child.width + CONTAINER_DIMENSIONS.RIGHT_PADDING,
+      height: child.y + child.height + CONTAINER_DIMENSIONS.BOTTOM_PADDING,
+    })
+  })
+
+  it('leaves the same gap under a child wherever the child sits', () => {
+    const gapUnder = (y: number) =>
+      calculateContainerDimensions([{ x: 600, y, width: 250, height: 112 }]).height - (y + 112)
+
+    expect(gapUnder(400)).toBe(CONTAINER_DIMENSIONS.BOTTOM_PADDING)
+    expect(gapUnder(700)).toBe(CONTAINER_DIMENSIONS.BOTTOM_PADDING)
+  })
+
+  it('holds a child pinned to the top-left clear of the chrome', () => {
+    /* The floor `clampPositionToContainer` applies is what encodes the header
+       and leading padding into the child's own coordinates — the sizing math
+       reads them from there rather than adding them again. */
+    const pinned = clampPositionToContainer(
+      { x: -999, y: -999 },
+      { width: 900, height: 900 },
+      { width: 250, height: 112 }
+    )
+
+    expect(pinned).toEqual({
+      x: CONTAINER_DIMENSIONS.LEFT_PADDING,
+      y: CONTAINER_DIMENSIONS.HEADER_HEIGHT + CONTAINER_DIMENSIONS.TOP_PADDING,
+    })
+  })
+
+  it('falls back to the default box when it holds nothing', () => {
+    expect(calculateContainerDimensions([])).toEqual({
+      width: CONTAINER_DIMENSIONS.DEFAULT_WIDTH,
+      height: CONTAINER_DIMENSIONS.DEFAULT_HEIGHT,
+    })
+  })
+
+  it('never sizes below the default box', () => {
+    expect(calculateContainerDimensions([{ x: 16, y: 66, width: 40, height: 20 }])).toEqual({
+      width: CONTAINER_DIMENSIONS.DEFAULT_WIDTH,
+      height: CONTAINER_DIMENSIONS.DEFAULT_HEIGHT,
+    })
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/node-position-utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/node-position-utils.ts
@@ -70,6 +70,15 @@ export function clampPositionToContainer(
  * Single source of truth for container sizing - ensures consistency between
  * live drag updates and final dimension calculations.
  *
+ * Child coordinates are relative to the container's own origin — React Flow
+ * places a child at the parent's origin plus its position, and
+ * {@link clampPositionToContainer} keeps them clear of the chrome by flooring
+ * them at `LEFT_PADDING` and `HEADER_HEIGHT + TOP_PADDING`. A child's far edge
+ * is therefore already the distance the container has to cover, and only the
+ * trailing padding is owed on top. Adding the header and leading padding here
+ * as well counted them twice, leaving every container 66px taller and 16px
+ * wider than its contents.
+ *
  * @param childPositions - Array of child positions with their dimensions
  * @returns Calculated width and height for the container
  */
@@ -93,14 +102,11 @@ export function calculateContainerDimensions(
 
   const width = Math.max(
     CONTAINER_DIMENSIONS.DEFAULT_WIDTH,
-    CONTAINER_DIMENSIONS.LEFT_PADDING + maxRight + CONTAINER_DIMENSIONS.RIGHT_PADDING
+    maxRight + CONTAINER_DIMENSIONS.RIGHT_PADDING
   )
   const height = Math.max(
     CONTAINER_DIMENSIONS.DEFAULT_HEIGHT,
-    CONTAINER_DIMENSIONS.HEADER_HEIGHT +
-      CONTAINER_DIMENSIONS.TOP_PADDING +
-      maxBottom +
-      CONTAINER_DIMENSIONS.BOTTOM_PADDING
+    maxBottom + CONTAINER_DIMENSIONS.BOTTOM_PADDING
   )
 
   return { width, height }

--- a/packages/workflow-renderer/src/dimensions.ts
+++ b/packages/workflow-renderer/src/dimensions.ts
@@ -83,27 +83,33 @@ export const estimateNoteBlockHeight = (content: string) => {
 /**
  * A container's box, and the gutter it keeps around the blocks inside it.
  *
- * Each padding is the gap between a child's edge and the container's, and
- * nothing else. The header is counted once, by the child's own position, which
- * `clampPositionToContainer` floors at `HEADER_HEIGHT + TOP_PADDING` — so these
- * are the numbers you see, and three of them match because those three edges
- * are only gutter.
+ * The single source for both halves of that: the layout math that sizes a
+ * container and clamps its children, and the card's own DOM. `subflow-node-view`
+ * renders its header and content box straight from these, so the gap the
+ * geometry reserves is the gap the container actually paints. They used to be
+ * separate — the same four numbers as Tailwind literals in the view — and had
+ * already drifted, the view drawing a 40px header against a constant that
+ * claimed 50.
  *
- * `RIGHT_PADDING` is the deliberate exception. The container's own output
- * handle sits on that edge, so a child needs clearance there it does not need
- * anywhere else. That makes it chrome rather than gutter, which is why it is
- * not tied to the other three.
+ * Each padding is the gap between a child's edge and the container's, counted
+ * once: the header is accounted for by the child's own position, which
+ * `clampPositionToContainer` floors at `HEADER_HEIGHT + TOP_PADDING`.
+ *
+ * The two edges that carry chrome are wider than the two that are only gutter.
+ * The container's output handle sits on the right, and the resize grip in the
+ * bottom-right corner spans 40px in from both — a child at the gutter width
+ * would sit underneath it.
  */
 export const CONTAINER_DIMENSIONS = {
   DEFAULT_WIDTH: 500,
   DEFAULT_HEIGHT: 300,
   MIN_WIDTH: 400,
   MIN_HEIGHT: 200,
-  HEADER_HEIGHT: 50,
+  HEADER_HEIGHT: 40,
   LEFT_PADDING: 24,
   RIGHT_PADDING: 80,
   TOP_PADDING: 24,
-  BOTTOM_PADDING: 24,
+  BOTTOM_PADDING: 80,
 } as const
 
 /**

--- a/packages/workflow-renderer/src/dimensions.ts
+++ b/packages/workflow-renderer/src/dimensions.ts
@@ -80,16 +80,30 @@ export const estimateNoteBlockHeight = (content: string) => {
   )
 }
 
+/**
+ * A container's box, and the gutter it keeps around the blocks inside it.
+ *
+ * Each padding is the gap between a child's edge and the container's, and
+ * nothing else. The header is counted once, by the child's own position, which
+ * `clampPositionToContainer` floors at `HEADER_HEIGHT + TOP_PADDING` — so these
+ * are the numbers you see, and three of them match because those three edges
+ * are only gutter.
+ *
+ * `RIGHT_PADDING` is the deliberate exception. The container's own output
+ * handle sits on that edge, so a child needs clearance there it does not need
+ * anywhere else. That makes it chrome rather than gutter, which is why it is
+ * not tied to the other three.
+ */
 export const CONTAINER_DIMENSIONS = {
   DEFAULT_WIDTH: 500,
   DEFAULT_HEIGHT: 300,
   MIN_WIDTH: 400,
   MIN_HEIGHT: 200,
   HEADER_HEIGHT: 50,
-  LEFT_PADDING: 16,
+  LEFT_PADDING: 24,
   RIGHT_PADDING: 80,
-  TOP_PADDING: 16,
-  BOTTOM_PADDING: 16,
+  TOP_PADDING: 24,
+  BOTTOM_PADDING: 24,
 } as const
 
 /**

--- a/packages/workflow-renderer/src/subflow/subflow-node-view.tsx
+++ b/packages/workflow-renderer/src/subflow/subflow-node-view.tsx
@@ -8,7 +8,7 @@ import {
   useStoreApi as useReactFlowStoreApi,
   useUpdateNodeInternals,
 } from 'reactflow'
-import { BLOCK_DIMENSIONS, HANDLE_POSITIONS } from '../dimensions'
+import { BLOCK_DIMENSIONS, CONTAINER_DIMENSIONS, HANDLE_POSITIONS } from '../dimensions'
 import { OverflowSpan } from '../lib/overflow-span'
 import type { DiffStatus } from '../types'
 import {
@@ -588,8 +588,8 @@ export function SubflowNodeView({
           aria-label={`Select ${blockName}`}
           onClick={onSelect}
           onKeyDown={(event) => handleKeyboardActivation(event, onSelect)}
-          className='workflow-drag-handle relative z-20 flex h-[40px] cursor-grab items-center justify-between px-2 [&:active]:cursor-grabbing'
-          style={{ pointerEvents: 'auto' }}
+          className='workflow-drag-handle relative z-20 flex cursor-grab items-center justify-between px-2 [&:active]:cursor-grabbing'
+          style={{ pointerEvents: 'auto', height: CONTAINER_DIMENSIONS.HEADER_HEIGHT }}
           data-subflow-header=''
         >
           <div
@@ -647,9 +647,16 @@ export function SubflowNodeView({
         )}
 
         <div
-          className='relative z-20 h-[calc(100%-40px)] pt-4 pr-[80px] pb-4 pl-4'
+          className='relative z-20'
           data-dragarea='true'
-          style={{ pointerEvents: 'none' }}
+          style={{
+            pointerEvents: 'none',
+            height: `calc(100% - ${CONTAINER_DIMENSIONS.HEADER_HEIGHT}px)`,
+            paddingTop: CONTAINER_DIMENSIONS.TOP_PADDING,
+            paddingRight: CONTAINER_DIMENSIONS.RIGHT_PADDING,
+            paddingBottom: CONTAINER_DIMENSIONS.BOTTOM_PADDING,
+            paddingLeft: CONTAINER_DIMENSIONS.LEFT_PADDING,
+          }}
         >
           <SubflowStartView
             parentId={id}

--- a/packages/workflow-renderer/src/workflow-block/workflow-block-border-mount.test.tsx
+++ b/packages/workflow-renderer/src/workflow-block/workflow-block-border-mount.test.tsx
@@ -13,6 +13,7 @@ import {
 import { createRoot, type Root } from 'react-dom/client'
 import { ReactFlowProvider } from 'reactflow'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { CONTAINER_DIMENSIONS } from '../dimensions'
 import {
   ERROR_SOURCE_HANDLE_POSITION,
   getCursorBranchSourceHandleId,
@@ -959,7 +960,10 @@ describe('WorkflowBlockBorder mount', () => {
     )
 
     const header = host.querySelector('[data-subflow-header]')
-    expect(header).toHaveClass('h-[40px]')
+    /* Height comes from `CONTAINER_DIMENSIONS`, which the layout math also
+       measures against — asserting the rendered value rather than a utility
+       class keeps the two from drifting apart again. */
+    expect(header).toHaveStyle({ height: `${CONTAINER_DIMENSIONS.HEADER_HEIGHT}px` })
     expect(header).not.toHaveClass('border-b')
     expect(header).not.toHaveClass('bg-[var(--surface-2)]')
     expect(host.querySelector('[data-subflow-type-tag="loop"]')).toHaveTextContent('Loop')

--- a/packages/workflow-renderer/vitest.setup.ts
+++ b/packages/workflow-renderer/vitest.setup.ts
@@ -1,3 +1,11 @@
+declare global {
+  /**
+   * React reads this to decide whether `act` is supported. It is not one of the
+   * ambient globals, so it has to be declared before it can be assigned.
+   */
+  var IS_REACT_ACT_ENVIRONMENT: boolean
+}
+
 /**
  * jest-dom only registers DOM matchers (`toHaveStyle`, `toHaveClass`, …), so it is
  * dead weight outside a DOM environment. This package's mount tests opt into jsdom
@@ -6,11 +14,10 @@
 if (typeof document !== 'undefined') {
   await import('@testing-library/jest-dom/vitest')
   /*
-   * React only treats `act` as supported when it can see this flag, and without
-   * it every render in the mount tests logs "The current testing environment is
-   * not configured to support act(...)". The warning is noise here — the tests
-   * already wrap their renders — but it buries real output, and React does not
-   * flush effects the way the tests assume until the flag is set.
+   * Without this React treats `act` as unsupported, and every render in the
+   * mount tests logs "The current testing environment is not configured to
+   * support act(...)" — around forty lines a run, which buries the output that
+   * matters when one of them fails.
    */
   globalThis.IS_REACT_ACT_ENVIRONMENT = true
 }

--- a/packages/workflow-renderer/vitest.setup.ts
+++ b/packages/workflow-renderer/vitest.setup.ts
@@ -5,4 +5,12 @@
  */
 if (typeof document !== 'undefined') {
   await import('@testing-library/jest-dom/vitest')
+  /*
+   * React only treats `act` as supported when it can see this flag, and without
+   * it every render in the mount tests logs "The current testing environment is
+   * not configured to support act(...)". The warning is noise here — the tests
+   * already wrap their renders — but it buries real output, and React does not
+   * flush effects the way the tests assume until the flag is set.
+   */
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
 }


### PR DESCRIPTION
## Summary
- A subflow renders at one size on load and then visibly grows a moment later, on every refresh.
- The container sizes itself from its children. When a child had not yet reported a height it used `estimateBlockDimensions` instead — a guess of `ceil(subBlockCount / 2)` rows clamped to `[3,7]`, which reads a 39-field Gmail card as **276px** tall against the **112px** it actually draws. The container painted that, the real height arrived a frame later, and it resized between the two.
- A card's height depends on what it actually renders — which rows survive its conditions, whether it draws a summary sentence, and for a reactive field even a credential it has to fetch (`useReactiveConditions` → `useWorkspaceCredential`). The card is the only thing that can know it. So: size only from heights children have themselves reported, and hold the container at its current size until they have.
- `getBlockDimensions` keeps the estimate for callers that only need a rough box (clamping a drag, placing a paste) and is now that same lookup plus the fallback, rather than a second copy of the policy.
- The gate reads `layout` (in-memory, written by `updateBlockLayoutMetrics` for cards and `updateNodeDimensions` for containers), not `height`/`data.height`. Those are persisted, so an unreported block can still carry last session's numbers and an unsized inner container hands back its 500x300 default — both of which the gate would otherwise treat as measured, and the second of which made nested containers resize twice.
- Separately, `calculateContainerDimensions` counted the container's chrome twice. Child coordinates are relative to the container's own origin and already held clear of the header by `clampPositionToContainer`, so a child's far edge is the distance to cover and only the trailing padding is owed. Adding the header and leading padding again left **every** container 66px taller and 16px wider than its contents.

For the reported workflow, the Loop went `300 → 565.5 → 401.5` on load. It now settles once, at `603 × 335.5` — the child's far edge plus exactly one padding.

## Type of Change
- [x] Bug fix

## Testing
New unit tests pin the sizing contract; two of them fail on the old math (`expected { width: 619, height: 401.5 } to deeply equal { width: 603, height: 335.5 }`, and `expected 82 to be 16` for the gap under a child). Full `utils` suite green (62), type-check and lint clean.

The two sizes were derived by running the real functions against the exported workflow state, and cross-checked against the reported screenshots: scaling both by the Gmail card's known 112px height (both at 0.58) gives container heights of ~412 and ~579 against the computed 401.5 and 565.5, with the child's offset staying ~207.5 in both. That also confirms the coordinate convention the padding fix depends on — children are positioned from the container's **outer** origin.

**Not verified in the running app.** I brought up `dev:full` but could not sign in to the local instance, so this is verified by unit test and arithmetic only.

## Follow-ups (not in this PR)
- **MCP blocks on the field-row path still resize once.** `estimateWorkflowBlockDimensions` is exact on the sentence path but deliberately biased high on the field-row path, because a `mcp-dynamic-args` field expands into one row per schema property when the card mounts. The bias is correct for autolayout (a gap beats an overlap) but still moves a container. It is fixable — contrary to that function's doc, the count *is* derivable from block state, since `_toolSchema` is an ordinary subblock value — but removing the slack changes autolayout spacing, so it wants its own change.
- `estimateWorkflowBlockDimensions` (`lib/workflows/autolayout/utils.ts`) already estimates from block *state* rather than type alone, and is far more accurate than `estimateBlockDimensions`. Routing the remaining estimate callers through it would fix the guess everywhere it is still painted (`workflow.tsx:2747` feeds it into React Flow node height, so selection bounds are 276px on a 112px card).
- `preview-workflow.tsx` re-implements `calculateContainerDimensions` — and already uses the corrected formula, independent corroboration that the double-count was a bug.
- `getNodeAbsolutePosition` hardcodes `headerHeight = 50 / leftPadding = 16 / topPadding = 16` and **adds** them to a child's position, which contradicts the outer-origin convention the rest of the code uses. It looks like a latent bug for nested containers, but it feeds reparenting math and deserves its own verification.
- **Containers still resize once per load, monotonically.** Correcting my own commit message: `block.height` and container `data.width`/`data.height` *are* persisted — what is missing is the write-back. `updateNodeDimensions` is a raw store action with no collaborative sync, and the realtime subflow-config handler re-floors `data` to 500x300, so a container paints the default on load and grows once when its children report. A tall loop still visibly grows from 300px each refresh. Removing that frame means writing the derived size back, which is a bigger change than this one.
- `updateContainerDimensionsDuringMove` (the drag path) still feeds `calculateContainerDimensions` estimates. Plausibly correct — a best-effort box while dragging — but it duplicates the gather loop.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

