### PR TITLE
fix(knowledge): refund a processing attempt whose dispatch never happened

### DIFF
--- a/apps/sim/lib/knowledge/connectors/sync-limits.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-limits.ts
@@ -16,8 +16,11 @@ export const CONNECTOR_SYNC_MAX_DURATION_SECONDS = 3600
  * lock for another sync, so a TTL at or below the run ceiling would start a second
  * sync while the first is still writing, both racing the same documents.
  *
- * Measured against `updatedAt`, which a running sync refreshes every
- * {@link SYNC_LOCK_HEARTBEAT_INTERVAL_MS}. That is what makes the TTL mean
+ * Measured against `COALESCE(syncLockLeaseAt, updatedAt)`, the lease a running
+ * sync refreshes every {@link SYNC_LOCK_HEARTBEAT_INTERVAL_MS}. The lease is a
+ * dedicated column precisely so an unrelated write to the row — a config edit on
+ * a wedged connector — can no longer pass for a heartbeat; `updatedAt` remains
+ * only as the fallback for a row locked before that column existed. That is what makes the TTL mean
  * "nobody is working on this" rather than "this started a long time ago" — the
  * distinction the in-process fallback path needs. A Trigger.dev run is killed at
  * {@link CONNECTOR_SYNC_MAX_DURATION_SECONDS} and so is provably dead well before

--- a/apps/sim/lib/knowledge/documents/processing-queue.test.ts
+++ b/apps/sim/lib/knowledge/documents/processing-queue.test.ts
@@ -254,3 +254,73 @@ describe('processDocumentsWithQueue dispatch backend', () => {
     expect(mockBatchTrigger).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * The processing-attempt budget exists to stop re-billing a document that keeps
+ * failing the same way *in processing*. A dispatch that never reached a worker
+ * teaches it nothing, so the charge is given back on the one path that proves
+ * nothing was dispatched. Without the refund a Trigger.dev outage burns the
+ * allowance without a single run, and after `MAX_PROCESSING_ATTEMPTS` of them
+ * the connector sweep — which skips documents at the cap — permanently stops
+ * recovering them.
+ */
+describe('processDocumentsWithQueue attempt refund', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+    dbChainMockFns.returning.mockResolvedValue([{ id: 'document-1' }])
+    for (const key of Object.keys(env)) {
+      delete (env as Record<string, unknown>)[key]
+    }
+    Object.assign(env, { ...defaultMockEnv, TRIGGER_SECRET_KEY: 'trigger-secret' })
+    dbChainMockFns.limit.mockResolvedValue([
+      { userId: 'knowledge-owner', workspaceId: 'workspace-1' },
+    ])
+  })
+
+  it('refunds the attempt in the same write that withdraws the queue stamp', async () => {
+    mockBatchTrigger.mockRejectedValue(new Error('trigger.dev region unavailable'))
+
+    await expect(
+      processDocumentsWithQueue(
+        [DOCUMENT],
+        'knowledge-base-1',
+        {},
+        'request-1',
+        BILLING_ATTRIBUTION
+      )
+    ).rejects.toThrow('document processing dispatches failed')
+
+    const withdrawCall = dbChainMockFns.set.mock.calls.find(
+      (call) => (call[0] as Record<string, unknown> | undefined)?.processingQueuedAt === null
+    )
+    expect(withdrawCall).toBeDefined()
+
+    const values = withdrawCall?.[0] as Record<string, unknown>
+    const attempts = values.processingAttempts as { toSQL: () => { sql: string } } | undefined
+    expect(attempts).toBeDefined()
+    // Given back as a SQL decrement in the same guarded statement as the stamp,
+    // so it can only ever undo the charge this call made.
+    expect(attempts?.toSQL().sql).toContain('- 1')
+    // Floored, so a refund can never drive the count below zero.
+    expect(attempts?.toSQL().sql).toContain('GREATEST')
+  })
+
+  it('leaves the attempt spent when a dispatch did get through', async () => {
+    mockBatchTrigger.mockResolvedValue({ batchId: 'batch-1' })
+
+    await processDocumentsWithQueue(
+      [DOCUMENT],
+      'knowledge-base-1',
+      {},
+      'request-1',
+      BILLING_ATTRIBUTION
+    )
+
+    expect(
+      dbChainMockFns.set.mock.calls.some(
+        (call) => (call[0] as Record<string, unknown> | undefined)?.processingQueuedAt === null
+      )
+    ).toBe(false)
+  })
+})

