### PR TITLE
fix(react): use stable keys for dynamic lists

### DIFF
--- a/apps/docs/app/api/og/route.tsx
+++ b/apps/docs/app/api/og/route.tsx
@@ -102,7 +102,12 @@ function splitOversizedWord(word: string, maxWidthEm: number): string[] {
  * so it sidesteps the bug instead of fighting Satori's own line-wrapping
  * (which is also disabled here — lines are pre-split, not auto-wrapped).
  */
-function wrapTitleLines(title: string, fontSize: number): string[] {
+interface TitleLine {
+  text: string
+  sourceOffset: number
+}
+
+function wrapTitleLines(title: string, fontSize: number): TitleLine[] {
   const maxWidthEm = TITLE_BOX_WIDTH / fontSize
   const words = title.split(' ')
   const lines: string[] = []
@@ -130,7 +135,12 @@ function wrapTitleLines(title: string, fontSize: number): string[] {
   }
   if (current) lines.push(current)
 
-  return lines.map((line) => line.replace(/ /g, ' '))
+  let lineOffset = 0
+  return lines.map((line) => {
+    const sourceOffset = lineOffset
+    lineOffset += line.length + 1
+    return { text: line.replace(/ /g, ' '), sourceOffset }
+  })
 }
 
 /**
@@ -211,8 +221,8 @@ export async function GET(request: NextRequest) {
       </div>
 
       <div style={getTitleStyle(title)}>
-        {titleLines.map((line, index) => (
-          <span key={index}>{line}</span>
+        {titleLines.map((line) => (
+          <span key={line.sourceOffset}>{line.text}</span>
         ))}
       </div>
     </div>,

--- a/apps/docs/components/workflow-preview/format-references.tsx
+++ b/apps/docs/components/workflow-preview/format-references.tsx
@@ -10,16 +10,19 @@ const REFERENCE_PATTERN = /(<[^<>]+>|\{\{[^{}]+\}\})/g
  */
 export function formatReferences(text: string): ReactNode[] {
   if (!text) return []
-  return text.split(REFERENCE_PATTERN).map((part, index) => {
+  let sourceOffset = 0
+  return text.split(REFERENCE_PATTERN).map((part) => {
+    const partOffset = sourceOffset
+    sourceOffset += part.length
     if (!part) return null
     const isReference =
       (part.startsWith('<') && part.endsWith('>')) || (part.startsWith('{{') && part.endsWith('}}'))
     return isReference ? (
-      <span key={index} className='text-[var(--brand-secondary)]'>
+      <span key={partOffset} className='text-[var(--brand-secondary)]'>
         {part}
       </span>
     ) : (
-      <span key={index}>{part}</span>
+      <span key={partOffset}>{part}</span>
     )
   })
 }

--- a/apps/sim/app/(interfaces)/chat/components/input/input.tsx
+++ b/apps/sim/app/(interfaces)/chat/components/input/input.tsx
@@ -21,6 +21,11 @@ interface AttachedFile {
   dataUrl?: string
 }
 
+interface UploadError {
+  id: string
+  message: string
+}
+
 export const ChatInput: React.FC<{
   onSubmit?: (value: string, files?: AttachedFile[]) => void
   isStreaming?: boolean
@@ -30,7 +35,7 @@ export const ChatInput: React.FC<{
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [inputValue, setInputValue] = useState('')
   const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([])
-  const [uploadErrors, setUploadErrors] = useState<string[]>([])
+  const [uploadErrors, setUploadErrors] = useState<UploadError[]>([])
   const [dragCounter, setDragCounter] = useState(0)
   const isDragOver = dragCounter > 0
 
@@ -54,7 +59,10 @@ export const ChatInput: React.FC<{
       const file = selectedFiles[i]
 
       if (file.size > maxSize) {
-        setUploadErrors((prev) => [...prev, `${file.name} is too large (max 10MB)`])
+        setUploadErrors((prev) => [
+          ...prev,
+          { id: generateId(), message: `${file.name} is too large (max 10MB)` },
+        ])
         continue
       }
 
@@ -62,7 +70,10 @@ export const ChatInput: React.FC<{
         (existing) => existing.name === file.name && existing.size === file.size
       )
       if (isDuplicate) {
-        setUploadErrors((prev) => [...prev, `${file.name} already added`])
+        setUploadErrors((prev) => [
+          ...prev,
+          { id: generateId(), message: `${file.name} already added` },
+        ])
         continue
       }
 
@@ -128,9 +139,9 @@ export const ChatInput: React.FC<{
       <div className='w-full max-w-3xl md:max-w-[748px]'>
         {uploadErrors.length > 0 && (
           <div className='mb-3 flex flex-col gap-2'>
-            {uploadErrors.map((error, idx) => (
-              <Badge key={`${error}-${idx}`} variant='red' size='lg' dot className='max-w-full'>
-                {error}
+            {uploadErrors.map((error) => (
+              <Badge key={error.id} variant='red' size='lg' dot className='max-w-full'>
+                {error.message}
               </Badge>
             ))}
           </div>

--- a/apps/sim/app/(landing)/components/hero/components/hero-visual/stage-home.tsx
+++ b/apps/sim/app/(landing)/components/hero/components/hero-visual/stage-home.tsx
@@ -114,11 +114,11 @@ const Caret = () => (
 function PromptAtoms({ atoms }: { atoms: PromptAtom[] }) {
   return (
     <>
-      {atoms.map((atom, i) =>
+      {atoms.map((atom) =>
         atom.kind === 'char' ? (
-          <span key={`${i}-${atom.char}`}>{atom.char}</span>
+          <span key={atom.id}>{atom.char}</span>
         ) : (
-          <span key={`${i}-${atom.label}`}>
+          <span key={atom.id}>
             <span className='relative'>
               <span className='invisible'>@</span>
               <atom.icon className='absolute inset-0 m-auto size-[12px] translate-y-[1.25px] text-[var(--text-icon)]' />

--- a/apps/sim/app/(landing)/components/hero/components/hero-visual/workflow-data.ts
+++ b/apps/sim/app/(landing)/components/hero/components/hero-visual/workflow-data.ts
@@ -238,8 +238,8 @@ export const SCENE_JIRA_FOCUS_TRANSLATE = { x: -645, y: 0 } as const
  * `@GitHub` / `@Jira` mention.
  */
 export type PromptAtom =
-  | { kind: 'char'; char: string }
-  | { kind: 'mention'; label: string; icon: IconComponent }
+  | { id: string; kind: 'char'; char: string }
+  | { id: string; kind: 'mention'; label: string; icon: IconComponent }
 
 const PROMPT_SEGMENTS: Array<string | { label: string; icon: IconComponent }> = [
   'Create me a ',
@@ -248,11 +248,26 @@ const PROMPT_SEGMENTS: Array<string | { label: string; icon: IconComponent }> = 
   { label: 'Jira', icon: JiraIcon },
 ]
 
-export const PROMPT_ATOMS: PromptAtom[] = PROMPT_SEGMENTS.flatMap((seg) =>
-  typeof seg === 'string'
-    ? [...seg].map((char): PromptAtom => ({ kind: 'char', char }))
-    : [{ kind: 'mention', label: seg.label, icon: seg.icon } as PromptAtom]
-)
+let promptSourceOffset = 0
+export const PROMPT_ATOMS: PromptAtom[] = PROMPT_SEGMENTS.flatMap((seg) => {
+  if (typeof seg === 'string') {
+    const atoms = [...seg].map((char): PromptAtom => {
+      const id = `char-${promptSourceOffset}`
+      promptSourceOffset += char.length
+      return { id, kind: 'char', char }
+    })
+    return atoms
+  }
+
+  const atom: PromptAtom = {
+    id: `mention-${promptSourceOffset}-${seg.label}`,
+    kind: 'mention',
+    label: seg.label,
+    icon: seg.icon,
+  }
+  promptSourceOffset += seg.label.length + 1
+  return [atom]
+})
 
 /** Greeting shown above the input in the home state (matches the Mothership home). */
 export const HOME_GREETING = 'What should we get done?'

--- a/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-workflow/preview-block-node.tsx
+++ b/apps/sim/app/(landing)/components/landing-preview/components/landing-preview-workflow/preview-block-node.tsx
@@ -287,22 +287,27 @@ export const PreviewBlockNode = memo(function PreviewBlockNode({
  * Supports ### headings, **bold**, _italic_, --- rules, and blank-line spacing.
  */
 function NoteMarkdown({ content }: { content: string }) {
-  const lines = content.split('\n')
+  let sourceOffset = 0
+  const lines = content.split('\n').map((text) => {
+    const line = { sourceOffset, text }
+    sourceOffset += text.length + 1
+    return line
+  })
 
   return (
     <div className='flex flex-col gap-1'>
-      {lines.map((line, i) => {
-        const trimmed = line.trim()
-        if (!trimmed) return <div key={`${line}-${i}`} className='h-[4px]' />
+      {lines.map((line) => {
+        const trimmed = line.text.trim()
+        if (!trimmed) return <div key={line.sourceOffset} className='h-[4px]' />
 
         if (trimmed === '---') {
-          return <hr key={`${line}-${i}`} className='my-1 border-[var(--border)] border-t' />
+          return <hr key={line.sourceOffset} className='my-1 border-[var(--border)] border-t' />
         }
 
         if (trimmed.startsWith('### ')) {
           return (
             <p
-              key={`${line}-${i}`}
+              key={line.sourceOffset}
               className='font-semibold text-[16px] text-[var(--text-primary)] leading-[1.3]'
             >
               {trimmed.slice(4)}
@@ -312,7 +317,7 @@ function NoteMarkdown({ content }: { content: string }) {
 
         return (
           <p
-            key={`${line}-${i}`}
+            key={line.sourceOffset}
             className='font-medium text-[13px] text-[var(--text-primary)] leading-[1.5]'
             dangerouslySetInnerHTML={{
               __html: trimmed

--- a/apps/sim/app/(landing)/components/prose-page/components/legal-block-group/components/legal-block/legal-block.tsx
+++ b/apps/sim/app/(landing)/components/prose-page/components/legal-block-group/components/legal-block/legal-block.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@sim/emcn'
+import { extractTextContent } from '@/lib/core/utils/react-node-text'
 import { PROSE_SPACING, PROSE_TYPE } from '@/app/(landing)/components/prose-page/constants'
 import type { LegalBlock } from '@/app/(landing)/components/prose-page/types'
 
@@ -21,19 +22,23 @@ export function LegalBlockView({ block }: LegalBlockViewProps) {
       return <p className={PROSE_TYPE.body}>{block.content}</p>
     case 'subheading':
       return <h3 className={PROSE_TYPE.h3}>{block.text}</h3>
-    case 'list':
+    case 'list': {
+      const itemOccurrences = new Map<string, number>()
       return (
         <ul className={cn('list-disc', PROSE_SPACING.listIndent, PROSE_SPACING.listStack)}>
-          {block.items.map((item, index) => {
-            const itemKey = `item-${index}`
+          {block.items.map((item) => {
+            const signature = extractTextContent(item)
+            const occurrence = itemOccurrences.get(signature) ?? 0
+            itemOccurrences.set(signature, occurrence + 1)
             return (
-              <li key={itemKey} className={PROSE_TYPE.list}>
+              <li key={`${signature}:${occurrence}`} className={PROSE_TYPE.list}>
                 {item}
               </li>
             )
           })}
         </ul>
       )
+    }
     case 'callout':
       return <div className={PROSE_TYPE.callout}>{block.content}</div>
     case 'table':

--- a/apps/sim/app/(landing)/components/prose-page/components/legal-block-group/legal-block-group.tsx
+++ b/apps/sim/app/(landing)/components/prose-page/components/legal-block-group/legal-block-group.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@sim/emcn'
+import { extractTextContent } from '@/lib/core/utils/react-node-text'
 import { LegalBlockView } from '@/app/(landing)/components/prose-page/components/legal-block-group/components'
 import { PROSE_SPACING } from '@/app/(landing)/components/prose-page/constants'
 import type { LegalBlock } from '@/app/(landing)/components/prose-page/types'
@@ -16,11 +17,21 @@ interface LegalBlockGroupProps {
 }
 
 export function LegalBlockGroup({ blocks }: LegalBlockGroupProps) {
+  const blockOccurrences = new Map<string, number>()
   return (
     <div className={cn('flex flex-col', PROSE_SPACING.blockStack)}>
-      {blocks.map((block, index) => (
-        <LegalBlockView key={`${block.kind}-${index}`} block={block} />
-      ))}
+      {blocks.map((block) => {
+        const content =
+          block.kind === 'subheading'
+            ? block.text
+            : block.kind === 'list'
+              ? block.items.map(extractTextContent).join('\u0000')
+              : extractTextContent(block.content)
+        const signature = `${block.kind}:${content}`
+        const occurrence = blockOccurrences.get(signature) ?? 0
+        blockOccurrences.set(signature, occurrence + 1)
+        return <LegalBlockView key={`${signature}:${occurrence}`} block={block} />
+      })}
     </div>
   )
 }

--- a/apps/sim/app/(landing)/enterprise/components/feature-graphics/build-methods-graphic.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/feature-graphics/build-methods-graphic.tsx
@@ -13,7 +13,7 @@ interface CodeSegment {
 }
 
 /** The `support-agent.ts` contents, split into tone-colored typewriter segments. */
-const CODE_LINES: CodeSegment[][] = [
+const RAW_CODE_LINES: CodeSegment[][] = [
   [
     { text: 'import', tone: 'muted' },
     { text: ' ' },
@@ -52,8 +52,24 @@ const CODE_LINES: CodeSegment[][] = [
   [{ text: '  })' }],
 ]
 
+const codeLineOccurrences = new Map<string, number>()
+const CODE_LINES = RAW_CODE_LINES.map((segments) => {
+  const text = segments.map((segment) => segment.text).join('')
+  const occurrence = codeLineOccurrences.get(text) ?? 0
+  codeLineOccurrences.set(text, occurrence + 1)
+  let sourceOffset = 0
+  return {
+    id: `${text}:${occurrence}`,
+    segments: segments.map((segment) => {
+      const id = `${sourceOffset}:${segment.text.length}`
+      sourceOffset += segment.text.length
+      return { ...segment, id }
+    }),
+  }
+})
+
 const CODE_LINE_LENGTHS = CODE_LINES.map((line) =>
-  line.reduce((total, segment) => total + segment.text.length, 0)
+  line.segments.reduce((total, segment) => total + segment.text.length, 0)
 )
 const CODE_LINE_STARTS = CODE_LINE_LENGTHS.map((_, index) =>
   CODE_LINE_LENGTHS.slice(0, index).reduce((total, length) => total + length, 0)
@@ -93,13 +109,13 @@ const SEGMENT_TONE_CLASS = {
 } as const
 
 /** Renders one code line clipped to the number of characters typed so far. */
-function renderCodeLine(segments: CodeSegment[], visibleChars: number) {
+function renderCodeLine(segments: Array<CodeSegment & { id: string }>, visibleChars: number) {
   const rendered = []
   let remaining = visibleChars
   for (let index = 0; index < segments.length && remaining > 0; index++) {
     const segment = segments[index]
     rendered.push(
-      <span key={index} className={segment.tone && SEGMENT_TONE_CLASS[segment.tone]}>
+      <span key={segment.id} className={segment.tone && SEGMENT_TONE_CLASS[segment.tone]}>
         {segment.text.slice(0, remaining)}
       </span>
     )
@@ -255,12 +271,12 @@ export function BuildMethodsGraphic() {
           <div className='min-h-[190px] space-y-2 p-4 font-mono text-caption leading-[1.7]'>
             {CODE_LINES.map((line, index) =>
               typedCodeChars > CODE_LINE_STARTS[index] ? (
-                <div key={index} className='flex gap-3'>
+                <div key={line.id} className='flex gap-3'>
                   <span className='w-3 select-none text-right text-[var(--text-muted)]'>
                     {index + 1}
                   </span>
                   <code>
-                    {renderCodeLine(line, typedCodeChars - CODE_LINE_STARTS[index])}
+                    {renderCodeLine(line.segments, typedCodeChars - CODE_LINE_STARTS[index])}
                     {codeTypingActive && index === lastStartedLine && (
                       <span className='ml-px inline-block h-[1.1em] w-px translate-y-[2px] animate-pulse bg-[var(--text-primary)] align-text-bottom' />
                     )}

--- a/apps/sim/app/playground/page.tsx
+++ b/apps/sim/app/playground/page.tsx
@@ -84,6 +84,7 @@ import {
   ZoomOut,
 } from '@sim/emcn'
 import { ArrowLeft, Folder, Moon, Sun } from '@sim/emcn/icons'
+import { generateShortId } from '@sim/utils/id'
 import { notFound, useRouter } from 'next/navigation'
 import { env, isTruthy } from '@/lib/core/config/env'
 
@@ -148,9 +149,14 @@ export default function PlaygroundPage() {
   const [dateValue, setDateValue] = useState('')
   const [dateRangeStart, setDateRangeStart] = useState('')
   const [dateRangeEnd, setDateRangeEnd] = useState('')
-  const [tagItems, setTagItems] = useState<TagItem[]>([
-    { value: 'user@example.com', isValid: true },
-    { value: 'invalid-email', isValid: false, error: 'Invalid email format' },
+  const [tagItems, setTagItems] = useState<TagItem[]>(() => [
+    { id: generateShortId(), value: 'user@example.com', isValid: true },
+    {
+      id: generateShortId(),
+      value: 'invalid-email',
+      isValid: false,
+      error: 'Invalid email format',
+    },
   ])
 
   const toggleDarkMode = () => {
@@ -439,7 +445,7 @@ export default function PlaygroundPage() {
                     items={tagItems}
                     onAdd={(value) => {
                       const isValid = value.includes('@') && value.includes('.')
-                      setTagItems((prev) => [...prev, { value, isValid }])
+                      setTagItems((prev) => [...prev, { id: generateShortId(), value, isValid }])
                       return isValid
                     }}
                     onRemove={(_, index) => {
@@ -454,8 +460,8 @@ export default function PlaygroundPage() {
                 <div className='w-80'>
                   <TagInput
                     items={[
-                      { value: 'workflow', isValid: true },
-                      { value: 'automation', isValid: true },
+                      { id: 'workflow', value: 'workflow', isValid: true },
+                      { id: 'automation', value: 'automation', isValid: true },
                     ]}
                     onAdd={() => true}
                     onRemove={() => {}}
@@ -468,7 +474,7 @@ export default function PlaygroundPage() {
               <VariantRow label='disabled'>
                 <div className='w-80'>
                   <TagInput
-                    items={[{ value: 'disabled@email.com', isValid: true }]}
+                    items={[{ id: 'disabled-email', value: 'disabled@email.com', isValid: true }]}
                     onAdd={() => false}
                     onRemove={() => {}}
                     placeholder='Disabled input'

--- a/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
@@ -268,7 +268,13 @@ export const MessageActions = memo(function MessageActions({
           onCancel={() => handleModalClose(false)}
           secondaryActions={
             pendingFeedback === 'down' && requestId
-              ? [{ label: copiedRequestId ? 'Copied' : 'Copy ID', onClick: copyRequestId }]
+              ? [
+                  {
+                    id: 'copy-request-id',
+                    label: copiedRequestId ? 'Copied' : 'Copy ID',
+                    onClick: copyRequestId,
+                  },
+                ]
               : undefined
           }
           primaryAction={{

--- a/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/resource/components/resource-header/resource-header.tsx
@@ -80,6 +80,19 @@ export interface BreadcrumbItem {
   terminal?: boolean
 }
 
+function keyedBreadcrumbs(breadcrumbs: BreadcrumbItem[]) {
+  const occurrences = new Map<string, number>()
+  return breadcrumbs.map((crumb, index) => {
+    const signature =
+      crumb.folderId !== undefined
+        ? `folder:${crumb.folderId ?? 'root'}`
+        : `segment:${crumb.label}:${crumb.terminal === true ? 'terminal' : 'resource'}`
+    const occurrence = occurrences.get(signature) ?? 0
+    occurrences.set(signature, occurrence + 1)
+    return { crumb, index, key: `${signature}:${occurrence}` }
+  })
+}
+
 /**
  * The single, strict contract for a top-right header action. Every action renders
  * as a {@link Chip} — consumers describe intent through these fields and nothing
@@ -160,6 +173,7 @@ export const ResourceHeader = memo(function ResourceHeader({
       : hasBreadcrumbs && breadcrumbs.length > 2
         ? breadcrumbs.length - 1
         : -1
+  const breadcrumbEntries = breadcrumbs ? keyedBreadcrumbs(breadcrumbs) : []
 
   return (
     <div
@@ -172,7 +186,7 @@ export const ResourceHeader = memo(function ResourceHeader({
       <div className='flex min-w-0 flex-1 items-center justify-between gap-3'>
         <div className='flex min-w-0 flex-1 items-center gap-2 overflow-hidden'>
           {hasBreadcrumbs ? (
-            breadcrumbs.map((crumb, i) => {
+            breadcrumbEntries.map(({ crumb, index: i, key }) => {
               const segmentClassName = getBreadcrumbSegmentClassName(
                 i,
                 breadcrumbs.length,
@@ -204,7 +218,7 @@ export const ResourceHeader = memo(function ResourceHeader({
                   : undefined
 
               return (
-                <Fragment key={`${crumb.label}-${i}`}>
+                <Fragment key={key}>
                   {i > 0 && (
                     <span className='mx-0.5 shrink-0 select-none text-[var(--text-icon)] text-sm'>
                       /
@@ -465,6 +479,7 @@ function BreadcrumbLocationPopover({
   const [open, setOpen] = useState(false)
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const rootBreadcrumb = breadcrumbs[0]
+  const breadcrumbEntries = keyedBreadcrumbs(breadcrumbs)
 
   const cancelScheduledClose = () => {
     if (closeTimeoutRef.current) {
@@ -569,9 +584,9 @@ function BreadcrumbLocationPopover({
             </span>
           </PopoverSection>
           <div className='flex flex-col gap-0.5'>
-            {breadcrumbs.map((crumb, index) => (
+            {breadcrumbEntries.map(({ crumb, index, key }) => (
               <BreadcrumbLocationItem
-                key={`${crumb.label}-${index}`}
+                key={key}
                 icon={crumb.icon || (index === 0 ? Icon : undefined)}
                 label={crumb.label}
                 onClick={crumb.onClick ? () => navigateAndClose(crumb.onClick) : undefined}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/data-table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/data-table.tsx
@@ -103,20 +103,27 @@ const DataTableBase = forwardRef<DataTableHandle, DataTableProps>(function DataT
   const isEditing = (row: number, col: number) =>
     editingCell?.row === row && editingCell?.col === col
 
+  const columnOccurrences = new Map<string, number>()
+  const columns = headers.map((header, columnIndex) => {
+    const occurrence = columnOccurrences.get(header) ?? 0
+    columnOccurrences.set(header, occurrence + 1)
+    return { id: JSON.stringify([header, occurrence]), header, columnIndex }
+  })
+
   return (
     <div className='document-table'>
       <table>
         <thead>
           <tr>
-            {headers.map((header, i) => (
+            {columns.map(({ id, header, columnIndex }) => (
               <th
-                key={i}
+                key={id}
                 className={cn(
                   editConfig && 'cursor-pointer select-none hover:bg-[var(--surface-active)]'
                 )}
-                onClick={() => editConfig && startEdit(-1, i, String(header ?? ''))}
+                onClick={() => editConfig && startEdit(-1, columnIndex, String(header ?? ''))}
               >
-                {isEditing(-1, i) ? (
+                {isEditing(-1, columnIndex) ? (
                   <input
                     ref={setInputRef}
                     value={editValue}
@@ -135,15 +142,17 @@ const DataTableBase = forwardRef<DataTableHandle, DataTableProps>(function DataT
         <tbody>
           {rows.map((row, ri) => (
             <tr key={ri}>
-              {headers.map((_, ci) => (
+              {columns.map(({ id, columnIndex }) => (
                 <td
-                  key={ci}
+                  key={id}
                   className={cn(
                     editConfig && 'cursor-pointer select-none hover:bg-[var(--surface-active)]'
                   )}
-                  onClick={() => editConfig && startEdit(ri, ci, String(row[ci] ?? ''))}
+                  onClick={() =>
+                    editConfig && startEdit(ri, columnIndex, String(row[columnIndex] ?? ''))
+                  }
                 >
-                  {isEditing(ri, ci) ? (
+                  {isEditing(ri, columnIndex) ? (
                     <input
                       ref={setInputRef}
                       value={editValue}
@@ -153,7 +162,7 @@ const DataTableBase = forwardRef<DataTableHandle, DataTableProps>(function DataT
                       className='w-full min-w-[60px] bg-transparent outline-none ring-1 ring-[var(--brand-secondary)] ring-inset'
                     />
                   ) : (
-                    String(row[ci] ?? '')
+                    String(row[columnIndex] ?? '')
                   )}
                 </td>
               ))}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/agent-group.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/agent-group/agent-group.tsx
@@ -154,6 +154,8 @@ export function AgentGroup({
     setManualExpanded(!expanded)
   }
 
+  let previousItemKey = `group:${agentName}:${agentLabel}`
+
   return (
     <div className='flex flex-col gap-1.5'>
       {hasItems ? (
@@ -195,10 +197,17 @@ export function AgentGroup({
             <BoundedViewport isStreaming={isStreaming} unbounded={nestedBrowserTakeover}>
               <div className='flex flex-col gap-1.5 py-0.5'>
                 {items.map((item, idx) => {
+                  const itemKey =
+                    item.type === 'tool'
+                      ? `tool:${item.data.id}`
+                      : item.type === 'agent_group'
+                        ? `agent:${item.group.id}`
+                        : `text-after:${previousItemKey}`
+                  previousItemKey = itemKey
                   if (item.type === 'tool') {
                     return (
                       <ToolCallItem
-                        key={item.data.id}
+                        key={itemKey}
                         toolCallId={item.data.id}
                         toolName={item.data.toolName}
                         displayTitle={item.data.displayTitle}
@@ -212,7 +221,7 @@ export function AgentGroup({
                   }
                   if (item.type === 'agent_group') {
                     return (
-                      <div key={item.group.id} className='pl-6'>
+                      <div key={itemKey} className='pl-6'>
                         <AgentGroup
                           agentName={item.group.agentName}
                           agentLabel={item.group.agentLabel}
@@ -227,7 +236,7 @@ export function AgentGroup({
                   }
                   return (
                     <NarrationText
-                      key={`text-${idx}`}
+                      key={itemKey}
                       content={item.content}
                       isStreaming={isStreaming && idx === items.length - 1}
                     />

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.tsx
@@ -569,15 +569,17 @@ function ChatContentInner({
     { type: 'text' } | { type: 'thinking' } | { type: 'workspace_resource' }
   >
   type RenderGroup =
-    | { kind: 'inline'; markdown: string }
-    | { kind: 'block'; segment: BlockSegment; index: number }
+    | { id: string; kind: 'inline'; markdown: string }
+    | { id: string; kind: 'block'; segment: BlockSegment; index: number }
 
   const groups: RenderGroup[] = []
   let pendingMarkdown = ''
+  let inlineAnchor = 'start'
+  const specialOccurrences = new Map<string, number>()
 
   const flushMarkdown = () => {
     if (pendingMarkdown.trim()) {
-      groups.push({ kind: 'inline', markdown: pendingMarkdown })
+      groups.push({ id: `inline-after:${inlineAnchor}`, kind: 'inline', markdown: pendingMarkdown })
     }
     pendingMarkdown = ''
   }
@@ -604,7 +606,12 @@ function ChatContentInner({
       pendingMarkdown += s.content
     } else {
       flushMarkdown()
-      groups.push({ kind: 'block', segment: s, index: i })
+      const signature = `${s.type}:${JSON.stringify(s.data)}`
+      const occurrence = specialOccurrences.get(signature) ?? 0
+      specialOccurrences.set(signature, occurrence + 1)
+      const id = `special:${signature}:${occurrence}`
+      groups.push({ id, kind: 'block', segment: s, index: i })
+      inlineAnchor = id
     }
   }
   flushMarkdown()
@@ -622,11 +629,11 @@ function ChatContentInner({
    */
   return (
     <div className='space-y-3'>
-      {groups.map((group, i) => {
+      {groups.map((group) => {
         if (group.kind === 'inline') {
           return (
             <div
-              key={`inline-${i}`}
+              key={group.id}
               className={cn(PROSE_CLASSES, '[&>:first-child]:mt-0 [&>:last-child]:mb-0')}
             >
               <Streamdown
@@ -643,7 +650,7 @@ function ChatContentInner({
         }
         return (
           <SpecialTags
-            key={`special-${group.index}`}
+            key={group.id}
             segment={group.segment}
             interactionId={`${messageId ?? 'message'}:${group.index}`}
             questionAnswers={questionAnswers}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/interaction-card.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/interaction-card.tsx
@@ -49,18 +49,27 @@ interface InteractionCardRecapProps {
 
 /** Shared answered-state layout used by questions and credential requests. */
 export function InteractionCardRecap({ items }: InteractionCardRecapProps) {
+  const itemOccurrences = new Map<string, number>()
   return (
     <InteractionCard>
-      {items.map((item, index) => (
-        <div key={`${item.label}-${index}`} className='px-2 py-2'>
-          <p className='text-[var(--text-primary)] text-sm'>{item.label}</p>
-          <div className='mt-1.5 flex flex-col gap-1 text-[var(--text-muted)] text-sm'>
-            {item.values.map((value, valueIndex) => (
-              <p key={`${value}-${valueIndex}`}>{value}</p>
-            ))}
+      {items.map((item) => {
+        const signature = `${item.label}\u0000${item.values.join('\u0000')}`
+        const occurrence = itemOccurrences.get(signature) ?? 0
+        itemOccurrences.set(signature, occurrence + 1)
+        const valueOccurrences = new Map<string, number>()
+        return (
+          <div key={`${signature}\u0000${occurrence}`} className='px-2 py-2'>
+            <p className='text-[var(--text-primary)] text-sm'>{item.label}</p>
+            <div className='mt-1.5 flex flex-col gap-1 text-[var(--text-muted)] text-sm'>
+              {item.values.map((value) => {
+                const valueOccurrence = valueOccurrences.get(value) ?? 0
+                valueOccurrences.set(value, valueOccurrence + 1)
+                return <p key={`${value}\u0000${valueOccurrence}`}>{value}</p>
+              })}
+            </div>
           </div>
-        </div>
-      ))}
+        )
+      })}
     </InteractionCard>
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/special-tags/special-tags.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/special-tags/special-tags.tsx
@@ -2695,14 +2695,16 @@ export function CredentialDisplay({
     )
   }
 
+  const itemOccurrences = new Map<string, number>()
+
   return (
     <div className={cn(data.length > 1 && 'space-y-3')}>
-      {data.map((item, index) => (
-        <CredentialItemDisplay
-          key={`${item.type}-${item.provider ?? item.name ?? index}`}
-          data={item}
-        />
-      ))}
+      {data.map((item) => {
+        const signature = JSON.stringify(item)
+        const occurrence = itemOccurrences.get(signature) ?? 0
+        itemOccurrences.set(signature, occurrence + 1)
+        return <CredentialItemDisplay key={`${signature}:${occurrence}`} data={item} />
+      })}
     </div>
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/message-content.tsx
@@ -59,6 +59,7 @@ interface AgentGroupSegment {
 
 interface OptionsSegment {
   type: 'options'
+  id: string
   items: OptionItem[]
 }
 
@@ -429,7 +430,11 @@ function parseBlocksWithSpanTree(blocks: ContentBlock[]): MessageSegment[] {
 
     if (block.type === 'options') {
       if (!block.options?.length) continue
-      segments.push({ type: 'options', items: block.options })
+      segments.push({
+        type: 'options',
+        id: `options-${block.timestamp ?? 'untimed'}-${block.options.map((item) => item.id).join(':')}`,
+        items: block.options,
+      })
       continue
     }
 
@@ -662,7 +667,11 @@ function parseBlocksLegacy(blocks: ContentBlock[]): MessageSegment[] {
     if (block.type === 'options') {
       if (!block.options?.length) continue
       flushLanes()
-      segments.push({ type: 'options', items: block.options })
+      segments.push({
+        type: 'options',
+        id: `options-${block.timestamp ?? 'untimed'}-${block.options.map((item) => item.id).join(':')}`,
+        items: block.options,
+      })
       continue
     }
 
@@ -966,7 +975,7 @@ function MessageContentInner({
             case 'options':
               return (
                 <div
-                  key={`options-${i}`}
+                  key={segment.id}
                   className={isStreaming ? 'animate-stream-fade-in' : undefined}
                 >
                   <Options items={segment.items} onSelect={onOptionSelect} />

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/drop-overlay/drop-overlay.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/drop-overlay/drop-overlay.tsx
@@ -14,15 +14,15 @@ import {
 } from '@/components/icons/document-icons'
 
 const DROP_OVERLAY_ICONS = [
-  PdfIcon,
-  DocxIcon,
-  XlsxIcon,
-  CsvIcon,
-  TxtIcon,
-  MarkdownIcon,
-  JsonIcon,
-  AudioIcon,
-  VideoIcon,
+  { id: 'pdf', Icon: PdfIcon },
+  { id: 'docx', Icon: DocxIcon },
+  { id: 'xlsx', Icon: XlsxIcon },
+  { id: 'csv', Icon: CsvIcon },
+  { id: 'txt', Icon: TxtIcon },
+  { id: 'markdown', Icon: MarkdownIcon },
+  { id: 'json', Icon: JsonIcon },
+  { id: 'audio', Icon: AudioIcon },
+  { id: 'video', Icon: VideoIcon },
 ] as const
 
 export const DropOverlay = memo(function DropOverlay() {
@@ -31,8 +31,8 @@ export const DropOverlay = memo(function DropOverlay() {
       <div className='flex flex-col items-center gap-2'>
         <span className='text-[13px] text-[var(--text-secondary)]'>Drop files</span>
         <div className='flex items-center gap-2 text-[var(--text-icon)]'>
-          {DROP_OVERLAY_ICONS.map((Icon, i) => (
-            <Icon key={i} className='size-[14px]' />
+          {DROP_OVERLAY_ICONS.map(({ id, Icon }) => (
+            <Icon key={id} className='size-[14px]' />
           ))}
         </div>
       </div>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/prompt-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/prompt-editor.tsx
@@ -182,7 +182,7 @@ export function PromptEditor({
 
       if (range.start > lastIndex) {
         const before = value.slice(lastIndex, range.start)
-        elements.push(<span key={`text-${i}-${lastIndex}-${range.start}`}>{before}</span>)
+        elements.push(<span key={`text-${lastIndex}-${range.start}`}>{before}</span>)
       }
 
       const mentionLabel = stripMentionTrigger(range.token)
@@ -196,7 +196,7 @@ export function PromptEditor({
       ) : null
 
       elements.push(
-        <span key={`mention-${i}-${range.start}-${range.end}`}>
+        <span key={`mention-${range.start}-${range.end}`}>
           <span className='relative'>
             {/* Invisible trigger glyph keeps the overlay's advance identical to
                 the transparent textarea; the icon centers over its slot. */}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-message-content/user-message-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-message-content/user-message-content.tsx
@@ -142,18 +142,18 @@ export function UserMessageContent({
 
     if (range.start > lastIndex) {
       const before = content.slice(lastIndex, range.start)
-      elements.push(<span key={`text-${i}-${lastIndex}`}>{before}</span>)
+      elements.push(<span key={`text-${lastIndex}-${range.start}`}>{before}</span>)
     }
 
     if (plainMentions) {
       elements.push(
-        <span key={`mention-${i}-${range.start}`} className='text-[var(--text-primary)]'>
+        <span key={`mention-${range.start}-${range.end}`} className='text-[var(--text-primary)]'>
           {content.slice(range.start, range.end)}
         </span>
       )
     } else {
       elements.push(
-        <MentionHighlight key={`mention-${i}-${range.start}`} context={range.context} />
+        <MentionHighlight key={`mention-${range.start}-${range.end}`} context={range.context} />
       )
     }
     lastIndex = range.end

--- a/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-service-account-modal/client-credential-account-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-service-account-modal/client-credential-account-modal.tsx
@@ -348,6 +348,7 @@ export function ClientCredentialAccountModal({
         onCancel={() => onOpenChange(false)}
         secondaryActions={[
           {
+            id: 'setup-guide',
             label: 'Setup guide',
             onClick: () => openDocs(descriptor.docsUrl),
           },

--- a/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-service-account-modal/connect-service-account-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-service-account-modal/connect-service-account-modal.tsx
@@ -416,6 +416,7 @@ function GoogleServiceAccountModal({
         onCancel={() => onOpenChange(false)}
         secondaryActions={[
           {
+            id: 'setup-guide',
             label: 'Setup guide',
             onClick: () => openDocs(GOOGLE_SERVICE_ACCOUNT_DOCS_URL),
           },
@@ -579,6 +580,7 @@ function AtlassianServiceAccountModal({
         onCancel={() => onOpenChange(false)}
         secondaryActions={[
           {
+            id: 'setup-guide',
             label: 'Setup guide',
             onClick: () => openDocs(ATLASSIAN_SERVICE_ACCOUNT_DOCS_URL),
           },

--- a/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-service-account-modal/token-service-account-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/components/connect-service-account-modal/token-service-account-modal.tsx
@@ -210,6 +210,7 @@ export function TokenServiceAccountModal({
         onCancel={() => onOpenChange(false)}
         secondaryActions={[
           {
+            id: 'setup-guide',
             label: 'Setup guide',
             onClick: () => openDocs(descriptor.docsUrl),
           },

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/chunk-editor/chunk-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/chunk-editor/chunk-editor.tsx
@@ -234,6 +234,8 @@ export function ChunkEditor({
     return getTokenStrings(editedContent)
   }, [editedContent, tokenizerOn])
 
+  let tokenOffset = 0
+
   const tokenCount = useMemo(() => {
     if (!editedContent) return 0
     if (tokenizerOn) return tokenStrings.length
@@ -257,16 +259,20 @@ export function ChunkEditor({
       >
         {tokenizerOn ? (
           <div className='mx-auto min-h-full w-full max-w-[48rem] cursor-default whitespace-pre-wrap break-words px-8 py-6 font-sans text-[var(--text-body)] text-sm'>
-            {tokenStrings.map((token, index) => (
-              <span
-                key={index}
-                style={{ backgroundColor: TOKEN_BG_COLORS[index % TOKEN_BG_COLORS.length] }}
-                onMouseEnter={() => setHoveredTokenIndex(index)}
-                onMouseLeave={() => setHoveredTokenIndex(null)}
-              >
-                {token}
-              </span>
-            ))}
+            {tokenStrings.map((token, index) => {
+              const sourceOffset = tokenOffset
+              tokenOffset += token.length
+              return (
+                <span
+                  key={`${sourceOffset}-${token.length}`}
+                  style={{ backgroundColor: TOKEN_BG_COLORS[index % TOKEN_BG_COLORS.length] }}
+                  onMouseEnter={() => setHoveredTokenIndex(index)}
+                  onMouseLeave={() => setHoveredTokenIndex(null)}
+                >
+                  {token}
+                </span>
+              )
+            })}
           </div>
         ) : (
           <textarea

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/search-highlight/search-highlight.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/search-highlight/search-highlight.tsx
@@ -26,23 +26,26 @@ export function SearchHighlight({ text, searchQuery, className = '' }: SearchHig
 
   const regex = new RegExp(`(${searchTerms.join('|')})`, 'gi')
   const parts = text.split(regex)
+  let sourceOffset = 0
 
   return (
     <span className={className}>
-      {parts.map((part, index) => {
+      {parts.map((part) => {
+        const partOffset = sourceOffset
+        sourceOffset += part.length
         if (!part) return null
 
         const isMatch = searchTerms.some((term) => new RegExp(term, 'gi').test(part))
 
         return isMatch ? (
           <span
-            key={index}
+            key={partOffset}
             className='bg-[var(--highlight-match-bg)] text-[var(--highlight-match-text)]'
           >
             {part}
           </span>
         ) : (
-          <span key={index}>{part}</span>
+          <span key={partOffset}>{part}</span>
         )
       })}
     </span>

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/status-bar/status-bar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/status-bar/status-bar.tsx
@@ -81,7 +81,7 @@ function StatusBarInner({
 
           return (
             <div
-              key={i}
+              key={segment.timestamp}
               role='button'
               tabIndex={0}
               aria-pressed={isSelected}

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/file-download/file-download.tsx
@@ -122,9 +122,9 @@ export function FileCards({ files, isExecutionFile = false, workspaceId }: FileC
   return (
     <div className='mt-1 flex flex-col gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2.5 py-2 dark:bg-transparent'>
       <span className='text-[var(--text-tertiary)] text-caption'>Files ({files.length})</span>
-      {files.map((file, index) => (
+      {files.map((file) => (
         <FileCard
-          key={file.id || `file-${index}`}
+          key={file.id || file.key}
           file={file}
           isExecutionFile={isExecutionFile}
           workspaceId={workspaceId}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
@@ -10,6 +10,7 @@ import {
   ChipModalField,
   ChipModalFooter,
   type ChipModalFooterAction,
+  type ChipModalFooterSecondaryAction,
   ChipModalHeader,
   cn,
   SecretInput,
@@ -17,6 +18,7 @@ import {
 import { ChevronDown, ChevronRight } from '@sim/emcn/icons'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
+import { generateShortId } from '@sim/utils/id'
 import type { McpAuthType, McpTransport } from '@/lib/mcp/types'
 import {
   checkEnvVarTrigger,
@@ -28,6 +30,7 @@ import { useMcpServerTest } from '@/hooks/queries/mcp'
 const logger = createLogger('McpServerFormModal')
 
 interface HeaderEntry {
+  id: string
   key: string
   value: string
 }
@@ -95,7 +98,7 @@ const DEFAULT_FORM_DATA: McpServerFormData = {
   transport: 'streamable-http',
   url: '',
   timeout: 30000,
-  headers: [{ key: '', value: '' }],
+  headers: [{ id: generateShortId(), key: '', value: '' }],
 }
 
 type InputFieldType = 'url' | 'header-key' | 'header-value'
@@ -293,7 +296,7 @@ function updateHeadersArray(
 
   const lastIdx = updated.length - 1
   if (index === lastIdx && updated[lastIdx] && (updated[lastIdx].key || updated[lastIdx].value)) {
-    updated.push({ key: '', value: '' })
+    updated.push({ id: generateShortId(), key: '', value: '' })
   }
 
   const lastIndex = updated.length - 1
@@ -619,14 +622,16 @@ export function McpServerFormModal({
     setSubmitError(null)
   }
 
-  const secondaryAction: ChipModalFooterAction | undefined =
+  const secondaryAction: ChipModalFooterSecondaryAction | undefined =
     mode === 'add'
       ? {
+          id: 'toggle-json-mode',
           label: formMode === 'form' ? 'Edit JSON' : 'Edit form',
           onClick: handleToggleJsonMode,
         }
       : formMode === 'form'
         ? {
+            id: 'test-connection',
             label: testButtonLabel,
             onClick: handleTestConnection,
             disabled: isTestingConnection || !isFormValid || isDomainBlocked,
@@ -726,7 +731,7 @@ export function McpServerFormModal({
               <div className='flex max-h-[140px] flex-col gap-2 overflow-y-auto'>
                 {(formData.headers || []).map((header, index) => (
                   <HeaderRow
-                    key={index}
+                    key={header.id}
                     header={header}
                     index={index}
                     headerScrollLeft={headerScrollLeft}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/mcp.tsx
@@ -5,6 +5,7 @@ import { Badge, Button, Chip, ChipConfirmModal, cn, Tooltip, toast } from '@sim/
 import { ArrowLeft, ChevronDown, Plus } from '@sim/emcn/icons'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
+import { generateShortId } from '@sim/utils/id'
 import { useParams } from 'next/navigation'
 import { useQueryState } from 'nuqs'
 import { McpIcon } from '@/components/icons'
@@ -154,12 +155,18 @@ function ServerListItem({
 }
 
 function buildEditInitialData(server: McpServer) {
-  const entries: { key: string; value: string }[] = server.headers
-    ? Object.entries(server.headers).map(([key, value]) => ({ key, value }))
+  const entries: { id: string; key: string; value: string }[] = server.headers
+    ? Object.entries(server.headers).map(([key, value]) => ({
+        id: generateShortId(),
+        key,
+        value,
+      }))
     : []
-  if (entries.length === 0) entries.push({ key: '', value: '' })
+  if (entries.length === 0) entries.push({ id: generateShortId(), key: '', value: '' })
   const last = entries[entries.length - 1]
-  if (last.key !== '' || last.value !== '') entries.push({ key: '', value: '' })
+  if (last.key !== '' || last.value !== '') {
+    entries.push({ id: generateShortId(), key: '', value: '' })
+  }
 
   return {
     name: server.name || '',

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/chat.tsx
@@ -1034,9 +1034,9 @@ export function Chat() {
                       File upload error
                     </div>
                     <div className='space-y-1'>
-                      {uploadErrors.map((err, idx) => (
-                        <div key={idx} className='text-[var(--text-error)] text-micro'>
-                          {err}
+                      {uploadErrors.map((error) => (
+                        <div key={error.id} className='text-[var(--text-error)] text-micro'>
+                          {error.message}
                         </div>
                       ))}
                     </div>

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/chat-message/chat-message.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/components/chat-message/chat-message.tsx
@@ -27,23 +27,30 @@ const WordWrap = ({ text }: { text: string }) => {
   if (!text) return null
 
   const parts = text.split(/(\s+)/g)
+  let sourceOffset = 0
 
   return (
     <>
-      {parts.map((part, index) => {
+      {parts.map((part) => {
+        const partOffset = sourceOffset
+        sourceOffset += part.length
+        if (!part) return null
         if (part.match(/\s+/) || part.length <= MAX_WORD_LENGTH) {
-          return <span key={index}>{part}</span>
+          return <span key={partOffset}>{part}</span>
         }
 
-        const chunks = []
+        const chunks: Array<{ sourceOffset: number; text: string }> = []
         for (let i = 0; i < part.length; i += MAX_WORD_LENGTH) {
-          chunks.push(part.substring(i, i + MAX_WORD_LENGTH))
+          chunks.push({
+            sourceOffset: partOffset + i,
+            text: part.substring(i, i + MAX_WORD_LENGTH),
+          })
         }
 
         return (
-          <span key={index} className='break-all'>
-            {chunks.map((chunk, chunkIndex) => (
-              <span key={chunkIndex}>{chunk}</span>
+          <span key={partOffset} className='break-all'>
+            {chunks.map((chunk) => (
+              <span key={chunk.sourceOffset}>{chunk.text}</span>
             ))}
           </span>
         )

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/hooks/use-chat-file-upload.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/hooks/use-chat-file-upload.test.tsx
@@ -61,7 +61,7 @@ describe('useChatFileUpload execution errors', () => {
       )
     })
 
-    expect(result().uploadErrors).toEqual([
+    expect(result().uploadErrors.map((error) => error.message)).toEqual([
       'Failed to upload report.pdf: Workspace file storage limit exceeded',
     ])
     expect(result().chatFiles).toHaveLength(1)
@@ -98,7 +98,33 @@ describe('useChatFileUpload execution errors', () => {
     })
 
     expect(result().chatFiles).toHaveLength(0)
-    expect(result().uploadErrors).toEqual(['oversized.pdf is too large (max 10MB)'])
+    expect(result().uploadErrors.map((error) => error.message)).toEqual([
+      'oversized.pdf is too large (max 10MB)',
+    ])
+
+    unmount()
+  })
+
+  it('gives duplicate error messages distinct stable identities', () => {
+    const { result, unmount } = renderChatFileUploadHook()
+    const files = [
+      new File(['first'], 'oversized.pdf', { type: 'application/pdf' }),
+      new File(['second'], 'oversized.pdf', { type: 'application/pdf' }),
+    ]
+    for (const file of files) {
+      Object.defineProperty(file, 'size', { value: MAX_CHAT_FILE_SIZE_BYTES + 1 })
+    }
+
+    act(() => {
+      result().addFiles(files)
+      vi.runAllTimers()
+    })
+
+    expect(result().uploadErrors.map((error) => error.message)).toEqual([
+      'oversized.pdf is too large (max 10MB)',
+      'oversized.pdf is too large (max 10MB)',
+    ])
+    expect(new Set(result().uploadErrors.map((error) => error.id)).size).toBe(2)
 
     unmount()
   })

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/hooks/use-chat-file-upload.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/chat/hooks/use-chat-file-upload.ts
@@ -9,6 +9,11 @@ export interface ChatFile {
   file: File
 }
 
+export interface ChatUploadError {
+  id: string
+  message: string
+}
+
 export const MAX_CHAT_FILES = 15
 export const MAX_CHAT_FILE_SIZE_BYTES = 10 * 1024 * 1024
 
@@ -18,7 +23,7 @@ export const MAX_CHAT_FILE_SIZE_BYTES = 10 * 1024 * 1024
  */
 export function useChatFileUpload() {
   const [chatFiles, setChatFiles] = useState<ChatFile[]>([])
-  const [uploadErrors, setUploadErrors] = useState<string[]>([])
+  const [uploadErrors, setUploadErrors] = useState<ChatUploadError[]>([])
   const [dragCounter, setDragCounter] = useState(0)
 
   const isDragOver = dragCounter > 0
@@ -31,13 +36,16 @@ export function useChatFileUpload() {
     setChatFiles((currentFiles) => {
       const remainingSlots = Math.max(0, MAX_CHAT_FILES - currentFiles.length)
       const candidateFiles = files.slice(0, remainingSlots)
-      const errors: string[] = []
+      const errors: ChatUploadError[] = []
       const validNewFiles: ChatFile[] = []
 
       for (const file of candidateFiles) {
         // Check file size
         if (file.size > MAX_CHAT_FILE_SIZE_BYTES) {
-          errors.push(`${file.name} is too large (max 10MB)`)
+          errors.push({
+            id: generateId(),
+            message: `${file.name} is too large (max 10MB)`,
+          })
           continue
         }
 
@@ -49,7 +57,7 @@ export function useChatFileUpload() {
           (newFile) => newFile.name === file.name && newFile.size === file.size
         )
         if (isDuplicateInCurrent || isDuplicateInNew) {
-          errors.push(`${file.name} already added`)
+          errors.push({ id: generateId(), message: `${file.name} already added` })
           continue
         }
 
@@ -88,7 +96,7 @@ export function useChatFileUpload() {
    * Surface an execution-time upload failure without removing the selected files.
    */
   const reportUploadError = useCallback((message: string) => {
-    setUploadErrors([message])
+    setUploadErrors([{ id: generateId(), message }])
   }, [])
 
   /**

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/version-description-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/deploy/components/deploy-modal/components/general/components/version-description-modal.tsx
@@ -164,6 +164,7 @@ export function VersionDescriptionModal({
           cancelDisabled={updateMutation.isPending || isGenerating}
           secondaryActions={[
             {
+              id: 'generate',
               label: isGenerating ? 'Generating...' : 'Generate',
               onClick: handleGenerateDescription,
               disabled: isGenerating || updateMutation.isPending,

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/messages-input/messages-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/messages-input/messages-input.tsx
@@ -542,11 +542,23 @@ export function MessagesInput({
     }
   }, [currentMessages.length])
 
+  const fallbackOccurrences = new Map<string, number>()
+  const keyedMessages = currentMessages.map((message, index) => {
+    const signature = `${message.role}\u0000${message.content}`
+    const occurrence = fallbackOccurrences.get(signature) ?? 0
+    fallbackOccurrences.set(signature, occurrence + 1)
+    return {
+      id: messageIdsRef.current[index] ?? `message:${signature}:${occurrence}`,
+      index,
+      message,
+    }
+  })
+
   return (
     <div className='flex w-full flex-col gap-2.5'>
-      {currentMessages.map((message, index) => (
+      {keyedMessages.map(({ id, index, message }) => (
         <div
-          key={messageIdsRef.current[index] ?? `fallback-${index}`}
+          key={id}
           className={cn(
             'relative flex w-full flex-col rounded-sm border border-[var(--border-1)] bg-[var(--surface-5)] transition-colors dark:bg-[var(--surface-5)]',
             disabled && 'opacity-50'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/components/custom-tool-modal/custom-tool-modal.tsx
@@ -391,6 +391,7 @@ export function CustomToolModal({
               isEditing
                 ? [
                     {
+                      id: 'delete',
                       label: 'Delete',
                       onClick: () => setShowDeleteConfirm(true),
                       variant: 'destructive',
@@ -412,11 +413,12 @@ export function CustomToolModal({
             secondaryActions={[
               isEditing
                 ? {
+                    id: 'delete',
                     label: 'Delete',
                     onClick: () => setShowDeleteConfirm(true),
                     variant: 'destructive',
                   }
-                : { label: 'Back', onClick: () => setActiveSection('schema') },
+                : { id: 'back', label: 'Back', onClick: () => setActiveSection('schema') },
             ]}
             primaryAction={{
               label: isEditing ? 'Update Tool' : 'Save Tool',

--- a/apps/sim/components/pii/custom-patterns-editor.test.tsx
+++ b/apps/sim/components/pii/custom-patterns-editor.test.tsx
@@ -81,4 +81,21 @@ describe('CustomPatternsEditor', () => {
     act(() => remove.dispatchEvent(new MouseEvent('click', { bubbles: true })))
     expect(onChange).toHaveBeenCalledWith([{ name: 'X', regex: 'b+', replacement: '<X>' }])
   })
+
+  it('preserves an existing row while rows are appended and truncated', () => {
+    const onChange = vi.fn()
+    const firstPattern = row('a+')
+    renderEditor([firstPattern], onChange)
+
+    const firstRegexInput = container.querySelector('input[value="a+"]') as HTMLInputElement
+    firstRegexInput.focus()
+
+    renderEditor([firstPattern, row('b+')], onChange)
+    expect(container.querySelector('input[value="a+"]')).toBe(firstRegexInput)
+    expect(document.activeElement).toBe(firstRegexInput)
+
+    renderEditor([firstPattern], onChange)
+    expect(container.querySelector('input[value="a+"]')).toBe(firstRegexInput)
+    expect(document.activeElement).toBe(firstRegexInput)
+  })
 })

--- a/apps/sim/components/pii/custom-patterns-editor.test.tsx
+++ b/apps/sim/components/pii/custom-patterns-editor.test.tsx
@@ -82,7 +82,7 @@ describe('CustomPatternsEditor', () => {
     expect(onChange).toHaveBeenCalledWith([{ name: 'X', regex: 'b+', replacement: '<X>' }])
   })
 
-  it('preserves an existing row while rows are appended and truncated', () => {
+  it('preserves rows while they are appended, edited, and truncated', () => {
     const onChange = vi.fn()
     const firstPattern = row('a+')
     renderEditor([firstPattern], onChange)
@@ -90,10 +90,18 @@ describe('CustomPatternsEditor', () => {
     const firstRegexInput = container.querySelector('input[value="a+"]') as HTMLInputElement
     firstRegexInput.focus()
 
-    renderEditor([firstPattern, row('b+')], onChange)
+    const secondPattern = row('b+')
+    renderEditor([firstPattern, secondPattern], onChange)
     expect(container.querySelector('input[value="a+"]')).toBe(firstRegexInput)
     expect(document.activeElement).toBe(firstRegexInput)
 
+    const secondRegexInput = container.querySelector('input[value="b+"]') as HTMLInputElement
+    secondRegexInput.focus()
+    renderEditor([firstPattern, { ...secondPattern, regex: 'b*' }], onChange)
+    expect(container.querySelector('input[value="b*"]')).toBe(secondRegexInput)
+    expect(document.activeElement).toBe(secondRegexInput)
+
+    firstRegexInput.focus()
     renderEditor([firstPattern], onChange)
     expect(container.querySelector('input[value="a+"]')).toBe(firstRegexInput)
     expect(document.activeElement).toBe(firstRegexInput)

--- a/apps/sim/components/pii/custom-patterns-editor.tsx
+++ b/apps/sim/components/pii/custom-patterns-editor.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import { useState } from 'react'
 import { Chip, ChipInput } from '@sim/emcn'
 import { Plus, Trash } from '@sim/emcn/icons'
+import { generateShortId } from '@sim/utils/id'
 import type { CustomPiiPattern } from '@/lib/guardrails/pii-entities'
 import { validateRegexPattern } from '@/lib/guardrails/validate_regex'
 
@@ -24,26 +26,42 @@ interface CustomPatternsEditorProps {
  * was removed rather than kept.
  */
 export function CustomPatternsEditor({ patterns, onChange }: CustomPatternsEditorProps) {
+  const [patternIds, setPatternIds] = useState(() => patterns.map(() => generateShortId()))
+
   function updateRow(index: number, patch: Partial<CustomPiiPattern>) {
     onChange(patterns.map((pattern, i) => (i === index ? { ...pattern, ...patch } : pattern)))
   }
 
   function removeRow(index: number) {
+    setPatternIds((current) => current.filter((_, i) => i !== index))
     onChange(patterns.filter((_, i) => i !== index))
   }
 
   function addRow() {
     if (patterns.length >= MAX_PATTERNS) return
+    setPatternIds((current) => [...current, generateShortId()])
     onChange([...patterns, { name: '', regex: '', replacement: '' }])
   }
 
+  const fallbackOccurrences = new Map<string, number>()
+  const rows = patterns.map((pattern, index) => {
+    const signature = `${pattern.name}\u0000${pattern.regex}\u0000${pattern.replacement}`
+    const occurrence = fallbackOccurrences.get(signature) ?? 0
+    fallbackOccurrences.set(signature, occurrence + 1)
+    return {
+      id: patternIds[index] ?? `pattern:${signature}:${occurrence}`,
+      index,
+      pattern,
+    }
+  })
+
   return (
     <div className='flex flex-col gap-2'>
-      {patterns.map((pattern, index) => {
+      {rows.map(({ id, index, pattern }) => {
         const validation = pattern.regex.length > 0 ? validateRegexPattern(pattern.regex) : null
         const error = validation && !validation.valid ? validation.error : undefined
         return (
-          <div key={index} className='flex flex-col gap-1'>
+          <div key={id} className='flex flex-col gap-1'>
             <div className='flex items-start gap-2'>
               <ChipInput
                 placeholder='Name'

--- a/apps/sim/components/pii/custom-patterns-editor.tsx
+++ b/apps/sim/components/pii/custom-patterns-editor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Chip, ChipInput } from '@sim/emcn'
 import { Plus, Trash } from '@sim/emcn/icons'
 import { generateShortId } from '@sim/utils/id'
@@ -27,6 +27,14 @@ interface CustomPatternsEditorProps {
  */
 export function CustomPatternsEditor({ patterns, onChange }: CustomPatternsEditorProps) {
   const [patternIds, setPatternIds] = useState(() => patterns.map(() => generateShortId()))
+
+  useEffect(() => {
+    setPatternIds((current) => {
+      if (current.length === patterns.length) return current
+      if (current.length > patterns.length) return current.slice(0, patterns.length)
+      return [...current, ...patterns.slice(current.length).map(() => generateShortId())]
+    })
+  }, [patterns.length])
 
   function updateRow(index: number, patch: Partial<CustomPiiPattern>) {
     onChange(patterns.map((pattern, i) => (i === index ? { ...pattern, ...patch } : pattern)))

--- a/apps/sim/ee/data-retention/components/data-retention-settings.tsx
+++ b/apps/sim/ee/data-retention/components/data-retention-settings.tsx
@@ -17,7 +17,7 @@ import {
 import { ArrowLeft, Plus } from '@sim/emcn/icons'
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
-import { generateId } from '@sim/utils/id'
+import { generateId, generateShortId } from '@sim/utils/id'
 import { CustomPatternsEditor } from '@/components/pii/custom-patterns-editor'
 import { saveDiscardActions } from '@/components/settings/save-discard-actions'
 import type { SettingsAction } from '@/components/settings/settings-header'
@@ -102,6 +102,7 @@ interface EditingPolicy {
   draft: PolicyDraft
   original: PolicyDraft
   isNew: boolean
+  editorKey: string
 }
 
 /** Day bounds the retention contract accepts (1 day … 5 years). */
@@ -364,6 +365,7 @@ function PiiLanguageSelect({ value, onChange }: PiiLanguageSelectProps) {
 }
 
 interface PiiStagePanelProps {
+  editorKey: string
   stageKey: PiiStageKey
   description: string
   value: PiiStagePolicy
@@ -375,7 +377,7 @@ interface PiiStagePanelProps {
  * stage is "on" purely by virtue of having entity types selected — `enabled` is
  * kept in sync with that, so there is no separate toggle.
  */
-function PiiStagePanel({ stageKey, description, value, onChange }: PiiStagePanelProps) {
+function PiiStagePanel({ editorKey, stageKey, description, value, onChange }: PiiStagePanelProps) {
   // Block outputs run in-flight on large payloads, so they are restricted to the
   // regex/checksum recognizers (no spaCy NER) — see the server fast path.
   const groups = getEntityGroupsForLanguage(value.language, {
@@ -432,6 +434,7 @@ function PiiStagePanel({ stageKey, description, value, onChange }: PiiStagePanel
           </Info>
         </div>
         <CustomPatternsEditor
+          key={`${editorKey}:${stageKey}`}
           patterns={value.customPatterns ?? []}
           onChange={(customPatterns) => update({ customPatterns })}
         />
@@ -441,6 +444,7 @@ function PiiStagePanel({ stageKey, description, value, onChange }: PiiStagePanel
 }
 
 interface PolicyDetailProps {
+  editorKey: string
   draft: PolicyDraft
   isNew: boolean
   changed: boolean
@@ -457,6 +461,7 @@ interface PolicyDetailProps {
 }
 
 function PolicyDetail({
+  editorKey,
   draft,
   isNew,
   changed,
@@ -641,6 +646,7 @@ function PolicyDetail({
                     />
                   )}
                   <PiiStagePanel
+                    editorKey={editorKey}
                     stageKey={effectiveStage}
                     description={activeStageMeta.description}
                     value={draft.piiStages[effectiveStage]}
@@ -843,7 +849,7 @@ export function DataRetentionSettings({ organizationId: orgId }: DataRetentionSe
       piiOverride: true,
       piiStages: defaultPii?.stages ?? emptyPiiStages(),
     }
-    setEditing({ draft, original: draft, isNew: false })
+    setEditing({ draft, original: draft, isNew: false, editorKey: generateShortId() })
   }
 
   function openAddOverride() {
@@ -857,7 +863,7 @@ export function DataRetentionSettings({ organizationId: orgId }: DataRetentionSe
       piiOverride: false,
       piiStages: emptyPiiStages(),
     }
-    setEditing({ draft, original: draft, isNew: true })
+    setEditing({ draft, original: draft, isNew: true, editorKey: generateShortId() })
   }
 
   function openEditOverride(workspaceId: string) {
@@ -872,7 +878,7 @@ export function DataRetentionSettings({ organizationId: orgId }: DataRetentionSe
       piiOverride: Boolean(pii),
       piiStages: pii?.stages ?? emptyPiiStages(),
     }
-    setEditing({ draft, original: draft, isNew: false })
+    setEditing({ draft, original: draft, isNew: false, editorKey: generateShortId() })
   }
 
   function closeEditing() {
@@ -880,7 +886,9 @@ export function DataRetentionSettings({ organizationId: orgId }: DataRetentionSe
   }
 
   function handleDiscard() {
-    if (editing) setEditing({ ...editing, draft: editing.original })
+    if (editing) {
+      setEditing({ ...editing, draft: editing.original, editorKey: generateShortId() })
+    }
   }
 
   async function savePolicy() {
@@ -970,6 +978,7 @@ export function DataRetentionSettings({ organizationId: orgId }: DataRetentionSe
     <>
       {editing ? (
         <PolicyDetail
+          editorKey={editing.editorKey}
           draft={editing.draft}
           isNew={editing.isNew}
           changed={editingChanged}

--- a/apps/sim/ee/workspace-forking/components/fork-sync/fork-sync-view.tsx
+++ b/apps/sim/ee/workspace-forking/components/fork-sync/fork-sync-view.tsx
@@ -15,6 +15,7 @@ import {
 } from '@sim/emcn'
 import { ArrowRight } from '@sim/emcn/icons'
 import type {
+  ForkClearedRef,
   ForkCopyableUnmapped,
   ForkDependentReconfig,
   ForkMappingEntry,
@@ -69,6 +70,20 @@ const COPYABLE_KIND_SECTIONS: ReadonlyArray<{
   { kind: 'skill', label: 'Skills' },
   { kind: 'mcp-server', label: 'MCP servers' },
 ]
+
+function withOccurrenceKeys<T>(items: T[], getSignature: (item: T) => string) {
+  const occurrences = new Map<string, number>()
+  return items.map((item, index) => {
+    const signature = getSignature(item)
+    const occurrence = occurrences.get(signature) ?? 0
+    occurrences.set(signature, occurrence + 1)
+    return { item, index, key: `${signature}:${occurrence}` }
+  })
+}
+
+function clearedRefSignature(ref: ForkClearedRef): string {
+  return `${ref.cause}:${ref.targetWorkflowId}:${ref.blockId}:${ref.kind}:${ref.sourceId}:${ref.fieldLabel}`
+}
 
 /**
  * Sentinel option value for the "New copy" entry - the displayed resolution while a copyable
@@ -763,6 +778,14 @@ export function ForkSyncView({ controller, onDirectionChange }: ForkSyncViewProp
     })),
   ]
 
+  const workflowChanges = withOccurrenceKeys(
+    controller.workflowChanges,
+    (change) => `${change.action}:${change.currentName}:${change.otherName}`
+  )
+  const keyedExcludedRows = withOccurrenceKeys(excludedRows, (row) => `${row.name}:${row.tooltip}`)
+  const blockingRefs = withOccurrenceKeys(controller.blockingRefs, clearedRefSignature)
+  const dependentClears = withOccurrenceKeys(controller.dependentClears, clearedRefSignature)
+
   return (
     <div className='flex flex-col gap-7'>
       <SettingsSection label='Sync direction'>
@@ -803,13 +826,10 @@ export function ForkSyncView({ controller, onDirectionChange }: ForkSyncViewProp
           {controller.workflowChanges.length + excludedRows.length > 0 ? (
             <Tooltip.Provider delayDuration={150}>
               <div className='flex flex-col gap-1'>
-                {controller.workflowChanges.map((change, index) => {
+                {workflowChanges.map(({ item: change, key }) => {
                   const renamed = change.currentName !== change.otherName
                   return (
-                    <div
-                      key={`${change.action}:${change.currentName}:${index}`}
-                      className='flex min-w-0 items-center gap-1.5'
-                    >
+                    <div key={key} className='flex min-w-0 items-center gap-1.5'>
                       <span className='min-w-0 truncate text-[var(--text-body)] text-sm'>
                         {change.currentName}
                       </span>
@@ -824,8 +844,8 @@ export function ForkSyncView({ controller, onDirectionChange }: ForkSyncViewProp
                     </div>
                   )
                 })}
-                {excludedRows.map(({ name, tooltip }, index) => (
-                  <div key={`excluded:${name}:${index}`} className='flex min-w-0 items-center'>
+                {keyedExcludedRows.map(({ item: { name, tooltip }, key }) => (
+                  <div key={key} className='flex min-w-0 items-center'>
                     <Tooltip.Root>
                       <Tooltip.Trigger asChild>
                         <span className='min-w-0 max-w-full truncate text-[var(--text-muted)] text-sm'>
@@ -950,12 +970,12 @@ export function ForkSyncView({ controller, onDirectionChange }: ForkSyncViewProp
           }
         >
           <div className='flex flex-col gap-1'>
-            {controller.blockingRefs.map((ref, index) => {
+            {blockingRefs.map(({ item: ref, index, key }) => {
               const dropKey = `${ref.kind}:${ref.sourceId}`
               const uses = controller.blockingUsesByResource.get(dropKey) ?? 1
               return (
                 <div
-                  key={`${ref.targetWorkflowId}:${ref.blockId}:${ref.kind}:${ref.sourceId}:${ref.fieldLabel}:${index}`}
+                  key={key}
                   className='flex min-w-0 items-start justify-between gap-3 text-[var(--text-secondary)] text-small'
                 >
                   <span className='min-w-0'>
@@ -994,12 +1014,12 @@ export function ForkSyncView({ controller, onDirectionChange }: ForkSyncViewProp
       {controller.dependentClears.length > 0 ? (
         <SettingsSection label='Will be cleared'>
           <div className='flex flex-col gap-1'>
-            {controller.dependentClears.map((ref, index) => {
+            {dependentClears.map(({ item: ref, key }) => {
               const droppedKey = `${ref.kind}:${ref.sourceId}`
               const dropped = controller.droppedRefs.has(droppedKey)
               return (
                 <div
-                  key={`${ref.targetWorkflowId}:${ref.blockId}:${ref.kind}:${ref.sourceId}:${ref.fieldLabel}:${index}`}
+                  key={key}
                   className='flex min-w-0 items-start justify-between gap-3 text-[var(--text-secondary)] text-small'
                 >
                   <span className='min-w-0'>

--- a/apps/sim/lib/content/faq.tsx
+++ b/apps/sim/lib/content/faq.tsx
@@ -1,21 +1,38 @@
 export function FAQ({ items }: { items: { q: string; a: string }[] }) {
   if (!items || items.length === 0) return null
+  const occurrences = new Map<string, number>()
   return (
     <section className='mt-12' itemScope itemType='https://schema.org/FAQPage'>
       <h2 className='mb-4 font-medium text-[24px] text-[var(--text-primary)]'>FAQ</h2>
       <div className='space-y-6'>
-        {items.map((it, i) => (
-          <div key={i} itemScope itemType='https://schema.org/Question' itemProp='mainEntity'>
-            <h3 className='mb-2 font-medium text-[20px] text-[var(--text-primary)]' itemProp='name'>
-              {it.q}
-            </h3>
-            <div itemScope itemType='https://schema.org/Answer' itemProp='acceptedAnswer'>
-              <p className='text-[19px] text-[var(--text-subtle)] leading-relaxed' itemProp='text'>
-                {it.a}
-              </p>
+        {items.map((it) => {
+          const signature = `${it.q}\u0000${it.a}`
+          const occurrence = occurrences.get(signature) ?? 0
+          occurrences.set(signature, occurrence + 1)
+          return (
+            <div
+              key={`${signature}\u0000${occurrence}`}
+              itemScope
+              itemType='https://schema.org/Question'
+              itemProp='mainEntity'
+            >
+              <h3
+                className='mb-2 font-medium text-[20px] text-[var(--text-primary)]'
+                itemProp='name'
+              >
+                {it.q}
+              </h3>
+              <div itemScope itemType='https://schema.org/Answer' itemProp='acceptedAnswer'>
+                <p
+                  className='text-[19px] text-[var(--text-subtle)] leading-relaxed'
+                  itemProp='text'
+                >
+                  {it.a}
+                </p>
+              </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </section>
   )

--- a/packages/emcn/src/components/chip-emails-input/chip-emails-input.tsx
+++ b/packages/emcn/src/components/chip-emails-input/chip-emails-input.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import { generateShortId } from '@sim/utils/id'
 import { isValidEmailSyntax, normalizeEmail } from '@sim/utils/string'
 import { TagInput, type TagItem } from '../tag-input/tag-input'
 
@@ -84,7 +85,7 @@ export function ChipEmailsInput({
   id,
 }: ChipEmailsInputProps) {
   const [items, setItems] = React.useState<TagItem[]>(() =>
-    value.map((v) => ({ value: v, isValid: true }))
+    value.map((v) => ({ id: generateShortId(), value: v, isValid: true }))
   )
 
   /**
@@ -113,7 +114,7 @@ export function ChipEmailsInput({
     if (prevValid.length === value.length && prevValid.every((v, idx) => v === value[idx])) {
       return
     }
-    itemsRef.current = value.map((v) => ({ value: v, isValid: true }))
+    itemsRef.current = value.map((v) => ({ id: generateShortId(), value: v, isValid: true }))
     setItems(itemsRef.current)
   }, [value])
 
@@ -128,6 +129,7 @@ export function ChipEmailsInput({
         commitItems([
           ...current,
           {
+            id: generateShortId(),
             value: email,
             isValid: false,
             error: allowDomains ? 'Invalid email or domain' : 'Invalid email format',
@@ -138,11 +140,14 @@ export function ChipEmailsInput({
 
       const reason = validate?.(email)
       if (reason) {
-        commitItems([...current, { value: email, isValid: false, error: reason }])
+        commitItems([
+          ...current,
+          { id: generateShortId(), value: email, isValid: false, error: reason },
+        ])
         return false
       }
 
-      const next = [...current, { value: email, isValid: true }]
+      const next = [...current, { id: generateShortId(), value: email, isValid: true }]
       commitItems(next)
       onChange(next.filter((item) => item.isValid).map((item) => item.value))
       return true

--- a/packages/emcn/src/components/chip-modal/chip-modal.tsx
+++ b/packages/emcn/src/components/chip-modal/chip-modal.tsx
@@ -1048,8 +1048,13 @@ export interface ChipModalFooterCustomAction {
   custom: React.ReactNode
 }
 
-/** One entry of the footer's left-docked `secondaryActions` cluster. */
+/** Declarative or custom action accepted by a footer slot. */
 export type ChipModalFooterSlotAction = ChipModalFooterAction | ChipModalFooterCustomAction
+
+/** A footer slot action with the stable identity required by `secondaryActions`. */
+export type ChipModalFooterSecondaryAction =
+  | (ChipModalFooterAction & { id: string })
+  | (ChipModalFooterCustomAction & { id: string })
 
 export interface ChipModalFooterProps {
   /**
@@ -1103,7 +1108,7 @@ export interface ChipModalFooterProps {
    * each entry is a constrained {@link ChipModalFooterSlotAction} — consumers
    * describe intent, never chrome.
    */
-  secondaryActions?: ChipModalFooterSlotAction[]
+  secondaryActions?: ChipModalFooterSecondaryAction[]
 }
 
 /**
@@ -1217,8 +1222,8 @@ function ChipModalFooter({
       leftSlot={
         secondaryActions && secondaryActions.length > 0 ? (
           <div className='flex min-w-0 flex-wrap items-center gap-2'>
-            {secondaryActions.map((action, index) => (
-              <React.Fragment key={index}>{renderFooterSlotAction(action)}</React.Fragment>
+            {secondaryActions.map((action) => (
+              <React.Fragment key={action.id}>{renderFooterSlotAction(action)}</React.Fragment>
             ))}
           </div>
         ) : undefined

--- a/packages/emcn/src/components/chip-select/chip-select.tsx
+++ b/packages/emcn/src/components/chip-select/chip-select.tsx
@@ -181,6 +181,14 @@ export function ChipSelect({
       .filter((g) => g.items.length > 0)
   }, [searchable, query, sections])
 
+  const sectionOccurrences = new Map<string, number>()
+  const keyedSections = filteredSections.map((group) => {
+    const signature = group.section ?? group.items.map((item) => item.value).join('\u0000')
+    const occurrence = sectionOccurrences.get(signature) ?? 0
+    sectionOccurrences.set(signature, occurrence + 1)
+    return { group, key: `${signature}\u0000${occurrence}` }
+  })
+
   const hasResults = filteredSections.some((g) => g.items.length > 0)
 
   const toggleValue = (val: string) => {
@@ -293,8 +301,8 @@ export function ChipSelect({
         ) : null}
 
         {hasResults ? (
-          filteredSections.map((group, index) => (
-            <React.Fragment key={group.section ?? `group-${index}`}>
+          keyedSections.map(({ group, key }) => (
+            <React.Fragment key={key}>
               {group.section ? <DropdownMenuLabel>{group.section}</DropdownMenuLabel> : null}
               {group.items.map(renderOption)}
             </React.Fragment>

--- a/packages/emcn/src/components/index.ts
+++ b/packages/emcn/src/components/index.ts
@@ -69,6 +69,7 @@ export {
   type ChipModalFooterAction,
   type ChipModalFooterCustomAction,
   type ChipModalFooterProps,
+  type ChipModalFooterSecondaryAction,
   type ChipModalFooterSlotAction,
   ChipModalHeader,
   type ChipModalHeaderProps,

--- a/packages/emcn/src/components/tag-input/tag-input.tsx
+++ b/packages/emcn/src/components/tag-input/tag-input.tsx
@@ -4,6 +4,7 @@
  * @example
  * ```tsx
  * import { TagInput, type TagItem } from '../../index'
+ * import { generateShortId } from '@sim/utils/id'
  *
  * const [items, setItems] = useState<TagItem[]>([])
  *
@@ -11,7 +12,7 @@
  *   items={items}
  *   onAdd={(value) => {
  *     const isValid = isValidEmail(value)
- *     setItems(prev => [...prev, { value, isValid }])
+ *     setItems(prev => [...prev, { id: generateShortId(), value, isValid }])
  *     return isValid
  *   }}
  *   onRemove={(value, index) => {
@@ -81,6 +82,8 @@ const tagInputVariants = cva(
  * Represents a tag item with its value and validity status.
  */
 export interface TagItem {
+  /** Stable identity retained while the tag is edited, reordered, or removed. */
+  id: string
   value: string
   isValid: boolean
   /**
@@ -402,7 +405,7 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
         )}
         {items.map((item, index) => (
           <TagInputTag
-            key={`item-${index}`}
+            key={item.id}
             item={item}
             index={index}
             onRemove={onRemove}

--- a/packages/workflow-renderer/src/workflow-block/canvas-sentence-view.tsx
+++ b/packages/workflow-renderer/src/workflow-block/canvas-sentence-view.tsx
@@ -41,13 +41,21 @@ export interface CanvasSentenceViewProps {
  * clauses differently in one of them reads as a rendering bug.
  */
 export function CanvasSentenceView({ segments, renderChip }: CanvasSentenceViewProps) {
+  const occurrences = new Map<string, number>()
   return (
     <p className='min-w-0 break-words text-[var(--text-muted)] text-sm leading-6'>
       {segments.map((segment, index) => {
+        const signature =
+          typeof segment === 'string'
+            ? `text:${segment}`
+            : `value:${segment.subBlockId}:${segment.noun ?? ''}`
+        const occurrence = occurrences.get(signature) ?? 0
+        occurrences.set(signature, occurrence + 1)
+        const key = `${signature}:${occurrence}`
         if (typeof segment === 'string') {
           const hugsPrevious = segment.startsWith(',') || segment.startsWith('.')
           const glue = index > 0 && !hugsPrevious ? ' ' : ''
-          return <Fragment key={`text-${index}`}>{`${glue}${segment}`}</Fragment>
+          return <Fragment key={key}>{`${glue}${segment}`}</Fragment>
         }
 
         /* A core slot keeps its place with the field's noun; an optional one
@@ -64,7 +72,7 @@ export function CanvasSentenceView({ segments, renderChip }: CanvasSentenceViewP
         /* The space before `{chip}` is significant — JSX keeps whitespace
            between text and an expression on the same line. It is what
            separates a chip from the copy in front of it. */
-        return <Fragment key={`value-${index}`}> {chip}</Fragment>
+        return <Fragment key={key}> {chip}</Fragment>
       })}
     </p>
   )


### PR DESCRIPTION
## Summary

Dynamic lists now keep each row's identity through duplicate values, deletion, filtering, and redaction-stage changes. This prevents focus, entered text, or submitted data from moving to the wrong row after React reconciles a changed list.

| Metric | Before | This PR |
| --- | ---: | ---: |
| Array-index key warnings | 44 | 0 |

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- `npx react-doctor@latest --verbose`: `no-array-index-as-key` is 0
- Sim focused suites: 207 tests passed across 9 files
- EMCN focused suites: 21 tests passed across 2 files
- Added controlled rerender coverage for stable PII pattern-row identity
- Both commits were verified as patch-equivalent after rebasing this PR onto `staging`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Not captured. The behavior is covered by focused tests that add, remove, and rerender controlled rows.

## Post-Deploy Monitoring & Validation

- Validation window: first 24 hours after deploy; owner: PR author
- Healthy signal: no increase in client errors on affected list and editor surfaces, and no wrong-row reports
- Failure signal: a reproducible focus, value, or action transfer between sibling rows
- Mitigation trigger: revert this PR if stable identity causes a list regression
