### PR TITLE
fix(forking): keep dependent overrides editable

### DIFF
--- a/apps/sim/ee/workspace-forking/components/fork-sync/dependent-value.test.ts
+++ b/apps/sim/ee/workspace-forking/components/fork-sync/dependent-value.test.ts
@@ -9,6 +9,7 @@ import {
   effectiveCopyDependentValue,
   effectiveDependentValue,
   getActionableDependentFields,
+  getDisplayedDependentFields,
   isDependentConfigurationActionable,
 } from '@/ee/workspace-forking/components/fork-sync/dependent-value'
 
@@ -165,6 +166,46 @@ describe('applyDependentRepick', () => {
     ).toEqual({
       [dependentKey(leaf)]: 'ISSUE-2',
       [dependentKey(unrelated)]: 'still-keep-me',
+    })
+  })
+
+  it('does not clear a descendant belonging to another nested tool instance', () => {
+    const projectOne = field({
+      subBlockKey: 'tools[0].projectId',
+      dependencyScope: 'tools[0]',
+      providesContextKey: 'projectId',
+    })
+    const issueOne = field({
+      subBlockKey: 'tools[0].issueKey',
+      dependencyScope: 'tools[0]',
+      consumesContextKeys: ['projectId'],
+    })
+    const projectTwo = field({
+      subBlockKey: 'tools[1].projectId',
+      dependencyScope: 'tools[1]',
+      providesContextKey: 'projectId',
+    })
+    const issueTwo = field({
+      subBlockKey: 'tools[1].issueKey',
+      dependencyScope: 'tools[1]',
+      consumesContextKeys: ['projectId'],
+    })
+    const previous = {
+      [dependentKey(issueOne)]: 'P1-1',
+      [dependentKey(issueTwo)]: 'P2-1',
+    }
+
+    expect(
+      applyDependentRepick(
+        previous,
+        projectOne,
+        [projectOne, issueOne, projectTwo, issueTwo],
+        'P1-NEW'
+      )
+    ).toEqual({
+      [dependentKey(projectOne)]: 'P1-NEW',
+      [dependentKey(issueOne)]: '',
+      [dependentKey(issueTwo)]: 'P2-1',
     })
   })
 })
@@ -340,5 +381,64 @@ describe('getActionableDependentFields', () => {
         unchangedMappedParent
       ).map((dependent) => dependent.subBlockKey)
     ).toEqual(['siteId', 'driveId', 'spreadsheetId'])
+  })
+
+  it('finds a required child provider only within the same nested tool instance', () => {
+    const projectOne = field({
+      subBlockKey: 'tools[0].projectId',
+      dependencyScope: 'tools[0]',
+      providesContextKey: 'projectId',
+    })
+    const projectTwo = field({
+      subBlockKey: 'tools[1].projectId',
+      dependencyScope: 'tools[1]',
+      providesContextKey: 'projectId',
+    })
+    const issueOne = field({
+      subBlockKey: 'tools[0].issueKey',
+      dependencyScope: 'tools[0]',
+      currentValue: '',
+      required: true,
+      consumesContextKeys: ['projectId'],
+    })
+
+    expect(
+      getActionableDependentFields(
+        [projectOne, projectTwo, issueOne],
+        {},
+        unchangedMappedParent
+      ).map((dependent) => dependent.subBlockKey)
+    ).toEqual(['tools[0].projectId', 'tools[0].issueKey'])
+  })
+})
+
+describe('getDisplayedDependentFields', () => {
+  const unchangedMappedParent = {
+    parentResolved: true,
+    parentChanged: false,
+    copying: false,
+  }
+
+  it('reveals configured and optional fields only after the explicit edit action', () => {
+    const configuredRequired = field({ subBlockKey: 'projectId', required: true })
+    const optional = field({ subBlockKey: 'issueKey', currentValue: '', required: false })
+
+    expect(
+      getDisplayedDependentFields([configuredRequired, optional], {}, unchangedMappedParent, false)
+    ).toEqual([])
+    expect(
+      getDisplayedDependentFields([configuredRequired, optional], {}, unchangedMappedParent, true)
+    ).toEqual([configuredRequired, optional])
+  })
+
+  it('never shows selectors before their parent mapping is resolved', () => {
+    expect(
+      getDisplayedDependentFields(
+        [field()],
+        {},
+        { ...unchangedMappedParent, parentResolved: false },
+        true
+      )
+    ).toEqual([])
   })
 })

