### PR TITLE
fix(knowledge): prevent processing status overlap

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -53,7 +53,6 @@ import type {
   FilterTag,
   ResourceAction,
   ResourceCell,
-  ResourceColumn,
   ResourceRow,
   SelectableConfig,
   SortConfig,
@@ -83,6 +82,7 @@ import {
   DocumentContextMenu,
   RenameDocumentModal,
 } from '@/app/workspace/[workspaceId]/knowledge/[id]/components'
+import { DOCUMENT_COLUMNS } from '@/app/workspace/[workspaceId]/knowledge/[id]/document-columns'
 import {
   addConnectorParam,
   documentFiltersParsers,
@@ -118,16 +118,6 @@ import { useUrlSort } from '@/hooks/use-url-sort'
 const logger = createLogger('KnowledgeBase')
 
 const DOCUMENTS_PER_PAGE = 50
-
-const DOCUMENT_COLUMNS: ResourceColumn[] = [
-  { id: 'name', header: 'Name', widthMultiplier: 0.8 },
-  { id: 'size', header: 'Size', widthMultiplier: 0.75 },
-  { id: 'tokens', header: 'Tokens', widthMultiplier: 0.75 },
-  { id: 'chunks', header: 'Chunks', widthMultiplier: 0.75 },
-  { id: 'uploaded', header: 'Uploaded' },
-  { id: 'status', header: 'Status', widthMultiplier: 0.75 },
-  { id: 'tags', header: 'Tags' },
-]
 
 const STATUS_FILTER_OPTIONS: ChipDropdownOption[] = [
   { value: 'all', label: 'All' },

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/document-columns.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/document-columns.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { DOCUMENT_COLUMNS } from '@/app/workspace/[workspaceId]/knowledge/[id]/document-columns'
+
+describe('DOCUMENT_COLUMNS', () => {
+  it('keeps the status column at the default width immediately before tags', () => {
+    const statusIndex = DOCUMENT_COLUMNS.findIndex((column) => column.id === 'status')
+
+    expect(DOCUMENT_COLUMNS[statusIndex]).toEqual({ id: 'status', header: 'Status' })
+    expect(DOCUMENT_COLUMNS[statusIndex + 1]?.id).toBe('tags')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/document-columns.ts
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/document-columns.ts
@@ -1,0 +1,11 @@
+import type { ResourceColumn } from '@/app/workspace/[workspaceId]/components'
+
+export const DOCUMENT_COLUMNS: ResourceColumn[] = [
+  { id: 'name', header: 'Name', widthMultiplier: 0.8 },
+  { id: 'size', header: 'Size', widthMultiplier: 0.75 },
+  { id: 'tokens', header: 'Tokens', widthMultiplier: 0.75 },
+  { id: 'chunks', header: 'Chunks', widthMultiplier: 0.75 },
+  { id: 'uploaded', header: 'Uploaded' },
+  { id: 'status', header: 'Status' },
+  { id: 'tags', header: 'Tags' },
+]

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/loading.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/loading.tsx
@@ -8,18 +8,9 @@ import {
   ResourceChromeFallback,
 } from '@/app/workspace/[workspaceId]/components'
 import { FOLDERED_RESOURCE_HEADERS } from '@/app/workspace/[workspaceId]/components/folders/foldered-resources'
+import { DOCUMENT_COLUMNS } from '@/app/workspace/[workspaceId]/knowledge/[id]/document-columns'
 
 const KNOWLEDGE_HEADER = FOLDERED_RESOURCE_HEADERS.knowledge_base
-
-const COLUMNS = [
-  { id: 'name', header: 'Name', widthMultiplier: 0.8 },
-  { id: 'size', header: 'Size', widthMultiplier: 0.75 },
-  { id: 'tokens', header: 'Tokens', widthMultiplier: 0.75 },
-  { id: 'chunks', header: 'Chunks', widthMultiplier: 0.75 },
-  { id: 'uploaded', header: 'Uploaded' },
-  { id: 'status', header: 'Status', widthMultiplier: 0.75 },
-  { id: 'tags', header: 'Tags' },
-]
 
 const ACTIONS: ChromeActionSpec[] = [
   { text: 'New connector', icon: Plus },
@@ -36,7 +27,7 @@ export default function KnowledgeBaseLoading() {
     <ResourceChromeFallback
       icon={Database}
       breadcrumbs={BREADCRUMBS}
-      columns={COLUMNS}
+      columns={DOCUMENT_COLUMNS}
       actions={ACTIONS}
       searchPlaceholder='Search documents...'
       hasSort


### PR DESCRIPTION
## Summary
- Gives the Knowledge Base document Status column its default full width so the icon-bearing Processing badge stays separated from Tags in narrow panels.
- Shares the document-column definition between the live list and loading fallback, with a focused regression test for the Status/Tags layout contract.

Reported in: [Slack thread](https://sim-ai.slack.com/archives/C093DF8MA21/p1787336501631469) (no GitHub issue).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- `bunx vitest run 'app/workspace/[workspaceId]/knowledge/[id]/document-columns.test.ts'`
- `bunx biome check --no-errors-on-unmatched` on the four changed files
- `bun run --cwd apps/sim type-check`
- Verified the resulting grid allocation at 1024px, 1100px, and 1280px in a headless browser with a Processing badge and long Tags value; the elements remain separated at each width.

Reviewers should focus on the feature-local column configuration and confirm the shared resource table and Badge component remain unchanged.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

The CLA attestation is intentionally left unchecked as requested.

## Screenshots/Videos
The original screenshot is available in the linked Slack report. It is not re-uploaded here because it contains workspace document data.
