### PR TITLE
fix(confluence): gate the page selector to operations that use it

### DIFF
--- a/apps/sim/blocks/blocks/confluence.test.ts
+++ b/apps/sim/blocks/blocks/confluence.test.ts
@@ -1,0 +1,307 @@
+/**
+ * @vitest-environment node
+ *
+ * Schema gating for the Confluence blocks' page selector.
+ *
+ * Expectations are derived from the tool contracts rather than hand-copied
+ * operation lists, so adding an operation that consumes a page id fails here
+ * until the block's `condition` is widened to match.
+ */
+import { describe, expect, it } from 'vitest'
+import { evaluateSubBlockCondition } from '@/lib/workflows/subblocks/visibility'
+import { ConfluenceBlock, ConfluenceV2Block } from '@/blocks/blocks/confluence'
+import type { BlockConfig, SubBlockConfig } from '@/blocks/types'
+import {
+  confluenceAddLabelTool,
+  confluenceCreateBlogPostTool,
+  confluenceCreateCommentTool,
+  confluenceCreatePagePropertyTool,
+  confluenceCreatePageTool,
+  confluenceCreateSpacePropertyTool,
+  confluenceCreateSpaceTool,
+  confluenceDeleteAttachmentTool,
+  confluenceDeleteBlogPostTool,
+  confluenceDeleteCommentTool,
+  confluenceDeleteLabelTool,
+  confluenceDeletePagePropertyTool,
+  confluenceDeletePageTool,
+  confluenceDeleteSpacePropertyTool,
+  confluenceDeleteSpaceTool,
+  confluenceGetBlogPostTool,
+  confluenceGetPageAncestorsTool,
+  confluenceGetPageChildrenTool,
+  confluenceGetPageDescendantsTool,
+  confluenceGetPagesByLabelTool,
+  confluenceGetPageVersionTool,
+  confluenceGetSpaceTool,
+  confluenceGetTaskTool,
+  confluenceGetUserTool,
+  confluenceListAttachmentsTool,
+  confluenceListBlogPostsInSpaceTool,
+  confluenceListBlogPostsTool,
+  confluenceListCommentsTool,
+  confluenceListLabelsTool,
+  confluenceListPagePropertiesTool,
+  confluenceListPagesInSpaceTool,
+  confluenceListPageVersionsTool,
+  confluenceListSpaceLabelsTool,
+  confluenceListSpacePermissionsTool,
+  confluenceListSpacePropertiesTool,
+  confluenceListSpacesTool,
+  confluenceListTasksTool,
+  confluenceRetrieveTool,
+  confluenceSearchInSpaceTool,
+  confluenceSearchTool,
+  confluenceUpdateBlogPostTool,
+  confluenceUpdateCommentTool,
+  confluenceUpdateSpaceTool,
+  confluenceUpdateTaskTool,
+  confluenceUpdateTool,
+  confluenceUploadAttachmentTool,
+} from '@/tools/confluence'
+import type { ToolConfig } from '@/tools/types'
+
+/**
+ * Confluence tools keyed by id. Imported directly rather than through
+ * `@/tools/registry`, which `vitest.setup.ts` mocks to `{}` for import cost —
+ * going through the registry would make every contract assertion pass vacuously.
+ */
+const TOOLS_BY_ID = new Map<string, ToolConfig>(
+  (
+    [
+      confluenceAddLabelTool,
+      confluenceCreateBlogPostTool,
+      confluenceCreateCommentTool,
+      confluenceCreatePagePropertyTool,
+      confluenceCreatePageTool,
+      confluenceCreateSpacePropertyTool,
+      confluenceCreateSpaceTool,
+      confluenceDeleteAttachmentTool,
+      confluenceDeleteBlogPostTool,
+      confluenceDeleteCommentTool,
+      confluenceDeleteLabelTool,
+      confluenceDeletePagePropertyTool,
+      confluenceDeletePageTool,
+      confluenceDeleteSpacePropertyTool,
+      confluenceDeleteSpaceTool,
+      confluenceGetBlogPostTool,
+      confluenceGetPageAncestorsTool,
+      confluenceGetPageChildrenTool,
+      confluenceGetPageDescendantsTool,
+      confluenceGetPageVersionTool,
+      confluenceGetPagesByLabelTool,
+      confluenceGetSpaceTool,
+      confluenceGetTaskTool,
+      confluenceGetUserTool,
+      confluenceListAttachmentsTool,
+      confluenceListBlogPostsInSpaceTool,
+      confluenceListBlogPostsTool,
+      confluenceListCommentsTool,
+      confluenceListLabelsTool,
+      confluenceListPagePropertiesTool,
+      confluenceListPageVersionsTool,
+      confluenceListPagesInSpaceTool,
+      confluenceListSpaceLabelsTool,
+      confluenceListSpacePermissionsTool,
+      confluenceListSpacePropertiesTool,
+      confluenceListSpacesTool,
+      confluenceListTasksTool,
+      confluenceRetrieveTool,
+      confluenceSearchInSpaceTool,
+      confluenceSearchTool,
+      confluenceUpdateBlogPostTool,
+      confluenceUpdateCommentTool,
+      confluenceUpdateSpaceTool,
+      confluenceUpdateTaskTool,
+      confluenceUpdateTool,
+      confluenceUploadAttachmentTool,
+    ] as ToolConfig[]
+  ).map((tool) => [tool.id, tool])
+)
+
+/**
+ * V2 operations that render a page target today but consume no page id: `create`
+ * and `create_blogpost` produce one, and the comment/attachment mutations address
+ * their own id. `list_tasks` accepts an optional page filter but has always been
+ * hidden — un-hiding it would make a stale stored value start filtering, so it
+ * stays out.
+ */
+const V2_PAGE_HIDDEN_OPERATIONS = [
+  'create',
+  'create_blogpost',
+  'update_comment',
+  'delete_comment',
+  'delete_attachment',
+] as const
+
+const PAGE_MEMBERS = ['pageId', 'manualPageId'] as const
+
+const operationOptions = (block: BlockConfig) =>
+  block.subBlocks.find((sb) => sb.id === 'operation')?.options as Array<{
+    id: string
+    label: string
+  }>
+
+const operationIdsOf = (block: BlockConfig) => operationOptions(block).map((o) => o.id)
+
+const subBlockOf = (block: BlockConfig, id: string): SubBlockConfig => {
+  const found = block.subBlocks.find((sb) => sb.id === id)
+  if (!found) throw new Error(`Block has no subblock "${id}"`)
+  return found
+}
+
+const isVisibleFor = (sb: SubBlockConfig, operation: string): boolean =>
+  evaluateSubBlockCondition(sb.condition, { operation })
+
+const isRequiredFor = (sb: SubBlockConfig, operation: string): boolean => {
+  if (typeof sb.required === 'boolean') return sb.required
+  if (!sb.required) return false
+  return evaluateSubBlockCondition(sb.required, { operation })
+}
+
+/**
+ * Field ids a canvas sentence names for one operation, flattening the
+ * basic/advanced pairs that a clause may reference as a tuple.
+ */
+const sentenceFieldsFor = (block: BlockConfig, operation: string): string[] => {
+  const clauses = block.canvasPresentation?.sentences?.byOperation?.[operation] ?? []
+  return clauses.flatMap((clause) =>
+    typeof clause === 'string' || !clause.field ? [] : [clause.field].flat()
+  )
+}
+
+const toolIdFor = (block: BlockConfig, operation: string): string =>
+  (block.tools.config?.tool as (params: Record<string, string>) => string)({ operation })
+
+const toolRequiresParam = (block: BlockConfig, operation: string, paramId: string): boolean => {
+  const toolId = toolIdFor(block, operation)
+  const tool = TOOLS_BY_ID.get(toolId)
+  if (!tool) throw new Error(`No imported tool for "${toolId}" (operation "${operation}")`)
+  return Boolean(tool.params?.[paramId]?.required)
+}
+
+describe('Confluence v2 page-selector gating', () => {
+  const operationIds = operationIdsOf(ConfluenceV2Block)
+
+  it('resolves every operation to an imported tool', () => {
+    const unresolved = operationIds.filter(
+      (operation) => !TOOLS_BY_ID.has(toolIdFor(ConfluenceV2Block, operation))
+    )
+    expect(unresolved).toEqual([])
+  })
+
+  it.each(operationIds)(
+    'shows the page target for %s whenever its tool requires pageId',
+    (operation) => {
+      if (!toolRequiresParam(ConfluenceV2Block, operation, 'pageId')) return
+      for (const id of PAGE_MEMBERS) {
+        expect(isVisibleFor(subBlockOf(ConfluenceV2Block, id), operation)).toBe(true)
+      }
+    }
+  )
+
+  it.each(V2_PAGE_HIDDEN_OPERATIONS)('hides the page target for %s', (operation) => {
+    expect(toolRequiresParam(ConfluenceV2Block, operation, 'pageId')).toBe(false)
+    for (const id of PAGE_MEMBERS) {
+      expect(isVisibleFor(subBlockOf(ConfluenceV2Block, id), operation)).toBe(false)
+    }
+  })
+
+  it('keeps the dedicated parent field on create, where the page target is gone', () => {
+    expect(isVisibleFor(subBlockOf(ConfluenceV2Block, 'pageId'), 'create')).toBe(false)
+    expect(isVisibleFor(subBlockOf(ConfluenceV2Block, 'parentId'), 'create')).toBe(true)
+  })
+
+  it('is visible on every operation where it is required', () => {
+    for (const id of PAGE_MEMBERS) {
+      const sb = subBlockOf(ConfluenceV2Block, id)
+      for (const operation of operationIds) {
+        if (!isRequiredFor(sb, operation)) continue
+        expect(isVisibleFor(sb, operation)).toBe(true)
+      }
+    }
+  })
+
+  it('renders both canonical twins identically', () => {
+    const basic = subBlockOf(ConfluenceV2Block, 'pageId')
+    const advanced = subBlockOf(ConfluenceV2Block, 'manualPageId')
+    expect(advanced.canonicalParamId).toBe(basic.canonicalParamId)
+    expect(advanced.dependsOn).toEqual(basic.dependsOn)
+    for (const operation of operationIds) {
+      expect(isVisibleFor(advanced, operation)).toBe(isVisibleFor(basic, operation))
+      expect(isRequiredFor(advanced, operation)).toBe(isRequiredFor(basic, operation))
+    }
+  })
+
+  it.each(operationIds)('%s leaves every rendered dependency satisfiable', (operation) => {
+    const visible = ConfluenceV2Block.subBlocks.filter((sb) => isVisibleFor(sb, operation))
+    const visibleIds = new Set(visible.map((sb) => sb.id))
+    for (const sb of visible) {
+      const deps = Array.isArray(sb.dependsOn) ? sb.dependsOn : []
+      for (const dep of deps) {
+        const depConfigs = ConfluenceV2Block.subBlocks.filter(
+          (candidate) => candidate.id === dep || candidate.canonicalParamId === dep
+        )
+        expect(
+          depConfigs.some((candidate) => visibleIds.has(candidate.id)),
+          `"${sb.id}" renders for "${operation}" but its dependency "${dep}" does not`
+        ).toBe(true)
+      }
+    }
+  })
+
+  it.each(operationIds)('%s names only fields its canvas sentence can render', (operation) => {
+    for (const field of sentenceFieldsFor(ConfluenceV2Block, operation)) {
+      const sb = ConfluenceV2Block.subBlocks.find((candidate) => candidate.id === field)
+      if (!sb) continue
+      expect(isVisibleFor(sb, operation), `"${field}" is named but never renders`).toBe(true)
+    }
+  })
+
+  it('uses the Get convention for the single-page read', () => {
+    const label = operationOptions(ConfluenceV2Block).find((o) => o.id === 'read')?.label
+    expect(label).toBe('Get Page')
+    expect(toolIdFor(ConfluenceV2Block, 'read')).toBe('confluence_retrieve')
+  })
+})
+
+describe('legacy Confluence block', () => {
+  const operationIds = operationIdsOf(ConfluenceBlock)
+
+  it('is sunset in favour of confluence_v2', () => {
+    expect(ConfluenceBlock.hideFromToolbar).toBe(true)
+    expect(ConfluenceBlock.sunset?.replacedBy).toBe('confluence_v2')
+  })
+
+  it('gates the page target instead of rendering it on every operation', () => {
+    for (const id of PAGE_MEMBERS) {
+      const sb = subBlockOf(ConfluenceBlock, id)
+      expect(sb.condition).toBeDefined()
+      const hidden = operationIds.filter((operation) => !isVisibleFor(sb, operation))
+      expect(hidden.length).toBeGreaterThan(0)
+    }
+  })
+
+  it.each(operationIds)(
+    'shows the page target for %s whenever its tool requires pageId',
+    (operation) => {
+      if (!toolRequiresParam(ConfluenceBlock, operation, 'pageId')) return
+      for (const id of PAGE_MEMBERS) {
+        expect(isVisibleFor(subBlockOf(ConfluenceBlock, id), operation)).toBe(true)
+      }
+    }
+  )
+
+  it.each(operationIds)('%s names only fields its canvas sentence can render', (operation) => {
+    for (const field of sentenceFieldsFor(ConfluenceBlock, operation)) {
+      const sb = ConfluenceBlock.subBlocks.find((candidate) => candidate.id === field)
+      if (!sb) continue
+      expect(isVisibleFor(sb, operation), `"${field}" is named but never renders`).toBe(true)
+    }
+  })
+
+  it('keeps its own operation labels untouched', () => {
+    const label = operationOptions(ConfluenceBlock).find((o) => o.id === 'read')?.label
+    expect(label).toBe('Read Page')
+  })
+})

