### PR TITLE
fix(access-control): default every operation and model picker to one the permission group allows

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/combobox/combobox.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/combobox/combobox.tsx
@@ -15,7 +15,6 @@ import { useAccessibleReferencePrefixes } from '@/app/workspace/[workspaceId]/w/
 import type { SubBlockConfig } from '@/blocks/types'
 import { getDependsOnFields } from '@/blocks/utils'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
-import { getProviderFromModel } from '@/providers/utils'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 
 /**
@@ -108,30 +107,18 @@ export const ComboBox = memo(function ComboBox({
   const value = isPreview ? previewValue : propValue !== undefined ? propValue : storeValue
 
   // Permission-based filtering for model dropdowns
-  const {
-    isProviderAllowed,
-    isModelAllowed,
-    isLoading: isPermissionLoading,
-  } = usePermissionConfig()
+  const { isModelUsable, isLoading: isPermissionLoading } = usePermissionConfig()
 
   // Evaluate static options if provided as a function
   const staticOptions = useMemo(() => {
     const opts = typeof options === 'function' ? options() : options
 
     if (subBlockId === 'model') {
-      return opts.filter((opt) => {
-        const modelId = typeof opt === 'string' ? opt : opt.id
-        if (!isModelAllowed(modelId)) return false
-        try {
-          return isProviderAllowed(getProviderFromModel(modelId))
-        } catch {
-          return true
-        }
-      })
+      return opts.filter((opt) => isModelUsable(typeof opt === 'string' ? opt : opt.id))
     }
 
     return opts
-  }, [options, subBlockId, isProviderAllowed, isModelAllowed])
+  }, [options, subBlockId, isModelUsable])
 
   const {
     fetchedOptions,
@@ -210,15 +197,7 @@ export const ComboBox = memo(function ComboBox({
       fetchOptions && normalizedFetchedOptions.length > 0 ? normalizedFetchedOptions : staticOptions
 
     if (subBlockId === 'model' && fetchOptions && normalizedFetchedOptions.length > 0) {
-      opts = opts.filter((opt) => {
-        const modelId = typeof opt === 'string' ? opt : opt.id
-        if (!isModelAllowed(modelId)) return false
-        try {
-          return isProviderAllowed(getProviderFromModel(modelId))
-        } catch {
-          return true
-        }
-      })
+      opts = opts.filter((opt) => isModelUsable(typeof opt === 'string' ? opt : opt.id))
     }
 
     // Merge hydrated option if not already present
@@ -251,8 +230,7 @@ export const ComboBox = memo(function ComboBox({
     hydratedOption,
     createdOption,
     subBlockId,
-    isProviderAllowed,
-    isModelAllowed,
+    isModelUsable,
   ])
 
   // Convert options to Combobox format

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/dropdown/dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/dropdown/dropdown.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { ChipTag, Combobox, type ComboboxOption } from '@sim/emcn'
 import { generateId } from '@sim/utils/id'
 import { isRecordLike } from '@sim/utils/object'
+import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
 import { formatDisplayText } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/formatted-text'
 import { getWorkflowSearchLabelHighlight } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/workflow-search-highlight'
 import { useFetchedOptions } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-fetched-options'
@@ -11,11 +12,13 @@ import { getBlock } from '@/blocks/registry'
 import type { SubBlockConfig } from '@/blocks/types'
 import { getDependsOnFields } from '@/blocks/utils'
 import { ResponseBlockHandler } from '@/executor/handlers/response/response-handler'
-import { usePermissionConfig } from '@/hooks/use-permission-config'
+import { useOperationAccess } from '@/hooks/use-operation-access'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 /** Selected-value badges shown before folding the rest into a "+N" badge. */
 const MAX_VISIBLE_MULTI_SELECT_BADGES = 2
