### PR TITLE
fix(utils): prevent randomInt power-of-two hangs

### DIFF
--- a/packages/utils/src/random.test.ts
+++ b/packages/utils/src/random.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { randomInt } from './random.js'
+
+const UINT32_MAX = 0xffffffff
+const UINT32_SAMPLE_SPACE_SIZE = 0x100000000
+
+function mockRandomValues(...values: number[]) {
+  let index = 0
+  return vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation((array) => {
+    if (!(array instanceof Uint32Array)) throw new Error('Expected a Uint32Array')
+    const value = values[index]
+    if (value === undefined) throw new Error('Unexpected additional random draw')
+    array[0] = value
+    index += 1
+    return array
+  })
+}
+
+describe('randomInt', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('terminates after one draw for a power-of-two range', () => {
+    const getRandomValues = mockRandomValues(7)
+
+    expect(randomInt(0, 16)).toBe(7)
+    expect(getRandomValues).toHaveBeenCalledOnce()
+  })
+
+  it('redraws values from the biased upper tail', () => {
+    const getRandomValues = mockRandomValues(UINT32_MAX, 42)
+
+    expect(randomInt(0, 10)).toBe(2)
+    expect(getRandomValues).toHaveBeenCalledTimes(2)
+  })
+
+  it('supports a range spanning the full Uint32 sample space', () => {
+    const getRandomValues = mockRandomValues(UINT32_MAX)
+
+    expect(randomInt(0, UINT32_SAMPLE_SPACE_SIZE)).toBe(UINT32_MAX)
+    expect(getRandomValues).toHaveBeenCalledOnce()
+  })
+
+  it('rejects ranges larger than the Uint32 sample space', () => {
+    expect(() => randomInt(0, UINT32_SAMPLE_SPACE_SIZE + 1)).toThrow(
+      'randomInt: range must not exceed 2^32'
+    )
+  })
+})

--- a/packages/utils/src/random.ts
+++ b/packages/utils/src/random.ts
@@ -8,6 +8,8 @@ export const LOWERCASE_ALPHANUMERIC_ALPHABET = 'abcdefghijklmnopqrstuvwxyz012345
 
 const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
+const UINT32_SAMPLE_SPACE_SIZE = 0x100000000
+
 /**
  * Generates cryptographically secure random bytes.
  * @param length - Number of bytes to generate
@@ -60,7 +62,10 @@ export function randomFloat(): number {
 export function randomInt(min: number, max: number): number {
   const range = max - min
   if (range <= 0) throw new RangeError(`randomInt: max (${max}) must be greater than min (${min})`)
-  const threshold = (0x100000000 - (0x100000000 % range)) >>> 0
+  if (range > UINT32_SAMPLE_SPACE_SIZE) {
+    throw new RangeError('randomInt: range must not exceed 2^32')
+  }
+  const threshold = UINT32_SAMPLE_SPACE_SIZE - (UINT32_SAMPLE_SPACE_SIZE % range)
   let value: number
   do {
     ;[value] = crypto.getRandomValues(new Uint32Array(1))


### PR DESCRIPTION
## Summary
Fixes `randomInt` hanging whenever the requested range divides `2^32`, including power-of-two ranges. The rejection threshold was correct at `2^32` and then wrapped to zero through a 32-bit coercion, so every draw was rejected forever.

The fix preserves the full `2^32` sample-space threshold, rejects unsupported ranges larger than one `Uint32` draw, and adds four deterministic regression cases. Only the shared helper and its focused test file change.

Slack report: https://sim-ai.slack.com/archives/C093DF8MA21/p1787258406733849

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- `bun run test` in `packages/utils`: 164 tests passed
- `bun run type-check` in `packages/utils`
- scoped Biome check for both changed files
- `bun run check:utils`
- `git diff --check`
- Chrome smoke against the locally running app through its configured development tunnel: automatic workflow naming completed immediately, password generation remained responsive and returned the expected 24-character value, and the disposable deployment/workflow was removed afterward. The literal localhost origin could not reuse the authenticated tunnel session because the local `.env` is configured for the tunnel URL.

The deterministic utility test is the authoritative regression proof; the current UI paths do not request a power-of-two range.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced by this patch
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Not applicable; there are no UI changes.