### PR TITLE
perf(react): hoist static render values

### DIFF
--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -9,6 +9,16 @@ export const revalidate = 0
 const DEFAULT_SEARCH_LIMIT = 10
 const MAX_SEARCH_LIMIT = 20
 
+/** Uses PostgreSQL's simple text-search configuration for unsupported Japanese and Chinese. */
+const LOCALE_MAP: Record<string, string> = {
+  en: 'english',
+  es: 'spanish',
+  fr: 'french',
+  de: 'german',
+  ja: 'simple',
+  zh: 'simple',
+}
+
 function getSearchLimit(value: unknown): number {
   const limit = Number.parseInt(String(value ?? DEFAULT_SEARCH_LIMIT), 10)
 
@@ -44,15 +54,7 @@ export async function GET(request: NextRequest) {
     const candidateLimit = limit * 3
     const similarityThreshold = 0.6
 
-    const localeMap: Record<string, string> = {
-      en: 'english',
-      es: 'spanish',
-      fr: 'french',
-      de: 'german',
-      ja: 'simple', // PostgreSQL doesn't have Japanese support, use simple
-      zh: 'simple', // PostgreSQL doesn't have Chinese support, use simple
-    }
-    const tsConfig = localeMap[locale] || 'simple'
+    const tsConfig = LOCALE_MAP[locale] || 'simple'
 
     const useVectorSearch = locale === 'en'
     let vectorResults: Array<{

--- a/apps/sim/app/(landing)/comparisons/page.tsx
+++ b/apps/sim/app/(landing)/comparisons/page.tsx
@@ -10,6 +10,14 @@ import { JsonLd } from '@/app/(landing)/components/json-ld'
 import { LandingFAQ } from '@/app/(landing)/components/landing-faq'
 
 const baseUrl = SITE_URL
+const BREADCRUMB_JSON_LD = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
+    { '@type': 'ListItem', position: 2, name: 'Comparisons', item: `${baseUrl}/comparisons` },
+  ],
+}
 
 export const revalidate = 3600
 
@@ -60,15 +68,6 @@ export const metadata: Metadata = buildLandingMetadata({
 })
 
 export default function ComparisonHubPage() {
-  const breadcrumbJsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: [
-      { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
-      { '@type': 'ListItem', position: 2, name: 'Comparisons', item: `${baseUrl}/comparisons` },
-    ],
-  }
-
   const itemListJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
@@ -96,7 +95,7 @@ export default function ComparisonHubPage() {
 
   return (
     <>
-      <JsonLd data={breadcrumbJsonLd} />
+      <JsonLd data={BREADCRUMB_JSON_LD} />
       <JsonLd data={itemListJsonLd} />
       <JsonLd data={faqJsonLd} />
 

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/line-chart/line-chart.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/dashboard/components/line-chart/line-chart.tsx
@@ -3,6 +3,8 @@ import { Button, cn } from '@sim/emcn'
 import { generateShortId } from '@sim/utils/id'
 import { formatDate, formatLatency } from '@/app/workspace/[workspaceId]/logs/utils'
 
+const CHART_PADDING = { top: 16, right: 28, bottom: 26, left: 26 } as const
+
 export interface LineChartPoint {
   timestamp: string
   value: number
@@ -34,7 +36,7 @@ function LineChartComponent({
   const [containerWidth, setContainerWidth] = useState<number | null>(null)
   const width = containerWidth ?? 0
   const height = 166
-  const padding = { top: 16, right: 28, bottom: 26, left: 26 }
+  const padding = CHART_PADDING
   useEffect(() => {
     if (!containerRef.current) return
     const element = containerRef.current

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/tag-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/tag-dropdown.tsx
@@ -40,6 +40,7 @@ import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 import type { BlockState } from '@/stores/workflows/workflow/types'
 
 const EMPTY_VARIABLES: Variable[] = []
+const EMPTY_VARIABLE_INFO_MAP: Record<string, { type: string; id: string }> = {}
 
 /**
  * Context for sharing nested navigation state between components.
@@ -1001,8 +1002,6 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
     [inputValue, cursorPosition]
   )
 
-  const emptyVariableInfoMap: Record<string, { type: string; id: string }> = {}
-
   /**
    * Computes tags, variable info, and block tag groups
    */
@@ -1010,7 +1009,7 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
     if (activeSourceBlockId) {
       const sourceBlock = blocks[activeSourceBlockId]
       if (!sourceBlock) {
-        return { tags: [], variableInfoMap: emptyVariableInfoMap, blockTagGroups: [] }
+        return { tags: [], variableInfoMap: EMPTY_VARIABLE_INFO_MAP, blockTagGroups: [] }
       }
 
       const blockConfig = getBlock(sourceBlock.type)
@@ -1034,9 +1033,9 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
             },
           ]
 
-          return { tags: blockTags, variableInfoMap: emptyVariableInfoMap, blockTagGroups }
+          return { tags: blockTags, variableInfoMap: EMPTY_VARIABLE_INFO_MAP, blockTagGroups }
         }
-        return { tags: [], variableInfoMap: emptyVariableInfoMap, blockTagGroups: [] }
+        return { tags: [], variableInfoMap: EMPTY_VARIABLE_INFO_MAP, blockTagGroups: [] }
       }
 
       const mergedSubBlocks = getMergedSubBlocks(activeSourceBlockId)
@@ -1063,12 +1062,12 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
         },
       ]
 
-      return { tags: blockTags, variableInfoMap: emptyVariableInfoMap, blockTagGroups }
+      return { tags: blockTags, variableInfoMap: EMPTY_VARIABLE_INFO_MAP, blockTagGroups }
     }
 
     const hasInvalidBlocks = Object.values(blocks).some((block) => !block || !block.type)
     if (hasInvalidBlocks) {
-      return { tags: [], variableInfoMap: emptyVariableInfoMap, blockTagGroups: [] }
+      return { tags: [], variableInfoMap: EMPTY_VARIABLE_INFO_MAP, blockTagGroups: [] }
     }
 
     const starterBlock = Object.values(blocks).find((block) => block.type === 'starter')


### PR DESCRIPTION
## Summary

Four values that do not depend on a render or request are now created once at module load. This removes repeated allocation and gives consumers a stable reference without changing their values.

The two remaining React Doctor warnings are intentional: `scrollingBoxes` and `frozenBoxes` are filled during each render, so hoisting them would leak stale collaborator selections.

| Metric | Before | This PR |
| --- | ---: | ---: |
| Static-value warnings | 6 | 2 confirmed false positives |

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: Performance and maintainability improvement

## Testing

- `npx react-doctor@latest --verbose`: only the 2 mutable-array false positives remain
- `bun run check:api-validation` passed
- Biome passed for the 4 files changed in this PR
- Patch equivalence was verified after rebasing this PR onto `staging`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Not applicable. The hoisted values and their runtime contents are unchanged.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. These constants preserve their previous values and do not change user-visible behavior.
