### PR TITLE
improvement(settings): drop the Delete account row's description

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
@@ -563,15 +563,9 @@ export function General() {
 
         {!isAuthDisabled && (
           <SettingsSection label='Account'>
-            <div className='flex flex-col gap-3'>
-              <div className='flex items-center justify-between'>
-                <Label>Delete account</Label>
-                <Chip onClick={() => setShowDeleteAccountModal(true)}>Delete</Chip>
-              </div>
-              <p className='text-[var(--text-muted)] text-small'>
-                Permanently deletes your account and everything only you can reach — workflows,
-                chats, files, knowledge bases and credentials. This cannot be undone.
-              </p>
+            <div className='flex items-center justify-between'>
+              <Label>Delete account</Label>
+              <Chip onClick={() => setShowDeleteAccountModal(true)}>Delete</Chip>
             </div>
           </SettingsSection>
         )}


### PR DESCRIPTION
## Summary

Removes the description under the **Delete account** row in General settings, matching #6844 which did the same for the Privacy row.

I checked that the warning isn't lost: the confirmation modal already carries it, and carries it better than the row did. It names the account being deleted, enumerates the workspaces that go with it, notes which ones transfer billing to another admin instead, marks **This cannot be undone** in the error color, and requires typing the account email before the destructive action is enabled.

So the consequence is stated at the point of action rather than one click early, which is where it does the work.

Also drops the `flex flex-col gap-3` wrapper the paragraph shared with the row — with the paragraph gone, the row is the section's only child.

## Type of Change
- [x] Other: copy/layout cleanup

## Testing

`type-check`, `lint:check`, all 29 `check:audits`, and 199 tests pass. No behavior change — only the row's static copy is removed; the modal, its guards, and the delete flow are untouched.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