--- a/apps/sim/blocks/blocks/confluence.test.ts
+++ b/apps/sim/blocks/blocks/confluence.test.ts
@@ -191,11 +191,16 @@ describe('Confluence v2 page-selector gating', () => {
   })
 
   it.each(operationIds)(
-    'shows the page target for %s whenever its tool requires pageId',
+    'shows the page target for %s exactly when its tool requires pageId',
     (operation) => {
-      if (!toolRequiresParam(ConfluenceV2Block, operation, 'pageId')) return
+      const required = toolRequiresParam(ConfluenceV2Block, operation, 'pageId')
       for (const id of PAGE_MEMBERS) {
-        expect(isVisibleFor(subBlockOf(ConfluenceV2Block, id), operation)).toBe(true)
+        expect(
+          isVisibleFor(subBlockOf(ConfluenceV2Block, id), operation),
+          required
+            ? `"${id}" must render for "${operation}", whose tool requires pageId`
+            : `"${id}" must not render for "${operation}", whose tool takes no required pageId`
+        ).toBe(required)
       }
     }
   )
@@ -283,11 +288,16 @@ describe('legacy Confluence block', () => {
   })
 
   it.each(operationIds)(
-    'shows the page target for %s whenever its tool requires pageId',
+    'shows the page target for %s exactly when its tool requires pageId',
     (operation) => {
-      if (!toolRequiresParam(ConfluenceBlock, operation, 'pageId')) return
+      const required = toolRequiresParam(ConfluenceBlock, operation, 'pageId')
       for (const id of PAGE_MEMBERS) {
-        expect(isVisibleFor(subBlockOf(ConfluenceBlock, id), operation)).toBe(true)
+        expect(
+          isVisibleFor(subBlockOf(ConfluenceBlock, id), operation),
+          required
+            ? `"${id}" must render for "${operation}", whose tool requires pageId`
+            : `"${id}" must not render for "${operation}", whose tool takes no required pageId`
+        ).toBe(required)
       }
     }
   )

