### PR TITLE
feat(consent): manage cookies from Settings, not from a card in the workspace

### DIFF
--- a/apps/sim/app/_shell/consent/consent-banner.tsx
+++ b/apps/sim/app/_shell/consent/consent-banner.tsx
@@ -1,80 +1,39 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useConsentManager, useHeadlessConsentUI } from '@c15t/nextjs/headless'
-import { Chip, Label, Switch } from '@sim/emcn'
+import { useHeadlessConsentUI } from '@c15t/nextjs/headless'
+import { Chip } from '@sim/emcn'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import Link from 'next/link'
-import { type ConsentCategory, OPEN_CONSENT_PREFERENCES_EVENT } from '@/lib/consent/constants'
-
-interface ConsentCategoryCopy {
-  title: string
-  description: string
-}
-
-/**
- * Sim's own wording per category. The runtime ships generic descriptions; these
- * say what the cookies actually do here.
- *
- * Typed by name rather than by {@link ConsentCategory} because the runtime's
- * union is wider than the three categories we configure — a policy that adds
- * one server-side falls back to the runtime's description instead of
- * disappearing. The `satisfies` still requires an entry for each of ours.
- */
-const CONSENT_CATEGORY_COPY: Record<string, ConsentCategoryCopy | undefined> = {
-  necessary: {
-    title: 'Necessary',
-    description: 'Sign-in and security. Always on.',
-  },
-  measurement: {
-    title: 'Analytics',
-    description: 'Shows us how Sim is used so we can make it better.',
-  },
-  marketing: {
-    title: 'Marketing',
-    description: 'Measures which campaigns bring builders to Sim.',
-  },
-} satisfies Record<ConsentCategory, ConsentCategoryCopy>
+import { OPEN_CONSENT_PREFERENCES_EVENT } from '@/lib/consent/constants'
+import { CONSENT_LINK_CLASS, ConsentPreferences } from '@/app/_shell/consent/consent-preferences'
 
 /** Shared expo-out easing and timings, matching the toast stack's motion. */
 const EASE = [0.22, 1, 0.36, 1] as const
 const ENTER_TRANSITION = { duration: 0.28, ease: EASE } as const
 const EXPAND_TRANSITION = { duration: 0.22, ease: EASE } as const
 
