### PR TITLE
fix(custom-blocks): give a custom block's logo a tile its header chip can paint

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/providers/custom-blocks-loader.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/custom-blocks-loader.test.tsx
@@ -7,13 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   mockBuildCustomBlockConfig,
-  mockGetCustomBlockIcon,
+  mockGetCustomBlockTile,
   mockHydrateClientCustomBlocks,
   mockUseCustomBlocks,
   mockUseOrgBrandConfig,
 } = vi.hoisted(() => ({
   mockBuildCustomBlockConfig: vi.fn(),
-  mockGetCustomBlockIcon: vi.fn(),
+  mockGetCustomBlockTile: vi.fn(),
   mockHydrateClientCustomBlocks: vi.fn(),
   mockUseCustomBlocks: vi.fn(),
   mockUseOrgBrandConfig: vi.fn(),
@@ -32,7 +32,7 @@ vi.mock('@/blocks/custom/client-overlay', () => ({
 }))
 
 vi.mock('@/blocks/custom/custom-block-icon', () => ({
-  getCustomBlockIcon: mockGetCustomBlockIcon,
+  getCustomBlockTile: mockGetCustomBlockTile,
 }))
 
 vi.mock('@/ee/whitelabeling/components/branding-provider', () => ({
@@ -72,7 +72,7 @@ describe('CustomBlocksLoader', () => {
         },
       ],
     })
-    mockGetCustomBlockIcon.mockReturnValue(() => null)
+    mockGetCustomBlockTile.mockReturnValue({ icon: () => null, bgColor: '#TILE' })
     mockBuildCustomBlockConfig.mockReturnValue({ type: 'custom_host_block' })
   })
 
@@ -88,12 +88,12 @@ describe('CustomBlocksLoader', () => {
     })
 
     expect(mockUseCustomBlocks).toHaveBeenCalledWith('workspace-b')
-    expect(mockGetCustomBlockIcon).toHaveBeenCalledWith(null, 'https://host-b.example/logo.png')
+    expect(mockGetCustomBlockTile).toHaveBeenCalledWith(null, 'https://host-b.example/logo.png')
     expect(mockBuildCustomBlockConfig).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'custom_host_block' }),
       [],
       expect.objectContaining({
-        bgColor: 'transparent',
+        bgColor: '#TILE',
         hideFromToolbar: false,
       })
     )

--- a/apps/sim/app/workspace/[workspaceId]/providers/custom-blocks-loader.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/custom-blocks-loader.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 import { useParams } from 'next/navigation'
 import { buildCustomBlockConfig } from '@/blocks/custom/build-config'
 import { hydrateClientCustomBlocks } from '@/blocks/custom/client-overlay'
-import { getCustomBlockIcon } from '@/blocks/custom/custom-block-icon'
+import { getCustomBlockTile } from '@/blocks/custom/custom-block-icon'
 import { useOrgBrandConfig } from '@/ee/whitelabeling/components/branding-provider'
 import { useCustomBlocks } from '@/hooks/queries/custom-blocks'
 
@@ -28,9 +28,8 @@ export function CustomBlocksLoader() {
       // Disabled blocks stay resolvable (so a still-placed instance renders on the
       // canvas and survives serialization instead of vanishing) but are hidden from
       // the palette so no new instance can be placed; a run fails loudly server-side.
-      (data ?? []).map((block) => {
-        const effectiveIcon = block.iconUrl || fallbackIconUrl
-        return buildCustomBlockConfig(
+      (data ?? []).map((block) =>
+        buildCustomBlockConfig(
           {
             type: block.type,
             name: block.name,
@@ -41,12 +40,11 @@ export function CustomBlocksLoader() {
           },
           block.inputFields,
           {
-            icon: getCustomBlockIcon(block.iconUrl, fallbackIconUrl),
-            bgColor: effectiveIcon ? 'transparent' : undefined,
+            ...getCustomBlockTile(block.iconUrl, fallbackIconUrl),
             hideFromToolbar: !block.enabled,
           }
         )
-      })
+      )
     )
   }, [data, fallbackIconUrl])
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/toolbar/toolbar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/toolbar/toolbar.tsx
@@ -34,13 +34,9 @@ import { useToolbarItemInteractions } from '@/app/workspace/[workspaceId]/w/[wor
 import { LoopTool } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/subflows/loop/loop-config'
 import { ParallelTool } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/subflows/parallel/parallel-config'
 import { BlockTile } from '@/blocks/block-tile'
