### PR TITLE
improvement(settings): drop the Privacy row's description

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
@@ -555,16 +555,9 @@ export function General() {
         </SettingsSection>
 
         <SettingsSection label='Privacy'>
-          <div className='flex flex-col gap-3'>
-            <div className='flex items-center justify-between'>
-              <Label>Privacy settings</Label>
-              <Chip onClick={() => setView('privacy')}>Manage</Chip>
-            </div>
-            <p className='text-[var(--text-muted)] text-small'>
-              {isHosted
-                ? 'Choose what Sim may collect about how you use it — anonymous telemetry, and which cookies this browser allows.'
-                : 'Choose what Sim may collect about how you use it.'}
-            </p>
+          <div className='flex items-center justify-between'>
+            <Label>Privacy settings</Label>
+            <Chip onClick={() => setView('privacy')}>Manage</Chip>
           </div>
         </SettingsSection>
 


### PR DESCRIPTION
## Summary

Removes the description under the **Privacy settings** row in General settings.

The row already reads "Privacy settings" with a **Manage** chip, and the sub-view it opens carries its own title and description ("Privacy — Control what Sim collects about how you use it."). The sentence beneath the row restated that a step before the user had asked for it.

Also drops the `flex flex-col gap-3` wrapper the paragraph shared with the row — with the paragraph gone, the row is the section's only child and the wrapper does nothing.

Note the Account section below keeps its description on purpose: "Delete account" is destructive and irreversible, so the consequence belongs on the row rather than one click away.

## Type of Change
- [x] Other: copy/layout cleanup

## Testing

`type-check`, `lint:check`, all 29 `check:audits`, and 199 tests pass. No behavior change — `isHosted` is still imported and used by the Home page action above.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