--- a/apps/sim/ee/workspace-forking/components/fork-sync/dependent-value.ts
+++ b/apps/sim/ee/workspace-forking/components/fork-sync/dependent-value.ts
@@ -5,6 +5,10 @@ export function dependentKey(dependent: ForkDependentReconfig): string {
   return `${dependent.targetWorkflowId}:${dependent.targetBlockId}:${dependent.subBlockKey}`
 }
 
+function sameDependencyScope(left: ForkDependentReconfig, right: ForkDependentReconfig): boolean {
+  return left.dependencyScope === right.dependencyScope
+}
+
 /**
  * Store a dependent re-pick and clear every selector transitively scoped by it. Empty-string
  * overrides are intentional: an absent override means "fall back to the stored value", while a
@@ -28,7 +32,13 @@ export function applyDependentRepick(
 
     for (const field of blockFields) {
       const fieldKey = dependentKey(field)
-      if (visitedFields.has(fieldKey) || !field.consumesContextKeys.includes(contextKey)) continue
+      if (
+        !sameDependencyScope(changedField, field) ||
+        visitedFields.has(fieldKey) ||
+        !field.consumesContextKeys.includes(contextKey)
+      ) {
+        continue
+      }
 
       visitedFields.add(fieldKey)
       nextState[fieldKey] = ''
@@ -106,9 +116,15 @@ export function getActionableDependentFields(
   const actionable = new Set(
     fields.filter((field) => isDependentConfigurationActionable(field, reconfig, state))
   )
-  const providersByContextKey = new Map<string, ForkDependentReconfig>()
+  const providersByScope = new Map<string | undefined, Map<string, ForkDependentReconfig>>()
   for (const field of fields) {
-    if (field.providesContextKey) providersByContextKey.set(field.providesContextKey, field)
+    if (!field.providesContextKey) continue
+    let providers = providersByScope.get(field.dependencyScope)
+    if (!providers) {
+      providers = new Map()
+      providersByScope.set(field.dependencyScope, providers)
+    }
+    providers.set(field.providesContextKey, field)
   }
 
   const pending = Array.from(actionable)
@@ -116,7 +132,7 @@ export function getActionableDependentFields(
     const field = pending[index]
     if (!field) continue
     for (const contextKey of field.consumesContextKeys) {
-      const provider = providersByContextKey.get(contextKey)
+      const provider = providersByScope.get(field.dependencyScope)?.get(contextKey)
       if (!provider || actionable.has(provider)) continue
       actionable.add(provider)
       pending.push(provider)
@@ -124,4 +140,19 @@ export function getActionableDependentFields(
   }
 
   return fields.filter((field) => actionable.has(field))
+}
+
+/**
+ * Fields rendered in the mapping UI. Required missing fields remain visible by default; an
+ * explicit edit action reveals every active selector under a resolved parent without changing
+ * which fields gate Sync.
+ */
+export function getDisplayedDependentFields(
+  fields: ForkDependentReconfig[],
+  reconfig: Record<string, string>,
+  state: DependentConfigurationState,
+  showConfigured: boolean
+): ForkDependentReconfig[] {
+  if (!state.parentResolved) return []
+  return showConfigured ? fields : getActionableDependentFields(fields, reconfig, state)
 }