--- a/apps/sim/lib/knowledge/documents/service.ts
+++ b/apps/sim/lib/knowledge/documents/service.ts
@@ -717,6 +717,8 @@ async function markDocumentsQueued(documentIds: string[], queuedAt: Date): Promi
       // Spent here because this is the one write every dispatch passes through,
       // and it is already guarded — so the budget cannot be charged twice for a
       // single dispatch, nor skipped by a caller that dispatches another way.
+      // Refunded by `clearDocumentsQueued` when the dispatch provably never
+      // happened, so only attempts a worker could have seen are ever spent.
       processingAttempts: sql`${document.processingAttempts} + 1`,
     })
     .where(and(inArray(document.id, documentIds), eq(document.processingStatus, 'pending')))
@@ -733,6 +735,18 @@ async function markDocumentsQueued(documentIds: string[], queuedAt: Date): Promi
  * failure is the one case where nothing was dispatched, so the stamp can be
  * taken back and the next sweep is free to reclaim them immediately.
  *
+ * The attempt {@link markDocumentsQueued} charged is refunded in the same
+ * statement. The budget exists to stop re-billing a document that keeps failing
+ * the same way *in processing*; an attempt that never reached a worker teaches
+ * it nothing. Leaving it spent let an infrastructure outage — a Trigger.dev
+ * region error, an exhausted quota — burn the allowance without a single run,
+ * and {@link MAX_PROCESSING_ATTEMPTS} such outages dead-letter a document the
+ * connector sweep then permanently excludes (`processingAttempts <
+ * MAX_PROCESSING_ATTEMPTS`), stranding it with no automatic recovery left.
+ * Floored at zero so a refund can never drive the count negative, and scoped by
+ * the same guard as the stamp, so it can only ever give back the charge this
+ * call made.
+ *
  * Scoped three ways so it can only ever undo its own write: to the ids in this
  * batch, to rows still `pending` (a worker that has since claimed one keeps its
  * timestamps — see {@link markDocumentsQueued}), and to the exact stamp this
