### PR TITLE
fix(workspaces): explain why org admins can't be removed from a workspace

### DIFF
--- a/apps/sim/app/api/workspaces/members/[id]/route.ts
+++ b/apps/sim/app/api/workspaces/members/[id]/route.ts
@@ -13,7 +13,10 @@ import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { revokeWorkspaceCredentialMembershipsTx } from '@/lib/credentials/access'
 import { captureServerEvent } from '@/lib/posthog/server'
 import { removeWorkspaceSkillMembershipsTx } from '@/lib/skills/access'
-import { hasWorkspaceAdminAccess } from '@/lib/workspaces/permissions/utils'
+import {
+  hasWorkspaceAdminAccess,
+  isOrganizationAdminOrOwner,
+} from '@/lib/workspaces/permissions/utils'
 import {
   reassignWorkflowOwnershipForWorkspaceMemberRemovalTx,
   transferWorkspaceOwnershipToBilledAccountForMemberRemovalTx,
@@ -51,9 +54,48 @@ export const DELETE = withRouteHandler(
         return NextResponse.json({ error: 'Workspace not found' }, { status: 404 })
       }
 
+      const organizationId = workspaceRow[0].organizationId
+
+      /**
+       * Authority is settled before anything is answered about the target, so
+       * the standing-specific replies below only ever describe someone the
+       * caller can already see in the members list.
+       */
+      const hasAdminAccess = await hasWorkspaceAdminAccess(session.user.id, workspaceId)
+      const isSelf = userId === session.user.id
+
+      if (!hasAdminAccess && !isSelf) {
+        return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
+      }
+
       if (workspaceRow[0].billedAccountUserId === userId) {
         return NextResponse.json(
           { error: 'Cannot remove the workspace billing account. Please reassign billing first.' },
+          { status: 400 }
+        )
+      }
+
+      /**
+       * Organization admins hold workspace admin across the whole organization
+       * through `member.role`, not through a `permissions` row, so removal has
+       * nothing to revoke. Left to fall through, the two shapes failed in two
+       * different ways: with no row it answered "user not found in workspace"
+       * about someone listed as an Admin on the very screen the caller clicked
+       * from, and with a row it deleted a grant the derived one immediately
+       * replaced — while the seat reconciliation below counts rows only, so
+       * that no-op could still drop the admin's organization membership.
+       *
+       * Mirrored by `workspaceMemberRemovalLockReason` on the client, and by the
+       * same guard on `PATCH /api/workspaces/[id]/permissions`, which refuses to
+       * re-role an organization admin for the same reason.
+       */
+      if (organizationId && (await isOrganizationAdminOrOwner(userId, organizationId))) {
+        return NextResponse.json(
+          {
+            error: isSelf
+              ? 'Organization admins are automatically workspace admins. Change your organization role to leave this workspace.'
+              : 'Organization admins are automatically workspace admins. Change their organization role to remove them from this workspace.',
+          },
           { status: 400 }
         )
       }
@@ -76,14 +118,6 @@ export const DELETE = withRouteHandler(
 
       if (!userPermission && !isOwnerOnlyRemoval) {
         return NextResponse.json({ error: 'User not found in workspace' }, { status: 404 })
-      }
-
-      // Check if current user has admin access to this workspace
-      const hasAdminAccess = await hasWorkspaceAdminAccess(session.user.id, workspaceId)
-      const isSelf = userId === session.user.id
-
-      if (!hasAdminAccess && !isSelf) {
-        return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
       }
 
       // Removing the workspace owner is allowed for any admin: ownership transfers
@@ -112,8 +146,6 @@ export const DELETE = withRouteHandler(
           )
         }
       }
