### PR TITLE
fix(setup): publish unscoped setup package

### DIFF
--- a/.agents/skills/validate-integration/SKILL.md
+++ b/.agents/skills/validate-integration/SKILL.md
@@ -300,7 +300,7 @@ block's generated `oauthServiceId` through the shared deployment capability cata
 - [ ] Every field listed by that capability exists in `apps/sim/lib/core/config/env.ts`
 - [ ] Every capability field has the correct `text` or `secret` entry in `OAUTH_CLIENT_SETUP_FIELDS`; no CLI naming heuristic is required
 - [ ] Shared Google/Microsoft service IDs resolve to their provider capability rather than duplicate entries
-- [ ] `npx @sim/setup add integration <capabilityId>` is the command emitted by availability; the CLI has only the exhaustive input-mode projection, not a second runtime provider definition
+- [ ] `npx sim-setup add integration <capabilityId>` is the command emitted by availability; the CLI has only the exhaustive input-mode projection, not a second runtime provider definition
 - [ ] If the canonical OAuth service declares `serviceAccountProviderId`,
       the generated `SERVICE_ACCOUNT_PROVIDER_BY_OAUTH_SERVICE_ID[serviceId]` has the same provider ID
 - [ ] The service-account `deploymentRequirement` matches how that credential actually works:

--- a/.github/workflows/publish-sim-setup.yml
+++ b/.github/workflows/publish-sim-setup.yml
@@ -155,8 +155,8 @@ jobs:
         env:
           VERSION: ${{ steps.release.outputs.version }}
         run: |
-          if bun pm view "@sim/setup@$VERSION" version > /dev/null 2>&1; then
-            echo "@sim/setup@$VERSION is already published. Bump packages/sim-setup/package.json before releasing another build." >&2
+          if bun pm view "sim-setup@$VERSION" version > /dev/null 2>&1; then
+            echo "sim-setup@$VERSION is already published. Bump packages/sim-setup/package.json before releasing another build." >&2
             exit 1
           fi
 
@@ -171,4 +171,4 @@ jobs:
         env:
           VERSION: ${{ steps.release.outputs.version }}
           NPM_TAG: ${{ steps.release.outputs.tag }}