-import {
-  buildCustomBlockConfig,
-  CUSTOM_BLOCK_TILE_COLOR,
-  isCustomBlockType,
-} from '@/blocks/custom/build-config'
+import { buildCustomBlockConfig, isCustomBlockType } from '@/blocks/custom/build-config'
 import { useCustomBlockOverlayVersion } from '@/blocks/custom/client-overlay'
-import { getCustomBlockIcon } from '@/blocks/custom/custom-block-icon'
+import { getCustomBlockTile } from '@/blocks/custom/custom-block-icon'
 import { getCanonicalBlocksByCategory } from '@/blocks/registry'
 import type { BlockConfig } from '@/blocks/types'
 import { useOrgBrandConfig } from '@/ee/whitelabeling/components/branding-provider'
@@ -484,10 +480,7 @@ export const Toolbar = memo(
       return customBlocksData
         .filter((cb) => cb.enabled && cb.workflowId !== currentWorkflowId)
         .map((cb) => {
-          const icon = getCustomBlockIcon(cb.iconUrl, fallbackIconUrl)
-          // An image (uploaded or whitelabel) renders on a transparent tile; the
-          // default glyph keeps the neutral tile so it stays visible.
-          const tileColor = cb.iconUrl || fallbackIconUrl ? 'transparent' : CUSTOM_BLOCK_TILE_COLOR
+          const { icon, bgColor } = getCustomBlockTile(cb.iconUrl, fallbackIconUrl)
           return {
             name: cb.name,
             type: cb.type,
@@ -500,10 +493,10 @@ export const Toolbar = memo(
                 exposedOutputs: cb.exposedOutputs,
               },
               cb.inputFields,
-              { icon, bgColor: tileColor }
+              { icon, bgColor }
             ),
             icon,
-            bgColor: tileColor,
+            bgColor,
           } satisfies BlockItem
         })
         .sort((a, b) => a.name.localeCompare(b.name))

--- a/apps/sim/blocks/custom/build-config.ts
+++ b/apps/sim/blocks/custom/build-config.ts
@@ -13,8 +13,20 @@ export function isCustomBlockType(type: string | undefined | null): type is stri
   return typeof type === 'string' && type.startsWith(CUSTOM_BLOCK_TYPE_PREFIX)
 }
 
-/** Tile background for custom-block icons (the uploaded image renders on top). */
+/** Tile background behind a custom block's default glyph, when it has no image. */
 export const CUSTOM_BLOCK_TILE_COLOR = '#6F6F6F'
+
+/**
+ * Tile background for a custom block whose icon is an uploaded image — the same
+ * white plate every other light-tiled provider wears.
+ *
+ * Not `'transparent'`: the header chip sets its label beside the icon, so an
+ * unpainted chip leaves the label nothing to contrast and it renders white on white.
+ *
+ * A fixed, non-theme fill, so this is a trade: a dark logo now reads in both
+ * themes, and a light one in neither. There is no per-org override.
+ */
+export const CUSTOM_BLOCK_IMAGE_TILE_COLOR = '#FFFFFF'
 
 /** A curated output exposed on the block, mapped from a child block output. */
 export interface CustomBlockOutput {

--- a/apps/sim/blocks/custom/custom-block-icon.test.tsx
+++ b/apps/sim/blocks/custom/custom-block-icon.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  CUSTOM_BLOCK_IMAGE_TILE_COLOR,
+  CUSTOM_BLOCK_TILE_COLOR,
+} from '@/blocks/custom/build-config'
+// client-boundary-allow: vitest ignores the 'use client' directive; this node-env test exercises the module directly
+import { DefaultCustomBlockIcon, getCustomBlockTile } from '@/blocks/custom/custom-block-icon'
+
+describe('getCustomBlockTile', () => {
+  it('puts an uploaded logo on the light provider plate', () => {
+    const tile = getCustomBlockTile('https://cdn.example/logo.png', null)
+
+    expect(tile.bgColor).toBe(CUSTOM_BLOCK_IMAGE_TILE_COLOR)
+    expect(tile.icon).not.toBe(DefaultCustomBlockIcon)
+  })
+
+  it('falls back to the org whitelabel logo, which is still an image', () => {
+    const tile = getCustomBlockTile(null, 'https://cdn.example/org.png')
+
+    expect(tile.bgColor).toBe(CUSTOM_BLOCK_IMAGE_TILE_COLOR)
+    expect(tile.icon).not.toBe(DefaultCustomBlockIcon)
+  })
+
+  /**
+   * The glyph is drawn in the tile's foreground colour, so it needs the neutral
+   * fill behind it — the white plate would leave it invisible.
+   */
+  it('keeps the default glyph on the neutral tile', () => {
+    const tile = getCustomBlockTile(null, null)
+
+    expect(tile.bgColor).toBe(CUSTOM_BLOCK_TILE_COLOR)
+    expect(tile.icon).toBe(DefaultCustomBlockIcon)
+  })
+
+  /** An empty string is not a logo — it must not select the image plate. */
+  it('treats an empty icon url as no icon', () => {
+    expect(getCustomBlockTile('', '').bgColor).toBe(CUSTOM_BLOCK_TILE_COLOR)
+  })
+
+  it('reuses one component per url so node identity stays stable across renders', () => {
+    const first = getCustomBlockTile('https://cdn.example/logo.png', null)
+    const second = getCustomBlockTile('https://cdn.example/logo.png', null)
+
+    expect(first.icon).toBe(second.icon)
+  })
+})

