### PR TITLE
fix(redis): reclaim a distributed lock that a timed-out acquire may have taken

### DIFF
--- a/apps/sim/app/api/cron/renew-subscriptions/route.test.ts
+++ b/apps/sim/app/api/cron/renew-subscriptions/route.test.ts
@@ -63,7 +63,8 @@ describe('Teams subscription renewal route (fire-and-forget)', () => {
     expect(redisConfigMockFns.mockAcquireLock).toHaveBeenCalledWith(
       'teams-subscription-renewal-lock',
       expect.any(String),
-      expect.any(Number)
+      expect.any(Number),
+      { reclaimOnFailure: true }
     )
 
     await flushMicrotasks()

--- a/apps/sim/app/api/cron/renew-subscriptions/route.ts
+++ b/apps/sim/app/api/cron/renew-subscriptions/route.ts
@@ -252,7 +252,9 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   }
 
   const lockValue = generateShortId()
-  const locked = await acquireLock(LOCK_KEY, lockValue, LOCK_TTL_SECONDS)
+  const locked = await acquireLock(LOCK_KEY, lockValue, LOCK_TTL_SECONDS, {
+    reclaimOnFailure: true,
+  })
   if (!locked) {
     return NextResponse.json(
       { success: true, message: 'Renewal already in progress – skipped', status: 'skip' },

--- a/apps/sim/app/api/resume/poll/route.ts
+++ b/apps/sim/app/api/resume/poll/route.ts
@@ -62,7 +62,9 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const authError = verifyCronAuth(request, 'Time-pause resume poll')
   if (authError) return authError
 
-  const lockAcquired = await acquireLock(LOCK_KEY, requestId, LOCK_TTL_SECONDS)
+  const lockAcquired = await acquireLock(LOCK_KEY, requestId, LOCK_TTL_SECONDS, {
+    reclaimOnFailure: true,
+  })
   if (!lockAcquired) {
     return NextResponse.json(
       { success: true, message: 'Polling already in progress – skipped', requestId },

--- a/apps/sim/app/api/webhooks/poll/[provider]/route.test.ts
+++ b/apps/sim/app/api/webhooks/poll/[provider]/route.test.ts
@@ -66,10 +66,13 @@ describe('webhook polling route (fire-and-forget)', () => {
     expect(response.status).toBe(202)
     const data = await response.json()
     expect(data).toMatchObject({ status: 'started' })
+    // `reclaimOnFailure` is what stops a timed-out acquire from leaving a lock
+    // no one owns, which skipped every poll until the TTL expired.
     expect(redisConfigMockFns.mockAcquireLock).toHaveBeenCalledWith(
       'gmail-polling-lock',
       expect.any(String),
-      expect.any(Number)
+      expect.any(Number),
+      { reclaimOnFailure: true }
     )
 
     await flushMicrotasks()

--- a/apps/sim/app/api/webhooks/poll/[provider]/route.ts
+++ b/apps/sim/app/api/webhooks/poll/[provider]/route.ts
@@ -40,7 +40,9 @@ export const GET = withRouteHandler(
 
       const LOCK_KEY = `${provider}-polling-lock`
       const lockValue = requestId
-      const locked = await acquireLock(LOCK_KEY, lockValue, LOCK_TTL_SECONDS)
+      const locked = await acquireLock(LOCK_KEY, lockValue, LOCK_TTL_SECONDS, {
+        reclaimOnFailure: true,
+      })
       if (!locked) {
         return NextResponse.json(
           {

--- a/apps/sim/app/api/workspace-events/poll/route.test.ts
+++ b/apps/sim/app/api/workspace-events/poll/route.test.ts
@@ -62,7 +62,8 @@ describe('workspace events polling route (fire-and-forget)', () => {
     expect(redisConfigMockFns.mockAcquireLock).toHaveBeenCalledWith(
       'workspace-events-no-activity-poll-lock',
       expect.any(String),
-      expect.any(Number)
+      expect.any(Number),
+      { reclaimOnFailure: true }
     )
 
     await flushMicrotasks()

--- a/apps/sim/app/api/workspace-events/poll/route.ts
+++ b/apps/sim/app/api/workspace-events/poll/route.ts
@@ -31,7 +31,9 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return authError
     }
 
-    const lockAcquired = await acquireLock(LOCK_KEY, requestId, LOCK_TTL_SECONDS)
+    const lockAcquired = await acquireLock(LOCK_KEY, requestId, LOCK_TTL_SECONDS, {
+      reclaimOnFailure: true,
+    })
 
     if (!lockAcquired) {
       return NextResponse.json(

--- a/apps/sim/lib/core/config/redis.test.ts
+++ b/apps/sim/lib/core/config/redis.test.ts
@@ -25,6 +25,7 @@ vi.mock('ioredis', () => ({
 }))
 
 import {
+  acquireLock,
   closeRedisConnection,
   extendLock,
   getRedisClient,
@@ -205,6 +206,58 @@ describe('redis config', () => {
       const extended = await extendLock(lockKey, value, ttlSeconds)
 
       expect(extended).toBe(true)
+    })
+  })
+
+  describe('acquireLock', () => {
+    const lockKey = 'outlook-polling-lock'
+    const value = 'req-abc'
+    const ttlSeconds = 180
+
+    it('returns true when SET NX takes the lock', async () => {
+      mockRedisInstance.set.mockResolvedValueOnce('OK')
+
+      expect(await acquireLock(lockKey, value, ttlSeconds)).toBe(true)
+      expect(mockRedisInstance.set).toHaveBeenCalledWith(lockKey, value, 'EX', ttlSeconds, 'NX')
+      expect(mockRedisInstance.eval).not.toHaveBeenCalled()
+    })
+
+    it('returns false without cleanup when the lock is already held', async () => {
+      mockRedisInstance.set.mockResolvedValueOnce(null)
+
+      expect(await acquireLock(lockKey, value, ttlSeconds)).toBe(false)
+      expect(mockRedisInstance.eval).not.toHaveBeenCalled()
+    })
+
+    it('reclaims the lock it may have taken when SET times out', async () => {
+      // ioredis gives up client-side on `commandTimeout` while the command can
+      // still land, so the lock would otherwise be held by a caller that never
+      // learned it won and never releases it.
+      mockRedisInstance.set.mockRejectedValueOnce(new Error('Command timed out'))
+      mockRedisInstance.eval.mockResolvedValueOnce(1)
+
+      await expect(acquireLock(lockKey, value, ttlSeconds)).rejects.toThrow('Command timed out')
+      expect(mockRedisInstance.eval).toHaveBeenCalledWith(
+        expect.stringContaining('del'),
+        1,
+        lockKey,
+        value
+      )
+    })
+
+    it('surfaces the original failure when the cleanup also fails', async () => {
+      mockRedisInstance.set.mockRejectedValueOnce(new Error('Command timed out'))
+      mockRedisInstance.eval.mockRejectedValueOnce(new Error('Connection is closed'))
+
+      // The TTL stays the backstop; the caller must still see why acquiring failed.
+      await expect(acquireLock(lockKey, value, ttlSeconds)).rejects.toThrow('Command timed out')
+    })
+
+    it('returns true as a no-op when the cache capability selects the database', async () => {
+      mockEnv.REDIS_URL = undefined
+
+      expect(await acquireLock(lockKey, value, ttlSeconds)).toBe(true)
+      expect(mockRedisInstance.set).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/sim/lib/core/config/redis.test.ts
+++ b/apps/sim/lib/core/config/redis.test.ts
@@ -229,14 +229,16 @@ describe('redis config', () => {
       expect(mockRedisInstance.eval).not.toHaveBeenCalled()
     })
 
-    it('reclaims the lock it may have taken when SET times out', async () => {
+    it('reclaims the lock it may have taken when SET times out and reclaim is on', async () => {
       // ioredis gives up client-side on `commandTimeout` while the command can
       // still land, so the lock would otherwise be held by a caller that never
       // learned it won and never releases it.
       mockRedisInstance.set.mockRejectedValueOnce(new Error('Command timed out'))
       mockRedisInstance.eval.mockResolvedValueOnce(1)
 
-      await expect(acquireLock(lockKey, value, ttlSeconds)).rejects.toThrow('Command timed out')
+      await expect(
+        acquireLock(lockKey, value, ttlSeconds, { reclaimOnFailure: true })
+      ).rejects.toThrow('Command timed out')
       expect(mockRedisInstance.eval).toHaveBeenCalledWith(
         expect.stringContaining('del'),
         1,
@@ -245,12 +247,24 @@ describe('redis config', () => {
       )
     })
 
+    it('leaves the lock alone by default so a fall-open caller keeps holding it', async () => {
+      // `withLeaderLock` and the MCP OAuth mutex run their work anyway when
+      // acquisition throws. Freeing the lock under them would let a second
+      // runner in alongside, so reclaiming has to stay opt-in.
+      mockRedisInstance.set.mockRejectedValueOnce(new Error('Command timed out'))
+
+      await expect(acquireLock(lockKey, value, ttlSeconds)).rejects.toThrow('Command timed out')
+      expect(mockRedisInstance.eval).not.toHaveBeenCalled()
+    })
+
     it('surfaces the original failure when the cleanup also fails', async () => {
       mockRedisInstance.set.mockRejectedValueOnce(new Error('Command timed out'))
       mockRedisInstance.eval.mockRejectedValueOnce(new Error('Connection is closed'))
 
       // The TTL stays the backstop; the caller must still see why acquiring failed.
-      await expect(acquireLock(lockKey, value, ttlSeconds)).rejects.toThrow('Command timed out')
+      await expect(
+        acquireLock(lockKey, value, ttlSeconds, { reclaimOnFailure: true })
+      ).rejects.toThrow('Command timed out')
     })
 
     it('returns true as a no-op when the cache capability selects the database', async () => {

--- a/apps/sim/lib/core/config/redis.ts
+++ b/apps/sim/lib/core/config/redis.ts
@@ -235,10 +235,32 @@ end
  * single-replica deployments to function without Redis. In multi-replica
  * deployments without Redis, the idempotency layer prevents duplicate processing.
  */
+export interface AcquireLockOptions {
+  /**
+   * Release the lock this call may have taken when the SET itself rejects.
+   *
+   * A rejected SET does not mean the server declined it: `commandTimeout` gives
+   * up client-side while the command can still reach Redis and take the lock,
+   * leaving it held by a caller that never learned it won and so never releases
+   * it. Every contender then skips until the TTL expires.
+   *
+   * Only opt in when BOTH hold, because the reclaim is unsafe otherwise:
+   *
+   * 1. `value` is unique to this holder. A value two holders can share — the
+   *    copilot chat lock keys on a client-supplied `userMessageId` — makes the
+   *    compare-and-delete match a lock another holder is actively using.
+   * 2. A throw means the caller does no work. One that falls open and runs
+   *    anyway (`withLeaderLock`, the MCP OAuth refresh mutex) would keep running
+   *    while this frees its lock, admitting a second concurrent runner.
+   */
+  reclaimOnFailure?: boolean
+}
+
 export async function acquireLock(
   lockKey: string,
   value: string,
-  expirySeconds: number
+  expirySeconds: number,
+  options?: AcquireLockOptions
 ): Promise<boolean> {
   const redis = getRedisClient()
   if (!redis) {
@@ -249,19 +271,13 @@ export async function acquireLock(
     const result = await redis.set(lockKey, value, 'EX', expirySeconds, 'NX')
     return result === 'OK'
   } catch (error) {
-    /*
-     * A rejected SET does not mean the server declined it. `commandTimeout`
-     * gives up client-side while the command may still reach Redis and take the
-     * lock, leaving it held by a caller that never learned it won and so never
-     * releases it — every contender then skips until the TTL expires.
-     *
-     * Reclaiming it is safe because this is the same compare-and-delete
-     * `releaseLock` uses on the success path: it deletes only while `value`
-     * still owns the key, so a lock a different holder won in the meantime is
-     * left alone. Best effort — if Redis is still unreachable the TTL remains
-     * the backstop, which is exactly the behavior without this cleanup.
-     */
-    await releaseLock(lockKey, value).catch(() => {})
+    // Best effort, and the same compare-and-delete `releaseLock` runs on the
+    // success path: it deletes only while `value` still owns the key. If Redis
+    // is still unreachable the TTL stays the backstop, which is the behavior
+    // without this cleanup.
+    if (options?.reclaimOnFailure) {
+      await releaseLock(lockKey, value).catch(() => {})
+    }
     throw error
   }
 }

--- a/apps/sim/lib/core/config/redis.ts
+++ b/apps/sim/lib/core/config/redis.ts
@@ -245,8 +245,25 @@ export async function acquireLock(
     return true // No-op when Redis unavailable; idempotency layer handles duplicates
   }
 
-  const result = await redis.set(lockKey, value, 'EX', expirySeconds, 'NX')
-  return result === 'OK'
+  try {
+    const result = await redis.set(lockKey, value, 'EX', expirySeconds, 'NX')
+    return result === 'OK'
+  } catch (error) {
+    /*
+     * A rejected SET does not mean the server declined it. `commandTimeout`
+     * gives up client-side while the command may still reach Redis and take the
+     * lock, leaving it held by a caller that never learned it won and so never
+     * releases it — every contender then skips until the TTL expires.
+     *
+     * Reclaiming it is safe because this is the same compare-and-delete
+     * `releaseLock` uses on the success path: it deletes only while `value`
+     * still owns the key, so a lock a different holder won in the meantime is
+     * left alone. Best effort — if Redis is still unreachable the TTL remains
+     * the backstop, which is exactly the behavior without this cleanup.
+     */
+    await releaseLock(lockKey, value).catch(() => {})
+    throw error
+  }
 }
 
 /**


### PR DESCRIPTION
## The bug

`acquireLock` awaited `SET NX` and let a rejection propagate:

```ts
const result = await redis.set(lockKey, value, 'EX', expirySeconds, 'NX')
return result === 'OK'
```

A rejected SET does not mean the server declined it. The client is configured with `commandTimeout: 5000` (`redis.ts:164`), and ioredis rejects locally when that elapses (`ioredis/built/Command.js:195`, message `Command timed out`) while the command can still reach Redis and take the lock.

When that happens the lock is held by a caller that never learned it won, so it never releases. Every caller treats a throw as "did not acquire", so nothing else releases it either. Every contender skips until the TTL expires.

## How staging hit it

The `sim-staging-us-east-1-cron-lambda-errors` alarm at 21:06 UTC:

- `acquireLock` threw `Command timed out` in `app/api/webhooks/poll/[provider]/route.ts:43`
- The outer catch returned 500 `outlook polling failed: Command timed out` after ~10.8s
- The next scheduled poll and the Lambda retry both got 202 `Polling already in progress - skipped`, against a lock whose holder had never started polling
- The 180s TTL cleared it

Worth being precise about one thing, because the incident's own remediation note pointed at it: the route's `finally`/`releaseLock` is **not** missing. It lives inside the `runDetached` task, which never started, because the throw happened at lock acquisition. The poll never ran, so there was nothing to terminate — the lock simply had no owner that could release it.

## The fix, and why it is opt-in

On failure, best-effort compare-and-delete through the existing `releaseLock` — but **only when the caller opts in**, because reclaiming unconditionally is unsafe for two caller classes that exist today. Both were caught in review; the first revision of this PR had it on for everyone and was wrong.

**Callers that fall open.** `withLeaderLock` (`leader-lock.ts:36-43`) and the MCP OAuth refresh mutex (`mcp/oauth/storage.ts:329-336`) catch the throw and run their work uncoordinated. If the SET landed, the lock they hold is what keeps everyone else out while they run. Freeing it under them admits a *second* concurrent runner — for OAuth refresh, two rotations of the same refresh token and an `invalid_grant`.

**Callers whose lock value is not unique.** The copilot chat lock keys on `streamId`, which is the client-supplied `userMessageId` (`copilot/chat/post.ts:266` declares it `z.string().max(128).optional()`; `post.ts:592` passes it as `streamId`). Two sends can carry the same value, so a compare-and-delete from a contender that timed out can match — and delete — the lock the active stream holds.

So the option carries its preconditions in its own TSDoc: the value must be unique to the holder, **and** a throw must mean the caller does no work. Default behavior is byte-for-byte what it was before this PR.

### Opted in

The four cron/poll callers that satisfy both preconditions — each mints its value with `generateShortId()` and returns 5xx rather than proceeding when acquisition throws:

| Caller | Value | On throw |
|---|---|---|
| `app/api/webhooks/poll/[provider]` | `generateShortId()` | 500 |
| `app/api/resume/poll` | `generateShortId()` | 5xx via route handler |
| `app/api/workspace-events/poll` | `generateShortId()` | 500 |
| `app/api/cron/renew-subscriptions` | `generateShortId()` | 5xx via route handler |

For those, every branch is better than today or identical to it:

| Case | Before | After |
|---|---|---|
| SET landed, client timed out | held for full TTL | reclaimed immediately |
| SET never landed, another holder won | untouched | untouched (value mismatch, no-op) |
| SET never landed, nobody holds it | no-op | no-op |
| Redis still unreachable | TTL backstop | TTL backstop (cleanup fails, swallowed) |

Not opted in, and unchanged: `lib/concurrency/leader-lock`, `lib/mcp/oauth/storage`, `lib/copilot/request/session/abort`, `lib/table/cascade-lock`, `app/api/tools/file/manage`.

## Control flow is unchanged

The error still propagates in every case, so callers see exactly what they saw before — the only difference is a best-effort side effect for the four that opt in. Deliberately **not** converted to `return false`: that would make the poll route answer `Polling already in progress - skipped` when polling was not in progress, hiding a real Redis outage from the alarm that correctly fired here.

It also makes the existing recovery work as designed — the Lambda retry that got `already in progress` will now find the lock free and actually poll.

## Tests

Six cases in `redis.test.ts`: SET NX taking the lock (no cleanup issued), contention returning false (no cleanup issued), a timed-out SET issuing the compare-and-delete and rethrowing when reclaim is on, **a timed-out SET issuing no cleanup by default** so a fall-open caller keeps holding its lock, a failed cleanup still surfacing the original error, and the no-Redis no-op path.

The webhook polling route test now asserts it passes `{ reclaimOnFailure: true }`, pinning the incident's actual fix at the call site rather than only in the primitive.

I verified the reclaim test fails against the original implementation (1 failed / 20 passed) and passes with the fix, so it isn't a test that would pass either way.

## Verification

- `bun run test` across `redis.test.ts` and all affected callers: 64 passed
- `bun run type-check` (apps/sim): clean
- `biome check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)