### PR TITLE
improvement(ui): give the two full-screen takeovers named design-system layers

### DIFF
--- a/.agents/skills/emcn-design-review/SKILL.md
+++ b/.agents/skills/emcn-design-review/SKILL.md
@@ -39,7 +39,7 @@ Use CSS variable pattern (`text-[var(--text-primary)]`), never Tailwind semantic
 **Surfaces**: `--bg`, `--surface-1` through `--surface-7`, `--surface-hover`, `--surface-active`
 **Borders**: `--border`, `--border-1`, `--border-muted`
 **Brand/accent**: `--brand-secondary`, `--brand-accent`
-**Z-Index**: `--z-dropdown` (100), `--z-toast` (150), `--z-modal` (200), `--z-popover` (300), `--z-tooltip` (400), `--z-takeover` (500)
+**Z-Index**: `--z-dropdown` (100), `--z-toast` (150), `--z-modal` (200), `--z-popover` (300), `--z-tooltip` (400), `--z-takeover` (500), `--z-shell-gate` (600)
 **Shadows**: `shadow-subtle`, `shadow-medium`, `shadow-overlay`, `shadow-card`
 **Badges**: `--badge-*` semantic families (success/error/gray/blue/purple/orange/amber/teal/cyan/pink, each with `-bg`/`-text`)
 

--- a/.agents/skills/emcn-design-review/SKILL.md
+++ b/.agents/skills/emcn-design-review/SKILL.md
@@ -39,7 +39,7 @@ Use CSS variable pattern (`text-[var(--text-primary)]`), never Tailwind semantic
 **Surfaces**: `--bg`, `--surface-1` through `--surface-7`, `--surface-hover`, `--surface-active`
 **Borders**: `--border`, `--border-1`, `--border-muted`
 **Brand/accent**: `--brand-secondary`, `--brand-accent`
-**Z-Index**: `--z-dropdown` (100), `--z-modal` (200), `--z-popover` (300), `--z-tooltip` (400), `--z-toast` (500)
+**Z-Index**: `--z-dropdown` (100), `--z-toast` (150), `--z-modal` (200), `--z-popover` (300), `--z-tooltip` (400), `--z-takeover` (500)
 **Shadows**: `shadow-subtle`, `shadow-medium`, `shadow-overlay`, `shadow-card`
 **Badges**: `--badge-*` semantic families (success/error/gray/blue/purple/orange/amber/teal/cyan/pink, each with `-bg`/`-text`)
 

--- a/apps/sim/app/_shell/desktop-update-gate.tsx
+++ b/apps/sim/app/_shell/desktop-update-gate.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import type { DesktopUpdateState } from '@sim/desktop-bridge'
-import { Button, useNativeSurfaceOcclusionReady } from '@sim/emcn'
+import { Chip, useNativeSurfaceOcclusionReady } from '@sim/emcn'
 import { getDesktopBridge, getDesktopShellVersion, getDesktopUpdates } from '@/lib/desktop'
 import { isShellOutdated } from '@/lib/desktop/min-version'
 
