### PR TITLE
fix(bitbucket): bind cursors and task locations case-insensitively

### DIFF
--- a/apps/sim/tools/bitbucket/merge_pull_request.ts
+++ b/apps/sim/tools/bitbucket/merge_pull_request.ts
@@ -11,6 +11,7 @@ import {
   bitbucketHeaders,
   bitbucketJson,
   bitbucketPullRequestPath,
+  equalsIgnoreCase,
   normalizeBitbucketPullRequest,
   validateBitbucketOpaqueUrl,
 } from '@/tools/bitbucket/utils'
@@ -52,7 +53,7 @@ function mergeTaskLocation(
   )
   const parsed = new URL(taskUrl)
   const expectedPrefix = `/2.0${bitbucketPullRequestPath(params.workspaceSlug, params.repoSlug, params.prId)}/merge/task-status/`
-  if (!parsed.pathname.startsWith(expectedPrefix)) {
+  if (!equalsIgnoreCase(parsed.pathname.slice(0, expectedPrefix.length), expectedPrefix)) {
     throw new Error('Bitbucket merge task Location did not match the requested pull request')
   }
   const taskId = decodeURIComponent(parsed.pathname.slice(expectedPrefix.length))

--- a/apps/sim/tools/bitbucket/merge_pull_request.ts
+++ b/apps/sim/tools/bitbucket/merge_pull_request.ts
@@ -11,7 +11,7 @@ import {
   bitbucketHeaders,
   bitbucketJson,
   bitbucketPullRequestPath,
-  equalsIgnoreCase,
+  bitbucketRepositoryPathHasPrefix,
   normalizeBitbucketPullRequest,
   validateBitbucketOpaqueUrl,
 } from '@/tools/bitbucket/utils'
@@ -53,7 +53,7 @@ function mergeTaskLocation(
   )
   const parsed = new URL(taskUrl)
   const expectedPrefix = `/2.0${bitbucketPullRequestPath(params.workspaceSlug, params.repoSlug, params.prId)}/merge/task-status/`
-  if (!equalsIgnoreCase(parsed.pathname.slice(0, expectedPrefix.length), expectedPrefix)) {
+  if (!bitbucketRepositoryPathHasPrefix(parsed.pathname, expectedPrefix)) {
     throw new Error('Bitbucket merge task Location did not match the requested pull request')
   }
   const taskId = decodeURIComponent(parsed.pathname.slice(expectedPrefix.length))

--- a/apps/sim/tools/bitbucket/pull-requests.test.ts
+++ b/apps/sim/tools/bitbucket/pull-requests.test.ts
@@ -505,6 +505,20 @@ describe('Bitbucket merge lifecycle', () => {
     })
   })
 
