### PR TITLE
fix(trigger): let workers see that Trigger.dev is available

### DIFF
--- a/apps/sim/lib/embeddings/client.test.ts
+++ b/apps/sim/lib/embeddings/client.test.ts
@@ -823,11 +823,8 @@ describe('knowledge embedding transport fallback', () => {
   })
 
   /**
-   * OpenAI returns 429 for an exhausted balance as well as for a rate limit, but
-   * only one of them reopens. Retrying a spent account cannot succeed, and since
-   * the sweep re-queues failed documents every sync it turns into permanent load
-   * — this was observed burning every attempt on thousands of documents for
-   * weeks against an account with no credit.
+   * A spent account never reopens, and the sweep re-queues failed documents every
+   * sync — so retrying one burns the budget per document, indefinitely.
    */
   it('does not retry a 429 that reports an exhausted balance', async () => {
     vi.useFakeTimers()

--- a/apps/sim/lib/embeddings/client.ts
+++ b/apps/sim/lib/embeddings/client.ts
@@ -79,10 +79,7 @@ const EMBEDDING_RETRY_BUDGET_MS = EMBEDDING_MAX_RETRIES * EMBEDDING_MAX_RETRY_DE
 export class EmbeddingAPIError extends Error {
   public status: number
 
-  /**
-   * The provider rejected this for an exhausted balance rather than a rate that
-   * will recover. Both arrive as 429.
-   */
+  /** Rejected for an exhausted balance rather than a recoverable rate. Both are 429. */
   public quotaExhausted?: boolean
 
   /**
@@ -100,13 +97,8 @@ export class EmbeddingAPIError extends Error {
 
 /**
  * True when a rejection body reports an exhausted balance rather than a rate
- * limit.
- *
- * OpenAI returns 429 for both, but only one of them reopens. `insufficient_quota`
- * stands until somebody adds credit, so retrying it cannot succeed no matter how
- * long the loop waits — and because a failed document is re-queued by the sweep
- * on every sync, an account that has run out turns into a permanent load: the
- * budget is spent per document, per attempt, forever.
+ * limit. OpenAI returns 429 for both, but only a rate limit reopens: a spent
+ * account stands until someone adds credit, so retrying it cannot succeed.
  */
 function isQuotaExhaustionBody(errorText: string): boolean {
   try {
@@ -148,13 +140,10 @@ function statedWaitOutlastsBudget(error: unknown): boolean {
 }
 
 /**
- * Whether another attempt against the same provider could plausibly succeed.
- *
- * Deliberately narrower than {@link isTransientEmbeddingError}, which also
- * decides whether the fallback chain should try a *different* provider. Those
- * two questions differ: an exhausted balance rules out the key we just used, but
- * says nothing about the next one in the chain, so a quota rejection stops the
- * retries here while remaining eligible for failover.
+ * Whether another attempt against the *same* provider could succeed. Narrower
+ * than {@link isTransientEmbeddingError}, which decides whether to fail over to a
+ * different one: an exhausted balance rules out the key just used but says
+ * nothing about the next in the chain.
  */
 function isWorthRetrying(error: unknown): boolean {
   if (!isTransientEmbeddingError(error)) return false

--- a/apps/sim/lib/knowledge/documents/service.ts
+++ b/apps/sim/lib/knowledge/documents/service.ts
@@ -756,11 +756,9 @@ async function dispatchViaBatchTrigger(
   }
 
   /**
-   * Only a total dispatch failure raises, so a chunk that failed on its own used
-   * to leave its documents sitting at `pending` with nothing recording why —
-   * invisible until the stuck-document sweep happened to pick them up, and never
-   * if they aged out of its window first. Running them here costs the caller time
-   * it hoped to hand to the queue, which is the point: the work still happens.
+   * Only a total dispatch failure raises, so a chunk failing alone would leave its
+   * documents at `pending` with nothing recording why. Processing them here is
+   * slower than the queue but does not drop the work.
    */
   if (undispatched.length > 0) {
     logger.warn(

--- a/apps/sim/lib/knowledge/documents/service.ts
+++ b/apps/sim/lib/knowledge/documents/service.ts
@@ -721,6 +721,7 @@ async function dispatchViaBatchTrigger(
 ): Promise<number> {
   let dispatched = 0
   const batchIds: string[] = []
+  const undispatched: DocumentProcessingPayload[] = []
   const region = await resolveTriggerRegion()
   for (let i = 0; i < jobPayloads.length; i += TRIGGER_BATCH_SIZE) {
     const chunk = jobPayloads.slice(i, i + TRIGGER_BATCH_SIZE)
@@ -747,11 +748,27 @@ async function dispatchViaBatchTrigger(
       logger.error(`[${requestId}] Failed to batchTrigger ${chunk.length} document jobs`, {
         error: getErrorMessage(error),
       })
+      undispatched.push(...chunk)
     }
   }
   if (batchIds.length > 0) {
     logger.info(`[${requestId}] Trigger.dev batches dispatched`, { batchIds })
   }
+
+  /**
+   * Only a total dispatch failure raises, so a chunk that failed on its own used
+   * to leave its documents sitting at `pending` with nothing recording why —
+   * invisible until the stuck-document sweep happened to pick them up, and never
+   * if they aged out of its window first. Running them here costs the caller time
+   * it hoped to hand to the queue, which is the point: the work still happens.
+   */
+  if (undispatched.length > 0) {
+    logger.warn(
+      `[${requestId}] Processing ${undispatched.length} documents in-process after failed enqueue`
+    )
+    dispatched += await dispatchInProcess(undispatched, requestId)
+  }
+
   return dispatched
 }
 

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -76,17 +76,11 @@ export default defineConfig({
       syncEnvVars(() => [
         { name: 'DB_APP_NAME', value: 'sim-trigger' },
         /**
-         * Workers run Trigger.dev by definition, but the flag that says so is
-         * read from the environment and was only ever set on the app container.
-         * `isTriggerAvailable()` therefore returned false inside every worker, so
-         * anything a task dispatched — document processing above all — silently
-         * took the in-process path instead of the queue it was written for. A
-         * connector sync ended up chunking and embedding thousands of documents
-         * itself, five at a time, and running until it hit its max duration.
-         *
-         * Safe to assert here because the check also requires TRIGGER_SECRET_KEY,
-         * which only the Trigger.dev runtime provides: where dispatching is not
-         * actually possible this stays false and nothing changes.
+         * Workers run Trigger.dev by definition, but the flag saying so was only
+         * set on the app container, so `isTriggerAvailable()` was false in every
+         * task run and dispatched work silently took the in-process fallback.
+         * Ineffective where dispatching is impossible: the check also requires
+         * TRIGGER_SECRET_KEY, which only the Trigger.dev runtime provides.
          */
         { name: 'TRIGGER_DEV_ENABLED', value: 'TRUE' },
       ]),

--- a/apps/sim/trigger.config.ts
+++ b/apps/sim/trigger.config.ts
@@ -73,7 +73,23 @@ export default defineConfig({
       '@daytona/sdk',
     ],
     extensions: [
-      syncEnvVars(() => [{ name: 'DB_APP_NAME', value: 'sim-trigger' }]),
+      syncEnvVars(() => [
+        { name: 'DB_APP_NAME', value: 'sim-trigger' },
+        /**
+         * Workers run Trigger.dev by definition, but the flag that says so is
+         * read from the environment and was only ever set on the app container.
+         * `isTriggerAvailable()` therefore returned false inside every worker, so
+         * anything a task dispatched — document processing above all — silently
+         * took the in-process path instead of the queue it was written for. A
+         * connector sync ended up chunking and embedding thousands of documents
+         * itself, five at a time, and running until it hit its max duration.
+         *
+         * Safe to assert here because the check also requires TRIGGER_SECRET_KEY,
+         * which only the Trigger.dev runtime provides: where dispatching is not
+         * actually possible this stays false and nothing changes.
+         */
+        { name: 'TRIGGER_DEV_ENABLED', value: 'TRUE' },
+      ]),
       additionalFiles({
         files: [
           './lib/execution/isolated-vm-worker.cjs',


### PR DESCRIPTION
## Problem

`isTriggerAvailable()` is `Boolean(env.TRIGGER_SECRET_KEY) && isTriggerDevEnabled`, and `isTriggerDevEnabled` reads `TRIGGER_DEV_ENABLED`. That variable is set on the app container but **not** in the Trigger.dev environment, so the check is false inside every task run — and work a task dispatches silently takes the in-process fallback instead of the queue it was written for.

| Runtime | `TRIGGER_DEV_ENABLED` | `isTriggerAvailable()` |
|---|---|---|
| App container | `TRUE` | true — dispatches to the queue |
| Trigger.dev worker | **absent** | **false** — `dispatchInProcess` |

Document processing is where this surfaced. A connector sync chunks and embeds its own documents at `IN_PROCESS_DISPATCH_CONCURRENCY = 5` instead of handing them to `knowledge-process-document`, so that task's queue concurrency limit, machine, retry policy and duration budget all sit unused, and a sync with thousands of documents runs until it hits its own max duration.

Evidence, three independent ways:

1. A connector sync ran the full hour and hit `MAX_DURATION_EXCEEDED`.
2. Its trace contains `"Document dispatch failed"` — a string that appears in exactly one place in the codebase, the `dispatchInProcess` catch block.
3. `knowledge-process-document` has **zero** runs for that knowledge base over two days, despite thousands of documents being processed.

The flag is read in 17 files, so the same silent downgrade applies to any dispatching path reachable from a task run, table backfills and imports among them.

## Change

Assert the flag for workers via the `syncEnvVars` extension that already runs there for `DB_APP_NAME`. Putting it in `trigger.config.ts` keeps it version-controlled and reviewable rather than being dashboard state that can drift out of agreement with the app again.

**This is fail-safe.** The availability check still requires `TRIGGER_SECRET_KEY`, which only the Trigger.dev runtime provides. Anywhere dispatching is not actually possible, the flag stays ineffective and behaviour is unchanged — the change cannot enable dispatch in an environment that cannot dispatch.

Dispatch failure is also made recoverable. Only a *total* failure raised before, so a single failed batch left its documents at `pending` with nothing recording why — invisible until the stuck-document sweep happened to reach them, and never if they aged out of its 7-day window first. Those are now processed in-process instead: it costs the caller the time it hoped to hand to the queue, but the work is not dropped. That path was unreachable from a worker until this change made dispatching happen there, which is why it belongs with it.

## Risk and how to verify

This changes where document processing executes for every connector sync, so it is worth watching rather than assuming:

- **Expected after deploy:** `knowledge-process-document` runs appear for connector-synced knowledge bases, where there are currently none; connector sync runs get much shorter.
- **If dispatching turns out not to work from a worker**, the flag stays false and nothing changes — or, if it half-works, the guard above processes the remainder in-process rather than dropping it.
- Worth confirming on staging first, since it also affects the table paths that gate on the same flag.

## Also here

A comment trim, carried in a second commit rather than its own PR. Both this change's TSDoc and the quota classification's from #6868 explained the incident that motivated the code rather than the code itself — narrative that stops being true as the system moves and misleads instead. Each is cut back to the reason a reader needs; no behaviour change.

## Verification

- 632 embedding and knowledge tests pass; 29/29 audits; type-check clean

