### PR TITLE
fix(kb): show spinner for pending connector sync

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx
@@ -1091,7 +1091,7 @@ export function KnowledgeBase({
               className={cn(chipVariants({ variant: 'filled' }), 'max-w-[180px]')}
             >
               <span className='relative flex size-[14px] flex-shrink-0 items-center justify-center'>
-                {connector.status === 'syncing' ? (
+                {isConnectorSyncingOrPending(connector) ? (
                   <Loader className='size-[14px]' animate />
                 ) : (
                   ConnectorIcon && <BrandIcon icon={ConnectorIcon} className='size-[14px]' />

--- a/apps/sim/hooks/queries/kb/connectors.test.ts
+++ b/apps/sim/hooks/queries/kb/connectors.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   requestJson: vi.fn(),
@@ -21,9 +21,37 @@ vi.mock('@/lib/api/client/request', () => ({
   requestJson: mocks.requestJson,
 }))
 
-import { listKnowledgeConnectorDocumentsContract } from '@/lib/api/contracts/knowledge'
+import {
+  type ConnectorData,
+  listKnowledgeConnectorDocumentsContract,
+} from '@/lib/api/contracts/knowledge'
 import { MAX_KNOWLEDGE_CONNECTOR_DOCUMENT_PAGE_SIZE } from '@/lib/knowledge/constants'
-import { useConnectorDocuments } from '@/hooks/queries/kb/connectors'
+import { isConnectorSyncingOrPending, useConnectorDocuments } from '@/hooks/queries/kb/connectors'
+
+const NOW_MS = new Date('2026-08-21T12:00:00.000Z').getTime()
+
+function makeConnector(overrides: Partial<ConnectorData> = {}): ConnectorData {
+  const createdAt = new Date(NOW_MS - 60_000).toISOString()
+
+  return {
+    id: 'connector-1',
+    knowledgeBaseId: 'knowledge-1',
+    connectorType: 'hubspot',
+    credentialId: 'credential-1',
+    sourceConfig: {},
+    syncMode: 'full',
+    syncIntervalMinutes: 1440,
+    status: 'active',
+    lastSyncAt: null,
+    lastSyncError: null,
+    lastSyncDocCount: null,
+    nextSyncAt: null,
+    consecutiveFailures: 0,
+    createdAt,
+    updatedAt: createdAt,
+    ...overrides,
+  }
+}
 
 interface ConnectorDocumentsPage {
   documents: Array<{ id: string }>
@@ -38,6 +66,53 @@ interface ConnectorDocumentsQueryOptions {
     pages: ConnectorDocumentsPage[]
   ) => number | undefined
 }
+
+describe('isConnectorSyncingOrPending', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW_MS)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('treats a recently created active connector without a completed sync as pending', () => {
+    expect(isConnectorSyncingOrPending(makeConnector())).toBe(true)
+  })
+
+  it('treats a syncing connector as syncing regardless of its age or sync history', () => {
+    const connector = makeConnector({
+      status: 'syncing',
+      createdAt: new Date(NOW_MS - 24 * 60 * 60 * 1000).toISOString(),
+      lastSyncAt: new Date(NOW_MS - 60 * 60 * 1000).toISOString(),
+    })
+
+    expect(isConnectorSyncingOrPending(connector)).toBe(true)
+  })
+
+  it('does not treat an active connector with a completed sync as pending', () => {
+    const connector = makeConnector({
+      lastSyncAt: new Date(NOW_MS - 30_000).toISOString(),
+    })
+
+    expect(isConnectorSyncingOrPending(connector)).toBe(false)
+  })
+
+  it('stops treating an active connector as pending at the two-minute boundary', () => {
+    const connector = makeConnector({
+      createdAt: new Date(NOW_MS - 2 * 60 * 1000).toISOString(),
+    })
+
+    expect(isConnectorSyncingOrPending(connector)).toBe(false)
+  })
+
+  it.each(['error', 'paused', 'disabled'] as const)(
+    'does not treat a recent %s connector as pending',
+    (status) => {
+      expect(isConnectorSyncingOrPending(makeConnector({ status }))).toBe(false)
+    }
+  )
+})
 
 describe('useConnectorDocuments', () => {
   beforeEach(() => {

--- a/apps/sim/hooks/queries/kb/connectors.test.ts
+++ b/apps/sim/hooks/queries/kb/connectors.test.ts
@@ -7,13 +7,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   requestJson: vi.fn(),
   useInfiniteQuery: vi.fn(),
+  useQuery: vi.fn(),
 }))
 
 vi.mock('@tanstack/react-query', () => ({
   keepPreviousData: Symbol('keepPreviousData'),
   useInfiniteQuery: mocks.useInfiniteQuery,
   useMutation: vi.fn(),
-  useQuery: vi.fn(),
+  useQuery: mocks.useQuery,
   useQueryClient: vi.fn(() => ({ invalidateQueries: vi.fn() })),
 }))
 
@@ -26,7 +27,11 @@ import {
   listKnowledgeConnectorDocumentsContract,
 } from '@/lib/api/contracts/knowledge'
 import { MAX_KNOWLEDGE_CONNECTOR_DOCUMENT_PAGE_SIZE } from '@/lib/knowledge/constants'
-import { isConnectorSyncingOrPending, useConnectorDocuments } from '@/hooks/queries/kb/connectors'
+import {
+  isConnectorSyncingOrPending,
+  useConnectorDocuments,
+  useConnectorList,
+} from '@/hooks/queries/kb/connectors'
 
 const NOW_MS = new Date('2026-08-21T12:00:00.000Z').getTime()
 
@@ -65,6 +70,10 @@ interface ConnectorDocumentsQueryOptions {
     lastPage: ConnectorDocumentsPage,
     pages: ConnectorDocumentsPage[]
   ) => number | undefined
+}
+
+interface ConnectorListQueryOptions {
+  notifyOnChangeProps?: 'all'
 }
 
 describe('isConnectorSyncingOrPending', () => {
@@ -112,6 +121,19 @@ describe('isConnectorSyncingOrPending', () => {
       expect(isConnectorSyncingOrPending(makeConnector({ status }))).toBe(false)
     }
   )
+})
+
+describe('useConnectorList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('notifies consumers when identical polls complete so pending UI can expire', () => {
+    useConnectorList('knowledge-1')
+
+    const options = mocks.useQuery.mock.calls[0]?.[0] as ConnectorListQueryOptions
+    expect(options.notifyOnChangeProps).toBe('all')
+  })
 })
 
 describe('useConnectorDocuments', () => {

--- a/apps/sim/hooks/queries/kb/connectors.ts
+++ b/apps/sim/hooks/queries/kb/connectors.ts
@@ -86,6 +86,9 @@ export function useConnectorList(knowledgeBaseId?: string) {
     enabled: Boolean(knowledgeBaseId),
     staleTime: CONNECTOR_LIST_STALE_TIME,
     placeholderData: keepPreviousData,
+    // Pending state is time-based, so identical poll responses must still trigger a render
+    // for consumers to drop the pending UI when its two-minute window expires.
+    notifyOnChangeProps: 'all',
     refetchInterval: (query) => {
       const connectors = query.state.data
       if (!connectors?.length) return false


### PR DESCRIPTION
## Summary

Updates the top knowledge-base connector chip to use the existing `isConnectorSyncingOrPending` predicate. Newly created connectors are persisted as active before their asynchronous initial sync acquires the syncing lock, so the previous literal status check kept showing the provider logo during that pending window.

The chip now shows its loader during both the initial pending-sync period and persisted syncing state without changing connector state transitions or other connector UI.

GitHub issue: N/A — reported in the [Slack thread](https://sim-ai.slack.com/archives/C093DF8MA21/p1787337022917089).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- `bun run --cwd apps/sim test hooks/queries/kb/connectors.test.ts`
- `bunx biome check 'apps/sim/app/workspace/[workspaceId]/knowledge/[id]/base.tsx' apps/sim/hooks/queries/kb/connectors.test.ts`
- `bun run --cwd apps/sim type-check`

Reviewers should focus on the top connector-chip condition and the focused coverage for recent unsynced, persisted syncing, completed, expired-pending, and non-active connector states.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

The [Slack thread](https://sim-ai.slack.com/archives/C093DF8MA21/p1787337022917089) contains the before screenshot. The focused regression test verifies the connector-state behavior that controls the logo-to-spinner swap.