### PR TITLE
fix(chat): focus the composer when opening a new or existing chat

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -46,6 +46,16 @@ export type { FileAttachmentForApi } from '@/app/workspace/[workspaceId]/home/ty
 
 const logger = createLogger('UserInput')
 
+/**
+ * Whether the element is somewhere the user could be typing. Focusing the composer on mount
+ * must not steal focus from another field, but may take it from a link or button — opening a
+ * chat leaves the sidebar link focused, and the composer should win.
+ */
+function isTextEntry(element: HTMLElement): boolean {
+  const tag = element.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || element.isContentEditable
+}
+
 interface UserInputProps {
   defaultValue?: string
   draftScopeKey?: string
@@ -453,12 +463,10 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
 
   useEffect(() => {
     const raf = window.requestAnimationFrame(() => {
+      if (!document.hasFocus()) return
       const active = document.activeElement
-      const pageHasFocus = document.hasFocus()
-      const hasNeutralFocus = active === document.body || active === document.documentElement
-      if (pageHasFocus && hasNeutralFocus) {
-        textareaRef.current?.focus()
-      }
+      if (active instanceof HTMLElement && isTextEntry(active)) return
+      textareaRef.current?.focus()
     })
     return () => window.cancelAnimationFrame(raf)
   }, [textareaRef])


### PR DESCRIPTION
## Summary
- Clicking "New chat" or opening a chat from the sidebar left focus on the link, so the composer's mount-time focus was skipped and you had to click into the textarea before typing
- The mount effect only focused when `document.activeElement` was `body`/`documentElement`; it now focuses unless the active element is a real text-entry field (input/textarea/select/contenteditable), so it takes focus from a link or button but never steals it from another field

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)