### PR TITLE
fix(workflow): derive the webhook URL only where a sub-block shows one

### DIFF
--- a/apps/sim/hooks/use-webhook-management.ts
+++ b/apps/sim/hooks/use-webhook-management.ts
@@ -100,13 +100,24 @@ export function useWebhookManagement({
     useCallback((state) => state.getValue(blockId, 'triggerPath') as string | null, [blockId])
   )
 
+  /**
+   * Derived only when the caller actually renders the URL. `getBaseUrl()` throws
+   * when `NEXT_PUBLIC_APP_URL` is unset, and `sub-block.tsx` mounts this hook for
+   * every sub-block in the editor panel — deriving the URL unconditionally turns
+   * a missing deployment value into a render throw for fields that never display
+   * one, taking down the whole editor instead of the single webhook field.
+   * Consumers already gate their reads on `useWebhookUrl`.
+   */
   const webhookUrl = useMemo(() => {
+    if (!useWebhookUrl) {
+      return ''
+    }
     const baseUrl = getBaseUrl()
     if (!webhookPath) {
       return `${baseUrl}/api/webhooks/trigger/${blockId}`
     }
     return `${baseUrl}/api/webhooks/trigger/${webhookPath}`
-  }, [webhookPath, blockId])
+  }, [useWebhookUrl, webhookPath, blockId])
 
   useEffect(() => {
     if (triggerId && !isPreview) {


### PR DESCRIPTION
## Summary
- `sub-block.tsx:485` mounts `useWebhookManagement` for **every** sub-block in the editor panel, and the hook derived a webhook URL for all of them. `getBaseUrl()` throws when `NEXT_PUBLIC_APP_URL` reads empty, so a missing deployment value took down the entire workflow route instead of the single webhook field that needed the URL.
- The hook already gates its query and its sub-block store writes on `useWebhookUrl` (`queryEnabled`, line 131). The derived URL was the one value ignoring that flag; it now agrees with the rest of the hook.
- No caller can observe the change: `short-input.tsx:219,341` already read it as `useWebhookUrl && webhookManagement.webhookUrl`, the copy button renders only when `config.showCopyButton && config.useWebhookUrl` (`sub-block.tsx:1209`), and `slack-setup-wizard.tsx:92` passes `useWebhookUrl: true`. The value is never read inside the hook itself.

## Type of Change
- [x] Bug fix

## Testing
Typecheck clean; `hooks/`, `stores/`, and `app/workspace` suites pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)