--- a/apps/sim/blocks/blocks/confluence.ts
+++ b/apps/sim/blocks/blocks/confluence.ts
@@ -19,6 +19,48 @@ const SPACE_FIELD = ['spaceSelector', 'spaceId'] as const
 /** Canonical upload/reference pair for an attachment's file. V2 only. */
 const ATTACHMENT_FILE_FIELD = ['attachmentFileUpload', 'attachmentFileReference'] as const
 
+/**
+ * V2 operations whose tool takes a page id. Creating a page or blog post produces
+ * one rather than consuming it, and the comment/attachment mutations address their
+ * own `commentId`/`attachmentId`, so none of those render the page target.
+ */
+const PAGE_ID_OPERATIONS = [
+  'read',
+  'update',
+  'delete',
+  'create_comment',
+  'list_comments',
+  'list_attachments',
+  'list_labels',
+  'upload_attachment',
+  'add_label',
+  'delete_label',
+  'delete_page_property',
+  'get_page_children',
+  'get_page_ancestors',
+  'list_page_versions',
+  'get_page_version',
+  'list_page_properties',
+  'create_page_property',
+  'get_page_descendants',
+] as const
+
+/**
+ * The legacy block's page-consuming operations. Kept separate from
+ * {@link PAGE_ID_OPERATIONS}: the two blocks expose different operation sets, and
+ * the legacy one is sunset, so it must not track changes to its replacement.
+ */
+const LEGACY_PAGE_ID_OPERATIONS = [
+  'read',
+  'update',
+  'delete',
+  'create_comment',
+  'list_comments',
+  'list_attachments',
+  'list_labels',
+  'upload_attachment',
+] as const
+
 export const ConfluenceBlock: BlockConfig<ConfluenceResponse> = {
   type: 'confluence',
   name: 'Confluence (Legacy)',
@@ -63,10 +105,7 @@ export const ConfluenceBlock: BlockConfig<ConfluenceResponse> = {
           { text: 'Rewrite comment', field: 'commentId', core: true },
           { text: 'as', field: 'comment' },
         ],
-        delete_comment: [
-          { text: 'Delete comment', field: 'commentId', core: true },
-          { text: 'from page', field: PAGE_FIELD },
-        ],
+        delete_comment: [{ text: 'Delete comment', field: 'commentId', core: true }],
         upload_attachment: [
           { text: 'Attach', field: 'attachmentFile', core: true },
           { text: 'to page', field: PAGE_FIELD, core: true },
@@ -75,10 +114,7 @@ export const ConfluenceBlock: BlockConfig<ConfluenceResponse> = {
           { text: 'List attachments on page', field: PAGE_FIELD, core: true },
           { text: ', up to', field: 'limit', after: 'results' },
         ],
-        delete_attachment: [
-          { text: 'Delete attachment', field: 'attachmentId', core: true },
-          { text: 'from page', field: PAGE_FIELD },
-        ],
+        delete_attachment: [{ text: 'Delete attachment', field: 'attachmentId', core: true }],
         list_labels: [{ text: 'List labels on page', field: PAGE_FIELD, core: true }],
         get_space: [{ text: 'Read space', field: 'spaceId', core: true }],
         list_spaces: ['List spaces', { text: ', up to', field: 'limit', after: 'results' }],
@@ -146,19 +182,8 @@ export const ConfluenceBlock: BlockConfig<ConfluenceResponse> = {
       placeholder: 'Select Confluence page',
       dependsOn: ['credential', 'domain'],
       mode: 'basic',
-      required: {
-        field: 'operation',
-        value: [
-          'read',
-          'update',
-          'delete',
-          'create_comment',
-          'list_comments',
-          'list_attachments',
-          'list_labels',
-          'upload_attachment',
-        ],
-      },
+      condition: { field: 'operation', value: [...LEGACY_PAGE_ID_OPERATIONS] },
+      required: { field: 'operation', value: [...LEGACY_PAGE_ID_OPERATIONS] },
     },
     {
       id: 'manualPageId',
@@ -166,20 +191,10 @@ export const ConfluenceBlock: BlockConfig<ConfluenceResponse> = {
       type: 'short-input',
       canonicalParamId: 'pageId',
       placeholder: 'Enter Confluence page ID',
+      dependsOn: ['credential', 'domain'],
       mode: 'advanced',
-      required: {
-        field: 'operation',
-        value: [
-          'read',
-          'update',
-          'delete',
-          'create_comment',
-          'list_comments',
-          'list_attachments',
-          'list_labels',
-          'upload_attachment',
-        ],
-      },
+      condition: { field: 'operation', value: [...LEGACY_PAGE_ID_OPERATIONS] },
+      required: { field: 'operation', value: [...LEGACY_PAGE_ID_OPERATIONS] },
     },
     {
       id: 'spaceId',
@@ -441,7 +456,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
     },
     sentences: {
       byOperation: {
-        read: [{ text: 'Read page', field: PAGE_FIELD, core: true }],
+        read: [{ text: 'Get page', field: PAGE_FIELD, core: true }],
         create: [
           { text: 'Create page', field: 'title', core: true },
           { text: 'in', field: SPACE_FIELD },
@@ -515,10 +530,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
           { text: 'Rewrite comment', field: 'commentId', core: true },
           { text: 'as', field: 'comment' },
         ],
-        delete_comment: [
-          { text: 'Delete comment', field: 'commentId', core: true },
-          { text: 'from page', field: PAGE_FIELD },
-        ],
+        delete_comment: [{ text: 'Delete comment', field: 'commentId', core: true }],
         upload_attachment: [
           { text: 'Attach', field: ATTACHMENT_FILE_FIELD, core: true },
           { text: 'to page', field: PAGE_FIELD, core: true },
@@ -527,10 +539,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
           { text: 'List attachments on page', field: PAGE_FIELD, core: true },
           { text: ', up to', field: 'limit', after: 'results' },
         ],
-        delete_attachment: [
-          { text: 'Delete attachment', field: 'attachmentId', core: true },
-          { text: 'from page', field: PAGE_FIELD },
-        ],
+        delete_attachment: [{ text: 'Delete attachment', field: 'attachmentId', core: true }],
         list_labels: [
           { text: 'List labels on page', field: PAGE_FIELD, core: true },
           { text: ', up to', field: 'limit', after: 'results' },
@@ -603,7 +612,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
       type: 'dropdown',
       options: [
         // Page Operations
-        { label: 'Read Page', id: 'read' },
+        { label: 'Get Page', id: 'read' },
         { label: 'Create Page', id: 'create' },
         { label: 'Update Page', id: 'update' },
         { label: 'Delete Page', id: 'delete' },
@@ -702,58 +711,8 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
       placeholder: 'Select Confluence page',
       dependsOn: ['credential', 'domain'],
       mode: 'basic',
-      condition: {
-        field: 'operation',
-        value: [
-          'list_pages_in_space',
-          'list_blogposts',
-          'get_blogpost',
-          'update_blogpost',
-          'delete_blogpost',
-          'list_blogposts_in_space',
-          'search',
-          'search_in_space',
-          'get_space',
-          'create_space',
-          'update_space',
-          'delete_space',
-          'list_spaces',
-          'get_pages_by_label',
-          'list_space_labels',
-          'list_space_permissions',
-          'list_space_properties',
-          'create_space_property',
-          'delete_space_property',
-          'list_tasks',
-          'get_task',
-          'update_task',
-          'get_user',
-        ],
-        not: true,
-      },
-      required: {
-        field: 'operation',
-        value: [
-          'read',
-          'update',
-          'delete',
-          'create_comment',
-          'list_comments',
-          'list_attachments',
-          'list_labels',
-          'upload_attachment',
-          'add_label',
-          'delete_label',
-          'delete_page_property',
-          'get_page_children',
-          'get_page_ancestors',
-          'list_page_versions',
-          'get_page_version',
-          'list_page_properties',
-          'create_page_property',
-          'get_page_descendants',
-        ],
-      },
+      condition: { field: 'operation', value: [...PAGE_ID_OPERATIONS] },
+      required: { field: 'operation', value: [...PAGE_ID_OPERATIONS] },
     },
     {
       id: 'manualPageId',
@@ -761,59 +720,10 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
       type: 'short-input',
       canonicalParamId: 'pageId',
       placeholder: 'Enter Confluence page ID',
+      dependsOn: ['credential', 'domain'],
       mode: 'advanced',
-      condition: {
-        field: 'operation',
-        value: [
-          'list_pages_in_space',
-          'list_blogposts',
-          'get_blogpost',
-          'update_blogpost',
-          'delete_blogpost',
-          'list_blogposts_in_space',
-          'search',
-          'search_in_space',
-          'get_space',
-          'create_space',
-          'update_space',
-          'delete_space',
-          'list_spaces',
-          'get_pages_by_label',
-          'list_space_labels',
-          'list_space_permissions',
-          'list_space_properties',
-          'create_space_property',
-          'delete_space_property',
-          'list_tasks',
-          'get_task',
-          'update_task',
-          'get_user',
-        ],
-        not: true,
-      },
-      required: {
-        field: 'operation',
-        value: [
-          'read',
-          'update',
-          'delete',
-          'create_comment',
-          'list_comments',
-          'list_attachments',
-          'list_labels',
-          'upload_attachment',
-          'add_label',
-          'delete_label',
-          'delete_page_property',
-          'get_page_children',
-          'get_page_ancestors',
-          'list_page_versions',
-          'get_page_version',
-          'list_page_properties',
-          'create_page_property',
-          'get_page_descendants',
-        ],
-      },
+      condition: { field: 'operation', value: [...PAGE_ID_OPERATIONS] },
+      required: { field: 'operation', value: [...PAGE_ID_OPERATIONS] },
     },
     {
       id: 'spaceSelector',

--- a/apps/sim/lib/integrations/integrations.json
+++ b/apps/sim/lib/integrations/integrations.json
@@ -4338,7 +4338,7 @@
       "docsUrl": "https://docs.sim.ai/integrations/confluence",
       "operations": [
         {
-          "name": "Read Page",
+          "name": "Get Page",
           "description": "Retrieve content from Confluence pages using the Confluence API."
         },
         {


### PR DESCRIPTION
## The bug

The v2 Confluence block gated its page target (`pageId` / `manualPageId`) with a 23-entry
`not: true` **denylist**, while the same two subblocks declared `required` as an 18-entry
**allowlist**. The two lists were not complements, so **Select Page rendered on operations that
consume no page id at all**. The most visible case is **Create Page**, where the page id is an
*output* of the operation, not an input: users were shown a required-looking page picker for the
page they were about to create.

## The fix

Both `condition` and `required` now share one positive `PAGE_ID_OPERATIONS` allowlist.

The list was derived rather than hand-written: every one of the 44 v2 operations was mapped through
the block's own `tools.config.tool` switch to its tool file, and the tool's `params` checked for a
`pageId` entry. Exactly **18** tools declare a required `pageId`, and those 18 are the allowlist -
identical to the `required` list that was already there.

**Newly hidden (5):** `create`, `create_blogpost`, `update_comment`, `delete_comment`,
`delete_attachment`. None of their tools declare `pageId`; the two create operations produce a page
id, and the comment/attachment mutations address their own `commentId` / `attachmentId`. No other
subblock depends on the page field for these operations, and `Create Page` keeps its dedicated
`parentId` field, which is the input people actually wanted there.

### Legacy block

`ConfluenceBlock` (`hideFromToolbar`, `sunset.replacedBy: 'confluence_v2'`) had **no `condition` at
all**, so it rendered the page target on all 15 of its operations. It now has its own
`LEGACY_PAGE_ID_OPERATIONS`, seeded from its existing 8-op `required` list and verified the same way
against the tools. It is deliberately a separate constant rather than a reference to
`PAGE_ID_OPERATIONS`: the two blocks expose different operation sets, and a sunset block must not
silently track changes to its replacement. Its labels and sentences are otherwise untouched.

### Also in this diff

- **`dependsOn` symmetry.** `manualPageId` was missing the `dependsOn: ['credential', 'domain']` its
  `pageId` twin has, so the manual field stayed editable while its credential was still unbound.
  Added. This is UI gating only - `dependsOn` does not affect serialization or `required` validation.
- **Dead canvas clauses.** With the page target hidden on `delete_comment` and `delete_attachment`,
  their canvas sentences' trailing `from page` clause referenced a field that can never render.
  The repo's `check:canvas-sentences` audit catches this; the clause is removed on both blocks. The
  rendered sentence is unchanged, since the clause had nothing to interpolate.
- **Label.** v2 `Read Page` becomes `Get Page`, matching the `Get *` convention used by the rest of
  the block's single-item reads, plus its canvas sentence and the generated `integrations.json`
  entry. The legacy block keeps `Read Page`.

## Deliberate non-change

`list_tasks` accepts an **optional** `pageId` filter and the block forwards it, but the selector has
always been hidden, so the filter has never been reachable. Un-hiding it now would make any existing
`list_tasks` block that carries a stale stored `pageId` silently start filtering its results. Left
hidden; worth a separate issue.

## Compatibility

Operation ids and tool ids are unchanged (`read` still maps to `confluence_retrieve`). Only the
display label, the visibility conditions, and one `dependsOn` array moved. Stored workflows are
unaffected: a saved `pageId` on a now-hidden operation was already being dropped by the tool, and
nothing about serialization or `required` validation changed for the 18 operations that use it.

## Tests

`apps/sim/blocks/blocks/confluence.test.ts` - 181 tests covering both blocks. They derive their
expectations from the tool contracts rather than hand-copied operation lists, so adding an operation
whose tool takes a `pageId` fails here until the block's condition is widened to match. A guard test
fails if any operation resolves to a tool the file does not import.

The tools are imported **directly** rather than through `@/tools/registry`: `vitest.setup.ts` mocks
the registry to `{}`, so routing through it would make every contract assertion pass vacuously.

Mutation-checked: stashing the block change turns 9 of them red, and re-adding a dead sentence
clause turns the new canvas-sentence guard red on both blocks.

## Verification

Live end-to-end against a real Confluence site (`sim-testing.atlassian.net`):

- All 44 operations swept in **both** basic and advanced mode and diffed identical - 18 show the
  page field in each, 26 do not.
- `create page` confirmed to render space / title / content / **parentId** and no page selector.
- `get page` executed successfully, returning real page content.
- A runtime `<block.output>` reference typed into the manual page field survived save and reload
  without the selector clobbering it.

Repo gates: `check:canvas-sentences`, `docs:check`, `integration-catalog:check`,
`tool-metadata:check`, `check:api-validation`, `type-check`, and biome all pass. 1711 tests green
across `blocks/`, `connectors/`, `lib/integrations/`, `lib/oauth/`, and `lib/workflows/blocks/`.

## Known pre-existing bug, not addressed here

Confluence v2 fails on any operation that has a rendered-but-empty **optional** field:

```
error: "Confluence: Invalid input: expected string, received null"
```

The block's `params` spreads `...rest` unnormalized, so an untouched subblock's stored `null` reaches
a tool param typed `string`. It hits `create` (via `parentId`) and all 20 list operations (via
`limit`), plus search / update / upload_attachment. Confirmed pre-existing: reproduced on unmodified
staging with this change stashed. It is why `create` could not be executed end to end here, and it
is tracked separately - **not a regression from this PR**.

A separate pre-existing issue also surfaced while validating: `search_in_space` can never succeed,
because its tool and route both require `spaceKey` while the block's space picker supplies `spaceId`.
Also out of scope here.