-const NO_CATEGORIES: ReturnType<ReturnType<typeof useConsentManager>['getDisplayedConsents']> = []
-
 const CATEGORIES_COLLAPSED = { height: 0, opacity: 0 } as const
 const CATEGORIES_OPEN = { height: 'auto', opacity: 1 } as const
 
 /**
- * A copy of `PROSE_TYPE.link` rather than an import: the banner lives in the
- * app shell and the token lives in the landing route group, and a shell module
- * reaching into a route group is the wrong direction for one class string.
- */
-const LINK_CLASS =
-  'text-[var(--text-primary)] underline underline-offset-2 transition-colors hover:text-[var(--text-body)]'
-
-/**
  * Cookie consent banner — a non-modal card docked bottom-left, opposite the
  * toast stack and wearing the same chrome. It never dims, blocks, or reflows
- * the page, and "Customize" expands this same card into per-category switches
- * rather than opening a dialog over the app.
+ * the page, and "Customize" expands this same card into the per-category
+ * switches rather than opening a dialog over the app.
  *
  * Visibility and the available actions come from the jurisdiction policy the
  * consent runtime resolves, so the banner is absent entirely where no consent
  * is required and never offers an action the policy does not allow. Accept and
  * reject carry identical weight, which GDPR requires.
  *
- * The card pins the `light` token layer rather than following the visitor's
- * theme, as every other public surface does (`LandingShell`, `AuthShell`, the
- * chat interfaces, the public file view). Consent is asked for on a first
- * visit, which lands on one of those. A record expiring against a live session
- * is the one path that renders this card over the themed app, where it will
- * read light-on-dark; accepted as the rarer case.
+ * It follows the visitor's theme. Every surface it can appear on either pins
+ * the light layer on `<html>` through `ThemeProvider`'s forced theme, or is a
+ * themed app page where inheriting is what should happen — the card no longer
+ * decides for itself. Inside the workspace it never renders at all; consent is
+ * managed from Settings → Privacy there.
  */
 export function ConsentBanner() {
-  const { consents, selectedConsents, setSelectedConsent, getDisplayedConsents } =
-    useConsentManager()
   const { banner, dialog, openDialog, performAction, saveCustomPreferences } =
     useHeadlessConsentUI()
   const prefersReducedMotion = useReducedMotion()
@@ -87,13 +46,6 @@ export function ConsentBanner() {
   const isExpanded = dialog.isVisible
   const surfaceName = isExpanded ? 'dialog' : 'banner'
   const { allowedActions } = isExpanded ? dialog : banner
-  /**
-   * The store's own selector, not a hand-rolled filter over `consentTypes`: the
-   * shipped defaults mark every category except `necessary` as `display: false`,
-   * so filtering on that flag silently renders a one-row list. It re-filters and
-   * re-allocates on every call, so only the expanded card pays for it.
-   */
-  const categories = isExpanded ? getDisplayedConsents() : NO_CATEGORIES
   const enterOffset = prefersReducedMotion ? 0 : 8
 
   return (
@@ -105,13 +57,13 @@ export function ConsentBanner() {
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: enterOffset }}
           transition={ENTER_TRANSITION}
-          className='light fixed bottom-4 left-4 z-[var(--z-toast)] flex w-[min(100vw-2rem,380px)] flex-col gap-3 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg)] p-4 shadow-overlay'
+          className='fixed bottom-4 left-4 z-[var(--z-toast)] flex w-[min(100vw-2rem,380px)] flex-col gap-3 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg)] p-4 shadow-overlay'
         >
           <div className='flex flex-col gap-1'>
             <p className='text-[var(--text-body)] text-sm leading-5'>Cookies</p>
             <p className='text-[var(--text-muted)] text-small leading-[18px]'>
               We use cookies to run Sim, understand how it is used, and improve it. Read our{' '}
-              <Link href='/cookie-policy' className={LINK_CLASS}>
+              <Link href='/cookie-policy' className={CONSENT_LINK_CLASS}>
                 Cookie Policy
               </Link>
               .
@@ -128,28 +80,7 @@ export function ConsentBanner() {
                 transition={EXPAND_TRANSITION}
                 className='overflow-hidden'
               >
-                <ul className='flex flex-col gap-3'>
-                  {categories.map((type) => {
-                    const copy = CONSENT_CATEGORY_COPY[type.name]
-                    const inputId = `consent-${type.name}`
-                    return (
-                      <li key={type.name} className='flex items-start justify-between gap-3'>
-                        <div className='flex min-w-0 flex-col gap-1'>
-                          <Label htmlFor={inputId}>{copy?.title ?? type.name}</Label>
-                          <p className='text-[var(--text-muted)] text-caption leading-4'>
-                            {copy?.description ?? type.description}
-                          </p>
-                        </div>
-                        <Switch
-                          id={inputId}
-                          checked={selectedConsents[type.name] ?? consents[type.name] ?? false}
-                          disabled={type.disabled}
-                          onCheckedChange={(checked) => setSelectedConsent(type.name, checked)}
-                        />
-                      </li>
-                    )
-                  })}
-                </ul>
+                <ConsentPreferences />
               </motion.div>
             )}
           </AnimatePresence>

--- a/apps/sim/app/_shell/consent/consent-preferences.tsx
+++ b/apps/sim/app/_shell/consent/consent-preferences.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useConsentManager } from '@c15t/nextjs/headless'
+import { Label, Switch } from '@sim/emcn'
+import type { ConsentCategory } from '@/lib/consent/constants'
+
+/**
+ * Inline link chrome for the consent surfaces, matching `PROSE_TYPE.link` on the
+ * legal pages. Copied rather than imported because both consumers sit outside
+ * the landing route group that owns that token, and defined here — the module
+ * they already share — so the copy exists once.
+ */
+export const CONSENT_LINK_CLASS =
+  'text-[var(--text-primary)] underline underline-offset-2 transition-colors hover:text-[var(--text-body)]'
+
+interface ConsentCategoryCopy {
+  title: string
+  description: string
+}
+
+/**
+ * Sim's own wording per category. The runtime ships generic descriptions; these
+ * say what the cookies actually do here.
+ *
+ * Typed by name rather than by {@link ConsentCategory} because the runtime's
+ * union is wider than the three categories we configure — a policy that adds
+ * one server-side falls back to the runtime's description instead of
+ * disappearing. The `satisfies` still requires an entry for each of ours.
+ */
+const CONSENT_CATEGORY_COPY: Record<string, ConsentCategoryCopy | undefined> = {
+  necessary: {
+    title: 'Necessary',
+    description: 'Sign-in and security. Always on.',
+  },
+  measurement: {
+    title: 'Analytics',
+    description: 'Shows us how Sim is used so we can make it better.',
+  },
+  marketing: {
+    title: 'Marketing',
+    description: 'Measures which campaigns bring builders to Sim.',
+  },
+} satisfies Record<ConsentCategory, ConsentCategoryCopy>
+
+/**
+ * The per-category consent switches, shared by the two surfaces that offer
+ * them: the banner's expanded state and the Privacy settings page. Both write
+ * to `selectedConsents`; committing is the caller's, since the banner saves
+ * from its own footer and settings saves from the shell's header.
+ *
+ * Must be rendered inside a `ConsentManagerProvider`.
+ */
+export function ConsentPreferences() {
+  const { consents, selectedConsents, setSelectedConsent, getDisplayedConsents } =
+    useConsentManager()
+
+  /**
+   * The store's own selector, not a hand-rolled filter over `consentTypes`: the
+   * shipped defaults mark every category except `necessary` as `display: false`,
+   * so filtering on that flag silently renders a one-row list.
+   */
+  const categories = getDisplayedConsents()
+
+  return (
+    <ul className='flex flex-col gap-3'>
+      {categories.map((type) => {
+        const copy = CONSENT_CATEGORY_COPY[type.name]
+        const inputId = `consent-${type.name}`
+        return (
+          <li key={type.name} className='flex items-start justify-between gap-3'>
+            <div className='flex min-w-0 flex-col gap-1'>
+              <Label htmlFor={inputId}>{copy?.title ?? type.name}</Label>
+              <p className='text-[var(--text-muted)] text-caption leading-4'>
+                {copy?.description ?? type.description}
+              </p>
+            </div>
+            <Switch
+              id={inputId}
+              checked={selectedConsents[type.name] ?? consents[type.name] ?? false}
+              disabled={type.disabled}
+              onCheckedChange={(checked) => setSelectedConsent(type.name, checked)}
+            />
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/apps/sim/app/_shell/consent/consent-provider.test.tsx
+++ b/apps/sim/app/_shell/consent/consent-provider.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { mockPathname, mockDynamicImport } = vi.hoisted(() => ({
+  mockPathname: vi.fn(),
+  mockDynamicImport: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({ usePathname: mockPathname }))
+
+/**
+ * Stands in for the lazily-loaded runtime and records whether the chunk was
+ * asked for at all — that, not just the absence of a banner, is what the
+ * workspace gate is for.
+ */
+vi.mock('next/dynamic', () => ({
+  default: (loader: () => Promise<unknown>) => {
+    return function LazyRuntime() {
+      mockDynamicImport(loader)
+      return <span data-testid='runtime' />
+    }
+  },
+}))
+
+import { ConsentProvider } from '@/app/_shell/consent/consent-provider'
+
+let root: Root | null = null
+
+function renderAt(pathname: string): HTMLDivElement {
+  mockPathname.mockReturnValue(pathname)
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(<ConsentProvider />))
+  return container
+}
+
+afterEach(() => {
+  act(() => root?.unmount())
+  root = null
+  vi.clearAllMocks()
+})
+
+describe('ConsentProvider', () => {
+  it.each(['/', '/pricing', '/login', '/cookie-policy', '/upgrade', '/workspaces'])(
+    'mounts the consent runtime on %s',
+    (pathname) => {
+      const container = renderAt(pathname)
+
+      expect(container.querySelector('[data-testid="runtime"]')).not.toBeNull()
+      expect(mockDynamicImport).toHaveBeenCalled()
+    }
+  )
+
+  it.each(['/workspace', '/workspace/abc', '/workspace/abc/logs'])(
+    'mounts nothing on %s',
+    (pathname) => {
+      const container = renderAt(pathname)
+
+      expect(container.querySelector('[data-testid="runtime"]')).toBeNull()
+      expect(mockDynamicImport).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/apps/sim/app/_shell/consent/consent-provider.tsx
+++ b/apps/sim/app/_shell/consent/consent-provider.tsx
@@ -1,21 +1,43 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { usePathname } from 'next/navigation'
 
 /**
  * The cookie-consent runtime, loaded on the client only and only once this
- * component is rendered — the root layout renders it behind `isHosted`, so a
+ * component renders it — the root layout renders it behind `isHosted`, so a
  * self-hosted deployment never fetches the chunk, never reaches Sim's consent
  * backend, and never sees the banner. Deferring it also keeps the third-party
  * store out of the server render and off the landing page's hydration path; the
  * banner cannot paint before its geo lookup resolves anyway.
- *
- * It mounts alongside the app rather than wrapping it because an `ssr: false`
- * boundary around the tree would disable SSR for every route. Nothing can reach
- * the store through context as a result, which is what
- * `OPEN_CONSENT_PREFERENCES_EVENT` exists for.
  */
-export const ConsentProvider = dynamic(
+const ConsentRuntime = dynamic(
   () => import('@/app/_shell/consent/consent-runtime').then((m) => m.ConsentRuntime),
   { ssr: false }
 )
+
+const WORKSPACE_SEGMENT = 'workspace'
+
+/**
+ * Mounts the consent runtime everywhere except the workspace.
+ *
+ * Inside the product a floating consent card is the wrong surface — a signed-in
+ * user manages this from Settings → Privacy, which mounts the same store. The
+ * check sits above the `dynamic()` rather than inside the loaded module so the
+ * workspace pays neither the chunk nor the consent init request: gating within
+ * the module would still have downloaded it, on the surface with the most hard
+ * loads.
+ *
+ * The gap this leaves — a visitor who reaches the workspace with no consent
+ * record is not prompted — closes when the analytics scripts move behind
+ * consent, since nothing non-essential loads without a record at all.
+ */
+export function ConsentProvider() {
+  const pathname = usePathname()
+
+  if (pathname.split('/')[1] === WORKSPACE_SEGMENT) {
+    return null
+  }
+
+  return <ConsentRuntime />
+}

--- a/apps/sim/app/_shell/consent/consent-runtime.tsx
+++ b/apps/sim/app/_shell/consent/consent-runtime.tsx
@@ -1,39 +1,16 @@
 'use client'
 
-import { type ConsentManagerOptions, ConsentManagerProvider } from '@c15t/nextjs/headless'
-import {
-  CONSENT_BACKEND_URL,
-  CONSENT_CATEGORIES,
-  DEV_CONSENT_COUNTRY,
-} from '@/lib/consent/constants'
 import { ConsentBanner } from '@/app/_shell/consent/consent-banner'
+import { ConsentStoreProvider } from '@/app/_shell/consent/consent-store-provider'
 
 /**
- * Imported from `@c15t/nextjs/headless`, not the package root: the headless
- * entry leaves the runtime's own components and stylesheet out of the bundle,
- * so {@link ConsentBanner} is the only consent UI that exists. The provider
- * still injects a `<style id="c15t-theme">` block of `--c15t-*` variables that
- * nothing here reads; it is inert, since none of those names collide with
- * Sim's tokens.
- *
- * `disableAutomaticBlocking` turns off the runtime's iframe blocker, which
- * otherwise installs a `childList`/`subtree` MutationObserver on `document.body`
- * for the life of every hosted page — including the workflow canvas, the
- * highest-mutation surface in the app — and re-scans each added subtree for
- * iframes. Sim gates no iframes by consent, so it is pure overhead.
+ * The consent banner and the store it reads. Loaded lazily and client-only by
+ * {@link ConsentProvider}, which also decides where it may mount.
  */
-const CONSENT_OPTIONS = {
-  mode: 'hosted',
-  backendURL: CONSENT_BACKEND_URL,
-  consentCategories: [...CONSENT_CATEGORIES],
-  store: { iframeBlockerConfig: { disableAutomaticBlocking: true } },
-  ...(DEV_CONSENT_COUNTRY ? { overrides: { country: DEV_CONSENT_COUNTRY } } : {}),
-} satisfies ConsentManagerOptions
-
 export function ConsentRuntime() {
   return (
-    <ConsentManagerProvider options={CONSENT_OPTIONS}>
+    <ConsentStoreProvider>
       <ConsentBanner />
-    </ConsentManagerProvider>
+    </ConsentStoreProvider>
   )
 }

--- a/apps/sim/app/_shell/consent/consent-store-provider.test.tsx
+++ b/apps/sim/app/_shell/consent/consent-store-provider.test.tsx
@@ -6,10 +6,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { mockConsentManagerProvider, mockConsentBanner } = vi.hoisted(() => ({
-  mockConsentManagerProvider: vi.fn(),
-  mockConsentBanner: vi.fn(),
-}))
+const { mockConsentManagerProvider } = vi.hoisted(() => ({ mockConsentManagerProvider: vi.fn() }))
 
 vi.mock('@c15t/nextjs/headless', () => ({
   ConsentManagerProvider: (props: { children: ReactNode; options: unknown }) => {
@@ -18,14 +15,7 @@ vi.mock('@c15t/nextjs/headless', () => ({
   },
 }))
 
-vi.mock('@/app/_shell/consent/consent-banner', () => ({
-  ConsentBanner: () => {
-    mockConsentBanner()
-    return <span data-testid='banner' />
-  },
-}))
-
-import { ConsentRuntime } from '@/app/_shell/consent/consent-runtime'
+import { ConsentStoreProvider } from '@/app/_shell/consent/consent-store-provider'
 
 let root: Root | null = null
 
@@ -35,16 +25,21 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-describe('ConsentRuntime', () => {
-  it('mounts the banner against the hosted consent backend', () => {
+describe('ConsentStoreProvider', () => {
+  it('configures the hosted consent backend with the iframe blocker off', () => {
     ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
     const container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
-    act(() => root?.render(<ConsentRuntime />))
+    act(() =>
+      root?.render(
+        <ConsentStoreProvider>
+          <span data-testid='child' />
+        </ConsentStoreProvider>
+      )
+    )
 
-    expect(container.querySelector('[data-testid="banner"]')).not.toBeNull()
-    expect(mockConsentBanner).toHaveBeenCalled()
+    expect(container.querySelector('[data-testid="child"]')).not.toBeNull()
     // `toMatchObject`, not exact equality: `DEV_CONSENT_COUNTRY` adds an
     // `overrides` key whenever a developer has NEXT_PUBLIC_CONSENT_COUNTRY set
     // locally, and the assertion is about the shipped configuration.
@@ -52,6 +47,7 @@ describe('ConsentRuntime', () => {
       mode: 'hosted',
       backendURL: 'https://sim-sim.inth.app',
       consentCategories: ['necessary', 'measurement', 'marketing'],
+      store: { iframeBlockerConfig: { disableAutomaticBlocking: true } },
     })
   })
 })

--- a/apps/sim/app/_shell/consent/consent-store-provider.tsx
+++ b/apps/sim/app/_shell/consent/consent-store-provider.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { type ConsentManagerOptions, ConsentManagerProvider } from '@c15t/nextjs/headless'
+import {
+  CONSENT_BACKEND_URL,
+  CONSENT_CATEGORIES,
+  DEV_CONSENT_COUNTRY,
+} from '@/lib/consent/constants'
+
+/**
+ * Imported from `@c15t/nextjs/headless`, not the package root: the headless
+ * entry leaves the runtime's own components and stylesheet out of the bundle,
+ * so `ConsentBanner` is the only consent UI that exists. The provider still
+ * injects a `<style id="c15t-theme">` block of `--c15t-*` variables that
+ * nothing here reads; it is inert, since none of those names collide with
+ * Sim's tokens.
+ *
+ * `disableAutomaticBlocking` turns off the runtime's iframe blocker, which
+ * otherwise installs a `childList`/`subtree` MutationObserver on `document.body`
+ * for the life of every hosted page — including the workflow canvas, the
+ * highest-mutation surface in the app — and re-scans each added subtree for
+ * iframes. Sim gates no iframes by consent, so it is pure overhead.
+ */
+const CONSENT_OPTIONS = {
+  mode: 'hosted',
+  backendURL: CONSENT_BACKEND_URL,
+  consentCategories: [...CONSENT_CATEGORIES],
+  store: { iframeBlockerConfig: { disableAutomaticBlocking: true } },
+  ...(DEV_CONSENT_COUNTRY ? { overrides: { country: DEV_CONSENT_COUNTRY } } : {}),
+} satisfies ConsentManagerOptions
+
+/**
+ * The consent store, for the two surfaces that read it: the banner on public
+ * pages and the Privacy settings page inside the workspace.
+ *
+ * They mount separately — the banner sits behind an `ssr: false` boundary that
+ * cannot wrap the app, so nothing reaches it through React context — yet share
+ * one store, because `getOrCreateConsentRuntime` caches manager and store by
+ * the option values. Keeping the options private to this component is what
+ * makes that structural: two call sites cannot drift into two stores.
+ */
+export function ConsentStoreProvider({ children }: { children: ReactNode }) {
+  return <ConsentManagerProvider options={CONSENT_OPTIONS}>{children}</ConsentManagerProvider>
+}

--- a/apps/sim/app/_shell/providers/theme-provider.tsx
+++ b/apps/sim/app/_shell/providers/theme-provider.tsx
@@ -3,30 +3,52 @@
 import { usePathname } from 'next/navigation'
 import type { ThemeProviderProps } from 'next-themes'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import { LANDING_ROUTES } from '@/lib/landing/routes'
+
+/**
+ * First path segments outside the `(landing)` group whose pages pin the light
+ * token layer in their own shell — `(auth)`, the chat interfaces, the public
+ * file view, the pages reached from an email, and the `AuthShell` handoffs for
+ * the CLI and credential groups. Segments, not prefixes: they are matched by
+ * set membership, so `f` covers `/f/<token>` and needs no trailing slash.
+ */
+const NON_LANDING_LIGHT_SEGMENTS = [
+  'login',
+  'signup',
+  'reset-password',
+  'sso',
+  'invite',
+  'verify',
+  'chat',
+  'resume',
+  'oauth',
+  'oauth-error',
+  'f',
+  'unsubscribe',
+  'cli',
+  'credential-groups',
+] as const
+
+/**
+ * Path segments rendered light regardless of the visitor's theme.
+ *
+ * `LandingShell`, `AuthShell` and the rest pin `light` on a wrapper *inside* the
+ * page, which leaves `<html>` on the visitor's theme. Forcing the theme here
+ * puts the same layer on `<html>`, so root-level chrome — scrollbars,
+ * `color-scheme`, and anything portalled to `<body>` such as the cookie consent
+ * banner — matches the page it sits on instead of contradicting it.
+ */
+const LIGHT_MODE_SEGMENTS: ReadonlySet<string> = new Set([
+  ...LANDING_ROUTES,
+  ...NON_LANDING_LIGHT_SEGMENTS,
+])
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   const pathname = usePathname()
 
-  // Force light mode on public/marketing pages, allow user preference elsewhere
-  const isLightModePage =
-    pathname === '/' ||
-    pathname.startsWith('/login') ||
-    pathname.startsWith('/signup') ||
-    pathname.startsWith('/reset-password') ||
-    pathname.startsWith('/sso') ||
-    pathname.startsWith('/terms') ||
-    pathname.startsWith('/privacy') ||
-    pathname.startsWith('/invite') ||
-    pathname.startsWith('/verify') ||
-    pathname.startsWith('/changelog') ||
-    pathname.startsWith('/chat') ||
-    pathname.startsWith('/blog') ||
-    pathname.startsWith('/resume') ||
-    pathname.startsWith('/oauth') ||
-    pathname.startsWith('/f/') ||
-    pathname.startsWith('/unsubscribe')
-
-  const forcedTheme = isLightModePage ? 'light' : undefined
+  const firstSegment = pathname.split('/')[1]
+  const forcedTheme =
+    firstSegment === '' || LIGHT_MODE_SEGMENTS.has(firstSegment) ? 'light' : undefined
 
   return (
     <NextThemesProvider

--- a/apps/sim/app/workspace/[workspaceId]/settings/[section]/settings.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/[section]/settings.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import { usePostHog } from 'posthog-js/react'
 import { useSession } from '@/lib/auth/auth-client'
+import { isHosted } from '@/lib/core/config/env-flags'
 import { captureEvent } from '@/lib/posthog/client'
 import { useWorkspaceHostContext } from '@/app/workspace/[workspaceId]/providers/workspace-host-provider'
 import { General } from '@/app/workspace/[workspaceId]/settings/components/general/general'
@@ -104,6 +105,9 @@ const DataRetentionSettings = dynamic(() =>
 const DataDrainsSettings = dynamic(() =>
   import('@/ee/data-drains/components/data-drains-settings').then((m) => m.DataDrainsSettings)
 )
+const Privacy = dynamic(() =>
+  import('@/app/workspace/[workspaceId]/settings/components/privacy/privacy').then((m) => m.Privacy)
+)
 const Desktop = dynamic(() =>
   import('@/app/workspace/[workspaceId]/settings/components/desktop/desktop').then((m) => m.Desktop)
 )
@@ -142,7 +146,9 @@ export function SettingsPage({ section }: SettingsPageProps) {
         ? 'general'
         : normalizedSection === 'mothership' && !sessionLoading && !isAdminRole
           ? 'general'
-          : normalizedSection
+          : normalizedSection === 'privacy' && !isHosted
+            ? 'general'
+            : normalizedSection
   const organizationId = hostContext.hostOrganizationId
   const meta = getSettingsSectionMeta(effectiveSection)
 
@@ -157,6 +163,7 @@ export function SettingsPage({ section }: SettingsPageProps) {
   return (
     <SettingsSectionProvider section={effectiveSection} meta={meta ?? undefined}>
       {effectiveSection === 'general' && <General />}
+      {effectiveSection === 'privacy' && <Privacy />}
       {effectiveSection === 'desktop' && <Desktop />}
       {effectiveSection === 'browser' && <Browser />}
       {effectiveSection === 'terminal' && <Terminal />}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/privacy/privacy.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/privacy/privacy.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { ReactNode } from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockUseConsentManager,
+  mockSaveConsents,
+  mockSetSelectedConsent,
+  mockActions,
+  mockGuard,
+  mockToastSuccess,
+} = vi.hoisted(() => ({
+  mockUseConsentManager: vi.fn(),
+  mockSaveConsents: vi.fn(),
+  mockSetSelectedConsent: vi.fn(),
+  mockActions: vi.fn(),
+  mockGuard: vi.fn(),
+  mockToastSuccess: vi.fn(),
+}))
+
+vi.mock('@sim/emcn', () => ({
+  toast: { success: mockToastSuccess, error: vi.fn() },
+}))
+
+vi.mock('@c15t/nextjs/headless', () => ({ useConsentManager: mockUseConsentManager }))
+
+vi.mock('@/app/_shell/consent/consent-store-provider', () => ({
+  ConsentStoreProvider: ({ children }: { children: ReactNode }) => children,
+}))
+
+vi.mock('@/app/_shell/consent/consent-preferences', () => ({
+  CONSENT_LINK_CLASS: 'link',
+  ConsentPreferences: () => <span data-testid='preferences' />,
+}))
+
+vi.mock('@/app/workspace/[workspaceId]/settings/components/settings-panel', () => ({
+  SettingsPanel: ({ actions, children }: { actions: unknown; children: ReactNode }) => {
+    mockActions(actions)
+    return <div>{children}</div>
+  },
+}))
+
+vi.mock('@/components/settings/use-settings-unsaved-guard', () => ({
+  useSettingsUnsavedGuard: mockGuard,
+}))
+
+import { Privacy } from '@/app/workspace/[workspaceId]/settings/components/privacy/privacy'
+
+let root: Root | null = null
+
+function render() {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(<Privacy />))
+  return container
+}
+
+/** The Save action the shell was handed on the latest render. */
+function actionById(id: string) {
+  const actions = (mockActions.mock.calls.at(-1)?.[0] ?? []) as {
+    id: string
+    disabled?: boolean
+    onSelect: () => void
+  }[]
+  return actions.find((action) => action.id === id)
+}
+
+beforeEach(() => {
+  mockUseConsentManager.mockReturnValue({
+    consents: { necessary: true, measurement: false, marketing: false },
+    selectedConsents: { necessary: true, measurement: false, marketing: false },
+    setSelectedConsent: mockSetSelectedConsent,
+    saveConsents: mockSaveConsents,
+  })
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  root = null
+  vi.clearAllMocks()
+})
+
+describe('Privacy settings', () => {
+  it('disables Save and reports clean while the staged consents match the saved ones', () => {
+    render()
+
+    expect(actionById('save')?.disabled).toBe(true)
+    expect(actionById('discard')).toBeUndefined()
+    expect(mockGuard).toHaveBeenLastCalledWith({ isDirty: false })
+  })
+
+  it('enables Save and reports dirty once a category is staged differently', () => {
+    mockUseConsentManager.mockReturnValue({
+      consents: { necessary: true, measurement: false, marketing: false },
+      selectedConsents: { necessary: true, measurement: true, marketing: false },
+      setSelectedConsent: mockSetSelectedConsent,
+      saveConsents: mockSaveConsents,
+    })
+    render()
+
+    expect(actionById('save')?.disabled).toBe(false)
+    expect(actionById('discard')).toBeDefined()
+    expect(mockGuard).toHaveBeenLastCalledWith({ isDirty: true })
+  })
+
+  it('saves the staged selection as a custom choice', async () => {
+    mockUseConsentManager.mockReturnValue({
+      consents: { necessary: true, measurement: false, marketing: false },
+      selectedConsents: { necessary: true, measurement: true, marketing: false },
+      setSelectedConsent: mockSetSelectedConsent,
+      saveConsents: mockSaveConsents.mockResolvedValue(undefined),
+    })
+    render()
+
+    const save = actionById('save')
+    // Awaited inside `act` so the save's own state updates settle here rather
+    // than leaking a render into the next test.
+    await act(async () => {
+      await save?.onSelect()
+    })
+
+    expect(mockSaveConsents).toHaveBeenCalledWith('custom', { uiSource: 'settings' })
+  })
+
+  it('discards by replaying the saved value onto only the changed categories', () => {
+    mockUseConsentManager.mockReturnValue({
+      consents: { necessary: true, measurement: false, marketing: false },
+      selectedConsents: { necessary: true, measurement: true, marketing: false },
+      setSelectedConsent: mockSetSelectedConsent,
+      saveConsents: mockSaveConsents,
+    })
+    render()
+
+    const discard = actionById('discard')
+    act(() => discard?.onSelect())
+
+    expect(mockSetSelectedConsent).toHaveBeenCalledTimes(1)
+    expect(mockSetSelectedConsent).toHaveBeenCalledWith('measurement', false)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/privacy/privacy.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/privacy/privacy.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState } from 'react'
+import { useConsentManager } from '@c15t/nextjs/headless'
+import { toast } from '@sim/emcn'
+import { getErrorMessage } from '@sim/utils/errors'
+import Link from 'next/link'
+import { saveDiscardActions } from '@/components/settings/save-discard-actions'
+import { useSettingsUnsavedGuard } from '@/components/settings/use-settings-unsaved-guard'
+import { CONSENT_LINK_CLASS, ConsentPreferences } from '@/app/_shell/consent/consent-preferences'
+import { ConsentStoreProvider } from '@/app/_shell/consent/consent-store-provider'
+import { SettingsPanel } from '@/app/workspace/[workspaceId]/settings/components/settings-panel'
+import { SettingsSection } from '@/app/workspace/[workspaceId]/settings/components/settings-section/settings-section'
+
+/**
+ * Body of the Privacy page, split from {@link Privacy} because it reads the
+ * consent store, which only exists below the provider.
+ */
+function PrivacySettings() {
+  const { consents, selectedConsents, setSelectedConsent, saveConsents } = useConsentManager()
+  const [saving, setSaving] = useState(false)
+
+  /**
+   * `selectedConsents` is the runtime's staging copy of `consents`, so the two
+   * diverging is exactly what "unsaved" means here.
+   */
+  const changed = (Object.keys(selectedConsents) as (keyof typeof selectedConsents)[]).filter(
+    (name) => selectedConsents[name] !== consents[name]
+  )
+  useSettingsUnsavedGuard({ isDirty: changed.length > 0 })
+
+  const save = async () => {
+    setSaving(true)
+    try {
+      await saveConsents('custom', { uiSource: 'settings' })
+      toast.success('Cookie preferences saved')
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Could not save your cookie preferences'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  /** The store has no reset, so discard replays the saved value per changed category. */
+  const discard = () => {
+    for (const name of changed) {
+      setSelectedConsent(name, consents[name])
+    }
+  }
+
+  return (
+    <SettingsPanel
+      actions={saveDiscardActions({
+        dirty: changed.length > 0,
+        saving,
+        onSave: save,
+        onDiscard: discard,
+      })}
+    >
+      <SettingsSection label='Cookies'>
+        <ConsentPreferences />
+      </SettingsSection>
+      <p className='text-[var(--text-muted)] text-small'>
+        Your choice applies to this browser and is kept for 365 days. The{' '}
+        <Link
+          href='/cookie-policy'
+          target='_blank'
+          rel='noopener noreferrer'
+          className={CONSENT_LINK_CLASS}
+        >
+          Cookie Policy
+        </Link>{' '}
+        lists what each category covers.
+      </p>
+    </SettingsPanel>
+  )
+}
+
+/**
+ * Privacy settings — where a signed-in user reviews and changes the cookie
+ * choice they made in the banner.
+ *
+ * Shares the banner's store through {@link ConsentStoreProvider}. The banner
+ * does not mount inside the workspace, so this is the product's only consent
+ * surface.
+ */
+export function Privacy() {
+  return (
+    <ConsentStoreProvider>
+      <PrivacySettings />
+    </ConsentStoreProvider>
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/settings/navigation.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/navigation.test.ts
@@ -21,6 +21,7 @@ describe('unified settings navigation', () => {
   it('keeps account, workspace, organization, and platform settings in one catalog', () => {
     expect(allNavigationItems.map(({ id, label, section }) => ({ id, label, section }))).toEqual([
       { id: 'general', label: 'General', section: 'account' },
+      { id: 'privacy', label: 'Privacy', section: 'account' },
       { id: 'desktop', label: 'Desktop', section: 'account' },
       { id: 'browser', label: 'Browser', section: 'account' },
       { id: 'terminal', label: 'Terminal', section: 'account' },
@@ -65,6 +66,7 @@ describe('unified settings navigation', () => {
       'desktop',
       'browser',
       'terminal',
+      'privacy',
     ])
     expect(idsForSection('workspace')).toEqual([
       'teammates',

--- a/apps/sim/components/settings/navigation.test.ts
+++ b/apps/sim/components/settings/navigation.test.ts
@@ -40,6 +40,7 @@ describe('settings navigation boundaries', () => {
   it('preserves the order of all four settings catalogs', () => {
     expect(buildUnifiedSettingsNavigation().map(({ id }) => id)).toEqual([
       'general',
+      'privacy',
       'desktop',
       'browser',
       'terminal',

--- a/apps/sim/components/settings/navigation.ts
+++ b/apps/sim/components/settings/navigation.ts
@@ -43,7 +43,13 @@ import {
 
 export type SettingsPlane = 'account' | 'organization' | 'selfhost' | 'workspace'
 
-export type AccountSettingsSection = 'general' | 'billing' | 'api-keys' | 'admin' | 'mothership'
+export type AccountSettingsSection =
+  | 'general'
+  | 'privacy'
+  | 'billing'
+  | 'api-keys'
+  | 'admin'
+  | 'mothership'
 
 /**
  * Settings a self-hoster needs from the managed service: their profile, what
@@ -97,6 +103,7 @@ export interface SettingsNavigationItem<Section extends string = string> {
 
 export type UnifiedSettingsSection =
   | 'general'
+  | 'privacy'
   | 'desktop'
   | 'browser'
   | 'terminal'
@@ -369,6 +376,20 @@ export const SETTINGS_SECTION_REGISTRY: readonly SettingsSectionRegistryEntry[] 
     planes: {
       account: { id: 'general', group: 'account', order: 0 },
       selfhost: { id: 'general', group: 'account', order: 0 },
+    },
+  },
+  {
+    label: 'Privacy',
+    icon: Lock,
+    unified: {
+      id: 'privacy',
+      description: 'Choose which cookies Sim may use in this browser.',
+      group: 'account',
+      order: 5,
+      requiresHosted: true,
+    },
+    planes: {
+      account: { id: 'privacy', group: 'account', order: 5 },
     },
   },
   {

--- a/apps/sim/components/settings/navigation.ts
+++ b/apps/sim/components/settings/navigation.ts
@@ -43,13 +43,7 @@ import {
 
 export type SettingsPlane = 'account' | 'organization' | 'selfhost' | 'workspace'
 
-export type AccountSettingsSection =
-  | 'general'
-  | 'privacy'
-  | 'billing'
-  | 'api-keys'
-  | 'admin'
-  | 'mothership'
+export type AccountSettingsSection = 'general' | 'billing' | 'api-keys' | 'admin' | 'mothership'
 
 /**
  * Settings a self-hoster needs from the managed service: their profile, what
@@ -387,9 +381,6 @@ export const SETTINGS_SECTION_REGISTRY: readonly SettingsSectionRegistryEntry[] 
       group: 'account',
       order: 5,
       requiresHosted: true,
-    },
-    planes: {
-      account: { id: 'privacy', group: 'account', order: 5 },
     },
   },
   {

--- a/apps/sim/lib/landing/routes.ts
+++ b/apps/sim/lib/landing/routes.ts
@@ -1,0 +1,44 @@
+/**
+ * Top-level path segments served by the `app/(landing)` route group, plus the
+ * root. The single source of truth for "is this the marketing surface", because
+ * a route group is not a path prefix and nothing else can derive the answer.
+ *
+ * Two consumers depend on this list being complete, and both fail silently when
+ * it is not:
+ *
+ * - `next.config.ts` exempts these paths from COEP. The header is a *document*
+ *   header inherited across client-side navigations, so an unlisted landing page
+ *   stays cross-origin isolated when it soft-navigates into `/demo`, where the
+ *   Cal.com booker then loads uncredentialed and hangs forever.
+ * - `ThemeProvider` forces the light theme on these paths, matching the `light`
+ *   token layer `LandingShell` renders. Leave one out and `<html>` keeps the
+ *   visitor's dark theme under a light page: root-level chrome (scrollbars,
+ *   `color-scheme`, anything portalled to `<body>`) renders dark against it.
+ *
+ * Imported by `next.config.ts` before the `@/` alias resolves, so this module
+ * must stay dependency-free.
+ *
+ * Add every new `app/(landing)` route here.
+ */
+export const LANDING_ROUTES = [
+  'blog',
+  'careers',
+  'changelog',
+  'comparisons',
+  'contact',
+  'cookie-policy',
+  'demo',
+  'enterprise',
+  'files',
+  'integrations',
+  'knowledge',
+  'library',
+  'logs',
+  'models',
+  'pricing',
+  'privacy',
+  'solutions',
+  'tables',
+  'terms',
+  'workflows',
+] as const

--- a/apps/sim/next.config.ts
+++ b/apps/sim/next.config.ts
@@ -7,38 +7,7 @@ import {
   getMainCSPPolicy,
   getWorkflowExecutionCSPPolicy,
 } from './lib/core/security/csp'
-
-/**
- * Marketing routes (`app/(landing)/**`, plus the root) exempted from COEP.
- *
- * COEP is a *document* header and is inherited across client-side `<Link>`
- * navigations, so `/demo`'s own exemption only applies on a direct load. Any
- * landing page left isolated soft-navigates into `/demo` still credentialless,
- * where the Cal.com booker iframe loads uncredentialed and hangs forever.
- * Every route under `app/(landing)` must be listed here.
- */
-const LANDING_ROUTES = [
-  'blog',
-  'careers',
-  'changelog',
-  'comparisons',
-  'contact',
-  'cookie-policy',
-  'demo',
-  'enterprise',
-  'files',
-  'integrations',
-  'knowledge',
-  'library',
-  'logs',
-  'models',
-  'pricing',
-  'privacy',
-  'solutions',
-  'tables',
-  'terms',
-  'workflows',
-] as const
+import { LANDING_ROUTES } from './lib/landing/routes'
 
 const nextConfig: NextConfig = {
   devIndicators: false,


### PR DESCRIPTION
## Summary

Follow-up to #6832. The consent banner mounted in the root layout, so it appeared on every page — including inside the product. This moves in-app consent to Settings and fixes the theme mismatch the banner was working around rather than papering over it.

### The banner never appears in the workspace

`ConsentProvider` returns before the `dynamic()` boundary on any `/workspace` path, so the product pays neither the consent chunk nor its init request — the surface with the most hard page loads. Gating *inside* the lazily-loaded module would still have downloaded it.

Consent inside the product is managed from **Settings → Privacy** instead, which is the documented pattern for authenticated surfaces: a floating card is the wrong shape once someone is signed in.

### One store, structurally

The banner sits behind an `ssr: false` boundary that cannot wrap the app, so nothing reaches its store through React context. Both surfaces therefore mount their own provider — but `getOrCreateConsentRuntime` caches manager and store by the option values, so they share one of each. `CONSENT_OPTIONS` now lives inside `ConsentStoreProvider` and is not exported, which makes that invariant unbreakable rather than conventional.

Verified directly rather than trusting the docs:

```
same store instance: true
same manager instance: true
different backendURL -> different store: true
```

### The theme fix, at the cause

The banner previously pinned the `light` token layer with a comment explaining why. The actual problem is that `LandingShell` pins `light` on a wrapper *inside* the page while `<html>` keeps the visitor's theme, so any landing route missing from `ThemeProvider`'s hand-written list rendered a light page under dark root chrome — scrollbars, `color-scheme`, and anything portalled to `<body>`.

`LANDING_ROUTES` becomes one source of truth in `lib/landing/routes.ts`, read by both `next.config.ts` (COEP exemptions) and `ThemeProvider` (forced light). That is the same drift that let `/cookie-policy` ship without its COEP exemption in the last PR. The banner now simply inherits the theme.

Two pre-existing gaps closed along the way: `/cli/auth` and `/credential-groups/complete` both render `AuthShell` (which pins light) and were in neither list.

## Type of Change
- [x] New feature
- [x] Bug fix

## Testing

- `type-check`, `lint:check`, all 29 `check:audits`, and 155 tests pass.
- Diffed forced-light behavior old vs new across every real route: **16 landing routes gain the correct `<html>` theme, nothing regresses in the other direction.**
- Browser-verified the theme inheritance: `/pricing` under a dark system theme renders `<html class="light">` with a light card; `/playground` renders `<html class="dark">` with a `#1b1b1b` card. The banner no longer decides for itself.
- `/workspace` needs auth, so the gate is covered by tests asserting the dynamic loader is **never invoked** on `/workspace`, `/workspace/abc`, `/workspace/abc/logs` — verified those fail when the gate is removed.
- **Reviewers should focus on** the `ThemeProvider` change: it moves from `startsWith` prefix matching to first-segment set membership, and that route-classification diff is the riskiest part of this PR.

## Known gap (unchanged from #6832)

Prior blocking is still not implemented — GTM, GA, and PostHog load before consent. This PR makes that more load-bearing, not less: a visitor who reaches the workspace with no consent record is now never prompted. It closes properly when the analytics scripts move behind consent, since nothing non-essential loads without a record at all.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