-        run: echo "Published @sim/setup@$VERSION with the '$NPM_TAG' tag."
+        run: echo "Published sim-setup@$VERSION with the '$NPM_TAG' tag."

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ### Self-hosted
 
 ```bash
-npx @sim/setup
+npx sim-setup
 ```
 
 Open [http://localhost:3000](http://localhost:3000)
@@ -72,7 +72,7 @@ Open [http://localhost:3000](http://localhost:3000)
 
 **Requirements:** [Node.js 20+](https://nodejs.org/) and [Docker](https://www.docker.com/).
 
-`npx @sim/setup` is an interactive wizard that creates a small `sim/` deployment directory, provisions the database, generates secrets, writes `.env`, connects a Chat API key, and starts the published Sim images with Docker Compose. It does not clone the repository.
+`npx sim-setup` is an interactive wizard that creates a small `sim/` deployment directory, provisions the database, generates secrets, writes `.env`, connects a Chat API key, and starts the published Sim images with Docker Compose. It does not clone the repository.
 
 When it finishes, open [http://localhost:3000](http://localhost:3000).
 
@@ -81,32 +81,32 @@ Inside a cloned Sim repository, run `bun run sim-setup` to unlock the source-onl
 Reconfigure an optional capability without rerunning the full wizard:
 
 ```bash
-npx @sim/setup config
-npx @sim/setup add email
-npx @sim/setup add storage
-npx @sim/setup add sandbox
-npx @sim/setup add jobs
-npx @sim/setup add cache
-npx @sim/setup add knowledge
-npx @sim/setup add llm
-npx @sim/setup add integration slack
+npx sim-setup config
+npx sim-setup add email
+npx sim-setup add storage
+npx sim-setup add sandbox
+npx sim-setup add jobs
+npx sim-setup add cache
+npx sim-setup add knowledge
+npx sim-setup add llm
+npx sim-setup add integration slack
 ```
 
-`npx @sim/setup config` detects the effective local-dev, Docker Compose, or current-context
+`npx sim-setup config` detects the effective local-dev, Docker Compose, or current-context
 Helm configuration and reports configured, missing, or invalid capabilities and OAuth
-integrations without printing credential values. This is separate from `npx @sim/setup status`,
+integrations without printing credential values. This is separate from `npx sim-setup status`,
 which reports whether installed services are running and healthy.
 
 Manage your install from its directory:
 
 ```bash
-npx @sim/setup start | stop | restart   # bring your install up / down / cycle
-npx @sim/setup update                   # pull and apply Compose images
-npx @sim/setup status                   # what's installed and healthy
-npx @sim/setup logs                     # follow logs
-npx @sim/setup doctor                   # diagnose configuration problems
-npx @sim/setup down                     # remove containers (data kept)
-npx @sim/setup reset                    # archive .env and wipe managed data
+npx sim-setup start | stop | restart   # bring your install up / down / cycle
+npx sim-setup update                   # pull and apply Compose images
+npx sim-setup status                   # what's installed and healthy
+npx sim-setup logs                     # follow logs
+npx sim-setup doctor                   # diagnose configuration problems
+npx sim-setup down                     # remove containers (data kept)
+npx sim-setup reset                    # archive .env and wipe managed data
 ```
 
 The setup package detects how you're running and acts accordingly. Use `--dir <path>` to create or manage a deployment somewhere other than `./sim`.
@@ -115,7 +115,7 @@ Sim also supports local models via [Ollama](https://ollama.ai) and [vLLM](https:
 
 ## Chat API Keys
 
-Chat is a Sim-managed service. `npx @sim/setup` connects a Chat API key for you — sign in when it opens your browser and the key is stored automatically. To view, create, or revoke keys later, go to [sim.ai/selfhost/settings/chat-keys](https://sim.ai/selfhost/settings/chat-keys).
+Chat is a Sim-managed service. `npx sim-setup` connects a Chat API key for you — sign in when it opens your browser and the key is stored automatically. To view, create, or revoke keys later, go to [sim.ai/selfhost/settings/chat-keys](https://sim.ai/selfhost/settings/chat-keys).
 
 ## Environment Variables
 

--- a/apps/docs/content/docs/en/platform/self-hosting/docker.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/docker.mdx
@@ -10,7 +10,7 @@ import { FAQ } from '@/components/ui/faq'
 ## Quick Start
 
 ```bash
-npx @sim/setup
+npx sim-setup
 ```
 
 Open [http://localhost:3000](http://localhost:3000)
@@ -144,7 +144,7 @@ docker compose -f docker-compose.prod.yml logs migrations
 docker compose -f docker-compose.prod.yml logs -f cron
 
 # Upgrade: bump SIM_VERSION in .env when pinned, then
-npx @sim/setup update
+npx sim-setup update
 ```
 
 <FAQ items={[

--- a/apps/docs/content/docs/en/platform/self-hosting/environment-variables.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/environment-variables.mdx
@@ -178,7 +178,7 @@ See [Observability](/platform/self-hosting/observability).
 | Variable | Description |
 |----------|-------------|
 | `COPILOT_API_KEY` | API key for Chat. Without it the Sim Chat block, scheduled prompt jobs, and Inbox cannot run |
-| `NEXT_PUBLIC_CHAT_DISABLED` | Set to `true` to hide the Chat module: the workspace lands on your first workflow, with no chats list, scheduled tasks, or editor Chat panel. Chat is shown when unset; `npx @sim/setup` sets it for you if you skip the chat key |
+| `NEXT_PUBLIC_CHAT_DISABLED` | Set to `true` to hide the Chat module: the workspace lands on your first workflow, with no chats list, scheduled tasks, or editor Chat panel. Chat is shown when unset; `npx sim-setup` sets it for you if you skip the chat key |
 | `PII_REDACTION` | Redact PII from workflow logs via Data Retention rules; requires the PII service and a cluster-reachable `INTERNAL_API_BASE_URL` |
 | `PII_GRANULAR_REDACTION` | Additionally expose the execution-altering redaction stages |
 | `DURABLE_SECRET_PROVENANCE_ENFORCED_SURFACES` | Durable stores where a value whose secret provenance was never recorded fails the run instead of logging a warning. `all`, or a comma-separated subset of `memory`, `table-row`, `knowledge`. Unset (nothing enforced) by default |

--- a/apps/docs/content/docs/en/platform/self-hosting/upgrades.mdx
+++ b/apps/docs/content/docs/en/platform/self-hosting/upgrades.mdx
@@ -142,11 +142,11 @@ kubectl logs -n simstudio deploy/sim-app -c migrations --tail=100
   <Tab value="Docker Compose">
 
 ```bash
-npx @sim/setup update
+npx sim-setup update
 docker compose -f docker-compose.prod.yml logs migrations
 ```
 
-`npx @sim/setup update` pulls the versions configured by `SIM_VERSION` (or `latest` when it is
+`npx sim-setup update` pulls the versions configured by `SIM_VERSION` (or `latest` when it is
 unset), recreates the changed services, and keeps data volumes. It is equivalent to running
 `docker compose pull` followed by `docker compose up -d`.
 

--- a/apps/sim/lib/core/config/env-capabilities.server.test.ts
+++ b/apps/sim/lib/core/config/env-capabilities.server.test.ts
@@ -31,13 +31,13 @@ describe('server environment capabilities', () => {
     expect(inspectConfiguredOAuthClient('slack')).toEqual({
       state: 'partial',
       missingFields: ['SLACK_CLIENT_SECRET'],
-      setupCommand: 'npx @sim/setup add integration slack',
+      setupCommand: 'npx sim-setup add integration slack',
     })
   })
 
   it('fails fast when an OAuth client is absent', () => {
     expect(() => requireConfiguredOAuthClient('shopify')).toThrow(
-      'OAuth client shopify is not configured. Run npx @sim/setup add integration shopify.'
+      'OAuth client shopify is not configured. Run npx sim-setup add integration shopify.'
     )
   })
 
@@ -45,7 +45,7 @@ describe('server environment capabilities', () => {
     setEnv({ SLACK_CLIENT_ID: 'slack-client' })
 
     expect(() => requireConfiguredOAuthClient('slack')).toThrow(
-      'OAuth client slack is partially configured — missing SLACK_CLIENT_SECRET. Run npx @sim/setup add integration slack.'
+      'OAuth client slack is partially configured — missing SLACK_CLIENT_SECRET. Run npx sim-setup add integration slack.'
     )
   })
 

--- a/apps/sim/lib/core/config/env-flags.ts
+++ b/apps/sim/lib/core/config/env-flags.ts
@@ -411,7 +411,7 @@ const sandboxProvider = inspectCapability(SANDBOX_CAPABILITY, env).providerId
  *
  * The browser cannot inspect provider credentials, so
  * `NEXT_PUBLIC_SANDBOXES_ENABLED` is its readiness projection. Set the public
- * value only after this server-side check succeeds; `npx @sim/setup doctor`
+ * value only after this server-side check succeeds; `npx sim-setup doctor`
  * reports mismatches in either direction.
  */
 export const isRemoteSandboxEnabled =

--- a/apps/sim/lib/integrations/availability.server.test.ts
+++ b/apps/sim/lib/integrations/availability.server.test.ts
@@ -50,7 +50,7 @@ describe('integration availability', () => {
       oauthAvailable: true,
       serviceAccountAvailable: false,
       missingFields: [],
-      setupCommand: 'npx @sim/setup add integration slack',
+      setupCommand: 'npx sim-setup add integration slack',
     })
   })
 
@@ -60,7 +60,7 @@ describe('integration availability', () => {
       oauthAvailable: false,
       serviceAccountAvailable: true,
       missingFields: ['NOTION_CLIENT_ID', 'NOTION_CLIENT_SECRET'],
-      setupCommand: 'npx @sim/setup add integration notion',
+      setupCommand: 'npx sim-setup add integration notion',
     })
   })
 
@@ -77,7 +77,7 @@ describe('integration availability', () => {
     expect(availabilityFor('x')).toMatchObject({
       state: 'unavailable',
       oauthAvailable: false,
-      setupCommand: 'npx @sim/setup add integration x',
+      setupCommand: 'npx sim-setup add integration x',
     })
   })
 
@@ -87,7 +87,7 @@ describe('integration availability', () => {
       oauthAvailable: false,
       serviceAccountAvailable: false,
       missingFields: ['SLACK_CLIENT_SECRET'],
-      setupCommand: 'npx @sim/setup add integration slack',
+      setupCommand: 'npx sim-setup add integration slack',
     })
   })
 
@@ -158,7 +158,7 @@ describe('integration availability', () => {
       state: 'unavailable',
       serviceAccountAvailable: false,
       missingFields: ['TRELLO_API_KEY'],
-      setupCommand: 'npx @sim/setup add integration trello',
+      setupCommand: 'npx sim-setup add integration trello',
     })
     expect(availabilityFor('trello', { TRELLO_API_KEY: 'trello-key' })).toMatchObject({
       state: 'ready',
@@ -181,7 +181,7 @@ describe('integration availability', () => {
 
     for (const integration of availability) {
       if (!integration.setupCommand) continue
-      const capabilityId = integration.setupCommand.replace('npx @sim/setup add integration ', '')
+      const capabilityId = integration.setupCommand.replace('npx sim-setup add integration ', '')
       expect(Object.hasOwn(OAUTH_CLIENT_CAPABILITIES, capabilityId)).toBe(true)
     }
   })

--- a/apps/sim/lib/oauth/oauth.test.ts
+++ b/apps/sim/lib/oauth/oauth.test.ts
@@ -559,7 +559,7 @@ describe('OAuth Token Refresh', () => {
       expect(result).toEqual({
         ok: false,
         message:
-          'OAuth client monday is partially configured — missing MONDAY_CLIENT_SECRET. Run npx @sim/setup add integration monday.',
+          'OAuth client monday is partially configured — missing MONDAY_CLIENT_SECRET. Run npx sim-setup add integration monday.',
       })
       expect(mockFetch).not.toHaveBeenCalled()
     })

--- a/bun.lock
+++ b/bun.lock
@@ -620,7 +620,7 @@
       },
     },
     "packages/sim-setup": {
-      "name": "@sim/setup",
+      "name": "sim-setup",
       "version": "1.0.0",
       "bin": {
         "sim-setup": "dist/index.js",
@@ -1839,7 +1839,7 @@
 
     "@sim/security": ["@sim/security@workspace:packages/security"],
 
-    "@sim/setup": ["@sim/setup@workspace:packages/sim-setup"],
+    "sim-setup": ["sim-setup@workspace:packages/sim-setup"],
 
     "@sim/terminal-protocol": ["@sim/terminal-protocol@workspace:packages/terminal-protocol"],
 

--- a/packages/deployment-config/src/env-capabilities.ts
+++ b/packages/deployment-config/src/env-capabilities.ts
@@ -343,7 +343,7 @@ export function defineCapability<const TDefinition extends CapabilityDefinition>
 
 /** Returns the canonical command for configuring a runtime capability. */
 export function getCapabilitySetupCommand(definition: CapabilityDefinition): string {
-  return `npx @sim/setup add ${definition.id}`
+  return `npx sim-setup add ${definition.id}`
 }
 
 interface RequirementInspection {
@@ -1429,7 +1429,7 @@ export function inspectOAuthClientCapability(
     return {
       state: 'absent',
       missingFields: [],
-      setupCommand: `npx @sim/setup add integration ${providerId}`,
+      setupCommand: `npx sim-setup add integration ${providerId}`,
     }
   }
 
@@ -1437,7 +1437,7 @@ export function inspectOAuthClientCapability(
   return {
     state: present.length === 0 ? 'absent' : present.length === fields.length ? 'ready' : 'partial',
     missingFields: fields.filter((key) => readOAuthClientFieldValue(values, key) === null),
-    setupCommand: `npx @sim/setup add integration ${providerId}`,
+    setupCommand: `npx sim-setup add integration ${providerId}`,
   }
 }
 

--- a/packages/deployment-config/src/integration-availability.ts
+++ b/packages/deployment-config/src/integration-availability.ts
@@ -90,7 +90,7 @@ function resolveOAuthIntegrationAvailability(
   }
 
   const oauth = inspectOAuthClientCapability(capabilityId, values)
-  const setupCommand = `npx @sim/setup add integration ${capabilityId}`
+  const setupCommand = `npx sim-setup add integration ${capabilityId}`
   const serviceAccountAvailable = Boolean(
     serviceAccount &&
       serviceAccount.deploymentRequirement !== 'preview-gated' &&

--- a/packages/sim-setup/README.md
+++ b/packages/sim-setup/README.md
@@ -1,9 +1,9 @@
-# @sim/setup
+# sim-setup
 
 Set up and manage a self-hosted Sim installation.
 
 ```bash
-npx @sim/setup
+npx sim-setup
 ```
 
 Outside a Sim source checkout, the command creates a Docker Compose installation using published

--- a/packages/sim-setup/THIRD_PARTY_LICENSES
+++ b/packages/sim-setup/THIRD_PARTY_LICENSES
@@ -1,4 +1,4 @@
-The @sim/setup bundle includes the following third-party software.
+The sim-setup bundle includes the following third-party software.
 
 @clack/core and @clack/prompts
 Copyright (c) 2025-Present Bombshell contributors

--- a/packages/sim-setup/package.json
+++ b/packages/sim-setup/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sim/setup",
+  "name": "sim-setup",
   "version": "1.0.0",
   "description": "Set up and manage a self-hosted Sim installation",
   "type": "module",

--- a/packages/sim-setup/src/capability-config.ts
+++ b/packages/sim-setup/src/capability-config.ts
@@ -863,7 +863,7 @@ export function getCapabilitySetup(id: string): CapabilitySetupDefinition | null
 }
 
 export function getSetupCommand(id: string): string {
-  return `npx @sim/setup add ${id}`
+  return `npx sim-setup add ${id}`
 }
 
 type OAuthClientSetupFields = {

--- a/packages/sim-setup/src/capability-status.test.ts
+++ b/packages/sim-setup/src/capability-status.test.ts
@@ -38,7 +38,7 @@ describe('env capability status', () => {
     expect(status.features.sandbox).toEqual({
       id: 'sandbox',
       label: 'Function sandboxes',
-      setupCommand: 'npx @sim/setup add sandbox',
+      setupCommand: 'npx sim-setup add sandbox',
       state: 'default',
       providerId: 'disabled',
     })

--- a/packages/sim-setup/src/capability-status.ts
+++ b/packages/sim-setup/src/capability-status.ts
@@ -38,7 +38,7 @@ export interface CapabilityStatusIssue {
 interface FeatureStatusBase<TId extends SetupStatusFeatureId> {
   id: TId
   label: string
-  setupCommand: `npx @sim/setup add ${TId}`
+  setupCommand: `npx sim-setup add ${TId}`
   state: CapabilityStatusState
   issue?: CapabilityStatusIssue
 }
@@ -143,7 +143,7 @@ function featureMetadata<TId extends SetupStatusFeatureId>(id: TId) {
   return {
     id,
     label: definition.label,
-    setupCommand: `npx @sim/setup add ${id}` as const,
+    setupCommand: `npx sim-setup add ${id}` as const,
   }
 }
 

--- a/packages/sim-setup/src/checks.ts
+++ b/packages/sim-setup/src/checks.ts
@@ -113,7 +113,7 @@ function checkFiles(ctx: CheckContext): Finding[] {
         group: 'files',
         status: 'fail',
         message: 'no env files found',
-        fix: 'run: npx @sim/setup',
+        fix: 'run: npx sim-setup',
       },
     ]
   }
@@ -135,7 +135,7 @@ function checkFiles(ctx: CheckContext): Finding[] {
       message: `${rel(file)} is missing`,
       fix: canSeed
         ? `run doctor --fix to seed it from apps/${target === 'db' ? '../packages/db' : target}/.env.example + apps/sim/.env`
-        : 'run: npx @sim/setup',
+        : 'run: npx sim-setup',
       autofix: canSeed
         ? () => {
             const keys = target === 'db' ? ['DATABASE_URL'] : [...SHARED_KEYS]
@@ -559,7 +559,7 @@ async function checkDatabase(sim: EnvFile): Promise<Finding[]> {
         group: 'live',
         status: 'fail',
         message: `database unreachable: ${probe.error}`,
-        fix: 'start Postgres (npx @sim/setup can manage a pgvector container) or fix DATABASE_URL',
+        fix: 'start Postgres (npx sim-setup can manage a pgvector container) or fix DATABASE_URL',
       })
     } else {
       findings.push({

--- a/packages/sim-setup/src/compose-asset.ts
+++ b/packages/sim-setup/src/compose-asset.ts
@@ -29,7 +29,7 @@ function readManagedState(root: string): ManagedState | null {
     !('composeSha256' in parsed) ||
     typeof parsed.composeSha256 !== 'string'
   ) {
-    throw new Error(`${file} is not a valid @sim/setup managed-state file`)
+    throw new Error(`${file} is not a valid sim-setup managed-state file`)
   }
   return { schemaVersion: 1, composeSha256: parsed.composeSha256 }
 }
@@ -58,7 +58,7 @@ export function ensureProductionComposeFile(context: SetupContext = SETUP_CONTEX
 
   const bundled = packagedComposeFile()
   if (!existsSync(bundled)) {
-    throw new Error(`The @sim/setup package is missing its bundled ${COMPOSE_FILE}`)
+    throw new Error(`The sim-setup package is missing its bundled ${COMPOSE_FILE}`)
   }
   mkdirSync(context.root, { recursive: true })
   const packaged = readFileSync(bundled, 'utf8')

--- a/packages/sim-setup/src/feature-setup.ts
+++ b/packages/sim-setup/src/feature-setup.ts
@@ -24,7 +24,7 @@ async function setupIntegration(
   vars: Map<string, string>
 ): Promise<Record<string, string>> {
   if (!requestedId) {
-    throw new Error('Missing integration id. Example: npx @sim/setup add integration slack')
+    throw new Error('Missing integration id. Example: npx sim-setup add integration slack')
   }
   const providerId = resolveOAuthClientCapabilityId(requestedId)
   if (!providerId) {
@@ -131,30 +131,30 @@ export function resolveFeatureSetupDestination(
   sources: readonly ConfigurationSource[]
 ): FeatureSetupDestination {
   if (sources.length === 0) {
-    throw new Error('No Sim configuration was detected. Run npx @sim/setup first.')
+    throw new Error('No Sim configuration was detected. Run npx sim-setup first.')
   }
 
   const managed = sources.filter((source) => source.managedByCurrentCheckout)
   if (managed.length === 0) {
     throw new Error(
-      'No effective configuration is safely writable by this checkout. Process overrides, higher-precedence development env files, external Compose projects, and Helm releases must be updated at their source. Run npx @sim/setup config for the detected sources.'
+      'No effective configuration is safely writable by this checkout. Process overrides, higher-precedence development env files, external Compose projects, and Helm releases must be updated at their source. Run npx sim-setup config for the detected sources.'
     )
   }
   if (managed.length > 1) {
     throw new Error(
-      `More than one effective configuration is writable by this checkout (${managed.map((source) => source.label).join(', ')}). Run npx @sim/setup config and remove the ambiguity before configuring a feature.`
+      `More than one effective configuration is writable by this checkout (${managed.map((source) => source.label).join(', ')}). Run npx sim-setup config and remove the ambiguity before configuring a feature.`
     )
   }
 
   const source = managed[0]
   if (!source.values) {
     throw new Error(
-      `${source.label} is managed by this checkout, but its effective environment could not be resolved. Run npx @sim/setup config and fix the reported source error first.`
+      `${source.label} is managed by this checkout, but its effective environment could not be resolved. Run npx sim-setup config and fix the reported source error first.`
     )
   }
   if (source.kind === 'helm') {
     throw new Error(
-      'Helm configuration cannot be updated by npx @sim/setup add. Update the release Secret or values and upgrade the release.'
+      'Helm configuration cannot be updated by npx sim-setup add. Update the release Secret or values and upgrade the release.'
     )
   }
 

--- a/packages/sim-setup/src/index.ts
+++ b/packages/sim-setup/src/index.ts
@@ -78,7 +78,7 @@ function renderFailure(error: unknown): void {
     }
   }
   console.error(
-    `\n  ${theme.muted('Your progress is saved — re-run')} ${theme.command('npx @sim/setup')} ${theme.muted('to pick up where you left off.')}`
+    `\n  ${theme.muted('Your progress is saved — re-run')} ${theme.command('npx sim-setup')} ${theme.muted('to pick up where you left off.')}`
   )
 }
 

--- a/packages/sim-setup/src/lifecycle.ts
+++ b/packages/sim-setup/src/lifecycle.ts
@@ -301,8 +301,8 @@ function start(install: Install): void {
     p.note(
       [
         `open ${APP_SIGNUP_URL}`,
-        'follow logs:  npx @sim/setup logs',
-        'stop:         npx @sim/setup stop',
+        'follow logs:  npx sim-setup logs',
+        'stop:         npx sim-setup stop',
       ].join('\n'),
       'Running'
     )
@@ -313,10 +313,9 @@ function start(install: Install): void {
     for (const name of names) dockerRun(['start', name], `docker start ${name} failed`)
     if (names.length) p.log.step(`Started ${names.join(', ')}`)
     p.note(
-      [
-        'start the dev server:  bun run dev:full',
-        'stop DB/Redis:         npx @sim/setup stop',
-      ].join('\n'),
+      ['start the dev server:  bun run dev:full', 'stop DB/Redis:         npx sim-setup stop'].join(
+        '\n'
+      ),
       'Ready'
     )
     return
@@ -331,7 +330,7 @@ function stop(install: Install): void {
     dockerRun(composeArgs(install, 'stop'), 'docker compose stop failed', install.dir)
     spin.stop('Containers stopped (data kept)')
     p.note(
-      ['start again:  npx @sim/setup start', 'remove:       npx @sim/setup down'].join('\n'),
+      ['start again:  npx sim-setup start', 'remove:       npx sim-setup down'].join('\n'),
       'Stopped'
     )
     return
@@ -351,7 +350,7 @@ function stop(install: Install): void {
     [
       `scale down:  kubectl --context ${c} -n ${K8S_NAMESPACE} scale deploy --all --replicas=0`,
       `scale up:    kubectl --context ${c} -n ${K8S_NAMESPACE} scale deploy --all --replicas=1`,
-      'tear down:   npx @sim/setup down',
+      'tear down:   npx sim-setup down',
     ].join('\n'),
     'Kubernetes'
   )
@@ -420,8 +419,8 @@ function update(install: Install): void {
   p.note(
     [
       `version: ${theme.command(`SIM_VERSION in ${path.join(install.dir, '.env')}`)} (latest when unset)`,
-      `check:   ${theme.command('npx @sim/setup status')}`,
-      `logs:    ${theme.command('npx @sim/setup logs')}`,
+      `check:   ${theme.command('npx sim-setup status')}`,
+      `logs:    ${theme.command('npx sim-setup logs')}`,
     ].join('\n'),
     'Update complete'
   )
@@ -534,7 +533,7 @@ async function reset(install: Install | null): Promise<void> {
     }
     p.log.step(`Uninstalled ${K8S_RELEASE}`)
   }
-  p.note(`start fresh with ${theme.command('npx @sim/setup')}`, 'Reset complete')
+  p.note(`start fresh with ${theme.command('npx sim-setup')}`, 'Reset complete')
 }
 
 async function status(): Promise<void> {
@@ -555,7 +554,7 @@ async function status(): Promise<void> {
   if (installs.length === 0) {
     console.log(
       docker
-        ? ` ${glyph.warn} No Sim install detected — run ${theme.command('npx @sim/setup')}.`
+        ? ` ${glyph.warn} No Sim install detected — run ${theme.command('npx sim-setup')}.`
         : ` ${glyph.warn} No install detected, but that may just be Docker being down.`
     )
     return
@@ -585,7 +584,7 @@ export async function runLifecycle(command: LifecycleCommand): Promise<void> {
 
   const install = await resolveInstall(installs)
   if (!install) {
-    p.log.warn(`No Sim install detected. Run ${theme.command('npx @sim/setup')} first.`)
+    p.log.warn(`No Sim install detected. Run ${theme.command('npx sim-setup')} first.`)
     return
   }
   switch (command) {

--- a/packages/sim-setup/src/modes/compose.ts
+++ b/packages/sim-setup/src/modes/compose.ts
@@ -125,7 +125,7 @@ async function ensureComposePortsFree(
   if (toCheck.length === 0) return
   if (await ensurePortsFree(toCheck)) return
   throw new SetupError(`ports ${toCheck.map((port) => `:${port}`).join('/')} are in use`, [
-    `free the ports, then re-run: ${theme.command('npx @sim/setup')}`,
+    `free the ports, then re-run: ${theme.command('npx sim-setup')}`,
     `see what holds them: ${theme.command('lsof -nP -iTCP:3000 -sTCP:LISTEN')}`,
     `stop a container publishing them: ${theme.command('docker ps')}`,
     `compose file in play: ${composeFile}`,

--- a/packages/sim-setup/src/modes/k8s.ts
+++ b/packages/sim-setup/src/modes/k8s.ts
@@ -174,7 +174,7 @@ async function ensureLocalContext(detection: Detection): Promise<string> {
         spin.stop(`${glyph.fail} kind cluster "sim" would not start`)
         throw new SetupError('the kind cluster "sim" exists but will not come up.', [
           `inspect it: ${theme.command('docker ps -a --filter name=sim-control-plane')}`,
-          `recreate it: ${theme.command('kind delete cluster --name sim')}, then re-run ${theme.command('npx @sim/setup')}`,
+          `recreate it: ${theme.command('kind delete cluster --name sim')}, then re-run ${theme.command('npx sim-setup')}`,
         ])
       }
       spin.stop('kind cluster "sim" started')

--- a/packages/sim-setup/src/setup-status.test.ts
+++ b/packages/sim-setup/src/setup-status.test.ts
@@ -76,7 +76,7 @@ describe('setup status', () => {
     expect(report.capabilityStatus?.features.email.state).toBe('configured')
     expect(output).toContain('Email delivery: Resend')
     expect(output).toContain('SMTP_PORT')
-    expect(output).toContain('configure: npx @sim/setup add email')
+    expect(output).toContain('configure: npx sim-setup add email')
     expect(output).not.toContain('resend-super-secret')
   })
 

--- a/packages/sim-setup/src/setup-status.test.ts
+++ b/packages/sim-setup/src/setup-status.test.ts
@@ -77,6 +77,7 @@ describe('setup status', () => {
     expect(output).toContain('Email delivery: Resend')
     expect(output).toContain('SMTP_PORT')
     expect(output).toContain('configure: npx sim-setup add email')
+    expect(output).not.toContain('Run npx sim-setup add email')
     expect(output).not.toContain('resend-super-secret')
   })
 

--- a/packages/sim-setup/src/setup-status.ts
+++ b/packages/sim-setup/src/setup-status.ts
@@ -330,7 +330,7 @@ export function renderSetupStatusReport(report: SetupStatusReport): string {
   const representedOAuthClients = new Set(
     deploymentIntegrations.flatMap((integration) => {
       if (!integration.setupCommand) return []
-      return [integration.setupCommand.replace('npx @sim/setup add integration ', '')]
+      return [integration.setupCommand.replace('npx sim-setup add integration ', '')]
     })
   )
   const additionalOAuthClients = Object.values(report.capabilityStatus.oauthClients.clients).filter(
@@ -357,7 +357,7 @@ export async function runSetupStatus(): Promise<number> {
   console.log(`\n${theme.heading('◆ Sim setup status')}\n`)
   if (sources.length === 0) {
     console.log(` ${glyph.fail} No local-dev, Docker Compose, or Helm configuration detected.`)
-    console.log(`   ${theme.muted('run: npx @sim/setup')}`)
+    console.log(`   ${theme.muted('run: npx sim-setup')}`)
     return 1
   }
 

--- a/packages/sim-setup/src/setup-status.ts
+++ b/packages/sim-setup/src/setup-status.ts
@@ -132,7 +132,7 @@ function featureGlyph(feature: FeatureStatus): string {
 }
 
 function withoutSetupCommand(message: string): string {
-  return message.replace(/\s+Run npx @sim\/setup setup[^.]*\.$/, '')
+  return message.replace(/\s+Run npx sim-setup add [^.]*\.$/, '')
 }
 
 function setupHint(source: SetupStatusSource, command: string): string | null {

--- a/packages/sim-setup/src/steps.ts
+++ b/packages/sim-setup/src/steps.ts
@@ -72,7 +72,7 @@ export async function promptCopilotKey(existing?: string): Promise<string | null
     // Both halves, because the caller writes the opt-out for a null key: a
     // hand-set credential alone restores capability while Chat stays hidden.
     p.log.warn(
-      'No key received — re-run npx @sim/setup to retry, or set COPILOT_API_KEY and NEXT_PUBLIC_CHAT_DISABLED=false yourself.'
+      'No key received — re-run npx sim-setup to retry, or set COPILOT_API_KEY and NEXT_PUBLIC_CHAT_DISABLED=false yourself.'
     )
     return null
   }
@@ -96,7 +96,7 @@ export function chatFlagValues(copilotKey: string | null): Record<string, string
  *
  *   SIM_CLI_AUTH_ORIGIN=https://www.staging.sim.ai \
  *   SIM_AGENT_API_URL=https://www.staging.copilot.sim.ai \
- *   npx @sim/setup
+ *   npx sim-setup
  *
  * The two belong together — SIM_CLI_AUTH_ORIGIN decides where the Chat key is
  * minted, SIM_AGENT_API_URL decides which backend validates it, and a key from

--- a/packages/sim-setup/src/version.ts
+++ b/packages/sim-setup/src/version.ts
@@ -10,7 +10,7 @@ function readPackageVersion(): string {
     !('version' in metadata) ||
     typeof metadata.version !== 'string'
   ) {
-    throw new Error('@sim/setup package metadata is missing a valid version')
+    throw new Error('sim-setup package metadata is missing a valid version')
   }
   return metadata.version
 }

--- a/packages/sim-setup/src/wizard.ts
+++ b/packages/sim-setup/src/wizard.ts
@@ -172,8 +172,8 @@ export async function runWizard(flags: WizardFlags): Promise<void> {
   p.note(
     [
       mode === 'k8s' ? `port-forward, then open ${APP_SIGNUP_URL}` : `open ${APP_SIGNUP_URL}`,
-      'manage it:  npx @sim/setup start · stop · update · status · logs',
-      'check your setup:  npx @sim/setup doctor',
+      'manage it:  npx sim-setup start · stop · update · status · logs',
+      'check your setup:  npx sim-setup doctor',
       mode === 'dev' && !startDevNow ? `start Sim:  bun run ${devScript}` : null,
     ]
       .filter(Boolean)


### PR DESCRIPTION
## Summary

- Publish the standalone setup CLI as the available `sim-setup` package.
- Update setup guidance, runtime messages, deployment metadata, tests, and release automation to use `npx sim-setup`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- `bun run --cwd packages/sim-setup test` (116 tests)
- affected Sim configuration/integration/OAuth tests (67 tests)
- setup and deployment-config type checks
- setup build and packed Node smoke test
- `bun run lint`
- env-flag and block-registry checks
- `bun run check:audits` (32 audits)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Not applicable; there are no UI changes.