--- a/apps/sim/ee/workspace-forking/components/fork-sync/fork-sync-view.tsx
+++ b/apps/sim/ee/workspace-forking/components/fork-sync/fork-sync-view.tsx
@@ -39,7 +39,8 @@ import {
   dependentKey,
   effectiveCopyDependentValue,
   effectiveDependentValue,
-  getActionableDependentFields,
+  getDisplayedDependentFields,
+  isDependentConfigurationActionable,
 } from '@/ee/workspace-forking/components/fork-sync/dependent-value'
 import type {
   ForkKindSummary,
@@ -109,7 +110,8 @@ function groupDependentsByWorkflow(
   workflows: ForkResourceUsage['workflows'],
   dependents: ForkDependentReconfig[],
   reconfig: Record<string, string>,
-  state: DependentConfigurationState
+  state: DependentConfigurationState,
+  showConfigured: boolean
 ): WorkflowDependents[] {
   const byWorkflow = new Map<string, ForkDependentReconfig[]>()
   for (const dependent of dependents) {
@@ -138,7 +140,12 @@ function groupDependentsByWorkflow(
       blocks: Array.from(byBlock.values())
         .map((block) => ({
           ...block,
-          configurableFields: getActionableDependentFields(block.fields, reconfig, state),
+          configurableFields: getDisplayedDependentFields(
+            block.fields,
+            reconfig,
+            state,
+            showConfigured
+          ),
         }))
         .filter((block) => block.configurableFields.length > 0)
         .sort((a, b) => a.blockName.localeCompare(b.blockName)),
@@ -149,11 +156,13 @@ function groupDependentsByWorkflow(
 /** Chain state for one block: the SelectorContext values its parent fields provide. */
 function blockChainState(
   block: DependentBlock,
+  activeField: ForkDependentReconfig,
   effectiveValue: (field: ForkDependentReconfig) => string
 ) {
   const providedValues: Record<string, string> = {}
   const providedContextKeys = new Set<string>()
   for (const field of block.fields) {
+    if (field.dependencyScope !== activeField.dependencyScope) continue
     if (field.providesContextKey) {
       providedContextKeys.add(field.providesContextKey)
       const value = effectiveValue(field)
@@ -199,7 +208,7 @@ function DependentSelector({
     copying
       ? effectiveCopyDependentValue(f, reconfig)
       : effectiveDependentValue(f, reconfig, parentChanged)
-  const { providedValues, providedContextKeys } = blockChainState(block, effectiveValue)
+  const { providedValues, providedContextKeys } = blockChainState(block, field, effectiveValue)
   // Disabled until every in-block parent it depends on has a value, so a child never queries
   // a stale upstream value.
   const ready = field.consumesContextKeys.every(
@@ -268,14 +277,17 @@ function DependentWorkflowCard({
       <div className='flex flex-col gap-3'>
         {workflow.blocks.map((block) => {
           const topLevel = block.configurableFields.filter((field) => !field.toolName)
-          const byTool = new Map<string, ForkDependentReconfig[]>()
+          const byTool = new Map<string, { name: string; fields: ForkDependentReconfig[] }>()
           for (const field of block.configurableFields) {
             if (!field.toolName) continue
-            const list = byTool.get(field.toolName)
-            if (list) list.push(field)
-            else byTool.set(field.toolName, [field])
+            const scope = field.dependencyScope ?? field.toolName
+            const group = byTool.get(scope)
+            if (group) group.fields.push(field)
+            else byTool.set(scope, { name: field.toolName, fields: [field] })
           }
-          const toolGroups = Array.from(byTool.entries()).sort(([a], [b]) => a.localeCompare(b))
+          const toolGroups = Array.from(byTool.entries()).sort(([, a], [, b]) =>
+            a.name.localeCompare(b.name)
+          )
 
           return (
             <div key={block.targetBlockId} className='flex flex-col gap-2'>
@@ -299,10 +311,10 @@ function DependentWorkflowCard({
                   />
                 </div>
               ))}
-              {toolGroups.map(([toolName, fields]) => (
-                <div key={toolName} className='flex flex-col gap-1.5 pl-2'>
-                  <span className='text-[var(--text-muted)] text-small'>{toolName}</span>
-                  {fields.map((field) => (
+              {toolGroups.map(([scope, tool]) => (
+                <div key={scope} className='flex flex-col gap-1.5 pl-2'>
+                  <span className='text-[var(--text-muted)] text-small'>{tool.name}</span>
+                  {tool.fields.map((field) => (
                     <div key={dependentKey(field)} className='flex flex-col gap-1'>
                       <Label className='text-[var(--text-muted)] text-caption'>
                         {field.title}
@@ -346,6 +358,7 @@ interface MappingEntryProps {
  * Workflows with nothing to configure are named in a muted note so the usage stays visible.
  */
 function MappingEntry({ controller, group, entry }: MappingEntryProps) {
+  const [showConfigured, setShowConfigured] = useState(false)
   const target = controller.targetFor(entry)
   const takenOwners = controller.takenOwnersFor(entry, group.items)
   const parentChanged = controller.parentChangedFor(entry)
@@ -354,17 +367,34 @@ function MappingEntry({ controller, group, entry }: MappingEntryProps) {
 
   const usages = controller.usagesForEntry(entry)
   const dependents = controller.dependentsForEntry(entry)
+  const parentResolved = target !== '' || copying
   const workflows = useMemo(
     () =>
-      groupDependentsByWorkflow(usages, dependents, controller.reconfig, {
-        parentResolved: target !== '' || copying,
-        parentChanged,
-        copying,
-      }),
-    [usages, dependents, controller.reconfig, target, parentChanged, copying]
+      groupDependentsByWorkflow(
+        usages,
+        dependents,
+        controller.reconfig,
+        { parentResolved, parentChanged, copying },
+        showConfigured
+      ),
+    [
+      usages,
+      dependents,
+      controller.reconfig,
+      parentResolved,
+      parentChanged,
+      copying,
+      showConfigured,
+    ]
   )
   const configurable = workflows.filter((workflow) => workflow.blocks.length > 0)
   const usedOnly = workflows.filter((workflow) => workflow.blocks.length === 0)
+  const configurationState = { parentResolved, parentChanged, copying }
+  const hasHiddenConfigured = dependents.some(
+    (field) => !isDependentConfigurationActionable(field, controller.reconfig, configurationState)
+  )
+  const canEditConfigured =
+    parentResolved && !parentChanged && !copying && (showConfigured || hasHiddenConfigured)
 
   return (
     <div className='flex flex-col gap-2'>
@@ -422,6 +452,13 @@ function MappingEntry({ controller, group, entry }: MappingEntryProps) {
           </p>
         ) : null}
       </div>
+      {canEditConfigured ? (
+        <div className='flex justify-end'>
+          <Chip active={showConfigured} onClick={() => setShowConfigured((value) => !value)}>
+            {showConfigured ? 'Done editing' : 'Edit configuration'}
+          </Chip>
+        </div>
+      ) : null}
       {configurable.map((workflow) => (
         <DependentWorkflowCard
           key={workflow.workflowId}
@@ -437,8 +474,8 @@ function MappingEntry({ controller, group, entry }: MappingEntryProps) {
       ))}
       {usedOnly.length > 0 ? (
         <p className='text-[var(--text-tertiary)] text-caption'>
-          Also used in {usedOnly.map((workflow) => workflow.workflowName).join(', ')} — nothing to
-          configure there.
+          Also used in {usedOnly.map((workflow) => workflow.workflowName).join(', ')} — no changes
+          required.
         </p>
       ) : null}
     </div>

--- a/apps/sim/ee/workspace-forking/components/fork-sync/fork-sync-view.tsx
+++ b/apps/sim/ee/workspace-forking/components/fork-sync/fork-sync-view.tsx
@@ -239,6 +239,7 @@ function DependentSelector({
 
 interface DependentWorkflowCardProps {
   workflow: WorkflowDependents
+  initiallyExpanded: boolean
   target: string
   parentChanged: boolean
   /** True when the parent is resolved by COPY - the selectors browse the SOURCE parent. */
@@ -253,10 +254,12 @@ interface DependentWorkflowCardProps {
  * One workflow's dependent fields as a collapsible card (the same `CollapsibleCard` the table
  * workflow sidebar's input mapping and the enrichment config use): the header names the
  * workflow; the body groups fields under block → optional tool → plain field label.
- * Cards holding a required field start expanded - a required field is what gates Sync.
+ * Cards holding a required field start expanded because that field gates Sync. Cards first
+ * revealed by explicit edit mode also start expanded so the edit action exposes its controls.
  */
 function DependentWorkflowCard({
   workflow,
+  initiallyExpanded,
   target,
   parentChanged,
   copying,
@@ -266,7 +269,9 @@ function DependentWorkflowCard({
   setReconfig,
 }: DependentWorkflowCardProps) {
   const [collapsed, setCollapsed] = useState(
-    () => !workflow.blocks.some((block) => block.configurableFields.some((field) => field.required))
+    () =>
+      !initiallyExpanded &&
+      !workflow.blocks.some((block) => block.configurableFields.some((field) => field.required))
   )
   return (
     <CollapsibleCard
@@ -463,6 +468,7 @@ function MappingEntry({ controller, group, entry }: MappingEntryProps) {
         <DependentWorkflowCard
           key={workflow.workflowId}
           workflow={workflow}
+          initiallyExpanded={showConfigured}
           target={target}
           parentChanged={parentChanged}
           copying={copying}

--- a/apps/sim/ee/workspace-forking/lib/mapping/dependent-reconfigs.test.ts
+++ b/apps/sim/ee/workspace-forking/lib/mapping/dependent-reconfigs.test.ts
@@ -466,11 +466,101 @@ describe('collectForkDependentReconfigs', () => {
         selectorKey: 'gmail.labels',
         title: 'Label',
         toolName: 'Gmail 1',
+        dependencyScope: 'tools[0]',
         currentValue: 'INBOX',
         required: true,
         consumesContextKeys: [],
         context: {},
         sourceValue: 'INBOX',
+      },
+    ])
+  })
+
+  it('preserves dependency chains independently for duplicate nested tool instances', () => {
+    vi.mocked(getBlock).mockImplementation((type) => {
+      if (type === 'agent') return blockWith([{ id: 'tools', title: 'Tools', type: 'tool-input' }])
+      if (type === 'jira')
+        return blockWith([
+          {
+            id: 'credential',
+            title: 'Jira Account',
+            type: 'oauth-input',
+            canonicalParamId: 'oauthCredential',
+          },
+          {
+            id: 'projectId',
+            title: 'Project',
+            type: 'project-selector',
+            canonicalParamId: 'projectId',
+            selectorKey: 'jira.projects',
+            dependsOn: ['credential'],
+          },
+          {
+            id: 'issueKey',
+            title: 'Issue',
+            type: 'file-selector',
+            selectorKey: 'jira.issues',
+            dependsOn: ['credential', 'projectId'],
+            required: true,
+          },
+        ])
+      return undefined as unknown as BlockConfig
+    })
+    const states = new Map<string, WorkflowState>([
+      [
+        'wf-src',
+        sourceState('agent', {
+          tools: {
+            value: [
+              {
+                type: 'jira',
+                title: 'Jira',
+                params: { credential: 'cred-src', projectId: 'P1', issueKey: 'P1-1' },
+              },
+              {
+                type: 'jira',
+                title: 'Jira',
+                params: { credential: 'cred-src', projectId: 'P2', issueKey: 'P2-1' },
+              },
+            ],
+          },
+        }),
+      ],
+    ])
+
+    const result = collectForkDependentReconfigs([replaceItem], states, resolve)
+
+    expect(
+      result.map((entry) => ({
+        key: entry.subBlockKey,
+        scope: entry.dependencyScope,
+        provides: entry.providesContextKey,
+        consumes: entry.consumesContextKeys,
+      }))
+    ).toEqual([
+      {
+        key: 'tools[0].projectId',
+        scope: 'tools[0]',
+        provides: 'projectId',
+        consumes: [],
+      },
+      {
+        key: 'tools[0].issueKey',
+        scope: 'tools[0]',
+        provides: undefined,
+        consumes: ['projectId'],
+      },
+      {
+        key: 'tools[1].projectId',
+        scope: 'tools[1]',
+        provides: 'projectId',
+        consumes: [],
+      },
+      {
+        key: 'tools[1].issueKey',
+        scope: 'tools[1]',
+        provides: undefined,
+        consumes: ['projectId'],
       },
     ])
   })

--- a/apps/sim/ee/workspace-forking/lib/mapping/dependent-reconfigs.ts
+++ b/apps/sim/ee/workspace-forking/lib/mapping/dependent-reconfigs.ts
@@ -80,12 +80,10 @@ interface EmitAnchoredParams {
   /** Nested `tool-input` tool display name; omitted for top-level block subblocks. */
   toolName?: string
   /**
-   * Emit `providesContextKey`/`consumesContextKeys` so the modal can chain in-block
-   * re-picks. Top-level chains; nested tool params don't (a tool's chain would need
-   * per-tool context scoping - out of scope - and the common nested case is a single
-   * credential-anchored field).
+   * Stable nested-tool instance boundary for dependency context and descendant invalidation.
+   * Omitted for top-level block subblocks, which share the block scope.
    */
-  chaining: boolean
+  dependencyScope?: string
   /**
    * Present ONLY for the nested `tool-input` pass: each param's resolved
    * {@link ParameterVisibility}, keyed by sub-block id and by canonical param id. Its presence
@@ -120,7 +118,7 @@ function emitAnchoredDependents(params: EmitAnchoredParams): void {
     makeSubBlockKey,
     makeTitle,
     toolName,
-    chaining,
+    dependencyScope,
     paramVisibilityById,
     out,
   } = params
@@ -185,20 +183,17 @@ function emitAnchoredDependents(params: EmitAnchoredParams): void {
         // is offered exactly once.
         if (seen.has(canonicalKey)) continue
         seen.add(canonicalKey)
-        const providesContextKey =
-          chaining && isSelectorContextKey(canonicalKey) ? canonicalKey : undefined
+        const providesContextKey = isSelectorContextKey(canonicalKey) ? canonicalKey : undefined
         // The SelectorContext keys this field needs from in-block siblings (e.g. a sheet
         // needs the spreadsheet), excluding the anchor key the modal already supplies, so
         // the modal can keep a child disabled until its re-picked parent is chosen.
-        const consumesContextKeys = chaining
-          ? [
-              ...new Set(
-                getDependsOnFields(dependent.dependsOn)
-                  .map((parent) => canonicalIndex.canonicalIdBySubBlockId[parent] ?? parent)
-                  .filter((key) => key !== anchor.parentContextKey && isSelectorContextKey(key))
-              ),
-            ]
-          : []
+        const consumesContextKeys = [
+          ...new Set(
+            getDependsOnFields(dependent.dependsOn)
+              .map((parent) => canonicalIndex.canonicalIdBySubBlockId[parent] ?? parent)
+              .filter((key) => key !== anchor.parentContextKey && isSelectorContextKey(key))
+          ),
+        ]
         // Carry the selector's static `mimeType` filter (Drive/Sheets pickers) so the
         // modal selector loads the same filtered list the editor would, not all files.
         const dependentContext =
@@ -239,6 +234,7 @@ function emitAnchoredDependents(params: EmitAnchoredParams): void {
           selectorKey: dependent.selectorKey,
           title: makeTitle(dependent),
           ...(toolName ? { toolName } : {}),
+          ...(dependencyScope ? { dependencyScope } : {}),
           // Source value, so the always-on listing pre-fills a stable parent's selector.
           // The diff route overlays the stored/target-draft value onto `currentValue`;
           // `sourceValue` stays the raw source reference (the copy-resolved parent's seed).
@@ -317,7 +313,6 @@ export function collectForkDependentReconfigs(
         resolveTargetBlockId: resolveBlockId,
         makeSubBlockKey: (id) => id,
         makeTitle: (dependent) => dependent.title ?? dependent.id ?? '',
-        chaining: true,
         out,
       })
 
@@ -387,7 +382,7 @@ export function collectForkDependentReconfigs(
             makeSubBlockKey: (id) => `${toolInputKey}[${toolIndex}].${id}`,
             makeTitle: (dependent) => dependent.title ?? dependent.id ?? '',
             toolName: toolLabel,
-            chaining: false,
+            dependencyScope: `${toolInputKey}[${toolIndex}]`,
             paramVisibilityById,
             out,
           })

--- a/apps/sim/lib/api/contracts/workspace-fork.ts
+++ b/apps/sim/lib/api/contracts/workspace-fork.ts
@@ -347,6 +347,12 @@ export const forkDependentReconfigSchema = z.object({
    */
   toolName: z.string().optional(),
   /**
+   * Stable scope for one nested tool instance (e.g. `tools[0]`). Dependency context and
+   * descendant invalidation never cross this boundary, even when two tools expose the same
+   * canonical parameter ids. Absent for top-level block subblocks, which share the block scope.
+   */
+  dependencyScope: z.string().optional(),
+  /**
    * The field's stored value (from the persisted mapping), so the always-on reconfigure listing
    * pre-fills the selector with what the user last set. Empty string when unset; for an edge
    * that predates the store the TARGET's currently-configured value is the fallback (never the


### PR DESCRIPTION
## Summary
- keep saved dependent mappings explicitly editable without making valid mappings noisy
- preserve canonical dependency chains per Agent tool instance so identical tools cannot invalidate each other
- keep optional and LLM-fillable inputs editable but nonblocking

## Type of Change
- [x] Bug fix

## Testing
- `bunx vitest run ee/workspace-forking/components/fork-sync/dependent-value.test.ts ee/workspace-forking/lib/mapping/dependent-reconfigs.test.ts lib/api/contracts/workspace-fork.test.ts`
- `bun run lint`
- `bun run type-check`
- `bun run check:audits`
- `bun run apps/sim/scripts/check-block-registry.ts origin/staging`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
