### PR TITLE
fix(selectors): respect trigger credentials in trigger mode

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-fetched-options.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-fetched-options.ts
@@ -131,6 +131,7 @@ export function useFetchedOptions({
       workflowId: activeWorkflowId ?? undefined,
       workspaceId: workspaceId ?? undefined,
       canonicalModes: block.data?.canonicalModes,
+      triggerMode: block.triggerMode,
     })
     if (selectorExcludeSelf && activeWorkflowId) context.excludeWorkflowId = activeWorkflowId
     return context

--- a/apps/sim/ee/workspace-forking/lib/mapping/dependent-reconfigs.test.ts
+++ b/apps/sim/ee/workspace-forking/lib/mapping/dependent-reconfigs.test.ts
@@ -131,6 +131,137 @@ describe('collectForkDependentReconfigs', () => {
     ])
   })
 
+  it('uses trigger canonical context for top-level trigger-mode reconfiguration', () => {
+    vi.mocked(getBlock).mockReturnValue(
+      blockWith([
+        {
+          id: 'credential',
+          title: 'Action Credential',
+          type: 'oauth-input',
+          canonicalParamId: 'oauthCredential',
+          mode: 'basic',
+        },
+        {
+          id: 'workspaceSelector',
+          title: 'Action Workspace',
+          type: 'project-selector',
+          canonicalParamId: 'teamId',
+          mode: 'basic',
+        },
+        {
+          id: 'triggerCredentials',
+          title: 'Trigger Credential',
+          type: 'oauth-input',
+          canonicalParamId: 'oauthCredential',
+          mode: 'trigger',
+        },
+        {
+          id: 'triggerWorkspaceId',
+          title: 'Trigger Workspace',
+          type: 'dropdown',
+          canonicalParamId: 'teamId',
+          dependsOn: ['triggerCredentials'],
+          selectorKey: 'clickup.workspaces',
+          mode: 'trigger',
+        },
+      ])
+    )
+    const state = sourceState('clickup', {
+      credential: { value: 'action-credential' },
+      workspaceSelector: { value: 'action-workspace' },
+      triggerCredentials: { value: 'trigger-credential' },
+      triggerWorkspaceId: { value: 'trigger-workspace' },
+    })
+    state.blocks['block-1'].triggerMode = true
+
+    const result = collectForkDependentReconfigs(
+      [replaceItem],
+      new Map([['wf-src', state]]),
+      resolve
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      parentSourceId: 'trigger-credential',
+      subBlockKey: 'triggerWorkspaceId',
+      context: { teamId: 'trigger-workspace' },
+    })
+  })
+
+  it('keeps nested tool selector context in action mode inside a trigger block', () => {
+    const agentConfig = blockWith([{ id: 'tools', title: 'Tools', type: 'tool-input' }])
+    const clickupToolConfig = blockWith([
+      {
+        id: 'credential',
+        title: 'Action Credential',
+        type: 'oauth-input',
+        canonicalParamId: 'oauthCredential',
+        mode: 'basic',
+      },
+      {
+        id: 'workspaceSelector',
+        title: 'Action Workspace',
+        type: 'project-selector',
+        canonicalParamId: 'teamId',
+        mode: 'basic',
+      },
+      {
+        id: 'triggerCredentials',
+        title: 'Trigger Credential',
+        type: 'oauth-input',
+        canonicalParamId: 'oauthCredential',
+        mode: 'trigger',
+      },
+      {
+        id: 'triggerWorkspaceId',
+        title: 'Trigger Workspace',
+        type: 'dropdown',
+        canonicalParamId: 'teamId',
+        mode: 'trigger',
+      },
+      {
+        id: 'listId',
+        title: 'List',
+        type: 'short-input',
+        dependsOn: ['credential'],
+        required: true,
+      },
+    ])
+    vi.mocked(getBlock).mockImplementation((type) =>
+      type === 'agent' ? agentConfig : clickupToolConfig
+    )
+    const state = sourceState('agent', {
+      tools: {
+        value: [
+          {
+            type: 'clickup',
+            params: {
+              credential: 'action-credential',
+              workspaceSelector: 'action-workspace',
+              triggerCredentials: 'trigger-credential',
+              triggerWorkspaceId: 'trigger-workspace',
+              listId: 'list-1',
+            },
+          },
+        ],
+      },
+    })
+    state.blocks['block-1'].triggerMode = true
+
+    const result = collectForkDependentReconfigs(
+      [replaceItem],
+      new Map([['wf-src', state]]),
+      resolve
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      parentSourceId: 'action-credential',
+      subBlockKey: 'tools[0].listId',
+      context: { teamId: 'action-workspace' },
+    })
+  })
+
   it('skips an anchor whose canonical pair is in advanced (manual) mode - the value passes through', () => {
     vi.mocked(getBlock).mockReturnValue(
       blockWith([

--- a/apps/sim/ee/workspace-forking/lib/mapping/dependent-reconfigs.ts
+++ b/apps/sim/ee/workspace-forking/lib/mapping/dependent-reconfigs.ts
@@ -75,6 +75,8 @@ interface EmitAnchoredParams {
   targetWorkflowId: string
   /** Canonical-mode overrides for resolving the active parent member (undefined -> value heuristic). */
   canonicalModes?: CanonicalModeOverrides
+  /** Applies trigger-only canonical precedence for a top-level trigger-mode block. */
+  triggerMode?: boolean
   /** Memoized so the deterministic target block id is derived at most once per block. */
   resolveTargetBlockId: () => string
   /** Map a dependent's config id to its wire `subBlockKey` (identity, or nested `tools[i].id`). */
@@ -117,6 +119,7 @@ function emitAnchoredDependents(params: EmitAnchoredParams): void {
     blockName,
     targetWorkflowId,
     canonicalModes,
+    triggerMode,
     resolveTargetBlockId,
     makeSubBlockKey,
     makeTitle,
@@ -127,6 +130,7 @@ function emitAnchoredDependents(params: EmitAnchoredParams): void {
   } = params
   const fullContext = buildSelectorContextFromBlock(contextBlockType, contextSubBlocks, {
     canonicalModes,
+    triggerMode,
   })
   const canonicalIndex = buildCanonicalIndex(config.subBlocks)
   const gates = createCanonicalModeGates(config.subBlocks, values, canonicalModes)
@@ -327,6 +331,7 @@ export function collectForkDependentReconfigs(
         blockName: block.name,
         targetWorkflowId: item.targetWorkflowId,
         canonicalModes: block.data?.canonicalModes,
+        triggerMode: block.triggerMode,
         resolveTargetBlockId: resolveBlockId,
         makeSubBlockKey: (id) => id,
         makeTitle: (dependent) => dependent.title ?? dependent.id ?? '',

--- a/apps/sim/hooks/queries/dynamic-subblock-options.test.tsx
+++ b/apps/sim/hooks/queries/dynamic-subblock-options.test.tsx
@@ -6,12 +6,21 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { mockGetSelectorDefinition } = vi.hoisted(() => ({
+const { mockBuildSelectorContextFromBlock, mockGetSelectorDefinition } = vi.hoisted(() => ({
+  mockBuildSelectorContextFromBlock: vi.fn(
+    (_blockType: string, _subBlocks: unknown, opts?: { workspaceId?: string }) => ({
+      workspaceId: opts?.workspaceId,
+    })
+  ),
   mockGetSelectorDefinition: vi.fn(),
 }))
 
 vi.mock('@/hooks/selectors/registry', () => ({
   getSelectorDefinition: mockGetSelectorDefinition,
+}))
+
+vi.mock('@/lib/workflows/subblocks/context', () => ({
+  buildSelectorContextFromBlock: mockBuildSelectorContextFromBlock,
 }))
 
 import type { SubBlockConfig } from '@/blocks/types'
@@ -20,6 +29,10 @@ import {
   useDynamicSubBlockOptionDisplayName,
 } from '@/hooks/queries/dynamic-subblock-options'
 import type { SelectorDefinition, SelectorKey } from '@/hooks/selectors/types'
+import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
+import { useSubBlockStore } from '@/stores/workflows/subblock/store'
+import { useWorkflowStore } from '@/stores/workflows/workflow/store'
+import type { BlockState } from '@/stores/workflows/workflow/types'
 
 /** Any registered key; the hook only uses it to look the definition up. */
 const SELECTOR_KEY = 'workspace.credentialGroups' as SelectorKey
@@ -70,6 +83,9 @@ describe('useDynamicSubBlockOptionDisplayName', () => {
 
   afterEach(() => {
     mounted.splice(0).forEach((unmount) => unmount())
+    useWorkflowRegistry.setState({ activeWorkflowId: null })
+    useWorkflowStore.setState({ blocks: {} })
+    useSubBlockStore.setState({ workflowValues: {} })
     vi.clearAllMocks()
   })
 
@@ -128,6 +144,57 @@ describe('useDynamicSubBlockOptionDisplayName', () => {
     mounted.push(hook.unmount)
 
     await waitForResult(() => expect(hook.result()).toBe('Gmail, Slack'))
+  })
+
+  it('uses trigger mode when hydrating a trigger field label', async () => {
+    const block = {
+      id: 'block-1',
+      type: 'gmail',
+      name: 'Gmail trigger',
+      position: { x: 0, y: 0 },
+      subBlocks: {},
+      outputs: {},
+      enabled: true,
+      triggerMode: true,
+    } satisfies BlockState
+    useWorkflowRegistry.setState({ activeWorkflowId: 'workflow-1' })
+    useWorkflowStore.setState({ blocks: { 'block-1': block } })
+    useSubBlockStore.setState({
+      workflowValues: {
+        'workflow-1': {
+          'block-1': { triggerCredentials: 'trigger-credential' },
+        },
+      },
+    })
+
+    const fetchById = vi.fn(async ({ detailId }: { detailId?: string }) => ({
+      id: detailId as string,
+      label: 'Inbox',
+    }))
+    mockDefinition({ key: SELECTOR_KEY, getQueryKey: () => [SELECTOR_KEY], fetchById })
+    const subBlock = {
+      id: 'labelIds',
+      title: 'Labels',
+      type: 'dropdown',
+      selectorKey: SELECTOR_KEY,
+    } satisfies SubBlockConfig
+
+    const hook = renderHookWithClient(() =>
+      useDynamicSubBlockOptionDisplayName({
+        workspaceId: 'workspace-1',
+        blockId: 'block-1',
+        subBlock,
+        value: 'INBOX',
+      })
+    )
+    mounted.push(hook.unmount)
+
+    await waitForResult(() => expect(hook.result()).toBe('Inbox'))
+    expect(mockBuildSelectorContextFromBlock).toHaveBeenCalledWith(
+      'gmail',
+      expect.objectContaining({ triggerCredentials: { value: 'trigger-credential' } }),
+      expect.objectContaining({ triggerMode: true })
+    )
   })
 
   it('re-resolves a label when the sibling its selector depends on changes', () => {

--- a/apps/sim/hooks/queries/dynamic-subblock-options.ts
+++ b/apps/sim/hooks/queries/dynamic-subblock-options.ts
@@ -89,6 +89,7 @@ export function useDynamicSubBlockOptionDisplayName({
       workflowId: activeWorkflowId ?? undefined,
       workspaceId,
       canonicalModes: block.data?.canonicalModes,
+      triggerMode: block.triggerMode,
     })
   }, [block, liveValues, activeWorkflowId, workspaceId])
 

--- a/apps/sim/lib/workflows/comparison/format-description.test.ts
+++ b/apps/sim/lib/workflows/comparison/format-description.test.ts
@@ -3,7 +3,8 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockGetBlock } = vi.hoisted(() => ({
+const { mockBuildSelectorContextFromBlock, mockGetBlock } = vi.hoisted(() => ({
+  mockBuildSelectorContextFromBlock: vi.fn(() => ({})),
   mockGetBlock: vi.fn(),
 }))
 
@@ -32,7 +33,7 @@ vi.mock('@/blocks/registry', () => ({
 }))
 
 vi.mock('@/lib/workflows/subblocks/context', () => ({
-  buildSelectorContextFromBlock: vi.fn(() => ({})),
+  buildSelectorContextFromBlock: mockBuildSelectorContextFromBlock,
 }))
 
 vi.mock('@/hooks/queries/oauth/oauth-credentials', () => ({
@@ -54,7 +55,11 @@ import {
   formatDiffSummaryForDescriptionAsync,
   generateWorkflowDiffSummary,
 } from '@/lib/workflows/comparison/compare'
-import { formatValueForDisplay, resolveFieldLabel } from '@/lib/workflows/comparison/resolve-values'
+import {
+  formatValueForDisplay,
+  resolveFieldLabel,
+  resolveValueForDisplay,
+} from '@/lib/workflows/comparison/resolve-values'
 
 function emptyDiffSummary(overrides: Partial<WorkflowDiffSummary> = {}): WorkflowDiffSummary {
   return {
@@ -128,6 +133,36 @@ describe('formatValueForDisplay', () => {
 
   it('handles empty string', () => {
     expect(formatValueForDisplay('')).toBe('(empty)')
+  })
+})
+
+describe('resolveValueForDisplay', () => {
+  it('builds off-canvas selector context with the block trigger mode', async () => {
+    mockGetBlock.mockReturnValue({
+      subBlocks: [{ id: 'labelIds', title: 'Labels', type: 'short-input' }],
+    })
+
+    await resolveValueForDisplay('INBOX', {
+      blockType: 'gmail',
+      subBlockId: 'labelIds',
+      workflowId: 'workflow-1',
+      currentState: {
+        blocks: {
+          'block-1': {
+            type: 'gmail',
+            triggerMode: true,
+            subBlocks: { triggerCredentials: { value: 'trigger-credential' } },
+          },
+        },
+      } as never,
+      blockId: 'block-1',
+    })
+
+    expect(mockBuildSelectorContextFromBlock).toHaveBeenCalledWith(
+      'gmail',
+      expect.any(Object),
+      expect.objectContaining({ triggerMode: true })
+    )
   })
 })
 

--- a/apps/sim/lib/workflows/comparison/resolve-values.ts
+++ b/apps/sim/lib/workflows/comparison/resolve-values.ts
@@ -179,6 +179,7 @@ function extractSelectorContext(
     workflowId,
     workspaceId,
     canonicalModes: block.data?.canonicalModes,
+    triggerMode: block.triggerMode,
   })
 }
 

--- a/apps/sim/lib/workflows/subblocks/context.test.ts
+++ b/apps/sim/lib/workflows/subblocks/context.test.ts
@@ -152,6 +152,67 @@ describe('buildSelectorContextFromBlock', () => {
     ).toBe('advanced-team')
   })
 
+  it('uses the Gmail trigger credential instead of dormant action credentials', () => {
+    const subBlocks = {
+      credential: { id: 'credential', type: 'oauth-input', value: 'action-basic' },
+      manualCredential: {
+        id: 'manualCredential',
+        type: 'short-input',
+        value: 'action-advanced',
+      },
+      triggerCredentials: {
+        id: 'triggerCredentials',
+        type: 'oauth-input',
+        value: 'trigger-credential',
+      },
+    }
+
+    expect(buildSelectorContextFromBlock('gmail', subBlocks).oauthCredential).toBe('action-basic')
+    expect(
+      buildSelectorContextFromBlock('gmail', subBlocks, {
+        canonicalModes: { oauthCredential: 'advanced' },
+      }).oauthCredential
+    ).toBe('action-advanced')
+    expect(
+      buildSelectorContextFromBlock('gmail', subBlocks, { triggerMode: true }).oauthCredential
+    ).toBe('trigger-credential')
+  })
+
+  it('does not leak a Gmail action credential when the active trigger credential is blank', () => {
+    const ctx = buildSelectorContextFromBlock(
+      'gmail',
+      {
+        credential: { id: 'credential', type: 'oauth-input', value: 'stale-action-credential' },
+        triggerCredentials: { id: 'triggerCredentials', type: 'oauth-input', value: '' },
+      },
+      { triggerMode: true }
+    )
+
+    expect(ctx.oauthCredential).toBeUndefined()
+  })
+
+  it('uses the condition-visible ClickUp trigger credential', () => {
+    const ctx = buildSelectorContextFromBlock(
+      'clickup',
+      {
+        selectedTriggerId: {
+          id: 'selectedTriggerId',
+          type: 'dropdown',
+          value: 'clickup_task_created',
+        },
+        credential: { id: 'credential', type: 'oauth-input', value: 'action-credential' },
+        triggerCredentials: {
+          id: 'triggerCredentials',
+          type: 'oauth-input',
+          value: 'trigger-credential',
+        },
+      },
+      { triggerMode: true }
+    )
+
+    expect(ctx.oauthCredential).toBe('trigger-credential')
+  })
+
   it('should ignore subblock keys not in SELECTOR_CONTEXT_FIELDS', () => {
     const ctx = buildSelectorContextFromBlock('knowledge', {
       operation: { id: 'operation', type: 'dropdown', value: 'search' },

--- a/apps/sim/lib/workflows/subblocks/context.ts
+++ b/apps/sim/lib/workflows/subblocks/context.ts
@@ -5,6 +5,7 @@ import {
   buildCanonicalIndex,
   buildSubBlockValues,
   type CanonicalModeOverrides,
+  evaluateSubBlockCondition,
   resolveActiveCanonicalValue,
 } from './visibility'
 
@@ -66,7 +67,12 @@ export const SELECTOR_CONTEXT_FIELDS = new Set<keyof SelectorContext>([
 export function buildSelectorContextFromBlock(
   blockType: string,
   subBlocks: Record<string, SubBlockState | { value?: unknown }>,
-  opts?: { workflowId?: string; workspaceId?: string; canonicalModes?: CanonicalModeOverrides }
+  opts?: {
+    workflowId?: string
+    workspaceId?: string
+    canonicalModes?: CanonicalModeOverrides
+    triggerMode?: boolean
+  }
 ): SelectorContext {
   const context: SelectorContext = {}
   if (opts?.workflowId) context.workflowId = opts.workflowId
@@ -78,6 +84,13 @@ export function buildSelectorContextFromBlock(
   const canonicalIndex = buildCanonicalIndex(blockConfig.subBlocks)
   const values = buildSubBlockValues(subBlocks)
   const resolvedGroups = new Set<string>()
+  const visibleTriggerSubBlocks = opts?.triggerMode
+    ? blockConfig.subBlocks.filter(
+        (subBlock) =>
+          (subBlock.mode === 'trigger' || subBlock.mode === 'trigger-advanced') &&
+          evaluateSubBlockCondition(subBlock.condition, values)
+      )
+    : []
 
   const setField = (key: string, value: unknown) => {
     if (value === null || value === undefined) return
@@ -85,6 +98,14 @@ export function buildSelectorContextFromBlock(
     if (!strValue) return
     if (SELECTOR_CONTEXT_FIELDS.has(key as keyof SelectorContext)) {
       context[key as keyof SelectorContext] = strValue
+    }
+  }
+
+  if (opts?.triggerMode) {
+    const triggerCanonicalIndex = buildCanonicalIndex(visibleTriggerSubBlocks)
+    for (const group of Object.values(triggerCanonicalIndex.groupsById)) {
+      resolvedGroups.add(group.canonicalId)
+      setField(group.canonicalId, resolveActiveCanonicalValue(group, values, opts.canonicalModes))
     }
   }
 
@@ -110,9 +131,10 @@ export function buildSelectorContextFromBlock(
   //
   // Only fills a gap: a block that does declare the canonical id has already set it above,
   // including the basic/advanced active-member resolution this loop cannot express.
-  if (!context.oauthCredential) {
+  if (!context.oauthCredential && !resolvedGroups.has('oauthCredential')) {
+    const credentialConfigs = opts?.triggerMode ? visibleTriggerSubBlocks : blockConfig.subBlocks
     for (const [subBlockId, subBlock] of Object.entries(subBlocks)) {
-      if (blockConfig.subBlocks.find((cfg) => cfg.id === subBlockId)?.type !== 'oauth-input') {
+      if (credentialConfigs.find((cfg) => cfg.id === subBlockId)?.type !== 'oauth-input') {
         continue
       }
       const value = subBlock?.value


### PR DESCRIPTION
## Summary
- make condition-visible trigger fields authoritative when selector context is built for a trigger-mode block
- prevent blank or stale action credentials from leaking into trigger selectors
- thread trigger mode through canvas, label hydration, comparison, and fork-dependent contexts while keeping nested tools in action mode

Prerequisite for #6934.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- focused selector-context, label hydration, comparison, and fork-dependent tests: 88 passed
- `bun run --cwd apps/sim type-check`
- scoped Biome check
- `git diff --check`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Not applicable; no visual changes.