@@ -41,11 +41,11 @@ function gateActionFor(state: DesktopUpdateState): GateAction {
   }
   switch (state.status) {
     case 'checking':
-      return { label: 'Checking for updates...', disabled: true, onClick: () => {} }
+      return { label: 'Checking for updates…', disabled: true, onClick: () => {} }
     case 'downloading':
       return {
         label:
-          state.percent !== undefined ? `Downloading ${state.percent}%` : 'Downloading update...',
+          state.percent !== undefined ? `Downloading ${state.percent}%` : 'Downloading update…',
         disabled: true,
         onClick: () => {},
       }
@@ -97,7 +97,7 @@ export function DesktopUpdateGate() {
 
   return (
     <div
-      className='fixed inset-0 z-[9999] flex flex-col items-center justify-center gap-4 bg-[var(--bg)] px-8 text-center'
+      className='fixed inset-0 z-[var(--z-takeover)] flex flex-col items-center justify-center gap-4 bg-[var(--bg)] px-8 text-center'
       style={{ opacity: nativeSurfaceReady ? 1 : 0 }}
       data-native-surface-occlusion='takeover'
     >
@@ -108,11 +108,11 @@ export function DesktopUpdateGate() {
           the update to keep going.
         </p>
       </div>
-      <Button variant='primary' disabled={action.disabled} onClick={action.onClick}>
+      <Chip variant='primary' disabled={action.disabled} onClick={action.onClick}>
         {action.label}
-      </Button>
+      </Chip>
       {updateState.status === 'error' && (
-        <p className='text-[var(--text-muted)] text-xs'>
+        <p className='text-[var(--text-error)] text-xs'>
           The update could not be downloaded. Check your connection and try again.
         </p>
       )}

--- a/apps/sim/app/_shell/desktop-update-gate.tsx
+++ b/apps/sim/app/_shell/desktop-update-gate.tsx
@@ -97,8 +97,8 @@ export function DesktopUpdateGate() {
 
   return (
     <div
-      className='fixed inset-0 z-[var(--z-takeover)] flex flex-col items-center justify-center gap-4 bg-[var(--bg)] px-8 text-center'
-      style={{ opacity: nativeSurfaceReady ? 1 : 0 }}
+      className='fixed inset-0 z-[var(--z-shell-gate)] flex flex-col items-center justify-center gap-4 bg-[var(--bg)] px-8 text-center'
+      style={{ visibility: nativeSurfaceReady ? undefined : 'hidden' }}
       data-native-surface-occlusion='takeover'
     >
       <div className='flex max-w-sm flex-col gap-2'>

--- a/apps/sim/app/_styles/globals.css
+++ b/apps/sim/app/_styles/globals.css
@@ -58,6 +58,9 @@
   --z-modal: 200;
   --z-popover: 300;
   --z-tooltip: 400;
+  /* Full-screen takeovers (session expired, minimum-shell-version gate) replace
+     the app entirely, so they sit above every other layer including poppers. */
+  --z-takeover: 500;
 
   /* Shadow scale */
   --shadow-subtle: 0 2px 4px 0 rgba(0, 0, 0, 0.08);

--- a/apps/sim/app/_styles/globals.css
+++ b/apps/sim/app/_styles/globals.css
@@ -58,9 +58,13 @@
   --z-modal: 200;
   --z-popover: 300;
   --z-tooltip: 400;
-  /* Full-screen takeovers (session expired, minimum-shell-version gate) replace
-     the app entirely, so they sit above every other layer including poppers. */
+  /* Full-screen takeovers replace the app entirely, so they sit above every
+     other layer including poppers. The desktop shell gate is the outermost of
+     them: an incompatible shell invalidates everything the web app renders
+     inside it, so it outranks in-app takeovers rather than tying with them and
+     letting document order decide. */
   --z-takeover: 500;
+  --z-shell-gate: 600;
 
   /* Shadow scale */
   --shadow-subtle: 0 2px 4px 0 rgba(0, 0, 0, 0.08);

--- a/apps/sim/app/workspace/[workspaceId]/components/session-expired/session-expired.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/session-expired/session-expired.tsx
@@ -65,7 +65,7 @@ export function SessionExpired() {
   return (
     <main
       className='fixed inset-0 z-[var(--z-takeover)] flex flex-col items-center justify-center gap-3 bg-[var(--bg)] p-6 text-center'
-      style={{ opacity: nativeSurfaceReady ? 1 : 0 }}
+      style={{ visibility: nativeSurfaceReady ? undefined : 'hidden' }}
       data-native-surface-occlusion='takeover'
     >
       <p

--- a/apps/sim/app/workspace/[workspaceId]/components/session-expired/session-expired.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/session-expired/session-expired.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Chip, useNativeSurfaceOcclusionReady } from '@sim/emcn'
+import { Chip, cn, useNativeSurfaceOcclusionReady } from '@sim/emcn'
 import { useSession } from '@/lib/auth/auth-client'
 import { recoverFromStaleSession } from '@/lib/auth/stale-session-recovery'
 
@@ -64,11 +64,16 @@ export function SessionExpired() {
 
   return (
     <main
-      className='fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-[var(--surface-1)] p-6'
+      className='fixed inset-0 z-[var(--z-takeover)] flex flex-col items-center justify-center gap-3 bg-[var(--bg)] p-6 text-center'
       style={{ opacity: nativeSurfaceReady ? 1 : 0 }}
       data-native-surface-occlusion='takeover'
     >
-      <p className='text-[var(--text-muted)] text-sm'>
+      <p
+        className={cn(
+          'text-sm',
+          failed ? 'text-[var(--text-error)]' : 'text-[var(--text-secondary)]'
+        )}
+      >
         {failed ? `${subject}, but signing out failed.` : `${subject}. Signing you out…`}
       </p>
       {failed && (


### PR DESCRIPTION
## Summary
- The app has exactly two full-screen takeovers — the session-expired screen and the desktop minimum-version gate — and they disagreed on every piece of chrome: an ad-hoc `z-[9999]` against a `z-50` that sat *below* `--z-dropdown`, `--bg` against `--surface-1`, a legacy `Button` against a `Chip`, and muted grey on their failure copy.
- The z-index was a real bug, not just an inconsistency. At `z-50` the session-expired takeover rendered underneath the desktop browser panel's replacement snapshot, which paints at `calc(var(--z-modal) - 1)`.
- Adds two named layers above the poppers rather than one shared layer: `--z-takeover: 500` for in-app takeovers, `--z-shell-gate: 600` for the desktop shell gate. The gate mounts earlier in the tree than the session screen, so a single shared layer would have let document order decide which wins — silently reversing the precedence the old `z-[9999]`/`z-50` pair had. An incompatible shell invalidates everything the web app renders inside it, so it outranks.
- Both takeovers hid their pre-paint state with `opacity: 0`, which still hit-tests, so a full-viewport surface could swallow clicks before it painted. They now use the `visibility` toggle `ModalContent` already uses for the same handshake.
- Aligns their background, primary action, body-copy and error tokens, and corrects the z-scale in the design-review skill, which listed `--z-toast` at 500 when it has long been 150.

## Type of Change
- [x] Bug fix

## Testing
- 85 tests across both takeovers, the workspace layout and the desktop lib pass; `bun run type-check`, `bun run lint`, `bun run check:audits` (29/29) and the block-registry check all pass
- Verified both tokens are defined once in the unconditional `:root`, so they resolve in both themes, and that `--text-error` / `--text-secondary` exist in both
- Swept for anything rendering above 400: the five hits are pre-existing ad-hoc z-index values on transient in-workspace surfaces, all already above the old `z-[9999]` and `z-50`, so this is not a regression — worth a separate cleanup

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
