### PR TITLE
fix(sap_concur): HMAC the token cache key and wire the sendback comment

### DIFF
--- a/apps/sim/app/api/tools/sap_concur/shared.ts
+++ b/apps/sim/app/api/tools/sap_concur/shared.ts
@@ -1,10 +1,11 @@
-import { createHash } from 'node:crypto'
+import { createHmac } from 'node:crypto'
 import { createLogger } from '@sim/logger'
 import { isPrivateIpHost } from '@sim/security/ssrf'
 import { getErrorMessage } from '@sim/utils/errors'
 import { truncate } from '@sim/utils/string'
 import { z } from 'zod'
 import { coalesceLocally } from '@/lib/concurrency/singleflight'
+import { env } from '@/lib/core/config/env'
 import {
   MAX_JSON_API_RESPONSE_BYTES,
   secureFetchWithValidation,
@@ -229,8 +230,18 @@ function readCachedToken(key: string): SapConcurToken | undefined {
  * and collide with a different tuple. The full sha256 digest is kept — truncating it
  * would lower the collision/forgery bar for no measurable gain.
  */
+/**
+ * Key the token cache by every credential that changes which token Concur mints.
+ *
+ * Keyed with a server-side secret rather than a bare digest. The inputs include a
+ * user-chosen password, which is low-entropy enough to brute-force from a plain
+ * SHA-256 if a key ever reached a heap dump or a debug log; an HMAC makes the key
+ * useless without the secret. A password-hashing KDF would be the wrong tool — this
+ * runs on every token fetch and the goal is collision-free partitioning, not
+ * verification of a stored credential.
+ */
 function tokenCacheKey(req: SapConcurAuth): string {
-  return createHash('sha256')
+  return createHmac('sha256', env.INTERNAL_API_SECRET)
     .update(
       JSON.stringify([
         req.datacenter,

--- a/apps/sim/app/api/tools/sap_concur/shared.ts
+++ b/apps/sim/app/api/tools/sap_concur/shared.ts
@@ -227,18 +227,14 @@ function readCachedToken(key: string): SapConcurToken | undefined {
  *
  * The whole tuple is JSON-encoded before hashing rather than concatenated with a
  * separator, so a free-form field (clientId, companyUuid) cannot span a field boundary
- * and collide with a different tuple. The full sha256 digest is kept — truncating it
- * would lower the collision/forgery bar for no measurable gain.
- */
-/**
- * Key the token cache by every credential that changes which token Concur mints.
+ * and collide with a different tuple.
  *
  * Keyed with a server-side secret rather than a bare digest. The inputs include a
- * user-chosen password, which is low-entropy enough to brute-force from a plain
- * SHA-256 if a key ever reached a heap dump or a debug log; an HMAC makes the key
- * useless without the secret. A password-hashing KDF would be the wrong tool — this
- * runs on every token fetch and the goal is collision-free partitioning, not
- * verification of a stored credential.
+ * user-chosen password, which is low-entropy enough to brute-force from a plain SHA-256
+ * if a key ever reached a heap dump or a debug log; an HMAC makes the key useless without
+ * the secret. A password-hashing KDF would be the wrong tool — this runs on every token
+ * fetch and the goal is collision-free partitioning, not verification of a stored
+ * credential.
  */
 function tokenCacheKey(req: SapConcurAuth): string {
   return createHmac('sha256', env.INTERNAL_API_SECRET)

--- a/apps/sim/blocks/blocks/sap_concur.ts
+++ b/apps/sim/blocks/blocks/sap_concur.ts
@@ -1011,8 +1011,12 @@ Return ONLY the YYYY-MM-DD date - no explanations, no extra text.`,
       id: 'sendbackComment',
       title: 'Sendback Comment',
       type: 'long-input',
-      placeholder: 'Visible wherever Request comments are shown (sendback only)',
-      condition: { field: 'operation', value: 'sap_concur_move_travel_request' },
+      placeholder: 'Visible wherever Request comments are shown',
+      condition: {
+        field: 'operation',
+        value: 'sap_concur_move_travel_request',
+        and: { field: 'action', value: 'sendback' },
+      },
       mode: 'advanced',
     },
     {
@@ -2272,7 +2276,8 @@ Return ONLY the JSON object - no explanations, no extra text.`,
               body: params.body || undefined,
               userId: params.travelRequestUserId || undefined,
               companyID: params.companyID || undefined,
-              comment: params.sendbackComment || undefined,
+              comment:
+                params.action === 'sendback' ? params.sendbackComment || undefined : undefined,
             }
           case 'sap_concur_list_travel_request_comments':
             return { ...auth, requestUuid: params.requestUuid }

--- a/apps/sim/blocks/blocks/sap_concur.ts
+++ b/apps/sim/blocks/blocks/sap_concur.ts
@@ -1008,6 +1008,14 @@ Return ONLY the YYYY-MM-DD date - no explanations, no extra text.`,
       required: { field: 'operation', value: 'sap_concur_create_report_comment' },
     },
     {
+      id: 'sendbackComment',
+      title: 'Sendback Comment',
+      type: 'long-input',
+      placeholder: 'Visible wherever Request comments are shown (sendback only)',
+      condition: { field: 'operation', value: 'sap_concur_move_travel_request' },
+      mode: 'advanced',
+    },
+    {
       id: 'includeAllComments',
       title: 'Include All Comments',
       type: 'switch',
@@ -2264,6 +2272,7 @@ Return ONLY the JSON object - no explanations, no extra text.`,
               body: params.body || undefined,
               userId: params.travelRequestUserId || undefined,
               companyID: params.companyID || undefined,
+              comment: params.sendbackComment || undefined,
             }
           case 'sap_concur_list_travel_request_comments':
             return { ...auth, requestUuid: params.requestUuid }
@@ -2533,6 +2542,11 @@ Return ONLY the JSON object - no explanations, no extra text.`,
       type: 'string',
       description:
         'Optional company identifier for a travel request workflow action (documented as companyID, distinct from companyUuid)',
+    },
+    sendbackComment: {
+      type: 'string',
+      description:
+        'Optional comment on a travel request workflow action — Concur applies it only to the sendback action, and it is visible wherever Request comments are shown',
     },
     travelRequestApprovedBefore: { type: 'string', description: 'Travel requests approved before' },
     travelRequestApprovedAfter: { type: 'string', description: 'Travel requests approved after' },

--- a/apps/sim/blocks/blocks/sap_concur.ts
+++ b/apps/sim/blocks/blocks/sap_concur.ts
@@ -1893,7 +1893,7 @@ Return ONLY the comma-separated travel config IDs - no explanations, no extra te
         enabled: true,
         prompt: `Generate the JSON request body for the selected SAP Concur operation from the user's request.
 
-Match the payload to the resource being written. Every family below is camelCase.
+Match the payload to the resource being written. Every family below is camelCase EXCEPT exchange rates, which is snake_case.
 
 Expense reports (v4): name, businessPurpose, comment, policyId, countryCode, countrySubDivisionCode, reportDate, startDate, endDate, and reportSource — reportSource is REQUIRED when updating a report and must be one of EA, MOB, OTHER, SE, TR, UI.
 
@@ -1904,6 +1904,8 @@ Travel requests and expected expenses (Request v4): name, businessPurpose, start
 SCIM users (Identity v4.1): create and update payloads use schemas, userName, name.givenName, name.familyName, emails, active, and companyId inside urn:ietf:params:scim:schemas:extension:enterprise:2.0:User. Update uses urn:ietf:params:scim:api:messages:2.0:PatchOp with Operations. Search payloads use schemas with urn:ietf:params:scim:api:messages:concur:2.0:SearchRequest plus filter, count, attributes and cursor — startIndex is NOT supported as a request parameter.
 
 List items: listId, level, value, shortCode. Cash advances: amountRequested as { currency, amount }, name and userId (all required), plus optional accountCode, comment and purpose.
+
+Exchange rates are the one snake_case family: currency_sets as an array of up to 100 entries, each { from_crn_code, to_crn_code, start_date as YYYY-MM-DD, rate }.
 
 Omit fields the user did not describe rather than inventing identifiers.
 


### PR DESCRIPTION
## Summary
Follow-up to #6790 — these two commits were pushed to that branch after it had already been merged, so they never landed. Cherry-picked onto current staging, unchanged.

- **HMAC the token cache key.** `tokenCacheKey` hashed a user-chosen password with a bare SHA-256, which CodeQL flagged ([alert 479](https://github.com/simstudioai/sim/security/code-scanning/479)). The key never leaves the process, but a password is low-entropy enough to brute-force out of a plain digest if a key ever reached a heap dump or a debug log. It is now `createHmac('sha256', env.INTERNAL_API_SECRET)` over the same tuple, so the digest is useless without the server secret. Deliberately not a password-hashing KDF: this runs on every token fetch and partitions a cache rather than verifying a stored credential, so bcrypt/argon2 would add latency for no gain. That reasoning is in TSDoc on the function.
- **Carve exchange rates out of the wand prompt.** The shared body wand prompt claimed every payload family is camelCase. `sap_concur_upload_exchange_rates` is in `BODY_OPS` and genuinely takes snake_case (`currency_sets` of `{ from_crn_code, to_crn_code, start_date, rate }`), so the blanket claim produced bodies Concur rejects.
- **Wire the travel-request sendback comment.** `move_travel_request` accepts a documented query `comment` that Concur applies to the `sendback` action, but the params branch never forwarded it and the block's only `comment` field is gated to `create_report_comment`, so it was unreachable from the UI. Uses a dedicated `sendbackComment` subblock — sharing the existing id would clash on required-ness and let values bleed between the two operations.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run check:audits` (29/29), `check-block-registry`, `lint`, `type-check`, and the 127 SAP Concur tests all pass against current staging.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)