--- a/apps/sim/blocks/custom/custom-block-icon.tsx
+++ b/apps/sim/blocks/custom/custom-block-icon.tsx
@@ -3,6 +3,10 @@
 import { memo, type SVGProps } from 'react'
 import { cn } from '@sim/emcn'
 import { Box } from '@sim/emcn/icons'
+import {
+  CUSTOM_BLOCK_IMAGE_TILE_COLOR,
+  CUSTOM_BLOCK_TILE_COLOR,
+} from '@/blocks/custom/build-config'
 import type { BlockIcon } from '@/blocks/types'
 
 const cache = new Map<string, BlockIcon>()
@@ -44,13 +48,24 @@ export function makeImageIcon(url: string): BlockIcon {
 export const DefaultCustomBlockIcon: BlockIcon = Box
 
 /**
- * Resolve a custom block's icon: the uploaded image, else the org's whitelabel logo
- * (`fallbackUrl`), else the default glyph.
+ * Resolve a custom block's icon and the tile it sits on: the uploaded image, else
+ * the org's whitelabel logo (`fallbackUrl`), else the default glyph. Both fall out
+ * of the same precedence, so a block can never paint a tile its icon disagrees with.
  */
+export function getCustomBlockTile(
+  iconUrl: string | null | undefined,
+  fallbackUrl?: string | null
+): { icon: BlockIcon; bgColor: string } {
+  const url = iconUrl || fallbackUrl
+  return url
+    ? { icon: makeImageIcon(url), bgColor: CUSTOM_BLOCK_IMAGE_TILE_COLOR }
+    : { icon: DefaultCustomBlockIcon, bgColor: CUSTOM_BLOCK_TILE_COLOR }
+}
+
+/** The icon half of {@link getCustomBlockTile}, for surfaces that paint no tile. */
 export function getCustomBlockIcon(
   iconUrl: string | null | undefined,
   fallbackUrl?: string | null
 ): BlockIcon {
-  const url = iconUrl || fallbackUrl
-  return url ? makeImageIcon(url) : DefaultCustomBlockIcon
+  return getCustomBlockTile(iconUrl, fallbackUrl).icon
 }


### PR DESCRIPTION
## Summary
- A custom block with an uploaded logo declared `bgColor: 'transparent'`, meaning "the image is the whole tile". That holds on tile surfaces, where the image fills the box, but not on the canvas node header — the chip sets its label *beside* the icon, so an unpainted chip left the label nothing to contrast against. `perceivedBrightness('transparent')` is `null`, so the foreground fell back to white and the block name rendered white on the white card; the header showed a bare logo where every other block shows a chip.
- Custom blocks with an image now wear the same white plate as every other light-tiled provider, so the header reads as logo + block name, exactly like Gmail.
- Icon and tile now resolve together from one precedence rule (`getCustomBlockTile`), replacing the same `iconUrl || fallbackIconUrl` test duplicated across the registry loader and the toolbar — a block can no longer paint a tile its icon disagrees with.

## Notes
- The plate is a fixed, non-theme fill, so this is a trade: a dark logo now reads in both themes, a light one in neither. Previously a dark logo was invisible in dark mode and a light one invisible in light mode. No per-org override exists.
- A non-square logo now letterboxes onto white bars in the palette and cmd+K, matching every other `#FFFFFF` provider tile.
- Follow-up, out of scope: `ChipTag variant='brand'` is fill-only with no edge, so any `#FFFFFF` provider chip is edgeless on a white card — the `workflow`/`neutral` tone carries an inset ring for exactly this reason. Giving `brand` the same ring when the fill is light would fix this for all ~97 white-tiled blocks at once.

## Type of Change
- [x] Bug fix

## Testing
- Reproduced and verified against the running app in both light and dark mode
- New unit tests for the icon/tile precedence, including the empty-string case and component identity reuse; verified they fail when the tile colour regresses
- `bun run check:audits` (32/32), `bun run lint`, `bun run type-check`, block-registry audit

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)