### PR TITLE
fix(billing): cast outbox payloads for JSONB operators

### DIFF
--- a/apps/sim/lib/billing/enterprise-provisioning.test.ts
+++ b/apps/sim/lib/billing/enterprise-provisioning.test.ts
@@ -650,6 +650,16 @@ describe('Enterprise workspace-move progress', () => {
       failedCount: 1,
       failed: [],
     })
+
+    const renderedJoin = JSON.stringify(dbChainMockFns.innerJoin.mock.calls[0]?.[0])
+    expect(renderedJoin).toContain("::jsonb -> 'sourceOperationIds'")
+    expect(renderedJoin).toContain('jsonb_typeof')
+
+    const renderedFilters = dbChainMockFns.where.mock.calls
+      .map(([condition]) => JSON.stringify(condition))
+      .join('\n')
+    expect(renderedFilters).toContain("::jsonb -> 'sourceOperationIds'")
+    expect(renderedFilters).toContain('?|')
   })
 
   it('rejects provisioning lookups larger than one admin page', async () => {

--- a/apps/sim/lib/billing/enterprise-provisioning.ts
+++ b/apps/sim/lib/billing/enterprise-provisioning.ts
@@ -1365,8 +1365,8 @@ async function getEnterpriseFollowUpProgress(
   const arrayOperationIdExpression = sql<string>`source_operations.operation_id`
   const sourceOperationRows = sql`lateral jsonb_array_elements_text(
     case
-      when jsonb_typeof(${outboxEvent.payload} -> 'sourceOperationIds') = 'array'
-      then ${outboxEvent.payload} -> 'sourceOperationIds'
+      when jsonb_typeof(${outboxEvent.payload}::jsonb -> 'sourceOperationIds') = 'array'
+      then ${outboxEvent.payload}::jsonb -> 'sourceOperationIds'
       else '[]'::jsonb
     end
   ) as source_operations(operation_id)`
@@ -1391,7 +1391,7 @@ async function getEnterpriseFollowUpProgress(
           .where(
             and(
               eq(outboxEvent.eventType, MIGRATED_INVITATION_EMAIL_EVENT_TYPE),
-              sql`coalesce(${outboxEvent.payload} -> 'sourceOperationIds', '[]'::jsonb) ?| array[${sql.join(
+              sql`coalesce(${outboxEvent.payload}::jsonb -> 'sourceOperationIds', '[]'::jsonb) ?| array[${sql.join(
                 uniqueOperationIds.map((operationId) => sql`${operationId}`),
                 sql`, `
               )}]::text[]`

--- a/apps/sim/lib/core/outbox/service.test.ts
+++ b/apps/sim/lib/core/outbox/service.test.ts
@@ -29,6 +29,7 @@ import {
   enqueueOrReschedulePendingOutboxEvent,
   enqueueOutboxEvent,
   enqueueOutboxEvents,
+  outboxEventHasSourceOperationId,
   outboxPayloadHasSourceOperationId,
   processOutboxEvents,
 } from './service'
@@ -123,6 +124,13 @@ describe('enqueueOutboxEvent', () => {
 })
 
 describe('outbox parent-operation correlation', () => {
+  it('casts JSON payloads before applying JSONB containment operators', () => {
+    const query = JSON.stringify(outboxEventHasSourceOperationId('operation-1'))
+
+    expect(query).toContain("::jsonb -> 'sourceOperationIds'")
+    expect(query).toContain('@> jsonb_build_array')
+  })
+
   it('retains both scalar and coalesced parent operation identities', () => {
     expect(
       outboxPayloadHasSourceOperationId({ sourceOperationId: 'operation-1' }, 'operation-1')

--- a/apps/sim/lib/core/outbox/service.ts
+++ b/apps/sim/lib/core/outbox/service.ts
@@ -329,7 +329,7 @@ export async function addOutboxEventSourceOperationId(
 export function outboxEventHasSourceOperationId(operationId: string) {
   return sql<boolean>`(
     ${outboxEvent.payload} ->> 'sourceOperationId' = ${operationId}
-    or coalesce(${outboxEvent.payload} -> 'sourceOperationIds', '[]'::jsonb)
+    or coalesce(${outboxEvent.payload}::jsonb -> 'sourceOperationIds', '[]'::jsonb)
       @> jsonb_build_array(${operationId}::text)
   )`
 }


### PR DESCRIPTION
## Summary
- explicitly cast JSON outbox payloads before JSONB-only follow-up correlation operators
- cover both Enterprise provisioning rollups and shared outbox correlation
- add regression assertions for the generated SQL expressions

## Type of Change
- [x] Bug fix

## Testing
- `bun run lint`
- `bun run type-check`
- `bun run check:audits`
- `bun run check:api-validation`
- `bun run apps/sim/scripts/check-block-registry.ts origin/staging`
- `bunx vitest run lib/billing/enterprise-provisioning.test.ts lib/core/outbox/service.test.ts` (78 tests)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)