@@ -742,7 +756,10 @@ async function markDocumentsQueued(documentIds: string[], queuedAt: Date): Promi
 async function clearDocumentsQueued(documentIds: string[], queuedAt: Date): Promise<void> {
   await db
     .update(document)
-    .set({ processingQueuedAt: null })
+    .set({
+      processingQueuedAt: null,
+      processingAttempts: sql`GREATEST(${document.processingAttempts} - 1, 0)`,
+    })
     .where(
       and(
         inArray(document.id, documentIds),

--- a/apps/sim/lib/knowledge/documents/types.ts
+++ b/apps/sim/lib/knowledge/documents/types.ts
@@ -7,9 +7,12 @@
  * that fails deterministically (a corrupt file, an unsupported encoding) was
  * billed once per sync indefinitely. Five is chosen against the unit that is
  * actually consumed: one attempt per *dispatch*, not per Trigger.dev retry, so
- * a short-interval connector can burn several inside one transient outage.
- * Three left too little room for that; five still bounds the spend well inside
- * `RETRY_WINDOW_DAYS`.
+ * a short-interval connector can still burn several inside one transient
+ * outage. A dispatch that provably reached nothing is refunded — see
+ * `clearDocumentsQueued` — which covers the total-failure shape, but a partial
+ * batch failure and an accepted dispatch whose run never starts both stay
+ * charged. Three left too little room for those; five still bounds the spend
+ * well inside `RETRY_WINDOW_DAYS`.
  *
  * Reaching it is a dead letter, not a deletion: the document keeps its `failed`
  * status and stays user-retryable, it simply stops being swept automatically.

--- a/scripts/check-tool-registry-boundary.baseline.json
+++ b/scripts/check-tool-registry-boundary.baseline.json
@@ -10,29 +10,29 @@
       "gateways": {}
     },
     "app/workspace/[workspaceId]/chat/[chatId]/page.tsx": {
-      "modules": 3005,
+      "modules": 3039,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/home/home.tsx": 1370,
-        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/mothership-view.tsx": 1021,
-        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/index.ts": 882,
-        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/index.ts": 879,
+        "apps/sim/app/workspace/[workspaceId]/home/home.tsx": 1375,
+        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/mothership-view.tsx": 1027,
+        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/index.ts": 888,
+        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/index.ts": 885,
         "apps/sim/triggers/registry.ts": 452,
-        "apps/sim/blocks/registry.ts": 311,
+        "apps/sim/blocks/registry.ts": 315,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx": 308,
-        "apps/sim/lib/auth/index.ts": 209
+        "apps/sim/lib/auth/index.ts": 224
       }
     },
     "app/workspace/[workspaceId]/files/[fileId]/page.tsx": {
-      "modules": 2002,
+      "modules": 2030,
       "gateways": {
         "apps/sim/triggers/registry.ts": 452,
-        "apps/sim/blocks/registry.ts": 334,
-        "apps/sim/app/workspace/[workspaceId]/files/files.tsx": 300,
-        "apps/sim/lib/auth/index.ts": 215,
+        "apps/sim/blocks/registry.ts": 341,
+        "apps/sim/app/workspace/[workspaceId]/files/files.tsx": 299,
+        "apps/sim/lib/auth/index.ts": 230,
         "apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/index.ts": 148,
         "apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx": 131,
         "apps/sim/lib/api/contracts/index.ts": 108,
-        "apps/sim/lib/webhooks/providers/index.ts": 103
+        "apps/sim/lib/webhooks/providers/index.ts": 104
       }
     },
     "app/workspace/[workspaceId]/files/[fileId]/view/page.tsx": {
@@ -43,16 +43,16 @@
       }
     },
     "app/workspace/[workspaceId]/files/page.tsx": {
-      "modules": 2002,
+      "modules": 2030,
       "gateways": {
         "apps/sim/triggers/registry.ts": 452,
-        "apps/sim/blocks/registry.ts": 334,
-        "apps/sim/app/workspace/[workspaceId]/files/files.tsx": 302,
-        "apps/sim/lib/auth/index.ts": 215,
+        "apps/sim/blocks/registry.ts": 341,
+        "apps/sim/app/workspace/[workspaceId]/files/files.tsx": 301,
+        "apps/sim/lib/auth/index.ts": 230,
         "apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/index.ts": 148,
         "apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer.tsx": 131,
         "apps/sim/lib/api/contracts/index.ts": 108,
-        "apps/sim/lib/webhooks/providers/index.ts": 103
+        "apps/sim/lib/webhooks/providers/index.ts": 104
       }
     },
     "app/workspace/[workspaceId]/home/layout.tsx": {
@@ -60,117 +60,117 @@
       "gateways": {}
     },
     "app/workspace/[workspaceId]/home/page.tsx": {
-      "modules": 3005,
+      "modules": 3039,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/home/home.tsx": 1370,
-        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/mothership-view.tsx": 1021,
-        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/index.ts": 882,
-        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/index.ts": 879,
+        "apps/sim/app/workspace/[workspaceId]/home/home.tsx": 1375,
+        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/mothership-view.tsx": 1027,
+        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/index.ts": 888,
+        "apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/index.ts": 885,
         "apps/sim/triggers/registry.ts": 452,
-        "apps/sim/blocks/registry.ts": 311,
+        "apps/sim/blocks/registry.ts": 315,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx": 308,
-        "apps/sim/lib/auth/index.ts": 209
+        "apps/sim/lib/auth/index.ts": 224
       }
     },
     "app/workspace/[workspaceId]/integrations/[block]/page.tsx": {
-      "modules": 1320,
+      "modules": 1330,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/integrations/[block]/integration-block-detail.tsx": 1294,
+        "apps/sim/app/workspace/[workspaceId]/integrations/[block]/integration-block-detail.tsx": 1304,
         "apps/sim/triggers/index.ts": 489,
-        "apps/sim/blocks/registry.ts": 439,
-        "apps/sim/lib/api/contracts/index.ts": 128,
-        "apps/sim/blocks/blocks/credential-group.ts": 105,
-        "apps/sim/stores/workflows/registry/store.ts": 80,
-        "apps/sim/hooks/queries/deployments.ts": 73,
-        "apps/sim/lib/workflows/comparison/compare.ts": 70
+        "apps/sim/blocks/registry.ts": 447,
+        "apps/sim/lib/api/contracts/index.ts": 129,
+        "apps/sim/blocks/blocks/credential-group.ts": 106,
+        "apps/sim/stores/workflows/registry/store.ts": 81,
+        "apps/sim/hooks/queries/deployments.ts": 74,
+        "apps/sim/lib/workflows/comparison/compare.ts": 71
       }
     },
     "app/workspace/[workspaceId]/integrations/connected/[credentialId]/page.tsx": {
-      "modules": 1299,
+      "modules": 1309,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx": 1298,
+        "apps/sim/app/workspace/[workspaceId]/integrations/connected/[credentialId]/connected-credential-detail.tsx": 1308,
         "apps/sim/triggers/registry.ts": 488,
-        "apps/sim/blocks/registry.ts": 341,
-        "apps/sim/lib/api/contracts/index.ts": 134,
-        "apps/sim/stores/workflows/registry/store.ts": 75,
-        "apps/sim/hooks/queries/deployments.ts": 72,
-        "apps/sim/lib/workflows/comparison/compare.ts": 69,
-        "apps/sim/lib/workflows/comparison/resolve-values.ts": 66
+        "apps/sim/blocks/registry.ts": 348,
+        "apps/sim/lib/api/contracts/index.ts": 135,
+        "apps/sim/stores/workflows/registry/store.ts": 76,
+        "apps/sim/hooks/queries/deployments.ts": 73,
+        "apps/sim/lib/workflows/comparison/compare.ts": 70,
+        "apps/sim/lib/workflows/comparison/resolve-values.ts": 67
       }
     },
     "app/workspace/[workspaceId]/integrations/page.tsx": {
-      "modules": 1305,
+      "modules": 1315,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/integrations/integrations.tsx": 1017,
-        "apps/sim/blocks/registry.ts": 933,
+        "apps/sim/app/workspace/[workspaceId]/integrations/integrations.tsx": 1025,
+        "apps/sim/blocks/registry.ts": 941,
         "apps/sim/triggers/index.ts": 489,
-        "apps/sim/lib/api/contracts/index.ts": 130,
-        "apps/sim/blocks/blocks/credential-group.ts": 106,
-        "apps/sim/stores/workflows/registry/store.ts": 80,
-        "apps/sim/hooks/queries/deployments.ts": 73,
-        "apps/sim/lib/workflows/comparison/compare.ts": 70
+        "apps/sim/lib/api/contracts/index.ts": 131,
+        "apps/sim/blocks/blocks/credential-group.ts": 107,
+        "apps/sim/stores/workflows/registry/store.ts": 81,
+        "apps/sim/hooks/queries/deployments.ts": 74,
+        "apps/sim/lib/workflows/comparison/compare.ts": 71
       }
     },
     "app/workspace/[workspaceId]/knowledge/[id]/[documentId]/page.tsx": {
-      "modules": 1523,
+      "modules": 1538,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx": 1232,
+        "apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/document.tsx": 1245,
         "apps/sim/triggers/registry.ts": 488,
-        "apps/sim/blocks/registry.ts": 337,
-        "apps/sim/blocks/registry-maps.ts": 334,
+        "apps/sim/blocks/registry.ts": 344,
+        "apps/sim/blocks/registry-maps.ts": 341,
         "apps/sim/lib/api/contracts/index.ts": 120,
-        "apps/sim/connectors/registry.ts": 61,
+        "apps/sim/connectors/registry.ts": 65,
         "apps/sim/app/workspace/[workspaceId]/components/index.ts": 60,
         "apps/sim/lib/api/contracts/tools/index.ts": 60
       }
     },
     "app/workspace/[workspaceId]/knowledge/[id]/page.tsx": {
-      "modules": 1538,
+      "modules": 1553,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx": 1247,
+        "apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx": 1260,
         "apps/sim/triggers/registry.ts": 488,
-        "apps/sim/blocks/registry.ts": 337,
-        "apps/sim/blocks/registry-maps.ts": 334,
+        "apps/sim/blocks/registry.ts": 344,
+        "apps/sim/blocks/registry-maps.ts": 341,
         "apps/sim/lib/api/contracts/index.ts": 120,
-        "apps/sim/connectors/registry.ts": 61,
+        "apps/sim/connectors/registry.ts": 65,
         "apps/sim/app/workspace/[workspaceId]/components/index.ts": 60,
         "apps/sim/lib/api/contracts/tools/index.ts": 60
       }
     },
     "app/workspace/[workspaceId]/knowledge/page.tsx": {
-      "modules": 2209,
+      "modules": 2255,
       "gateways": {
         "apps/sim/triggers/registry.ts": 452,
-        "apps/sim/blocks/registry.ts": 332,
-        "apps/sim/app/workspace/[workspaceId]/knowledge/prefetch.ts": 276,
-        "apps/sim/lib/knowledge/application/knowledge-bases.ts": 220,
-        "apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx": 184,
-        "apps/sim/lib/auth/index.ts": 164,
-        "apps/sim/lib/knowledge/orchestration/index.ts": 138,
-        "apps/sim/lib/knowledge/orchestration/connectors.ts": 133
+        "apps/sim/blocks/registry.ts": 339,
+        "apps/sim/app/workspace/[workspaceId]/knowledge/prefetch.ts": 289,
+        "apps/sim/lib/knowledge/application/knowledge-bases.ts": 233,
+        "apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx": 183,
+        "apps/sim/lib/auth/index.ts": 178,
+        "apps/sim/lib/knowledge/orchestration/index.ts": 148,
+        "apps/sim/lib/knowledge/orchestration/connectors.ts": 142
       }
     },
     "app/workspace/[workspaceId]/layout.tsx": {
-      "modules": 2053,
+      "modules": 2081,
       "gateways": {
         "apps/sim/triggers/registry.ts": 452,
-        "apps/sim/blocks/registry.ts": 333,
-        "apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/index.ts": 306,
-        "apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx": 298,
-        "apps/sim/lib/auth/index.ts": 284,
+        "apps/sim/blocks/registry.ts": 340,
+        "apps/sim/app/workspace/[workspaceId]/components/workspace-chrome/index.ts": 305,
+        "apps/sim/lib/auth/index.ts": 301,
+        "apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx": 297,
         "apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/index.ts": 205,
         "apps/sim/lib/api/contracts/index.ts": 109,
-        "apps/sim/lib/webhooks/providers/index.ts": 103
+        "apps/sim/lib/webhooks/providers/index.ts": 104
       }
     },
     "app/workspace/[workspaceId]/logs/page.tsx": {
-      "modules": 1760,
+      "modules": 1770,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/logs/logs.tsx": 1471,
+        "apps/sim/app/workspace/[workspaceId]/logs/logs.tsx": 1479,
         "apps/sim/triggers/registry.ts": 488,
         "apps/sim/app/workspace/[workspaceId]/logs/components/index.ts": 421,
         "apps/sim/app/workspace/[workspaceId]/logs/components/log-details/components/execution-snapshot/index.ts": 367,
-        "apps/sim/blocks/registry.ts": 328,
+        "apps/sim/blocks/registry.ts": 335,
         "apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-editor/index.ts": 323,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/index.ts": 288,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx": 256
@@ -185,14 +185,14 @@
       "gateways": {}
     },
     "app/workspace/[workspaceId]/settings/[section]/page.tsx": {
-      "modules": 2071,
+      "modules": 2098,
       "gateways": {
         "apps/sim/triggers/registry.ts": 452,
         "apps/sim/app/workspace/[workspaceId]/settings/[section]/settings.tsx": 444,
-        "apps/sim/blocks/registry.ts": 332,
-        "apps/sim/lib/auth/index.ts": 294,
+        "apps/sim/blocks/registry.ts": 339,
+        "apps/sim/lib/auth/index.ts": 310,
         "apps/sim/lib/api/contracts/index.ts": 107,
-        "apps/sim/lib/webhooks/providers/index.ts": 103,
+        "apps/sim/lib/webhooks/providers/index.ts": 104,
         "apps/sim/lib/api/contracts/tools/index.ts": 59,
         "apps/sim/lib/uploads/utils/file-utils.server.ts": 46
       }
@@ -202,16 +202,16 @@
       "gateways": {}
     },
     "app/workspace/[workspaceId]/settings/billing/credit-usage/page.tsx": {
-      "modules": 1632,
+      "modules": 1661,
       "gateways": {
-        "apps/sim/lib/auth/index.ts": 1496,
-        "apps/sim/blocks/registry.ts": 622,
-        "apps/sim/blocks/registry-maps.ts": 619,
+        "apps/sim/lib/auth/index.ts": 1524,
+        "apps/sim/blocks/registry.ts": 616,
+        "apps/sim/blocks/registry-maps.ts": 613,
         "apps/sim/triggers/index.ts": 453,
-        "apps/sim/blocks/blocks/credential-group.ts": 270,
-        "apps/sim/stores/workflows/registry/store.ts": 252,
-        "apps/sim/hooks/queries/deployments.ts": 244,
-        "apps/sim/lib/workflows/comparison/compare.ts": 239
+        "apps/sim/blocks/blocks/credential-group.ts": 271,
+        "apps/sim/stores/workflows/registry/store.ts": 253,
+        "apps/sim/hooks/queries/deployments.ts": 245,
+        "apps/sim/lib/workflows/comparison/compare.ts": 240
       }
     },
     "app/workspace/[workspaceId]/settings/layout.tsx": {
@@ -223,115 +223,115 @@
       "gateways": {}
     },
     "app/workspace/[workspaceId]/settings/secrets/[credentialId]/page.tsx": {
-      "modules": 1337,
+      "modules": 1347,
       "gateways": {
         "apps/sim/triggers/registry.ts": 488,
-        "apps/sim/blocks/registry.ts": 343,
-        "apps/sim/blocks/registry-maps.ts": 340,
-        "apps/sim/lib/api/contracts/index.ts": 135,
-        "apps/sim/stores/workflows/registry/store.ts": 75,
-        "apps/sim/hooks/queries/deployments.ts": 72,
-        "apps/sim/lib/workflows/comparison/compare.ts": 69,
+        "apps/sim/blocks/registry.ts": 350,
+        "apps/sim/blocks/registry-maps.ts": 347,
+        "apps/sim/lib/api/contracts/index.ts": 136,
+        "apps/sim/stores/workflows/registry/store.ts": 76,
+        "apps/sim/hooks/queries/deployments.ts": 73,
+        "apps/sim/lib/workflows/comparison/compare.ts": 70,
         "apps/sim/app/workspace/[workspaceId]/settings/secrets/[credentialId]/secret-detail.tsx": 68
       }
     },
     "app/workspace/[workspaceId]/skills/[skillId]/page.tsx": {
-      "modules": 1422,
+      "modules": 1432,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/skills/[skillId]/skill-detail.tsx": 1421,
+        "apps/sim/app/workspace/[workspaceId]/skills/[skillId]/skill-detail.tsx": 1431,
         "apps/sim/triggers/registry.ts": 488,
-        "apps/sim/blocks/registry.ts": 342,
-        "apps/sim/blocks/registry-maps.ts": 340,
-        "apps/sim/lib/api/contracts/index.ts": 126,
+        "apps/sim/blocks/registry.ts": 349,
+        "apps/sim/blocks/registry-maps.ts": 347,
+        "apps/sim/lib/api/contracts/index.ts": 127,
         "apps/sim/app/workspace/[workspaceId]/skills/components/skill-fields/index.ts": 89,
         "apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx": 86,
         "apps/sim/lib/api/contracts/tools/index.ts": 60
       }
     },
     "app/workspace/[workspaceId]/skills/new/page.tsx": {
-      "modules": 1420,
+      "modules": 1430,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/skills/new/skill-create.tsx": 1419,
+        "apps/sim/app/workspace/[workspaceId]/skills/new/skill-create.tsx": 1429,
         "apps/sim/triggers/registry.ts": 488,
-        "apps/sim/blocks/registry.ts": 342,
-        "apps/sim/blocks/registry-maps.ts": 340,
-        "apps/sim/lib/api/contracts/index.ts": 126,
+        "apps/sim/blocks/registry.ts": 349,
+        "apps/sim/blocks/registry-maps.ts": 347,
+        "apps/sim/lib/api/contracts/index.ts": 127,
         "apps/sim/app/workspace/[workspaceId]/skills/components/skill-fields/index.ts": 89,
         "apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx": 86,
         "apps/sim/lib/api/contracts/tools/index.ts": 60
       }
     },
     "app/workspace/[workspaceId]/skills/page.tsx": {
-      "modules": 1288,
+      "modules": 1298,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/skills/skills.tsx": 1000,
-        "apps/sim/app/workspace/[workspaceId]/integrations/components/showcase-with-explore/index.ts": 988,
-        "apps/sim/blocks/registry.ts": 976,
-        "apps/sim/blocks/registry-maps.ts": 974,
+        "apps/sim/app/workspace/[workspaceId]/skills/skills.tsx": 1008,
+        "apps/sim/app/workspace/[workspaceId]/integrations/components/showcase-with-explore/index.ts": 996,
+        "apps/sim/blocks/registry.ts": 984,
+        "apps/sim/blocks/registry-maps.ts": 982,
         "apps/sim/triggers/index.ts": 489,
-        "apps/sim/lib/api/contracts/index.ts": 135,
-        "apps/sim/blocks/blocks/credential-group.ts": 119,
-        "apps/sim/stores/workflows/registry/store.ts": 91
+        "apps/sim/lib/api/contracts/index.ts": 136,
+        "apps/sim/blocks/blocks/credential-group.ts": 120,
+        "apps/sim/stores/workflows/registry/store.ts": 92
       }
     },
     "app/workspace/[workspaceId]/tables/[tableId]/page.tsx": {
-      "modules": 2264,
+      "modules": 2293,
       "gateways": {
         "apps/sim/app/workspace/[workspaceId]/tables/[tableId]/table.tsx": 585,
         "apps/sim/triggers/registry.ts": 452,
         "apps/sim/app/workspace/[workspaceId]/w/components/preview/index.ts": 337,
-        "apps/sim/lib/auth/index.ts": 315,
-        "apps/sim/blocks/registry.ts": 311,
+        "apps/sim/lib/auth/index.ts": 332,
+        "apps/sim/blocks/registry.ts": 315,
         "apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-editor/index.ts": 295,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/index.ts": 267,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx": 236
       }
     },
     "app/workspace/[workspaceId]/tables/page.tsx": {
-      "modules": 1857,
+      "modules": 1885,
       "gateways": {
         "apps/sim/triggers/registry.ts": 452,
-        "apps/sim/blocks/registry.ts": 333,
-        "apps/sim/lib/auth/index.ts": 304,
-        "apps/sim/app/workspace/[workspaceId]/tables/tables.tsx": 143,
+        "apps/sim/blocks/registry.ts": 340,
+        "apps/sim/lib/auth/index.ts": 321,
+        "apps/sim/app/workspace/[workspaceId]/tables/tables.tsx": 142,
         "apps/sim/lib/api/contracts/index.ts": 112,
-        "apps/sim/lib/webhooks/providers/index.ts": 103,
+        "apps/sim/lib/webhooks/providers/index.ts": 104,
         "apps/sim/lib/api/contracts/tools/index.ts": 60,
         "apps/sim/app/workspace/[workspaceId]/components/index.ts": 58
       }
     },
     "app/workspace/[workspaceId]/upgrade/page.tsx": {
-      "modules": 271,
+      "modules": 273,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/upgrade/upgrade.tsx": 264,
-        "apps/sim/app/workspace/[workspaceId]/upgrade/hooks/index.ts": 216,
-        "apps/sim/lib/billing/client/upgrade.ts": 208,
-        "apps/sim/hooks/queries/organization.ts": 204,
-        "apps/sim/hooks/queries/workspace.ts": 196,
-        "apps/sim/lib/api/contracts/index.ts": 194,
+        "apps/sim/app/workspace/[workspaceId]/upgrade/upgrade.tsx": 266,
+        "apps/sim/app/workspace/[workspaceId]/upgrade/hooks/index.ts": 218,
+        "apps/sim/lib/billing/client/upgrade.ts": 210,
+        "apps/sim/hooks/queries/organization.ts": 206,
+        "apps/sim/hooks/queries/workspace.ts": 197,
+        "apps/sim/lib/api/contracts/index.ts": 195,
         "apps/sim/lib/api/contracts/tools/index.ts": 61,
         "apps/sim/lib/api/contracts/v1/index.ts": 38
       }
     },
     "app/workspace/[workspaceId]/w/[workflowId]/layout.tsx": {
-      "modules": 2230,
+      "modules": 2240,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/error/index.tsx": 2229,
+        "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/error/index.tsx": 2239,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/index.ts": 544,
         "apps/sim/triggers/registry.ts": 488,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/index.ts": 461,
-        "apps/sim/blocks/registry.ts": 328,
+        "apps/sim/blocks/registry.ts": 335,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/index.ts": 289,
         "apps/sim/app/workspace/[workspaceId]/w/components/sidebar/sidebar.tsx": 162,
         "apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/index.ts": 151
       }
     },
     "app/workspace/[workspaceId]/w/[workflowId]/page.tsx": {
-      "modules": 2257,
+      "modules": 2267,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx": 2256,
+        "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx": 2266,
         "apps/sim/triggers/registry.ts": 488,
-        "apps/sim/blocks/registry.ts": 328,
+        "apps/sim/blocks/registry.ts": 335,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/index.ts": 308,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/index.ts": 270,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/index.ts": 227,
@@ -340,12 +340,12 @@
       }
     },
     "app/workspace/[workspaceId]/w/page.tsx": {
-      "modules": 2230,
+      "modules": 2240,
       "gateways": {
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/index.ts": 950,
         "apps/sim/triggers/registry.ts": 488,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/index.ts": 461,
-        "apps/sim/blocks/registry.ts": 328,
+        "apps/sim/blocks/registry.ts": 335,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/index.ts": 289,
         "apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/error/index.tsx": 163,
         "apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/index.ts": 151,
@@ -353,29 +353,29 @@
       }
     },
     "app/workspace/layout.tsx": {
-      "modules": 1234,
+      "modules": 1244,
       "gateways": {
-        "apps/sim/app/workspace/providers/socket-provider.tsx": 1224,
+        "apps/sim/app/workspace/providers/socket-provider.tsx": 1234,
         "apps/sim/triggers/registry.ts": 488,
-        "apps/sim/blocks/registry.ts": 343,
-        "apps/sim/blocks/registry-maps.ts": 340,
-        "apps/sim/stores/workflows/registry/store.ts": 271,
-        "apps/sim/hooks/queries/deployments.ts": 268,
-        "apps/sim/lib/workflows/comparison/compare.ts": 262,
-        "apps/sim/lib/workflows/comparison/resolve-values.ts": 259
+        "apps/sim/blocks/registry.ts": 350,
+        "apps/sim/blocks/registry-maps.ts": 347,
+        "apps/sim/stores/workflows/registry/store.ts": 274,
+        "apps/sim/hooks/queries/deployments.ts": 271,
+        "apps/sim/lib/workflows/comparison/compare.ts": 265,
+        "apps/sim/lib/workflows/comparison/resolve-values.ts": 262
       }
     },
     "app/workspace/page.tsx": {
-      "modules": 1228,
+      "modules": 1238,
       "gateways": {
-        "apps/sim/lib/auth/stale-session-recovery.ts": 993,
+        "apps/sim/lib/auth/stale-session-recovery.ts": 1001,
         "apps/sim/triggers/index.ts": 489,
-        "apps/sim/blocks/registry.ts": 343,
-        "apps/sim/blocks/registry-maps.ts": 340,
-        "apps/sim/lib/api/contracts/index.ts": 138,
-        "apps/sim/stores/workflows/registry/store.ts": 81,
-        "apps/sim/hooks/queries/deployments.ts": 74,
-        "apps/sim/lib/workflows/comparison/compare.ts": 71
+        "apps/sim/blocks/registry.ts": 350,
+        "apps/sim/blocks/registry-maps.ts": 347,
+        "apps/sim/lib/api/contracts/index.ts": 139,
+        "apps/sim/stores/workflows/registry/store.ts": 82,
+        "apps/sim/hooks/queries/deployments.ts": 75,
+        "apps/sim/lib/workflows/comparison/compare.ts": 72
       }
     }
   }


