### PR TITLE
fix(files): serve mothership chat attachments stored under a workspace key

### DIFF
--- a/apps/sim/app/api/files/authorization.ts
+++ b/apps/sim/app/api/files/authorization.ts
@@ -31,6 +31,13 @@ interface AuthorizationResult {
 type WorkspacePermission = 'read' | 'write' | 'admin'
 
 /**
+ * The two contexts stored under a `workspace/…` key. They share a bucket and a
+ * workspace-membership permission model; only the owning module differs — a
+ * mothership attachment belongs to a chat, a workspace file to the Files module.
+ */
+type WorkspaceScopedContext = 'workspace' | 'mothership'
+
+/**
  * Whether a resolved workspace permission satisfies a file operation. Read and
  * download paths accept any membership; destructive operations (`requireWrite`)
  * require write or admin, matching the permission needed to create the file.
@@ -49,12 +56,12 @@ function workspacePermissionSatisfies(
  */
 async function lookupWorkspaceFileByKey(
   key: string,
-  options?: { includeDeleted?: boolean }
+  options?: { includeDeleted?: boolean; context?: WorkspaceScopedContext }
 ): Promise<{ workspaceId: string; uploadedBy: string } | null> {
   try {
-    const { includeDeleted = false } = options ?? {}
+    const { includeDeleted = false, context = 'workspace' } = options ?? {}
     // Priority 1: Check new workspaceFiles table
-    const fileRecord = await getFileMetadataByKey(key, 'workspace', { includeDeleted })
+    const fileRecord = await getFileMetadataByKey(key, context, { includeDeleted })
 
     if (fileRecord) {
       return {
@@ -158,7 +165,14 @@ export async function verifyFileAccess(
 
     // 1. Workspace / mothership files: Check database first (most reliable for both local and cloud)
     if (inferredContext === 'workspace' || inferredContext === 'mothership') {
-      return await verifyWorkspaceFileAccess(cloudKey, userId, customConfig, isLocal, requireWrite)
+      return await verifyWorkspaceFileAccess(
+        cloudKey,
+        userId,
+        customConfig,
+        isLocal,
+        requireWrite,
+        inferredContext
+      )
     }
 
     // 2. Execution files: workspace_id/workflow_id/execution_id/filename
@@ -200,10 +214,11 @@ async function verifyWorkspaceFileAccess(
   userId: string,
   customConfig?: StorageConfig,
   isLocal?: boolean,
-  requireWrite = false
+  requireWrite = false,
+  context: WorkspaceScopedContext = 'workspace'
 ): Promise<boolean> {
   try {
-    const anyWorkspaceFileRecord = await getFileMetadataByKey(cloudKey, 'workspace', {
+    const anyWorkspaceFileRecord = await getFileMetadataByKey(cloudKey, context, {
       includeDeleted: true,
     })
     if (anyWorkspaceFileRecord?.deletedAt) {
@@ -215,7 +230,7 @@ async function verifyWorkspaceFileAccess(
     }
 
     // Priority 1: Check database (most reliable, works for both local and cloud)
-    const workspaceFileRecord = await lookupWorkspaceFileByKey(cloudKey)
+    const workspaceFileRecord = await lookupWorkspaceFileByKey(cloudKey, { context })
     if (workspaceFileRecord) {
       const permission = await getUserEntityPermissions(
         userId,

--- a/apps/sim/app/api/files/serve/[...path]/route.test.ts
+++ b/apps/sim/app/api/files/serve/[...path]/route.test.ts
@@ -20,6 +20,7 @@ const {
   mockIsUsingCloudStorage,
   mockDownloadCopilotFile,
   mockInferContextFromKey,
+  mockResolveStoredFileContext,
   mockParseWorkspaceFileKey,
   mockAuthenticateWorkspaceFile,
   mockReadWorkspaceFileContentByKey,
@@ -44,6 +45,7 @@ const {
     mockIsUsingCloudStorage: vi.fn(),
     mockDownloadCopilotFile: vi.fn(),
     mockInferContextFromKey: vi.fn(),
+    mockResolveStoredFileContext: vi.fn(),
     mockParseWorkspaceFileKey: vi.fn(),
     mockAuthenticateWorkspaceFile: vi.fn(),
     mockReadWorkspaceFileContentByKey: vi.fn(),
@@ -77,6 +79,10 @@ vi.mock('@/lib/uploads/core/storage-service', () => storageServiceMock)
 
 vi.mock('@/lib/uploads/utils/file-utils', () => ({
   inferContextFromKey: mockInferContextFromKey,
+}))
+
+vi.mock('@/lib/uploads/server/metadata', () => ({
+  resolveStoredFileContext: mockResolveStoredFileContext,
 }))
 
 vi.mock('@/lib/uploads/setup.server', () => ({}))
@@ -129,7 +135,11 @@ describe('File Serve API Route', () => {
     mockReadFile.mockResolvedValue(Buffer.from('test content'))
     mockIsUsingCloudStorage.mockReturnValue(false)
     storageServiceMockFns.mockHasCloudStorage.mockReturnValue(true)
-    mockInferContextFromKey.mockReturnValue('mothership')
+    // A `workspace/…` key is what both a workspace file and a mothership chat
+    // attachment carry; only the stored binding tells them apart, so the default
+    // here is the attachment and the workspace cases opt in explicitly.
+    mockInferContextFromKey.mockReturnValue('workspace')
+    mockResolveStoredFileContext.mockResolvedValue('mothership')
     mockParseWorkspaceFileKey.mockReturnValue(undefined)
     mockAuthenticateWorkspaceFile.mockResolvedValue({
       kind: 'session',
@@ -240,7 +250,7 @@ describe('File Serve API Route', () => {
         workflowId: 'workflow-1',
       },
     }
-    mockInferContextFromKey.mockReturnValue('workspace')
+    mockResolveStoredFileContext.mockResolvedValue('workspace')
     mockParseWorkspaceFileKey.mockReturnValue('test-workspace-id')
     mockAuthenticateWorkspaceFile.mockResolvedValue(principal)
     mockResolveServableDocBytes.mockResolvedValue({
@@ -274,6 +284,41 @@ describe('File Serve API Route', () => {
     )
     expect(hybridAuthMockFns.mockCheckSessionOrInternalAuth).not.toHaveBeenCalled()
     expect(mockVerifyFileAccess).not.toHaveBeenCalled()
+  })
+
+  it('serves a mothership chat attachment stored under a workspace key', async () => {
+    /**
+     * The attachment shares the `workspace/…` prefix but is recorded as
+     * `context = 'mothership'`, so the workspace-file use case — which matches on
+     * `context = 'workspace'` — would answer 404 for a file that is right there.
+     */
+    mockIsUsingCloudStorage.mockReturnValue(true)
+    storageServiceMockFns.mockDownloadFile.mockResolvedValue(Buffer.from('attachment bytes'))
+    mockGetContentType.mockReturnValue('image/png')
+
+    const req = new NextRequest(
+      'http://localhost:3000/api/files/serve/workspace/test-workspace-id/1234567890-photo.png?preview=1'
+    )
+    const response = await GET(req, {
+      params: Promise.resolve({
+        path: ['workspace', 'test-workspace-id', '1234567890-photo.png'],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(mockReadWorkspaceFileContentByKey).not.toHaveBeenCalled()
+    expect(mockAuthenticateWorkspaceFile).not.toHaveBeenCalled()
+    expect(mockVerifyFileAccess).toHaveBeenCalledWith(
+      'workspace/test-workspace-id/1234567890-photo.png',
+      'test-user-id',
+      undefined,
+      'mothership',
+      false
+    )
+    expect(storageServiceMockFns.mockDownloadFile).toHaveBeenCalledWith({
+      key: 'workspace/test-workspace-id/1234567890-photo.png',
+      context: 'mothership',
+    })
   })
 
   it('should return 404 when file not found', async () => {

--- a/apps/sim/app/api/files/serve/[...path]/route.ts
+++ b/apps/sim/app/api/files/serve/[...path]/route.ts
@@ -18,6 +18,7 @@ import type { StorageContext } from '@/lib/uploads/config'
 import { parseWorkspaceFileKey } from '@/lib/uploads/contexts/workspace/workspace-file-manager'
 import { downloadFile } from '@/lib/uploads/core/storage-service'
 import { resolveServableImageBytes } from '@/lib/uploads/server/image-derivative'
+import { resolveStoredFileContext } from '@/lib/uploads/server/metadata'
 import { inferContextFromKey } from '@/lib/uploads/utils/file-utils'
 import { internalWorkspaceFileServeAuth } from '@/lib/workspace-files/api'
 import { readWorkspaceFileContentByKey } from '@/lib/workspace-files/application/read-workspace-file-content-by-key'
@@ -165,7 +166,10 @@ export const GET = withRouteHandler(
         return await handleLocalFilePublic(fullPath)
       }
 
-      const storageContext = inferContextFromKey(cloudKey)
+      // Resolved from the key's stored binding, not its prefix alone: a mothership chat
+      // attachment carries a `workspace/…` key but is not a workspace file, and the
+      // workspace-file use case below would resolve it to a 404.
+      const storageContext = await resolveStoredFileContext(cloudKey)
       const workspacePrincipal =
         storageContext === 'workspace'
           ? await internalWorkspaceFileServeAuth.authenticate(request, { path })
@@ -201,10 +205,10 @@ export const GET = withRouteHandler(
       if (!userId) throw new Error('Authenticated file serve request is missing a user ID')
 
       if (isUsingCloudStorage()) {
-        return await handleCloudProxy(cloudKey, userId, options, request.signal)
+        return await handleCloudProxy(cloudKey, userId, options, request.signal, storageContext)
       }
 
-      return await handleLocalFile(cloudKey, userId, options, request.signal)
+      return await handleLocalFile(cloudKey, userId, options, request.signal, storageContext)
     } catch (error) {
       if (error instanceof InternalUnauthenticatedError) {
         logger.warn('Unauthorized file access attempt', { error: error.message })
@@ -285,19 +289,16 @@ async function handleLocalFile(
   filename: string,
   userId: string,
   options: ServeOptions,
-  signal: AbortSignal | undefined
+  signal: AbortSignal | undefined,
+  context: StorageContext
 ): Promise<NextResponse> {
   const ownerKey = `user:${userId}`
   try {
-    const contextParam: StorageContext | undefined = inferContextFromKey(filename) as
-      | StorageContext
-      | undefined
-
     const hasAccess = await verifyFileAccess(
       filename,
       userId,
       undefined, // customConfig
-      contextParam, // context
+      context,
       true // isLocal
     )
 
@@ -332,7 +333,7 @@ async function handleLocalFile(
       buffer: fileBuffer,
       contentType,
       filename: displayName,
-      cacheControl: resolveServeCacheControl(options.versioned, contextParam),
+      cacheControl: resolveServeCacheControl(options.versioned, context),
     })
   } catch (error) {
     logServeFailure('Error reading local file:', error)
@@ -344,12 +345,12 @@ async function handleCloudProxy(
   cloudKey: string,
   userId: string,
   options: ServeOptions,
-  signal: AbortSignal | undefined
+  signal: AbortSignal | undefined,
+  context: StorageContext
 ): Promise<NextResponse> {
   const ownerKey = `user:${userId}`
   try {
-    const context = inferContextFromKey(cloudKey)
-    logger.info(`Inferred context: ${context} from key pattern: ${cloudKey}`)
+    logger.info(`Resolved context: ${context} for key: ${cloudKey}`)
 
     const hasAccess = await verifyFileAccess(
       cloudKey,

--- a/apps/sim/lib/uploads/server/metadata.test.ts
+++ b/apps/sim/lib/uploads/server/metadata.test.ts
@@ -18,6 +18,7 @@ import {
   insertFileMetadataMany,
   insertImmutableFileMetadata,
   recordKnowledgeBaseFileOwnership,
+  resolveStoredFileContext,
 } from '@/lib/uploads/server/metadata'
 
 describe('recordKnowledgeBaseFileOwnership', () => {
@@ -316,5 +317,40 @@ describe('insertFileMetadataMany active-key idempotence', () => {
     ).rejects.toBeInstanceOf(ActiveFileMetadataKeyConflictError)
 
     expect(dbChainMockFns.insert).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveStoredFileContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+  })
+
+  const workspaceKey = 'workspace/workspace-1/1234567890-abcdef-photo.png'
+
+  it('reports a mothership attachment stored under a workspace key', async () => {
+    queueTableRows(workspaceFiles, [
+      { id: 'file-1', key: workspaceKey, context: 'mothership', deletedAt: null },
+    ])
+
+    await expect(resolveStoredFileContext(workspaceKey)).resolves.toBe('mothership')
+  })
+
+  it('keeps a workspace file on the workspace context', async () => {
+    queueTableRows(workspaceFiles, [
+      { id: 'file-1', key: workspaceKey, context: 'workspace', deletedAt: null },
+    ])
+
+    await expect(resolveStoredFileContext(workspaceKey)).resolves.toBe('workspace')
+  })
+
+  it('falls back to the inferred context for an unbound key', async () => {
+    await expect(resolveStoredFileContext(workspaceKey)).resolves.toBe('workspace')
+  })
+
+  it('trusts the prefix without a lookup when it cannot be a workspace key', async () => {
+    await expect(resolveStoredFileContext('copilot/file.png')).resolves.toBe('copilot')
+
+    expect(dbChainMockFns.select).not.toHaveBeenCalled()
   })
 })

--- a/apps/sim/lib/uploads/server/metadata.ts
+++ b/apps/sim/lib/uploads/server/metadata.ts
@@ -4,6 +4,7 @@ import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
 import { and, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
 import type { DbOrTx, DbTransaction } from '@/lib/db/types'
+import { inferContextFromKey } from '@/lib/uploads/utils/file-utils'
 import { type StorageContext, toLegacyWorkspaceFileSize } from '../shared/types'
 
 const logger = createLogger('FileMetadata')
@@ -334,6 +335,28 @@ export async function getFileMetadataByKey(
     .limit(1)
 
   return record ?? null
+}
+
+/**
+ * Resolve the storage context a stored object must be read and authorized under.
+ *
+ * A `workspace/…` key prefix is not by itself proof of a workspace file. A
+ * mothership chat attachment is minted with the same prefix — same bucket, same
+ * workspace scope — but is recorded as `context = 'mothership'` and never enters
+ * the Files module, so every workspace-file lookup (which matches on
+ * `context = 'workspace'`) resolves it to nothing. The row bound to the key is
+ * the only thing that separates the two, and it is server-authored at upload
+ * time, so it is as trustworthy as the prefix itself.
+ *
+ * An unbound key keeps its inferred context: absent metadata is not evidence of
+ * an attachment, and the caller's own not-found handling is the right answer.
+ */
+export async function resolveStoredFileContext(key: string): Promise<StorageContext> {
+  const inferred = inferContextFromKey(key)
+  if (inferred !== 'workspace') return inferred
+
+  const metadata = await getFileMetadataByKey(key)
+  return metadata?.context === 'mothership' ? 'mothership' : inferred
 }
 
 /**


### PR DESCRIPTION
## Summary
- Chat attachment thumbnails and click-throughs were 404ing with `{"error":"FileNotFoundError","message":"File not found"}`. A mothership attachment is minted with the same key shape as a workspace file (`resolveUploadStorage` calls `generateWorkspaceFileKey` for `mothership_attachment`) but its row carries `context = 'mothership'`, so the serve route's key-prefix branch sent it into the workspace-file use case, which matches on `context = 'workspace'` and resolved it to nothing. Regressed in #6654.
- Serve resolves the storage context from the key's stored binding (`resolveStoredFileContext`) rather than the prefix alone, and threads it into the cloud/local handlers instead of re-inferring. Genuine workspace files still go through the authorized use case.
- Fixes previews in chat history, restored drafts, queued messages, and HEIC at upload time — all build the same serve URL. A freshly picked PNG still previewed because that thumbnail is a local blob URL, which is why this looked partial.

Second commit states the contract the fix depends on, so the next reader doesn't re-derive module ownership from the prefix:

- **Prefix = bucket + tenancy. Row = module owner.** `workspace_files.context` is server-authored like the key, but unlike the key it is *mutable* — `materialize_file` promotes an attachment to a workspace file by flipping that column. Encoding a mutable fact in an immutable key would mean copying the bytes on every transition just to restate them, which is why the prefix can't own this and `executeSave` stays a metadata-only flip.
- `resolveTrustedFileContext` claimed the prefix was flatly "authoritative" — the claim that made routing on it look safe. Now scoped to what it actually defends: a caller-supplied context still can never relabel a private key. `resolveStoredFileContext` is documented as the sanctioned reader, not a workaround.
- `verifyWorkspaceFileAccess` filtered its binding lookup to `context = 'workspace'`, so attachments missed the row and fell through to object metadata, which can't see a soft delete. It now matches either workspace-scoped context — which is what callers already wanted, since the LLM-attachment and presigned-URL paths pass `'workspace'` for attachment keys today. **A soft-deleted attachment is now denied on all of them.**
- The parse route carried the same gate, labelling parsed attachments with the raw storage segment instead of the uploaded filename.
- Module-scoped filters are deliberately untouched: the Files module, folder manager, forking and the workspace-file use cases match `context = 'workspace'` because they mean the Files module, not the bucket.

## Type of Change
- [x] Bug fix

## Testing
Both regressions are pinned by tests that fail against the pre-fix code, and in both cases the reason they shipped green was a mock asserting something the real function never does:

- The serve tests mocked `inferContextFromKey` to return `'mothership'` for a `workspace/…` key. Made honest — 9 of them fail against the old route.
- The new authorization tests use a `getFileMetadataByKey` mock that honors the `context`/`includeDeleted` arguments, so they actually exercise the filter. 2 fail against the old authorizer; the workspace-context cases still pass, showing no Files-module regression.

`bun run test app/api/files lib/uploads lib/workspace-files` — 861 pass (77 files). `type-check`, `lint`, and all 29 audits clean. Not exercised against a running app.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