+
+const EMPTY_DENIED_OPERATIONS: ReadonlySet<string> = new Set()
 
 /**
  * Dropdown option type - can be a simple string or an object with label, id, and optional icon.
@@ -97,7 +100,7 @@ export const Dropdown = memo(function Dropdown({
   preserveLabelCase = false,
 }: DropdownProps) {
   const activeSearchTarget = useActiveSearchTarget()
-  const { isToolAllowed } = usePermissionConfig()
+  const { getDeniedOperations, resolveDefaultOperation } = useOperationAccess()
   const [storeValue, setStoreValue] = useSubBlockValue<string | string[]>(blockId, subBlockId) as [
     string | string[] | null | undefined,
     (value: string | string[]) => void,
@@ -189,26 +192,17 @@ export const Dropdown = memo(function Dropdown({
 
   /**
    * Operation IDs whose resolved tool is denied by the caller's permission
-   * group. Only the `operation` selector of a block with a tool selector is
-   * gated. Denied operations are hidden from the picker (still resolvable for
-   * label display); the server is the authoritative gate regardless.
+   * group. Only the `operation` selector is gated. Denied operations are hidden
+   * from the picker (still resolvable for label display); the server is the
+   * authoritative gate regardless.
    */
   const deniedOperationIds = useMemo(() => {
-    const denied = new Set<string>()
-    if (subBlockId !== 'operation') return denied
-    const selectTool = blockConfig?.tools?.config?.tool
-    if (!selectTool) return denied
-    for (const opt of allOptions) {
-      const optionId = typeof opt === 'string' ? opt : opt.id
-      try {
-        const toolId = selectTool({ operation: optionId })
-        if (toolId && !isToolAllowed(toolId)) denied.add(optionId)
-      } catch {
-        // Unresolvable from the operation alone — leave it visible; the server still enforces.
-      }
-    }
-    return denied
-  }, [subBlockId, blockConfig, allOptions, isToolAllowed])
+    if (subBlockId !== OPERATION_SUBBLOCK_ID) return EMPTY_DENIED_OPERATIONS
+    return getDeniedOperations(
+      blockConfig,
+      allOptions.map((opt) => (typeof opt === 'string' ? opt : opt.id))
+    )
+  }, [subBlockId, blockConfig, allOptions, getDeniedOperations])
 
   const comboboxOptions = useMemo((): ComboboxOption[] => {
     const toLabel = (raw: string) => (preserveLabelCase ? raw : raw.toLowerCase())
@@ -232,17 +226,23 @@ export const Dropdown = memo(function Dropdown({
   const defaultOptionValue = useMemo(() => {
     if (multiSelect) return undefined
 
-    const firstSelectable = comboboxOptions.find((opt) => !opt.hidden)
-    if (defaultValue !== undefined) {
-      // Don't seed a denied operation as the default; use the first allowed option.
-      if (deniedOperationIds.has(defaultValue)) {
-        return firstSelectable?.value
-      }
-      return defaultValue
+    const selectableIds = comboboxOptions.filter((opt) => !opt.hidden).map((opt) => opt.value)
+
+    /**
+     * The operation field defaults through the permission gate, which withholds
+     * a value until the group config has loaded. Seeding the static first
+     * option in that window would persist an operation the group denies —
+     * nothing revisits a field that already holds a value, so the correction
+     * that arrives with the config would never apply.
+     */
+    if (subBlockId === OPERATION_SUBBLOCK_ID) {
+      return resolveDefaultOperation(blockConfig, selectableIds, defaultValue)
     }
 
-    return firstSelectable?.value
-  }, [defaultValue, comboboxOptions, deniedOperationIds, multiSelect])
+    if (defaultValue !== undefined) return defaultValue
+
+    return selectableIds[0]
+  }, [defaultValue, comboboxOptions, multiSelect, subBlockId, blockConfig, resolveDefaultOperation])
 
   useEffect(() => {
     if (multiSelect || defaultOptionValue === undefined) {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/dropdown/dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/dropdown/dropdown.tsx
@@ -2,7 +2,10 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { ChipTag, Combobox, type ComboboxOption } from '@sim/emcn'
 import { generateId } from '@sim/utils/id'
 import { isRecordLike } from '@sim/utils/object'
-import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
+import {
+  NO_DENIED_OPERATIONS,
+  OPERATION_SUBBLOCK_ID,
+} from '@/lib/permission-groups/operation-access'
 import { formatDisplayText } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/formatted-text'
 import { getWorkflowSearchLabelHighlight } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/workflow-search-highlight'
 import { useFetchedOptions } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-fetched-options'
@@ -17,8 +20,6 @@ import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 /** Selected-value badges shown before folding the rest into a "+N" badge. */
 const MAX_VISIBLE_MULTI_SELECT_BADGES = 2
-
-const EMPTY_DENIED_OPERATIONS: ReadonlySet<string> = new Set()
 
 /**
  * Dropdown option type - can be a simple string or an object with label, id, and optional icon.
@@ -197,7 +198,7 @@ export const Dropdown = memo(function Dropdown({
    * authoritative gate regardless.
    */
   const deniedOperationIds = useMemo(() => {
-    if (subBlockId !== OPERATION_SUBBLOCK_ID) return EMPTY_DENIED_OPERATIONS
+    if (subBlockId !== OPERATION_SUBBLOCK_ID) return NO_DENIED_OPERATIONS
     return getDeniedOperations(
       blockConfig,
       allOptions.map((opt) => (typeof opt === 'string' ? opt : opt.id))
@@ -226,8 +227,6 @@ export const Dropdown = memo(function Dropdown({
   const defaultOptionValue = useMemo(() => {
     if (multiSelect) return undefined
 
-    const selectableIds = comboboxOptions.filter((opt) => !opt.hidden).map((opt) => opt.value)
-
     /**
      * The operation field defaults through the permission gate, which withholds
      * a value until the group config has loaded. Seeding the static first
@@ -236,12 +235,13 @@ export const Dropdown = memo(function Dropdown({
      * that arrives with the config would never apply.
      */
     if (subBlockId === OPERATION_SUBBLOCK_ID) {
+      const selectableIds = comboboxOptions.filter((opt) => !opt.hidden).map((opt) => opt.value)
       return resolveDefaultOperation(blockConfig, selectableIds, defaultValue)
     }
 
     if (defaultValue !== undefined) return defaultValue
 
-    return selectableIds[0]
+    return comboboxOptions.find((opt) => !opt.hidden)?.value
   }, [defaultValue, comboboxOptions, multiSelect, subBlockId, blockConfig, resolveDefaultOperation])
 
   useEffect(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/dropdown/dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/dropdown/dropdown.tsx
@@ -101,7 +101,7 @@ export const Dropdown = memo(function Dropdown({
   preserveLabelCase = false,
 }: DropdownProps) {
   const activeSearchTarget = useActiveSearchTarget()
-  const { getDeniedOperations, resolveDefaultOperation } = useOperationAccess()
+  const { getDeniedOperations, resolveDefaultOperation, isPermissionLoading } = useOperationAccess()
   const [storeValue, setStoreValue] = useSubBlockValue<string | string[]>(blockId, subBlockId) as [
     string | string[] | null | undefined,
     (value: string | string[]) => void,
@@ -437,7 +437,9 @@ export const Dropdown = memo(function Dropdown({
       onChange={handleChange}
       onMultiSelectChange={handleMultiSelectChange}
       placeholder={placeholder}
-      disabled={disabled}
+      /* The operation list only drops denied entries once the config resolves,
+         and a pick here persists — matching the agent tool selector. */
+      disabled={disabled || (subBlockId === OPERATION_SUBBLOCK_ID && isPermissionLoading)}
       editable={false}
       onOpenChange={handleOpenChange}
       overlayContent={multiSelectOverlay ?? singleSelectOverlay}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -694,9 +694,8 @@ export const ToolInput = memo(function ToolInput({
   const customBlockOverlayVersion = useCustomBlockOverlayVersion()
   const toolBlocks = useMemo(() => {
     const allToolBlocks = getAllBlocks().filter(isAgentToolBlock)
-    /* A multi-operation block whose every operation is denied has nothing the
-       caller can run, so it leaves the picker alongside the blocks denied
-       outright by `filterBlocks`. */
+    /* An empty option list means the block declares no selectable operation, so
+       there is nothing to gate — only a wholly denied one leaves the picker. */
     return filterBlocks(allToolBlocks).filter((block) => {
       if (!hasMultipleOperations(block)) return true
       const { options, denied } = getOperationChoices(block)
@@ -818,7 +817,7 @@ export const ToolInput = memo(function ToolInput({
       if (isPreview || disabled) return
 
       const { options, denied } = hasMultipleOperations(toolBlock)
-        ? getOperationChoices(toolBlock ?? undefined)
+        ? getOperationChoices(toolBlock)
         : { options: [], denied: NO_DENIED_OPERATIONS }
       const defaultOperation = options.find((option) => !denied.has(option.id))?.id
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -26,7 +26,10 @@ import {
 } from '@/lib/mcp/tool-validation'
 import type { McpToolSchema } from '@/lib/mcp/types'
 import { getProviderIdFromServiceId, type OAuthProvider, type OAuthService } from '@/lib/oauth'
-import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
+import {
+  NO_DENIED_OPERATIONS,
+  OPERATION_SUBBLOCK_ID,
+} from '@/lib/permission-groups/operation-access'
 import { extractInputFieldsFromBlocks } from '@/lib/workflows/input-format'
 import { resolveStoredToolName } from '@/lib/workflows/subblocks/display'
 import { buildToolSubBlockId } from '@/lib/workflows/tool-input/synthetic-subblocks'
@@ -666,18 +669,24 @@ export const ToolInput = memo(function ToolInput({
   const { getDeniedOperations } = useOperationAccess()
 
   /**
-   * A tool block's operations minus the ones the caller's permission group
-   * denies, so this surface never offers — or silently defaults to — an
-   * operation that would be rejected at execution.
+   * A tool block's selectable operations paired with the ones the caller's
+   * permission group denies.
+   *
+   * Both callers derive from this single result so they cannot drift: the
+   * picker *removes* denied operations (it must never offer or default to one),
+   * while the editor's selector *hides* them (a tool already saved on one keeps
+   * showing its name).
    */
-  const getAllowedOperationOptions = useCallback(
+  const getOperationChoices = useCallback(
     (block: BlockConfig | undefined) => {
-      const options = getOperationOptions(block)
-      const denied = getDeniedOperations(
-        block,
-        options.map((option) => option.id)
-      )
-      return denied.size === 0 ? options : options.filter((option) => !denied.has(option.id))
+      const options = getOperationOptions(block).filter((option) => option.id !== '')
+      return {
+        options,
+        denied: getDeniedOperations(
+          block,
+          options.map((option) => option.id)
+        ),
+      }
     },
     [getDeniedOperations]
   )
@@ -688,10 +697,12 @@ export const ToolInput = memo(function ToolInput({
     /* A multi-operation block whose every operation is denied has nothing the
        caller can run, so it leaves the picker alongside the blocks denied
        outright by `filterBlocks`. */
-    return filterBlocks(allToolBlocks).filter(
-      (block) => !hasMultipleOperations(block) || getAllowedOperationOptions(block).length > 0
-    )
-  }, [filterBlocks, customBlockOverlayVersion, getAllowedOperationOptions])
+    return filterBlocks(allToolBlocks).filter((block) => {
+      if (!hasMultipleOperations(block)) return true
+      const { options, denied } = getOperationChoices(block)
+      return options.length === 0 || options.some((option) => !denied.has(option.id))
+    })
+  }, [filterBlocks, customBlockOverlayVersion, getOperationChoices])
 
   const hasBackfilledRef = useRef(false)
   useEffect(() => {
@@ -806,9 +817,10 @@ export const ToolInput = memo(function ToolInput({
     (toolBlock: (typeof toolBlocks)[0]) => {
       if (isPreview || disabled) return
 
-      const hasOperations = hasMultipleOperations(toolBlock)
-      const operationOptions = hasOperations ? getAllowedOperationOptions(toolBlock) : []
-      const defaultOperation = operationOptions.length > 0 ? operationOptions[0].id : undefined
+      const { options, denied } = hasMultipleOperations(toolBlock)
+        ? getOperationChoices(toolBlock ?? undefined)
+        : { options: [], denied: NO_DENIED_OPERATIONS }
+      const defaultOperation = options.find((option) => !denied.has(option.id))?.id
 
       const toolId = getToolIdForOperation(toolBlock.type, defaultOperation, toolBlock)
       if (!toolId) return
@@ -844,14 +856,7 @@ export const ToolInput = memo(function ToolInput({
 
       setOpen(false)
     },
-    [
-      isPreview,
-      disabled,
-      isToolAlreadySelected,
-      selectedTools,
-      setStoreValue,
-      getAllowedOperationOptions,
-    ]
+    [isPreview, disabled, isToolAlreadySelected, selectedTools, setStoreValue, getOperationChoices]
   )
 
   const handleAddCustomTool = useCallback(
@@ -1830,7 +1835,7 @@ export const ToolInput = memo(function ToolInput({
             : []
 
           const hasOperations =
-            !isCustomTool && !isMcpTool && hasMultipleOperations(getBlock(tool.type))
+            !isCustomTool && !isMcpTool && hasMultipleOperations(toolBlock ?? undefined)
           const hasParams = useSubBlocks
             ? displaySubBlocks.length > 0
             : displayParams.filter((param) => evaluateParameterCondition(param, tool)).length > 0
@@ -2090,19 +2095,11 @@ export const ToolInput = memo(function ToolInput({
                 <div className='flex flex-col gap-2.5 overflow-visible rounded-b-[4px] border-[var(--border-1)] border-t bg-[var(--surface-2)] p-2'>
                   {/* Operation dropdown for tools with multiple operations */}
                   {(() => {
-                    const block = getBlock(tool.type)
-                    const operationOptions = hasMultipleOperations(block)
-                      ? getOperationOptions(block).filter((option) => option.id !== '')
-                      : []
-                    if (operationOptions.length === 0) return null
-
-                    /* Denied operations are hidden from the picker rather than
-                       dropped, so a tool already saved on one keeps showing its
-                       name; the unset fallback skips to the first allowed. */
-                    const denied = getDeniedOperations(
-                      block,
-                      operationOptions.map((option) => option.id)
+                    if (!hasOperations) return null
+                    const { options: operationOptions, denied } = getOperationChoices(
+                      toolBlock ?? undefined
                     )
+                    if (operationOptions.length === 0) return null
 
                     return (
                       <div className='relative space-y-1.5'>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/lib/mcp/tool-validation'
 import type { McpToolSchema } from '@/lib/mcp/types'
 import { getProviderIdFromServiceId, type OAuthProvider, type OAuthService } from '@/lib/oauth'
+import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
 import { extractInputFieldsFromBlocks } from '@/lib/workflows/input-format'
 import { resolveStoredToolName } from '@/lib/workflows/subblocks/display'
 import { buildToolSubBlockId } from '@/lib/workflows/tool-input/synthetic-subblocks'
@@ -65,7 +66,7 @@ import { getAllBlocks, getBlock } from '@/blocks'
 import { isCustomBlockType } from '@/blocks/custom/build-config'
 import { useCustomBlockOverlayVersion } from '@/blocks/custom/client-overlay'
 import { getTileIconColorClass } from '@/blocks/icon-color'
-import type { SubBlockConfig as BlockSubBlockConfig } from '@/blocks/types'
+import type { BlockConfig, SubBlockConfig as BlockSubBlockConfig } from '@/blocks/types'
 import { BUILT_IN_TOOL_TYPES } from '@/blocks/utils'
 import { useMcpOauthPopup } from '@/hooks/mcp/use-mcp-oauth-popup'
 import { useMcpTools } from '@/hooks/mcp/use-mcp-tools'
@@ -85,6 +86,7 @@ import {
 import { useWorkflowState, useWorkflows } from '@/hooks/queries/workflows'
 import { useAvailableEnvVarKeys } from '@/hooks/use-available-env-vars'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
+import { useOperationAccess } from '@/hooks/use-operation-access'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
 import { useSettingsNavigation } from '@/hooks/use-settings-navigation'
 import { getProviderFromModel, supportsToolUsageControl } from '@/providers/utils'
@@ -355,25 +357,23 @@ function resolveCustomToolFromReference(
 /**
  * Checks if a block supports multiple operations.
  *
- * @param blockType - The block type to check
+ * @param block - The block config to check
  * @returns `true` if the block has more than one tool operation available
  */
-function hasMultipleOperations(blockType: string): boolean {
-  const block = getAllBlocks().find((b) => b.type === blockType)
+function hasMultipleOperations(block: BlockConfig | undefined): boolean {
   return (block?.tools?.access?.length || 0) > 1
 }
 
 /**
  * Gets the available operation options for a multi-operation tool.
  *
- * @param blockType - The block type to get operations for
+ * @param block - The block config to get operations for
  * @returns Array of operation options with label and id properties
  */
-function getOperationOptions(blockType: string): { label: string; id: string }[] {
-  const block = getAllBlocks().find((b) => b.type === blockType)
+function getOperationOptions(block: BlockConfig | undefined): { label: string; id: string }[] {
   if (!block || !block.tools?.access) return []
 
-  const operationSubBlock = block.subBlocks.find((sb) => sb.id === 'operation')
+  const operationSubBlock = block.subBlocks.find((sb) => sb.id === OPERATION_SUBBLOCK_ID)
   if (
     operationSubBlock &&
     operationSubBlock.type === 'dropdown' &&
@@ -663,12 +663,35 @@ export const ToolInput = memo(function ToolInput({
   const supportsToolControl = provider ? supportsToolUsageControl(provider) : false
 
   const { filterBlocks, config: permissionConfig } = usePermissionConfig()
+  const { getDeniedOperations } = useOperationAccess()
+
+  /**
+   * A tool block's operations minus the ones the caller's permission group
+   * denies, so this surface never offers — or silently defaults to — an
+   * operation that would be rejected at execution.
+   */
+  const getAllowedOperationOptions = useCallback(
+    (block: BlockConfig | undefined) => {
+      const options = getOperationOptions(block)
+      const denied = getDeniedOperations(
+        block,
+        options.map((option) => option.id)
+      )
+      return denied.size === 0 ? options : options.filter((option) => !denied.has(option.id))
+    },
+    [getDeniedOperations]
+  )
 
   const customBlockOverlayVersion = useCustomBlockOverlayVersion()
   const toolBlocks = useMemo(() => {
     const allToolBlocks = getAllBlocks().filter(isAgentToolBlock)
-    return filterBlocks(allToolBlocks)
-  }, [filterBlocks, customBlockOverlayVersion])
+    /* A multi-operation block whose every operation is denied has nothing the
+       caller can run, so it leaves the picker alongside the blocks denied
+       outright by `filterBlocks`. */
+    return filterBlocks(allToolBlocks).filter(
+      (block) => !hasMultipleOperations(block) || getAllowedOperationOptions(block).length > 0
+    )
+  }, [filterBlocks, customBlockOverlayVersion, getAllowedOperationOptions])
 
   const hasBackfilledRef = useRef(false)
   useEffect(() => {
@@ -744,7 +767,7 @@ export const ToolInput = memo(function ToolInput({
    * @returns `true` if tool is already selected (for single-operation tools only)
    */
   const isToolAlreadySelected = (toolId: string, blockType: string) => {
-    if (hasMultipleOperations(blockType)) {
+    if (hasMultipleOperations(getBlock(blockType))) {
       return false
     }
     // Custom blocks all share toolId `workflow_executor`, so dedup-by-toolId would
@@ -783,8 +806,8 @@ export const ToolInput = memo(function ToolInput({
     (toolBlock: (typeof toolBlocks)[0]) => {
       if (isPreview || disabled) return
 
-      const hasOperations = hasMultipleOperations(toolBlock.type)
-      const operationOptions = hasOperations ? getOperationOptions(toolBlock.type) : []
+      const hasOperations = hasMultipleOperations(toolBlock)
+      const operationOptions = hasOperations ? getAllowedOperationOptions(toolBlock) : []
       const defaultOperation = operationOptions.length > 0 ? operationOptions[0].id : undefined
 
       const toolId = getToolIdForOperation(toolBlock.type, defaultOperation, toolBlock)
@@ -821,7 +844,14 @@ export const ToolInput = memo(function ToolInput({
 
       setOpen(false)
     },
-    [isPreview, disabled, isToolAlreadySelected, selectedTools, setStoreValue]
+    [
+      isPreview,
+      disabled,
+      isToolAlreadySelected,
+      selectedTools,
+      setStoreValue,
+      getAllowedOperationOptions,
+    ]
   )
 
   const handleAddCustomTool = useCallback(
@@ -1799,7 +1829,8 @@ export const ToolInput = memo(function ToolInput({
               )
             : []
 
-          const hasOperations = !isCustomTool && !isMcpTool && hasMultipleOperations(tool.type)
+          const hasOperations =
+            !isCustomTool && !isMcpTool && hasMultipleOperations(getBlock(tool.type))
           const hasParams = useSubBlocks
             ? displaySubBlocks.length > 0
             : displayParams.filter((param) => evaluateParameterCondition(param, tool)).length > 0
@@ -2059,26 +2090,39 @@ export const ToolInput = memo(function ToolInput({
                 <div className='flex flex-col gap-2.5 overflow-visible rounded-b-[4px] border-[var(--border-1)] border-t bg-[var(--surface-2)] p-2'>
                   {/* Operation dropdown for tools with multiple operations */}
                   {(() => {
-                    const hasOperations = hasMultipleOperations(tool.type)
-                    const operationOptions = hasOperations ? getOperationOptions(tool.type) : []
+                    const block = getBlock(tool.type)
+                    const operationOptions = hasMultipleOperations(block)
+                      ? getOperationOptions(block).filter((option) => option.id !== '')
+                      : []
+                    if (operationOptions.length === 0) return null
 
-                    return hasOperations && operationOptions.length > 0 ? (
+                    /* Denied operations are hidden from the picker rather than
+                       dropped, so a tool already saved on one keeps showing its
+                       name; the unset fallback skips to the first allowed. */
+                    const denied = getDeniedOperations(
+                      block,
+                      operationOptions.map((option) => option.id)
+                    )
+
+                    return (
                       <div className='relative space-y-1.5'>
                         <div className='text-[var(--text-primary)] text-small'>Operation</div>
                         <Combobox
-                          options={operationOptions
-                            .filter((option) => option.id !== '')
-                            .map((option) => ({
-                              label: option.label,
-                              value: option.id,
-                            }))}
-                          value={tool.operation || operationOptions[0].id}
+                          options={operationOptions.map((option) => ({
+                            label: option.label,
+                            value: option.id,
+                            hidden: denied.has(option.id),
+                          }))}
+                          value={
+                            tool.operation ||
+                            operationOptions.find((option) => !denied.has(option.id))?.id
+                          }
                           onChange={(value) => handleOperationChange(toolIndex, value)}
                           placeholder='Select operation'
                           disabled={disabled}
                         />
                       </div>
-                    ) : null
+                    )
                   })()}
 
                   {(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -665,7 +665,11 @@ export const ToolInput = memo(function ToolInput({
   const provider = model ? getProviderFromModel(model) : ''
   const supportsToolControl = provider ? supportsToolUsageControl(provider) : false
 
-  const { filterBlocks, config: permissionConfig } = usePermissionConfig()
+  const {
+    filterBlocks,
+    config: permissionConfig,
+    isLoading: isPermissionLoading,
+  } = usePermissionConfig()
   const { getDeniedOperations } = useOperationAccess()
 
   /**
@@ -1704,7 +1708,11 @@ export const ToolInput = memo(function ToolInput({
         options={[]}
         groups={toolGroups}
         placeholder='Add tool...'
-        disabled={disabled}
+        /* Every list this picker offers — blocks, operations, MCP and custom
+           tools — reads as unrestricted until the permission config resolves,
+           and adding a tool is a one-shot write that nothing revisits. Closed
+           rather than optimistic for that beat. */
+        disabled={disabled || isPermissionLoading}
         searchable
         searchPlaceholder='Search tools...'
         maxHeight={240}
@@ -2115,7 +2123,9 @@ export const ToolInput = memo(function ToolInput({
                           }
                           onChange={(value) => handleOperationChange(toolIndex, value)}
                           placeholder='Select operation'
-                          disabled={disabled}
+                          /* Denied operations only drop out once the config
+                             resolves, and picking one rewrites the stored tool. */
+                          disabled={disabled || isPermissionLoading}
                         />
                       </div>
                     )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -895,11 +895,6 @@ const WorkflowContent = React.memo(
         if (parentId) blockData.parentId = parentId
         if (extent) blockData.extent = extent
 
-        /**
-         * `undefined` until the permission config has resolved, so a declared
-         * default is never vetoed — or let through — on a guess. Blocks pre-fill
-         * two fields the group can restrict; both go through the same gate.
-         */
         const operationGate = resolveOperationGate(getBlock(type))
         const seedGate = operationGate
           ? (subBlockId: string, value: string) => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -17,6 +17,7 @@ import 'reactflow/dist/style.css'
 import { toast } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
+import { omit } from '@sim/utils/object'
 import type { SubflowNodeData } from '@sim/workflow-renderer'
 import {
   BLOCK_DIMENSIONS,
@@ -40,6 +41,7 @@ import { useSession } from '@/lib/auth/auth-client'
 import type { OAuthConnectEventDetail } from '@/lib/copilot/tools/client/base-tool'
 import { consumeOAuthReturnContext, writeOAuthReturnContext } from '@/lib/credentials/client-state'
 import type { OAuthProvider } from '@/lib/oauth'
+import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
 import { getDefaultBlockName } from '@/lib/workflows/blocks/canvas-presentation'
 import { requestNoteImage, requestNoteRename } from '@/lib/workflows/notes/canvas-requests'
 import { TriggerUtils } from '@/lib/workflows/triggers/triggers'
@@ -126,6 +128,7 @@ import { useUpdateWorkflow, useWorkflowMap } from '@/hooks/queries/workflows'
 import { useCanvasViewport } from '@/hooks/use-canvas-viewport'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
 import { useOAuthReturnForWorkflow } from '@/hooks/use-oauth-return'
+import { useOperationAccess } from '@/hooks/use-operation-access'
 import { useCanvasModeStore } from '@/stores/canvas-mode'
 import { useChatStore } from '@/stores/chat/store'
 import {
@@ -867,6 +870,8 @@ const WorkflowContent = React.memo(
      */
     const pendingFocusBlockIdRef = useRef<string | null>(null)
 
+    const { isOperationAllowed, isReady: isOperationAccessReady } = useOperationAccess()
+
     const addBlock = useCallback(
       (
         id: string,
@@ -888,6 +893,14 @@ const WorkflowContent = React.memo(
         if (parentId) blockData.parentId = parentId
         if (extent) blockData.extent = extent
 
+        /**
+         * Withheld until the permission config has resolved, since it reads as
+         * "nothing denied" in flight and would let a denied default through.
+         */
+        const operationGate = isOperationAccessReady
+          ? (operationId: string) => isOperationAllowed(getBlock(type), operationId)
+          : undefined
+
         const block = prepareBlockState({
           id,
           type,
@@ -897,6 +910,7 @@ const WorkflowContent = React.memo(
           parentId,
           extent,
           triggerMode,
+          isOperationAllowed: operationGate,
         })
 
         const subBlockValues: Record<string, Record<string, unknown>> = {}
@@ -914,7 +928,21 @@ const WorkflowContent = React.memo(
           if (!subBlockValues[id]) {
             subBlockValues[id] = {}
           }
-          Object.assign(subBlockValues[id], presetSubBlockValues)
+          /* Search and the connection picker already drop denied operations, so
+             this only catches one arriving by another route — a recent pick that
+             outlived a permission change. Dropping the key rather than the whole
+             preset leaves the permission-corrected default from
+             `prepareBlockState` in place. */
+          const presetOperation = presetSubBlockValues[OPERATION_SUBBLOCK_ID]
+          const presetOperationDenied =
+            operationGate && typeof presetOperation === 'string' && !operationGate(presetOperation)
+
+          Object.assign(
+            subBlockValues[id],
+            presetOperationDenied
+              ? omit(presetSubBlockValues, [OPERATION_SUBBLOCK_ID])
+              : presetSubBlockValues
+          )
         }
 
         collaborativeBatchAddBlocks(
@@ -926,7 +954,13 @@ const WorkflowContent = React.memo(
         )
         usePanelEditorStore.getState().setCurrentBlockId(id)
       },
-      [collaborativeBatchAddBlocks, setSelectedEdges, setPendingSelection]
+      [
+        collaborativeBatchAddBlocks,
+        setSelectedEdges,
+        setPendingSelection,
+        isOperationAllowed,
+        isOperationAccessReady,
+      ]
     )
 
     const { activeBlockIds, pendingBlocks, isDebugging, isExecuting } = useExecutionStore(

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -41,7 +41,7 @@ import { useSession } from '@/lib/auth/auth-client'
 import type { OAuthConnectEventDetail } from '@/lib/copilot/tools/client/base-tool'
 import { consumeOAuthReturnContext, writeOAuthReturnContext } from '@/lib/credentials/client-state'
 import type { OAuthProvider } from '@/lib/oauth'
-import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
+import { MODEL_SUBBLOCK_ID, OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
 import { getDefaultBlockName } from '@/lib/workflows/blocks/canvas-presentation'
 import { requestNoteImage, requestNoteRename } from '@/lib/workflows/notes/canvas-requests'
 import { TriggerUtils } from '@/lib/workflows/triggers/triggers'
@@ -129,6 +129,7 @@ import { useCanvasViewport } from '@/hooks/use-canvas-viewport'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
 import { useOAuthReturnForWorkflow } from '@/hooks/use-oauth-return'
 import { useOperationAccess } from '@/hooks/use-operation-access'
+import { usePermissionConfig } from '@/hooks/use-permission-config'
 import { useCanvasModeStore } from '@/stores/canvas-mode'
 import { useChatStore } from '@/stores/chat/store'
 import {
@@ -870,7 +871,8 @@ const WorkflowContent = React.memo(
      */
     const pendingFocusBlockIdRef = useRef<string | null>(null)
 
-    const { isOperationAllowed, isReady: isOperationAccessReady } = useOperationAccess()
+    const { resolveOperationGate } = useOperationAccess()
+    const { isModelUsable } = usePermissionConfig()
 
     const addBlock = useCallback(
       (
@@ -894,11 +896,17 @@ const WorkflowContent = React.memo(
         if (extent) blockData.extent = extent
 
         /**
-         * Withheld until the permission config has resolved, since it reads as
-         * "nothing denied" in flight and would let a denied default through.
+         * `undefined` until the permission config has resolved, so a declared
+         * default is never vetoed — or let through — on a guess. Blocks pre-fill
+         * two fields the group can restrict; both go through the same gate.
          */
-        const operationGate = isOperationAccessReady
-          ? (operationId: string) => isOperationAllowed(getBlock(type), operationId)
+        const operationGate = resolveOperationGate(getBlock(type))
+        const seedGate = operationGate
+          ? (subBlockId: string, value: string) => {
+              if (subBlockId === OPERATION_SUBBLOCK_ID) return operationGate(value)
+              if (subBlockId === MODEL_SUBBLOCK_ID) return isModelUsable(value)
+              return true
+            }
           : undefined
 
         const block = prepareBlockState({
@@ -910,7 +918,7 @@ const WorkflowContent = React.memo(
           parentId,
           extent,
           triggerMode,
-          isOperationAllowed: operationGate,
+          isSeededValueAllowed: seedGate,
         })
 
         const subBlockValues: Record<string, Record<string, unknown>> = {}
@@ -958,8 +966,8 @@ const WorkflowContent = React.memo(
         collaborativeBatchAddBlocks,
         setSelectedEdges,
         setPendingSelection,
-        isOperationAllowed,
-        isOperationAccessReady,
+        resolveOperationGate,
+        isModelUsable,
       ]
     )
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -41,7 +41,7 @@ import { useSession } from '@/lib/auth/auth-client'
 import type { OAuthConnectEventDetail } from '@/lib/copilot/tools/client/base-tool'
 import { consumeOAuthReturnContext, writeOAuthReturnContext } from '@/lib/credentials/client-state'
 import type { OAuthProvider } from '@/lib/oauth'
-import { MODEL_SUBBLOCK_ID, OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
+import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
 import { getDefaultBlockName } from '@/lib/workflows/blocks/canvas-presentation'
 import { requestNoteImage, requestNoteRename } from '@/lib/workflows/notes/canvas-requests'
 import { TriggerUtils } from '@/lib/workflows/triggers/triggers'
@@ -129,7 +129,6 @@ import { useCanvasViewport } from '@/hooks/use-canvas-viewport'
 import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
 import { useOAuthReturnForWorkflow } from '@/hooks/use-oauth-return'
 import { useOperationAccess } from '@/hooks/use-operation-access'
-import { usePermissionConfig } from '@/hooks/use-permission-config'
 import { useCanvasModeStore } from '@/stores/canvas-mode'
 import { useChatStore } from '@/stores/chat/store'
 import {
@@ -871,8 +870,7 @@ const WorkflowContent = React.memo(
      */
     const pendingFocusBlockIdRef = useRef<string | null>(null)
 
-    const { resolveOperationGate } = useOperationAccess()
-    const { isModelUsable } = usePermissionConfig()
+    const { resolveSeedGate } = useOperationAccess()
 
     const addBlock = useCallback(
       (
@@ -895,20 +893,7 @@ const WorkflowContent = React.memo(
         if (parentId) blockData.parentId = parentId
         if (extent) blockData.extent = extent
 
-        const operationGate = resolveOperationGate(getBlock(type))
-
-        /**
-         * Creation is one-shot, so an unknown permission config cannot be
-         * answered by waiting the way the editor's pickers do — a value written
-         * here is never revisited. The restricted fields therefore seed empty
-         * until the config resolves, and the pickers fill them the moment it
-         * does. Seeding the declared default instead would persist it unchecked.
-         */
-        const seedGate = (subBlockId: string, value: string) => {
-          if (subBlockId !== OPERATION_SUBBLOCK_ID && subBlockId !== MODEL_SUBBLOCK_ID) return true
-          if (!operationGate) return false
-          return subBlockId === OPERATION_SUBBLOCK_ID ? operationGate(value) : isModelUsable(value)
-        }
+        const seedGate = resolveSeedGate(getBlock(type))
 
         const block = prepareBlockState({
           id,
@@ -937,15 +922,14 @@ const WorkflowContent = React.memo(
           if (!subBlockValues[id]) {
             subBlockValues[id] = {}
           }
-          /* Search and the connection picker already drop denied operations, so
-             this only catches one arriving by another route — a recent pick that
-             outlived a permission change. Dropping the key rather than the whole
-             preset leaves whatever `prepareBlockState` seeded in place. Unlike a
-             declared default, a preset is the user's explicit pick, so an
-             unknown config honours it and leaves the server to gate the run. */
+          /* The same gate as the declared default, deliberately: a preset is
+             offered by search and the connection picker, whose index reads as
+             unrestricted until the config resolves — so it is not the informed
+             pick it looks like, and honouring it would persist an operation
+             from an unfiltered list. */
           const presetOperation = presetSubBlockValues[OPERATION_SUBBLOCK_ID]
           const presetOperationDenied =
-            operationGate && typeof presetOperation === 'string' && !operationGate(presetOperation)
+            typeof presetOperation === 'string' && !seedGate(OPERATION_SUBBLOCK_ID, presetOperation)
 
           Object.assign(
             subBlockValues[id],
@@ -964,13 +948,7 @@ const WorkflowContent = React.memo(
         )
         usePanelEditorStore.getState().setCurrentBlockId(id)
       },
-      [
-        collaborativeBatchAddBlocks,
-        setSelectedEdges,
-        setPendingSelection,
-        resolveOperationGate,
-        isModelUsable,
-      ]
+      [collaborativeBatchAddBlocks, setSelectedEdges, setPendingSelection, resolveSeedGate]
     )
 
     const { activeBlockIds, pendingBlocks, isDebugging, isExecuting } = useExecutionStore(

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -896,13 +896,19 @@ const WorkflowContent = React.memo(
         if (extent) blockData.extent = extent
 
         const operationGate = resolveOperationGate(getBlock(type))
-        const seedGate = operationGate
-          ? (subBlockId: string, value: string) => {
-              if (subBlockId === OPERATION_SUBBLOCK_ID) return operationGate(value)
-              if (subBlockId === MODEL_SUBBLOCK_ID) return isModelUsable(value)
-              return true
-            }
-          : undefined
+
+        /**
+         * Creation is one-shot, so an unknown permission config cannot be
+         * answered by waiting the way the editor's pickers do — a value written
+         * here is never revisited. The restricted fields therefore seed empty
+         * until the config resolves, and the pickers fill them the moment it
+         * does. Seeding the declared default instead would persist it unchecked.
+         */
+        const seedGate = (subBlockId: string, value: string) => {
+          if (subBlockId !== OPERATION_SUBBLOCK_ID && subBlockId !== MODEL_SUBBLOCK_ID) return true
+          if (!operationGate) return false
+          return subBlockId === OPERATION_SUBBLOCK_ID ? operationGate(value) : isModelUsable(value)
+        }
 
         const block = prepareBlockState({
           id,
@@ -934,8 +940,9 @@ const WorkflowContent = React.memo(
           /* Search and the connection picker already drop denied operations, so
              this only catches one arriving by another route — a recent pick that
              outlived a permission change. Dropping the key rather than the whole
-             preset leaves the permission-corrected default from
-             `prepareBlockState` in place. */
+             preset leaves whatever `prepareBlockState` seeded in place. Unlike a
+             declared default, a preset is the user's explicit pick, so an
+             unknown config honours it and leaves the server to gate the run. */
           const presetOperation = presetSubBlockValues[OPERATION_SUBBLOCK_ID]
           const presetOperationDenied =
             operationGate && typeof presetOperation === 'string' && !operationGate(presetOperation)

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx
@@ -457,6 +457,7 @@ export const Sidebar = memo(function Sidebar({
     config: permissionConfig,
     filterBlocks,
     isBlockAllowed,
+    isToolAllowed,
     integrationAvailability,
   } = usePermissionConfig()
   const { navigateToSettings } = useSettingsNavigation()
@@ -472,8 +473,14 @@ export const Sidebar = memo(function Sidebar({
   )
 
   useEffect(() => {
-    initializeSearchData(filterBlocks)
-  }, [initializeSearchData, filterBlocks, providerModelSignature, customBlockOverlayVersion])
+    initializeSearchData(filterBlocks, isToolAllowed)
+  }, [
+    initializeSearchData,
+    filterBlocks,
+    isToolAllowed,
+    providerModelSignature,
+    customBlockOverlayVersion,
+  ])
 
   const setSidebarWidth = useSidebarStore((state) => state.setSidebarWidth)
   const toggleCollapsed = useSidebarStore((state) => state.toggleCollapsed)

--- a/apps/sim/hooks/use-operation-access.ts
+++ b/apps/sim/hooks/use-operation-access.ts
@@ -3,27 +3,14 @@
 import { useMemo } from 'react'
 import {
   collectDeniedOperationIds,
-  isOperationAllowed as isOperationAllowedFor,
+  isOperationAllowed,
+  NO_DENIED_OPERATIONS,
   type OperationGateBlock,
   pickDefaultOperation,
 } from '@/lib/permission-groups/operation-access'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
 
-const EMPTY_DENIED: ReadonlySet<string> = new Set()
-
 export interface OperationAccess {
-  /**
-   * Whether the caller's permission config has resolved. Filtering reads
-   * optimistically before it does — a denied option stays visible for a beat —
-   * but nothing may be *persisted* until it is true.
-   */
-  isReady: boolean
-  /**
-   * Whether the caller may run `operationId` of `block`. Answers `true` for
-   * everything while the config loads, so a caller persisting on the answer
-   * must check `isReady` first — the two withholding members below already do.
-   */
-  isOperationAllowed: (block: OperationGateBlock | null | undefined, operationId: string) => boolean
   /**
    * The operation ids of `block` the caller may not run. Empty while the
    * config loads, so pickers show everything rather than flashing a short list.
@@ -35,17 +22,25 @@ export interface OperationAccess {
   /**
    * The operation to seed an unset field with: `preferred` when allowed, else
    * the first allowed candidate.
-   *
-   * `undefined` while the config is loading, because it resolves as "nothing
-   * denied" in flight and a default written then would outlive the correction —
-   * a seeding caller only ever writes a defined value, so gating on
-   * `!== undefined` is the whole guard.
    */
   resolveDefaultOperation: (
     block: OperationGateBlock | null | undefined,
     candidates: Iterable<string>,
     preferred?: string
   ) => string | undefined
+  /**
+   * A predicate for deciding whether an operation of `block` may be *persisted*
+   * — or `undefined` while the permission config is still loading.
+   *
+   * The withholding is the point. The config resolves as "nothing denied" in
+   * flight, so a value written during that window would outlive the correction
+   * that arrives with it. Handing back `undefined` rather than an
+   * always-`true` predicate means a caller cannot persist without first
+   * deciding what to do when the answer is unknown.
+   */
+  resolveOperationGate: (
+    block: OperationGateBlock | null | undefined
+  ) => ((operationId: string) => boolean) | undefined
 }
 
 /**
@@ -62,13 +57,16 @@ export function useOperationAccess(): OperationAccess {
   return useMemo(() => {
     const isReady = !isLoading
     return {
-      isReady,
-      isOperationAllowed: (block, operationId) =>
-        isOperationAllowedFor(block, operationId, isToolAllowed),
       getDeniedOperations: (block, operationIds) =>
-        isReady ? collectDeniedOperationIds(block, operationIds, isToolAllowed) : EMPTY_DENIED,
+        isReady
+          ? collectDeniedOperationIds(block, operationIds, isToolAllowed)
+          : NO_DENIED_OPERATIONS,
       resolveDefaultOperation: (block, candidates, preferred) =>
         isReady ? pickDefaultOperation(block, candidates, isToolAllowed, preferred) : undefined,
+      resolveOperationGate: (block) =>
+        isReady
+          ? (operationId: string) => isOperationAllowed(block, operationId, isToolAllowed)
+          : undefined,
     }
   }, [isToolAllowed, isLoading])
 }

--- a/apps/sim/hooks/use-operation-access.ts
+++ b/apps/sim/hooks/use-operation-access.ts
@@ -1,0 +1,74 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  collectDeniedOperationIds,
+  isOperationAllowed as isOperationAllowedFor,
+  type OperationGateBlock,
+  pickDefaultOperation,
+} from '@/lib/permission-groups/operation-access'
+import { usePermissionConfig } from '@/hooks/use-permission-config'
+
+const EMPTY_DENIED: ReadonlySet<string> = new Set()
+
+export interface OperationAccess {
+  /**
+   * Whether the caller's permission config has resolved. Filtering reads
+   * optimistically before it does — a denied option stays visible for a beat —
+   * but nothing may be *persisted* until it is true.
+   */
+  isReady: boolean
+  /**
+   * Whether the caller may run `operationId` of `block`. Answers `true` for
+   * everything while the config loads, so a caller persisting on the answer
+   * must check `isReady` first — the two withholding members below already do.
+   */
+  isOperationAllowed: (block: OperationGateBlock | null | undefined, operationId: string) => boolean
+  /**
+   * The operation ids of `block` the caller may not run. Empty while the
+   * config loads, so pickers show everything rather than flashing a short list.
+   */
+  getDeniedOperations: (
+    block: OperationGateBlock | null | undefined,
+    operationIds: Iterable<string>
+  ) => ReadonlySet<string>
+  /**
+   * The operation to seed an unset field with: `preferred` when allowed, else
+   * the first allowed candidate.
+   *
+   * `undefined` while the config is loading, because it resolves as "nothing
+   * denied" in flight and a default written then would outlive the correction —
+   * a seeding caller only ever writes a defined value, so gating on
+   * `!== undefined` is the whole guard.
+   */
+  resolveDefaultOperation: (
+    block: OperationGateBlock | null | undefined,
+    candidates: Iterable<string>,
+    preferred?: string
+  ) => string | undefined
+}
+
+/**
+ * Permission-group access to a block's operations.
+ *
+ * The single place the "which operations may this user run, and which one
+ * should an unset field land on" question is answered, so every surface that
+ * offers operations — the block editor's dropdown, the agent block's tool list,
+ * canvas search, block creation — agrees.
+ */
+export function useOperationAccess(): OperationAccess {
+  const { isToolAllowed, isLoading } = usePermissionConfig()
+
+  return useMemo(() => {
+    const isReady = !isLoading
+    return {
+      isReady,
+      isOperationAllowed: (block, operationId) =>
+        isOperationAllowedFor(block, operationId, isToolAllowed),
+      getDeniedOperations: (block, operationIds) =>
+        isReady ? collectDeniedOperationIds(block, operationIds, isToolAllowed) : EMPTY_DENIED,
+      resolveDefaultOperation: (block, candidates, preferred) =>
+        isReady ? pickDefaultOperation(block, candidates, isToolAllowed, preferred) : undefined,
+    }
+  }, [isToolAllowed, isLoading])
+}

--- a/apps/sim/hooks/use-operation-access.ts
+++ b/apps/sim/hooks/use-operation-access.ts
@@ -4,13 +4,22 @@ import { useMemo } from 'react'
 import {
   collectDeniedOperationIds,
   isOperationAllowed,
+  MODEL_SUBBLOCK_ID,
   NO_DENIED_OPERATIONS,
+  OPERATION_SUBBLOCK_ID,
   type OperationGateBlock,
   pickDefaultOperation,
+  type SeedValueGate,
 } from '@/lib/permission-groups/operation-access'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
 
 export interface OperationAccess {
+  /**
+   * Whether the permission config is still loading. Every list this module
+   * filters reads as unrestricted until it resolves, so a surface that
+   * *persists* a pick from one must not accept input while this is true.
+   */
+  isPermissionLoading: boolean
   /**
    * The operation ids of `block` the caller may not run. Empty while the
    * config loads, so pickers show everything rather than flashing a short list.
@@ -41,6 +50,16 @@ export interface OperationAccess {
   resolveOperationGate: (
     block: OperationGateBlock | null | undefined
   ) => ((operationId: string) => boolean) | undefined
+  /**
+   * The veto `prepareBlockState` applies to a new block's declared defaults.
+   *
+   * Creation is one-shot, so unlike the pickers it cannot answer "unknown" by
+   * waiting — a value written there is never revisited. This gate therefore
+   * rejects both restricted fields until the config resolves, leaving them
+   * empty for the pickers to fill, and owns that rule so no caller re-derives
+   * it. Every other field passes through untouched.
+   */
+  resolveSeedGate: (block: OperationGateBlock | null | undefined) => SeedValueGate
 }
 
 /**
@@ -52,11 +71,12 @@ export interface OperationAccess {
  * canvas search, block creation — agrees.
  */
 export function useOperationAccess(): OperationAccess {
-  const { isToolAllowed, isLoading } = usePermissionConfig()
+  const { isToolAllowed, isModelUsable, isLoading } = usePermissionConfig()
 
   return useMemo(() => {
     const isReady = !isLoading
     return {
+      isPermissionLoading: isLoading,
       getDeniedOperations: (block, operationIds) =>
         isReady
           ? collectDeniedOperationIds(block, operationIds, isToolAllowed)
@@ -67,6 +87,13 @@ export function useOperationAccess(): OperationAccess {
         isReady
           ? (operationId: string) => isOperationAllowed(block, operationId, isToolAllowed)
           : undefined,
+      resolveSeedGate: (block) => (subBlockId, value) => {
+        if (subBlockId !== OPERATION_SUBBLOCK_ID && subBlockId !== MODEL_SUBBLOCK_ID) return true
+        if (!isReady) return false
+        return subBlockId === OPERATION_SUBBLOCK_ID
+          ? isOperationAllowed(block, value, isToolAllowed)
+          : isModelUsable(value)
+      },
     }
-  }, [isToolAllowed, isLoading])
+  }, [isToolAllowed, isModelUsable, isLoading])
 }

--- a/apps/sim/hooks/use-permission-config.ts
+++ b/apps/sim/hooks/use-permission-config.ts
@@ -24,6 +24,7 @@ import { useOptionalWorkspaceHostContext } from '@/app/workspace/[workspaceId]/p
 import { useCustomBlockOverlayVersion } from '@/blocks/custom/client-overlay'
 import { overlayVisibility } from '@/blocks/visibility/context'
 import { useUserPermissionConfig } from '@/ee/access-control/hooks/permission-groups'
+import { getProviderFromModel } from '@/providers/utils'
 
 export interface PermissionConfigResult {
   config: PermissionGroupConfig
@@ -34,6 +35,12 @@ export interface PermissionConfigResult {
   isBlockAllowed: (blockType: string) => boolean
   isProviderAllowed: (providerId: string) => boolean
   isModelAllowed: (model: string) => boolean
+  /**
+   * Whether a model is usable at all: allowed by the model denylist *and* by the
+   * provider allowlist. Both gates apply to every model field, so prefer this
+   * over calling `isModelAllowed` and `isProviderAllowed` separately.
+   */
+  isModelUsable: (model: string) => boolean
   isToolAllowed: (toolId: string) => boolean
   isInvitationsDisabled: boolean
   isPublicApiDisabled: boolean
@@ -120,20 +127,39 @@ export function usePermissionConfig(): PermissionConfigResult {
     }
   }, [config.allowedModelProviders])
 
+  /** Indexed so the per-model check stays O(1) over a long denylist. */
+  const deniedModelSet = useMemo(
+    () => new Set(config.deniedModels.map((denied) => denied.toLowerCase())),
+    [config.deniedModels]
+  )
+
   const isModelAllowed = useMemo(() => {
+    return (model: string) => !deniedModelSet.has(model.toLowerCase())
+  }, [deniedModelSet])
+
+  const isModelUsable = useMemo(() => {
     return (model: string) => {
-      if (config.deniedModels.length === 0) return true
-      const normalized = model.toLowerCase()
-      return !config.deniedModels.some((denied) => denied.toLowerCase() === normalized)
+      if (!isModelAllowed(model)) return false
+      try {
+        return isProviderAllowed(getProviderFromModel(model))
+      } catch {
+        /* A model whose provider cannot be derived is left to the server gate
+           rather than hidden on a parse failure. */
+        return true
+      }
     }
-  }, [config.deniedModels])
+  }, [isModelAllowed, isProviderAllowed])
+
+  /**
+   * Indexed rather than scanned: the operation gate calls this once per option
+   * of every block it offers, so a linear scan made the cost of a check scale
+   * with the length of the denylist.
+   */
+  const deniedToolSet = useMemo(() => new Set(config.deniedTools), [config.deniedTools])
 
   const isToolAllowed = useMemo(() => {
-    return (toolId: string) => {
-      if (config.deniedTools.length === 0) return true
-      return !config.deniedTools.includes(toolId)
-    }
-  }, [config.deniedTools])
+    return (toolId: string) => !deniedToolSet.has(toolId)
+  }, [deniedToolSet])
 
   const filterBlocks = useMemo(() => {
     return <T extends { type: string }>(blocks: T[]): T[] => {
@@ -173,6 +199,7 @@ export function usePermissionConfig(): PermissionConfigResult {
       isBlockAllowed,
       isProviderAllowed,
       isModelAllowed,
+      isModelUsable,
       isToolAllowed,
       isInvitationsDisabled,
       isPublicApiDisabled,
@@ -187,6 +214,7 @@ export function usePermissionConfig(): PermissionConfigResult {
       isBlockAllowed,
       isProviderAllowed,
       isModelAllowed,
+      isModelUsable,
       isToolAllowed,
       isInvitationsDisabled,
       isPublicApiDisabled,

--- a/apps/sim/hooks/use-permission-config.ts
+++ b/apps/sim/hooks/use-permission-config.ts
@@ -150,11 +150,7 @@ export function usePermissionConfig(): PermissionConfigResult {
     }
   }, [isModelAllowed, isProviderAllowed])
 
-  /**
-   * Indexed rather than scanned: the operation gate calls this once per option
-   * of every block it offers, so a linear scan made the cost of a check scale
-   * with the length of the denylist.
-   */
+  /** Indexed so the per-tool check stays O(1) over a long denylist. */
   const deniedToolSet = useMemo(() => new Set(config.deniedTools), [config.deniedTools])
 
   const isToolAllowed = useMemo(() => {

--- a/apps/sim/hooks/use-permission-config.ts
+++ b/apps/sim/hooks/use-permission-config.ts
@@ -33,12 +33,10 @@ export interface PermissionConfigResult {
   filterBlocks: <T extends { type: string }>(blocks: T[]) => T[]
   filterProviders: (providerIds: string[]) => string[]
   isBlockAllowed: (blockType: string) => boolean
-  isProviderAllowed: (providerId: string) => boolean
-  isModelAllowed: (model: string) => boolean
   /**
-   * Whether a model is usable at all: allowed by the model denylist *and* by the
-   * provider allowlist. Both gates apply to every model field, so prefer this
-   * over calling `isModelAllowed` and `isProviderAllowed` separately.
+   * Whether a model is usable at all: allowed by the model denylist *and* by
+   * the provider allowlist. Both gates apply to every model field, so this is
+   * the only model predicate the interface exposes.
    */
   isModelUsable: (model: string) => boolean
   isToolAllowed: (toolId: string) => boolean
@@ -193,8 +191,6 @@ export function usePermissionConfig(): PermissionConfigResult {
       filterBlocks,
       filterProviders,
       isBlockAllowed,
-      isProviderAllowed,
-      isModelAllowed,
       isModelUsable,
       isToolAllowed,
       isInvitationsDisabled,
@@ -208,8 +204,6 @@ export function usePermissionConfig(): PermissionConfigResult {
       filterBlocks,
       filterProviders,
       isBlockAllowed,
-      isProviderAllowed,
-      isModelAllowed,
       isModelUsable,
       isToolAllowed,
       isInvitationsDisabled,

--- a/apps/sim/hooks/use-permission-config.ts
+++ b/apps/sim/hooks/use-permission-config.ts
@@ -24,7 +24,7 @@ import { useOptionalWorkspaceHostContext } from '@/app/workspace/[workspaceId]/p
 import { useCustomBlockOverlayVersion } from '@/blocks/custom/client-overlay'
 import { overlayVisibility } from '@/blocks/visibility/context'
 import { useUserPermissionConfig } from '@/ee/access-control/hooks/permission-groups'
-import { getProviderFromModel } from '@/providers/utils'
+import { findProviderFromModel } from '@/providers/utils'
 
 export interface PermissionConfigResult {
   config: PermissionGroupConfig
@@ -138,13 +138,13 @@ export function usePermissionConfig(): PermissionConfigResult {
   const isModelUsable = useMemo(() => {
     return (model: string) => {
       if (!isModelAllowed(model)) return false
-      try {
-        return isProviderAllowed(getProviderFromModel(model))
-      } catch {
-        /* A model whose provider cannot be derived is left to the server gate
-           rather than hidden on a parse failure. */
-        return true
-      }
+      const providerId = findProviderFromModel(model)
+      /* Only chat models resolve to a provider. A `model` field holding an
+         embedding, speech, image or video id is not a provider choice, so the
+         provider allowlist has nothing to say about it — judging it anyway
+         would read every such id as Ollama and reject it. */
+      if (!providerId) return true
+      return isProviderAllowed(providerId)
     }
   }, [isModelAllowed, isProviderAllowed])
 

--- a/apps/sim/lib/permission-groups/operation-access.test.ts
+++ b/apps/sim/lib/permission-groups/operation-access.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  collectDeniedOperationIds,
+  isOperationAllowed,
+  type OperationGateBlock,
+  pickDefaultOperation,
+  resolveOperationToolId,
+} from '@/lib/permission-groups/operation-access'
+
+/** A block that resolves its tool from the operation, like most integrations. */
+const selectorBlock: OperationGateBlock = {
+  tools: {
+    access: ['slack_message', 'slack_canvas', 'slack_read'],
+    config: {
+      tool: (params) => {
+        const map: Record<string, string> = {
+          send: 'slack_message',
+          canvas: 'slack_canvas',
+          read: 'slack_read',
+        }
+        const toolId = map[params.operation as string]
+        if (!toolId) throw new Error(`unknown operation: ${params.operation}`)
+        return toolId
+      },
+    },
+  },
+}
+
+/** A block with no selector, whose operation ids are its tool ids. */
+const bareBlock: OperationGateBlock = {
+  tools: { access: ['sqs_send', 'sqs_receive'] },
+}
+
+const singleToolBlock: OperationGateBlock = {
+  tools: { access: ['dropcontact_enrich_contact'] },
+}
+
+const denyAll = () => false
+const allowAll = () => true
+const deny = (...toolIds: string[]) => {
+  const denied = new Set(toolIds)
+  return (toolId: string) => !denied.has(toolId)
+}
+
+describe('resolveOperationToolId', () => {
+  it('resolves through the block tool selector', () => {
+    expect(resolveOperationToolId(selectorBlock, 'canvas')).toBe('slack_canvas')
+  })
+
+  it('returns the only tool when the block has no selection to make', () => {
+    expect(resolveOperationToolId(singleToolBlock, 'anything')).toBe('dropcontact_enrich_contact')
+  })
+
+  it('treats an operation id as a tool id when the block has no selector', () => {
+    expect(resolveOperationToolId(bareBlock, 'sqs_receive')).toBe('sqs_receive')
+  })
+
+  it('returns null rather than guessing when the selector throws', () => {
+    expect(resolveOperationToolId(selectorBlock, 'not-an-operation')).toBeNull()
+  })
+
+  it('returns null for a block with no tools', () => {
+    expect(resolveOperationToolId({ tools: { access: [] } }, 'send')).toBeNull()
+    expect(resolveOperationToolId(null, 'send')).toBeNull()
+    expect(resolveOperationToolId(undefined, 'send')).toBeNull()
+  })
+})
+
+describe('isOperationAllowed', () => {
+  it('denies an operation whose tool the group denies', () => {
+    expect(isOperationAllowed(selectorBlock, 'canvas', deny('slack_canvas'))).toBe(false)
+    expect(isOperationAllowed(selectorBlock, 'send', deny('slack_canvas'))).toBe(true)
+  })
+
+  it('allows an unresolvable operation, leaving the server as the gate', () => {
+    expect(isOperationAllowed(selectorBlock, 'not-an-operation', denyAll)).toBe(true)
+  })
+})
+
+describe('collectDeniedOperationIds', () => {
+  it('collects only the operations whose tools are denied', () => {
+    const denied = collectDeniedOperationIds(
+      selectorBlock,
+      ['send', 'canvas', 'read'],
+      deny('slack_message', 'slack_read')
+    )
+    expect([...denied]).toEqual(['send', 'read'])
+  })
+
+  it('is empty when nothing is denied', () => {
+    expect(collectDeniedOperationIds(selectorBlock, ['send', 'canvas'], allowAll).size).toBe(0)
+  })
+})
+
+describe('pickDefaultOperation', () => {
+  const candidates = ['send', 'canvas', 'read']
+
+  it('keeps the preferred operation when the group allows it', () => {
+    expect(pickDefaultOperation(selectorBlock, candidates, allowAll, 'canvas')).toBe('canvas')
+  })
+
+  it('falls back to the first allowed operation when the preferred one is denied', () => {
+    expect(pickDefaultOperation(selectorBlock, candidates, deny('slack_message'), 'send')).toBe(
+      'canvas'
+    )
+  })
+
+  it('takes the first allowed operation when there is no preference', () => {
+    expect(pickDefaultOperation(selectorBlock, candidates, deny('slack_message'))).toBe('canvas')
+  })
+
+  it('returns undefined when every candidate is denied', () => {
+    expect(
+      pickDefaultOperation(
+        selectorBlock,
+        candidates,
+        deny('slack_message', 'slack_canvas', 'slack_read'),
+        'send'
+      )
+    ).toBeUndefined()
+  })
+
+  it('keeps a preferred operation it cannot resolve, matching the permissive gate', () => {
+    expect(pickDefaultOperation(selectorBlock, candidates, denyAll, 'not-an-operation')).toBe(
+      'not-an-operation'
+    )
+  })
+})

--- a/apps/sim/lib/permission-groups/operation-access.test.ts
+++ b/apps/sim/lib/permission-groups/operation-access.test.ts
@@ -7,7 +7,6 @@ import {
   isOperationAllowed,
   type OperationGateBlock,
   pickDefaultOperation,
-  resolveOperationToolId,
 } from '@/lib/permission-groups/operation-access'
 
 /** A block that resolves its tool from the operation, like most integrations. */
@@ -45,27 +44,27 @@ const deny = (...toolIds: string[]) => {
   return (toolId: string) => !denied.has(toolId)
 }
 
-describe('resolveOperationToolId', () => {
+describe('operation-to-tool resolution', () => {
   it('resolves through the block tool selector', () => {
-    expect(resolveOperationToolId(selectorBlock, 'canvas')).toBe('slack_canvas')
+    expect(isOperationAllowed(selectorBlock, 'canvas', deny('slack_canvas'))).toBe(false)
+    expect(isOperationAllowed(selectorBlock, 'canvas', deny('slack_message'))).toBe(true)
   })
 
-  it('returns the only tool when the block has no selection to make', () => {
-    expect(resolveOperationToolId(singleToolBlock, 'anything')).toBe('dropcontact_enrich_contact')
+  it('gates on the only tool when the block has no selection to make', () => {
+    expect(
+      isOperationAllowed(singleToolBlock, 'anything', deny('dropcontact_enrich_contact'))
+    ).toBe(false)
   })
 
   it('treats an operation id as a tool id when the block has no selector', () => {
-    expect(resolveOperationToolId(bareBlock, 'sqs_receive')).toBe('sqs_receive')
+    expect(isOperationAllowed(bareBlock, 'sqs_receive', deny('sqs_receive'))).toBe(false)
+    expect(isOperationAllowed(bareBlock, 'sqs_receive', deny('sqs_send'))).toBe(true)
   })
 
-  it('returns null rather than guessing when the selector throws', () => {
-    expect(resolveOperationToolId(selectorBlock, 'not-an-operation')).toBeNull()
-  })
-
-  it('returns null for a block with no tools', () => {
-    expect(resolveOperationToolId({ tools: { access: [] } }, 'send')).toBeNull()
-    expect(resolveOperationToolId(null, 'send')).toBeNull()
-    expect(resolveOperationToolId(undefined, 'send')).toBeNull()
+  it('allows rather than guessing when a block has no tools at all', () => {
+    expect(isOperationAllowed({ tools: { access: [] } }, 'send', denyAll)).toBe(true)
+    expect(isOperationAllowed(null, 'send', denyAll)).toBe(true)
+    expect(isOperationAllowed(undefined, 'send', denyAll)).toBe(true)
   })
 })
 

--- a/apps/sim/lib/permission-groups/operation-access.ts
+++ b/apps/sim/lib/permission-groups/operation-access.ts
@@ -10,6 +10,12 @@ import type { BlockConfig } from '@/blocks/types'
  */
 export const OPERATION_SUBBLOCK_ID = 'operation'
 
+/** The subblock id that carries a block's model. */
+export const MODEL_SUBBLOCK_ID = 'model'
+
+/** Shared empty result, so a caller's memo sees a stable identity. */
+export const NO_DENIED_OPERATIONS: ReadonlySet<string> = new Set()
+
 /** The slice of a block config the operation gate reads. */
 export type OperationGateBlock = Pick<BlockConfig, 'tools'>
 
@@ -19,6 +25,12 @@ export type IsToolAllowed = (toolId: string) => boolean
 /**
  * The tool id a block operation maps to, or `null` when it cannot be resolved
  * from the operation alone.
+ *
+ * Deliberately not `getToolIdForOperation` from `@/tools/params`: that one ends
+ * with an unconditional `access[0]` fallback, which for a gate would authorize
+ * an unrecognized operation against a tool it has nothing to do with. It also
+ * logs on every selector throw, and this runs once per option of every block
+ * offered.
  *
  * Never guesses. A selector that also reads sibling fields throws when handed
  * an operation on its own, and an operation the block does not recognize has

--- a/apps/sim/lib/permission-groups/operation-access.ts
+++ b/apps/sim/lib/permission-groups/operation-access.ts
@@ -10,7 +10,6 @@ import type { BlockConfig } from '@/blocks/types'
  */
 export const OPERATION_SUBBLOCK_ID = 'operation'
 
-/** The subblock id that carries a block's model. */
 export const MODEL_SUBBLOCK_ID = 'model'
 
 /** Shared empty result, so a caller's memo sees a stable identity. */
@@ -56,8 +55,7 @@ export function resolveOperationToolId(
       const toolId = selectTool({ operation: operationId })
       if (toolId) return toolId
     } catch {
-      /* Falls through rather than guessing a tool for an operation the
-         selector could not resolve on its own. */
+      /* Unresolvable from the operation alone; see the TSDoc above. */
     }
   }
 

--- a/apps/sim/lib/permission-groups/operation-access.ts
+++ b/apps/sim/lib/permission-groups/operation-access.ts
@@ -22,6 +22,13 @@ export type OperationGateBlock = Pick<BlockConfig, 'tools'>
 export type IsToolAllowed = (toolId: string) => boolean
 
 /**
+ * Vetoes a subblock's declared default when the caller's permission group does
+ * not allow it — or when the group config is not known yet, since a default
+ * written during block creation is never revisited.
+ */
+export type SeedValueGate = (subBlockId: string, value: string) => boolean
+
+/**
  * The tool id a block operation maps to, or `null` when it cannot be resolved
  * from the operation alone.
  *
@@ -38,7 +45,7 @@ export type IsToolAllowed = (toolId: string) => boolean
  * way, so a `null` only ever costs a denied option staying visible, never a
  * permitted option disappearing.
  */
-export function resolveOperationToolId(
+function resolveOperationToolId(
   block: OperationGateBlock | null | undefined,
   operationId: string
 ): string | null {

--- a/apps/sim/lib/permission-groups/operation-access.ts
+++ b/apps/sim/lib/permission-groups/operation-access.ts
@@ -1,0 +1,110 @@
+import type { BlockConfig } from '@/blocks/types'
+
+/**
+ * The subblock id that carries a block's operation.
+ *
+ * Singular only. Four blocks (`elasticsearch`, `mailchimp`, `onepassword`,
+ * `typeform`) also declare an `operations` subblock, but it holds a JSON-patch
+ * payload rather than an operation selector — matching it could only ever key
+ * a gate off the wrong value.
+ */
+export const OPERATION_SUBBLOCK_ID = 'operation'
+
+/** The slice of a block config the operation gate reads. */
+export type OperationGateBlock = Pick<BlockConfig, 'tools'>
+
+/** Decides whether the caller's permission group allows a concrete tool id. */
+export type IsToolAllowed = (toolId: string) => boolean
+
+/**
+ * The tool id a block operation maps to, or `null` when it cannot be resolved
+ * from the operation alone.
+ *
+ * Never guesses. A selector that also reads sibling fields throws when handed
+ * an operation on its own, and an operation the block does not recognize has
+ * no tool — both yield `null`, which callers read as "not gateable here". The
+ * server-side gate in `assertPermissionsAllowed` stays authoritative either
+ * way, so a `null` only ever costs a denied option staying visible, never a
+ * permitted option disappearing.
+ */
+export function resolveOperationToolId(
+  block: OperationGateBlock | null | undefined,
+  operationId: string
+): string | null {
+  const access = block?.tools?.access
+  if (!access || access.length === 0) return null
+
+  /* One tool means there is nothing to select: the block runs that tool
+     whatever its operation dropdown says. */
+  if (access.length === 1) return access[0]
+
+  const selectTool = block?.tools?.config?.tool
+  if (selectTool) {
+    try {
+      const toolId = selectTool({ operation: operationId })
+      if (toolId) return toolId
+    } catch {
+      /* Falls through rather than guessing a tool for an operation the
+         selector could not resolve on its own. */
+    }
+  }
+
+  /* Blocks with no selector list their tool ids as their operation ids. */
+  return access.includes(operationId) ? operationId : null
+}
+
+/** Whether the caller's permission group allows a block operation. */
+export function isOperationAllowed(
+  block: OperationGateBlock | null | undefined,
+  operationId: string,
+  isToolAllowed: IsToolAllowed
+): boolean {
+  const toolId = resolveOperationToolId(block, operationId)
+  if (!toolId) return true
+  return isToolAllowed(toolId)
+}
+
+/**
+ * The operation ids of `block` whose tool the caller's permission group denies.
+ *
+ * Denied operations are hidden from pickers rather than removed from the model,
+ * so a workflow that already references one keeps resolving its label.
+ */
+export function collectDeniedOperationIds(
+  block: OperationGateBlock | null | undefined,
+  operationIds: Iterable<string>,
+  isToolAllowed: IsToolAllowed
+): ReadonlySet<string> {
+  const denied = new Set<string>()
+  for (const operationId of operationIds) {
+    if (!isOperationAllowed(block, operationId, isToolAllowed)) {
+      denied.add(operationId)
+    }
+  }
+  return denied
+}
+
+/**
+ * The operation an unset field should be seeded with: `preferred` when the
+ * group allows it, otherwise the first candidate it does allow.
+ *
+ * Returns `undefined` when every candidate is denied. `useOperationAccess`
+ * additionally returns `undefined` while the permission config is loading, so a
+ * caller that seeds only on a defined value can never persist a denied default.
+ */
+export function pickDefaultOperation(
+  block: OperationGateBlock | null | undefined,
+  candidates: Iterable<string>,
+  isToolAllowed: IsToolAllowed,
+  preferred?: string
+): string | undefined {
+  if (preferred !== undefined && isOperationAllowed(block, preferred, isToolAllowed)) {
+    return preferred
+  }
+
+  for (const candidate of candidates) {
+    if (isOperationAllowed(block, candidate, isToolAllowed)) return candidate
+  }
+
+  return undefined
+}

--- a/apps/sim/lib/workflows/blocks/canvas-sentence.ts
+++ b/apps/sim/lib/workflows/blocks/canvas-sentence.ts
@@ -1,3 +1,4 @@
+import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
 import { resolveFieldNoun } from '@/lib/workflows/blocks/canvas-sentence-noun'
 import { resolveTriggerSentence } from '@/lib/workflows/blocks/canvas-trigger-sentence'
 import type {
@@ -25,16 +26,6 @@ import type {
  * sentence a user reads has the same shape before and after they fill it in.
  */
 export type ResolvedSentenceSegment = string | { subBlockId: string; noun?: string }
-
-/**
- * The subblock id that carries a block's operation.
- *
- * Singular only. Four blocks (`elasticsearch`, `mailchimp`, `onepassword`,
- * `typeform`) also declare an `operations` subblock, but it holds a JSON-patch
- * payload rather than an operation selector — matching it could only ever key
- * a sentence off the wrong value.
- */
-const OPERATION_SUBBLOCK_ID = 'operation'
 
 type CanvasSentenceConfig = Pick<BlockConfig, 'canvasPresentation' | 'subBlocks'>
 

--- a/apps/sim/providers/utils.test.ts
+++ b/apps/sim/providers/utils.test.ts
@@ -16,6 +16,7 @@ import {
   describeModelLevel,
   extractAndParseJSON,
   filterBlacklistedModels,
+  findProviderFromModel,
   formatCost,
   generateStructuredOutputInstructions,
   getAllModelProviders,
@@ -2043,5 +2044,29 @@ describe('describeModelLevel', () => {
   it('reports an absent level without throwing', () => {
     expect(describeModelLevel(undefined)).toBe('(unset)')
     expect(describeModelLevel('')).toBe('(unset)')
+  })
+})
+
+describe('findProviderFromModel', () => {
+  it('resolves a chat model to its declaring provider', () => {
+    expect(findProviderFromModel('claude-sonnet-5')).toBe('anthropic')
+    expect(findProviderFromModel('gpt-5.2')).toBe('openai')
+  })
+
+  it('is case-insensitive, like getProviderFromModel', () => {
+    expect(findProviderFromModel('Claude-Sonnet-5')).toBe('anthropic')
+  })
+
+  it('returns null for ids the registry does not declare, instead of guessing ollama', () => {
+    /* The registry holds chat models only. Speech, image, video and embedding
+       ids reach `model` subblocks too, and a permission gate must not read them
+       as Ollama models — see isModelUsable. */
+    for (const id of ['whisper-1', 'dall-e-3', 'veo-3.1', 'embed-v4.0', 'tts-1']) {
+      expect(findProviderFromModel(id)).toBeNull()
+    }
+  })
+
+  it('still lets getProviderFromModel fall back to ollama for those ids', () => {
+    expect(getProviderFromModel('whisper-1')).toBe('ollama')
   })
 })

--- a/apps/sim/providers/utils.ts
+++ b/apps/sim/providers/utils.ts
@@ -286,26 +286,34 @@ export function getAllModelProviders(): Record<string, ProviderId> {
   )
 }
 
+/**
+ * The provider that declares `model`, or `null` when none does.
+ *
+ * The non-guessing half of {@link getProviderFromModel}. A caller that *gates*
+ * on the answer needs "unknown" to stay distinct from "ollama": this registry
+ * holds chat models only, so every embedding, speech, image and video model id
+ * would otherwise read as an Ollama model and be judged against an allowlist
+ * that was never about it.
+ */
+export function findProviderFromModel(model: string): ProviderId | null {
+  const normalizedModel = model.toLowerCase()
+
+  const declared = getAllModelProviders()[normalizedModel]
+  if (declared) return declared
+
+  for (const [id, config] of Object.entries(providers)) {
+    for (const pattern of config.modelPatterns ?? []) {
+      if (pattern.test(normalizedModel)) return id as ProviderId
+    }
+  }
+
+  return null
+}
+
 export function getProviderFromModel(model: string): ProviderId {
   const normalizedModel = model.toLowerCase()
 
-  let providerId: ProviderId | null = null
-
-  if (normalizedModel in getAllModelProviders()) {
-    providerId = getAllModelProviders()[normalizedModel]
-  } else {
-    for (const [id, config] of Object.entries(providers)) {
-      if (config.modelPatterns) {
-        for (const pattern of config.modelPatterns) {
-          if (pattern.test(normalizedModel)) {
-            providerId = id as ProviderId
-            break
-          }
-        }
-      }
-      if (providerId) break
-    }
-  }
+  let providerId = findProviderFromModel(model)
 
   if (!providerId) {
     logger.warn(`No provider found for model: ${model}, defaulting to ollama`)

--- a/apps/sim/stores/modals/search/store.test.ts
+++ b/apps/sim/stores/modals/search/store.test.ts
@@ -136,7 +136,10 @@ describe('search modal store', () => {
 
     mockGetAllBlocks.mockReturnValue([visibleBlock, hiddenBlock])
 
-    useSearchModalStore.getState().initializeData((blocks) => blocks)
+    useSearchModalStore.getState().initializeData(
+      (blocks) => blocks,
+      () => true
+    )
 
     const { tools } = useSearchModalStore.getState().data
     expect(tools).toHaveLength(1)

--- a/apps/sim/stores/modals/search/store.ts
+++ b/apps/sim/stores/modals/search/store.ts
@@ -1,10 +1,11 @@
 import { Repeat, Split } from '@sim/emcn/icons'
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
+import { isOperationAllowed } from '@/lib/permission-groups/operation-access'
 import { toSearchToken } from '@/lib/search/tokens'
 import { getToolOperationsIndex } from '@/lib/search/tool-operations'
 import { getTriggersForSidebar } from '@/lib/workflows/triggers/trigger-utils'
-import { getAllBlocks } from '@/blocks'
+import { getAllBlocks, getBlock } from '@/blocks'
 import type { BlockConfig, SubBlockConfig } from '@/blocks/types'
 import type {
   SearchBlockItem,
@@ -80,7 +81,7 @@ export const useSearchModalStore = create<SearchModalState>()(
         set({ isOpen: false })
       },
 
-      initializeData: (filterBlocks) => {
+      initializeData: (filterBlocks, isToolAllowed) => {
         const allBlocks = getAllBlocks()
         const filteredAllBlocks = filterBlocks(allBlocks) as typeof allBlocks
 
@@ -158,6 +159,10 @@ export const useSearchModalStore = create<SearchModalState>()(
         const allowedBlockTypes = new Set(tools.map((t) => t.type))
         const toolOperations: SearchToolOperationItem[] = getToolOperationsIndex()
           .filter((op) => allowedBlockTypes.has(op.blockType))
+          /* Selecting a result drops a block already set to that operation, so
+             the group's tool denylist has to apply here too — the block-level
+             allowlist above only decides whether the integration is offered. */
+          .filter((op) => isOperationAllowed(getBlock(op.blockType), op.operationId, isToolAllowed))
           .map((op) => {
             const aliasesStr = op.aliases?.length
               ? ` ${op.aliases.map(toSearchToken).join(' ')}`

--- a/apps/sim/stores/modals/search/types.ts
+++ b/apps/sim/stores/modals/search/types.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react'
+import type { IsToolAllowed } from '@/lib/permission-groups/operation-access'
 import type { BlockConfig } from '@/blocks/types'
 
 /**
@@ -78,7 +79,11 @@ export interface SearchModalState {
   close: () => void
 
   /**
-   * Initialize search data. Called once on app load.
+   * Initialize search data. Re-runs whenever the caller's permission config
+   * resolves or changes, since both predicates are derived from it.
    */
-  initializeData: (filterBlocks: <T extends { type: string }>(blocks: T[]) => T[]) => void
+  initializeData: (
+    filterBlocks: <T extends { type: string }>(blocks: T[]) => T[],
+    isToolAllowed: IsToolAllowed
+  ) => void
 }

--- a/apps/sim/stores/workflows/utils.test.ts
+++ b/apps/sim/stores/workflows/utils.test.ts
@@ -1076,6 +1076,8 @@ describe('prepareBlockState — permission-group seed veto', () => {
       { id: 'operation', type: 'dropdown', defaultValue: 'send' },
       { id: 'model', type: 'combobox', defaultValue: 'claude-sonnet-5' },
       { id: 'channel', type: 'short-input', defaultValue: '#general' },
+      { id: 'blank', type: 'short-input', defaultValue: '' },
+      { id: 'headers', type: 'table', defaultValue: [] },
     ],
   }
 
@@ -1102,6 +1104,8 @@ describe('prepareBlockState — permission-group seed veto', () => {
       operation: 'send',
       model: 'claude-sonnet-5',
       channel: '#general',
+      blank: '',
+      headers: [],
     })
   })
 
@@ -1110,7 +1114,27 @@ describe('prepareBlockState — permission-group seed veto', () => {
       operation: 'send',
       model: 'claude-sonnet-5',
       channel: '#general',
+      blank: '',
+      headers: [],
     })
+  })
+
+  it('never consults the gate for an empty or non-string default', () => {
+    /* Both are "nothing was declared" rather than a value to authorize, and a
+       gate that saw them would veto every unfilled field. */
+    const seen: string[] = []
+    seededValues((subBlockId) => {
+      seen.push(subBlockId)
+      return true
+    })
+    expect(seen).not.toContain('blank')
+    expect(seen).not.toContain('headers')
+  })
+
+  it('keeps an empty or non-string default even when the gate rejects everything', () => {
+    const values = seededValues(() => false)
+    expect(values.blank).toBe('')
+    expect(values.headers).toEqual([])
   })
 
   it('leaves a denied operation unseeded rather than substituting one', () => {
@@ -1124,18 +1148,6 @@ describe('prepareBlockState — permission-group seed veto', () => {
     const values = seededValues((subBlockId) => subBlockId !== 'model')
     expect(values.model).toBeNull()
     expect(values.operation).toBe('send')
-  })
-
-  it('seeds nothing restricted when the gate answers no for an unknown config', () => {
-    /* Creation is one-shot: the caller vetoes both restricted fields while the
-       permission config is loading, since a value written here is never
-       revisited. Unrestricted fields still seed. */
-    const values = seededValues(
-      (subBlockId) => subBlockId !== 'operation' && subBlockId !== 'model'
-    )
-    expect(values.operation).toBeNull()
-    expect(values.model).toBeNull()
-    expect(values.channel).toBe('#general')
   })
 
   it('passes the seeded value to the gate, not just the field id', () => {

--- a/apps/sim/stores/workflows/utils.test.ts
+++ b/apps/sim/stores/workflows/utils.test.ts
@@ -7,9 +7,10 @@ import {
   createStarterBlock,
 } from '@sim/testing'
 import type { Edge } from 'reactflow'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getBlock } from '@/blocks/registry'
 import { normalizeName } from '@/executor/constants'
-import { filterNewEdges, getUniqueBlockName, regenerateBlockIds } from './utils'
+import { filterNewEdges, getUniqueBlockName, prepareBlockState, regenerateBlockIds } from './utils'
 
 describe('normalizeName', () => {
   it.concurrent('should convert to lowercase', () => {
@@ -1061,5 +1062,80 @@ describe('regenerateBlockIds — cloned webhook path', () => {
     expect(result.subBlockValues[newId].triggerConfig).toEqual({ labelIds: ['a'] })
     expect(result.subBlockValues[newId].triggerId).toBe('generic_webhook')
     expect(result.subBlockValues[newId].token).toBe('user-secret')
+  })
+})
+
+describe('prepareBlockState — permission-group seed veto', () => {
+  const blockWithDefaults = {
+    name: 'Mock Block',
+    description: '',
+    icon: () => null,
+    outputs: {},
+    tools: { access: ['slack_message'] },
+    subBlocks: [
+      { id: 'operation', type: 'dropdown', defaultValue: 'send' },
+      { id: 'model', type: 'combobox', defaultValue: 'claude-sonnet-5' },
+      { id: 'channel', type: 'short-input', defaultValue: '#general' },
+    ],
+  }
+
+  const seededValues = (isSeededValueAllowed?: (subBlockId: string, value: string) => boolean) => {
+    vi.mocked(getBlock).mockReturnValueOnce(blockWithDefaults as never)
+    const block = prepareBlockState({
+      id: 'b1',
+      type: 'slack',
+      name: 'Slack',
+      position: { x: 0, y: 0 },
+      isSeededValueAllowed,
+    })
+    return Object.fromEntries(
+      Object.entries(block.subBlocks).map(([id, subBlock]) => [id, subBlock.value])
+    )
+  }
+
+  afterEach(() => {
+    vi.mocked(getBlock).mockReset()
+  })
+
+  it('seeds every declared default when no gate is supplied', () => {
+    expect(seededValues()).toEqual({
+      operation: 'send',
+      model: 'claude-sonnet-5',
+      channel: '#general',
+    })
+  })
+
+  it('seeds every declared default when the gate allows them', () => {
+    expect(seededValues(() => true)).toEqual({
+      operation: 'send',
+      model: 'claude-sonnet-5',
+      channel: '#general',
+    })
+  })
+
+  it('leaves a denied operation unseeded rather than substituting one', () => {
+    const values = seededValues((subBlockId) => subBlockId !== 'operation')
+    expect(values.operation).toBeNull()
+    expect(values.model).toBe('claude-sonnet-5')
+    expect(values.channel).toBe('#general')
+  })
+
+  it('leaves a denied model unseeded', () => {
+    const values = seededValues((subBlockId) => subBlockId !== 'model')
+    expect(values.model).toBeNull()
+    expect(values.operation).toBe('send')
+  })
+
+  it('passes the seeded value to the gate, not just the field id', () => {
+    const seen: Array<[string, string]> = []
+    seededValues((subBlockId, value) => {
+      seen.push([subBlockId, value])
+      return true
+    })
+    expect(seen).toEqual([
+      ['operation', 'send'],
+      ['model', 'claude-sonnet-5'],
+      ['channel', '#general'],
+    ])
   })
 })

--- a/apps/sim/stores/workflows/utils.test.ts
+++ b/apps/sim/stores/workflows/utils.test.ts
@@ -1126,6 +1126,18 @@ describe('prepareBlockState — permission-group seed veto', () => {
     expect(values.operation).toBe('send')
   })
 
+  it('seeds nothing restricted when the gate answers no for an unknown config', () => {
+    /* Creation is one-shot: the caller vetoes both restricted fields while the
+       permission config is loading, since a value written here is never
+       revisited. Unrestricted fields still seed. */
+    const values = seededValues(
+      (subBlockId) => subBlockId !== 'operation' && subBlockId !== 'model'
+    )
+    expect(values.operation).toBeNull()
+    expect(values.model).toBeNull()
+    expect(values.channel).toBe('#general')
+  })
+
   it('passes the seeded value to the gate, not just the field id', () => {
     const seen: Array<[string, string]> = []
     seededValues((subBlockId, value) => {

--- a/apps/sim/stores/workflows/utils.ts
+++ b/apps/sim/stores/workflows/utils.ts
@@ -2,6 +2,7 @@ import { generateId } from '@sim/utils/id'
 import { mergeSubblockStateWithValues } from '@sim/workflow-persistence/subblocks'
 import { filterUniqueWorkflowEdges } from '@sim/workflow-types/workflow'
 import type { Edge } from 'reactflow'
+import type { SeedValueGate } from '@/lib/permission-groups/operation-access'
 import { DEFAULT_DUPLICATE_OFFSET } from '@/lib/workflows/autolayout/constants'
 import { getEffectiveBlockOutputs } from '@/lib/workflows/blocks/block-outputs'
 import { remapConditionBlockIds, remapConditionEdgeHandle } from '@/lib/workflows/condition-ids'
@@ -112,10 +113,12 @@ export interface PrepareBlockStateOptions {
    * that knows how to make it. Substituting here instead would also drift from
    * `getDefaultBlockName`, which names the block after its *declared* default.
    *
-   * Omitted where the acting user's config is unknown or does not apply, in
-   * which case declared defaults are seeded unchanged.
+   * Omit it entirely only where permission gating does not apply, in which case
+   * declared defaults are seeded unchanged. A caller that cannot yet answer —
+   * config still loading — vetoes rather than omitting, since a value written
+   * here is never revisited.
    */
-  isSeededValueAllowed?: (subBlockId: string, value: string) => boolean
+  isSeededValueAllowed?: SeedValueGate
 }
 
 /**

--- a/apps/sim/stores/workflows/utils.ts
+++ b/apps/sim/stores/workflows/utils.ts
@@ -1,7 +1,9 @@
 import { generateId } from '@sim/utils/id'
+import { isRecordLike } from '@sim/utils/object'
 import { mergeSubblockStateWithValues } from '@sim/workflow-persistence/subblocks'
 import { filterUniqueWorkflowEdges } from '@sim/workflow-types/workflow'
 import type { Edge } from 'reactflow'
+import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
 import { DEFAULT_DUPLICATE_OFFSET } from '@/lib/workflows/autolayout/constants'
 import { getEffectiveBlockOutputs } from '@/lib/workflows/blocks/block-outputs'
 import { remapConditionBlockIds, remapConditionEdgeHandle } from '@/lib/workflows/condition-ids'
@@ -10,6 +12,7 @@ import { createDefaultInputFormatField } from '@/lib/workflows/input-format'
 import { buildDefaultCanonicalModes } from '@/lib/workflows/subblocks/visibility'
 import { hasTriggerCapability } from '@/lib/workflows/triggers/trigger-utils'
 import { getBlock } from '@/blocks'
+import type { SubBlockConfig } from '@/blocks/types'
 import { escapeRegExp, normalizeName } from '@/executor/constants'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
@@ -101,6 +104,44 @@ export interface PrepareBlockStateOptions {
   parentId?: string
   extent?: 'parent'
   triggerMode?: boolean
+  /**
+   * Gate for the seeded operation. A block whose declared default operation the
+   * creator's permission group denies is seeded with the first operation they
+   * can run instead — nothing revisits a field that already holds a value, so
+   * an unpermitted default would otherwise survive until it failed at
+   * execution. Omitted where the acting user's config is unknown or does not
+   * apply, in which case the declared default is used unchanged.
+   */
+  isOperationAllowed?: (operationId: string) => boolean
+}
+
+/**
+ * The first operation the caller may run from an operation subblock's declared
+ * options, skipping the ones its block hides from the picker.
+ */
+function firstAllowedOperation(
+  subBlock: SubBlockConfig,
+  isOperationAllowed: (operationId: string) => boolean
+): string | null {
+  let options: unknown
+  try {
+    options = typeof subBlock.options === 'function' ? subBlock.options() : subBlock.options
+  } catch {
+    return null
+  }
+  if (!Array.isArray(options)) return null
+
+  for (const option of options) {
+    if (typeof option === 'string') {
+      if (isOperationAllowed(option)) return option
+      continue
+    }
+    if (isRecordLike(option) && typeof option.id === 'string' && !option.hidden) {
+      if (isOperationAllowed(option.id)) return option.id
+    }
+  }
+
+  return null
 }
 
 /**
@@ -108,7 +149,17 @@ export interface PrepareBlockStateOptions {
  * Generates subBlocks and outputs from the block registry.
  */
 export function prepareBlockState(options: PrepareBlockStateOptions): BlockState {
-  const { id, type, name, position, data, parentId, extent, triggerMode = false } = options
+  const {
+    id,
+    type,
+    name,
+    position,
+    data,
+    parentId,
+    extent,
+    triggerMode = false,
+    isOperationAllowed,
+  } = options
 
   const blockConfig = getBlock(type)
 
@@ -151,6 +202,15 @@ export function prepareBlockState(options: PrepareBlockStateOptions): BlockState
         initialValue = [createDefaultInputFormatField()]
       } else if (subBlock.type === 'table') {
         initialValue = []
+      }
+
+      if (
+        isOperationAllowed &&
+        subBlock.id === OPERATION_SUBBLOCK_ID &&
+        typeof initialValue === 'string' &&
+        !isOperationAllowed(initialValue)
+      ) {
+        initialValue = firstAllowedOperation(subBlock, isOperationAllowed)
       }
 
       subBlocks[subBlock.id] = {

--- a/apps/sim/stores/workflows/utils.ts
+++ b/apps/sim/stores/workflows/utils.ts
@@ -1,9 +1,7 @@
 import { generateId } from '@sim/utils/id'
-import { isRecordLike } from '@sim/utils/object'
 import { mergeSubblockStateWithValues } from '@sim/workflow-persistence/subblocks'
 import { filterUniqueWorkflowEdges } from '@sim/workflow-types/workflow'
 import type { Edge } from 'reactflow'
-import { OPERATION_SUBBLOCK_ID } from '@/lib/permission-groups/operation-access'
 import { DEFAULT_DUPLICATE_OFFSET } from '@/lib/workflows/autolayout/constants'
 import { getEffectiveBlockOutputs } from '@/lib/workflows/blocks/block-outputs'
 import { remapConditionBlockIds, remapConditionEdgeHandle } from '@/lib/workflows/condition-ids'
@@ -12,7 +10,6 @@ import { createDefaultInputFormatField } from '@/lib/workflows/input-format'
 import { buildDefaultCanonicalModes } from '@/lib/workflows/subblocks/visibility'
 import { hasTriggerCapability } from '@/lib/workflows/triggers/trigger-utils'
 import { getBlock } from '@/blocks'
-import type { SubBlockConfig } from '@/blocks/types'
 import { escapeRegExp, normalizeName } from '@/executor/constants'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
@@ -105,43 +102,20 @@ export interface PrepareBlockStateOptions {
   extent?: 'parent'
   triggerMode?: boolean
   /**
-   * Gate for the seeded operation. A block whose declared default operation the
-   * creator's permission group denies is seeded with the first operation they
-   * can run instead — nothing revisits a field that already holds a value, so
-   * an unpermitted default would otherwise survive until it failed at
-   * execution. Omitted where the acting user's config is unknown or does not
-   * apply, in which case the declared default is used unchanged.
+   * Vetoes a declared default that the creator's permission group denies —
+   * today the `operation` and `model` fields, both of which blocks pre-fill.
+   *
+   * A vetoed field is seeded with nothing rather than a substitute. The editor's
+   * own permission-aware pickers already resolve the right replacement (first
+   * allowed operation; preferred-then-first allowed model) and they only fill a
+   * field that is empty, so leaving it empty hands the choice to the one place
+   * that knows how to make it. Substituting here instead would also drift from
+   * `getDefaultBlockName`, which names the block after its *declared* default.
+   *
+   * Omitted where the acting user's config is unknown or does not apply, in
+   * which case declared defaults are seeded unchanged.
    */
-  isOperationAllowed?: (operationId: string) => boolean
-}
-
-/**
- * The first operation the caller may run from an operation subblock's declared
- * options, skipping the ones its block hides from the picker.
- */
-function firstAllowedOperation(
-  subBlock: SubBlockConfig,
-  isOperationAllowed: (operationId: string) => boolean
-): string | null {
-  let options: unknown
-  try {
-    options = typeof subBlock.options === 'function' ? subBlock.options() : subBlock.options
-  } catch {
-    return null
-  }
-  if (!Array.isArray(options)) return null
-
-  for (const option of options) {
-    if (typeof option === 'string') {
-      if (isOperationAllowed(option)) return option
-      continue
-    }
-    if (isRecordLike(option) && typeof option.id === 'string' && !option.hidden) {
-      if (isOperationAllowed(option.id)) return option.id
-    }
-  }
-
-  return null
+  isSeededValueAllowed?: (subBlockId: string, value: string) => boolean
 }
 
 /**
@@ -158,7 +132,7 @@ export function prepareBlockState(options: PrepareBlockStateOptions): BlockState
     parentId,
     extent,
     triggerMode = false,
-    isOperationAllowed,
+    isSeededValueAllowed,
   } = options
 
   const blockConfig = getBlock(type)
@@ -205,12 +179,12 @@ export function prepareBlockState(options: PrepareBlockStateOptions): BlockState
       }
 
       if (
-        isOperationAllowed &&
-        subBlock.id === OPERATION_SUBBLOCK_ID &&
+        isSeededValueAllowed &&
         typeof initialValue === 'string' &&
-        !isOperationAllowed(initialValue)
+        initialValue !== '' &&
+        !isSeededValueAllowed(subBlock.id, initialValue)
       ) {
-        initialValue = firstAllowedOperation(subBlock, isOperationAllowed)
+        initialValue = null
       }
 
       subBlocks[subBlock.id] = {


### PR DESCRIPTION
## Summary
- Fixes the reported bug: a block's operation placeholder should be the first operation you have access to in your permission group. The dropdown already hid denied operations, but it seeded its default *before* the permission config query resolved — `usePermissionConfig` reads as "nothing denied" while in flight, so a freshly dropped block persisted the static first operation, and nothing revisits a field that already holds a value. A group denying `slack_message` still got a Slack block sitting on Send Message.
- The same bug existed on the model axis: `agent`, `router` and `evaluator` declare `defaultValue: 'claude-sonnet-5'`, `prepareBlockState` wrote it unconditionally, and the model combobox only fills an *empty* field — so a group denying that model (or the Anthropic provider) got an Agent block pre-filled with a model it can't run.
- Consolidates the rule behind `lib/permission-groups/operation-access` + `useOperationAccess`, which resolves an operation to its tool without guessing (unresolvable stays visible; the server gate stays authoritative).

## The governing rule
**A one-shot persisting write must never read a predicate that answers "nothing denied" while the permission config is loading.** Display filtering stays optimistic and self-corrects; anything persisted is withheld until the config is known.

That rule was originally re-implemented per callsite and got missed twice, so it now lives in one place:
- `useOperationAccess.resolveSeedGate` owns the creation-time veto for both restricted fields — `workflow.tsx` states no policy of its own, it asks for a gate and passes it to `prepareBlockState`.
- The agent tool picker and both operation selectors close while the config is unknown. Every list they offer — blocks via `filterBlocks`, operations, MCP and custom tools — reads as unrestricted for that beat, and each pick writes in one shot.
- A preset operation goes through the same gate as a declared default: it comes from the search index, which is itself unfiltered while loading, so it is not the informed pick it appears to be.
- `isPermissionLoading` is exposed from one hook so every surface reads the same symbol.

## Surfaces covered
- block editor dropdown — default waits for the config
- agent block tool list — operations were not gated at all; denied ones are now hidden, blocks whose every operation is denied leave the picker, and the default is the first allowed
- canvas search / connection picker — the tool-operation index was filtered only by the block allowlist, so denied operations were still offered as one-click block drops
- block creation — a denied or not-yet-knowable declared default seeds empty rather than pre-filled

## Notes
- Denied operations are hidden, not removed, so a workflow already saved on one keeps resolving its label. No stored value is ever rewritten — only never-chosen defaults are affected.
- Users with no permission group get identical behavior, except the operation default is seeded after the config query resolves rather than on first render.
- Single-tool blocks with an operation subblock (`dropcontact`, `enrichment`, `sqs`) are now gated where they weren't. Because they're single-tool, denying the tool denies every operation, so the picker empties rather than pre-filling.
- `usePermissionConfig` gains `isModelUsable` (model denylist AND provider allowlist) and drops `isModelAllowed`/`isProviderAllowed`, which had no remaining external consumer once the combobox consolidated onto it. Both denylists are now indexed — the gate calls them once per option of every block offered, so a linear scan made a check's cost scale with denylist length (3.2ms → 0.30ms per search-index build at 500 denied tools).
- Copilot's `edit-workflow` validation checks operations against the block's option list but not against `deniedTools`, so it can still author a denied operation. Execution blocks it server-side. Left as a follow-up — it needs `userId`/`workspaceId` plumbed into the server validator.

## Type of Change
- [x] Bug fix

## Testing
- Unit tests on the operation gate and the creation-time seed veto, including the branches where an empty-string or non-string declared default must bypass the gate; verified each fails when the guard it covers is removed
- `bun run type-check` clean, `bun run check:audits` 26/26, 16,596 tests passing
- Enumerated the block registry to check the widened gate: every multi-operation block has a tool selector, no block has an empty operation list, and only 3 of 326 blocks declare an operation default at all

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
