### PR TITLE
docs(integrations): add missing manual intros; fix light brand tiles rendering white glyphs

### DIFF
--- a/apps/docs/content/docs/en/integrations/buffer.mdx
+++ b/apps/docs/content/docs/en/integrations/buffer.mdx
@@ -10,6 +10,22 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
   color="#FFFFFF"
 />
 
+{/* MANUAL-CONTENT-START:intro */}
+[Buffer](https://buffer.com/) is a social media management platform that lets teams draft, schedule, and publish content across their connected social channels from a single queue. Each channel — Instagram, LinkedIn, X, Facebook, TikTok, and more — is connected once in Buffer, and posts are published on the schedule you define.
+
+With the Buffer integration in Sim, you can:
+
+- **Publish and schedule posts**: Create a post for a channel and add it to the queue, share it immediately, schedule it for a specific time, or save it as a draft
+- **Attach media**: Include an image or video with a post
+- **Manage existing posts**: Edit, retrieve, list, and delete posts
+- **Browse channels**: List the social channels connected to the account, along with their IDs and service types
+- **Capture ideas**: Create ideas and list ideas and idea groups from the Buffer content pipeline
+- **Read account details**: Retrieve the authenticated Buffer account
+
+In Sim, the Buffer integration enables your agents to turn generated content into scheduled social posts without manual copy-paste. An agent can draft copy, look up the right channel, attach a generated image, and queue the post — or review the existing queue and clean up posts that are no longer relevant.
+{/* MANUAL-CONTENT-END */}
+
+
 ## Usage Instructions
 
 Integrate Buffer into your workflow. Create, schedule, edit, and delete posts across connected social channels (Instagram, LinkedIn, X, Facebook, TikTok, and more), attach images or videos, browse channels, and capture content ideas using the Buffer API.

--- a/apps/docs/content/docs/en/integrations/clickup.mdx
+++ b/apps/docs/content/docs/en/integrations/clickup.mdx
@@ -10,6 +10,25 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
   color="#FFFFFF"
 />
 
+{/* MANUAL-CONTENT-START:intro */}
+[ClickUp](https://clickup.com/) is a work management platform that organizes tasks into a hierarchy of workspaces, spaces, folders, and lists. It combines task tracking, comments, checklists, custom fields, and time tracking in one place, with configurable statuses and views for each team.
+
+With the ClickUp integration in Sim, you can:
+
+- **Manage tasks**: Create, get, update, and delete tasks, and list or search tasks across a workspace
+- **Collaborate with comments**: Create, list, update, and delete comments on tasks
+- **Organize the hierarchy**: Look up workspaces, spaces, folders, and lists, and create new folders and lists
+- **Work with custom fields**: Retrieve a list's custom fields, and set or clear their values on a task
+- **Track checklists**: Create, update, and delete checklists and their individual items
+- **Track time**: List, create, update, and delete time entries, and start, stop, or inspect a running timer
+- **Apply tags and attachments**: Add or remove space tags on a task and upload file attachments
+- **Look up people**: Retrieve the members of a task or a list
+- **React to changes**: Trigger workflows on task, list, folder, space, goal, and key-result events
+
+In Sim, the ClickUp integration enables your agents to participate in your team's project workflow. Agents can open tasks from incoming requests, comment with context they gathered elsewhere, move work through statuses, log time, and run downstream automation the moment a task is created, updated, or moved.
+{/* MANUAL-CONTENT-END */}
+
+
 ## Usage Instructions
 
 Integrate ClickUp into the workflow. Create, read, update, and delete tasks, manage comments, tags, folders, and lists, upload attachments, and look up workspaces, members, and custom fields. Can also trigger workflows on ClickUp events like task, list, folder, space, and goal changes.

--- a/apps/docs/content/docs/en/integrations/mssql.mdx
+++ b/apps/docs/content/docs/en/integrations/mssql.mdx
@@ -10,6 +10,20 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
   color="#FFFFFF"
 />
 
+{/* MANUAL-CONTENT-START:intro */}
+[Microsoft SQL Server](https://www.microsoft.com/sql-server) is Microsoft's relational database system, used for transactional and analytical workloads on-premises, on Azure SQL, and on other managed hosts. It stores structured data in tables and is queried with T-SQL.
+
+With the Microsoft SQL Server integration in Sim, you can:
+
+- **Query data**: Run SELECT statements and get back rows with a row count
+- **Insert, update, and delete rows**: Write key-value data to a table, or modify and remove existing rows with a WHERE clause
+- **Execute raw T-SQL**: Run arbitrary statements, including DDL such as creating or altering tables
+- **Introspect schemas**: Retrieve table structures, columns, primary and foreign keys, and indexes
+
+In Sim, the Microsoft SQL Server integration allows your agents to read from and write to a SQL Server database as part of a workflow — pulling records to feed downstream logic, writing agent output back to a table, and inspecting the schema before generating a query. Connections take a host, port, database, credentials, and TLS settings, so the same block works against a self-hosted instance or a managed one.
+{/* MANUAL-CONTENT-END */}
+
+
 ## Usage Instructions
 
 Integrate Microsoft SQL Server into the workflow. Can query, insert, update, delete, execute raw T-SQL, and introspect schemas.

--- a/apps/docs/content/docs/en/integrations/rocketlane.mdx
+++ b/apps/docs/content/docs/en/integrations/rocketlane.mdx
@@ -10,6 +10,25 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
   color="#000000"
 />
 
+{/* MANUAL-CONTENT-START:intro */}
+[Rocketlane](https://www.rocketlane.com/) is a professional-services automation platform for customer onboarding and project delivery. It keeps projects, phases, tasks, templates, time tracking, and billing in one system so services teams and their customers work from the same plan.
+
+With the Rocketlane integration in Sim, you can:
+
+- **Manage projects**: Create, get, list, update, archive, and delete projects, and add or remove project members
+- **Work with templates**: Import a template into a project, then list, assign, and unassign its placeholders
+- **Manage tasks**: Create, get, list, update, and delete tasks, move them between phases, and manage assignees, followers, and dependencies
+- **Structure delivery**: Create, get, list, update, and delete project phases
+- **Configure custom fields**: Create, get, list, update, and delete fields, and add or update their options
+- **Track time**: Create, get, list, search, update, and delete time entries, and list time-entry categories
+- **Handle time-off**: Create, get, list, and delete time-off records
+- **Organize knowledge**: Create, get, list, update, and delete spaces and space documents
+- **Review capacity and billing**: List resource allocations, and retrieve invoices with their line items and payments
+
+In Sim, the Rocketlane integration enables your agents to run onboarding as an automated process. An agent can spin up a project from a signed deal, apply the right template, assign placeholders to real people, keep tasks and phases moving, log time, and pull invoice and allocation data for reporting.
+{/* MANUAL-CONTENT-END */}
+
+
 ## Usage Instructions
 
 Integrate Rocketlane into your workflow. Rocketlane is a professional-services automation platform for client onboarding and project delivery. Create and manage projects, tasks, phases, custom fields, time entries, time-offs, spaces, documents, resource allocations, and invoices.

--- a/apps/docs/content/docs/en/integrations/smartlead.mdx
+++ b/apps/docs/content/docs/en/integrations/smartlead.mdx
@@ -10,6 +10,25 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
   color="#000000"
 />
 
+{/* MANUAL-CONTENT-START:intro */}
+[Smartlead](https://www.smartlead.ai/) is a cold email outreach platform. Campaigns pair a multi-step email sequence with a pool of sending mailboxes and a schedule, and Smartlead handles delivery, follow-ups, reply detection, and per-campaign analytics.
+
+With the Smartlead integration in Sim, you can:
+
+- **Manage campaigns**: Create, get, list, duplicate, and delete campaigns, and update their status, schedule, and settings
+- **Build sequences**: Retrieve and save the multi-step email sequence attached to a campaign
+- **Import and manage leads**: Add leads to a campaign, list and export them, look leads up by ID or email, and update their fields
+- **Control lead state**: Change a lead's category, pause or resume it, mark it complete, unsubscribe it from a campaign or globally, and remove it from a campaign
+- **Organize lead lists**: Create, get, list, update, and delete lead lists, and list the available lead categories
+- **Manage sending mailboxes**: List email accounts, and add or remove them from a campaign
+- **Read analytics**: Pull campaign analytics overall or by date, plus campaign, lead, and mailbox statistics
+- **Follow conversations**: List inbox replies, lead activities, and a lead's full message history
+- **Register webhooks**: List, create or update, and delete campaign webhooks, and read the webhook summary
+
+In Sim, the Smartlead integration enables your agents to run outreach end to end. An agent can build a campaign and its sequence from a brief, enrich and import leads from another system, react to replies and engagement webhooks by recategorizing or pausing a lead, and roll campaign analytics into a report.
+{/* MANUAL-CONTENT-END */}
+
+
 ## Usage Instructions
 
 Integrate Smartlead into workflows. Create campaigns, write multi-step email sequences, import and categorize leads, pull campaign analytics, and register webhooks for engagement events.

--- a/apps/docs/content/docs/en/integrations/snowflake.mdx
+++ b/apps/docs/content/docs/en/integrations/snowflake.mdx
@@ -17,7 +17,7 @@ With the Snowflake integration in Sim, you can:
 
 - **Run SQL**: Execute a parameterized statement, poll a statement's status, and cancel one that is still running
 - **Synchronize rows**: Insert, update, upsert, and delete rows in a table
-- **Move staged data**: Load data from a stage into a table and unload query results back out to a stage
+- **Move staged data**: Load data from a stage into a table, and unload a table back out to a stage (materialize a query as a view or `CREATE TABLE AS SELECT` first to export its results)
 - **Browse the account**: List databases, schemas, and tables, and introspect a table's schema
 - **Control warehouses**: List and get warehouses, resume or suspend them, and alter their size and settings
 - **Run and schedule tasks**: List and get tasks, run, resume, or suspend them, list task runs, and read a run's output or cancel its query

--- a/apps/docs/content/docs/en/integrations/snowflake.mdx
+++ b/apps/docs/content/docs/en/integrations/snowflake.mdx
@@ -10,6 +10,24 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
   color="#FFFFFF"
 />
 
+{/* MANUAL-CONTENT-START:intro */}
+[Snowflake](https://www.snowflake.com/) is a cloud data platform that separates storage from compute: data lives in databases and schemas, while virtual warehouses supply the compute that runs each query. Sim connects to it over the Snowflake SQL API using a programmatic access token.
+
+With the Snowflake integration in Sim, you can:
+
+- **Run SQL**: Execute a parameterized statement, poll a statement's status, and cancel one that is still running
+- **Synchronize rows**: Insert, update, upsert, and delete rows in a table
+- **Move staged data**: Load data from a stage into a table and unload query results back out to a stage
+- **Browse the account**: List databases, schemas, and tables, and introspect a table's schema
+- **Control warehouses**: List and get warehouses, resume or suspend them, and alter their size and settings
+- **Run and schedule tasks**: List and get tasks, run, resume, or suspend them, list task runs, and read a run's output or cancel its query
+- **Review history**: List query history and copy (load) history
+- **Call procedures**: Invoke a stored procedure with arguments
+
+In Sim, the Snowflake integration allows your agents to work directly against your warehouse. Agents can query for facts that inform a decision, write results back as rows, kick off or unblock a scheduled task, resize a warehouse for a heavy job and suspend it afterward, and read query and load history when something needs investigating.
+{/* MANUAL-CONTENT-END */}
+
+
 ## Usage Instructions
 
 Connect with a Snowflake programmatic access token to execute SQL, synchronize structured rows, load and unload staged data, browse databases and schemas, size and control warehouses, run and schedule tasks, review query and load history, inspect schemas, and call stored procedures.

--- a/apps/docs/content/docs/en/integrations/splunk.mdx
+++ b/apps/docs/content/docs/en/integrations/splunk.mdx
@@ -10,6 +10,21 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
   color="#FFFFFF"
 />
 
+{/* MANUAL-CONTENT-START:intro */}
+[Splunk](https://www.splunk.com/) indexes machine data — logs, metrics, and events — and makes it searchable with SPL, its search processing language. Teams use it for operational monitoring, incident investigation, and security analytics, with saved searches and alerts watching for conditions on a schedule.
+
+With the Splunk integration in Sim, you can:
+
+- **Run searches**: Execute an SPL search synchronously and get its results in a single call
+- **Run long searches as jobs**: Create a search job, check its status, page through its results, and cancel it
+- **Use saved searches**: List and get saved searches, and dispatch one on demand
+- **Inspect alerts**: List fired alerts and get the fired instances of a specific alert
+- **Explore the instance**: List indexes and installed apps
+
+In Sim, the Splunk integration enables your agents to investigate and act on operational data. An agent can run a search when an incident opens, dispatch a saved search to reproduce a known query, page through a large job's results, and read fired alerts to decide what to escalate. It works against both Splunk Enterprise and Splunk Cloud, authenticating with a bearer token.
+{/* MANUAL-CONTENT-END */}
+
+
 ## Usage Instructions
 
 Integrate Splunk Enterprise or Splunk Cloud into workflows. Run SPL searches synchronously or as asynchronous jobs, fetch results, dispatch saved searches, and inspect fired alerts and indexes.

--- a/apps/docs/content/docs/en/integrations/tiktok.mdx
+++ b/apps/docs/content/docs/en/integrations/tiktok.mdx
@@ -10,6 +10,21 @@ import { BlockInfoCard } from "@/components/ui/block-info-card"
   color="#000000"
 />
 
+{/* MANUAL-CONTENT-START:intro */}
+[TikTok](https://www.tiktok.com/) is a short-form video platform. Its Display and Content Posting APIs expose the authenticated creator's profile and videos, and let an application send a video to the creator's TikTok inbox as a draft, which the creator then reviews and publishes from the app.
+
+With the TikTok integration in Sim, you can:
+
+- **Read the profile**: Get the authenticated user's display name, avatar, bio, verification status, and follower, following, likes, and video counts
+- **Browse videos**: List videos with cover images, embed links, and metadata, or query specific videos by ID
+- **Send drafts for review**: Upload a video to the TikTok inbox as a draft for the creator to publish
+- **Track publishing**: Check the status of a submitted post
+- **React to post events**: Trigger workflows when a draft is delivered to the inbox, a post finishes or fails publishing, a post becomes publicly available or stops being public, or authorization is removed
+
+In Sim, the TikTok integration enables your agents to prepare content and report on it without ever publishing unattended. An agent can render or select a video, send it to the inbox as a draft, and follow the publish-status events — while profile and video data feed reporting workflows elsewhere in Sim.
+{/* MANUAL-CONTENT-END */}
+
+
 ## Usage Instructions
 
 Integrate TikTok into your workflow. Get user profile information including follower counts and video statistics. List and query videos with cover images, embed links, and metadata. Send uploaded videos to the TikTok inbox as drafts for human review and publishing, then track post status.

--- a/apps/sim/tailwind.config.ts
+++ b/apps/sim/tailwind.config.ts
@@ -20,6 +20,20 @@ export default {
      * class unique to this directory silently resolves to nothing.
      */
     './lib/**/*.{js,ts,jsx,tsx,mdx}',
+    /**
+     * Block definitions and their shared helpers emit classes too — most
+     * importantly `blocks/icon-color.ts`, whose `getTileIconColorClass` returns
+     * the only bare `text-black` candidate in the app. Scanned files spell it
+     * exclusively as `dark:text-black` or `text-black/75`, which compile to
+     * different selectors, so leaving this directory out meant `.text-black`
+     * was never generated at all and every light-background brand tile
+     * inherited the ambient (near-white) color instead.
+     */
+    './blocks/**/*.{js,ts,jsx,tsx}',
+    './ee/**/*.{js,ts,jsx,tsx}',
+    './providers/**/*.{js,ts,jsx,tsx}',
+    './tools/**/*.{js,ts,jsx,tsx}',
+    './content/**/*.{js,ts,jsx,tsx}',
     '../../packages/emcn/src/**/*.{js,ts,jsx,tsx}',
     '../../packages/workflow-renderer/src/**/*.{js,ts,jsx,tsx}',
     '!./app/node_modules/**',


### PR DESCRIPTION
## Summary

Two related integration-surface fixes.

**1. Missing manual intro sections (docs)**

Every generated integration page carries a hand-written `MANUAL-CONTENT:intro` block between the `BlockInfoCard` and `## Usage Instructions`. Eight were missing one: Buffer, ClickUp, Microsoft SQL Server, Rocketlane, Smartlead, Snowflake, Splunk, TikTok.

Each got an intro in the existing shape — a linked paragraph on the service, a "With the X integration in Sim, you can:" list derived from that block's real actions and triggers, and a closing paragraph on what agents do with it. The 22 `*-service-account` credential guides, `index.mdx`, and `hubspot-setup.mdx` are hand-written pages with no backing block (they're in the generator's `HANDWRITTEN_INTEGRATION_DOCS` set), so they intentionally keep no markers.

**2. Light-background brand tiles rendered a white glyph**

Infisical (`#F7FE62`), Intercom, Notion, and Daytona (`#FFFFFF`) showed a white icon on a light tile — near-invisible on the white ones.

The component logic was correct the whole time. `getTileIconColorClass()` in `blocks/icon-color.ts` returns the literal `'text-black'` for a light tile, and the icons paint with `fill='currentColor'`. The problem is that **`.text-black` was never generated**: `blocks/` was not in the Tailwind `content` globs, so the string literal in `icon-color.ts` was never scanned — and no scanned file contains a bare `text-black` candidate, only `dark:text-black` and `text-black/75`, which compile to different selectors. With no rule to match, `currentColor` fell back to the inherited ambient color, which is near-white in dark mode. Dark tiles looked fine only because `text-white` *is* emitted elsewhere, which is why this hid for so long.

Building the utility layer against the config confirms it — `.text-black{` appears 0 times before the change and once after.

Fixed by adding the unscanned directories that emit classes (`blocks`, `ee`, `providers`, `tools`, `content`) to `content`, matching the reasoning the config already documents for the `./lib/**` glob. Diffing emitted classes before/after shows 14 that were silently dead, all now live:

- `text-black`, `!text-black`, `!text-white` — `blocks/icon-color.ts` (the tile bug, including the canvas block tiles that pass `important`)
- `font-bold` — `blocks/block-tile.tsx`
- `max-h-44`, `ml-6`, `w-[380px]` — workspace-forking picker, file tree, sync view
- `min-h-[60px]`, `hover:bg-transparent` — SSO settings; `pl-[46px]` — verified domains
- `!size-[9px]` — access-control group detail; `hover:bg-[var(--surface-3)]` — whitelabeling and custom-block detail

Note: scanning `blocks/` also makes Tailwind extract one false-positive candidate from a Cypher example in the Neo4j block's help text, emitting a harmless 30-byte `.\[r\:KNOWS\]{r:KNOWS}` rule that no element carries. Narrowing the glob to dodge it would recreate exactly the bug class this PR fixes, so the broad glob stays.

## Type of Change
- [x] Bug fix
- [x] Documentation

## Testing
`bun run docs:check` reports "Generated integration docs are in sync" — the new intro blocks round-trip through `scripts/generate-docs.ts` unchanged. The tile fix was verified by building the utility layer with the Tailwind CLI against the real config and diffing emitted class names before and after. `bun run lint`, `bun run check:audits` (29 audits), and `check-block-registry.ts origin/staging` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)