### PR TITLE
fix(knowledge): remove caution triangle overlay from connector icon

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connectors-section/connectors-section.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connectors-section/connectors-section.tsx
@@ -358,27 +358,22 @@ function ConnectorCard({
     >
       <div className='flex items-center justify-between gap-2 px-2 py-2'>
         <div className='flex min-w-0 items-center gap-2.5'>
-          <div className='relative size-9 flex-shrink-0'>
-            <div
-              className={cn(
-                'flex size-full items-center justify-center rounded-xl border',
-                brandBg
-                  ? 'border-[var(--border-1)]'
-                  : 'border-[var(--border-muted)] bg-[var(--surface-4)]'
-              )}
-              style={brandBg ? { background: brandBg } : undefined}
-            >
-              {Icon && (
-                <Icon
-                  className={cn(
-                    'size-5',
-                    brandBg ? getTileIconColorClass(brandBg) : 'text-[var(--text-icon)]'
-                  )}
-                />
-              )}
-            </div>
-            {connector.status === 'disabled' && (
-              <TriangleAlert className='-right-0.5 -top-0.5 absolute size-3 text-[var(--caution)]' />
+          <div
+            className={cn(
+              'flex size-9 flex-shrink-0 items-center justify-center rounded-xl border',
+              brandBg
+                ? 'border-[var(--border-1)]'
+                : 'border-[var(--border-muted)] bg-[var(--surface-4)]'
+            )}
+            style={brandBg ? { background: brandBg } : undefined}
+          >
+            {Icon && (
+              <Icon
+                className={cn(
+                  'size-5',
+                  brandBg ? getTileIconColorClass(brandBg) : 'text-[var(--text-icon)]'
+                )}
+              />
             )}
           </div>
           <div className='flex min-w-0 flex-col gap-0.5'>


### PR DESCRIPTION
## Summary
- Remove the caution triangle badge overlaid on the connector icon in the Connected Sources modal when a connector is disabled
- Collapse the now-redundant relative wrapper so the icon tile is a single element
- The disabled state is still conveyed by the "Disabled" badge and the callout below

## Type of Change
- [x] Bug fix

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)