### PR TITLE
fix(workflows): deduplicate generated workflow names

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/folder-item/folder-item.tsx
@@ -65,6 +65,7 @@ export const FolderItem = memo(function FolderItem({ workspaceId, folder }: Fold
   const router = useRouter()
   const updateFolderMutation = useUpdateFolder()
   const createWorkflowMutation = useCreateWorkflow()
+  const createWorkflowMutate = createWorkflowMutation.mutate
   const createFolderMutation = useCreateFolder()
   const userPermissions = useUserPermissionsContext()
   const selectedFolders = useFolderStore((state) => state.selectedFolders)
@@ -149,18 +150,19 @@ export const FolderItem = memo(function FolderItem({ workspaceId, folder }: Fold
     const name = generateCreativeWorkflowName()
     const id = generateId()
 
-    createWorkflowMutation.mutate({
+    createWorkflowMutate({
       workspaceId,
       folderId: folder.id,
       name,
       id,
+      deduplicate: true,
     })
 
     useWorkflowRegistry.getState().markWorkflowCreating(id)
     expandFolder()
     router.push(`/workspace/${workspaceId}/w/${id}`)
     window.dispatchEvent(new CustomEvent(SIDEBAR_SCROLL_EVENT, { detail: { itemId: id } }))
-  }, [createWorkflowMutation, workspaceId, folder.id, effectiveLocked, router, expandFolder])
+  }, [createWorkflowMutate, workspaceId, folder.id, effectiveLocked, router, expandFolder])
 
   const handleCreateFolderInFolder = useCallback(async () => {
     if (effectiveLocked) return

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/hooks/use-workflow-operations.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/hooks/use-workflow-operations.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockClearDiff, mockCreateWorkflow, mockMarkWorkflowCreating, mockPush } = vi.hoisted(
+  () => ({
+    mockClearDiff: vi.fn(),
+    mockCreateWorkflow: vi.fn(),
+    mockMarkWorkflowCreating: vi.fn(),
+    mockPush: vi.fn(),
+  })
+)
+
+vi.mock('@sim/utils/id', () => ({
+  generateId: () => 'workflow-1',
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+vi.mock('@/hooks/queries/workflows', () => ({
+  useCreateWorkflow: () => ({ mutate: mockCreateWorkflow, isPending: false }),
+  useWorkflowMap: () => ({ data: {}, isLoading: false }),
+}))
+
+vi.mock('@/stores/workflow-diff/store', () => ({
+  useWorkflowDiffStore: {
+    getState: () => ({ clearDiff: mockClearDiff }),
+  },
+}))
+
+vi.mock('@/stores/workflows/registry/store', () => ({
+  useWorkflowRegistry: {
+    getState: () => ({ markWorkflowCreating: mockMarkWorkflowCreating }),
+  },
+}))
+
+vi.mock('@/stores/workflows/registry/utils', () => ({
+  generateCreativeWorkflowName: () => 'bolt-ivy',
+}))
+
+import { useWorkflowOperations } from '@/app/workspace/[workspaceId]/w/components/sidebar/hooks/use-workflow-operations'
+
+let operations: ReturnType<typeof useWorkflowOperations> | null = null
+
+function Harness() {
+  operations = useWorkflowOperations({ workspaceId: 'workspace-1' })
+  return null
+}
+
+describe('useWorkflowOperations', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    operations = null
+    vi.clearAllMocks()
+  })
+
+  it('requests server-side deduplication for a generated workflow name', async () => {
+    act(() => root.render(<Harness />))
+    if (!operations) throw new Error('Workflow operations did not render')
+
+    await act(async () => {
+      await operations?.handleCreateWorkflow()
+    })
+
+    expect(mockCreateWorkflow).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      name: 'bolt-ivy',
+      id: 'workflow-1',
+      deduplicate: true,
+    })
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/hooks/use-workflow-operations.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/hooks/use-workflow-operations.ts
@@ -38,6 +38,7 @@ export function useWorkflowOperations({ workspaceId }: UseWorkflowOperationsProp
       workspaceId,
       name,
       id,
+      deduplicate: true,
     })
 
     useWorkflowRegistry.getState().markWorkflowCreating(id)

--- a/apps/sim/lib/workflows/orchestration/workflow-lifecycle.test.ts
+++ b/apps/sim/lib/workflows/orchestration/workflow-lifecycle.test.ts
@@ -88,6 +88,27 @@ describe('performCreateWorkflowTransition unique-violation handling', () => {
     })
   })
 
+  it('retries with a newly deduplicated name after a concurrent create claims the candidate', async () => {
+    workflowsUtilsMockFns.mockDeduplicateWorkflowName
+      .mockResolvedValueOnce('My Workflow')
+      .mockResolvedValueOnce('My Workflow (2)')
+    dbChainMockFns.transaction.mockRejectedValueOnce(
+      uniqueViolation('workflow_workspace_folder_name_active_unique')
+    )
+
+    const result = await performCreateWorkflowTransition({
+      ...createParams,
+      deduplicate: true,
+    })
+
+    expect(workflowsUtilsMockFns.mockDeduplicateWorkflowName).toHaveBeenCalledTimes(2)
+    expect(dbChainMockFns.transaction).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({
+      success: true,
+      workflow: { name: 'My Workflow (2)' },
+    })
+  })
+
   it('does not report a block-id collision as a name conflict', async () => {
     /**
      * `workflow_blocks.id` is a global primary key and the same transaction runs

--- a/apps/sim/lib/workflows/orchestration/workflow-lifecycle.test.ts
+++ b/apps/sim/lib/workflows/orchestration/workflow-lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
   workflowsPersistenceUtilsMock,
   workflowsPersistenceUtilsMockFns,
   workflowsUtilsMock,
+  workflowsUtilsMockFns,
 } from '@sim/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -65,6 +66,25 @@ describe('performCreateWorkflowTransition unique-violation handling', () => {
       success: false,
       error: 'A workflow named "My Workflow" already exists in this folder',
       errorCode: 'conflict',
+    })
+  })
+
+  it('uses a deduplicated workflow name when requested', async () => {
+    workflowsUtilsMockFns.mockDeduplicateWorkflowName.mockResolvedValueOnce('My Workflow (2)')
+
+    const result = await performCreateWorkflowTransition({
+      ...createParams,
+      deduplicate: true,
+    })
+
+    expect(workflowsUtilsMockFns.mockDeduplicateWorkflowName).toHaveBeenCalledWith(
+      'My Workflow',
+      'workspace-1',
+      null
+    )
+    expect(result).toMatchObject({
+      success: true,
+      workflow: { name: 'My Workflow (2)' },
     })
   })
 

--- a/apps/sim/lib/workflows/orchestration/workflow-lifecycle.ts
+++ b/apps/sim/lib/workflows/orchestration/workflow-lifecycle.ts
@@ -19,6 +19,7 @@ const logger = createLogger('WorkflowLifecycle')
 
 /** Partial unique index on `(workspace_id, coalesce(folder_id, ''), name) WHERE archived_at IS NULL`. */
 const WORKFLOW_NAME_UNIQUE_INDEX = 'workflow_workspace_folder_name_active_unique'
+const WORKFLOW_NAME_DEDUPLICATION_ATTEMPTS = 8
 
 export interface PerformCreateWorkflowParams {
   userId: string
@@ -235,9 +236,7 @@ export async function performCreateWorkflowTransition(
     return { success: false, error: 'Target folder not found', errorCode: 'validation' }
   }
 
-  const name = params.deduplicate
-    ? await deduplicateWorkflowName(params.name, params.workspaceId, folderId)
-    : params.name
+  let name = params.name
 
   if (!params.deduplicate) {
     const duplicate = await workflowNameExistsInFolder({
@@ -261,51 +260,61 @@ export async function performCreateWorkflowTransition(
   const now = new Date()
   const { workflowState, subBlockValues, startBlockId } = buildDefaultWorkflowArtifacts()
 
-  try {
-    await db.transaction(async (tx) => {
-      await tx.insert(workflow).values({
-        id: workflowId,
-        userId: params.userId,
-        workspaceId: params.workspaceId,
-        folderId,
-        sortOrder,
-        name,
-        description: params.description,
-        lastSynced: now,
-        createdAt: now,
-        updatedAt: now,
-        isDeployed: false,
-        runCount: 0,
-        variables: {},
-      })
-
-      await saveWorkflowToNormalizedTables(workflowId, workflowState, tx)
-    })
-  } catch (error) {
-    /**
-     * The name pre-check above is a `SELECT`, so two concurrent creates of the same
-     * name both pass it and the loser is rejected by
-     * {@link WORKFLOW_NAME_UNIQUE_INDEX} as a raw Postgres `23505`. Reported as the
-     * conflict the pre-check already raises, so a caller sees one answer whether it
-     * lost the race or simply arrived second.
-     *
-     * Matched on the constraint name, not on the code alone. This transaction also
-     * runs `saveWorkflowToNormalizedTables`, whose inserts can raise `23505` from
-     * `workflow_blocks_pkey` — a globally unique block id colliding across
-     * workflows, an integrity fault this repository has already hit in production.
-     * A code-only match reported that as a name conflict and hid it.
-     */
-    if (
-      getPostgresErrorCode(error) === '23505' &&
-      getPostgresConstraintName(error) === WORKFLOW_NAME_UNIQUE_INDEX
-    ) {
-      return {
-        success: false,
-        error: `A workflow named "${name}" already exists in this folder`,
-        errorCode: 'conflict',
-      }
+  const maxAttempts = params.deduplicate ? WORKFLOW_NAME_DEDUPLICATION_ATTEMPTS : 1
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (params.deduplicate) {
+      name = await deduplicateWorkflowName(params.name, params.workspaceId, folderId)
     }
-    throw error
+
+    try {
+      await db.transaction(async (tx) => {
+        await tx.insert(workflow).values({
+          id: workflowId,
+          userId: params.userId,
+          workspaceId: params.workspaceId,
+          folderId,
+          sortOrder,
+          name,
+          description: params.description,
+          lastSynced: now,
+          createdAt: now,
+          updatedAt: now,
+          isDeployed: false,
+          runCount: 0,
+          variables: {},
+        })
+
+        await saveWorkflowToNormalizedTables(workflowId, workflowState, tx)
+      })
+      break
+    } catch (error) {
+      /**
+       * Name selection is a `SELECT`, so a concurrent create can claim the candidate
+       * before this transaction inserts it. Deduplicated creates retry against the
+       * newly committed names; exact-name creates keep returning the conflict the
+       * pre-check reports. Matching the constraint avoids relabeling a `23505` from
+       * normalized workflow tables as a name collision.
+       */
+      const isNameConflict =
+        getPostgresErrorCode(error) === '23505' &&
+        getPostgresConstraintName(error) === WORKFLOW_NAME_UNIQUE_INDEX
+      if (!isNameConflict) {
+        throw error
+      }
+
+      if (!params.deduplicate || attempt === maxAttempts - 1) {
+        return {
+          success: false,
+          error: `A workflow named "${name}" already exists in this folder`,
+          errorCode: 'conflict',
+        }
+      }
+
+      logger.warn(`[${requestId}] Workflow name was claimed during creation; retrying`, {
+        name,
+        attempt: attempt + 1,
+      })
+    }
   }
 
   logger.info(`[${requestId}] Successfully created workflow ${workflowId}`)

--- a/apps/sim/lib/workflows/utils.test.ts
+++ b/apps/sim/lib/workflows/utils.test.ts
@@ -13,6 +13,9 @@ import {
   createWorkflowRecord,
   expectWorkflowAccessDenied,
   expectWorkflowAccessGranted,
+  queueTableRows,
+  resetDbChainMock,
+  schemaMock,
   workflowAuthzMockFns,
 } from '@sim/testing'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -23,7 +26,11 @@ afterAll(() => {
   mockAuthorizeWorkflow.mockReset()
 })
 
-import { createHttpResponseFromBlock, validateWorkflowPermissions } from '@/lib/workflows/utils'
+import {
+  createHttpResponseFromBlock,
+  deduplicateWorkflowName,
+  validateWorkflowPermissions,
+} from '@/lib/workflows/utils'
 
 const mockSession = createSession({ userId: 'user-1', email: 'user1@test.com' })
 const mockWorkflow = createWorkflowRecord({
@@ -54,6 +61,23 @@ const denied = (status: number, message: string, workspacePermission: string | n
   message,
   workflow: mockWorkflow,
   workspacePermission,
+})
+
+describe('deduplicateWorkflowName', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+  })
+
+  it('appends the next available numerical suffix within the workflow folder', async () => {
+    queueTableRows(schemaMock.workflow, [{ id: 'workflow-1' }])
+    queueTableRows(schemaMock.workflow, [{ id: 'workflow-2' }])
+    queueTableRows(schemaMock.workflow, [])
+
+    await expect(deduplicateWorkflowName('city-grove', 'workspace-1', null)).resolves.toBe(
+      'city-grove (3)'
+    )
+  })
 })
 
 describe('validateWorkflowPermissions', () => {


### PR DESCRIPTION
## Summary

Generated workflows now request server-side name deduplication in both root and folder creation paths, so concurrent or repeated creation does not surface avoidable name conflicts. Deduplicated creates retry workflow-name unique-index races with a freshly computed name, while exact-name conflicts and unrelated database violations keep their existing behavior. Folder creation also depends on the stable mutation function, which keeps its callback stable when mutation state changes.

This is the foundation of a two-PR stack. #6906 adds the new generated-name vocabulary on top.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- `bun run --cwd apps/sim test -- lib/workflows/utils.test.ts lib/workflows/orchestration/workflow-lifecycle.test.ts 'app/workspace/[workspaceId]/w/components/sidebar/hooks/use-workflow-operations.test.tsx'` (25 tests passed)
- `bun run --cwd apps/sim test -- lib/workflows/orchestration/workflow-lifecycle.test.ts` (5 tests passed after the race-retry fix)
- `bun run check:api-validation`
- `bun run lint` (passes with one pre-existing unused-suppression warning)
- `bun run check`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Not applicable; this changes workflow creation behavior without changing the interface.
