### PR TITLE
fix(copilot): align principal lifetime with orchestration

### DIFF
--- a/apps/sim/lib/copilot/application/execute-workflow-use-case.test.ts
+++ b/apps/sim/lib/copilot/application/execute-workflow-use-case.test.ts
@@ -14,6 +14,7 @@ import {
   executeCopilotWorkflowUseCase,
   messageForCopilotWorkflowError,
 } from '@/lib/copilot/application/execute-workflow-use-case'
+import { ORCHESTRATION_TIMEOUT_MS } from '@/lib/copilot/constants'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 import { workflowOperations } from '@/lib/workflows/application/operations'
 
@@ -57,7 +58,7 @@ describe('Copilot Workflow application adapter', () => {
         delegationId: 'copilot-tool:tool-call-1',
         audience: 'sim:workflows',
         issuedAt: new Date('2026-01-01T00:00:00Z'),
-        expiresAt: new Date('2026-01-01T00:05:00Z'),
+        expiresAt: new Date(Date.now() + ORCHESTRATION_TIMEOUT_MS),
         resourceScope: { chatId: 'chat-1', executionId: 'execution-1' },
       },
       input: { workflowId: 'workflow-1', assertedWorkspaceId: 'workspace-1' },

--- a/apps/sim/lib/copilot/auth/application-delegation.ts
+++ b/apps/sim/lib/copilot/auth/application-delegation.ts
@@ -1,6 +1,8 @@
 import type { DelegatedPrincipal } from '@sim/auth/principal'
+import { ORCHESTRATION_TIMEOUT_MS } from '@/lib/copilot/constants'
 
-export const COPILOT_APPLICATION_DELEGATION_TTL_MS = 5 * 60 * 1000
+/** Keeps delegated authority valid for the full bounded Copilot orchestration lifetime. */
+export const COPILOT_APPLICATION_DELEGATION_TTL_MS = ORCHESTRATION_TIMEOUT_MS
 
 export interface CopilotExecutionContext {
   userId?: string

--- a/apps/sim/lib/copilot/auth/file-delegation.test.ts
+++ b/apps/sim/lib/copilot/auth/file-delegation.test.ts
@@ -8,6 +8,7 @@ import {
   messageForCopilotFileError,
   resolveCopilotFilePrincipal,
 } from '@/lib/copilot/auth/file-delegation'
+import { ORCHESTRATION_TIMEOUT_MS } from '@/lib/copilot/constants'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 
 const trustedContext = {
@@ -20,7 +21,7 @@ const trustedContext = {
 }
 
 describe('Copilot file delegation', () => {
-  it('creates a short-lived principal scoped to the trusted workspace and file', () => {
+  it('creates an orchestration-bounded principal scoped to the trusted workspace and file', () => {
     const principal = resolveCopilotFilePrincipal(trustedContext, 'file-1')
 
     expect(principal).toMatchObject({
@@ -36,7 +37,9 @@ describe('Copilot file delegation', () => {
         executionId: 'execution-1',
       },
     })
-    expect(principal.expiresAt.getTime()).toBeGreaterThan(principal.issuedAt.getTime())
+    expect(principal.expiresAt.getTime() - principal.issuedAt.getTime()).toBe(
+      ORCHESTRATION_TIMEOUT_MS
+    )
   })
 
   it('creates a workspace-scoped principal for file creation', () => {


### PR DESCRIPTION
## Summary
- Set Copilot delegated Principal TTL from the shared 60-minute orchestration timeout
- Add regression coverage for the exact delegation lifetime

## Type of Change
- [x] Bug fix

## Testing
- 17 focused Copilot delegation tests
- Full lint and 25 CI audits
- Sim and auth type-check

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)