### PR TITLE
fix(enrichments): project provider failures

### DIFF
--- a/apps/sim/enrichments/index.ts
+++ b/apps/sim/enrichments/index.ts
@@ -4,6 +4,8 @@ export type {
   EnrichmentInputField,
   EnrichmentOutputField,
   EnrichmentProvider,
+  EnrichmentProviderFailure,
+  EnrichmentProviderFailureProjection,
   EnrichmentRegistry,
   EnrichmentRunContext,
 } from './types'

--- a/apps/sim/enrichments/phone-number/phone-number.test.ts
+++ b/apps/sim/enrichments/phone-number/phone-number.test.ts
@@ -76,6 +76,27 @@ describe('phone-number enrichment cascade', () => {
       expect(p.buildParams({ fullName: 'John Doe' })).toBeNull()
       expect(p.mapOutput({ person: { mobile: { mobile: '+1555' } } })).toEqual({ phone: '+1555' })
     })
+
+    it('recognizes only Prospeo NO_MATCH as a clean miss', () => {
+      expect(
+        p.projectFailure({
+          error: 'NO_MATCH',
+          output: { status: 400, data: { error: true, error_code: 'NO_MATCH' } },
+        })
+      ).toEqual({ status: 'no_match' })
+      expect(
+        p.projectFailure({
+          error: 'INVALID_API_KEY',
+          output: { status: 400, data: { error: true, error_code: 'INVALID_API_KEY' } },
+        })
+      ).toEqual({ status: 'error', error: 'INVALID_API_KEY' })
+      expect(
+        p.projectFailure({
+          error: 'Bad Request',
+          output: { status: 400, data: { error: true } },
+        })
+      ).toEqual({ status: 'error', error: 'Bad Request' })
+    })
   })
 
   describe('leadmagic', () => {

--- a/apps/sim/enrichments/phone-number/phone-number.ts
+++ b/apps/sim/enrichments/phone-number/phone-number.ts
@@ -1,6 +1,12 @@
 import { Phone } from '@sim/emcn/icons'
-import { filterUndefined } from '@sim/utils/object'
-import { firstNonEmpty, normalizeDomain, str, toolProvider } from '@/enrichments/providers'
+import { filterUndefined, isRecordLike } from '@sim/utils/object'
+import {
+  firstNonEmpty,
+  normalizeDomain,
+  projectEnrichmentProviderFailure,
+  str,
+  toolProvider,
+} from '@/enrichments/providers'
 import type { EnrichmentConfig } from '@/enrichments/types'
 
 /**
@@ -102,6 +108,16 @@ export const phoneNumberEnrichment: EnrichmentConfig = {
           company_website: companyWebsite || undefined,
           enrich_mobile: true,
         })
+      },
+      projectFailure: (failure) => {
+        if (
+          isRecordLike(failure.output) &&
+          isRecordLike(failure.output.data) &&
+          failure.output.data.error_code === 'NO_MATCH'
+        ) {
+          return { status: 'no_match' }
+        }
+        return projectEnrichmentProviderFailure(failure)
       },
       mapOutput: (output) => {
         const person = output.person as Record<string, unknown> | undefined

--- a/apps/sim/enrichments/phone-number/phone-number.ts
+++ b/apps/sim/enrichments/phone-number/phone-number.ts
@@ -1,12 +1,7 @@
 import { Phone } from '@sim/emcn/icons'
-import { filterUndefined, isRecordLike } from '@sim/utils/object'
-import {
-  firstNonEmpty,
-  normalizeDomain,
-  projectEnrichmentProviderFailure,
-  str,
-  toolProvider,
-} from '@/enrichments/providers'
+import { filterUndefined } from '@sim/utils/object'
+import { projectProspeoEnrichmentFailure } from '@/enrichments/provider-failures/prospeo'
+import { firstNonEmpty, normalizeDomain, str, toolProvider } from '@/enrichments/providers'
 import type { EnrichmentConfig } from '@/enrichments/types'
 
 /**
@@ -109,16 +104,7 @@ export const phoneNumberEnrichment: EnrichmentConfig = {
           enrich_mobile: true,
         })
       },
-      projectFailure: (failure) => {
-        if (
-          isRecordLike(failure.output) &&
-          isRecordLike(failure.output.data) &&
-          failure.output.data.error_code === 'NO_MATCH'
-        ) {
-          return { status: 'no_match' }
-        }
-        return projectEnrichmentProviderFailure(failure)
-      },
+      projectFailure: projectProspeoEnrichmentFailure,
       mapOutput: (output) => {
         const person = output.person as Record<string, unknown> | undefined
         const mobile = person?.mobile as Record<string, unknown> | undefined

--- a/apps/sim/enrichments/provider-failures/prospeo.ts
+++ b/apps/sim/enrichments/provider-failures/prospeo.ts
@@ -1,0 +1,20 @@
+import { isRecordLike } from '@sim/utils/object'
+import { projectEnrichmentProviderFailure } from '@/enrichments/providers'
+import type {
+  EnrichmentProviderFailure,
+  EnrichmentProviderFailureProjection,
+} from '@/enrichments/types'
+
+/** Projects Prospeo's documented `NO_MATCH` error as a clean provider miss. */
+export function projectProspeoEnrichmentFailure(
+  failure: EnrichmentProviderFailure
+): EnrichmentProviderFailureProjection {
+  if (
+    isRecordLike(failure.output) &&
+    isRecordLike(failure.output.data) &&
+    failure.output.data.error_code === 'NO_MATCH'
+  ) {
+    return { status: 'no_match' }
+  }
+  return projectEnrichmentProviderFailure(failure)
+}

--- a/apps/sim/enrichments/providers.ts
+++ b/apps/sim/enrichments/providers.ts
@@ -1,7 +1,10 @@
+import { isRecordLike } from '@sim/utils/object'
 import type {
   EnrichmentInputField,
   EnrichmentOutputField,
   EnrichmentProvider,
+  EnrichmentProviderFailure,
+  EnrichmentProviderFailureProjection,
 } from '@/enrichments/types'
 
 /**
@@ -56,6 +59,20 @@ export function splitName(fullName: unknown): { firstName: string; lastName: str
   return { firstName: parts[0], lastName: parts.slice(1).join(' ') }
 }
 
+/** Projects the standard provider failure contract into a cascade outcome. */
+export function projectEnrichmentProviderFailure(
+  failure: EnrichmentProviderFailure
+): EnrichmentProviderFailureProjection {
+  if (isRecordLike(failure.output) && failure.output.status === 404) {
+    return { status: 'no_match' }
+  }
+  return { status: 'error', error: failure.error }
+}
+
+type EnrichmentProviderDefinition = Omit<EnrichmentProvider, 'projectFailure'> & {
+  projectFailure?: EnrichmentProvider['projectFailure']
+}
+
 /**
  * Declares a tool-backed enrichment provider as plain data. Keeping this free of
  * any `@/tools` reference (the cascade runner does the `executeTool` call) means
@@ -63,6 +80,9 @@ export function splitName(fullName: unknown): { firstName: string; lastName: str
  * metadata. Workspace scope and BYOK / hosted-key injection are handled by the
  * runner when it executes `toolId`.
  */
-export function toolProvider(provider: EnrichmentProvider): EnrichmentProvider {
-  return provider
+export function toolProvider(provider: EnrichmentProviderDefinition): EnrichmentProvider {
+  return {
+    ...provider,
+    projectFailure: provider.projectFailure ?? projectEnrichmentProviderFailure,
+  }
 }

--- a/apps/sim/enrichments/run.test.ts
+++ b/apps/sim/enrichments/run.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const { mockExecuteTool } = vi.hoisted(() => ({ mockExecuteTool: vi.fn() }))
 vi.mock('@/tools', () => ({ executeTool: mockExecuteTool }))
 
+import { projectEnrichmentProviderFailure, toolProvider } from '@/enrichments/providers'
 import { runEnrichment, skippedEnrichmentDetail } from '@/enrichments/run'
 import type { EnrichmentConfig, EnrichmentProvider } from '@/enrichments/types'
 import { ResolvedSecretTraceRegistry } from '@/executor/utils/resolved-secret-trace-registry'
@@ -16,16 +17,18 @@ function prov(
   id: string,
   opts: {
     build?: (inputs: Record<string, unknown>) => Record<string, unknown> | null
+    projectFailure?: EnrichmentProvider['projectFailure']
     map?: (output: Record<string, unknown>) => Record<string, unknown> | null
   } = {}
 ): EnrichmentProvider {
-  return {
+  return toolProvider({
     id,
     label: id.toUpperCase(),
     toolId: `tool_${id}`,
     buildParams: opts.build ?? (() => ({ q: 'x' })),
+    projectFailure: opts.projectFailure,
     mapOutput: opts.map ?? ((o) => (o.email ? { email: o.email } : null)),
-  }
+  })
 }
 
 function config(providers: EnrichmentProvider[]): EnrichmentConfig {
@@ -136,6 +139,82 @@ describe('runEnrichment cascade detail', () => {
     expect(outcome.result).toEqual({})
     expect(outcome.error).toBeNull()
     expect(outcome.detail.providers.map((p) => p.status)).toEqual(['no_match'])
+  })
+
+  it('continues after a provider translates a documented error into a clean miss', async () => {
+    mockExecuteTool.mockImplementation((toolId: string) => {
+      if (toolId === 'tool_a') {
+        return {
+          success: false,
+          error: 'NO_MATCH',
+          output: { status: 400, data: { error: true, error_code: 'NO_MATCH' } },
+        }
+      }
+      return { success: true, output: { email: 'j@acme.com' } }
+    })
+
+    const outcome = await runEnrichment(
+      config([
+        prov('a', {
+          projectFailure: (failure) => {
+            if (
+              typeof failure.output === 'object' &&
+              failure.output !== null &&
+              'data' in failure.output &&
+              typeof failure.output.data === 'object' &&
+              failure.output.data !== null &&
+              'error_code' in failure.output.data &&
+              failure.output.data.error_code === 'NO_MATCH'
+            ) {
+              return { status: 'no_match' }
+            }
+            return projectEnrichmentProviderFailure(failure)
+          },
+        }),
+        prov('b'),
+      ]),
+      {},
+      ctx
+    )
+
+    expect(outcome.result).toEqual({ email: 'j@acme.com' })
+    expect(outcome.error).toBeNull()
+    expect(outcome.detail.providers.map((p) => p.status)).toEqual(['no_match', 'matched'])
+    expect(mockExecuteTool).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps non-miss provider errors as errors', async () => {
+    mockExecuteTool.mockResolvedValue({
+      success: false,
+      error: 'INVALID_API_KEY',
+      output: { status: 400, data: { error: true, error_code: 'INVALID_API_KEY' } },
+    })
+
+    const outcome = await runEnrichment(
+      config([
+        prov('a', {
+          projectFailure: (failure) => {
+            if (
+              typeof failure.output === 'object' &&
+              failure.output !== null &&
+              'data' in failure.output &&
+              typeof failure.output.data === 'object' &&
+              failure.output.data !== null &&
+              'error_code' in failure.output.data &&
+              failure.output.data.error_code === 'NO_MATCH'
+            ) {
+              return { status: 'no_match' }
+            }
+            return projectEnrichmentProviderFailure(failure)
+          },
+        }),
+      ]),
+      {},
+      ctx
+    )
+
+    expect(outcome.error).toBe('INVALID_API_KEY')
+    expect(outcome.detail.providers.map((p) => p.status)).toEqual(['error'])
   })
 
   it('skippedEnrichmentDetail marks every provider skipped without running', () => {

--- a/apps/sim/enrichments/run.ts
+++ b/apps/sim/enrichments/run.ts
@@ -119,13 +119,11 @@ export async function runEnrichment(
         }
       )
       if (!response.success) {
-        // A 404 means the provider simply has no record for these inputs — a
-        // clean no-match, not an infra failure. Fall through to the next
-        // provider without counting it as an error (so the cell shows "Not
-        // found" rather than an error). Other statuses (auth, rate-limit, 5xx)
-        // are real errors and propagate.
-        const status = (response.output as { status?: unknown } | undefined)?.status
-        if (status === 404) {
+        const projection = provider.projectFailure({
+          error: response.error ?? `${provider.toolId} failed`,
+          output: response.output,
+        })
+        if (projection.status === 'no_match') {
           providers.push({
             id: provider.id,
             label: provider.label,
@@ -137,7 +135,7 @@ export async function runEnrichment(
           })
           continue
         }
-        throw new Error(response.error ?? `${provider.toolId} failed`)
+        throw new Error(projection.error)
       }
       const providerCost = readCost(response.output)
       cost += providerCost

--- a/apps/sim/enrichments/types.ts
+++ b/apps/sim/enrichments/types.ts
@@ -36,6 +36,17 @@ export interface EnrichmentRunContext {
   resolvedSecretTraceRegistry?: ResolvedSecretTraceRegistry
 }
 
+/** Failed tool result projected into the enrichment provider boundary. */
+export interface EnrichmentProviderFailure {
+  error: string
+  output: unknown
+}
+
+/** Normalized result of projecting a failed provider tool call. */
+export type EnrichmentProviderFailureProjection =
+  | { status: 'no_match' }
+  | { status: 'error'; error: string }
+
 /**
  * One data source an enrichment can try, described as plain data so the catalog
  * (which the table UI imports for metadata) never pulls in server-only tool
@@ -55,6 +66,11 @@ export interface EnrichmentProvider {
    * inputs to run this provider (cascade falls through to the next).
    */
   buildParams: (inputs: Record<string, unknown>) => Record<string, unknown> | null
+  /**
+   * Projects a failed tool call into the provider-neutral cascade outcome.
+   * `toolProvider` supplies the standard HTTP projection unless overridden.
+   */
+  projectFailure: (failure: EnrichmentProviderFailure) => EnrichmentProviderFailureProjection
   /**
    * Maps the tool's output to `{ [outputId]: value }`, or `null` for no result.
    * An empty/`null` result falls through to the next provider.

--- a/apps/sim/enrichments/work-email/work-email.test.ts
+++ b/apps/sim/enrichments/work-email/work-email.test.ts
@@ -68,6 +68,21 @@ describe('work-email enrichment cascade', () => {
         email: 'j@acme.com',
       })
     })
+
+    it('projects Prospeo NO_MATCH as a clean miss without hiding genuine errors', () => {
+      expect(
+        p.projectFailure({
+          error: 'NO_MATCH',
+          output: { status: 400, data: { error: true, error_code: 'NO_MATCH' } },
+        })
+      ).toEqual({ status: 'no_match' })
+      expect(
+        p.projectFailure({
+          error: 'INVALID_API_KEY',
+          output: { status: 400, data: { error: true, error_code: 'INVALID_API_KEY' } },
+        })
+      ).toEqual({ status: 'error', error: 'INVALID_API_KEY' })
+    })
   })
 
   describe('wiza (opportunistic)', () => {

--- a/apps/sim/enrichments/work-email/work-email.ts
+++ b/apps/sim/enrichments/work-email/work-email.ts
@@ -1,5 +1,6 @@
 import { Mail } from '@sim/emcn/icons'
 import { filterUndefined } from '@sim/utils/object'
+import { projectProspeoEnrichmentFailure } from '@/enrichments/provider-failures/prospeo'
 import { normalizeDomain, splitName, str, toolProvider } from '@/enrichments/providers'
 import type { EnrichmentConfig } from '@/enrichments/types'
 
@@ -86,6 +87,7 @@ export const workEmailEnrichment: EnrichmentConfig = {
           company_website: companyWebsite || undefined,
         })
       },
+      projectFailure: projectProspeoEnrichmentFailure,
       mapOutput: (output) => {
         const person = output.person as Record<string, unknown> | undefined
         const emailObj = person?.email as Record<string, unknown> | undefined

--- a/apps/sim/tools/enrichment-hosting.test.ts
+++ b/apps/sim/tools/enrichment-hosting.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import { findEmailFromNameTool } from '@/tools/findymail/find_email_from_name'
 import { findEmailsByDomainTool } from '@/tools/findymail/find_emails_by_domain'
 import { findPhoneTool } from '@/tools/findymail/find_phone'
@@ -76,6 +77,7 @@ describe('Prospeo hosted key pricing', () => {
   it('declares hosting with the shared env prefix and BYOK provider', () => {
     expect(enrichPersonTool.hosting?.envKeyPrefix).toBe('PROSPEO_API_KEY')
     expect(enrichPersonTool.hosting?.byokProviderId).toBe('prospeo')
+    expect(enrichPersonTool.errorExtractor).toBe(ErrorExtractorId.PROSPEO_ERRORS)
   })
 
   it('charges 1 credit for a person match and 10 when a mobile is revealed', () => {

--- a/apps/sim/tools/error-extractors.test.ts
+++ b/apps/sim/tools/error-extractors.test.ts
@@ -286,4 +286,31 @@ describe('Error Extractors', () => {
       )
     })
   })
+
+  describe('prospeo-errors', () => {
+    it('extracts the machine-readable no-match code from a 400 response', () => {
+      const errorInfo: ErrorInfo = {
+        status: 400,
+        statusText: 'Bad Request',
+        data: { error: true, error_code: 'NO_MATCH' },
+      }
+
+      expect(extractErrorMessage(errorInfo, ErrorExtractorId.PROSPEO_ERRORS)).toBe('NO_MATCH')
+    })
+
+    it('preserves genuine Prospeo failure details', () => {
+      const errorInfo: ErrorInfo = {
+        status: 400,
+        data: {
+          error: true,
+          error_code: 'INVALID_DATAPOINTS',
+          filter_error: 'full_name and company_website are required',
+        },
+      }
+
+      expect(extractErrorMessage(errorInfo, ErrorExtractorId.PROSPEO_ERRORS)).toBe(
+        'INVALID_DATAPOINTS: full_name and company_website are required'
+      )
+    })
+  })
 })

--- a/apps/sim/tools/error-extractors.ts
+++ b/apps/sim/tools/error-extractors.ts
@@ -375,6 +375,20 @@ const ERROR_EXTRACTORS: ErrorExtractorConfig[] = [
     },
   },
   {
+    id: 'prospeo-errors',
+    description: 'Prospeo API error_code with optional filter_error and message details',
+    examples: ['Prospeo API'],
+    extract: (errorInfo) => {
+      const data = errorInfo?.data
+      if (!data || typeof data !== 'object') return undefined
+
+      const parts = [data.error_code, data.filter_error, data.message].filter(
+        (part): part is string => typeof part === 'string' && Boolean(part.trim())
+      )
+      return parts.length > 0 ? parts.join(': ') : undefined
+    },
+  },
+  {
     id: 'crunchbase-errors',
     description:
       'Crunchbase Data API error envelope: a top-level JSON array of {status, code, message}. Nothing else in this registry reads a bare array, so without it a rejected key or malformed predicate reports only its HTTP status',
@@ -499,6 +513,7 @@ export const ErrorExtractorId = {
   DYNATRACE_ERRORS: 'dynatrace-errors',
   SMARTLEAD_ERRORS: 'smartlead-errors',
   POSTHOG_ERRORS: 'posthog-errors',
+  PROSPEO_ERRORS: 'prospeo-errors',
   CRUNCHBASE_ERRORS: 'crunchbase-errors',
   SPLUNK_ERRORS: 'splunk-errors',
   PLAIN_TEXT_DATA: 'plain-text-data',

--- a/apps/sim/tools/index.test.ts
+++ b/apps/sim/tools/index.test.ts
@@ -36,6 +36,7 @@ import {
   ResolvedSecretTraceRegistry,
 } from '@/executor/utils/resolved-secret-trace-registry'
 import { bitbucketGetPipelineStepLogTool } from '@/tools/bitbucket/get_pipeline_step_log'
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import { fileGetContentTool } from '@/tools/file/get'
 import { memoryAddTool } from '@/tools/memory/add'
 import { tableBatchInsertRowsTool } from '@/tools/table/batch_insert_rows'
@@ -4262,6 +4263,17 @@ describe('Centralized Error Handling', () => {
       { errors: [{ detail: 'Rate limit exceeded' }] },
       'Rate limit exceeded'
     )
+  })
+
+  it('uses a tool-specific Prospeo extractor before flattening a failed response', async () => {
+    const originalExtractor = tools.function_execute.errorExtractor
+    tools.function_execute.errorExtractor = ErrorExtractorId.PROSPEO_ERRORS
+
+    try {
+      await testErrorFormat('Prospeo', { error: true, error_code: 'NO_MATCH' }, 'NO_MATCH')
+    } finally {
+      tools.function_execute.errorExtractor = originalExtractor
+    }
   })
 
   it('should extract Hunter API error format', async () => {

--- a/apps/sim/tools/prospeo/account_information.ts
+++ b/apps/sim/tools/prospeo/account_information.ts
@@ -1,3 +1,4 @@
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import {
   extractProspeoError,
   type ProspeoAccountInformationParams,
@@ -14,6 +15,7 @@ export const accountInformationTool: ToolConfig<
   description:
     'Retrieve the current plan, remaining credits, and renewal date of your Prospeo account.',
   version: '1.0.0',
+  errorExtractor: ErrorExtractorId.PROSPEO_ERRORS,
 
   params: {
     apiKey: {

--- a/apps/sim/tools/prospeo/bulk_enrich_company.ts
+++ b/apps/sim/tools/prospeo/bulk_enrich_company.ts
@@ -1,3 +1,4 @@
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import { prospeoHosting } from '@/tools/prospeo/hosting'
 import {
   extractProspeoError,
@@ -15,6 +16,7 @@ export const bulkEnrichCompanyTool: ToolConfig<
   name: 'Prospeo Bulk Enrich Company',
   description: 'Enrich up to 50 company records at once.',
   version: '1.0.0',
+  errorExtractor: ErrorExtractorId.PROSPEO_ERRORS,
 
   hosting: prospeoHosting<ProspeoBulkEnrichCompanyParams>((_params, output) => {
     // Prospeo reports the exact credits spent for the batch in total_cost.

--- a/apps/sim/tools/prospeo/bulk_enrich_person.ts
+++ b/apps/sim/tools/prospeo/bulk_enrich_person.ts
@@ -1,3 +1,4 @@
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import { prospeoHosting } from '@/tools/prospeo/hosting'
 import {
   extractProspeoError,
@@ -15,6 +16,7 @@ export const bulkEnrichPersonTool: ToolConfig<
   name: 'Prospeo Bulk Enrich Person',
   description: 'Enrich up to 50 person records at once.',
   version: '1.0.0',
+  errorExtractor: ErrorExtractorId.PROSPEO_ERRORS,
 
   hosting: prospeoHosting<ProspeoBulkEnrichPersonParams>((_params, output) => {
     // Prospeo reports the exact credits spent for the batch in total_cost.

--- a/apps/sim/tools/prospeo/enrich_company.ts
+++ b/apps/sim/tools/prospeo/enrich_company.ts
@@ -1,3 +1,4 @@
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import { prospeoHosting } from '@/tools/prospeo/hosting'
 import {
   extractProspeoError,
@@ -14,6 +15,7 @@ export const enrichCompanyTool: ToolConfig<
   name: 'Prospeo Enrich Company',
   description: 'Enrich a company with complete B2B data.',
   version: '1.0.0',
+  errorExtractor: ErrorExtractorId.PROSPEO_ERRORS,
 
   hosting: prospeoHosting<ProspeoEnrichCompanyParams>((_params, output) => {
     // 1 credit per company match; no charge on a no-match or repeat enrichment.

--- a/apps/sim/tools/prospeo/enrich_person.ts
+++ b/apps/sim/tools/prospeo/enrich_person.ts
@@ -1,3 +1,4 @@
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import { prospeoHosting } from '@/tools/prospeo/hosting'
 import {
   extractProspeoError,
@@ -12,6 +13,7 @@ export const enrichPersonTool: ToolConfig<ProspeoEnrichPersonParams, ProspeoEnri
     name: 'Prospeo Enrich Person',
     description: 'Enrich a person with complete B2B profile data, email address and mobile.',
     version: '1.0.0',
+    errorExtractor: ErrorExtractorId.PROSPEO_ERRORS,
 
     hosting: prospeoHosting<ProspeoEnrichPersonParams>((_params, output) => {
       // No charge on a no-match or a repeat enrichment.

--- a/apps/sim/tools/prospeo/search_company.ts
+++ b/apps/sim/tools/prospeo/search_company.ts
@@ -1,3 +1,4 @@
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import { prospeoHosting } from '@/tools/prospeo/hosting'
 import {
   extractProspeoError,
@@ -16,6 +17,7 @@ export const searchCompanyTool: ToolConfig<
   name: 'Prospeo Search Company',
   description: 'Search for companies using 20+ filters to build account lists.',
   version: '1.0.0',
+  errorExtractor: ErrorExtractorId.PROSPEO_ERRORS,
 
   hosting: prospeoHosting<ProspeoSearchCompanyParams>((_params, output) => {
     // 1 credit per page that returns at least one result; free on 30-day dedup.

--- a/apps/sim/tools/prospeo/search_person.ts
+++ b/apps/sim/tools/prospeo/search_person.ts
@@ -1,3 +1,4 @@
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import { prospeoHosting } from '@/tools/prospeo/hosting'
 import {
   extractProspeoError,
@@ -14,6 +15,7 @@ export const searchPersonTool: ToolConfig<ProspeoSearchPersonParams, ProspeoSear
     name: 'Prospeo Search Person',
     description: 'Search for leads using 20+ filters to build targeted contact lists.',
     version: '1.0.0',
+    errorExtractor: ErrorExtractorId.PROSPEO_ERRORS,
 
     hosting: prospeoHosting<ProspeoSearchPersonParams>((_params, output) => {
       // 1 credit per page that returns at least one result; free on 30-day dedup.

--- a/apps/sim/tools/prospeo/search_suggestions.ts
+++ b/apps/sim/tools/prospeo/search_suggestions.ts
@@ -1,3 +1,4 @@
+import { ErrorExtractorId } from '@/tools/error-extractors'
 import {
   extractProspeoError,
   type ProspeoSearchSuggestionsParams,
@@ -14,6 +15,7 @@ export const searchSuggestionsTool: ToolConfig<
   description:
     'Free endpoint to retrieve valid location or job title values for use in Search filters. Provide exactly one of location_search or job_title_search.',
   version: '1.0.0',
+  errorExtractor: ErrorExtractorId.PROSPEO_ERRORS,
 
   params: {
     apiKey: {


### PR DESCRIPTION
## Summary
- add standard, overridable failure projections to enrichment providers
- treat Prospeo `NO_MATCH` responses as clean misses while preserving genuine errors

## Type of Change
- [x] Bug fix

## Testing
- 225 tests passing
- TypeScript, Biome, and all 32 repository audits passing

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
