### PR TITLE
fix(copilot): sanitize edit_workflow result state before returning it to the agent

### DIFF
--- a/apps/sim/lib/copilot/tools/handlers/workflow/mutations.ts
+++ b/apps/sim/lib/copilot/tools/handlers/workflow/mutations.ts
@@ -448,7 +448,6 @@ export async function executeSetBlockEnabled(
         blockId: params.blockId,
         enabled: params.enabled,
         affectedBlockIds: result.affectedBlockIds,
-        workflowState: result.state,
         copilotSanitizedWorkflowState: sanitizeForCopilot(result.state),
         ...(!result.changed
           ? {

--- a/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/index.ts
+++ b/apps/sim/lib/copilot/tools/server/workflow/edit-workflow/index.ts
@@ -33,6 +33,7 @@ import {
   loadWorkflowFromNormalizedTables,
   saveWorkflowToNormalizedTables,
 } from '@/lib/workflows/persistence/utils'
+import { sanitizeForCopilot } from '@/lib/workflows/sanitization/json-sanitizer'
 import { validateWorkflowState } from '@/lib/workflows/sanitization/validation'
 import { withBlockVisibility } from '@/blocks/visibility/server-context'
 import { getUserPermissionConfig } from '@/ee/access-control/utils/permission-check'
@@ -408,7 +409,7 @@ export const editWorkflowServerTool: BaseServerTool<EditWorkflowParams, unknown>
       success: true,
       workflowId,
       workflowName: workflowName ?? 'Workflow',
-      workflowState: { ...finalWorkflowState, blocks: layoutedBlocks },
+      workflowState: sanitizeForCopilot(workflowStateForDb),
       workflowLint,
       ...(workflowLintMessage && { workflowLintMessage }),
       ...(inputErrors && {


### PR DESCRIPTION
## Summary
- `edit_workflow` returned the raw post-layout workflow state in its result, so the agent saw every block's `position`, `height`, `layout`, and `outputs` and could quote canvas coordinates back to the user
- route the returned `workflowState` through `sanitizeForCopilot` — the same projection `state.json` already uses — so the agent gets the same shape in both places (block ids, inputs, connections, nested subflows) and no UI-only fields
- drop the redundant raw `workflowState` from `set_block_enabled`, which already returned the sanitized copy alongside it
- no consumer reads the raw contents: the canvas re-fetches state from the DB after an edit, the Go side only checks for the key's presence, and `edit_workflow` declares no result schema

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `type-check`, `lint`, `check:audits`, and the edit-workflow / workflow-handler test suites pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)