### PR TITLE
fix(tables): re-check the find match at the reveal, not just before paging

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -1315,8 +1315,16 @@ export function TableGrid({
     // trusting the check `goToMatch` made before its await.
     if (!isStillAMatch(match)) {
       pendingMatchRef.current = null
-      activeMatchRef.current = null
-      cursorIsOnMatchRef.current = false
+      // Release the cursor only if this reveal still owns it. A pending reveal
+      // waits here for its row to load, and the user can start a newer jump in
+      // that window — which has already claimed the ref. Clearing it blindly
+      // would strand that newer jump with no identity to re-point from, which
+      // is the skip-on-next failure this guard exists to prevent.
+      const active = activeMatchRef.current
+      if (active && active.rowId === match.rowId && active.column === match.column) {
+        activeMatchRef.current = null
+        cursorIsOnMatchRef.current = false
+      }
       return
     }
     const rowIndex = rows.findIndex((r) => r.id === match.rowId)

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -1229,6 +1229,15 @@ export function TableGrid({
   const findOpenRef = useRef(findOpen)
   findOpenRef.current = findOpen
 
+  /**
+   * Whether `match` is still in the live result set. Both the paging await and
+   * the deferred reveal can outlast a refetch that removed it, and revealing a
+   * cell that no longer matches would select a non-hit and mark the cursor as
+   * sitting on a result.
+   */
+  const isStillAMatch = (match: TableFindMatch) =>
+    findMatchesRef.current.some((m) => m.rowId === match.rowId && m.column === match.column)
+
   /** Loads the row containing match `index` (wrapping), then queues the cell reveal. */
   const goToMatch = useCallback(async (index: number) => {
     const matches = findMatchesRef.current
@@ -1256,10 +1265,7 @@ export function TableGrid({
     // revealing it would select a cell that no longer matches and mark the
     // cursor as sitting on a result, which then makes the next step skip the
     // match that replaced it.
-    const stillMatches = findMatchesRef.current.some(
-      (m) => m.rowId === match.rowId && m.column === match.column
-    )
-    if (!stillMatches) {
+    if (!isStillAMatch(match)) {
       activeMatchRef.current = null
       cursorIsOnMatchRef.current = false
       return
@@ -1304,6 +1310,15 @@ export function TableGrid({
   useEffect(() => {
     const match = pendingMatchRef.current
     if (!match) return
+    // Last gate before the selection moves: the queue-to-reveal hop is another
+    // commit the result set can change under, so re-check here too rather than
+    // trusting the check `goToMatch` made before its await.
+    if (!isStillAMatch(match)) {
+      pendingMatchRef.current = null
+      activeMatchRef.current = null
+      cursorIsOnMatchRef.current = false
+      return
+    }
     const rowIndex = rows.findIndex((r) => r.id === match.rowId)
     if (rowIndex === -1) return
     const colIndex = displayColumns.findIndex((c) => c.key === match.column)


### PR DESCRIPTION
## Summary
Follow-up to #6733, which merged while the last review round was still in flight — this is the one fix from that round that didn't make it in.

#6733 added a guard in `goToMatch` so a match removed *while its row was paging* isn't revealed. Greptile's next round pointed out one more window: between `goToMatch` queueing the reveal and the reveal effect running is another commit, and a refetch there can remove the match after the guard has already passed.

- Extracts the membership check into `isStillAMatch(match)` and applies it at the reveal too — the one place the selection actually moves.
- When the match is gone, the pending jump is dropped and the cursor is released (`activeMatchRef` nulled, `cursorIsOnMatchRef` false), so the next step lands on the clamped replacement instead of skipping it.

Without this, a row write or SSE update landing in that window selects a cell that no longer matches and marks the cursor as sitting on a result.

## Type of Change
- [x] Bug fix

## Testing
- Typecheck, `bun run lint:check`, `bun run check:audits` (27 audits), 1313 table tests — all pass on top of current `staging`.
- The async race itself isn't unit-covered: the existing tests exercise the find bar, and driving this needs the 4,600-line grid mounted with a mid-flight refetch. The invariant is now enforced at both seams that can observe it (post-await in `goToMatch`, and the reveal effect).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)