### PR TITLE
fix(canvas): show full Agent prompt tooltips

### DIFF
--- a/apps/sim/lib/workflows/subblocks/display.test.ts
+++ b/apps/sim/lib/workflows/subblocks/display.test.ts
@@ -287,4 +287,13 @@ describe('getDisplayValue', () => {
     ).toBe('one, two +1')
     expect(getDisplayValue(['a', 'b'])).toBe('a, b')
   })
+
+  it('keeps the full first message for renderer-owned clipping and tooltips', () => {
+    const content = `You are a research assistant. ${'Keep every instruction. '.repeat(4)}`.trim()
+    const messages = [{ role: 'system', content }]
+    const serializedMessages = JSON.stringify(messages)
+
+    expect(getDisplayValue(messages)).toBe(content)
+    expect(getDisplayValue(serializedMessages)).toBe(content)
+  })
 })

--- a/apps/sim/lib/workflows/subblocks/display.ts
+++ b/apps/sim/lib/workflows/subblocks/display.ts
@@ -191,8 +191,7 @@ export const getDisplayValue = (value: unknown): string => {
   if (isMessagesArray(parsedValue)) {
     const firstMessage = parsedValue[0]
     if (!firstMessage?.content || firstMessage.content.trim() === '') return '-'
-    const content = firstMessage.content.trim()
-    return truncate(content, 50)
+    return firstMessage.content.trim()
   }
 
   if (isVariableAssignmentsArray(parsedValue)) {


### PR DESCRIPTION
## Summary
Separates compact canvas display values from tooltip labels so long Agent prompts are no longer shortened before the tooltip receives them. Agent cards keep the existing 50-character first-message preview, block sizing, and auto-layout behavior, while editor and read-only preview tooltips receive the complete first-message content. Long plain strings such as Function code remain unchanged.

The renderer now supports an optional full tooltip value and opens the tooltip when the visible text is clipped or when it was shortened upstream. Password masking, selector hydration, regular row tooltip behavior, and structured-value summaries are unchanged.


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- `bun run test lib/workflows/subblocks/display.test.ts` in `apps/sim`: 28 tests passed
- `bun run test src/workflow-block/sub-block-row-view.test.tsx` in `packages/workflow-renderer`: 1 test passed
- `bun run type-check` in `apps/sim`
- `bun run type-check` in `packages/workflow-renderer`
- Scoped Biome check across all 7 changed files
- `git diff --check`

Reviewers should focus on the display-versus-tooltip separation: the compact Agent chip must remain unchanged while its tooltip exposes the complete first message, including when the compact string itself fits and was truncated upstream.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Before behavior and both comparison screenshots are in the linked Slack thread. No after screenshot is attached because the compact preview and layout intentionally remain visually unchanged; only the tooltip content changes, and that behavior is covered by the focused renderer regression test.