### PR TITLE
fix(agent): show files in tool picker

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.test.ts
@@ -4,10 +4,28 @@
 import { describe, expect, it } from 'vitest'
 import type { StoredTool } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/types'
 import {
+  isAgentToolBlock,
   isCustomToolAlreadySelected,
   isMcpToolAlreadySelected,
   isWorkflowAlreadySelected,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/utils'
+
+describe('isAgentToolBlock', () => {
+  it('includes the current File block and excludes the legacy File block', () => {
+    expect(isAgentToolBlock({ type: 'file_v5', category: 'blocks', hideFromToolbar: false })).toBe(
+      true
+    )
+    expect(isAgentToolBlock({ type: 'file', category: 'blocks', hideFromToolbar: true })).toBe(
+      false
+    )
+  })
+
+  it('does not make every visible core block agent-callable', () => {
+    expect(isAgentToolBlock({ type: 'memory', category: 'blocks', hideFromToolbar: false })).toBe(
+      false
+    )
+  })
+})
 
 describe('isMcpToolAlreadySelected', () => {
   describe('basic functionality', () => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.test.ts
@@ -11,10 +11,13 @@ import {
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/utils'
 
 describe('isAgentToolBlock', () => {
-  it('includes the current File block and excludes the legacy File block', () => {
+  it('includes the current File block', () => {
     expect(isAgentToolBlock({ type: 'file_v5', category: 'blocks', hideFromToolbar: false })).toBe(
       true
     )
+  })
+
+  it('excludes hidden blocks such as the legacy File block', () => {
     expect(isAgentToolBlock({ type: 'file', category: 'blocks', hideFromToolbar: true })).toBe(
       false
     )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -46,6 +46,7 @@ import { ToolSubBlockRenderer } from '@/app/workspace/[workspaceId]/w/[workflowI
 import { clearDependentToolParams } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/param-dependents'
 import type { StoredTool } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/types'
 import {
+  isAgentToolBlock,
   isCustomToolAlreadySelected,
   isMcpToolAlreadySelected,
   isWorkflowAlreadySelected,
@@ -665,21 +666,7 @@ export const ToolInput = memo(function ToolInput({
 
   const customBlockOverlayVersion = useCustomBlockOverlayVersion()
   const toolBlocks = useMemo(() => {
-    const allToolBlocks = getAllBlocks().filter(
-      (block) =>
-        !block.hideFromToolbar &&
-        (block.category === 'tools' ||
-          block.type === 'api' ||
-          block.type === 'webhook_request' ||
-          block.type === 'workflow' ||
-          block.type === 'workflow_input' ||
-          block.type === 'knowledge' ||
-          block.type === 'function' ||
-          block.type === 'table') &&
-        block.type !== 'evaluator' &&
-        block.type !== 'mcp' &&
-        block.type !== 'file'
-    )
+    const allToolBlocks = getAllBlocks().filter(isAgentToolBlock)
     return filterBlocks(allToolBlocks)
   }, [filterBlocks, customBlockOverlayVersion])
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/utils.ts
@@ -12,8 +12,6 @@ const CORE_AGENT_TOOL_TYPES = new Set([
   'file_v5',
 ])
 
-const EXCLUDED_AGENT_TOOL_TYPES = new Set(['evaluator', 'mcp', 'file'])
-
 /**
  * Checks whether a registered block should appear in the agent tool picker.
  */
@@ -21,9 +19,7 @@ export function isAgentToolBlock(
   block: Pick<BlockConfig, 'category' | 'hideFromToolbar' | 'type'>
 ): boolean {
   return (
-    !block.hideFromToolbar &&
-    (block.category === 'tools' || CORE_AGENT_TOOL_TYPES.has(block.type)) &&
-    !EXCLUDED_AGENT_TOOL_TYPES.has(block.type)
+    !block.hideFromToolbar && (block.category === 'tools' || CORE_AGENT_TOOL_TYPES.has(block.type))
   )
 }
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/utils.ts
@@ -1,4 +1,31 @@
 import type { StoredTool } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/types'
+import type { BlockConfig } from '@/blocks/types'
+
+const CORE_AGENT_TOOL_TYPES = new Set([
+  'api',
+  'webhook_request',
+  'workflow',
+  'workflow_input',
+  'knowledge',
+  'function',
+  'table',
+  'file_v5',
+])
+
+const EXCLUDED_AGENT_TOOL_TYPES = new Set(['evaluator', 'mcp', 'file'])
+
+/**
+ * Checks whether a registered block should appear in the agent tool picker.
+ */
+export function isAgentToolBlock(
+  block: Pick<BlockConfig, 'category' | 'hideFromToolbar' | 'type'>
+): boolean {
+  return (
+    !block.hideFromToolbar &&
+    (block.category === 'tools' || CORE_AGENT_TOOL_TYPES.has(block.type)) &&
+    !EXCLUDED_AGENT_TOOL_TYPES.has(block.type)
+  )
+}
 
 /**
  * Checks if an MCP tool is already selected.

--- a/apps/sim/blocks/utils.test.ts
+++ b/apps/sim/blocks/utils.test.ts
@@ -69,6 +69,7 @@ vi.mock('@/lib/oauth/utils', () => ({
 
 import type { SubBlockConfig } from '@/blocks/types'
 import {
+  BUILT_IN_TOOL_TYPES,
   getApiKeyCondition,
   getDependsOnFields,
   getSubBlocksDependingOnChange,
@@ -76,6 +77,13 @@ import {
   parseOptionalJsonInput,
   parseOptionalNumberInput,
 } from '@/blocks/utils'
+
+describe('BUILT_IN_TOOL_TYPES', () => {
+  it('classifies the current File block instead of the legacy File block', () => {
+    expect(BUILT_IN_TOOL_TYPES.has('file_v5')).toBe(true)
+    expect(BUILT_IN_TOOL_TYPES.has('file')).toBe(false)
+  })
+})
 
 const BASE_CLOUD_MODELS: Record<string, string> = {
   'gpt-4o': 'openai',

--- a/apps/sim/blocks/utils.ts
+++ b/apps/sim/blocks/utils.ts
@@ -658,7 +658,7 @@ export function normalizeFileInput(
  */
 export const BUILT_IN_TOOL_TYPES = new Set([
   'api',
-  'file',
+  'file_v5',
   'function',
   'knowledge',
   'search',


### PR DESCRIPTION
## Summary

- add the current `file_v5` block to the Agent tool picker
- classify `file_v5`—rather than legacy `file`—as a built-in tool
- centralize Agent tool eligibility around visible integration tools and an explicit allowlist of supported core blocks
- remove the redundant legacy exclusion list; legacy File remains hidden, while the registry MCP and Evaluator blocks remain outside the positive allowlist
- add regression coverage for File eligibility and built-in classification

Dynamic tools fetched from configured MCP servers use a separate picker path and are unaffected.

## Type of Change

- [x] Bug fix

## Testing

- 90 targeted tests passed
- `bun run lint`
- block registry audit
- all 26 repository audits

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
