### PR TITLE
improvement(mship): preview recent runs in @ mention, with the logs icon

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -27,6 +27,7 @@ import {
   buildResourceFolderTree,
   type ResourceTreeNode,
 } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-folder-tree'
+import { resourceFromItem } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-from-item'
 import {
   byResourceMenuOrder,
   getResourceConfig,
@@ -265,12 +266,26 @@ export function useAvailableResources(
         type: 'task' as const,
         items: (tasks ?? []).map((t) => ({ id: t.id, name: t.name })),
       },
+      /**
+       * The chip's `name` keeps the absolute timestamp because it is persisted
+       * with the chat, where "2m ago" would age into a lie; the row renders the
+       * relative form, which is what reads at a glance. `mentionFamily` is what
+       * lets `@logs` reach rows named after their workflow.
+       */
       {
         type: 'log' as const,
         items: logs.map((log) => {
           const workflowName = log.workflow?.name ?? log.workflowId ?? 'Unknown'
-          const time = formatDate(log.createdAt).compact
-          return { id: log.id, name: `${workflowName} · ${time}`, workflowName, time }
+          const when = formatDate(log.createdAt)
+          return {
+            id: log.id,
+            name: `${workflowName} · ${when.compact}`,
+            mentionFamily: getResourceConfig('log').label,
+            executionId: log.executionId ?? undefined,
+            workflowName,
+            time: when.relative,
+            status: log.status,
+          }
         }),
       },
     ]
