### PR TITLE
fix(desktop): let sites copy to the clipboard in the browser tab

### DIFF
--- a/apps/desktop/src/main/browser-agent/session.test.ts
+++ b/apps/desktop/src/main/browser-agent/session.test.ts
@@ -1770,7 +1770,7 @@ describe('browser-agent session', () => {
     expect(event.preventDefault).toHaveBeenCalledOnce()
   })
 
-  it('permission handlers deny every request on the agent partition', () => {
+  it('permission handlers deny every request on the agent partition but the copy button', () => {
     const tab = session.ensureTab()
     const ses = (tab.view as unknown as MockView).webContents.session
     const requestHandler = ses.setPermissionRequestHandler.mock.calls[0][0] as (
@@ -1778,12 +1778,26 @@ describe('browser-agent session', () => {
       permission: string,
       callback: (granted: boolean) => void
     ) => void
-    const callback = vi.fn()
-    requestHandler(null, 'media', callback)
-    expect(callback).toHaveBeenCalledWith(false)
+    const checkHandler = ses.setPermissionCheckHandler.mock.calls[0][0] as (
+      wc: unknown,
+      permission: string
+    ) => boolean
 
-    const checkHandler = ses.setPermissionCheckHandler.mock.calls[0][0] as () => boolean
-    expect(checkHandler()).toBe(false)
+    // Reading the clipboard would leak whatever the user last copied anywhere
+    // else, so it stays denied alongside everything a page could spy through.
+    for (const permission of ['media', 'geolocation', 'notifications', 'clipboard-read']) {
+      const callback = vi.fn()
+      requestHandler(null, permission, callback)
+      expect(callback).toHaveBeenCalledWith(false)
+      expect(checkHandler(null, permission)).toBe(false)
+    }
+
+    // Chromium routes navigator.clipboard.writeText through this one; denying
+    // it silently broke every copy button that does not use execCommand.
+    const writeCallback = vi.fn()
+    requestHandler(null, 'clipboard-sanitized-write', writeCallback)
+    expect(writeCallback).toHaveBeenCalledWith(true)
+    expect(checkHandler(null, 'clipboard-sanitized-write')).toBe(true)
   })
 
   it('leaves nothing of the signed-out user behind in the browser profile', async () => {

--- a/apps/desktop/src/main/browser-agent/session.ts
+++ b/apps/desktop/src/main/browser-agent/session.ts
@@ -811,15 +811,34 @@ export async function importAgentCookies(
 }
 
 /**
+ * The single site permission a browsing surface cannot withhold: the one every
+ * "Copy" button on the web goes through. Blanket-denying it made
+ * `navigator.clipboard.writeText` reject with `NotAllowedError`, so those
+ * buttons did nothing at all — no error, no copied text — while the legacy
+ * `document.execCommand('copy')` path kept working, which is why only some
+ * sites looked broken.
+ *
+ * Granting it hands the page no reach it lacked: Chromium still requires the
+ * document to be focused and to hold a transient user activation, and a
+ * sanitized write only places text the page already renders onto the clipboard.
+ * Reading stays denied — that is the direction that would leak whatever the
+ * user last copied from anywhere else.
+ */
+const ALLOWED_SITE_PERMISSIONS = new Set(['clipboard-sanitized-write'])
+
+/**
  * Default-deny hardening for the agent partition. Site permissions remain
- * denied, while uploads use Chromium's native file chooser and downloads are
- * saved into the device-level browser download directory.
+ * denied apart from ALLOWED_SITE_PERMISSIONS, while uploads use Chromium's
+ * native file chooser and downloads are saved into the device-level browser
+ * download directory.
  */
 function configureAgentPartition(ses: Session): void {
   if (configuredPartitions.has(ses)) return
   configuredPartitions.add(ses)
-  ses.setPermissionRequestHandler((_wc, _permission, callback) => callback(false))
-  ses.setPermissionCheckHandler(() => false)
+  ses.setPermissionRequestHandler((_wc, permission, callback) =>
+    callback(ALLOWED_SITE_PERMISSIONS.has(permission))
+  )
+  ses.setPermissionCheckHandler((_wc, permission) => ALLOWED_SITE_PERMISSIONS.has(permission))
   // Service workers do not inherit a tab's user agent. With only the tab's set,
   // the document request carries the browser string while the worker's own
   // script request still announces Electron — and on a site that routes its


### PR DESCRIPTION
## Summary
- The browser tab's partition denied **every** site permission, which included `clipboard-sanitized-write` — the permission Chromium routes `navigator.clipboard.writeText` through. Copy buttons rejected with `NotAllowedError` and did nothing at all: no error shown, nothing copied.
- Sites still using the legacy `document.execCommand('copy')` kept working, which is why only some sites looked broken and the cause wasn't obvious.
- Allow that one permission. Reading the clipboard stays denied, along with media, geolocation, and notifications.

Granting it hands the page no reach it lacked: Chromium still requires the document to be focused and holding a transient user activation, and a sanitized write only places text the page already renders onto the clipboard. Clipboard *read* is the direction that would leak whatever the user last copied from anywhere else — that stays denied.

## Type of Change
- [x] Bug fix

## Testing
Measured against the app's exact partition configuration on a real Electron 43.1.1 runtime, with transient user activation (as a real copy-button click has):

**Before** — `navigator.clipboard.writeText` → `rejected: NotAllowedError Failed to execute 'writeText' on 'Clipboard': Write permission denied`, and `navigator.permissions.query({name:'clipboard-write'})` → `denied`.

**After** — `writeText` → `resolved`, permission query → `granted`, and the text actually landed on the system clipboard. Re-checked in the same run that the rest stay denied: `clipboard.readText()` → `NotAllowedError`, `Notification.requestPermission()` → `denied`, `geolocation.getCurrentPosition` → `denied: code 1`.

Unit test asserts the grant/deny split across `media`, `geolocation`, `notifications`, `clipboard-read` (denied) and `clipboard-sanitized-write` (granted); confirmed it fails when the fix is reverted. Type-check and lint pass.

Note: repo CI has been cancelling at `Install dependencies` on every branch including `staging` for several hours, so the CI signal here is unrelated to this change.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)