### PR TITLE
fix(search): prioritize actions and prevent palette clipping

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-chrome/command-chrome.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-chrome/command-chrome.test.tsx
@@ -57,9 +57,12 @@ describe('CommandFadedList', () => {
     })
 
     const list = container.querySelector('[cmdk-list]')
+    const input = container.querySelector<HTMLInputElement>('[cmdk-input]')
     const search = container.querySelector('[cmdk-input]')?.parentElement
     expect(list?.className).toContain('transparent_36px,black_58px,black_calc(100%_-_13px)')
     expect(list?.className).not.toContain('scrollbar-track')
+    expect(input?.className).toContain('-ml-1')
+    expect(input?.className).toContain('indent-1')
     expect(search?.className).toContain('var(--bg)')
   })
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-chrome/command-chrome.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-chrome/command-chrome.tsx
@@ -58,12 +58,14 @@ const LIST_FADE_CLASSNAME = {
 /**
  * Borderless search field layered over a fading command-result list.
  *
- * The input carries `pl-[3px]` with a compensating `-ml-[3px]`: inputs clip
- * glyph ink at their padding box, and the brand font's `j` overhangs left of
- * its pen origin, so with zero padding a leading `j` loses its hook — worst
- * at low zoom, where the clip edge snaps to whole device pixels and eats up
- * to 2 CSS px. The negative margin keeps the text at the same x, aligned
- * with the result-row titles.
+ * The input carries `indent-[3px]` with a compensating `-ml-[3px]`: Chrome
+ * clips input text at the content box (verified — padding gives no ink
+ * clearance), and the first glyph's ink starts exactly at that clip edge,
+ * so a leading `j` loses its hook — worst at low browser zoom, where the
+ * clip edge snaps to whole device pixels and eats up to ~2 CSS px of the
+ * first letter. The indent starts the text 3px inside the clip region and
+ * the negative margin keeps it at the same x, aligned with the result-row
+ * titles.
  */
 export const CommandSearch = forwardRef<HTMLInputElement, CommandSearchProps>(
   function CommandSearch(
@@ -94,7 +96,7 @@ export const CommandSearch = forwardRef<HTMLInputElement, CommandSearchProps>(
         <Search className='size-[14px] flex-shrink-0 text-[var(--text-muted)]' />
         <Command.Input
           ref={ref}
-          className='-ml-[3px] h-8 min-w-0 flex-1 cursor-text bg-transparent pl-[3px] text-[var(--text-body)] text-sm outline-none placeholder:text-[var(--text-muted)] focus:outline-none'
+          className='-ml-[3px] h-8 min-w-0 flex-1 cursor-text bg-transparent text-[var(--text-body)] text-sm indent-[3px] outline-none placeholder:text-[var(--text-muted)] focus:outline-none'
           onKeyDown={handleKeyDown}
           {...props}
         />

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-chrome/command-chrome.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-chrome/command-chrome.tsx
@@ -58,14 +58,8 @@ const LIST_FADE_CLASSNAME = {
 /**
  * Borderless search field layered over a fading command-result list.
  *
- * The input carries `indent-[3px]` with a compensating `-ml-[3px]`: Chrome
- * clips input text at the content box (verified — padding gives no ink
- * clearance), and the first glyph's ink starts exactly at that clip edge,
- * so a leading `j` loses its hook — worst at low browser zoom, where the
- * clip edge snaps to whole device pixels and eats up to ~2 CSS px of the
- * first letter. The indent starts the text 3px inside the clip region and
- * the negative margin keeps it at the same x, aligned with the result-row
- * titles.
+ * The matching indent and negative margin give leading glyphs room inside
+ * Chrome's input clip edge without moving the text out of alignment.
  */
 export const CommandSearch = forwardRef<HTMLInputElement, CommandSearchProps>(
   function CommandSearch(
@@ -96,7 +90,7 @@ export const CommandSearch = forwardRef<HTMLInputElement, CommandSearchProps>(
         <Search className='size-[14px] flex-shrink-0 text-[var(--text-muted)]' />
         <Command.Input
           ref={ref}
-          className='-ml-[3px] h-8 min-w-0 flex-1 cursor-text bg-transparent text-[var(--text-body)] text-sm indent-[3px] outline-none placeholder:text-[var(--text-muted)] focus:outline-none'
+          className='-ml-1 h-8 min-w-0 flex-1 cursor-text bg-transparent indent-1 text-[var(--text-body)] text-sm outline-none placeholder:text-[var(--text-muted)] focus:outline-none'
           onKeyDown={handleKeyDown}
           {...props}
         />

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-chrome/command-chrome.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/components/command-chrome/command-chrome.tsx
@@ -55,7 +55,16 @@ const LIST_FADE_CLASSNAME = {
     '[-webkit-mask-image:linear-gradient(to_bottom,transparent_0px,transparent_36px,black_58px,black_calc(100%_-_13px),transparent_100%)] [mask-image:linear-gradient(to_bottom,transparent_0px,transparent_36px,black_58px,black_calc(100%_-_13px),transparent_100%)]',
 } as const
 
-/** Borderless search field layered over a fading command-result list. */
+/**
+ * Borderless search field layered over a fading command-result list.
+ *
+ * The input carries `pl-[3px]` with a compensating `-ml-[3px]`: inputs clip
+ * glyph ink at their padding box, and the brand font's `j` overhangs left of
+ * its pen origin, so with zero padding a leading `j` loses its hook — worst
+ * at low zoom, where the clip edge snaps to whole device pixels and eats up
+ * to 2 CSS px. The negative margin keeps the text at the same x, aligned
+ * with the result-row titles.
+ */
 export const CommandSearch = forwardRef<HTMLInputElement, CommandSearchProps>(
   function CommandSearch(
     { surface, cycleResultsOnTab = false, endAdornment, onKeyDown, ...props },
@@ -85,7 +94,7 @@ export const CommandSearch = forwardRef<HTMLInputElement, CommandSearchProps>(
         <Search className='size-[14px] flex-shrink-0 text-[var(--text-muted)]' />
         <Command.Input
           ref={ref}
-          className='h-8 min-w-0 flex-1 cursor-text bg-transparent text-[var(--text-body)] text-sm outline-none placeholder:text-[var(--text-muted)] focus:outline-none'
+          className='-ml-[3px] h-8 min-w-0 flex-1 cursor-text bg-transparent pl-[3px] text-[var(--text-body)] text-sm outline-none placeholder:text-[var(--text-muted)] focus:outline-none'
           onKeyDown={handleKeyDown}
           {...props}
         />

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.test.tsx
@@ -278,6 +278,24 @@ describe('SearchModal', () => {
     expect(rows[2]).toContain('Beta')
   })
 
+  it('puts New chat first for the module-name query, then the chats', async () => {
+    const chats = [
+      { id: 'chat-a', name: 'Alpha', href: '/workspace/workspace-1/home?chatId=chat-a' },
+      { id: 'chat-b', name: 'Beta', href: '/workspace/workspace-1/home?chatId=chat-b' },
+    ]
+    await act(async () => {
+      root.render(<SearchModal open onOpenChange={vi.fn()} chats={chats} />)
+    })
+
+    await enterSearchQuery('chats')
+    const rows = Array.from(document.querySelectorAll<HTMLElement>('[cmdk-item]')).map(
+      (el) => el.textContent ?? ''
+    )
+    expect(rows[0]).toContain('New chat')
+    expect(rows[1]).toContain('Alpha')
+    expect(rows[2]).toContain('Beta')
+  })
+
   it('shows an empty state when search has no results', async () => {
     await act(async () => {
       root.render(<SearchModal open onOpenChange={vi.fn()} />)

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.test.tsx
@@ -252,6 +252,45 @@ describe('SearchModal', () => {
     expect(rows[2]).toContain('Onboarding')
   })
 
+  it('puts an exact-name block before its page and contents on the workflow editor', async () => {
+    const Icon = () => null
+    const original = { ...mockSearchState.data }
+    mockSearchState.data = {
+      ...mockSearchState.data,
+      blocks: [{ id: 'logs', name: 'Logs', icon: Icon, bgColor: '#111', type: 'logs' }],
+    }
+    const logs = [
+      {
+        id: 'log-1',
+        name: 'Billing sync',
+        href: '/workspace/workspace-1/logs?executionId=e1',
+        date: 'Aug 8, 1:00 PM',
+      },
+      {
+        id: 'log-2',
+        name: 'Onboarding',
+        href: '/workspace/workspace-1/logs?executionId=e2',
+        date: 'Aug 8, 2:00 PM',
+      },
+    ]
+    try {
+      await act(async () => {
+        root.render(<SearchModal open onOpenChange={vi.fn()} pageContext='workflow' logs={logs} />)
+      })
+
+      await enterSearchQuery('Logs')
+      const rows = Array.from(document.querySelectorAll<HTMLElement>('[cmdk-item]'))
+      expect(rows.slice(0, 4).map((row) => row.textContent ?? '')).toEqual([
+        'Logs',
+        'Logs⇧⌘L',
+        'Billing syncAug 8, 1:00 PM',
+        'OnboardingAug 8, 2:00 PM',
+      ])
+    } finally {
+      mockSearchState.data = original
+    }
+  })
+
   it('puts Create workflow first for the module-name query, then the workflows', async () => {
     const workflows = [
       { id: 'workflow-a', name: 'Alpha', href: '/workspace/workspace-1/w/workflow-a' },

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -99,6 +99,17 @@ import { useSearchModalStore } from '@/stores/modals/search/store'
 import type { SearchBlockItem, SearchToolOperationItem } from '@/stores/modals/search/types'
 
 const logger = createLogger('SearchModal')
+
+/**
+ * Half of the dialog's effective width (`min(500px, 100% - 32px)`), used to
+ * clamp the centered `left` position. The dialog centers over the content
+ * area — offset right by the sidebar (and panel on the canvas) — so on narrow
+ * viewports the unclamped position pushes it past the right edge, clipping
+ * the input adornment and the empty state. Clamping keeps a 16px gutter on
+ * both sides; when the viewport is narrower than the dialog plus gutters,
+ * both clamp bounds collapse to `50%` and the dialog re-centers.
+ */
+const PALETTE_HALF_WIDTH = 'min(250px, 50% - 16px)'
 /**
  * Global row budget for the browse (empty-query) list, applied cumulatively in
  * section order. Individual sections are never capped in browse — the budget
@@ -1306,14 +1317,15 @@ function SearchModalContent({
         aria-hidden={!visuallyOpen}
         aria-label='Search'
         className={cn(
-          '-translate-x-1/2 fixed top-[15%] z-[var(--z-modal)] w-[500px] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)] dark:bg-[var(--surface-5)]',
+          '-translate-x-1/2 fixed top-[15%] z-[var(--z-modal)] w-[min(500px,calc(100%-32px))] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)] dark:bg-[var(--surface-5)]',
           visuallyOpen ? 'visible opacity-100' : 'invisible opacity-0'
         )}
         style={{
-          left:
+          left: `clamp(calc(16px + ${PALETTE_HALF_WIDTH}), ${
             pageContext === 'workflow'
               ? 'calc(50% + (var(--sidebar-width) - var(--panel-width)) / 2)'
-              : 'calc(var(--sidebar-width) / 2 + 50%)',
+              : 'calc(var(--sidebar-width) / 2 + 50%)'
+          }, calc(100% - 16px - ${PALETTE_HALF_WIDTH}))`,
         }}
       >
         <div className='overflow-hidden rounded-lg border border-[var(--border-1)] bg-[var(--bg)]'>
@@ -1324,11 +1336,17 @@ function SearchModalContent({
             value={askMode ? askSimLabel : undefined}
           >
             <div className='relative'>
+              {/* 85dvh - 26px = viewport minus the 15% top offset, 10px of
+                  dialog chrome, and a 16px bottom gutter. The cap keeps the
+                  scroll box fully on-screen: cmdk aligns the selected row to
+                  the box's bottom edge, so a box past the fold parks the
+                  selection below the viewport and held arrow keys judder
+                  rows against an edge the user cannot see. */}
               <CommandFadedList
                 ref={listRef}
                 fade='palette'
                 className={cn(
-                  'scrollbar-none max-h-[448px] [clip-path:inset(3px_round_13px)]',
+                  'scrollbar-none max-h-[min(448px,calc(85dvh-26px))] [clip-path:inset(3px_round_13px)]',
                   CMDK_ITEM_GAP_CLASS,
                   CMDK_SECTION_GAP_CLASS
                 )}

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -1066,7 +1066,11 @@ function SearchModalContent({
         availableBlocks,
         (item) => item.name,
         (item) => item.searchValue
-      ).map(({ item, score }) => ({ section: 'blocks', item, score })),
+      ).map(({ item, score }) => ({
+        section: 'blocks',
+        item,
+        score: item.name.toLowerCase() === query.toLowerCase() ? PAGE_MATCH_TIER : score,
+      })),
       triggers: rank(
         'triggers',
         displayTriggers,

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -377,7 +377,8 @@ function SearchModalContent({
       list.push({
         id: 'new-chat',
         name: 'New chat',
-        keywords: 'chat message ask sim assistant home',
+        keywords: 'chat chats message ask sim assistant home',
+        exactQueries: ['chats'],
         icon: Home,
         context: 'global',
         run: () => routerRef.current.push(`/workspace/${workspaceId}/home`),


### PR DESCRIPTION
## Summary
- Show **New chat** first for the exact `chats` query
- On the workflow editor, rank an exact block match (for example, **Logs**) ahead of the matching page and individual results
- Keep the command palette inside constrained viewports and preserve leading glyphs at low browser zoom without shifting input alignment

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
- Manually verified the leading-glyph fix in the affected real-browser zoom condition
- 27 focused command-palette Vitest tests
- `bun run type-check` in `apps/sim`
- `bun run lint:check`
- `bun run check:audits` (29 audits)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Not included; the rendering regression depended on low browser zoom and was verified in the affected browser environment.
