### PR TITLE
improvement(tabs): fade the tab strip with a mask, and shrink the tab chip

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tab-controls.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-tabs/resource-tab-controls.ts
@@ -22,9 +22,14 @@ export const RESOURCE_HEADER_CLASSES = {
    * CONTENT box both clusters centre in, so the strip's box has to be a pixel
    * taller than it or the tabs would centre in 43px while the overlaid toggle
    * centres in 44px, and the two rows would sit half a pixel apart.
+   *
+   * The band is the tabs' own height, set below the 30px the collapse toggle
+   * keeps: a tab paints a fill, so its box is visible and wants air around it,
+   * where the toggle and the action buttons are bare glyphs whose box only shows
+   * on hover.
    */
   stripGeometry:
-    '[--tab-strip-height:calc(var(--resource-header-controls-height)_+_1px)] [--tab-strip-max-tab-width:160px] [--tab-strip-inline-start:var(--resource-header-end-inset)] [--tab-strip-inline-end:var(--resource-header-fixed-reserve)]',
+    '[--tab-strip-height:calc(var(--resource-header-controls-height)_+_1px)] [--tab-strip-band:26px] [--tab-strip-max-tab-width:160px] [--tab-strip-inline-start:var(--resource-header-end-inset)] [--tab-strip-inline-end:var(--resource-header-fixed-reserve)]',
   /**
    * Centred, matching the `floating` strip: its tabs and controls sit centred in
    * the header band rather than hanging from the top, so an overlaid control has

--- a/packages/emcn/src/components/tab-strip/tab-strip.dom.test.tsx
+++ b/packages/emcn/src/components/tab-strip/tab-strip.dom.test.tsx
@@ -341,7 +341,9 @@ describe('TabStrip interactions', () => {
     const row = scrollRow()
     Object.defineProperties(row, {
       clientWidth: { configurable: true, value: 100 },
-      scrollWidth: { configurable: true, value: 300 },
+      // Roomy enough that the clamp does not fire, so this exercises the inset
+      // on its own; the test below covers the clamp.
+      scrollWidth: { configurable: true, value: 400 },
       scrollLeft: { configurable: true, value: 0, writable: true },
     })
     row.getBoundingClientRect = () => ({ left: 0, right: 100, width: 100 }) as DOMRect
@@ -352,9 +354,9 @@ describe('TabStrip interactions', () => {
     act(() => root?.render(renderStrip(tabs.map((tab) => ({ ...tab, active: tab.id === 'two' })))))
 
     // 280 - 100 would park the tab's right edge flush with the container's,
-    // which is exactly where the fade gradient sits — the tab would arrive
-    // half-faded. The extra 16px carries it clear of the gradient.
-    expect(row.scrollTo).toHaveBeenCalledWith({ left: 196, behavior: 'smooth' })
+    // which is exactly where the fade sits — the tab would arrive half-faded.
+    // The extra EDGE_FADE_PX (24) carries it clear of the fade.
+    expect(row.scrollTo).toHaveBeenCalledWith({ left: 204, behavior: 'smooth' })
   })
 
   it('lets the last tab rest flush, since no gradient is drawn at a scroll extreme', () => {
@@ -373,7 +375,7 @@ describe('TabStrip interactions', () => {
 
     act(() => root?.render(renderStrip(tabs.map((tab) => ({ ...tab, active: tab.id === 'two' })))))
 
-    // Wants 216; clamped to the 200 maximum rather than over-scrolling.
+    // Wants 224; clamped to the 200 maximum rather than over-scrolling.
     expect(row.scrollTo).toHaveBeenCalledWith({ left: 200, behavior: 'smooth' })
   })
 })

--- a/packages/emcn/src/components/tab-strip/tab-strip.tsx
+++ b/packages/emcn/src/components/tab-strip/tab-strip.tsx
@@ -28,7 +28,30 @@ const TITLE_TOOLTIP_HIDDEN_PX = 8
  * revealed flush against the container edge lands under its gradient and reads
  * as half-faded, which is indistinguishable from "there is more to scroll".
  */
-const EDGE_FADE_PX = 16
+const EDGE_FADE_PX = 24
+
+/**
+ * Edge fades, as a mask rather than a tinted gradient laid over the tabs.
+ *
+ * Tabs paint their own fills, and an overlay tinted with the surface colour
+ * washes a pill's edge toward that colour instead of dissolving it — and it is
+ * only correct while whatever sits behind the strip is exactly that colour. A
+ * mask fades pill and label together to real transparency, over any background.
+ * This is how the command palette fades its results, and how every other
+ * horizontal fade in the app is drawn.
+ *
+ * The four combinations are spelled out because Tailwind scans for literal class
+ * strings; a template built at runtime would never be generated. Keep the 24px
+ * stops in step with {@link EDGE_FADE_PX}, which is how far `revealActiveTab`
+ * insets a tab so it lands clear of the fade rather than under it.
+ */
+const SCROLL_FADE = {
+  none: '',
+  start:
+    '[-webkit-mask-image:linear-gradient(to_right,transparent_0px,black_24px)] [mask-image:linear-gradient(to_right,transparent_0px,black_24px)]',
+  end: '[-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_24px),transparent_100%)] [mask-image:linear-gradient(to_right,black_calc(100%_-_24px),transparent_100%)]',
+  both: '[-webkit-mask-image:linear-gradient(to_right,transparent_0px,black_24px,black_calc(100%_-_24px),transparent_100%)] [mask-image:linear-gradient(to_right,transparent_0px,black_24px,black_calc(100%_-_24px),transparent_100%)]',
+} as const
 const TAB_TRANSITION = { duration: 0.1, ease: [0.2, 0, 0, 1] as const }
 
 /**
@@ -445,7 +468,7 @@ const Tab = forwardRef<HTMLDivElement, TabProps>(function Tab(
           aria-label={`Close ${tab.title}`}
           tabIndex={-1}
           className={cn(
-            'absolute top-[3px] right-0.5 z-20 size-[24px] p-0 transition-opacity',
+            '-translate-y-1/2 absolute top-1/2 right-0.5 z-20 size-[24px] p-0 transition-opacity',
             tab.active
               ? 'opacity-100'
               : 'opacity-0 group-focus-within:opacity-100 group-hover:opacity-100'
@@ -851,25 +874,27 @@ export function TabStrip({
             </AnimatePresence>
           </div>
         )}
-        <div className='relative flex min-w-0 shrink'>
+        <div className='flex min-w-0 shrink'>
           <div
             ref={scrollNodeRef}
             className={cn(
               'flex min-w-0 shrink select-none gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-              variant === 'attached' ? 'items-end' : 'items-center gap-2'
+              variant === 'attached' ? 'items-end' : 'items-center gap-2',
+              SCROLL_FADE[
+                canScrollLeft
+                  ? canScrollRight
+                    ? 'both'
+                    : 'start'
+                  : canScrollRight
+                    ? 'end'
+                    : 'none'
+              ]
             )}
           >
             <AnimatePresence initial={false} mode='popLayout'>
               {regularTabs.map(renderTab)}
             </AnimatePresence>
           </div>
-          {canScrollLeft && (
-            /* w-4 — see EDGE_FADE_PX */
-            <div className='pointer-events-none absolute inset-y-0 left-0 z-20 w-4 bg-gradient-to-r from-[var(--bg)] to-transparent' />
-          )}
-          {canScrollRight && (
-            <div className='pointer-events-none absolute inset-y-0 right-0 z-20 w-4 bg-gradient-to-l from-[var(--bg)] to-transparent' />
-          )}
         </div>
       </div>
       {/* Both slots sit in the tab row's band so whatever fills them lines up


### PR DESCRIPTION
## Summary
- Fade the tab strip with a `mask-image` instead of a tinted gradient div laid over the tabs. Tabs paint their own fills, so at an edge the overlay washed a pill toward the surface colour rather than dissolving it, and it was only correct while whatever sat behind the strip was exactly that colour. A mask fades pill and label together to real transparency — the technique the command palette uses, and the one every other horizontal fade in the app uses (gradient-overlay fades appear 3 times in the app and all are vertical)
- Lengthen the fade ramp from 16px to 24px, near the palette's 22px. A short ramp reads as a cut rather than as "there is more"
- Drop the tab chip from 30px to 26px, leaving 7px of air above and below instead of 5px. The collapse toggle and action buttons stay 30px: a tab paints a fill so its box is visible and wants air, where those are bare glyphs whose box only shows on hover
- Centre the close button instead of encoding `(band - 24) / 2` as a magic `top-[3px]`, which would have gone off-centre the moment the band changed

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
