### PR TITLE
fix(copilot): persist workflow drafts across navigation

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
@@ -764,6 +764,7 @@ export function MothershipChat({
               onCancelEdit={onCancelQueueEdit}
             />
             <UserInput
+              key={draftScopeKey}
               ref={userInputRef}
               onSubmit={onSubmit}
               isSending={isStreamActive}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -117,6 +117,7 @@ export const Panel = memo(function Panel() {
   const router = useRouter()
   const params = useParams()
   const workspaceId = params.workspaceId as string
+  const routeWorkflowId = params.workflowId as string | undefined
 
   const posthog = usePostHog()
   const posthogRef = useRef(posthog)
@@ -396,6 +397,10 @@ export const Panel = memo(function Panel() {
       },
     })
   )
+  const copilotDraftWorkflowId = activeWorkflowId ?? routeWorkflowId
+  const copilotDraftScopeKey = copilotDraftWorkflowId
+    ? `${workspaceId}:workflow-copilot:${copilotDraftWorkflowId}`
+    : undefined
 
   const handleCopilotNewChat = useCallback(() => {
     if (!activeWorkflowId || !workspaceId) return
@@ -943,6 +948,7 @@ export const Panel = memo(function Panel() {
                   onCancelQueueEdit={copilotCancelQueueEdit}
                   userId={session?.user?.id}
                   chatId={copilotResolvedChatId}
+                  draftScopeKey={copilotDraftScopeKey}
                   layout='copilot-view'
                 />
               </div>


### PR DESCRIPTION
## Summary
- Persist unsent workflow Copilot text, completed attachments, and context chips across navigation and refresh.
- Reuse the existing localStorage-backed Mothership draft store with one namespaced bucket per workspace and workflow.
- Use the route workflow on initial hydration, then follow the active operational workflow so the draft, transcript, and send target change together.
- Key only the composer when the workflow scope changes; transcript and scroll state remain untouched.
- Keep the scope stable while a new Copilot chat receives its server ID so queued follow-up text cannot be lost.
- Leave Copilot rendering, cross-surface handoffs, APIs, schemas, backend logic, and the draft store unchanged.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- `bunx biome check` on both changed files
- `bun run check:audits` — 29/29 audits passed
- `bun run lint:check` — 24/24 tasks passed
- `bun run type-check` — 24/24 tasks passed
- `bun run test` — 17/17 tasks passed; app suite 27,406 passed, 46 skipped
- `bunx turbo run build --filter=@sim/app` — passed
- `git diff --check` — passed
- After review changes: scoped Biome, `@sim/app` type-check, and diff check passed

Interactive localhost QA was not available in the agent browser session. Reviewer focus: type an unsent workflow Copilot draft, navigate away and return or refresh, confirm it restores; switch workflows and confirm isolation; send and confirm the draft clears.

No new automated test was added because this adopts an existing persistence path, while a mocked Panel test would only assert prop wiring rather than route-navigation behavior.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Existing tests are passing; no wiring-only test added
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the Contributor License Agreement

## Screenshots/Videos
Not attached because an interactive localhost browser session was unavailable.