### PR TITLE
fix(credential-groups): pin the clock in the enrollment tests

### DIFF
--- a/apps/sim/lib/credential-groups/enrollments.test.ts
+++ b/apps/sim/lib/credential-groups/enrollments.test.ts
@@ -3,7 +3,7 @@
  */
 import { dbChainMockFns, queueTableRows, resetDbChainMock, schemaMock } from '@sim/testing'
 import { inArray } from 'drizzle-orm'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { adapter } = vi.hoisted(() => ({
   adapter: {
@@ -40,6 +40,23 @@ import { CREDENTIAL_GROUP_PROVIDER_IDS } from '@/lib/credential-groups/providers
 import { sendEmail } from '@/lib/messaging/email/mailer'
 
 const MAX_CONNECTION_SUMMARIES = CREDENTIAL_GROUP_PROVIDER_IDS.length * 3
+
+/**
+ * The invitation fixtures below are dated relative to a fixed point in the enrollment
+ * window, and the code under test compares them against the wall clock. Pinning the
+ * clock keeps those literals meaningful and keeps the suite deterministic — dating the
+ * expiry to a real future instant only moves the failure, it does not remove it.
+ */
+const NOW = new Date('2026-08-11T12:10:00.000Z')
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.setSystemTime(NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 const ENROLLMENT = {
   id: 'enrollment-1',


### PR DESCRIPTION
## Summary

`apps/sim/lib/credential-groups/enrollments.test.ts` had a time bomb that has now gone off. It blocks CI on every branch, not just this one.

`ENROLLMENT.invitationExpiresAt` was hardcoded to `2026-08-18T12:00:00.000Z`, and `completeCredentialGroupEnrollment` compares it against the wall clock. Before that instant the invitation was valid and the suite passed; after it, the invitation is expired, the function returns `null`, and two tests fail.

The evidence is a single unchanged commit running twice:

| Run | Time | `enrollments.test.ts` |
|---|---|---|
| First | 2026-08-18T07:21Z | 11 passed |
| Re-run | 2026-08-18T14:55Z | 11 tests, 2 failed |

Same SHA, same base, no code change between them — only the clock moved past 12:00Z.

Confirmed locally: on clean `origin/staging` the two tests fail deterministically; re-dating the fixture to 2027 makes all 11 pass.

## Fix

Pin the clock to a point inside the invitation window rather than re-dating the fixture:

```ts
const NOW = new Date('2026-08-11T12:10:00.000Z')
beforeEach(() => {
  vi.useFakeTimers({ shouldAdvanceTime: true })
  vi.setSystemTime(NOW)
})
afterEach(() => { vi.useRealTimers() })
```

Every existing date literal keeps its meaning, and the suite stops depending on when it runs. Bumping the date to a later instant would only re-arm the same failure.

## Type of Change
- [x] Bug fix (broken CI)

## Testing
`lib/credential-groups` — 63 tests across 13 files pass. `type-check` clean, lint clean. Verified the cause by moving the fixture date forward and back.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
