### PR TITLE
fix(auth): drop the redundant "Continue with" from the Google sign-in button

### DIFF
--- a/apps/sim/app/(auth)/components/social-login-buttons.tsx
+++ b/apps/sim/app/(auth)/components/social-login-buttons.tsx
@@ -85,12 +85,12 @@ export function SocialLoginButtons({
   const googleButton = (
     <Chip
       fullWidth
-      leftAdornment={<GoogleIcon className='size-[20px] shrink-0' />}
+      leftIcon={GoogleIcon}
       className={cn(AUTH_BUTTON_CLASS, 'border border-[var(--border-1)]')}
       disabled={!googleAvailable || isGoogleLoading}
       onClick={signInWithGoogle}
     >
-      {isGoogleLoading ? 'Connecting…' : 'Continue with Google'}
+      {isGoogleLoading ? 'Connecting…' : 'Google'}
     </Chip>
   )
 

--- a/apps/sim/app/(landing)/components/auth-modal/auth-modal.tsx
+++ b/apps/sim/app/(landing)/components/auth-modal/auth-modal.tsx
@@ -202,7 +202,7 @@ export function AuthModal({ children, defaultView = 'login', source }: AuthModal
                     disabled={!!socialLoading}
                     className={SOCIAL_BTN}
                   >
-                    <GoogleIcon className='absolute left-4 size-[20px] shrink-0' />
+                    <GoogleIcon className='absolute left-4 size-[18px] shrink-0' />
                     <span>
                       {socialLoading === 'google' ? 'Connecting...' : 'Continue with Google'}
                     </span>


### PR DESCRIPTION
## Summary

Follow-up to #6786, which changed the Google button label to "Continue with Google" and bumped its icon to 20px on both auth surfaces. Two surfaces, two different problems:

**Login / signup** (`social-login-buttons.tsx`) — these buttons sit under an `AuthDivider label="Or continue with"`, so the button rendered as "Or continue with → Continue with Google". Its siblings in the same stack are bare "GitHub" and "Microsoft". Restored to "Google", and handed the icon back to the chip's `leftIcon` slot so it uses the canonical 16px `chipContentIconClass` like its siblings, instead of a `leftAdornment` + `className` size override.

**Landing auth modal** (`auth-modal.tsx`) — different surface, no divider, and every button there reads "Continue with X" (Microsoft, GitHub, email). The Google label is correct and stays. Only the icon changes, 20px back to the 18px both siblings use.

Both files are now byte-identical to their pre-#6786 blobs. The Google artwork refresh and the Google Vault product-icon fix from that PR are untouched.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- [x] `bun run type-check`
- [x] `bun run lint:check`
- [x] No tests reference these labels (the snapshot suite was removed in #6786)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings introduced