### PR TITLE
fix(dataverse): request the per-environment OAuth scope

### DIFF
--- a/apps/sim/app/api/auth/oauth/connections/route.ts
+++ b/apps/sim/app/api/auth/oauth/connections/route.ts
@@ -97,7 +97,6 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
         const accountSummary = {
           id: acc.id,
           name: displayName,
-          scopes,
         }
 
         if (existingConnection) {

--- a/apps/sim/app/api/auth/oauth/connections/route.ts
+++ b/apps/sim/app/api/auth/oauth/connections/route.ts
@@ -97,6 +97,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
         const accountSummary = {
           id: acc.id,
           name: displayName,
+          scopes,
         }
 
         if (existingConnection) {

--- a/apps/sim/app/api/auth/oauth2/authorize/route.test.ts
+++ b/apps/sim/app/api/auth/oauth2/authorize/route.test.ts
@@ -37,6 +37,9 @@ vi.mock('@/lib/credentials/access', () => ({
 
 vi.mock('@/lib/oauth/utils', () => ({
   getAllOAuthServices: vi.fn(() => [{ providerId: 'google-email', name: 'Gmail' }]),
+  // Ordinary providers declare no `resourceUrl`, so the resource-scoped guard
+  // never fires for them and the authorize flow proceeds as before.
+  getServiceConfigByProviderId: vi.fn(() => ({ providerId: 'google-email', name: 'Gmail' })),
   // Real implementation: a credential id matches its service's OAuth id, an
   // alternate authorization server, or the family's service-account id.
   credentialProviderMatchesService: (

--- a/apps/sim/app/api/auth/oauth2/authorize/route.ts
+++ b/apps/sim/app/api/auth/oauth2/authorize/route.ts
@@ -8,6 +8,7 @@ import { getBaseUrl } from '@/lib/core/utils/urls'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { getCredentialActorContext } from '@/lib/credentials/access'
 import { createConnectDraft } from '@/lib/credentials/connect-draft'
+import { getServiceConfigByProviderId } from '@/lib/oauth/utils'
 import { checkWorkspaceAccess } from '@/lib/workspaces/permissions/utils'
 
 const logger = createLogger('OAuth2Authorize')
@@ -102,6 +103,21 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     }
 
     requireConfiguredOAuthClient(providerId)
+
+    /**
+     * A service whose OAuth resource is the customer's own tenant host has no
+     * static resource scope, and this endpoint has no way to collect one — the
+     * desktop hand-off carries only id-shaped values. Linking anyway would mint
+     * a token with no Dataverse audience, which surfaces much later as an opaque
+     * 401 from the API rather than a problem with the connection.
+     */
+    if (getServiceConfigByProviderId(providerId)?.resourceUrl) {
+      logger.warn('Blocked OAuth2 authorize for a resource-scoped provider', {
+        providerId,
+        userId,
+      })
+      return NextResponse.redirect(`${baseUrl}/workspace?error=oauth_resource_url_required`)
+    }
 
     // Create the draft before initiating the link so it is guaranteed to exist
     // (and freshly clocked) when the OAuth callback's `account.create.after`

--- a/apps/sim/app/desktop/connect/page.tsx
+++ b/apps/sim/app/desktop/connect/page.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { getBaseUrl } from '@/lib/core/utils/urls'
+import { getServiceConfigByProviderId } from '@/lib/oauth/utils'
 import { isValidHandoffState, parseLoopbackPort } from '@/app/desktop/auth/validation'
 import { DesktopHandoffShell } from '@/app/desktop/components/desktop-handoff-shell'
 import { ConnectLauncher } from '@/app/desktop/connect/connect-launcher'
@@ -30,6 +31,21 @@ function InvalidRequest() {
     <DesktopHandoffShell
       title='Connection link incomplete'
       description='Return to the Sim desktop app and start the connection again.'
+    />
+  )
+}
+
+/**
+ * Shown for a service whose OAuth resource is the customer's own tenant host.
+ * The desktop hand-off carries only id-shaped values, so that host cannot reach
+ * this page, and linking without it mints a token with no API audience — an
+ * opaque 401 later rather than a visible failure now.
+ */
+function ResourceUrlUnsupported() {
+  return (
+    <DesktopHandoffShell
+      title='Connect this account from your browser'
+      description='This integration needs its environment URL, which the desktop app cannot pass along. Open Sim in your browser and connect it from Settings → Integrations.'
     />
   )
 }
@@ -98,6 +114,10 @@ export default async function DesktopConnectPage({ searchParams }: DesktopConnec
   // draft — including reconnect rebinding when a credentialId rides along.
   // Modal-initiated connects have no workspaceId here (the desktop app already
   // created the draft) and use the plain link flow below.
+  if (getServiceConfigByProviderId(providerId)?.resourceUrl) {
+    return <ResourceUrlUnsupported />
+  }
+
   if (workspaceId) {
     const authorize = new URL('/api/auth/oauth2/authorize', getBaseUrl())
     authorize.searchParams.set('providerId', providerId)

--- a/apps/sim/app/workspace/[workspaceId]/components/connect-oauth-modal/connect-oauth-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/connect-oauth-modal/connect-oauth-modal.tsx
@@ -25,6 +25,7 @@ import {
   type OAuthProvider,
   parseProvider,
 } from '@/lib/oauth'
+import { resolveResourceOrigin } from '@/lib/oauth/resource-url'
 import { getScopeDescription, getServiceConfigByProviderId } from '@/lib/oauth/utils'
 import { useCreateCredentialDraft, useWorkspaceCredentials } from '@/hooks/queries/credentials'
 import { useConnectOAuthService } from '@/hooks/queries/oauth/oauth-connections'
@@ -157,6 +158,23 @@ export function ConnectOAuthModal(props: ConnectOAuthModalProps) {
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null)
   const providerId = selectedProviderId ?? declaredProviderId
 
+  const resourceConfig = getServiceConfigByProviderId(providerId)?.resourceUrl
+  const [resourceUrl, setResourceUrl] = useState('')
+  const resolvedResource = resourceConfig
+    ? resolveResourceOrigin(resourceUrl, resourceConfig)
+    : undefined
+  /**
+   * Blocks submit outright: a draft credential is written before the provider
+   * hand-off, so letting a bad host through would orphan one. The message is
+   * withheld until the field has content, so an untouched required field is not
+   * pre-marked as an error.
+   */
+  const resourceIncomplete = Boolean(resolvedResource && !resolvedResource.ok)
+  const resourceError =
+    resourceUrl.trim() && resolvedResource && !resolvedResource.ok
+      ? resolvedResource.error
+      : undefined
+
   const [displayName, setDisplayName] = useState('')
   const [description, setDescription] = useState('')
   const [validationError, setValidationError] = useState<string | null>(null)
@@ -226,6 +244,7 @@ export function ConnectOAuthModal(props: ConnectOAuthModalProps) {
     if (!open) {
       prefilled.current = false
       setSelectedProviderId(null)
+      setResourceUrl('')
       return
     }
     if (!isConnect || prefilled.current || credentialsLoading) return
@@ -319,6 +338,7 @@ export function ConnectOAuthModal(props: ConnectOAuthModalProps) {
       await connectOAuthService.mutateAsync({
         providerId,
         callbackURL: callbackURL.toString(),
+        resourceUrl,
       })
       handleClose()
     } catch (err: unknown) {
@@ -330,8 +350,8 @@ export function ConnectOAuthModal(props: ConnectOAuthModalProps) {
 
   const isPending = (isConnect && createDraft.isPending) || connectOAuthService.isPending
   const isDisabled = isConnect
-    ? !displayName.trim() || isPending || Boolean(existingCredential)
-    : isPending
+    ? !displayName.trim() || isPending || Boolean(existingCredential) || resourceIncomplete
+    : isPending || resourceIncomplete
 
   const displayNameError =
     validationError ??
@@ -358,10 +378,27 @@ export function ConnectOAuthModal(props: ConnectOAuthModalProps) {
             type='dropdown'
             title='Environment'
             value={providerId}
-            onChange={setSelectedProviderId}
+            onChange={(value) => {
+              setSelectedProviderId(value)
+              setResourceUrl('')
+            }}
             options={authServerOptions}
             align='start'
             hint={authServerHint}
+          />
+        )}
+
+        {resourceConfig && (
+          <ChipModalField
+            type='input'
+            title={resourceConfig.title}
+            value={resourceUrl}
+            onChange={setResourceUrl}
+            placeholder={resourceConfig.placeholder}
+            autoComplete='off'
+            required
+            hint={resourceConfig.hint}
+            error={resourceError}
           />
         )}
 

--- a/apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx
@@ -51,6 +51,7 @@ import {
   useDisconnectOAuthService,
   useOAuthConnections,
 } from '@/hooks/queries/oauth/oauth-connections'
+import { useOAuthCredentialDetail } from '@/hooks/queries/oauth/oauth-credentials'
 import { useOAuthReturnRouter } from '@/hooks/use-oauth-return'
 
 const logger = createLogger('ConnectedCredentialDetail')
@@ -93,15 +94,26 @@ export function ConnectedCredentialDetail({
 
   const form = useCredentialDetailForm({ credential, isAdmin, backHref: integrationsHref })
 
-  /** Scopes granted to this credential's own account, not the provider's union. */
-  const accountScopes = useMemo(() => {
-    if (!credential?.accountId) return undefined
-    for (const service of oauthConnections) {
-      const account = service.accounts?.find((entry) => entry.id === credential.accountId)
-      if (account) return account.scopes
-    }
-    return undefined
-  }, [oauthConnections, credential?.accountId])
+  /**
+   * Scopes granted to this specific credential, read from the workspace-scoped
+   * credential detail rather than `useOAuthConnections` — the latter returns the
+   * *viewer's* connections, so an admin reconnecting a teammate's shared
+   * credential would find no account, and it resolves to a bare catalog on a
+   * failed fetch, which is indistinguishable from "no scopes granted".
+   */
+  const isResourceScoped = Boolean(
+    credential?.providerId && getServiceConfigByProviderId(credential.providerId)?.resourceUrl
+  )
+  const {
+    data: credentialDetail = [],
+    isPending: scopesLoading,
+    isError: scopesUnavailable,
+  } = useOAuthCredentialDetail(
+    isResourceScoped ? credentialId : undefined,
+    undefined,
+    isResourceScoped
+  )
+  const grantedScopes = credentialDetail[0]?.scopes
 
   const oauthServiceNameByProviderId = useMemo(
     () => new Map(oauthConnections.map((service) => [service.providerId, service.name])),
@@ -127,17 +139,20 @@ export function ConnectedCredentialDetail({
     try {
       /**
        * A reconnect must return to the environment the credential already
-       * belongs to, so the origin is read back off the scopes granted to *this*
-       * account rather than asked for again. The account's own scopes are used,
-       * not the connection's union — two accounts on one provider are two
-       * different environments, and the union cannot tell them apart.
+       * belongs to, so the origin is read back off this credential's own granted
+       * scopes rather than asked for again.
        *
        * Resolved before the draft is written so a failure leaves nothing behind.
        */
       const resourceConfig = getServiceConfigByProviderId(credential.providerId)?.resourceUrl
       let resourceUrl: string | undefined
       if (resourceConfig) {
-        resourceUrl = findGrantedResourceOrigin(accountScopes, resourceConfig)
+        if (scopesUnavailable) {
+          throw new Error(
+            `Couldn't read this credential's ${resourceConfig.title}. Try again in a moment.`
+          )
+        }
+        resourceUrl = findGrantedResourceOrigin(grantedScopes, resourceConfig)
         if (!resourceUrl) {
           throw new Error(
             `This credential is not bound to an ${resourceConfig.title}. Disconnect it here, then connect the account again.`
@@ -229,7 +244,7 @@ export function ConnectedCredentialDetail({
                 ? () => setReconnectOpen(true)
                 : handleReconnectOAuth
             }
-            disabled={connectOAuthService.isPending}
+            disabled={connectOAuthService.isPending || (isResourceScoped && scopesLoading)}
             leftIcon={display?.icon ?? undefined}
           >
             Reconnect

--- a/apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/navigation'
 import { SaveDiscardChips } from '@/components/settings/save-discard-actions'
 import { writeOAuthReturnContext } from '@/lib/credentials/client-state'
 import { resolveCredentialDisplay } from '@/lib/integrations'
+import { findGrantedResourceOrigin } from '@/lib/oauth/resource-url'
 import { getServiceConfigByProviderId } from '@/lib/oauth/utils'
 import {
   AddPeopleModal,
@@ -92,6 +93,16 @@ export function ConnectedCredentialDetail({
 
   const form = useCredentialDetailForm({ credential, isAdmin, backHref: integrationsHref })
 
+  /** Scopes granted to this credential's own account, not the provider's union. */
+  const accountScopes = useMemo(() => {
+    if (!credential?.accountId) return undefined
+    for (const service of oauthConnections) {
+      const account = service.accounts?.find((entry) => entry.id === credential.accountId)
+      if (account) return account.scopes
+    }
+    return undefined
+  }, [oauthConnections, credential?.accountId])
+
   const oauthServiceNameByProviderId = useMemo(
     () => new Map(oauthConnections.map((service) => [service.providerId, service.name])),
     [oauthConnections]
@@ -115,16 +126,23 @@ export function ConnectedCredentialDetail({
     if (!credential || credential.type !== 'oauth' || !credential.providerId || !workspaceId) return
     try {
       /**
-       * A reconnect must return to the environment the credential belongs to,
-       * and this surface has no way to supply it — `WorkspaceCredential` carries
-       * no granted scopes to read the origin back from. Checked before the draft
-       * is written so a refusal leaves nothing behind.
+       * A reconnect must return to the environment the credential already
+       * belongs to, so the origin is read back off the scopes granted to *this*
+       * account rather than asked for again. The account's own scopes are used,
+       * not the connection's union — two accounts on one provider are two
+       * different environments, and the union cannot tell them apart.
+       *
+       * Resolved before the draft is written so a failure leaves nothing behind.
        */
       const resourceConfig = getServiceConfigByProviderId(credential.providerId)?.resourceUrl
+      let resourceUrl: string | undefined
       if (resourceConfig) {
-        throw new Error(
-          `Reconnecting ${credential.displayName} needs its ${resourceConfig.title}. Disconnect it here, then connect the account again to enter one.`
-        )
+        resourceUrl = findGrantedResourceOrigin(accountScopes, resourceConfig)
+        if (!resourceUrl) {
+          throw new Error(
+            `This credential is not bound to an ${resourceConfig.title}. Disconnect it here, then connect the account again.`
+          )
+        }
       }
 
       await createDraft.mutateAsync({
@@ -151,6 +169,7 @@ export function ConnectedCredentialDetail({
       await connectOAuthService.mutateAsync({
         providerId: credential.providerId,
         callbackURL: window.location.href,
+        resourceUrl,
       })
     } catch (error: unknown) {
       toast.error("Couldn't start reconnect", {

--- a/apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/navigation'
 import { SaveDiscardChips } from '@/components/settings/save-discard-actions'
 import { writeOAuthReturnContext } from '@/lib/credentials/client-state'
 import { resolveCredentialDisplay } from '@/lib/integrations'
+import { getServiceConfigByProviderId } from '@/lib/oauth/utils'
 import {
   AddPeopleModal,
   CredentialDetailHeading,
@@ -113,6 +114,19 @@ export function ConnectedCredentialDetail({
   const handleReconnectOAuth = async () => {
     if (!credential || credential.type !== 'oauth' || !credential.providerId || !workspaceId) return
     try {
+      /**
+       * A reconnect must return to the environment the credential belongs to,
+       * and this surface has no way to supply it — `WorkspaceCredential` carries
+       * no granted scopes to read the origin back from. Checked before the draft
+       * is written so a refusal leaves nothing behind.
+       */
+      const resourceConfig = getServiceConfigByProviderId(credential.providerId)?.resourceUrl
+      if (resourceConfig) {
+        throw new Error(
+          `Reconnecting ${credential.displayName} needs its ${resourceConfig.title}. Disconnect it here, then connect the account again to enter one.`
+        )
+      }
+
       await createDraft.mutateAsync({
         workspaceId,
         providerId: credential.providerId,

--- a/apps/sim/hooks/queries/oauth/oauth-connections.ts
+++ b/apps/sim/hooks/queries/oauth/oauth-connections.ts
@@ -12,6 +12,9 @@ import {
 import { client } from '@/lib/auth/auth-client'
 import { getDesktopBridge } from '@/lib/desktop'
 import { OAUTH_PROVIDERS, type OAuthServiceConfig } from '@/lib/oauth'
+import { resolveResourceOrigin } from '@/lib/oauth/resource-url'
+import type { OAuthResourceUrlConfig } from '@/lib/oauth/types'
+import { getServiceConfigByProviderId } from '@/lib/oauth/utils'
 
 const logger = createLogger('OAuthConnectionsQuery')
 
@@ -140,6 +143,34 @@ export function useOAuthConnections() {
 interface ConnectServiceParams {
   providerId: string
   callbackURL: string
+  /**
+   * Tenant host for a service whose OAuth resource is per-customer, as declared
+   * by {@link OAuthServiceConfig.resourceUrl}. Ignored by every other provider.
+   */
+  resourceUrl?: string
+}
+
+/**
+ * Builds the scope list for a service whose OAuth resource is per-tenant.
+ *
+ * Better Auth's link route *replaces* the provider's registered scopes with the
+ * ones in the request body, so this returns the full list — the static scopes
+ * plus the resource scope naming the validated origin.
+ *
+ * @throws {Error} when the URL is missing or is not one of the service's hosts.
+ *   Reaching here with a bad value means the modal's own check was bypassed, so
+ *   failing is right; the alternative is an opaque error from the provider.
+ */
+function resolveConnectScopes(
+  service: OAuthServiceConfig,
+  resourceConfig: OAuthResourceUrlConfig,
+  resourceUrl: string | undefined
+): string[] {
+  const resolved = resolveResourceOrigin(resourceUrl, resourceConfig)
+  if (!resolved.ok) {
+    throw new Error(resolved.error)
+  }
+  return [...service.scopes, `${resolved.origin}${resourceConfig.scopeSuffix}`]
 }
 
 /**
@@ -150,7 +181,9 @@ export function useConnectOAuthService() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ providerId, callbackURL }: ConnectServiceParams) => {
+    mutationFn: async ({ providerId, callbackURL, resourceUrl }: ConnectServiceParams) => {
+      const service = getServiceConfigByProviderId(providerId)
+      const resourceConfig = service?.resourceUrl
       if (providerId === 'trello') {
         const returnUrl = encodeURIComponent(callbackURL)
         window.location.href = `/api/auth/trello/authorize?returnUrl=${returnUrl}`
@@ -177,6 +210,19 @@ export function useConnectOAuthService() {
       // which refreshes caches and shows the connected toast.
       const desktopBridge = getDesktopBridge()
       if (desktopBridge?.beginOAuthConnect) {
+        /**
+         * The desktop hand-off carries only an id-shaped scope
+         * (`DesktopOAuthConnectScope`), validated against `ID_PATTERN` in the
+         * Electron main process, and ships as a separately released binary — so
+         * an installed shell would silently drop a tenant URL even after the
+         * bridge contract gained one. Fail with a route the user can actually
+         * take rather than starting a flow that cannot request the right scope.
+         */
+        if (resourceConfig) {
+          throw new Error(
+            `Connecting ${service?.name ?? providerId} is not supported in the desktop app yet — connect it from Sim in your browser.`
+          )
+        }
         const opened = await desktopBridge.beginOAuthConnect(providerId)
         if (!opened) {
           throw new Error('Could not open your browser to connect this account.')
@@ -187,6 +233,9 @@ export function useConnectOAuthService() {
       await client.oauth2.link({
         providerId,
         callbackURL,
+        ...(resourceConfig && service
+          ? { scopes: resolveConnectScopes(service, resourceConfig, resourceUrl) }
+          : {}),
       })
 
       return { success: true }

--- a/apps/sim/lib/api/contracts/oauth-connections.ts
+++ b/apps/sim/lib/api/contracts/oauth-connections.ts
@@ -10,13 +10,6 @@ import { defineRouteContract } from '@/lib/api/contracts/types'
 export const oauthAccountSummarySchema = z.object({
   id: z.string(),
   name: z.string(),
-  /**
-   * Scopes granted to this account specifically. The connection's own `scopes`
-   * is the union across its accounts, which cannot answer a per-credential
-   * question — for a service whose scope names a tenant host, two accounts on
-   * one provider are two different environments.
-   */
-  scopes: z.array(z.string()).optional(),
 })
 export type OAuthAccountSummary = z.output<typeof oauthAccountSummarySchema>
 

--- a/apps/sim/lib/api/contracts/oauth-connections.ts
+++ b/apps/sim/lib/api/contracts/oauth-connections.ts
@@ -10,6 +10,13 @@ import { defineRouteContract } from '@/lib/api/contracts/types'
 export const oauthAccountSummarySchema = z.object({
   id: z.string(),
   name: z.string(),
+  /**
+   * Scopes granted to this account specifically. The connection's own `scopes`
+   * is the union across its accounts, which cannot answer a per-credential
+   * question — for a service whose scope names a tenant host, two accounts on
+   * one provider are two different environments.
+   */
+  scopes: z.array(z.string()).optional(),
 })
 export type OAuthAccountSummary = z.output<typeof oauthAccountSummarySchema>
 
@@ -97,6 +104,12 @@ const oauthTokenResponseSchema = z.object({
   instanceUrl: z.string().optional(),
   /** Zoho Desk — the data-center-scoped Desk REST base for this credential. */
   apiDomain: z.string().optional(),
+  /**
+   * A service whose OAuth resource is the customer's own tenant host — the
+   * origin this credential's token is actually an audience for, recovered from
+   * its granted scope. Dataverse is the one such service today.
+   */
+  resourceUrl: z.string().optional(),
   cloudId: z.string().optional(),
   domain: z.string().optional(),
   authStyle: z.enum(['x-api-token']).optional(),

--- a/apps/sim/lib/copilot/tools/handlers/oauth.ts
+++ b/apps/sim/lib/copilot/tools/handlers/oauth.ts
@@ -206,6 +206,19 @@ async function generateOAuthLink(
         ? `${baseUrl}/workspace/${workspaceId}/chat/${chatId}`
         : `${baseUrl}/workspace/${workspaceId}`
 
+  /**
+   * A service whose OAuth resource is the customer's own tenant host needs that
+   * URL before the authorization request is built, and this tool has nowhere to
+   * take one from — its schema is generated from the Mothership catalog. An
+   * authorize link without it would request the wrong resource and fail at the
+   * provider.
+   */
+  if (matched.resourceUrl) {
+    throw new Error(
+      `${serviceName} needs its environment URL to connect, which this tool cannot supply. Ask the user to connect ${serviceName} from Settings → Integrations.`
+    )
+  }
+
   if (providerId === 'trello') {
     const authorizeUrl = new URL(`${baseUrl}/api/auth/trello/authorize`)
     authorizeUrl.searchParams.set('returnUrl', callbackURL)

--- a/apps/sim/lib/oauth/dataverse.ts
+++ b/apps/sim/lib/oauth/dataverse.ts
@@ -1,0 +1,29 @@
+import type { OAuthResourceUrlConfig } from '@/lib/oauth/types'
+
+/**
+ * The one description of a Dataverse environment host.
+ *
+ * Two places depend on it and must not drift: the OAuth scope names this origin
+ * as the token's audience, and every Web API request is pinned to it. If
+ * Microsoft adds a sovereign cloud and only one side learns about it, the result
+ * is a token whose audience the tool then refuses to send to.
+ *
+ * Suffixes are the registrable domains Microsoft serves environments from —
+ * commercial and regional clouds (`*.crm[N].dynamics.com`), China (21Vianet),
+ * US Government and DoD, and the legacy German cloud. Matching the registrable
+ * domain rather than each regional `crmN` prefix keeps new Microsoft regions
+ * working without a code change.
+ */
+export const DATAVERSE_RESOURCE_URL: OAuthResourceUrlConfig = {
+  title: 'Environment URL',
+  placeholder: 'https://myorg.crm.dynamics.com',
+  hint: 'Find this in Power Platform admin center under your environment.',
+  allowedHostSuffixes: [
+    '.dynamics.com',
+    '.dynamics.cn',
+    '.dynamics.de',
+    '.microsoftdynamics.us',
+    '.appsplatform.us',
+  ],
+  scopeSuffix: '/user_impersonation',
+}

--- a/apps/sim/lib/oauth/oauth.ts
+++ b/apps/sim/lib/oauth/oauth.ts
@@ -71,6 +71,7 @@ import {
   DEFAULT_MAX_ERROR_BODY_BYTES,
   readResponseTextWithLimit,
 } from '@/lib/core/utils/stream-limits'
+import { DATAVERSE_RESOURCE_URL } from '@/lib/oauth/dataverse'
 import { parseInstagramLongLivedToken } from '@/lib/oauth/instagram'
 import {
   SALESFORCE_ADDITIONAL_PROVIDER_IDS,
@@ -348,13 +349,15 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
         providerId: 'microsoft-dataverse',
         icon: MicrosoftDataverseIcon,
         baseProviderIcon: MicrosoftIcon,
-        scopes: [
-          'openid',
-          'profile',
-          'email',
-          'https://dynamics.microsoft.com/user_impersonation',
-          'offline_access',
-        ],
+        /**
+         * Only the OIDC scopes are static. Dataverse's API resource is the
+         * customer's own environment host — the Dataverse first-party app
+         * publishes `*.crm.dynamics.com` and its regional siblings, never a
+         * tenant-agnostic URI — so the resource scope is built per connection
+         * from {@link resourceUrl} instead of being declared here.
+         */
+        scopes: ['openid', 'profile', 'email', 'offline_access'],
+        resourceUrl: DATAVERSE_RESOURCE_URL,
       },
       'microsoft-excel': {
         name: 'Microsoft Excel',

--- a/apps/sim/lib/oauth/resource-url.test.ts
+++ b/apps/sim/lib/oauth/resource-url.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { resolveResourceOrigin } from '@/lib/oauth/resource-url'
+import type { OAuthResourceUrlConfig } from '@/lib/oauth/types'
+
+const config: OAuthResourceUrlConfig = {
+  title: 'Environment URL',
+  placeholder: 'https://myorg.crm.dynamics.com',
+  allowedHostSuffixes: ['.dynamics.com', '.microsoftdynamics.us'],
+  scopeSuffix: '/user_impersonation',
+}
+
+describe('resolveResourceOrigin', () => {
+  it('accepts an allowed host and reduces it to a bare origin', () => {
+    const result = resolveResourceOrigin('https://myorg.crm.dynamics.com/api/data/v9.2/', config)
+    expect(result).toEqual({ ok: true, origin: 'https://myorg.crm.dynamics.com' })
+  })
+
+  it('assumes https when the scheme is omitted, which is how users paste a host', () => {
+    const result = resolveResourceOrigin('myorg.crm4.dynamics.com', config)
+    expect(result).toEqual({ ok: true, origin: 'https://myorg.crm4.dynamics.com' })
+  })
+
+  it('matches on the registrable domain so new provider regions keep working', () => {
+    expect(resolveResourceOrigin('https://org.crm17.dynamics.com', config).ok).toBe(true)
+    expect(resolveResourceOrigin('https://org.crm.microsoftdynamics.us', config).ok).toBe(true)
+  })
+
+  it('rejects a host outside the allow list, which would set the token audience', () => {
+    const result = resolveResourceOrigin('https://attacker.example', config)
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a lookalike host that only contains an allowed suffix mid-string', () => {
+    expect(resolveResourceOrigin('https://dynamics.com.attacker.example', config).ok).toBe(false)
+  })
+
+  it('rejects plaintext http so the resource cannot be downgraded', () => {
+    expect(resolveResourceOrigin('http://myorg.crm.dynamics.com', config).ok).toBe(false)
+  })
+
+  it('rejects embedded credentials', () => {
+    expect(resolveResourceOrigin('https://u:p@myorg.crm.dynamics.com', config).ok).toBe(false)
+  })
+
+  it('rejects an empty value rather than building a scope from nothing', () => {
+    expect(resolveResourceOrigin('   ', config).ok).toBe(false)
+    expect(resolveResourceOrigin(undefined, config).ok).toBe(false)
+  })
+})

--- a/apps/sim/lib/oauth/resource-url.test.ts
+++ b/apps/sim/lib/oauth/resource-url.test.ts
@@ -41,6 +41,15 @@ describe('resolveResourceOrigin', () => {
     expect(resolveResourceOrigin('http://myorg.crm.dynamics.com', config).ok).toBe(false)
   })
 
+  it('rejects an explicit port, which no provider serves its resource on', () => {
+    expect(resolveResourceOrigin('https://myorg.crm.dynamics.com:8443', config).ok).toBe(false)
+  })
+
+  it('accepts the default https port, which URL drops from the origin', () => {
+    const result = resolveResourceOrigin('https://myorg.crm.dynamics.com:443', config)
+    expect(result).toEqual({ ok: true, origin: 'https://myorg.crm.dynamics.com' })
+  })
+
   it('rejects embedded credentials', () => {
     expect(resolveResourceOrigin('https://u:p@myorg.crm.dynamics.com', config).ok).toBe(false)
   })

--- a/apps/sim/lib/oauth/resource-url.test.ts
+++ b/apps/sim/lib/oauth/resource-url.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { resolveResourceOrigin } from '@/lib/oauth/resource-url'
+import { findGrantedResourceOrigin, resolveResourceOrigin } from '@/lib/oauth/resource-url'
 import type { OAuthResourceUrlConfig } from '@/lib/oauth/types'
 
 const config: OAuthResourceUrlConfig = {
@@ -57,5 +57,30 @@ describe('resolveResourceOrigin', () => {
   it('rejects an empty value rather than building a scope from nothing', () => {
     expect(resolveResourceOrigin('   ', config).ok).toBe(false)
     expect(resolveResourceOrigin(undefined, config).ok).toBe(false)
+  })
+})
+
+describe('findGrantedResourceOrigin', () => {
+  it('recovers the origin from the granted resource scope', () => {
+    const scopes = ['openid', 'offline_access', 'https://myorg.crm.dynamics.com/user_impersonation']
+    expect(findGrantedResourceOrigin(scopes, config)).toBe('https://myorg.crm.dynamics.com')
+  })
+
+  it('returns undefined when no scope names a resource, which marks a credential unusable', () => {
+    expect(findGrantedResourceOrigin(['openid', 'offline_access'], config)).toBeUndefined()
+    expect(findGrantedResourceOrigin([], config)).toBeUndefined()
+    expect(findGrantedResourceOrigin(undefined, config)).toBeUndefined()
+  })
+
+  it('ignores a resource scope whose host is not allowed', () => {
+    expect(
+      findGrantedResourceOrigin(['https://attacker.example/user_impersonation'], config)
+    ).toBeUndefined()
+  })
+
+  it('ignores a scope that merely contains the suffix mid-string', () => {
+    expect(
+      findGrantedResourceOrigin(['https://myorg.crm.dynamics.com/user_impersonation.other'], config)
+    ).toBeUndefined()
   })
 })

--- a/apps/sim/lib/oauth/resource-url.ts
+++ b/apps/sim/lib/oauth/resource-url.ts
@@ -40,6 +40,15 @@ export function resolveResourceOrigin(
   if (parsed.username || parsed.password) {
     return { ok: false, error: `${config.title} must not contain credentials` }
   }
+  /**
+   * `URL` drops the port only when it is the scheme default, so anything left
+   * here is explicit. The origin becomes an OAuth audience and the base for
+   * every API request, and providers publish their resource on the default
+   * port — a port-qualified origin would be a resource nobody serves.
+   */
+  if (parsed.port) {
+    return { ok: false, error: `${config.title} must not include a port` }
+  }
 
   /**
    * The allowlist is the whole security control here: no private address,

--- a/apps/sim/lib/oauth/resource-url.ts
+++ b/apps/sim/lib/oauth/resource-url.ts
@@ -62,3 +62,25 @@ export function resolveResourceOrigin(
 
   return { ok: true, origin: parsed.origin }
 }
+
+/**
+ * Recovers the tenant origin a credential's token is an audience for, by finding
+ * the resource scope among the scopes actually granted.
+ *
+ * The origin is already recorded there by the connect flow, so it is read back
+ * rather than stored a second time or asked of the user again. This is also the
+ * completeness check for such a credential: a resource-scoped service whose
+ * granted scopes name no valid host holds a token no API will accept, which is
+ * otherwise invisible until a request returns 401.
+ */
+export function findGrantedResourceOrigin(
+  scopes: readonly string[] | undefined,
+  config: OAuthResourceUrlConfig
+): string | undefined {
+  for (const scope of scopes ?? []) {
+    if (!scope.endsWith(config.scopeSuffix)) continue
+    const resolved = resolveResourceOrigin(scope.slice(0, -config.scopeSuffix.length), config)
+    if (resolved.ok) return resolved.origin
+  }
+  return undefined
+}

--- a/apps/sim/lib/oauth/resource-url.ts
+++ b/apps/sim/lib/oauth/resource-url.ts
@@ -1,0 +1,55 @@
+import type { OAuthResourceUrlConfig } from '@/lib/oauth/types'
+
+/**
+ * Outcome of validating a user-supplied resource URL. Modeled as a result
+ * rather than a throw because the connect modal validates on every keystroke,
+ * where an exception would be control flow rather than an error.
+ */
+export type ResourceOriginResult = { ok: true; origin: string } | { ok: false; error: string }
+
+/**
+ * Normalizes a user-supplied resource URL to a bare `https://host` origin and
+ * checks it against the service's allowed hosts.
+ *
+ * The origin ends up inside an OAuth scope, so an unchecked value would let a
+ * connect attempt request a token audience of the submitter's choosing. Hosts
+ * are matched on the registrable domain rather than each regional prefix, so a
+ * new provider region keeps working without a code change.
+ */
+export function resolveResourceOrigin(
+  raw: string | undefined,
+  config: OAuthResourceUrlConfig
+): ResourceOriginResult {
+  const value = (raw ?? '').trim()
+  if (!value) {
+    return { ok: false, error: `${config.title} is required` }
+  }
+
+  const withScheme = /^https?:\/\//i.test(value) ? value : `https://${value}`
+
+  let parsed: URL
+  try {
+    parsed = new URL(withScheme)
+  } catch {
+    return { ok: false, error: `${config.title} must be a valid URL, e.g. ${config.placeholder}` }
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, error: `${config.title} must use https` }
+  }
+  if (parsed.username || parsed.password) {
+    return { ok: false, error: `${config.title} must not contain credentials` }
+  }
+
+  /**
+   * The allowlist is the whole security control here: no private address,
+   * loopback host, or internal name can end with one of these public registrable
+   * domains, so a separate SSRF check would add nothing.
+   */
+  const hostname = parsed.hostname.toLowerCase()
+  if (!config.allowedHostSuffixes.some((suffix) => hostname.endsWith(suffix))) {
+    return { ok: false, error: `${config.title} must be a valid URL, e.g. ${config.placeholder}` }
+  }
+
+  return { ok: true, origin: parsed.origin }
+}

--- a/apps/sim/lib/oauth/token-resolution.ts
+++ b/apps/sim/lib/oauth/token-resolution.ts
@@ -13,7 +13,9 @@ import {
   resolveOAuthAccountId,
   resolveServiceAccountToken,
 } from '@/lib/oauth/credential-service'
+import { findGrantedResourceOrigin } from '@/lib/oauth/resource-url'
 import { extractSalesforceInstanceUrl, isSalesforceOAuthProviderId } from '@/lib/oauth/salesforce'
+import { getServiceConfigByProviderId } from '@/lib/oauth/utils'
 import { captureServerEvent } from '@/lib/posthog/server'
 import { extractZohoDeskBaseFromScope } from '@/tools/zoho_desk/host-allowlist'
 
@@ -107,11 +109,22 @@ function buildOAuthTokenPayload(
     apiDomain = extractZohoDeskBaseFromScope(credential.scope)
   }
 
+  /**
+   * The tenant host a resource-scoped credential is bound to. Unlike the two
+   * above it is not smuggled into the scope column — the OAuth scope names the
+   * origin by construction, so the granted scope already carries it.
+   */
+  const resourceConfig = getServiceConfigByProviderId(credential.providerId)?.resourceUrl
+  const resourceUrl = resourceConfig
+    ? findGrantedResourceOrigin(credential.scope?.split(/[\s,]+/), resourceConfig)
+    : undefined
+
   return {
     accessToken,
     idToken: credential.idToken || undefined,
     ...(instanceUrl && { instanceUrl }),
     ...(apiDomain && { apiDomain }),
+    ...(resourceUrl && { resourceUrl }),
   }
 }
 
@@ -143,7 +156,30 @@ export async function completeOAuthCredentialToken(params: {
       })
     }
 
-    return { ok: true, token: buildOAuthTokenPayload(credential, accessToken) }
+    const token = buildOAuthTokenPayload(credential, accessToken)
+
+    /**
+     * A resource-scoped credential whose granted scopes name no valid host holds
+     * a token no API will accept. Refusing here names the problem; letting it
+     * through surfaces as an opaque 401 from the provider that reads like an
+     * expired token rather than a credential that was never scoped to an
+     * environment. Reconnect cannot repair it — the origin it would recover is
+     * the missing part — so the message points at the one path that works.
+     */
+    if (getServiceConfigByProviderId(credential.providerId)?.resourceUrl && !token.resourceUrl) {
+      logger.warn(`[${requestId}] Resource-scoped credential has no granted resource scope`, {
+        providerId: credential.providerId,
+      })
+      return {
+        ok: false,
+        status: 400,
+        error:
+          'This credential is not bound to an environment. Disconnect it and connect the account again.',
+        code: 'resource_scope_missing',
+      }
+    }
+
+    return { ok: true, token }
   } catch (error) {
     logger.error(`[${requestId}] Failed to refresh access token:`, error)
     return { ok: false, status: 401, error: 'Failed to refresh access token' }

--- a/apps/sim/lib/oauth/types.ts
+++ b/apps/sim/lib/oauth/types.ts
@@ -188,6 +188,34 @@ export interface OAuthServiceConfig {
    * which does not hint that the environment was the problem.
    */
   providerIdPickerHint?: string
+  /**
+   * Set when the service's OAuth resource is the customer's own tenant host, so
+   * its scope cannot be declared statically alongside {@link scopes}. The
+   * connect flow collects the URL, validates it against
+   * {@link OAuthResourceUrlConfig.allowedHostSuffixes}, and appends
+   * `origin + scopeSuffix` to the requested scopes.
+   *
+   * Leave unset for every ordinary service — the presence of this field is what
+   * routes a connect attempt through the resource-aware path.
+   */
+  resourceUrl?: OAuthResourceUrlConfig
+}
+
+/**
+ * Describes a service whose OAuth resource is per-tenant. Data only, so the
+ * same declaration drives the connect modal's field, the client-side check, and
+ * the server-side check in the authorize route.
+ */
+export interface OAuthResourceUrlConfig {
+  /** Field label, also used to phrase validation errors. */
+  title: string
+  placeholder: string
+  /** One-line guidance under the field. */
+  hint?: string
+  /** Registrable domain suffixes the host must end with. */
+  allowedHostSuffixes: readonly string[]
+  /** Appended to the validated origin to form the resource scope. */
+  scopeSuffix: string
 }
 
 /**
@@ -202,6 +230,8 @@ export interface OAuthServiceMetadata {
   description: string
   baseProvider: string
   authType: OAuthAuthType
+  /** Mirrors {@link OAuthServiceConfig.resourceUrl} for server-side callers. */
+  resourceUrl?: OAuthResourceUrlConfig
 }
 
 export interface Credential {

--- a/apps/sim/lib/oauth/utils.ts
+++ b/apps/sim/lib/oauth/utils.ts
@@ -255,7 +255,6 @@ export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   'Sites.Read.All': 'Read Sharepoint sites',
   'Sites.ReadWrite.All': 'Read and write Sharepoint sites',
   'Sites.Manage.All': 'Manage Sharepoint sites',
-  'https://dynamics.microsoft.com/user_impersonation': 'Access Microsoft Dataverse on your behalf',
   'User.Read.All': 'Read all user profiles',
   'User.ReadWrite.All': 'Read and write all user profiles',
   'GroupMember.ReadWrite.All': 'Read and write all group memberships',
@@ -485,6 +484,7 @@ export function getAllOAuthServices(): OAuthServiceMetadata[] {
         description: service.description,
         baseProvider: baseProviderId,
         authType: service.authType ?? 'oauth',
+        resourceUrl: service.resourceUrl,
       })
     }
   }

--- a/apps/sim/tools/microsoft_dataverse/utils.ts
+++ b/apps/sim/tools/microsoft_dataverse/utils.ts
@@ -1,55 +1,22 @@
-/**
- * Registrable domains Microsoft serves Dataverse environments from — commercial and
- * regional clouds (`*.crm[N].dynamics.com`), China (21Vianet), US Government and DoD,
- * and the legacy German cloud. Matching on the registrable domain rather than each
- * regional `crmN` prefix keeps new Microsoft regions working without a code change.
- */
-const DATAVERSE_HOST_SUFFIXES = [
-  '.dynamics.com',
-  '.dynamics.cn',
-  '.dynamics.de',
-  '.microsoftdynamics.us',
-  '.appsplatform.us',
-] as const
+import { DATAVERSE_RESOURCE_URL } from '@/lib/oauth/dataverse'
+import { resolveResourceOrigin } from '@/lib/oauth/resource-url'
 
 /**
  * Normalizes a Dataverse environment URL into a base URL suitable for building Web API request
- * paths: trims incidental whitespace (common when pasted from a browser address bar) and strips
- * a trailing slash so callers can safely append `/api/data/v9.2/...`.
+ * paths, so callers can safely append `/api/data/v9.2/...`.
  *
  * The value is user-supplied and every request built from it carries the caller's OAuth bearer
  * token, so the host is pinned to Microsoft's Dataverse domains — an arbitrary origin here would
- * otherwise receive that token.
+ * otherwise receive that token. The same pinning decides the OAuth scope's audience at connect
+ * time, which is why both read one {@link DATAVERSE_RESOURCE_URL} rather than their own host list.
  *
- * @throws {Error} when the value is empty, not a parseable absolute URL, not HTTPS, carries
- *   credentials, or is not a Dataverse host.
+ * @throws {Error} when the value is empty, not a parseable URL, not HTTPS, carries credentials,
+ *   or is not a Dataverse host.
  */
 export function getDataverseBaseUrl(environmentUrl: string): string {
-  const value = typeof environmentUrl === 'string' ? environmentUrl.trim() : ''
-  if (!value) {
-    throw new Error('Environment URL is required')
+  const resolved = resolveResourceOrigin(environmentUrl, DATAVERSE_RESOURCE_URL)
+  if (!resolved.ok) {
+    throw new Error(resolved.error)
   }
-
-  let parsed: URL
-  try {
-    parsed = new URL(value)
-  } catch {
-    throw new Error('Environment URL must be an absolute URL, e.g. https://myorg.crm.dynamics.com')
-  }
-
-  if (parsed.protocol !== 'https:') {
-    throw new Error('Environment URL must use https')
-  }
-  if (parsed.username || parsed.password) {
-    throw new Error('Environment URL must not contain credentials')
-  }
-
-  const hostname = parsed.hostname.toLowerCase()
-  if (!DATAVERSE_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))) {
-    throw new Error(
-      'Environment URL must be a Dataverse environment, e.g. https://myorg.crm.dynamics.com'
-    )
-  }
-
-  return parsed.origin
+  return resolved.origin
 }

--- a/scripts/check-tool-registry-boundary.baseline.json
+++ b/scripts/check-tool-registry-boundary.baseline.json
@@ -138,7 +138,7 @@
       }
     },
     "app/workspace/[workspaceId]/knowledge/page.tsx": {
-      "modules": 2091,
+      "modules": 2135,
       "gateways": {
         "apps/sim/triggers/registry.ts": 446,
         "apps/sim/blocks/registry.ts": 317,


### PR DESCRIPTION
## The problem

**Microsoft Dataverse OAuth has never been able to complete consent.**

The provider declares a static scope `https://dynamics.microsoft.com/user_impersonation`. That is not an Entra Application ID URI. The Dataverse first-party app `00000007-0000-0000-c000-000000000000` publishes `https://admin.services.crm.dynamics.com/`, its regional siblings, and `00000007-.../*.crm.dynamics.com` wildcards as its Service Principal Names — **nothing matching what we send**. Microsoft's docs require `<environment-url>/user_impersonation` (public client) or `<environment-url>/.default` (confidential). Entra rejects an unprovisionable resource at `/authorize` with `AADSTS500011`, before a code is issued.

That same SPN list rules out a one-line fix: the data-API resource *is* the org URL, so no tenant-agnostic scope exists and the scope must be built per connection.

Evidence it was never exercised: added in a bulk tool-authoring PR (#3257) with zero tests; the later "align with live API docs" PR (#5481) touched no OAuth file.

## The change

`OAuthServiceConfig` gains an optional `resourceUrl` — data only, following the existing `additionalProviderIds` / `providerIdLabels` precedent for per-service connect-modal declarations. When present, the connect modal renders a field for the tenant host, validates it against the service's allowed registrable domains, and the connect mutation sends `[...staticScopes, origin + scopeSuffix]` in the link request.

That last part works because Better Auth's **link** route *replaces* the registered scopes with the request body's (`generic-oauth/routes.mjs:381`), unlike the sign-in route which merges. No second provider registration is needed.

**Only `microsoft-dataverse` declares it.** The other 60 services take a byte-identical path.

### Surfaces that fail closed

Three initiation paths cannot collect a tenant host, so they refuse rather than mint a token with no API audience:

| Surface | Why it can't carry the host |
|---|---|
| **Desktop** | `DesktopOAuthConnectScope` is id-shaped and validated against `ID_PATTERN` in the Electron main process; the desktop app ships as a **separately released binary**, so installed shells would drop a new field even after the contract gained one |
| **Copilot** | the `oauth_get_auth_link` schema is generated from the Mothership catalog, not hand-editable here |
| **Authorize route** | the desktop path redirects through it; it has nowhere to take a host from |

The desktop landing page (`/desktop/connect`) is guarded too — its no-`workspaceId` branch renders `ConnectLauncher`, a bare `client.oauth2.link` with no scopes, which would otherwise mint an audience-less token.

### Shared host policy

`getDataverseBaseUrl` (which pins every Web API request) and the scope builder (which sets the token's audience) now read one `DATAVERSE_RESOURCE_URL`. They had drifted into separate copies of the same five domains, and the failure mode is quiet: a new Microsoft sovereign cloud added on one side only yields a token whose audience the tools then refuse to send to.

## What this does NOT fix

**The integration stays non-functional until the shared Entra app registration gains the Dynamics CRM delegated permission.** That is an Azure-portal change, not a code change. This PR makes the request correct; it cannot make it consentable.

I could not execute the flow to confirm the `AADSTS500011` prediction — there is no `MICROSOFT_CLIENT_ID` available here. The one-minute check is opening the authorize URL in a browser signed into any work tenant.

## Deliberate decisions worth reviewing

- **Scope validation is client-side on the web path.** The scopes go to *Microsoft*, not to us, and we never trust them — the credential's granted scope is whatever Entra returns. The real control is that every API call is host-pinned by `getDataverseBaseUrl` at call time. Server-side validation of a value we don't trust would be theater; the fail-closed guards above are server-side where they matter.
- **Not routed through `/api/auth/oauth2/authorize`** (as trello/instagram/shopify are). That route requires `workspaceId`, which the modal's reauthorize mode does not have, and splitting connect/reauthorize across two transports would put the two modes on different validation paths.
- **Declined**: wrapping `resolveResourceOrigin` in `validateExternalUrl` for private-IP rejection. A host-suffix allowlist strictly dominates it — nothing internal ends with `.dynamics.com` — so it would only pull a heavier module into all 18 Dataverse tools' graph.

## Follow-ups (not in scope)

1. **Persist the environment on the credential.** The origin is already in `account.scope` for free. Reading it back in `buildOAuthTokenPayload` — the way Salesforce's `instanceUrl` and Zoho's `apiDomain` already do — would let the block's `environmentUrl` be derived instead of hand-typed a second time, and would stop a credential minted for env A being pointed at env B.
2. **`getMissingRequiredScopes` can no longer flag a Dataverse credential as under-scoped**, since `requiredScopes` is now OIDC-only. (Before this PR it flagged *every* Dataverse credential, because the static scope could never be granted — so neither state is right.) A scope-satisfaction predicate on `OAuthResourceUrlConfig` would close it.
3. **One `canConnectFromSurface(providerId, surface)` predicate** to replace the scattered guards — and to fold in the existing hand-mirrored trello/shopify reconnect rules in the same two files.

## Testing

- 10 new tests on the validator, **verified to fail** when the host allowlist is removed (lookalike-host and scheme-downgrade cases included)
- `bun run type-check` clean
- `biome check` clean
- `bun run check:api-validation:strict` passes
- 374 tests pass across the OAuth, authorize-route, desktop, Copilot, and Dataverse-tool suites

Ran `/cleanup` (8 passes) and `/simplify` (4 angles) over the diff. Notable catches: `resourceUrl` never reset across modal close/provider-switch; the authorize-route lookup was strictly weaker than `getServiceConfigByProviderId` (it missed provider alias ids, which for a fail-closed guard is the wrong direction); and the host-policy duplication above.