### PR TITLE
fix(chat): disambiguate folder mentions

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/mention-row-content.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/mention-row-content.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { MentionRowContent } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/mention-row-content'
+
+let container: HTMLDivElement
+let root: Root
+
+/** Stands in for a family renderer that pins trailing content with `ml-auto`, as the log row does. */
+function LogLikeRow() {
+  return (
+    <>
+      <span className='truncate'>Daily digest</span>
+      <span data-testid='trailing' className='ml-auto flex-shrink-0'>
+        2m ago
+      </span>
+    </>
+  )
+}
+
+function renderRow(node: React.ReactNode) {
+  act(() => {
+    root.render(<button type='button'>{node}</button>)
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('MentionRowContent', () => {
+  it('leaves a location-less row unwrapped so `ml-auto` still reaches the row edge', () => {
+    renderRow(
+      <MentionRowContent>
+        <LogLikeRow />
+      </MentionRowContent>
+    )
+
+    const trailing = container.querySelector('[data-testid="trailing"]')
+    expect(trailing).not.toBeNull()
+    expect(trailing?.parentElement?.tagName).toBe('BUTTON')
+  })
+
+  it('wraps and caps the name only when a location follows it', () => {
+    renderRow(
+      <MentionRowContent location={{ familyType: 'file', parentNames: ['Growth'] }}>
+        <span>Enterprise</span>
+      </MentionRowContent>
+    )
+
+    const name = container.querySelector('button > span')
+    expect(name?.className).toContain('max-w-[65%]')
+    expect(name?.className).toContain('flex-shrink-0')
+    expect(container.textContent).toContain('Files')
+    expect(container.textContent).toContain('Growth')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/mention-row-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/mention-row-content.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { FolderPathLabel } from '@/components/ui'
+import { getResourceConfig } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry'
+import type { FolderMentionLocation } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items'
+
+export interface MentionRowContentProps {
+  /** The resource family's own row rendering, a fragment of the row's flex children. */
+  children: ReactNode
+  /** Present only for folder rows, which need a location to disambiguate same-named siblings. */
+  location?: FolderMentionLocation
+}
+
+/**
+ * Body of one flat mention row.
+ *
+ * Rows without a location render their family output as direct children of the row
+ * button, unwrapped. That is load-bearing rather than incidental: renderers such as
+ * the log row pin trailing content with `ml-auto`, which only reaches the row's right
+ * edge while the button is its flex parent. Wrapping every row would silently pull
+ * those timestamps back beside the name.
+ */
+export function MentionRowContent({ children, location }: MentionRowContentProps) {
+  if (!location) return <>{children}</>
+
+  return (
+    <>
+      {/* Capped rather than shrinkable so a long name cannot squeeze out the segment
+          that tells two same-named folders apart. */}
+      <span className='flex max-w-[65%] flex-shrink-0 items-center gap-2 [&>span]:min-w-0 [&>span]:truncate'>
+        {children}
+      </span>
+      <FolderPathLabel
+        prefix={getResourceConfig(location.familyType).label}
+        segments={location.parentNames}
+      />
+    </>
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuSearchInput,
   DropdownMenuTrigger,
 } from '@sim/emcn'
+import { FolderPathLabel } from '@/components/ui'
 import {
   ResourceMenuSections,
   useAvailableResources,
@@ -41,35 +42,6 @@ const MENTION_ONLY_RESOURCE_TYPES = new Set<MothershipResourceType>(['integratio
 const NON_ATTACHABLE_RESOURCE_TYPES = new Set<MothershipResourceType>(['browser'])
 const EMPTY_BROWSER_TABS = [] as const
 const EMPTY_TERMINAL_TABS = [] as const
-
-interface FolderMentionPathProps {
-  segments: readonly string[]
-}
-
-/** Right-aligned folder location whose middle ancestors yield space first. */
-function FolderMentionPath({ segments }: FolderMentionPathProps) {
-  const family = segments[0]
-  const parentNames = segments.slice(1)
-  const nearestParent = parentNames.at(-1)
-  const middleParents = parentNames.slice(0, -1)
-
-  return (
-    <span className='ml-auto flex min-w-0 pl-2 text-[var(--text-subtle)] text-small'>
-      <span className='flex-shrink-0'>{family}</span>
-      {middleParents.length > 0 && (
-        <span className='min-w-0 truncate whitespace-pre [flex-shrink:9999]'>
-          {` / ${middleParents.join(' / ')}`}
-        </span>
-      )}
-      {nearestParent && (
-        <>
-          <span className='flex-shrink-0 whitespace-pre'> / </span>
-          <span className='min-w-0 truncate'>{nearestParent}</span>
-        </>
-      )}
-    </span>
-  )
-}
 
 interface PlusMenuDropdownProps {
   workspaceId: string
@@ -333,7 +305,9 @@ export const PlusMenuDropdown = React.memo(
             // Plus-click shows short fixed labels (Workflows, Tables, …) — let it size
             // to its content via the emcn DropdownMenuContent default max-w.
             // Mention mode renders resource names directly, so widen for breathing room.
-            isMention && 'max-w-[min(300px,calc(100vw-32px))]'
+            // Wide enough that a folder row fits its name and its right-aligned
+            // location column without either collapsing to a stub.
+            isMention && 'w-[min(380px,calc(100vw-32px))] max-w-[calc(100vw-32px)]'
           )}
           onCloseAutoFocus={handleCloseAutoFocus}
           onOpenAutoFocus={handleOpenAutoFocus}
@@ -370,9 +344,6 @@ export const PlusMenuDropdown = React.memo(
                   const config = getResourceConfig(type)
                   const isActive = index === activeIndex
                   const location = folderMentionLocations.get(`${type}:${item.id}`)
-                  const locationPath = location
-                    ? [getResourceConfig(location.familyType).label, ...location.parentNames]
-                    : null
                   return (
                     <button
                       key={`${type}:${item.id}`}
@@ -384,13 +355,27 @@ export const PlusMenuDropdown = React.memo(
                         handleSelect({ type, id: item.id, title: item.name })
                       }}
                       className={cn(
-                        'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors duration-0 [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
+                        'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors duration-0 [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
                         /* `activeIndex` is the cursor, not a selection — hover surface. */
                         isActive && 'bg-[var(--surface-hover)]'
                       )}
                     >
-                      {config.renderDropdownItem({ item })}
-                      {locationPath && <FolderMentionPath segments={locationPath} />}
+                      {/* Capped, not shrinkable: a long name must never squeeze out the
+                          location that tells two same-named folders apart. */}
+                      <span
+                        className={cn(
+                          'flex min-w-0 items-center gap-2 [&>span]:min-w-0 [&>span]:truncate',
+                          location && 'max-w-[65%] flex-shrink-0'
+                        )}
+                      >
+                        {config.renderDropdownItem({ item })}
+                      </span>
+                      {location && (
+                        <FolderPathLabel
+                          prefix={getResourceConfig(location.familyType).label}
+                          segments={location.parentNames}
+                        />
+                      )}
                     </button>
                   )
                 })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -8,7 +8,6 @@ import {
   DropdownMenuSearchInput,
   DropdownMenuTrigger,
 } from '@sim/emcn'
-import { FolderPathLabel } from '@/components/ui'
 import {
   ResourceMenuSections,
   useAvailableResources,
@@ -16,6 +15,7 @@ import {
 } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown'
 import { getResourceConfig } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry'
 import type { PlusMenuHandle } from '@/app/workspace/[workspaceId]/home/components/user-input/components/constants'
+import { MentionRowContent } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/mention-row-content'
 import {
   buildFolderMentionLocationMap,
   resourceMentionMatches,
@@ -355,27 +355,14 @@ export const PlusMenuDropdown = React.memo(
                         handleSelect({ type, id: item.id, title: item.name })
                       }}
                       className={cn(
-                        'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors duration-0 [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
+                        'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors duration-0 [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
                         /* `activeIndex` is the cursor, not a selection — hover surface. */
                         isActive && 'bg-[var(--surface-hover)]'
                       )}
                     >
-                      {/* Capped, not shrinkable: a long name must never squeeze out the
-                          location that tells two same-named folders apart. */}
-                      <span
-                        className={cn(
-                          'flex min-w-0 items-center gap-2 [&>span]:min-w-0 [&>span]:truncate',
-                          location && 'max-w-[65%] flex-shrink-0'
-                        )}
-                      >
+                      <MentionRowContent location={location}>
                         {config.renderDropdownItem({ item })}
-                      </span>
-                      {location && (
-                        <FolderPathLabel
-                          prefix={getResourceConfig(location.familyType).label}
-                          segments={location.parentNames}
-                        />
-                      )}
+                      </MentionRowContent>
                     </button>
                   )
                 })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -16,6 +16,7 @@ import {
 import { getResourceConfig } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry'
 import type { PlusMenuHandle } from '@/app/workspace/[workspaceId]/home/components/user-input/components/constants'
 import {
+  buildFolderMentionLocationMap,
   resourceMentionMatches,
   withDesktopTabMentions,
 } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items'
@@ -40,6 +41,35 @@ const MENTION_ONLY_RESOURCE_TYPES = new Set<MothershipResourceType>(['integratio
 const NON_ATTACHABLE_RESOURCE_TYPES = new Set<MothershipResourceType>(['browser'])
 const EMPTY_BROWSER_TABS = [] as const
 const EMPTY_TERMINAL_TABS = [] as const
+
+interface FolderMentionPathProps {
+  segments: readonly string[]
+}
+
+/** Right-aligned folder location whose middle ancestors yield space first. */
+function FolderMentionPath({ segments }: FolderMentionPathProps) {
+  const family = segments[0]
+  const parentNames = segments.slice(1)
+  const nearestParent = parentNames.at(-1)
+  const middleParents = parentNames.slice(0, -1)
+
+  return (
+    <span className='ml-auto flex min-w-0 pl-2 text-[var(--text-subtle)] text-small'>
+      <span className='flex-shrink-0'>{family}</span>
+      {middleParents.length > 0 && (
+        <span className='min-w-0 truncate whitespace-pre [flex-shrink:9999]'>
+          {` / ${middleParents.join(' / ')}`}
+        </span>
+      )}
+      {nearestParent && (
+        <>
+          <span className='flex-shrink-0 whitespace-pre'> / </span>
+          <span className='min-w-0 truncate'>{nearestParent}</span>
+        </>
+      )}
+    </span>
+  )
+}
 
 interface PlusMenuDropdownProps {
   workspaceId: string
@@ -118,6 +148,11 @@ export const PlusMenuDropdown = React.memo(
       )
       return attachable.filter(({ type }) => !MENTION_ONLY_RESOURCE_TYPES.has(type))
     }, [availableResources, browserTabs, isMention, terminalTabs])
+
+    const folderMentionLocations = useMemo(
+      () => buildFolderMentionLocationMap(visibleResources),
+      [visibleResources]
+    )
 
     const treeSections = useResourceTreeSections({
       groups: visibleResources,
@@ -334,6 +369,10 @@ export const PlusMenuDropdown = React.memo(
                 filteredItems.map(({ type, item }, index) => {
                   const config = getResourceConfig(type)
                   const isActive = index === activeIndex
+                  const location = folderMentionLocations.get(`${type}:${item.id}`)
+                  const locationPath = location
+                    ? [getResourceConfig(location.familyType).label, ...location.parentNames]
+                    : null
                   return (
                     <button
                       key={`${type}:${item.id}`}
@@ -351,6 +390,7 @@ export const PlusMenuDropdown = React.memo(
                       )}
                     >
                       {config.renderDropdownItem({ item })}
+                      {locationPath && <FolderMentionPath segments={locationPath} />}
                     </button>
                   )
                 })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.test.ts
@@ -4,6 +4,7 @@ import {
   TERMINAL_SESSION_RESOURCE_ID,
 } from '@/lib/copilot/resources/types'
 import {
+  buildFolderMentionLocationMap,
   resourceMentionMatches,
   withDesktopTabMentions,
 } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items'
@@ -19,6 +20,88 @@ const groups = [
     items: [{ id: TERMINAL_SESSION_RESOURCE_ID, name: 'Terminal' }],
   },
 ]
+
+describe('buildFolderMentionLocationMap', () => {
+  it('distinguishes same-named top-level workflow and file folders by family', () => {
+    const locations = buildFolderMentionLocationMap([
+      {
+        type: 'folder',
+        items: [{ id: 'enterprise', name: 'Enterprise', parentId: null }],
+      },
+      {
+        type: 'filefolder',
+        items: [{ id: 'enterprise', name: 'Enterprise', parentId: null }],
+      },
+    ])
+
+    expect(locations.get('folder:enterprise')).toEqual({
+      familyType: 'workflow',
+      parentNames: [],
+    })
+    expect(locations.get('filefolder:enterprise')).toEqual({
+      familyType: 'file',
+      parentNames: [],
+    })
+  })
+
+  it('returns root-first parents without repeating the current folder name', () => {
+    const locations = buildFolderMentionLocationMap([
+      {
+        type: 'folder',
+        items: [
+          { id: 'engineering', name: 'Engineering', parentId: null },
+          { id: 'accounts', name: 'Accounts', parentId: 'engineering' },
+          { id: 'enterprise', name: 'Enterprise', parentId: 'accounts' },
+        ],
+      },
+    ])
+
+    expect(locations.get('folder:enterprise')).toEqual({
+      familyType: 'workflow',
+      parentNames: ['Engineering', 'Accounts'],
+    })
+  })
+
+  it('falls back to the family when a parent is missing', () => {
+    const locations = buildFolderMentionLocationMap([
+      {
+        type: 'filefolder',
+        items: [{ id: 'enterprise', name: 'Enterprise', parentId: 'missing' }],
+      },
+    ])
+
+    expect(locations.get('filefolder:enterprise')).toEqual({
+      familyType: 'file',
+      parentNames: [],
+    })
+  })
+
+  it('terminates cyclic ancestry without repeating the current folder', () => {
+    const locations = buildFolderMentionLocationMap([
+      {
+        type: 'folder',
+        items: [
+          { id: 'enterprise', name: 'Enterprise', parentId: 'accounts' },
+          { id: 'accounts', name: 'Accounts', parentId: 'enterprise' },
+        ],
+      },
+    ])
+
+    expect(locations.get('folder:enterprise')).toEqual({
+      familyType: 'workflow',
+      parentNames: ['Accounts'],
+    })
+  })
+
+  it('does not add locations for non-folder resources', () => {
+    const locations = buildFolderMentionLocationMap([
+      { type: 'workflow', items: [{ id: 'workflow-1', name: 'Enterprise' }] },
+      { type: 'file', items: [{ id: 'file-1', name: 'Enterprise' }] },
+    ])
+
+    expect(locations.size).toBe(0)
+  })
+})
 
 describe('withDesktopTabMentions', () => {
   it('keeps Browser and Terminal as flat resource mentions with no live tabs', () => {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.ts
@@ -4,6 +4,7 @@ import {
   BROWSER_SESSION_RESOURCE_ID,
   TERMINAL_SESSION_RESOURCE_ID,
 } from '@/lib/copilot/resources/types'
+import { folderAncestorChain } from '@/lib/folders/tree'
 import type { AvailableItem } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-folder-tree'
 import { browserTabTitle } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-tab-label'
 import type { MothershipResourceType } from '@/app/workspace/[workspaceId]/home/types'
@@ -14,6 +15,57 @@ export interface ResourceMentionGroup {
 }
 
 export type ResourceMentionLevel = 'resource' | 'tab'
+
+export interface FolderMentionLocation {
+  familyType: 'workflow' | 'file'
+  parentNames: string[]
+}
+
+interface FolderMentionNode {
+  id: string
+  name: string
+  parentId: string | null
+}
+
+function folderFamilyType(
+  type: MothershipResourceType
+): FolderMentionLocation['familyType'] | null {
+  if (type === 'folder') return 'workflow'
+  if (type === 'filefolder') return 'file'
+  return null
+}
+
+/** Builds display-only locations for the folder rows in the flat resource picker. */
+export function buildFolderMentionLocationMap(
+  groups: readonly ResourceMentionGroup[]
+): Map<string, FolderMentionLocation> {
+  const locations = new Map<string, FolderMentionLocation>()
+
+  for (const group of groups) {
+    const familyType = folderFamilyType(group.type)
+    if (!familyType) continue
+
+    const nodes = new Map<string, FolderMentionNode>(
+      group.items.map((item) => [
+        item.id,
+        {
+          id: item.id,
+          name: item.name,
+          parentId: typeof item.parentId === 'string' ? item.parentId : null,
+        },
+      ])
+    )
+
+    for (const node of nodes.values()) {
+      const parentNames = folderAncestorChain(node.parentId, (id) => nodes.get(id))
+        .filter((parent) => parent.id !== node.id)
+        .map((parent) => parent.name)
+      locations.set(`${group.type}:${node.id}`, { familyType, parentNames })
+    }
+  }
+
+  return locations
+}
 
 /** A family query such as "browser" keeps that resource's live tabs visible. */
 export function resourceMentionMatches(item: AvailableItem, query: string): boolean {

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items/command-items.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-items/command-items.tsx
@@ -4,6 +4,7 @@ import type { ComponentType } from 'react'
 import { memo } from 'react'
 import { File, Workflow } from '@sim/emcn/icons'
 import { Command } from 'cmdk'
+import { FolderPathLabel } from '@/components/ui'
 import { HEX_COLOR_REGEX } from '@/lib/branding'
 import type { CommandItemProps } from '@/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils'
 import { COMMAND_ITEM_CLASSNAME } from '@/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/utils'
@@ -20,27 +21,6 @@ interface ItemMetaProps {
 function ItemMeta({ meta }: ItemMetaProps) {
   return (
     <span className='ml-auto flex-shrink-0 pl-2 text-[var(--text-subtle)] text-small'>{meta}</span>
-  )
-}
-
-interface ItemFolderPathProps {
-  folderPath: string[]
-}
-
-/** Trailing folder-path receipt whose head segments yield space to the leaf. */
-function ItemFolderPath({ folderPath }: ItemFolderPathProps) {
-  return (
-    <span className='ml-auto flex min-w-0 pl-2 text-[var(--text-subtle)] text-small'>
-      {folderPath.length > 1 && (
-        <>
-          <span className='min-w-0 truncate [flex-shrink:9999]'>
-            {folderPath.slice(0, -1).join(' / ')}
-          </span>
-          <span className='flex-shrink-0 whitespace-pre'> / </span>
-        </>
-      )}
-      <span className='min-w-0 truncate'>{folderPath[folderPath.length - 1]}</span>
-    </span>
   )
 }
 
@@ -167,7 +147,7 @@ export const MemoizedWorkflowItem = memo(
         {meta ? (
           <ItemMeta meta={meta} />
         ) : folderPath && folderPath.length > 0 ? (
-          <ItemFolderPath folderPath={folderPath} />
+          <FolderPathLabel segments={folderPath} />
         ) : null}
       </Command.Item>
     )
@@ -204,7 +184,7 @@ export const MemoizedFileItem = memo(
         {meta ? (
           <ItemMeta meta={meta} />
         ) : folderPath && folderPath.length > 0 ? (
-          <ItemFolderPath folderPath={folderPath} />
+          <FolderPathLabel segments={folderPath} />
         ) : null}
       </Command.Item>
     )
@@ -349,7 +329,7 @@ export const MemoizedIconItem = memo(
         {meta ? (
           <ItemMeta meta={meta} />
         ) : folderPath && folderPath.length > 0 ? (
-          <ItemFolderPath folderPath={folderPath} />
+          <FolderPathLabel segments={folderPath} />
         ) : null}
       </Command.Item>
     )

--- a/apps/sim/components/ui/folder-path-label.test.ts
+++ b/apps/sim/components/ui/folder-path-label.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { collapseFolderPath } from '@/components/ui/folder-path-label'
+
+describe('collapseFolderPath', () => {
+  it('leaves a shallow chain untouched', () => {
+    expect(collapseFolderPath([])).toEqual([])
+    expect(collapseFolderPath(['Growth'])).toEqual(['Growth'])
+    expect(collapseFolderPath(['Growth', 'Campaigns', 'Q3'])).toEqual(['Growth', 'Campaigns', 'Q3'])
+  })
+
+  it('drops whole ancestors rather than clipping one mid-word', () => {
+    expect(collapseFolderPath(['Growth', 'Campaigns', 'Paid', 'Q3'])).toEqual(['Growth', '…', 'Q3'])
+  })
+
+  it('keeps the root and the leaf however deep the chain runs', () => {
+    const deep = ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+    expect(collapseFolderPath(deep)).toEqual(['A', '…', 'G'])
+  })
+
+  it('does not mutate the input', () => {
+    const segments = ['A', 'B', 'C', 'D']
+    collapseFolderPath(segments)
+    expect(segments).toEqual(['A', 'B', 'C', 'D'])
+  })
+})

--- a/apps/sim/components/ui/folder-path-label.tsx
+++ b/apps/sim/components/ui/folder-path-label.tsx
@@ -1,0 +1,64 @@
+import { cn } from '@sim/emcn'
+
+/**
+ * Ancestors kept before the path collapses. Three is the widest chain that still
+ * reads at the ~30% of a menu row this label is allowed to occupy.
+ */
+const MAX_VISIBLE_SEGMENTS = 3
+const ELLIPSIS = '…'
+
+/**
+ * Collapses a root-first folder chain so an over-long path drops whole ancestors
+ * instead of clipping one mid-word: `Growth / … / Q3` rather than `Growth / Mark…`.
+ *
+ * The root orients and the leaf disambiguates, so those are the two that survive;
+ * everything between them is what the reader can least act on.
+ */
+export function collapseFolderPath(segments: readonly string[]): string[] {
+  if (segments.length <= MAX_VISIBLE_SEGMENTS) return [...segments]
+  return [segments[0], ELLIPSIS, segments[segments.length - 1]]
+}
+
+export interface FolderPathLabelProps {
+  /** Root-first ancestor names of the row's resource. */
+  segments: readonly string[]
+  /**
+   * Pinned lead-in that never clips — the resource family (`Files`, `Workflows`)
+   * when the label doubles as the row's disambiguator.
+   */
+  prefix?: string
+  className?: string
+}
+
+/**
+ * Right-aligned location receipt for a menu row. Head segments yield their space
+ * first so the leaf — the segment that tells two same-named rows apart — is the
+ * last thing to clip.
+ */
+export function FolderPathLabel({ segments, prefix, className }: FolderPathLabelProps) {
+  const visible = collapseFolderPath(segments)
+  const leaf = visible.at(-1)
+  const head = visible.slice(0, -1)
+  const hasLeadIn = Boolean(prefix) || head.length > 0
+
+  if (!hasLeadIn && !leaf) return null
+
+  return (
+    <span
+      className={cn('ml-auto flex min-w-0 pl-2 text-[var(--text-subtle)] text-small', className)}
+    >
+      {prefix && <span className='flex-shrink-0'>{prefix}</span>}
+      {head.length > 0 && (
+        <span className='min-w-0 truncate whitespace-pre [flex-shrink:9999]'>
+          {prefix ? ` / ${head.join(' / ')}` : head.join(' / ')}
+        </span>
+      )}
+      {leaf && (
+        <>
+          {hasLeadIn && <span className='flex-shrink-0 whitespace-pre'> / </span>}
+          <span className='min-w-0 truncate'>{leaf}</span>
+        </>
+      )}
+    </span>
+  )
+}

--- a/apps/sim/components/ui/index.ts
+++ b/apps/sim/components/ui/index.ts
@@ -1,4 +1,9 @@
 export { Button, buttonVariants } from './button'
+export {
+  collapseFolderPath,
+  FolderPathLabel,
+  type FolderPathLabelProps,
+} from './folder-path-label'
 export { GeneratedPasswordInput } from './generated-password-input'
 export { Progress } from './progress'
 export {


### PR DESCRIPTION
## Summary
- show the resource family on workflow-folder and file-folder rows in flat @ mention results
- reuse existing folder ancestry data to show root-first parent paths with middle truncation
- keep nested browse menus, selection behavior, APIs, and persisted mentions unchanged

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- targeted resource mention tests: 8 passed
- bun run lint:check: 24/24 tasks passed
- bun run type-check: 24/24 tasks passed
- git diff --check
- manually verified on localhost that same-named Enterprise folders render as Files and Workflows

Reviewers should focus on the flat @ autocomplete and filtered + menu at narrow widths; nested browsing is intentionally unchanged.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Manually verified in localhost using same-named workflow and file folders; the right-side labels display Files and Workflows.