### PR TITLE
improvement(tabs): port resource tabs onto the shared TabStrip

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-tab-strip.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-tab-strip.tsx
@@ -207,33 +207,34 @@ export function BrowserTabStrip({
       onTabContextMenu={openTabContextMenu}
       onTabDragStart={startTabDrag}
       onReorder={onReorderTab}
-    >
-      <ContextMenu
-        isOpen={contextMenuOpen && Boolean(contextTab)}
-        position={contextMenuPosition}
-        menuRef={contextMenuRef}
-        onClose={closeTabContextMenu}
-        onOpenInNewTab={openTabInExternalBrowser}
-        openInNewTabLabel='Open in External Browser'
-        openInNewTabPosition='last'
-        separateNavigationAction
-        showOpenInNewTab={Boolean(contextTab?.url && contextTab.url !== 'about:blank')}
-        groupNonDestructiveActions
-        onTogglePin={
-          contextTab ? () => onSetTabPinned(contextTab.tabId, !contextTab.pinned) : undefined
-        }
-        onDuplicate={contextTab ? () => onDuplicateTab(contextTab.tabId) : undefined}
-        // Pinned tabs are durable and deliberately have no close action.
-        {...(contextTab && !contextTab.pinned
-          ? { onCloseTab: () => onCloseTab(contextTab.tabId), showCloseTab: true }
-          : {})}
-        onDelete={() => {}}
-        showPin={Boolean(contextTab)}
-        isPinned={Boolean(contextTab?.pinned)}
-        showRename={false}
-        showDuplicate={Boolean(contextTab)}
-        showDelete={false}
-      />
-    </TabStrip>
+      overlays={
+        <ContextMenu
+          isOpen={contextMenuOpen && Boolean(contextTab)}
+          position={contextMenuPosition}
+          menuRef={contextMenuRef}
+          onClose={closeTabContextMenu}
+          onOpenInNewTab={openTabInExternalBrowser}
+          openInNewTabLabel='Open in External Browser'
+          openInNewTabPosition='last'
+          separateNavigationAction
+          showOpenInNewTab={Boolean(contextTab?.url && contextTab.url !== 'about:blank')}
+          groupNonDestructiveActions
+          onTogglePin={
+            contextTab ? () => onSetTabPinned(contextTab.tabId, !contextTab.pinned) : undefined
+          }
+          onDuplicate={contextTab ? () => onDuplicateTab(contextTab.tabId) : undefined}
+          // Pinned tabs are durable and deliberately have no close action.
+          {...(contextTab && !contextTab.pinned
+            ? { onCloseTab: () => onCloseTab(contextTab.tabId), showCloseTab: true }
+            : {})}
+          onDelete={() => {}}
+          showPin={Boolean(contextTab)}
+          isPinned={Boolean(contextTab?.pinned)}
+          showRename={false}
+          showDuplicate={Boolean(contextTab)}
+          showDelete={false}
+        />
+      }
+    />
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session.tsx
@@ -1090,26 +1090,27 @@ export function TerminalSession({ visible, scopeId }: TerminalSessionProps) {
         {...(canReorderTabs ? { onReorder: handleReorder } : {})}
         newTabLabel='New terminal'
         onClose={handleClose}
-      >
-        <ContextMenu
-          isOpen={isContextMenuOpen && Boolean(contextTab)}
-          position={contextMenuPosition}
-          menuRef={contextMenuRef}
-          onClose={closeContextMenu}
-          onDuplicate={contextTab ? () => handleDuplicate(contextTab.cwd) : undefined}
-          onCloseOtherTabs={contextTab ? closeOtherTabs : undefined}
-          onCloseTabsToRight={contextTab ? closeTabsToRight : undefined}
-          disableCloseOtherTabs={tabs.length <= 1}
-          disableCloseTabsToRight={contextIndex < 0 || contextIndex === tabs.length - 1}
-          {...(contextTab
-            ? { onCloseTab: () => handleClose(contextTab.terminalId), showCloseTab: true }
-            : {})}
-          onDelete={() => {}}
-          showRename={false}
-          showDuplicate={Boolean(contextTab)}
-          showDelete={false}
-        />
-      </TabStrip>
+        overlays={
+          <ContextMenu
+            isOpen={isContextMenuOpen && Boolean(contextTab)}
+            position={contextMenuPosition}
+            menuRef={contextMenuRef}
+            onClose={closeContextMenu}
+            onDuplicate={contextTab ? () => handleDuplicate(contextTab.cwd) : undefined}
+            onCloseOtherTabs={contextTab ? closeOtherTabs : undefined}
+            onCloseTabsToRight={contextTab ? closeTabsToRight : undefined}
+            disableCloseOtherTabs={tabs.length <= 1}
+            disableCloseTabsToRight={contextIndex < 0 || contextIndex === tabs.length - 1}
+            {...(contextTab
+              ? { onCloseTab: () => handleClose(contextTab.terminalId), showCloseTab: true }
+              : {})}
+            onDelete={() => {}}
+            showRename={false}
+            showDuplicate={Boolean(contextTab)}
+            showDelete={false}
+          />
+        }
+      />
 
       <div className='relative min-h-0 flex-1'>
         {tabs.map((tab) => (

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tab-controls.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tab-controls.ts
@@ -1,17 +1,31 @@
-export const RESOURCE_TAB_GAP_CLASS = 'gap-1.5'
-
-export const RESOURCE_TAB_ICON_BUTTON_CLASS = 'shrink-0 bg-transparent px-2 py-[5px] text-caption'
+/**
+ * Icon-only controls in the resource header — add, preview mode, the per-resource
+ * actions — fill the tab strip's control band, so they match the strip's own
+ * new-tab button and the panel's collapse toggle and the header reads as one row.
+ */
+export const RESOURCE_TAB_ICON_BUTTON_CLASS = 'size-[var(--tab-strip-band,30px)] shrink-0 p-0'
 
 export const RESOURCE_TAB_ICON_CLASS = 'size-[16px] text-[var(--text-icon)]'
 
 /** Shared geometry for the resource header and controls positioned over it. */
 export const RESOURCE_HEADER_CLASSES = {
   layout:
-    '[--resource-header-controls-height:43px] [--resource-header-end-inset:16px] [--resource-header-fixed-reserve:54px] [--resource-header-toggle-size:30px]',
-  bar: 'h-[calc(var(--resource-header-controls-height)_+_1px)]',
-  overlay: 'absolute top-0 flex h-[var(--resource-header-controls-height)] items-center',
-  startPadding: 'pl-[var(--resource-header-end-inset)]',
-  endPadding: 'pr-[var(--resource-header-fixed-reserve)]',
+    '[--resource-header-controls-height:34px] [--resource-header-end-inset:16px] [--resource-header-fixed-reserve:54px] [--resource-header-toggle-size:30px]',
+  /**
+   * Drives the tab strip from this header's own tokens rather than restating the
+   * strip's defaults, so the height the overlaid controls below are positioned
+   * against and the height the strip renders at cannot drift apart. Set on the
+   * strip itself, not an ancestor — the browser and terminal strips nested in
+   * this panel keep their own geometry.
+   */
+  stripGeometry:
+    '[--tab-strip-height:var(--resource-header-controls-height)] [--tab-strip-inline-start:var(--resource-header-end-inset)] [--tab-strip-inline-end:var(--resource-header-fixed-reserve)]',
+  /**
+   * Bottom-aligned rather than centred: the header's own controls sit in the tab
+   * strip's band, one pixel clear of its border, and an overlaid control has to
+   * land in that same band to read as part of the row.
+   */
+  overlay: 'absolute top-0 flex h-[var(--resource-header-controls-height)] items-end pb-px',
   endPosition: 'right-[var(--resource-header-end-inset)]',
   /**
    * Sits a control 1px clear of the overlaid 30px collapse toggle — the same

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tabs.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tabs.tsx
@@ -1,16 +1,24 @@
 import {
   type ComponentProps,
-  type Dispatch,
-  memo,
+  type DragEvent as ReactDragEvent,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
-  type SetStateAction,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react'
-import { Button, cn, Tooltip, tabStripWheelPosition } from '@sim/emcn'
+import {
+  Button,
+  cn,
+  TabStrip,
+  type TabStripDragContext,
+  type TabStripItem,
+  type TabStripSelectionSource,
+  Tooltip,
+  tabStripItemSelector,
+} from '@sim/emcn'
 import { Columns3, Eye, Pencil } from '@sim/emcn/icons'
 import { sendBrowserPanelAction } from '@/lib/browser-agent/transport'
 import { SIM_RESOURCE_DRAG_TYPE, SIM_RESOURCES_DRAG_TYPE } from '@/lib/copilot/resource-types'
@@ -22,7 +30,6 @@ import { AddResourceDropdown } from '@/app/workspace/[workspaceId]/home/componen
 import { getResourceConfig } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry'
 import {
   RESOURCE_HEADER_CLASSES,
-  RESOURCE_TAB_GAP_CLASS,
   RESOURCE_TAB_ICON_BUTTON_CLASS,
   RESOURCE_TAB_ICON_CLASS,
 } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tab-controls'
@@ -40,9 +47,6 @@ import {
 import { useTablesList } from '@/hooks/queries/tables'
 import { useWorkflows } from '@/hooks/queries/workflows'
 import { useWorkspaceFiles } from '@/hooks/queries/workspace-files'
-
-const EDGE_ZONE = 40
-const SCROLL_SPEED = 8
 
 /** Opens another inner tab when a singleton desktop resource already exists. */
 export function openExistingResourceTab(
@@ -96,10 +100,10 @@ function findNearestId(
  * snapshotted it.
  */
 function buildMultiDragImage(
-  scrollNode: HTMLElement | null,
+  tabList: Element | null,
   selected: MothershipResource[]
 ): HTMLElement | null {
-  if (!scrollNode || selected.length === 0) return null
+  if (!tabList || selected.length === 0) return null
   const container = document.createElement('div')
   Object.assign(container.style, {
     position: 'fixed',
@@ -113,9 +117,7 @@ function buildMultiDragImage(
   } satisfies Partial<CSSStyleDeclaration>)
   let appendedAny = false
   for (const r of selected) {
-    const original = scrollNode.querySelector<HTMLElement>(
-      `[data-resource-tab-id="${CSS.escape(r.id)}"]`
-    )
+    const original = tabList.querySelector<HTMLElement>(tabStripItemSelector(r.id))
     if (!original) continue
     const clone = original.cloneNode(true) as HTMLElement
     clone.style.opacity = '0.95'
@@ -140,10 +142,9 @@ const PREVIEW_MODE_LABELS: Record<PreviewMode, string> = {
 }
 
 /**
- * Stable identity for the empty lookup across `enabled` toggles. Unlike
- * `NO_RESOURCE_GROUPS`, nothing downstream keys on this identity — tab rows
- * receive the derived `displayName` string — so it is cheap insurance rather
- * than a guard against busting a downstream memo.
+ * Stable identity for the empty lookup across `enabled` toggles. The tab list
+ * memo below takes this map as a dependency, so a fresh empty map each time
+ * `enabled` flips would rebuild every tab for no change in what they say.
  */
 const NO_RESOURCE_NAMES = new Map<string, string>()
 
@@ -172,118 +173,6 @@ function useResourceNameLookup(workspaceId: string, enabled: boolean): Map<strin
   }, [enabled, workflows, tables, files, knowledgeBases, folders])
 }
 
-interface ResourceTabItemProps {
-  resource: MothershipResource
-  idx: number
-  isActive: boolean
-  isHovered: boolean
-  isDragging: boolean
-  isSelected: boolean
-  hasActivity: boolean
-  showGapBefore: boolean
-  showGapAfter: boolean
-  displayName: string
-  onDragStart: (e: React.DragEvent, idx: number) => void
-  onDragOver: (e: React.DragEvent, idx: number) => void
-  onDragLeave: () => void
-  onDragEnd: () => void
-  onTabClick: (e: React.MouseEvent, idx: number) => void
-  setHoveredTabId: Dispatch<SetStateAction<string | null>>
-  onRemove: (e: React.SyntheticEvent, resource: MothershipResource) => void
-}
-
-const ResourceTabItem = memo(function ResourceTabItem({
-  resource,
-  idx,
-  isActive,
-  isHovered,
-  isDragging,
-  isSelected,
-  hasActivity,
-  showGapBefore,
-  showGapAfter,
-  displayName,
-  onDragStart,
-  onDragOver,
-  onDragLeave,
-  onDragEnd,
-  onTabClick,
-  setHoveredTabId,
-  onRemove,
-}: ResourceTabItemProps) {
-  const config = getResourceConfig(resource.type)
-  return (
-    <div className='relative flex shrink-0 items-center'>
-      {showGapBefore && (
-        <div className='-translate-x-1/2 -translate-y-1/2 pointer-events-none absolute top-1/2 left-0 z-10 h-[16px] w-[2px] rounded-full bg-[var(--text-subtle)]' />
-      )}
-      <Button
-        variant='subtle'
-        draggable
-        data-resource-tab-id={resource.id}
-        onDragStart={(e) => onDragStart(e, idx)}
-        onDragOver={(e) => onDragOver(e, idx)}
-        onDragLeave={onDragLeave}
-        onDragEnd={onDragEnd}
-        onMouseDown={(e) => {
-          if (e.button === 1) {
-            e.preventDefault()
-            onRemove(e, resource)
-          }
-        }}
-        onClick={(e) => onTabClick(e, idx)}
-        onMouseEnter={() => setHoveredTabId(resource.id)}
-        onMouseLeave={() => setHoveredTabId(null)}
-        className={cn(
-          'group relative shrink-0 bg-transparent px-2 py-[3px] pr-[22px] text-caption transition-colors duration-150',
-          isActive && 'bg-[var(--surface-4)]',
-          isSelected && !isActive && 'bg-[var(--surface-3)]',
-          isDragging && 'opacity-30'
-        )}
-      >
-        {config.renderTabIcon(resource, 'mr-1.5 size-[14px]')}
-        {displayName}
-        {hasActivity && !isActive && !isHovered && (
-          <span
-            className='-translate-y-1/2 absolute top-1/2 right-[9px] size-1.5 rounded-full bg-[var(--brand-primary)]'
-            aria-label='Background activity'
-          />
-        )}
-        {/* Closable without a chat, matching the add control: a resource opened
-            while composing the first prompt has to be removable too, and
-            removal already skips the server delete when nothing is persisted. */}
-        {(isHovered || isActive) && (
-          <span
-            role='button'
-            tabIndex={-1}
-            onClick={(e) => onRemove(e, resource)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') onRemove(e, resource)
-            }}
-            className='-translate-y-1/2 absolute top-1/2 right-[4px] flex items-center justify-center rounded-sm p-[1px] hover-hover:bg-[var(--surface-5)]'
-            aria-label={`Close ${displayName}`}
-          >
-            <svg
-              className='size-[10px] text-[var(--text-icon)]'
-              viewBox='0 0 24 24'
-              fill='none'
-              stroke='currentColor'
-              strokeWidth='2.5'
-              strokeLinecap='round'
-              strokeLinejoin='round'
-            >
-              <path d='M18 6 6 18M6 6l12 12' />
-            </svg>
-          </span>
-        )}
-      </Button>
-      {showGapAfter && (
-        <div className='-translate-y-1/2 pointer-events-none absolute top-1/2 right-0 z-10 h-[16px] w-[2px] translate-x-1/2 rounded-full bg-[var(--text-subtle)]' />
-      )}
-    </div>
-  )
-})
-
 interface ResourceTabsProps {
   workspaceId: string
   desktopScopeId: string
@@ -298,6 +187,15 @@ interface ResourceTabsProps {
   onAddResourceClose?: () => Promise<void>
 }
 
+/**
+ * The resource panel's tab strip: the shared {@link TabStrip} plus the three
+ * things only this surface has — a multi-tab selection that drags into the chat
+ * as context, an add control that is a resource picker rather than a plain
+ * button, and the active resource's own actions trailing the row. Everything
+ * else — fixed tab widths, clipped-title tooltips, the scroll-edge fades,
+ * keyboard navigation, drag reordering — comes from the strip, which is the same
+ * component the browser and terminal panels nested inside this one use.
+ */
 export function ResourceTabs({
   workspaceId,
   desktopScopeId,
@@ -319,59 +217,26 @@ export function ResourceTabs({
     removeResource: onRemoveResource,
     reorderResources: onReorderResources,
   } = useMothershipResources()
-  const scrollNodeRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const node = scrollNodeRef.current
-    if (!node) return
-    const handler = (e: WheelEvent) => {
-      const next = tabStripWheelPosition(
-        node.scrollLeft,
-        node.scrollWidth,
-        node.clientWidth,
-        e.deltaX,
-        e.deltaY
-      )
-      if (next === null) return
-      node.scrollLeft = next
-      e.preventDefault()
-    }
-    node.addEventListener('wheel', handler, { passive: false })
-    return () => node.removeEventListener('wheel', handler)
-  }, [])
-
-  useEffect(() => {
-    const node = scrollNodeRef.current
-    if (!node || !activeId) return
-    const tab = node.querySelector<HTMLElement>(`[data-resource-tab-id="${CSS.escape(activeId)}"]`)
-    if (!tab) return
-    // Use bounding rects because the tab's offsetParent is a `position: relative`
-    // wrapper, so `offsetLeft` is relative to that wrapper rather than `node`.
-    const tabRect = tab.getBoundingClientRect()
-    const nodeRect = node.getBoundingClientRect()
-    const tabLeft = tabRect.left - nodeRect.left + node.scrollLeft
-    const tabRight = tabLeft + tabRect.width
-    const viewLeft = node.scrollLeft
-    const viewRight = viewLeft + node.clientWidth
-    if (tabLeft < viewLeft) {
-      node.scrollTo({ left: tabLeft, behavior: 'smooth' })
-    } else if (tabRight > viewRight) {
-      node.scrollTo({ left: tabRight - node.clientWidth, behavior: 'smooth' })
-    }
-  }, [activeId])
 
   const addResource = useAddChatResource(chatId)
   const removeResource = useRemoveChatResource(chatId)
   const reorderResources = useReorderChatResources(chatId)
 
-  const [hoveredTabId, setHoveredTabId] = useState<string | null>(null)
-  const [draggedIdx, setDraggedIdx] = useState<number | null>(null)
-  const [dropGapIdx, setDropGapIdx] = useState<number | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const dragStartIdx = useRef<number | null>(null)
-  const autoScrollRaf = useRef<number | null>(null)
   const anchorIdRef = useRef<string | null>(null)
   const prevChatIdRef = useRef(chatId)
+  // The drag image lives on `document.body` rather than in the React tree,
+  // because `setDragImage` snapshots a real, laid-out element. Holding it lets
+  // a drag whose source tab unmounts mid-gesture still be cleaned up.
+  const dragImageRef = useRef<HTMLElement | null>(null)
+
+  useEffect(
+    () => () => {
+      dragImageRef.current?.remove()
+      dragImageRef.current = null
+    },
+    []
+  )
 
   // Reset selection when switching chats — component instance persists across
   // chat switches so stale IDs would otherwise carry over.
@@ -381,7 +246,23 @@ export function ResourceTabs({
     anchorIdRef.current = null
   }
 
-  const existingKeys = new Set(resources.map((r) => `${r.type}:${r.id}`))
+  const existingKeys = useMemo(
+    () => new Set(resources.map((r) => `${r.type}:${r.id}`)),
+    [resources]
+  )
+
+  const tabs = useMemo<TabStripItem[]>(
+    () =>
+      resources.map((resource) => ({
+        id: resource.id,
+        title: nameLookup.get(`${resource.type}:${resource.id}`) ?? resource.title,
+        icon: getResourceConfig(resource.type).renderTabIcon(resource, 'size-[14px] shrink-0'),
+        active: activeId === resource.id,
+        selected: selectedIds.size > 1 && selectedIds.has(resource.id),
+        attention: activityIds?.has(resource.id) ?? false,
+      })),
+    [resources, nameLookup, activeId, selectedIds, activityIds]
+  )
 
   const handleAdd = useCallback(
     (resource: MothershipResource) => {
@@ -405,13 +286,14 @@ export function ResourceTabs({
     [desktopScopeId, selectResource]
   )
 
-  const handleTabClick = useCallback(
-    (e: React.MouseEvent, idx: number) => {
+  const handleSelect = useCallback(
+    (id: string, _source?: TabStripSelectionSource, e?: ReactMouseEvent<HTMLButtonElement>) => {
+      const idx = resources.findIndex((r) => r.id === id)
       const resource = resources[idx]
       if (!resource) return
 
       // Shift+click: contiguous range from anchor
-      if (e.shiftKey) {
+      if (e?.shiftKey) {
         // Fall back to activeId when no explicit anchor exists (e.g. tab opened via sidebar)
         const anchorId = anchorIdRef.current ?? activeId
         const anchorIdx = anchorId ? resources.findIndex((r) => r.id === anchorId) : -1
@@ -427,7 +309,7 @@ export function ResourceTabs({
       }
 
       // Cmd/Ctrl+click: toggle individual tab in/out of selection
-      if (e.metaKey || e.ctrlKey) {
+      if (e?.metaKey || e?.ctrlKey) {
         const wasSelected = selectedIds.has(resource.id)
         if (wasSelected) {
           const next = new Set(selectedIds)
@@ -455,9 +337,10 @@ export function ResourceTabs({
     [resources, selectResource, selectedIds, activeId]
   )
 
-  const handleRemove = useCallback(
-    (e: React.SyntheticEvent, resource: MothershipResource) => {
-      e.stopPropagation()
+  const handleClose = useCallback(
+    (id: string) => {
+      const resource = resources.find((r) => r.id === id)
+      if (!resource) return
       const isMulti = selectedIds.has(resource.id) && selectedIds.size > 1
       const targets = isMulti ? resources.filter((r) => selectedIds.has(r.id)) : [resource]
       // Update parent state immediately for all targets
@@ -468,7 +351,7 @@ export function ResourceTabs({
       const removedIds = new Set(targets.map((r) => r.id))
       setSelectedIds((prev) => {
         const next = new Set(prev)
-        for (const id of removedIds) next.delete(id)
+        for (const removedId of removedIds) next.delete(removedId)
         return next
       })
       if (anchorIdRef.current && removedIds.has(anchorIdRef.current)) {
@@ -488,29 +371,34 @@ export function ResourceTabs({
     [chatId, onRemoveResource, resources, selectedIds]
   )
 
-  const handleDragStart = useCallback(
-    (e: React.DragEvent, idx: number) => {
-      const resource = resources[idx]
+  const handleTabDragStart = useCallback(
+    (e: ReactDragEvent<HTMLDivElement>, id: string, drag: TabStripDragContext) => {
+      const resource = resources.find((r) => r.id === id)
       if (!resource) return
       const selected = resources.filter((r) => selectedIds.has(r.id))
       const isMultiDrag = selected.length > 1 && selectedIds.has(resource.id)
       if (isMultiDrag) {
         e.dataTransfer.effectAllowed = 'copy'
         e.dataTransfer.setData(SIM_RESOURCES_DRAG_TYPE, JSON.stringify(selected))
-        const dragImage = buildMultiDragImage(scrollNodeRef.current, selected)
+        const dragImage = buildMultiDragImage(e.currentTarget.closest('[role="tablist"]'), selected)
         if (dragImage) {
           e.dataTransfer.setDragImage(dragImage, 16, 16)
-          setTimeout(() => dragImage.remove(), 0)
+          dragImageRef.current = dragImage
+          setTimeout(() => {
+            dragImage.remove()
+            if (dragImageRef.current === dragImage) dragImageRef.current = null
+          }, 0)
         }
-        // Skip dragStartIdx so internal reorder is disabled for multi-select drags
-        dragStartIdx.current = null
-        setDraggedIdx(null)
+        // This gesture carries the whole selection out to the chat, so it is not
+        // a reorder; the strip drops its drag tracking rather than showing a
+        // drop indicator for a move that will never happen.
+        drag.preventReorder()
         return
       }
-      dragStartIdx.current = idx
-      setDraggedIdx(idx)
+      // `copyMove` because the strip already set `move` for its own reordering,
+      // and a drop target asking for `copy` is refused outright unless copying
+      // is allowed too.
       e.dataTransfer.effectAllowed = 'copyMove'
-      e.dataTransfer.setData('text/plain', String(idx))
       e.dataTransfer.setData(
         SIM_RESOURCE_DRAG_TYPE,
         JSON.stringify({ type: resource.type, id: resource.id, title: resource.title })
@@ -519,78 +407,13 @@ export function ResourceTabs({
     [resources, selectedIds]
   )
 
-  const stopAutoScroll = useCallback(() => {
-    if (autoScrollRaf.current) {
-      cancelAnimationFrame(autoScrollRaf.current)
-      autoScrollRaf.current = null
-    }
-  }, [])
-
-  const startEdgeScroll = useCallback(
-    (clientX: number) => {
-      const container = scrollNodeRef.current
-      if (!container) return
-      const cRect = container.getBoundingClientRect()
-      if (autoScrollRaf.current) cancelAnimationFrame(autoScrollRaf.current)
-      if (clientX < cRect.left + EDGE_ZONE) {
-        const tick = () => {
-          container.scrollLeft -= SCROLL_SPEED
-          autoScrollRaf.current = requestAnimationFrame(tick)
-        }
-        autoScrollRaf.current = requestAnimationFrame(tick)
-      } else if (clientX > cRect.right - EDGE_ZONE) {
-        const tick = () => {
-          container.scrollLeft += SCROLL_SPEED
-          autoScrollRaf.current = requestAnimationFrame(tick)
-        }
-        autoScrollRaf.current = requestAnimationFrame(tick)
-      } else {
-        stopAutoScroll()
-      }
-    },
-    [stopAutoScroll]
-  )
-
-  const handleDragOver = useCallback(
-    (e: React.DragEvent, idx: number) => {
-      e.preventDefault()
-      e.dataTransfer.dropEffect = 'move'
-      const rect = e.currentTarget.getBoundingClientRect()
-      const midpoint = rect.left + rect.width / 2
-      const gap = e.clientX < midpoint ? idx : idx + 1
-      setDropGapIdx(gap)
-      startEdgeScroll(e.clientX)
-    },
-    [startEdgeScroll]
-  )
-
-  const handleDragLeave = useCallback(() => {
-    setDropGapIdx(null)
-    stopAutoScroll()
-  }, [stopAutoScroll])
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault()
-      stopAutoScroll()
-      const fromIdx = dragStartIdx.current
-      const gapIdx = dropGapIdx
-      if (fromIdx === null || gapIdx === null) {
-        setDraggedIdx(null)
-        setDropGapIdx(null)
-        dragStartIdx.current = null
-        return
-      }
-      const insertAt = gapIdx > fromIdx ? gapIdx - 1 : gapIdx
-      if (insertAt === fromIdx) {
-        setDraggedIdx(null)
-        setDropGapIdx(null)
-        dragStartIdx.current = null
-        return
-      }
+  const handleReorder = useCallback(
+    (id: string, targetIndex: number) => {
+      const fromIndex = resources.findIndex((r) => r.id === id)
+      if (fromIndex < 0 || fromIndex === targetIndex) return
       const reordered = [...resources]
-      const [moved] = reordered.splice(fromIdx, 1)
-      reordered.splice(insertAt, 0, moved)
+      const [moved] = reordered.splice(fromIndex, 1)
+      reordered.splice(targetIndex, 0, moved)
       onReorderResources(reordered)
       if (chatId) {
         const persistable = reordered.filter((r) => !isEphemeralResource(r))
@@ -598,128 +421,64 @@ export function ResourceTabs({
           reorderResources.mutate({ chatId, resources: persistable })
         }
       }
-      setDraggedIdx(null)
-      setDropGapIdx(null)
-      dragStartIdx.current = null
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [chatId, resources, onReorderResources, dropGapIdx, stopAutoScroll]
+    [chatId, resources, onReorderResources]
   )
 
-  const handleDragEnd = useCallback(() => {
-    stopAutoScroll()
-    setDraggedIdx(null)
-    setDropGapIdx(null)
-    dragStartIdx.current = null
-  }, [stopAutoScroll])
-
-  const addResourceDropdown = (
-    <AddResourceDropdown
-      workspaceId={workspaceId}
-      existingKeys={existingKeys}
-      onAdd={handleAdd}
-      onOpenExisting={handleOpenExisting}
-      excludeTypes={ADD_RESOURCE_EXCLUDED_TYPES}
-      onRequestOpen={onRequestAddResourceOpen}
-      onClose={onAddResourceClose}
-    />
-  )
+  const previewToggle =
+    previewMode && onCyclePreviewMode ? (
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <Button
+            variant='subtle'
+            onClick={onCyclePreviewMode}
+            className={RESOURCE_TAB_ICON_BUTTON_CLASS}
+            aria-label='Cycle preview mode'
+          >
+            <PreviewModeIcon mode={previewMode} className={RESOURCE_TAB_ICON_CLASS} />
+          </Button>
+        </Tooltip.Trigger>
+        <Tooltip.Content side='bottom'>
+          <p>{PREVIEW_MODE_LABELS[previewMode]}</p>
+        </Tooltip.Content>
+      </Tooltip.Root>
+    ) : null
 
   return (
-    <div
-      className={cn(
-        'flex shrink-0 items-center border-[var(--border)] border-b',
-        RESOURCE_HEADER_CLASSES.bar,
-        RESOURCE_HEADER_CLASSES.startPadding,
-        RESOURCE_HEADER_CLASSES.endPadding,
-        RESOURCE_TAB_GAP_CLASS
-      )}
-    >
-      <div className={cn('flex min-w-0 flex-1 items-center', RESOURCE_TAB_GAP_CLASS)}>
-        <div
-          ref={scrollNodeRef}
-          className={cn(
-            'flex min-w-0 items-center overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-            RESOURCE_TAB_GAP_CLASS
-          )}
-          onDragOver={(e) => {
-            e.preventDefault()
-            startEdgeScroll(e.clientX)
-          }}
-          onDrop={handleDrop}
-        >
-          {resources.map((resource, idx) => {
-            const displayName = nameLookup.get(`${resource.type}:${resource.id}`) ?? resource.title
-            const isActive = activeId === resource.id
-            const isHovered = hoveredTabId === resource.id
-            const isDragging = draggedIdx === idx
-            const isSelected = selectedIds.has(resource.id) && selectedIds.size > 1
-            const showGapBefore =
-              dropGapIdx === idx &&
-              draggedIdx !== null &&
-              draggedIdx !== idx &&
-              draggedIdx !== idx - 1
-            const showGapAfter =
-              idx === resources.length - 1 &&
-              dropGapIdx === resources.length &&
-              draggedIdx !== null &&
-              draggedIdx !== idx
-
-            return (
-              <ResourceTabItem
-                key={resource.id}
-                resource={resource}
-                idx={idx}
-                isActive={isActive}
-                isHovered={isHovered}
-                isDragging={isDragging}
-                isSelected={isSelected}
-                hasActivity={activityIds?.has(resource.id) ?? false}
-                showGapBefore={showGapBefore}
-                showGapAfter={showGapAfter}
-                displayName={displayName}
-                onDragStart={handleDragStart}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-                onDragEnd={handleDragEnd}
-                onTabClick={handleTabClick}
-                setHoveredTabId={setHoveredTabId}
-                onRemove={handleRemove}
-              />
-            )
-          })}
+    <TabStrip
+      tabs={tabs}
+      onSelect={handleSelect}
+      onClose={handleClose}
+      onReorder={handleReorder}
+      onTabDragStart={handleTabDragStart}
+      className={RESOURCE_HEADER_CLASSES.stripGeometry}
+      newTabControl={
+        // Offered before the chat exists too: a resource opened while composing
+        // the first prompt is context for that prompt, and gating on a chat id
+        // meant the panel could be opened but not filled.
+        <div className={cn(resources.length === 0 && RESOURCE_HEADER_CLASSES.emptyAddOffset)}>
+          <AddResourceDropdown
+            workspaceId={workspaceId}
+            existingKeys={existingKeys}
+            onAdd={handleAdd}
+            onOpenExisting={handleOpenExisting}
+            excludeTypes={ADD_RESOURCE_EXCLUDED_TYPES}
+            onRequestOpen={onRequestAddResourceOpen}
+            onClose={onAddResourceClose}
+          />
         </div>
-        {/* Offered before the chat exists too: a resource opened while composing
-            the first prompt is context for that prompt, and gating on a chat id
-            meant the panel could be opened but not filled. */}
-        <div
-          className={cn('flex', resources.length === 0 && RESOURCE_HEADER_CLASSES.emptyAddOffset)}
-        >
-          {addResourceDropdown}
-        </div>
-      </div>
-      {(actions || (previewMode && onCyclePreviewMode)) && (
-        <div className={cn('ml-auto flex shrink-0 items-center', RESOURCE_TAB_GAP_CLASS)}>
-          {actions}
-          {previewMode && onCyclePreviewMode && (
-            <Tooltip.Root>
-              <Tooltip.Trigger asChild>
-                <Button
-                  variant='subtle'
-                  onClick={onCyclePreviewMode}
-                  className={RESOURCE_TAB_ICON_BUTTON_CLASS}
-                  aria-label='Cycle preview mode'
-                >
-                  <PreviewModeIcon mode={previewMode} className={RESOURCE_TAB_ICON_CLASS} />
-                </Button>
-              </Tooltip.Trigger>
-              <Tooltip.Content side='bottom'>
-                <p>{PREVIEW_MODE_LABELS[previewMode]}</p>
-              </Tooltip.Content>
-            </Tooltip.Root>
-          )}
-        </div>
-      )}
-    </div>
+      }
+      // A bare fragment is always truthy, so the empty case has to be `null` or
+      // the strip renders an empty trailing cluster.
+      endActions={
+        actions || previewToggle ? (
+          <>
+            {actions}
+            {previewToggle}
+          </>
+        ) : null
+      }
+    />
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -725,7 +725,7 @@ export function Home({ chatId, userName, userId, tableViewsEnabled }: HomeProps)
           size={null}
           type='button'
           onClick={isResourceCollapsed ? expandResource : collapseResource}
-          className='size-[var(--resource-header-toggle-size)] rounded-[8px] hover-hover:bg-[var(--surface-active)]'
+          className='size-[var(--resource-header-toggle-size)] hover-hover:bg-[var(--surface-active)]'
           aria-label={isResourceCollapsed ? 'Expand resource view' : 'Collapse resource view'}
         >
           <span className='relative'>

--- a/packages/emcn/src/components/index.ts
+++ b/packages/emcn/src/components/index.ts
@@ -183,10 +183,12 @@ export { Switch } from './switch/switch'
 export {
   isTabTitleTruncated,
   TabStrip,
+  type TabStripDragContext,
   type TabStripItem,
   type TabStripProps,
   type TabStripSelectionSource,
   tabDropIndex,
+  tabStripItemSelector,
   tabStripWheelPosition,
 } from './tab-strip/tab-strip'
 export {

--- a/packages/emcn/src/components/tab-strip/tab-strip.dom.test.tsx
+++ b/packages/emcn/src/components/tab-strip/tab-strip.dom.test.tsx
@@ -40,6 +40,21 @@ function tabButton(id: string): HTMLButtonElement {
   return button
 }
 
+function stripItem(id: string): HTMLElement {
+  const item = container?.querySelector<HTMLElement>(`[data-tab-strip-item="${id}"]`)
+  if (!item) throw new Error(`Missing tab item ${id}`)
+  return item
+}
+
+/** jsdom fires no real DragEvent, and the strip writes to `dataTransfer`. */
+function dragStartEvent(): MouseEvent {
+  const event = new MouseEvent('dragstart', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', {
+    value: { effectAllowed: '', dropEffect: '', setData: vi.fn(), setDragImage: vi.fn() },
+  })
+  return event
+}
+
 function scrollRow(): HTMLDivElement {
   const row = container?.querySelector<HTMLDivElement>('.overflow-x-auto')
   if (!row) throw new Error('Missing scrolling tab row')
@@ -93,7 +108,74 @@ describe('TabStrip interactions', () => {
 
     act(() => tabButton('two').click())
 
-    expect(onSelect).toHaveBeenCalledWith('two', 'pointer')
+    expect(onSelect.mock.calls[0]?.slice(0, 2)).toEqual(['two', 'pointer'])
+  })
+
+  it('forwards the originating click so callers can read its modifiers', () => {
+    const onSelect = vi.fn()
+    mount(renderStrip(tabs, onSelect))
+
+    act(() => {
+      tabButton('two').dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true, shiftKey: true })
+      )
+    })
+
+    expect(onSelect.mock.calls[0]?.[2]?.shiftKey).toBe(true)
+  })
+
+  it('marks a tab in a multi-selection without making it the active tab', () => {
+    mount(renderStrip(tabs.map((tab) => ({ ...tab, selected: tab.id === 'two' }))))
+
+    expect(tabButton('two').className).toContain('bg-[var(--surface-active)]')
+    expect(tabButton('two').getAttribute('aria-selected')).toBe('false')
+    // The active tab owns the surface below it, so it never takes the
+    // secondary highlight even when it is part of the selection.
+    expect(tabButton('one').className).not.toContain('bg-[var(--surface-active)]')
+  })
+
+  // Supplying both `newTabControl` and `onNew` is a type error, so the built-in
+  // button can never be silently shadowed by a caller's own control.
+  it('fills the new-tab slot with a supplied control, and the end slot with actions', () => {
+    mount(
+      <TabStrip
+        tabs={tabs}
+        onSelect={vi.fn()}
+        newTabControl={<button type='button'>Add resource</button>}
+        endActions={<button type='button'>Download</button>}
+      />
+    )
+
+    expect(container?.querySelector('[aria-label="New tab"]')).toBeNull()
+    expect(container?.textContent).toContain('Add resource')
+    expect(container?.textContent).toContain('Download')
+  })
+
+  it('tracks a plain tab drag as a reorder', () => {
+    mount(<TabStrip tabs={tabs} onSelect={vi.fn()} onReorder={vi.fn()} />)
+
+    const item = stripItem('two')
+    act(() => item.dispatchEvent(dragStartEvent()))
+
+    expect(item.className).toContain('opacity-30')
+  })
+
+  it('lets the drag owner declare a gesture is not a reorder', () => {
+    mount(
+      <TabStrip
+        tabs={tabs}
+        onSelect={vi.fn()}
+        onReorder={vi.fn()}
+        onTabDragStart={(_event, _id, drag) => drag.preventReorder()}
+      />
+    )
+
+    const item = stripItem('two')
+    act(() => item.dispatchEvent(dragStartEvent()))
+
+    // Nothing is being tracked, so the tab never dims and no drop indicator
+    // offers a move the strip has been told will not happen.
+    expect(item.className).not.toContain('opacity-30')
   })
 
   it('closes an unpinned tab with the middle mouse button', () => {

--- a/packages/emcn/src/components/tab-strip/tab-strip.tsx
+++ b/packages/emcn/src/components/tab-strip/tab-strip.tsx
@@ -40,6 +40,13 @@ export interface TabStripItem {
    */
   pinned?: boolean
   /**
+   * Belongs to a multi-tab selection without being the tab on screen. Renders
+   * as a secondary highlight on `--surface-active` — the token the app already
+   * uses for a selected row — so it never competes with the active tab, which
+   * stays the only one merged into the surface below.
+   */
+  selected?: boolean
+  /**
    * Fuller detail for the hover tooltip — a path the label abbreviates, the
    * command a tab is running. Shown whenever present, not only when the label
    * is clipped: it says something the tab cannot, so there is always a reason
@@ -51,16 +58,62 @@ export interface TabStripItem {
   attention?: boolean
 }
 
+/** Handed to {@link TabStripBaseProps.onTabDragStart} to shape the gesture it starts. */
+export interface TabStripDragContext {
+  /**
+   * Declares that this gesture is not a reorder — a drag carrying a whole
+   * multi-tab selection out of the strip, say. The strip drops its own drag
+   * tracking, so no drop indicator, no edge auto-scroll and no `onReorder`
+   * follow.
+   */
+  preventReorder: () => void
+}
+
 /** How a tab selection was initiated. */
 export type TabStripSelectionSource = 'pointer' | 'keyboard'
 
-export interface TabStripProps {
+/**
+ * The new-tab slot holds either the built-in button or a caller's own control,
+ * never both — a supplied control owns its own label and limit, so `onNew`,
+ * `newTabLabel` and `maxTabs` are not merely ignored alongside it, they are
+ * rejected.
+ */
+type TabStripNewTabProps =
+  | {
+      /** Omit to hide the new-tab button. */
+      onNew?: () => void
+      newTabLabel?: string
+      /** Disables the new-tab button, with a tooltip explaining why. */
+      maxTabs?: number
+      newTabControl?: never
+    }
+  | {
+      /**
+       * Replaces the built-in new-tab button for a strip whose "new" action opens
+       * a menu rather than acting on click. It takes the same slot, so it keeps
+       * its place beside the last tab and inside the wheel-scroll region.
+       */
+      newTabControl: ReactNode
+      onNew?: never
+      newTabLabel?: never
+      maxTabs?: never
+    }
+
+export type TabStripProps = TabStripBaseProps & TabStripNewTabProps
+
+interface TabStripBaseProps {
   tabs: TabStripItem[]
-  onSelect: (id: string, source?: TabStripSelectionSource) => void
+  /**
+   * The originating click is forwarded so a caller can layer modifier
+   * behaviour — shift for a range, cmd/ctrl to toggle — over plain selection.
+   */
+  onSelect: (
+    id: string,
+    source?: TabStripSelectionSource,
+    event?: ReactMouseEvent<HTMLButtonElement>
+  ) => void
   /** Omit to make tabs uncloseable. Never offered for a pinned tab. */
   onClose?: (id: string) => void
-  /** Omit to hide the new-tab button. */
-  onNew?: () => void
   /** Enables drag reordering. Receives the tab's final index. */
   onReorder?: (id: string, targetIndex: number) => void
   onTabContextMenu?: (event: ReactMouseEvent<HTMLDivElement>, id: string) => void
@@ -68,13 +121,34 @@ export interface TabStripProps {
    * Called as a tab starts being dragged, to add whatever that tab means
    * outside the strip to the drag. Supplying it also makes tabs draggable in a
    * strip that cannot be reordered.
+   *
+   * The `drag` handle lets it declare that the gesture is not a reorder at all;
+   * see {@link TabStripDragContext.preventReorder}.
    */
-  onTabDragStart?: (event: ReactDragEvent<HTMLDivElement>, id: string) => void
-  /** Disables the new-tab button, with a tooltip explaining why. */
-  maxTabs?: number
-  newTabLabel?: string
-  /** Rendered after the new-tab button, for menus and overlays. */
-  children?: ReactNode
+  onTabDragStart?: (
+    event: ReactDragEvent<HTMLDivElement>,
+    id: string,
+    drag: TabStripDragContext
+  ) => void
+  /** In-flow controls pinned to the far end, past the tabs and the new-tab slot. */
+  endActions?: ReactNode
+  /**
+   * Out-of-flow content that has to live inside the strip — a context menu
+   * anchored to a tab, say. Rendered last and contributing no layout, which is
+   * what separates it from {@link TabStripBaseProps.endActions}.
+   */
+  overlays?: ReactNode
+  /**
+   * Merged onto the strip root. Intended for the geometry custom properties
+   * below rather than for competing utility classes, so a caller that owns the
+   * surrounding header can size the strip without fighting its base classes:
+   *
+   * - `--tab-strip-height` (default `34px`) — the strip's own height.
+   * - `--tab-strip-band` (default `30px`) — the height of the tabs and the
+   *   controls beside them, which is the band an overlaid control must match.
+   * - `--tab-strip-inline-start` / `--tab-strip-inline-end` (default `8px`).
+   */
+  className?: string
 }
 
 /**
@@ -87,6 +161,15 @@ export function isTabTitleTruncated(
 ): boolean {
   const hiddenWidth = element.scrollWidth - element.clientWidth
   return hiddenWidth >= TITLE_TOOLTIP_HIDDEN_PX
+}
+
+/**
+ * Selector matching a tab's outer element. Part of the strip's API: a caller
+ * building its own drag image needs the real, laid-out nodes to snapshot, and
+ * this keeps it from hardcoding the attribute.
+ */
+export function tabStripItemSelector(id: string): string {
+  return `[data-tab-strip-item="${CSS.escape(id)}"]`
 }
 
 /** Final horizontal position for a wheel gesture, or null when it cannot move the strip. */
@@ -131,7 +214,11 @@ export function tabDropIndex(
 
 interface TabProps {
   tab: TabStripItem
-  onSelect: (id: string, source?: TabStripSelectionSource) => void
+  onSelect: (
+    id: string,
+    source?: TabStripSelectionSource,
+    event?: ReactMouseEvent<HTMLButtonElement>
+  ) => void
   onClose?: (id: string) => void
   onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>, id: string) => void
   onKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>, id: string) => void
@@ -226,13 +313,14 @@ const Tab = forwardRef<HTMLDivElement, TabProps>(function Tab(
             data-tab-strip-button={tab.id}
             tabIndex={focusable ? 0 : -1}
             className={cn(
-              'h-[30px] w-full select-none rounded-b-none border border-transparent border-b-0 bg-transparent py-0 text-caption',
+              'h-[var(--tab-strip-band,30px)] w-full select-none rounded-b-none border border-transparent border-b-0 bg-transparent py-0 text-caption',
               tab.pinned ? 'justify-center px-0' : 'justify-start gap-1.5 px-2',
               closeable && !tab.pinned && 'pr-8',
+              tab.selected && !tab.active && 'bg-[var(--surface-active)]',
               tab.active &&
                 'hover-hover:!border-[var(--border)] hover-hover:!bg-[var(--bg)] hover-hover:!text-[var(--text-primary)] hover-hover:!brightness-100 hover-hover:!opacity-100 relative z-10 border-[var(--border)] bg-[var(--bg)] text-[var(--text-primary)] transition-none'
             )}
-            onClick={() => onSelect(tab.id, 'pointer')}
+            onClick={(event) => onSelect(tab.id, 'pointer', event)}
             onKeyDown={(event) => onKeyDown(event, tab.id)}
           >
             {tab.icon}
@@ -301,7 +389,10 @@ export function TabStrip({
   onTabDragStart,
   maxTabs,
   newTabLabel = 'New tab',
-  children,
+  newTabControl,
+  endActions,
+  overlays,
+  className,
 }: TabStripProps) {
   const atLimit = maxTabs !== undefined && tabs.length >= maxTabs
   const stripRef = useRef<HTMLDivElement>(null)
@@ -434,8 +525,18 @@ export function TabStrip({
       }
       // The strip knows about ordering and nothing else. Anything a tab means
       // outside it — the page it holds, the shell it runs — belongs to whoever
-      // owns the tabs, so they attach it.
-      onTabDragStart?.(event, id)
+      // owns the tabs, so they attach it, and they may decline the reorder the
+      // strip just started tracking.
+      let reorderPrevented = false
+      onTabDragStart?.(event, id, {
+        preventReorder: () => {
+          reorderPrevented = true
+        },
+      })
+      if (reorderPrevented) {
+        draggedIdRef.current = null
+        setDraggedId(null)
+      }
     },
     [reorderable, onTabDragStart]
   )
@@ -577,7 +678,13 @@ export function TabStrip({
   return (
     <div
       ref={stripRef}
-      className='flex h-[34px] shrink-0 select-none items-end gap-1 border-[var(--border)] border-b bg-transparent px-2 pt-1'
+      // Geometry reads from custom properties with defaults baked into the
+      // `var()` calls, so a caller resizes the strip by setting a property
+      // rather than by passing a utility class that has to out-merge this one.
+      className={cn(
+        'flex h-[var(--tab-strip-height,34px)] shrink-0 select-none items-end gap-1 border-[var(--border)] border-b bg-transparent pt-1 pr-[var(--tab-strip-inline-end,8px)] pl-[var(--tab-strip-inline-start,8px)]',
+        className
+      )}
       onDragOver={handleDragOver}
       onDragLeave={(event) => {
         if (
@@ -636,7 +743,13 @@ export function TabStrip({
           )}
         </div>
       </div>
-      {onNew && (
+      {/* Both slots sit in the tab row's band so whatever fills them lines up
+          with the tabs rather than with the taller strip box. */}
+      {newTabControl ? (
+        <div className='mb-px flex h-[var(--tab-strip-band,30px)] shrink-0 items-center'>
+          {newTabControl}
+        </div>
+      ) : onNew ? (
         <Tooltip.Root>
           <Tooltip.Trigger asChild>
             <Button
@@ -644,7 +757,7 @@ export function TabStrip({
               variant='ghost-secondary'
               size='sm'
               aria-label={newTabLabel}
-              className='mb-px size-[30px] shrink-0 p-0'
+              className='mb-px size-[var(--tab-strip-band,30px)] shrink-0 p-0'
               disabled={atLimit}
               onClick={onNew}
             >
@@ -655,8 +768,13 @@ export function TabStrip({
             {atLimit ? `Maximum of ${maxTabs} tabs` : newTabLabel}
           </Tooltip.Content>
         </Tooltip.Root>
+      ) : null}
+      {endActions && (
+        <div className='mb-px ml-auto flex h-[var(--tab-strip-band,30px)] shrink-0 items-center gap-1'>
+          {endActions}
+        </div>
       )}
-      {children}
+      {overlays}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Port the mothership resource tab bar onto the shared `TabStrip` primitive instead of its own hand-rolled implementation — fixed tab widths with truncation, scroll-edge fades, keyboard nav and tab semantics, tooltips on clipped titles
- Give `TabStrip` a caller-supplied new-tab slot, an end-actions slot, and geometry custom properties, so the resource header can drive it without fighting its base classes
- Let a drag opt out of reordering (`drag.preventReorder()`), so a multi-tab drag out to the chat no longer shows a drop indicator for a move that never happens
- Rename `TabStrip`'s `children` to `overlays` — both existing callers only used it for anchored context menus
- Align the resource header to the strip's 34px band and drop a one-off 8px radius on the collapse toggle

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