-
-      const organizationId = workspaceRow[0].organizationId
 
       const { ownershipTransferred, workflowOwnershipReassignment } = await db.transaction(
         async (tx) => {

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/row-actions-menu/row-actions-menu.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/row-actions-menu/row-actions-menu.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * A row action the server would refuse stays visible and greyed rather than
+ * disappearing, so the row can say why. That only works if three things hold at
+ * once: the item is actually disabled (Radix greys it), the reason reaches
+ * pointer users through the platform tooltip — which needs the wrapping span,
+ * since a disabled item is `pointer-events-none` and never sees the hover — and
+ * the reason reaches assistive tech through the accessible name, since Radix
+ * skips disabled items in a menu's roving focus.
+ */
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { RowActionsMenu } from '@/app/workspace/[workspaceId]/settings/components/row-actions-menu/row-actions-menu'
+
+const LOCK_REASON = 'Organization admins are automatically workspace admins.'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function mount(ui: ReactNode) {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(ui))
+}
+
+/** Opens the `...` menu the way a pointer does — Radix opens on `pointerdown`. */
+function openMenu() {
+  const trigger = container?.querySelector('button')
+  if (!trigger) throw new Error('Menu trigger did not render')
+  act(() => {
+    trigger.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+  })
+}
+
+function item(): HTMLElement {
+  const node = document.querySelector('[role="menuitem"]')
+  if (!node) throw new Error('No menu item rendered')
+  return node as HTMLElement
+}
+
+afterEach(() => {
+  if (root) act(() => root?.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+describe('a disabled row action explains itself', () => {
+  function mountLockedRemove() {
+    mount(
+      <RowActionsMenu
+        label='Teammate actions'
+        actions={[
+          {
+            label: 'Remove',
+            destructive: true,
+            disabled: true,
+            tooltip: LOCK_REASON,
+            onSelect: () => {},
+          },
+        ]}
+      />
+    )
+    openMenu()
+  }
+
+  it('greys the item out instead of hiding it', () => {
+    mountLockedRemove()
+
+    const remove = item()
+    expect(remove.textContent).toBe('Remove')
+    expect(remove.getAttribute('data-disabled')).not.toBeNull()
+    expect(remove.className).toContain('data-[disabled]:opacity-50')
+  })
+
+  it('shows the reason in the platform tooltip on hover', () => {
+    mountLockedRemove()
+
+    expect(document.querySelector('[role="tooltip"]')).toBeNull()
+
+    /* The wrapping span, not the item — a disabled item is `pointer-events-none`. */
+    const hoverTarget = item().parentElement
+    if (!hoverTarget) throw new Error('Tooltip trigger wrapper did not render')
+    act(() => {
+      hoverTarget.dispatchEvent(
+        new MouseEvent('pointerover', { bubbles: true, clientX: 120, clientY: 120 })
+      )
+    })
+
+    expect(document.querySelector('[role="tooltip"]')?.textContent).toBe(LOCK_REASON)
+  })
+
+  it('folds the reason into the accessible name for assistive tech', () => {
+    mountLockedRemove()
+
+    expect(item().getAttribute('aria-label')).toBe(`Remove — ${LOCK_REASON}`)
+  })
+
+  it('leaves an enabled action unlabelled and untooltipped', () => {
+    mount(
+      <RowActionsMenu
+        label='Teammate actions'
+        actions={[{ label: 'Copy email', onSelect: () => {} }]}
+      />
+    )
+    openMenu()
+
+    expect(item().getAttribute('aria-label')).toBeNull()
+    expect(item().getAttribute('data-disabled')).toBeNull()
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/row-actions-menu/row-actions-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/row-actions-menu/row-actions-menu.tsx
@@ -34,6 +34,11 @@ interface RowActionsMenuProps {
  * An action with a `tooltip` gets its item wrapped in a plain span tooltip
  * trigger (the settings-header chip pattern) — a disabled item is
  * `pointer-events-none`, so the wrapper is what keeps hover working.
+ *
+ * A disabled item's tooltip also folds into its accessible name, because Radix
+ * skips disabled items in a menu's roving focus: without this the explanation
+ * would reach pointer users only, and assistive tech would announce a dead
+ * "Remove" with no reason attached.
  */
 export function RowActionsMenu({ label, actions, triggerClassName }: RowActionsMenuProps) {
   return (
@@ -50,6 +55,11 @@ export function RowActionsMenu({ label, actions, triggerClassName }: RowActionsM
               key={action.label}
               onSelect={action.onSelect}
               disabled={action.disabled}
+              aria-label={
+                action.disabled && action.tooltip
+                  ? `${action.label} — ${action.tooltip}`
+                  : undefined
+              }
               className={action.destructive ? 'text-[var(--text-error)]' : undefined}
             >
               {action.label}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/teammates/teammates.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/teammates/teammates.tsx
@@ -9,6 +9,7 @@ import { useParams, useRouter } from 'next/navigation'
 import {
   RoleLockTooltip,
   type WorkspaceRoleSource,
+  workspaceMemberRemovalLockReason,
   workspaceRoleLockReason,
 } from '@/components/permissions'
 import { canMutateWorkspaceSettingsSection } from '@/components/settings/navigation'
@@ -56,6 +57,7 @@ interface Teammate {
   invitationId?: string
   token?: string
   roleSource?: WorkspaceRoleSource
+  isOrgAdmin?: boolean
   isBilledAccount?: boolean
 }
 
@@ -139,6 +141,7 @@ export function Teammates() {
       isPending: false,
       userId: member.userId,
       roleSource: member.roleSource,
+      isOrgAdmin: member.isOrgAdmin,
       isBilledAccount: member.isBilledAccount,
     }))
 
@@ -206,20 +209,33 @@ export function Teammates() {
             searchTerm.trim() ? `No teammates found matching “${searchTerm}”` : 'No teammates yet'
           }
         >
-          {filteredTeammates.map((teammate) => (
-            <MemberRow
-              key={teammate.key}
-              name={teammate.name}
-              email={teammate.email}
-              image={teammate.image}
-              status={teammate.status}
-              roleControl={(() => {
-                const lockReason = teammate.isPending
-                  ? null
-                  : workspaceRoleLockReason(teammate.roleSource, {
-                      isBilledAccount: teammate.isBilledAccount,
-                    })
-                return (
+          {filteredTeammates.map((teammate) => {
+            const lockReason = teammate.isPending
+              ? null
+              : workspaceRoleLockReason(teammate.roleSource, {
+                  isBilledAccount: teammate.isBilledAccount,
+                })
+            /**
+             * Removal is refused for a different set than the role control locks,
+             * so it carries its own reason — and stays visible-but-disabled rather
+             * than hidden, so the row explains the derived access instead of
+             * leaving an Admin who cannot be acted on.
+             */
+            const removalLockReason = teammate.isPending
+              ? null
+              : workspaceMemberRemovalLockReason({
+                  isOrgAdmin: teammate.isOrgAdmin,
+                  isBilledAccount: teammate.isBilledAccount,
+                })
+
+            return (
+              <MemberRow
+                key={teammate.key}
+                name={teammate.name}
+                email={teammate.email}
+                image={teammate.image}
+                status={teammate.status}
+                roleControl={
                   <RoleLockTooltip reason={lockReason}>
                     <ChipDropdown
                       value={teammate.role}
@@ -234,83 +250,85 @@ export function Teammates() {
                       }
                     />
                   </RoleLockTooltip>
-                )
-              })()}
-              menu={
-                <RowActionsMenu
-                  label='Teammate actions'
-                  actions={[
-                    {
-                      label: 'Copy email',
-                      onSelect: () => copyToClipboard(teammate.email),
-                    },
-                    ...(canManage && teammate.isPending
-                      ? [
-                          {
-                            label: 'Resend invite',
-                            onSelect: () => {
-                              if (teammate.invitationId) {
-                                resendInvitation.mutate({
-                                  invitationId: teammate.invitationId,
-                                  workspaceId,
-                                })
-                              }
+                }
+                menu={
+                  <RowActionsMenu
+                    label='Teammate actions'
+                    actions={[
+                      {
+                        label: 'Copy email',
+                        onSelect: () => copyToClipboard(teammate.email),
+                      },
+                      ...(canManage && teammate.isPending
+                        ? [
+                            {
+                              label: 'Resend invite',
+                              onSelect: () => {
+                                if (teammate.invitationId) {
+                                  resendInvitation.mutate({
+                                    invitationId: teammate.invitationId,
+                                    workspaceId,
+                                  })
+                                }
+                              },
                             },
-                          },
-                          {
-                            label: 'Copy invite link',
-                            onSelect: () => {
-                              if (teammate.invitationId && teammate.token) {
-                                copyToClipboard(
-                                  buildInviteLink(teammate.invitationId, teammate.token)
-                                )
-                              }
+                            {
+                              label: 'Copy invite link',
+                              onSelect: () => {
+                                if (teammate.invitationId && teammate.token) {
+                                  copyToClipboard(
+                                    buildInviteLink(teammate.invitationId, teammate.token)
+                                  )
+                                }
+                              },
                             },
-                          },
-                          {
-                            label: 'Revoke invite',
-                            destructive: true,
-                            onSelect: () => {
-                              if (teammate.invitationId) {
-                                cancelInvitation.mutate({
-                                  invitationId: teammate.invitationId,
-                                  workspaceId,
-                                })
-                              }
+                            {
+                              label: 'Revoke invite',
+                              destructive: true,
+                              onSelect: () => {
+                                if (teammate.invitationId) {
+                                  cancelInvitation.mutate({
+                                    invitationId: teammate.invitationId,
+                                    workspaceId,
+                                  })
+                                }
+                              },
                             },
-                          },
-                        ]
-                      : []),
-                    ...(canManage && !teammate.isPending && teammate.userId !== viewer?.userId
-                      ? [
-                          {
-                            label: 'Remove',
-                            destructive: true,
-                            onSelect: () => {
-                              if (teammate.userId) {
-                                removeMember.mutate(
-                                  { userId: teammate.userId, workspaceId },
-                                  {
-                                    onError: (error) => {
-                                      toast.error("Couldn't remove teammate", {
-                                        description: getErrorMessage(
-                                          error,
-                                          'Please try again in a moment.'
-                                        ),
-                                      })
-                                    },
-                                  }
-                                )
-                              }
+                          ]
+                        : []),
+                      ...(canManage && !teammate.isPending && teammate.userId !== viewer?.userId
+                        ? [
+                            {
+                              label: 'Remove',
+                              destructive: true,
+                              disabled: removalLockReason !== null,
+                              tooltip: removalLockReason ?? undefined,
+                              onSelect: () => {
+                                if (teammate.userId) {
+                                  removeMember.mutate(
+                                    { userId: teammate.userId, workspaceId },
+                                    {
+                                      onError: (error) => {
+                                        toast.error("Couldn't remove teammate", {
+                                          description: getErrorMessage(
+                                            error,
+                                            'Please try again in a moment.'
+                                          ),
+                                        })
+                                      },
+                                    }
+                                  )
+                                }
+                              },
                             },
-                          },
-                        ]
-                      : []),
-                  ]}
-                />
-              }
-            />
-          ))}
+                          ]
+                        : []),
+                    ]}
+                  />
+                }
+              />
+            )
+          })}
         </MemberSection>
       </SettingsPanel>
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
@@ -18,9 +18,11 @@ import {
   Send,
   Skeleton,
   Tooltip,
+  toast,
 } from '@sim/emcn'
 import { MoreHorizontal, PanelLeft, Pin, Search } from '@sim/emcn/icons'
 import { createLogger } from '@sim/logger'
+import { getErrorMessage } from '@sim/utils/errors'
 import { useQueryClient } from '@tanstack/react-query'
 import { isBillingEnabled } from '@/lib/core/config/env-flags'
 import { InviteModal } from '@/app/workspace/[workspaceId]/components/invite-modal'
@@ -419,6 +421,15 @@ function WorkspaceHeaderImpl({
       setLeaveTarget(null)
     } catch (error) {
       logger.error('Error leaving workspace:', error)
+      /**
+       * The endpoint refuses several standings it can explain — the billing
+       * account, the last admin, a derived organization admin. Logging alone
+       * left the confirm modal sitting open with no indication of why, so the
+       * server's reason is surfaced the way the teammates list surfaces it.
+       */
+      toast.error("Couldn't leave workspace", {
+        description: getErrorMessage(error, 'Please try again in a moment.'),
+      })
     }
   }
 
@@ -887,6 +898,15 @@ function WorkspaceHeaderImpl({
         const contextCanAdmin = capturedPermissions === 'admin'
         const capturedWorkspace = workspaces.find((w) => w.id === capturedWorkspaceRef.current?.id)
         const isOwner = capturedWorkspace && sessionUserId === capturedWorkspace.ownerId
+        /**
+         * An organization admin holds this workspace through their org role, not
+         * a permission row, so there is nothing to give up and the removal
+         * endpoint refuses it. `permissions === 'admin'` cannot tell them apart
+         * from an explicit workspace admin, who may leave. This menu has no
+         * tooltip affordance to explain a greyed row, so the entry is withheld
+         * rather than shown dead.
+         */
+        const canLeave = !isOwner && !capturedWorkspace?.isOrgAdmin && !!onLeaveWorkspace
 
         return (
           <ContextMenu
@@ -904,7 +924,7 @@ function WorkspaceHeaderImpl({
             isPinned={Boolean(menuOpenWorkspaceId && pinnedWorkspaceIds.has(menuOpenWorkspaceId))}
             showRename={true}
             showUploadLogo={!!onUploadLogo}
-            showLeave={!isOwner && !!onLeaveWorkspace}
+            showLeave={canLeave}
             disableRename={!contextCanAdmin}
             disableDelete={!contextCanAdmin || workspaces.length <= 1}
             disableUploadLogo={!contextCanAdmin}

--- a/apps/sim/components/permissions/index.ts
+++ b/apps/sim/components/permissions/index.ts
@@ -19,5 +19,6 @@ export {
   RoleLockTooltip,
   skillEditorLockReason,
   type WorkspaceRoleSource,
+  workspaceMemberRemovalLockReason,
   workspaceRoleLockReason,
 } from './role-lock'

--- a/apps/sim/components/permissions/role-lock.tsx
+++ b/apps/sim/components/permissions/role-lock.tsx
@@ -25,6 +25,32 @@ export function workspaceRoleLockReason(
 }
 
 /**
+ * Explanation shown when a workspace member cannot be removed from the
+ * workspace. Returns null when removal is allowed.
+ *
+ * Mirrors the server guards on `DELETE /api/workspaces/members/[id]`, so every
+ * reason here must have a guard there and vice versa.
+ *
+ * Deliberately keyed on facts rather than on `roleSource` like
+ * {@link workspaceRoleLockReason}: the two disagree about the workspace owner,
+ * whose role is fixed but who can still be removed (ownership transfers to the
+ * billing account) — and `roleSource` ranks `owner` above `org-admin`, so it
+ * cannot answer for someone who is both.
+ */
+export function workspaceMemberRemovalLockReason(options?: {
+  isOrgAdmin?: boolean
+  isBilledAccount?: boolean
+}): string | null {
+  if (options?.isOrgAdmin) {
+    return 'Organization admins are automatically workspace admins. Change their organization role to remove them.'
+  }
+  if (options?.isBilledAccount) {
+    return 'Reassign billing before removing the workspace billing account'
+  }
+  return null
+}
+
+/**
  * Explanation shown when a credential member's role is fixed because they are a
  * workspace admin. Returns null for editable (`explicit`) roles.
  */

--- a/apps/sim/lib/api/contracts/workspaces.ts
+++ b/apps/sim/lib/api/contracts/workspaces.ts
@@ -94,6 +94,7 @@ export const workspaceUserSchema = z.object({
   isExternal: z.boolean(),
   joinedAt: z.string(),
   roleSource: z.enum(['owner', 'explicit', 'org-admin']),
+  isOrgAdmin: z.boolean(),
   isBilledAccount: z.boolean(),
 })
 

--- a/apps/sim/lib/api/contracts/workspaces.ts
+++ b/apps/sim/lib/api/contracts/workspaces.ts
@@ -19,6 +19,12 @@ export const workspaceSchema = z.object({
   role: z.string().optional(),
   membershipId: z.string().optional(),
   permissions: workspacePermissionSchema.nullable().optional(),
+  /**
+   * The viewer holds admin here through their organization role rather than a
+   * permission row, so they cannot leave. Optional because not every workspace
+   * response builder resolves organization standing.
+   */
+  isOrgAdmin: z.boolean().optional(),
   billedAccountUserId: z.string().nullable().optional(),
   allowPersonalApiKeys: z.boolean().optional(),
   inviteMembersEnabled: z.boolean().optional(),

--- a/apps/sim/lib/workspaces/list.ts
+++ b/apps/sim/lib/workspaces/list.ts
@@ -22,6 +22,14 @@ export type WorkspaceWithInviteFlags = WorkspaceRow &
   WorkspaceInviteFlags & {
     role: 'owner' | 'admin' | 'member'
     permissions: PermissionType
+    /**
+     * The viewer's admin access to this workspace derives from their
+     * organization role. `role: 'admin'` alone cannot say so — an explicit
+     * workspace admin looks identical — and the two differ in what the viewer
+     * can do: derived access has no permission row to give up, so leaving is
+     * refused by `DELETE /api/workspaces/members/[id]`.
+     */
+    isOrgAdmin: boolean
   }
 
 /** The GET /api/workspaces payload assembled by {@link listWorkspacesForViewer}. */
@@ -39,7 +47,11 @@ export interface WorkspaceListPayload {
  * billed user / organization).
  */
 async function buildWorkspacesWithInviteFlags(
-  userWorkspaces: Array<{ workspace: WorkspaceRow; permissionType: PermissionType }>,
+  userWorkspaces: Array<{
+    workspace: WorkspaceRow
+    permissionType: PermissionType
+    viaOrgAdmin: boolean
+  }>,
   userId: string
 ): Promise<WorkspaceWithInviteFlags[]> {
   const nonOrgBilledUserIds = [
@@ -70,7 +82,7 @@ async function buildWorkspacesWithInviteFlags(
     }),
   ])
 
-  return userWorkspaces.map(({ workspace: workspaceDetails, permissionType }) => {
+  return userWorkspaces.map(({ workspace: workspaceDetails, permissionType, viaOrgAdmin }) => {
     const billedPlanCategory: PlanCategory =
       workspaceDetails.workspaceMode === WORKSPACE_MODE.ORGANIZATION
         ? workspaceDetails.organizationId
@@ -88,6 +100,7 @@ async function buildWorkspacesWithInviteFlags(
             ? ('admin' as const)
             : ('member' as const),
       permissions: permissionType,
+      isOrgAdmin: viaOrgAdmin,
       ...resolveInviteFlags(invitePolicy, workspaceDetails.billedAccountUserId === userId),
     }
   })

--- a/apps/sim/lib/workspaces/permissions/utils.test.ts
+++ b/apps/sim/lib/workspaces/permissions/utils.test.ts
@@ -196,6 +196,7 @@ describe('Permission Utils', () => {
           isExternal: false,
           joinedAt: '2026-04-22T00:00:00.000Z',
           roleSource: 'explicit',
+          isOrgAdmin: false,
           isBilledAccount: false,
         },
       ])
@@ -253,8 +254,39 @@ describe('Permission Utils', () => {
       expect(orgAdmin).toMatchObject({
         permissionType: 'admin',
         roleSource: 'org-admin',
+        isOrgAdmin: true,
         isExternal: false,
       })
+    })
+
+    it('reports isOrgAdmin on a workspace owner whose roleSource outranks it', async () => {
+      mockSelectSequence([
+        [{ id: 'ws', ownerId: 'owner-user', organizationId: 'org-1' }],
+        [
+          {
+            userId: 'owner-user',
+            email: 'owner@example.com',
+            name: 'Owner',
+            image: null,
+            permissionType: 'admin' as PermissionType,
+            joinedAt,
+            userOrganizationId: 'org-1',
+          },
+        ],
+        [
+          {
+            userId: 'owner-user',
+            email: 'owner@example.com',
+            name: 'Owner',
+            image: null,
+            joinedAt,
+          },
+        ],
+      ])
+
+      const result = await getUsersWithPermissions('ws')
+
+      expect(result[0]).toMatchObject({ roleSource: 'owner', isOrgAdmin: true })
     })
 
     it('marks users as external when they are not members of the workspace organization', async () => {

--- a/apps/sim/lib/workspaces/permissions/utils.ts
+++ b/apps/sim/lib/workspaces/permissions/utils.ts
@@ -328,6 +328,13 @@ export interface WorkspaceMemberWithRole {
    */
   roleSource: MemberRoleSource
   /**
+   * Admin of the workspace's organization, and so a workspace admin everywhere
+   * in it. Reported separately from `roleSource` because that field ranks
+   * `owner` first, which would otherwise hide the org-admin standing on a
+   * workspace owner — and removal is refused for the org admin, not the owner.
+   */
+  isOrgAdmin: boolean
+  /**
    * The account the workspace bills to. Its role is pinned to `admin` by the
    * workspace-permissions route, so the member UI must not offer to change it.
    */
@@ -369,6 +376,7 @@ export async function getUsersWithPermissions(
       isExternal: !isOwner && row.userOrganizationId !== ws.organizationId,
       joinedAt: row.joinedAt.toISOString(),
       roleSource: isOwner ? 'owner' : 'explicit',
+      isOrgAdmin: false,
       isBilledAccount: row.userId === ws.billedAccountUserId,
     })
   }
@@ -397,6 +405,7 @@ export async function getUsersWithPermissions(
       if (existing) {
         existing.permissionType = 'admin'
         existing.isExternal = false
+        existing.isOrgAdmin = true
         if (existing.roleSource !== 'owner') {
           existing.roleSource = isOwner ? 'owner' : 'org-admin'
         }
@@ -410,6 +419,7 @@ export async function getUsersWithPermissions(
           isExternal: false,
           joinedAt: row.joinedAt.toISOString(),
           roleSource: isOwner ? 'owner' : 'org-admin',
+          isOrgAdmin: true,
           isBilledAccount: row.userId === ws.billedAccountUserId,
         })
       }

--- a/apps/sim/lib/workspaces/utils.test.ts
+++ b/apps/sim/lib/workspaces/utils.test.ts
@@ -287,7 +287,7 @@ describe('listAccessibleWorkspaceRowsForUser', () => {
 
     const rows = await listAccessibleWorkspaceRowsForUser('user-1', 'active')
 
-    expect(rows).toEqual([{ workspace: orgWorkspace, permissionType: 'admin' }])
+    expect(rows).toEqual([{ workspace: orgWorkspace, permissionType: 'admin', viaOrgAdmin: true }])
   })
 
   it('keeps a lower explicit grant on a workspace owned by a different organization', async () => {
@@ -309,8 +309,20 @@ describe('listAccessibleWorkspaceRowsForUser', () => {
     const rows = await listAccessibleWorkspaceRowsForUser('user-1', 'active')
 
     expect(rows).toEqual([
-      { workspace: externalWorkspace, permissionType: 'write' },
-      { workspace: orgWorkspace, permissionType: 'admin' },
+      { workspace: externalWorkspace, permissionType: 'write', viaOrgAdmin: false },
+      { workspace: orgWorkspace, permissionType: 'admin', viaOrgAdmin: true },
     ])
+  })
+
+  it('reports viaOrgAdmin false for every row when the viewer administers no organization', async () => {
+    const ownWorkspace = { id: 'ws-own', name: 'Own', ownerId: 'user-1', organizationId: null }
+
+    dbChainMockFns.select
+      .mockReturnValueOnce(createMockChain([{ workspace: ownWorkspace, permissionType: 'admin' }]))
+      .mockReturnValueOnce(createMockChain([]))
+
+    const rows = await listAccessibleWorkspaceRowsForUser('user-1', 'active')
+
+    expect(rows).toEqual([{ workspace: ownWorkspace, permissionType: 'admin', viaOrgAdmin: false }])
   })
 })

--- a/apps/sim/lib/workspaces/utils.ts
+++ b/apps/sim/lib/workspaces/utils.ts
@@ -101,7 +101,16 @@ export async function listAccessibleWorkspaceRowsForUser(
   userId: string,
   scope: WorkspaceScope = 'active'
 ): Promise<
-  Array<{ workspace: typeof workspaceTable.$inferSelect; permissionType: PermissionType }>
+  Array<{
+    workspace: typeof workspaceTable.$inferSelect
+    permissionType: PermissionType
+    /**
+     * The viewer is an admin of this workspace's organization, so their admin
+     * access is derived and cannot be given up — no permission row to delete.
+     * True whether or not they also hold an explicit grant.
+     */
+    viaOrgAdmin: boolean
+  }>
 > {
   const explicit = await db
     .select({ workspace: workspaceTable, permissionType: permissions.permissionType })
@@ -126,18 +135,20 @@ export async function listAccessibleWorkspaceRowsForUser(
 
   const orgRows = await getOrgAdminWorkspaceRows(userId, scope)
   if (orgRows.length === 0) {
-    return explicit
+    return explicit.map((row) => ({ ...row, viaOrgAdmin: false }))
   }
 
   const orgWorkspaceIds = new Set(orgRows.map((ws) => ws.id))
   const seen = new Set(explicit.map((row) => row.workspace.id))
 
   const elevatedExplicit = explicit.map((row) =>
-    orgWorkspaceIds.has(row.workspace.id) ? { ...row, permissionType: 'admin' as const } : row
+    orgWorkspaceIds.has(row.workspace.id)
+      ? { ...row, permissionType: 'admin' as const, viaOrgAdmin: true }
+      : { ...row, viaOrgAdmin: false }
   )
   const derived = orgRows
     .filter((ws) => !seen.has(ws.id))
-    .map((ws) => ({ workspace: ws, permissionType: 'admin' as const }))
+    .map((ws) => ({ workspace: ws, permissionType: 'admin' as const, viaOrgAdmin: true }))
 
   return [...elevatedExplicit, ...derived]
 }


### PR DESCRIPTION
## Summary
- Removing an org admin from a workspace failed with `User not found in workspace` — they hold workspace admin through their org role, not a `permissions` row, so there was never a row to find
- `DELETE /api/workspaces/members/[id]` now returns a 400 naming the actual reason: organization admins are automatically workspace admins, change their organization role to remove them
- The guard fires whether or not they also hold an explicit row. That case was quietly worse than the 404: it deleted a grant the derived one immediately replaced, and because the seat reconciliation counts `permissions` rows only, removing an org admin from their last org workspace could drop their org membership and seat while they stayed a workspace admin
- Moved the admin/self authorization check above the target lookups so the new standing-specific reply can't be used to probe org membership for an arbitrary userId — same oracle concern the permissions PATCH route documents
- Teammates rows no longer offer a `Remove` the server will refuse: new `workspaceMemberRemovalLockReason` mirrors the two server guards and renders the item disabled with the reason as a tooltip
- Added `isOrgAdmin` to the workspace member payload. `roleSource` ranks `owner` above `org-admin`, so it can't answer for a workspace owner who is also an org admin — the one case the client previously couldn't see

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `tsc --noEmit` clean, `bun run lint`, `check:audits` (29 audits) and `check:block-registry` pass, `lib/workspaces/permissions/utils.test.ts` 64/64 — updated the exact-shape assertion and added a case pinning that an owner who is also an org admin keeps `roleSource: 'owner'` and still reports `isOrgAdmin: true`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)