### PR TITLE
fix(connectors): treat a zero-byte source file as nothing to index

### DIFF
--- a/apps/sim/connectors/onedrive/onedrive.ts
+++ b/apps/sim/connectors/onedrive/onedrive.ts
@@ -8,6 +8,7 @@ import {
   ConnectorFileTooLargeError,
   connectorFileExtension,
   extractConnectorText,
+  hasIndexablePayload,
   isIndexableConnectorFile,
   isSkippedDocument,
   markSkipped,
@@ -383,7 +384,7 @@ export const onedriveConnector: ConnectorConfig = {
 
     try {
       const payload = await fetchFilePayload(accessToken, item.id, item.name)
-      if (!payload.sourceFile && !payload.content.trim()) return null
+      if (!hasIndexablePayload(payload)) return null
 
       const stub = fileToStub(item)
       return { ...stub, ...payload, contentDeferred: false }

--- a/apps/sim/connectors/sharepoint/sharepoint.ts
+++ b/apps/sim/connectors/sharepoint/sharepoint.ts
@@ -8,6 +8,7 @@ import {
   ConnectorFileTooLargeError,
   connectorFileExtension,
   extractConnectorText,
+  hasIndexablePayload,
   isIndexableConnectorFile,
   isSkippedDocument,
   markSkipped,
@@ -931,7 +932,7 @@ export const sharepointConnector: ConnectorConfig = {
 
     try {
       const payload = await fetchFilePayload(accessToken, driveId, item.id, item.name)
-      if (!payload.sourceFile && !payload.content.trim()) return null
+      if (!hasIndexablePayload(payload)) return null
 
       const stub = itemToStub(item, siteName ?? siteUrl)
       return { ...stub, ...payload, contentDeferred: false }

--- a/apps/sim/connectors/utils.test.ts
+++ b/apps/sim/connectors/utils.test.ts
@@ -63,6 +63,7 @@ import { typeformConnector } from '@/connectors/typeform/typeform'
 import {
   ConnectorFileTooLargeError,
   extractConnectorText,
+  hasIndexablePayload,
   htmlToPlainText,
   isIndexableConnectorFile,
   isSkippedDocument,
@@ -1480,5 +1481,35 @@ describe('pipelineParsedMimeType', () => {
     expect(pipelineParsedMimeType('REPORT.PDF')).toBe('application/pdf')
     expect(pipelineParsedMimeType('archive.zip')).toBeUndefined()
     expect(pipelineParsedMimeType('README')).toBeUndefined()
+  })
+})
+
+describe('hasIndexablePayload', () => {
+  const bytes = (value: string) => ({
+    bytes: Buffer.from(value),
+    fileName: 'Report.pdf',
+    mimeType: 'application/pdf',
+  })
+
+  it('accepts a source file with bytes', () => {
+    expect(hasIndexablePayload({ content: '', sourceFile: bytes('%PDF') })).toBe(true)
+  })
+
+  it('accepts extracted text', () => {
+    expect(hasIndexablePayload({ content: 'notes' })).toBe(true)
+  })
+
+  /**
+   * Observed in production: a zero-byte PDF was stored and shipped to OCR, which
+   * answered `400 Bad Request` — an external call billed to discover the file was
+   * empty, reported as an API fault rather than as an empty file. Before source
+   * files existed this was dropped at the empty-content check.
+   */
+  it('rejects a zero-byte source file rather than sending it to OCR', () => {
+    expect(hasIndexablePayload({ content: '', sourceFile: bytes('') })).toBe(false)
+  })
+
+  it('rejects blank text', () => {
+    expect(hasIndexablePayload({ content: '   ' })).toBe(false)
   })
 })

--- a/apps/sim/connectors/utils.ts
+++ b/apps/sim/connectors/utils.ts
@@ -227,6 +227,21 @@ export function isIndexableConnectorFile(fileName: string): boolean {
 }
 
 /**
+ * Whether a document carries anything worth indexing.
+ *
+ * A source file has to have bytes. A zero-byte file is not payload: it produces an
+ * empty stored object, and for a PDF that reaches OCR as an empty request and comes
+ * back as an opaque `400 Bad Request` — billing an external call to learn the file
+ * was empty, and reporting it as an API fault rather than as what it is.
+ */
+export function hasIndexablePayload(
+  doc: Pick<ExternalDocument, 'content' | 'sourceFile'>
+): boolean {
+  if (doc.sourceFile) return doc.sourceFile.bytes.length > 0
+  return doc.content.trim().length > 0
+}
+
+/**
  * MIME type to store a file under when the shared pipeline should parse it, or
  * `undefined` when the connector should decode it as text itself.
  *

--- a/apps/sim/lib/knowledge/connectors/sync-engine.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.ts
@@ -33,6 +33,7 @@ import type {
   ExternalDocument,
   SyncResult,
 } from '@/connectors/types'
+import { hasIndexablePayload } from '@/connectors/utils'
 
 const logger = createLogger('ConnectorSyncEngine')
 
@@ -157,7 +158,7 @@ export function classifyExternalDoc(
   if (extDoc.skippedReason) {
     return existing ? { type: 'unchanged' } : { type: 'skip' }
   }
-  if (!hasPayload(extDoc) && !extDoc.contentDeferred) {
+  if (!hasIndexablePayload(extDoc) && !extDoc.contentDeferred) {
     return { type: 'drop' }
   }
   if (!existing) {
@@ -201,11 +202,6 @@ export function mergeHydratedDocument(
     sourceUrl: hydrated.sourceUrl ?? stub.sourceUrl,
     metadata: { ...stub.metadata, ...hydrated.metadata },
   }
-}
-
-/** Whether a document carries anything to index — extracted text or the source file. */
-function hasPayload(extDoc: Pick<ExternalDocument, 'content' | 'sourceFile'>): boolean {
-  return extDoc.sourceFile !== undefined || extDoc.content.trim().length > 0
 }
 
 /** Estimated source bytes for a pending op, taken from its listing metadata. */
@@ -1093,7 +1089,7 @@ export async function executeSync(
               }
               return null
             }
-            if (!fullDoc || !hasPayload(fullDoc)) {
+            if (!fullDoc || !hasIndexablePayload(fullDoc)) {
               // An empty re-fetch leaves an already-indexed update as last-known-good; count
               // it as unchanged so the totals still reconcile with documents seen. Not a
               // verified refresh, though — see failedExternalIds below.


### PR DESCRIPTION
## Summary

- A zero-byte source file is no longer treated as something to index
- The emptiness rule now lives in one place, `hasIndexablePayload`, shared by the sync engine's classify and hydrate gates and both connectors' `getDocument`

## Why

Found by auditing production after connectors began delivering source files. A zero-byte PDF was stored and sent to OCR, which answered `400 Bad Request`:

```
OCR failed: 400 Bad Request - {"success":false,"error":"Mistral API error: Bad Request"}
file_size: 0
```

Two problems in one. It bills an external API call to discover the file was empty, and it reports the result as a provider fault rather than as an empty file, so the row gives no one a reason they can act on.

This was a regression. Before source files existed, an empty file produced empty extracted text and was dropped at the empty-content check.

The rule also existed in two places that disagreed: the connectors asked whether a source file was *present*, the sync engine asked the same question a second way, and a source file with no bytes satisfied both. One definition now, so the two gates cannot drift.

## Scope

This is the only unexplained failure class in the fleet since the source-file change deployed. Everything else post-deploy is legitimate and correctly reported: image-only decks, password-protected workbooks, files over the 100MB cap, and archives caught by the decompression guard.

## Testing

- `vitest run connectors/ lib/knowledge/ lib/uploads/ lib/file-parsers/ app/api/knowledge/` — **2,007 passed** (129 files)
- New cases cover a source file with bytes, extracted text, blank text, and the zero-byte file; verified the zero-byte case fails when the guard is weakened
- `bun run check:audits` — 29/29
- `tsgo --noEmit` — no errors in changed files (pre-existing `mssql` and `@c15t/nextjs` resolution errors unrelated)

## Checklist

- [x] Self-reviewed
- [x] No secrets or customer data introduced