@@ -364,7 +379,7 @@ export function ResourceFolderTreeItems({
         node.kind === 'item' ? (
           <DropdownMenuItem
             key={node.id}
-            onClick={() => onSelect({ type, id: node.id, title: node.item.name })}
+            onClick={() => onSelect(resourceFromItem(type, node.item))}
           >
             {config.renderDropdownItem({ item: node.item })}
           </DropdownMenuItem>
@@ -518,10 +533,7 @@ export function ResourceMenuSections({
         if (!section && (type === 'browser' || type === 'terminal')) {
           const item = items[0]
           return (
-            <DropdownMenuItem
-              key={type}
-              onClick={() => onSelect({ type, id: item.id, title: item.name })}
-            >
+            <DropdownMenuItem key={type} onClick={() => onSelect(resourceFromItem(type, item))}>
               <Icon className='size-[14px]' />
               <span>{config.label}</span>
             </DropdownMenuItem>
@@ -546,7 +558,7 @@ export function ResourceMenuSections({
                 items.map((item) => (
                   <DropdownMenuItem
                     key={item.id}
-                    onClick={() => onSelect({ type, id: item.id, title: item.name })}
+                    onClick={() => onSelect(resourceFromItem(type, item))}
                   >
                     {config.renderDropdownItem({ item })}
                   </DropdownMenuItem>
@@ -642,7 +654,7 @@ export function AddResourceDropdown({
       if (filtered.length > 0 && filtered[activeIndex]) {
         e.preventDefault()
         const { type, item } = filtered[activeIndex]
-        select({ type, id: item.id, title: item.name })
+        select(resourceFromItem(type, item))
       }
     }
   }
@@ -694,7 +706,7 @@ export function AddResourceDropdown({
                     key={`${type}:${item.id}`}
                     className={cn(index === activeIndex && 'bg-[var(--surface-hover)]')}
                     onMouseEnter={() => setActiveIndex(index)}
-                    onClick={() => select({ type, id: item.id, title: item.name })}
+                    onClick={() => select(resourceFromItem(type, item))}
                   >
                     {config.renderDropdownItem({ item })}
                   </DropdownMenuItem>

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/index.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/index.ts
@@ -6,3 +6,4 @@ export {
   useAvailableResources,
   useResourceTreeSections,
 } from './add-resource-dropdown'
+export { resourceFromItem } from './resource-from-item'

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-from-item.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-from-item.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { resourceFromItem } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-from-item'
+
+describe('resourceFromItem', () => {
+  it('carries a log item execution id onto the resource', () => {
+    expect(
+      resourceFromItem('log', {
+        id: 'log-row-1',
+        name: 'Nightly sync · Aug 21 11:03:46',
+        executionId: 'exec-9',
+      })
+    ).toEqual({
+      type: 'log',
+      id: 'log-row-1',
+      title: 'Nightly sync · Aug 21 11:03:46',
+      executionId: 'exec-9',
+    })
+  })
+
+  it('builds the plain resource for a family that carries no extra identifier', () => {
+    expect(resourceFromItem('workflow', { id: 'wf-1', name: 'Nightly sync' })).toEqual({
+      type: 'workflow',
+      id: 'wf-1',
+      title: 'Nightly sync',
+    })
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-from-item.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-from-item.ts
@@ -1,0 +1,22 @@
+import type { AvailableItem } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-folder-tree'
+import type {
+  MothershipResource,
+  MothershipResourceType,
+} from '@/app/workspace/[workspaceId]/home/types'
+
+/**
+ * Builds the resource a picker row stands for.
+ *
+ * Every menu that selects a candidate goes through here so a family's extra
+ * identifier reaches the resource. Constructing the literal inline silently
+ * drops it — a log selected that way loses the execution id its chat context is
+ * addressed by. Only `executionId` is carried today; add a field here when
+ * another family needs one.
+ */
+export function resourceFromItem(
+  type: MothershipResourceType,
+  item: AvailableItem
+): MothershipResource {
+  const executionId = typeof item.executionId === 'string' ? item.executionId : undefined
+  return { type, id: item.id, title: item.name, ...(executionId ? { executionId } : {}) }
+}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/resource-registry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/resource-registry.tsx
@@ -20,6 +20,7 @@ import type {
   MothershipResource,
   MothershipResourceType,
 } from '@/app/workspace/[workspaceId]/home/types'
+import { getDisplayStatus, STATUS_CONFIG } from '@/app/workspace/[workspaceId]/logs/utils'
 import { BrandIcon, type StyleableIcon } from '@/blocks/brand-icon'
 import { logKeys } from '@/hooks/queries/logs'
 import { mothershipChatKeys } from '@/hooks/queries/mothership-chats'
@@ -40,6 +41,12 @@ export interface ResourceTypeConfig {
   icon: ElementType
   renderTabIcon: (resource: MothershipResource, className: string) => ReactNode
   renderDropdownItem: (props: DropdownItemRenderProps) => ReactNode
+  /**
+   * How many of this family's candidates an unfiltered `@` list shows.
+   * Uncapped by default; set it for a family whose near-identical rows would
+   * otherwise bury every other family.
+   */
+  mentionPreviewLimit?: number
 }
 
 function WorkflowDropdownItem({ item }: DropdownItemRenderProps) {
@@ -91,15 +98,37 @@ function IntegrationDropdownItem({ item }: DropdownItemRenderProps) {
   )
 }
 
+/**
+ * A run, not the workflow it ran — the Logs icon is what says so, and it is the
+ * same one the sidebar, the search palette, and the resulting chip already use.
+ *
+ * A run that did not simply succeed carries the same dot `Badge` draws at `sm`,
+ * so a status reads identically here and on the logs page. Marking every row
+ * would mark nothing, so a plain success gets none.
+ */
 function LogDropdownItem({ item }: DropdownItemRenderProps) {
   const workflowName = (item.workflowName as string) ?? item.name
   const time = (item.time as string) ?? ''
+  const status = getDisplayStatus(item.status as string | null | undefined)
+  const statusColor = status === 'info' ? null : STATUS_CONFIG[status].color
   return (
     <>
-      <Workflow className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
+      <Library className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
       <span className='truncate'>{workflowName}</span>
+      {statusColor && (
+        <div
+          aria-hidden
+          className='ml-auto size-[5px] flex-shrink-0 rounded-xs'
+          style={{ backgroundColor: statusColor }}
+        />
+      )}
       {time && (
-        <span className='ml-auto flex-shrink-0 text-[var(--text-tertiary)] text-caption'>
+        <span
+          className={cn(
+            'flex-shrink-0 text-[var(--text-tertiary)] text-caption',
+            !statusColor && 'ml-auto'
+          )}
+        >
           {time}
         </span>
       )}
@@ -189,6 +218,7 @@ export const RESOURCE_REGISTRY: Record<MothershipResourceType, ResourceTypeConfi
       <Library className={cn(className, 'text-[var(--text-icon)]')} />
     ),
     renderDropdownItem: (props) => <LogDropdownItem {...props} />,
+    mentionPreviewLimit: 5,
   },
   integration: {
     type: 'integration',

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/constants.ts
@@ -125,7 +125,12 @@ const RESOURCE_TO_CONTEXT: Record<
   folder: (r) => ({ kind: 'folder', folderId: r.id, label: r.title }),
   filefolder: (r) => ({ kind: 'filefolder', fileFolderId: r.id, label: r.title }),
   task: (r) => ({ kind: 'past_chat', chatId: r.id, label: r.title }),
-  log: (r) => ({ kind: 'logs', executionId: r.id, label: r.title }),
+  // Addressed by run, not by log row: `id` is the row's key, and the server
+  // resolves this context against `workflow_execution_logs.execution_id`. A
+  // picked resource carries the run id; one rebuilt from the wire (a restored
+  // or agent-opened tab) cannot, since the stored and streamed resource shapes
+  // are the identity triple — those keep the row id they have always sent.
+  log: (r) => ({ kind: 'logs', executionId: r.executionId ?? r.id, label: r.title }),
   integration: (r) => ({ kind: 'integration', blockType: r.id, label: r.title }),
   generic: (r) => ({ kind: 'docs', label: r.title }),
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -10,6 +10,7 @@ import {
 } from '@sim/emcn'
 import {
   ResourceMenuSections,
+  resourceFromItem,
   useAvailableResources,
   useResourceTreeSections,
 } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown'
@@ -127,10 +128,13 @@ export const PlusMenuDropdown = React.memo(
     const filteredItems = useMemo(() => {
       const rawQuery = isMention ? (mentionQuery ?? '') : search
       const q = rawQuery.toLowerCase().trim()
-      // In mention mode always render a flat filtered list — empty query = show everything.
       if (!isMention && !q) return null
       if (isMention && !q) {
-        return visibleResources.flatMap(({ type, items }) => items.map((item) => ({ type, item })))
+        return visibleResources.flatMap(({ type, items }) => {
+          const limit = getResourceConfig(type).mentionPreviewLimit
+          const previewed = limit === undefined ? items : items.slice(0, limit)
+          return previewed.map((item) => ({ type, item }))
+        })
       }
       return visibleResources.flatMap(({ type, items }) =>
         items.filter((item) => resourceMentionMatches(item, q)).map((item) => ({ type, item }))
@@ -181,11 +185,7 @@ export const PlusMenuDropdown = React.memo(
           const items = filteredItemsRef.current
           const target = items?.length ? (items[activeIndexRef.current] ?? items[0]) : undefined
           if (!target) return isHydratingRef.current ? 'hydrating' : 'empty'
-          handleSelectRef.current({
-            type: target.type,
-            id: target.item.id,
-            title: target.item.name,
-          })
+          handleSelectRef.current(resourceFromItem(target.type, target.item))
           return 'selected'
         },
       }),
@@ -224,7 +224,7 @@ export const PlusMenuDropdown = React.memo(
       } else if (e.key === 'Enter' || (e.key === 'Tab' && !e.shiftKey)) {
         e.preventDefault()
         const target = filteredItems[activeIndex] ?? filteredItems[0]
-        if (target) handleSelect({ type: target.type, id: target.item.id, title: target.item.name })
+        if (target) handleSelect(resourceFromItem(target.type, target.item))
       }
     }
 
@@ -342,7 +342,7 @@ export const PlusMenuDropdown = React.memo(
                       data-filtered-idx={index}
                       onMouseEnter={() => setActiveIndex(index)}
                       onClick={() => {
-                        handleSelect({ type, id: item.id, title: item.name })
+                        handleSelect(resourceFromItem(type, item))
                       }}
                       className={cn(
                         'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors duration-0 [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',

--- a/apps/sim/lib/copilot/resources/types.ts
+++ b/apps/sim/lib/copilot/resources/types.ts
@@ -22,6 +22,12 @@ export interface MothershipResource {
   path?: string
   /** Saved table view to open pinned (type "table" only). */
   viewId?: string
+  /**
+   * The run this log row records (type "log" only). Distinct from `id`, which
+   * is the log row's own key: the tab loads by row id, while chat context and
+   * the logs deep-link address the run itself.
+   */
+  executionId?: string
 }
 
 /**


### PR DESCRIPTION
## Summary
- The Logs family flooded the `@` picker with up to 50 near-identical rows, named after their workflow and drawn with the workflow icon — they read as workflow snapshots and buried every other family
- Preview the 5 most recent runs while the query is empty; typing still searches the full fetched set. The cap spans the whole workspace rather than one workflow, so a few background runs cannot evict a run you just started
- Draw the row with the Logs icon, matching the sidebar, the search palette, and the chip the selection turns into
- Trail the row with relative time, and with the dot `Badge` draws at `sm` for a run that did not simply succeed, so runs of one workflow are told apart at a glance
- Make `@logs` reach the family, which nothing in a row's text names

## Bug fixed
Mentioning a log resolved to nothing. A log row is keyed by `id`, but its run is addressed by `execution_id`, and the picker sent the former where the server resolves the latter. The run id now rides on the resource, and every menu builds that resource through one `resourceFromItem` helper instead of eight inline literals that each silently dropped it.

## Scope note
This fixes the mention path, which is self-contained: a picked resource is mapped to its context at selection time, and the context schema already carries the run id.

A log resource that has been through the wire — a tab restored from a saved chat, or one the agent opens mid-stream — still carries only the row id. Closing that means giving log resources a single identifier end to end: the resource is rebuilt from the identity triple at eight further points, including from the stream's generated resource descriptor, which has no field for it. That is its own change, not this one, so this PR does not widen the stored or streamed resource shape for a value that could not survive the round trip anyway.

## Type of Change
- [x] Bug fix
- [x] Improvement

## Testing
Tested manually. `bun run type-check`, `bun run lint`, `bun run check:audits` (32/32), and the home + hooks + copilot suites (2561 tests) all pass. Added unit coverage for the selection helper, verified failing when the behavior is reverted.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)