### PR DESCRIPTION
## Summary
- `markDocumentsQueued` spends one attempt from the processing budget on every dispatch. `clearDocumentsQueued` already withdraws the queue stamp on the one path that proves nothing was dispatched, but left the attempt spent.
- The budget exists to stop re-billing a document that keeps failing the same way *in processing*. An attempt that never reached a worker teaches it nothing, so an infrastructure outage — a provider region error, an exhausted quota — burned the allowance without a single run.
- `MAX_PROCESSING_ATTEMPTS` such outages dead-letter the document, and the connector sweep filters on `processingAttempts < MAX_PROCESSING_ATTEMPTS`, so automatic recovery stops for a document that was never processed once.
- Refunded in the same guarded statement as the stamp, so it can only ever give back the charge this call made, and floored at zero.
- Also corrects two comments that had drifted: the stale-lock TTL still described the reclaim as measuring `updatedAt` after it moved to `COALESCE(syncLockLeaseAt, updatedAt)`, and the attempt-budget rationale predates the refund (a partial batch failure and an accepted dispatch whose run never starts both still stay charged, correctly).

## Type of Change
- [x] Bug fix

## Testing
- Two new tests in `processing-queue.test.ts`; mutation-tested both ways — dropping the refund and dropping the `GREATEST` floor each turn the named test red.
- `lib/knowledge` + `app/api/knowledge` + full dependent surface: 64 files / 855 tests passing.
- `type-check` clean, `lint` clean, 31/32 audits passing.
- `check:tool-registry-boundary` fails identically on `origin/staging` (knowledge page at 2255 modules vs a 2209 baseline) — pre-existing, unrelated to this change, which adds zero modules to that graph.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)