+  it('accepts a canonical-cased merge task Location for a mixed-case slug', async () => {
+    const result = await bitbucketMergePullRequestTool.transformResponse!(
+      new Response(null, {
+        status: 202,
+        headers: {
+          Location:
+            'https://api.bitbucket.org/2.0/repositories/acme%20team/sdk%2Fcore/pullrequests/7/merge/task-status/task-1',
+        },
+      }),
+      { ...PULL_REQUEST_PARAMS, workspaceSlug: 'ACME Team', repoSlug: 'SDK/Core' }
+    )
+    expect(result.output).toMatchObject({ status: 'pending', taskId: 'task-1' })
+  })
+
   it('rejects missing, cross-origin, and wrong-pull-request task Locations', async () => {
     await expect(
       bitbucketMergePullRequestTool.transformResponse!(

--- a/apps/sim/tools/bitbucket/utils.test.ts
+++ b/apps/sim/tools/bitbucket/utils.test.ts
@@ -101,6 +101,32 @@ describe('Bitbucket path and pagination safety', () => {
     }
   })
 
+  it('accepts a canonical-cased cursor for a mixed-case slug but not a re-cased file path', () => {
+    const canonical = 'https://api.bitbucket.org/2.0/repositories/acme/demo/commits?page=2'
+    expect(bitbucketApiUrl('/repositories/ACME/Demo/commits', { nextUrl: canonical })).toBe(
+      canonical
+    )
+
+    const revision = '0123456789abcdef0123456789abcdef01234567'
+    expect(
+      bitbucketApiUrl(`/repositories/ACME/Demo/src/${revision.toUpperCase()}/src/dir`, {
+        nextUrl: `https://api.bitbucket.org/2.0/repositories/acme/demo/src/${revision}/src/dir?page=2`,
+        nextPathPrefix: '/repositories/ACME/Demo/src',
+        nextPathSuffix: 'src/dir',
+        nextRevision: revision.toUpperCase(),
+      })
+    ).toBe(`https://api.bitbucket.org/2.0/repositories/acme/demo/src/${revision}/src/dir?page=2`)
+
+    expect(() =>
+      bitbucketApiUrl(`/repositories/acme/demo/src/${revision}/src/Dir`, {
+        nextUrl: `https://api.bitbucket.org/2.0/repositories/acme/demo/src/${revision}/src/dir?page=2`,
+        nextPathPrefix: '/repositories/acme/demo/src',
+        nextPathSuffix: 'src/Dir',
+        nextRevision: revision,
+      })
+    ).toThrow(/does not preserve the requested Bitbucket directory path/)
+  })
+
   it('binds directory cursors to the selected repository path', () => {
     const revision = '0123456789abcdef0123456789abcdef01234567'
     const next = `https://api.bitbucket.org/2.0/repositories/acme/demo/src/${revision}/src/my%20dir?page=2`

--- a/apps/sim/tools/bitbucket/utils.test.ts
+++ b/apps/sim/tools/bitbucket/utils.test.ts
@@ -117,6 +117,16 @@ describe('Bitbucket path and pagination safety', () => {
       })
     ).toBe(`https://api.bitbucket.org/2.0/repositories/acme/demo/src/${revision}/src/dir?page=2`)
 
+    for (const recased of [
+      'https://api.bitbucket.org/2.0/Repositories/acme/demo/commits?page=2',
+      'https://api.bitbucket.org/2.0/repositories/acme/demo/Commits?page=2',
+    ]) {
+      expect(
+        () => bitbucketApiUrl('/repositories/ACME/Demo/commits', { nextUrl: recased }),
+        recased
+      ).toThrow(/does not belong to this Bitbucket list endpoint/)
+    }
+
     expect(() =>
       bitbucketApiUrl(`/repositories/acme/demo/src/${revision}/src/Dir`, {
         nextUrl: `https://api.bitbucket.org/2.0/repositories/acme/demo/src/${revision}/src/dir?page=2`,

--- a/apps/sim/tools/bitbucket/utils.ts
+++ b/apps/sim/tools/bitbucket/utils.ts
@@ -320,11 +320,52 @@ export function validateBitbucketOpaqueUrl(value: string): string {
  * Bitbucket resolves workspace and repository slugs case-insensitively but echoes the canonical
  * lowercase form in `next` links, redirect `Location` headers, and merge task URLs. Binding those
  * back to the caller's slug must therefore ignore case, or a mixed-case slug that Bitbucket just
- * accepted fails on the follow-up request. Repository file paths are compared verbatim — git
- * treats those as case-sensitive.
+ * accepted fails on the follow-up request.
+ *
+ * Only those two segments are canonicalized, so only those two are folded. Fixed API literals and
+ * repository file paths compare verbatim, keeping a malformed path a deterministic local failure
+ * rather than one deferred to Bitbucket. Hex revisions are folded by their own dedicated check.
  */
+function isBitbucketSlugSegment(segments: string[], index: number): boolean {
+  return segments[0] === '2.0' && segments[1] === 'repositories' && (index === 2 || index === 3)
+}
+
+function bitbucketSegmentsMatch(candidate: string[], expected: string[]): boolean {
+  if (candidate.length !== expected.length) return false
+  return expected.every(
+    (segment, index) =>
+      candidate[index] === segment ||
+      (isBitbucketSlugSegment(expected, index) && equalsIgnoreCase(candidate[index], segment))
+  )
+}
+
+/** Compares two absolute API paths segment-wise under the slug-only case rule above. */
+function bitbucketPathsMatch(candidatePath: string, expectedPath: string): boolean {
+  return bitbucketSegmentsMatch(
+    candidatePath.replace(/^\//, '').split('/'),
+    expectedPath.replace(/^\//, '').split('/')
+  )
+}
+
+/** True when `candidatePath` begins with every segment of `expectedPrefix`, same case rule. */
+function bitbucketPathHasPrefix(candidatePath: string, expectedPrefix: string): boolean {
+  const expected = expectedPrefix.replace(/^\//, '').replace(/\/$/, '').split('/')
+  const candidate = candidatePath.replace(/^\//, '').split('/')
+  return (
+    candidate.length > expected.length &&
+    bitbucketSegmentsMatch(candidate.slice(0, expected.length), expected)
+  )
+}
+
 export function equalsIgnoreCase(a: string, b: string): boolean {
   return a.toLowerCase() === b.toLowerCase()
+}
+
+export function bitbucketRepositoryPathHasPrefix(
+  candidatePath: string,
+  expectedPrefix: string
+): boolean {
+  return bitbucketPathHasPrefix(candidatePath, expectedPrefix)
 }
 
 export type BitbucketPullRequestRedirectKind = 'diff' | 'diffstat'
@@ -338,10 +379,7 @@ export function validateBitbucketPullRequestRedirect(
   const validated = validateBitbucketOpaqueUrl(value)
   const parsed = new URL(validated)
   const expectedPrefix = `/2.0${bitbucketRepositoryPath(workspaceSlug, repoSlug)}/${kind}/`
-  const encodedSpec = equalsIgnoreCase(
-    parsed.pathname.slice(0, expectedPrefix.length),
-    expectedPrefix
-  )
+  const encodedSpec = bitbucketPathHasPrefix(parsed.pathname, expectedPrefix)
     ? parsed.pathname.slice(expectedPrefix.length)
     : ''
   if (!encodedSpec) {
@@ -431,9 +469,7 @@ export function bitbucketApiUrl(
       const prefixSegments = decodePath(prefix)
       if (
         candidateSegments.length <= prefixSegments.length ||
-        !prefixSegments.every((segment, index) =>
-          equalsIgnoreCase(candidateSegments[index], segment)
-        )
+        !bitbucketSegmentsMatch(candidateSegments.slice(0, prefixSegments.length), prefixSegments)
       ) {
         throw new Error('nextUrl does not belong to this Bitbucket list endpoint')
       }
@@ -452,7 +488,7 @@ export function bitbucketApiUrl(
       ) {
         throw new Error('nextUrl does not preserve the requested Bitbucket directory path')
       }
-    } else if (!equalsIgnoreCase(candidatePath.replace(/\/$/, ''), exactPath)) {
+    } else if (!bitbucketPathsMatch(candidatePath.replace(/\/$/, ''), exactPath)) {
       throw new Error('nextUrl does not belong to this Bitbucket list endpoint')
     }
     return validated

--- a/apps/sim/tools/bitbucket/utils.ts
+++ b/apps/sim/tools/bitbucket/utils.ts
@@ -316,6 +316,17 @@ export function validateBitbucketOpaqueUrl(value: string): string {
   return parsed.toString()
 }
 
+/**
+ * Bitbucket resolves workspace and repository slugs case-insensitively but echoes the canonical
+ * lowercase form in `next` links, redirect `Location` headers, and merge task URLs. Binding those
+ * back to the caller's slug must therefore ignore case, or a mixed-case slug that Bitbucket just
+ * accepted fails on the follow-up request. Repository file paths are compared verbatim — git
+ * treats those as case-sensitive.
+ */
+export function equalsIgnoreCase(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
 export type BitbucketPullRequestRedirectKind = 'diff' | 'diffstat'
 
 export function validateBitbucketPullRequestRedirect(
@@ -327,7 +338,10 @@ export function validateBitbucketPullRequestRedirect(
   const validated = validateBitbucketOpaqueUrl(value)
   const parsed = new URL(validated)
   const expectedPrefix = `/2.0${bitbucketRepositoryPath(workspaceSlug, repoSlug)}/${kind}/`
-  const encodedSpec = parsed.pathname.startsWith(expectedPrefix)
+  const encodedSpec = equalsIgnoreCase(
+    parsed.pathname.slice(0, expectedPrefix.length),
+    expectedPrefix
+  )
     ? parsed.pathname.slice(expectedPrefix.length)
     : ''
   if (!encodedSpec) {
@@ -417,12 +431,17 @@ export function bitbucketApiUrl(
       const prefixSegments = decodePath(prefix)
       if (
         candidateSegments.length <= prefixSegments.length ||
-        !prefixSegments.every((segment, index) => candidateSegments[index] === segment)
+        !prefixSegments.every((segment, index) =>
+          equalsIgnoreCase(candidateSegments[index], segment)
+        )
       ) {
         throw new Error('nextUrl does not belong to this Bitbucket list endpoint')
       }
       const revisionAndPath = candidateSegments.slice(prefixSegments.length)
-      if (options.nextRevision === undefined || revisionAndPath[0] !== options.nextRevision) {
+      if (
+        options.nextRevision === undefined ||
+        !equalsIgnoreCase(revisionAndPath[0], options.nextRevision)
+      ) {
         throw new Error('nextUrl does not preserve the requested Bitbucket revision')
       }
       const expectedSuffix = decodePath(options.nextPathSuffix ?? '')
@@ -433,7 +452,7 @@ export function bitbucketApiUrl(
       ) {
         throw new Error('nextUrl does not preserve the requested Bitbucket directory path')
       }
-    } else if (candidatePath.replace(/\/$/, '') !== exactPath) {
+    } else if (!equalsIgnoreCase(candidatePath.replace(/\/$/, ''), exactPath)) {
       throw new Error('nextUrl does not belong to this Bitbucket list endpoint')
     }
     return validated


### PR DESCRIPTION
Follow-up to #6860, which merged before this round of review feedback landed.

Cursor Bugbot flagged this on #6860 (thread [r3818428661](https://github.com/simstudioai/sim/pull/6860#discussion_r3818428661)) after the squash merge, so the fix goes up separately.

## Problem

Bitbucket resolves workspace and repository slugs case-insensitively but echoes the **canonical lowercase** form back in `next` links, diff/diffstat redirect targets, and async merge task `Location` headers. Three call sites bound those responses back to the caller's slug with exact string equality, so a mixed-case `workspaceSlug` or `repoSlug` succeeded on the first request and then threw on every follow-up:

- pagination broke on the second page
- PR diff/diffstat redirect resolution failed
- **merge task polling failed after a 202** — the worst case, since the merge has already started by then

## Fix

All three now compare through a shared `equalsIgnoreCase`:

| Site | Scope of the change |
|---|---|
| `bitbucketApiUrl` | exact-path branch, `nextPathPrefix` segment match, and `nextRevision` (hex SHAs are case-insensitive, and `requireBitbucketSha1` already accepts uppercase) |
| `validateBitbucketPullRequestRedirect` | prefix match only — the opaque spec after it is still sliced from the original pathname verbatim |
| `mergeTaskLocation` | same, with the task id decoded from the untouched pathname |

Repository **file paths** keep verbatim comparison — git treats those as case-sensitive, so `src/Dir` must not match `src/dir`.

## Tests

Three cases added, each verified to fail without the fix:
- a canonical-cased cursor accepted for a mixed-case slug (`utils.test.ts`)
- a re-cased **file path** still rejected (`utils.test.ts`)
- a canonical-cased merge task `Location` accepted for a mixed-case slug (`pull-requests.test.ts`)

The same bug class was fixed in the repository selector route in #6860; this closes it in the tool layer.