### PR TITLE
improvement(menus): tighten dropdown spacing and cap the @ mention list

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -41,7 +41,7 @@ import type {
   MothershipResourceType,
 } from '@/app/workspace/[workspaceId]/home/types'
 import { formatDate } from '@/app/workspace/[workspaceId]/logs/utils'
-import { listIntegrations } from '@/blocks/integration-matcher'
+import { listIntegrationsByPopularity } from '@/blocks/integration-matcher'
 import { useFolders } from '@/hooks/queries/folders'
 import { useKnowledgeBasesQuery } from '@/hooks/queries/kb/knowledge'
 import { useLogsList } from '@/hooks/queries/logs'
@@ -255,7 +255,7 @@ export function useAvailableResources(
       },
       {
         type: 'integration' as const,
-        items: listIntegrations().map((integration) => ({
+        items: listIntegrationsByPopularity().map((integration) => ({
           id: integration.blockType,
           name: integration.name,
           iconComponent: integration.icon,

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-downloads.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-downloads.tsx
@@ -163,7 +163,7 @@ export function BrowserDownloads({ scopeId, open, requestOpen, onClose }: Browse
           )}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align='end' sideOffset={5} className='w-[320px] p-1'>
+      <DropdownMenuContent align='end' sideOffset={5} className='w-[320px]'>
         <DropdownMenuLabel>Downloads</DropdownMenuLabel>
         {downloads.map((download) => {
           const completed = download.state === 'completed'

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/index.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/index.ts
@@ -3,6 +3,7 @@ export {
   byResourceMenuOrder,
   getResourceConfig,
   invalidateResourceQueries,
+  MENTION_PREVIEW_DEFAULT_LIMIT,
   RESOURCE_MENU_ORDER,
   RESOURCE_REGISTRY,
 } from './resource-registry'

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/resource-registry.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry/resource-registry.tsx
@@ -42,9 +42,10 @@ export interface ResourceTypeConfig {
   renderTabIcon: (resource: MothershipResource, className: string) => ReactNode
   renderDropdownItem: (props: DropdownItemRenderProps) => ReactNode
   /**
-   * How many of this family's candidates an unfiltered `@` list shows.
-   * Uncapped by default; set it for a family whose near-identical rows would
-   * otherwise bury every other family.
+   * How many of this family's candidates an unfiltered `@` list shows, overriding
+   * {@link MENTION_PREVIEW_DEFAULT_LIMIT}. Raise it only for a family whose rows a
+   * user browses; the unfiltered list is a preview, not a browser, and typing a
+   * query lifts the cap entirely — see `buildMentionPreview`.
    */
   mentionPreviewLimit?: number
 }
@@ -218,7 +219,6 @@ export const RESOURCE_REGISTRY: Record<MothershipResourceType, ResourceTypeConfi
       <Library className={cn(className, 'text-[var(--text-icon)]')} />
     ),
     renderDropdownItem: (props) => <LogDropdownItem {...props} />,
-    mentionPreviewLimit: 5,
   },
   integration: {
     type: 'integration',
@@ -248,6 +248,13 @@ export const RESOURCE_REGISTRY: Record<MothershipResourceType, ResourceTypeConfi
     renderDropdownItem: (props) => <IconDropdownItem {...props} icon={TerminalWindow} />,
   },
 } as const
+
+/**
+ * Rows per family in the unfiltered `@` preview, unless the family overrides it
+ * with {@link ResourceTypeConfig.mentionPreviewLimit}. Enough to show what a family
+ * holds without any one of them crowding out the rest.
+ */
+export const MENTION_PREVIEW_DEFAULT_LIMIT = 5
 
 /**
  * Top-down order for every menu that lists resource families, mirroring the
@@ -324,7 +331,7 @@ const RESOURCE_INVALIDATORS: Record<
   },
   /**
    * Integrations are sourced from the static integration catalog
-   * (`listIntegrations()`), not a server-backed query, so there is nothing to
+   * (`listIntegrationsByPopularity()`), not a server-backed query, so there is nothing to
    * invalidate when one is added.
    */
   integration: () => {},

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -5,8 +5,10 @@ import {
   cn,
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuLabel,
   DropdownMenuSearchInput,
   DropdownMenuTrigger,
+  dropdownMenuRowClass,
 } from '@sim/emcn'
 import {
   ResourceMenuSections,
@@ -14,9 +16,13 @@ import {
   useAvailableResources,
   useResourceTreeSections,
 } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown'
-import { getResourceConfig } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry'
+import {
+  getResourceConfig,
+  MENTION_PREVIEW_DEFAULT_LIMIT,
+} from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-registry'
 import type { PlusMenuHandle } from '@/app/workspace/[workspaceId]/home/components/user-input/components/constants'
 import {
+  buildMentionPreview,
   resourceMentionMatches,
   withDesktopTabMentions,
 } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items'
@@ -26,6 +32,14 @@ import type {
 } from '@/app/workspace/[workspaceId]/home/types'
 import { useBrowserSessionStore } from '@/stores/browser-session/store'
 import { useCopilotTerminalStore } from '@/stores/copilot-terminal/store'
+
+/**
+ * The `@` list is shorter than the emcn menu default (420px, sized for right-click
+ * action menus). This one floats directly over the chat input, so a menu tall enough
+ * to swallow the conversation behind it reads as a takeover rather than an
+ * autocomplete. ~10 rows is enough to show several families at once.
+ */
+const MENTION_MAX_HEIGHT_CLASS = 'max-h-[min(280px,var(--radix-popper-available-height,280px))]'
 
 /**
  * Resource types that are only offered via `@`-mention autocomplete and hidden
@@ -130,11 +144,10 @@ export const PlusMenuDropdown = React.memo(
       const q = rawQuery.toLowerCase().trim()
       if (!isMention && !q) return null
       if (isMention && !q) {
-        return visibleResources.flatMap(({ type, items }) => {
-          const limit = getResourceConfig(type).mentionPreviewLimit
-          const previewed = limit === undefined ? items : items.slice(0, limit)
-          return previewed.map((item) => ({ type, item }))
-        })
+        return buildMentionPreview(
+          visibleResources,
+          (type) => getResourceConfig(type).mentionPreviewLimit ?? MENTION_PREVIEW_DEFAULT_LIMIT
+        )
       }
       return visibleResources.flatMap(({ type, items }) =>
         items.filter((item) => resourceMentionMatches(item, q)).map((item) => ({ type, item }))
@@ -298,7 +311,7 @@ export const PlusMenuDropdown = React.memo(
             // Plus-click shows short fixed labels (Workflows, Tables, …) — let it size
             // to its content via the emcn DropdownMenuContent default max-w.
             // Mention mode renders resource names directly, so widen for breathing room.
-            isMention && 'max-w-[min(300px,calc(100vw-32px))]'
+            isMention && `max-w-[min(300px,calc(100vw-32px))] ${MENTION_MAX_HEIGHT_CLASS}`
           )}
           onCloseAutoFocus={handleCloseAutoFocus}
           onOpenAutoFocus={handleOpenAutoFocus}
@@ -334,28 +347,36 @@ export const PlusMenuDropdown = React.memo(
                 filteredItems.map(({ type, item }, index) => {
                   const config = getResourceConfig(type)
                   const isActive = index === activeIndex
+                  /* Items arrive grouped by family (one group per type, ordered by
+                     RESOURCE_MENU_ORDER), so a type change marks a section boundary.
+                     Deriving the heading from the flat list keeps `activeIndex` — and
+                     therefore every keyboard path — indexing exactly what it did. */
+                  const startsSection = index === 0 || filteredItems[index - 1]?.type !== type
                   return (
-                    <button
-                      key={`${type}:${item.id}`}
-                      type='button'
-                      role='menuitem'
-                      data-filtered-idx={index}
-                      onMouseEnter={() => setActiveIndex(index)}
-                      onClick={() => {
-                        handleSelect(resourceFromItem(type, item))
-                      }}
-                      className={cn(
-                        'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors duration-0 [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
-                        /* `activeIndex` is the cursor, not a selection — hover surface. */
-                        isActive && 'bg-[var(--surface-hover)]'
-                      )}
-                    >
-                      {config.renderDropdownItem({ item })}
-                    </button>
+                    <React.Fragment key={`${type}:${item.id}`}>
+                      {startsSection && <DropdownMenuLabel>{config.label}</DropdownMenuLabel>}
+                      <button
+                        type='button'
+                        role='menuitem'
+                        data-filtered-idx={index}
+                        onMouseEnter={() => setActiveIndex(index)}
+                        onClick={() => {
+                          handleSelect(resourceFromItem(type, item))
+                        }}
+                        className={cn(
+                          dropdownMenuRowClass,
+                          'w-full text-left',
+                          /* `activeIndex` is the cursor, not a selection — hover surface. */
+                          isActive && 'bg-[var(--surface-hover)]'
+                        )}
+                      >
+                        {config.renderDropdownItem({ item })}
+                      </button>
+                    </React.Fragment>
                   )
                 })
               ) : (
-                <div className='px-2 py-1.5 text-center text-[var(--text-tertiary)] text-caption'>
+                <div className='flex h-[28px] items-center justify-center px-2 text-[var(--text-muted)] text-caption'>
                   No results
                 </div>
               ))}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.test.ts
@@ -3,7 +3,9 @@ import {
   BROWSER_SESSION_RESOURCE_ID,
   TERMINAL_SESSION_RESOURCE_ID,
 } from '@/lib/copilot/resources/types'
+import type { AvailableItem } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/resource-folder-tree'
 import {
+  buildMentionPreview,
   resourceMentionMatches,
   withDesktopTabMentions,
 } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items'
@@ -104,5 +106,55 @@ describe('withDesktopTabMentions', () => {
     expect(resourceMentionMatches(tab, 'docs')).toBe(true)
     expect(resourceMentionMatches(tab, 'browser')).toBe(true)
     expect(resourceMentionMatches(tab, 'terminal')).toBe(false)
+  })
+})
+
+describe('buildMentionPreview', () => {
+  const item = (id: string): AvailableItem => ({ id, name: id })
+  const many = (n: number) => Array.from({ length: n }, (_, i) => item(`i${i}`))
+
+  it('caps each family so a large one cannot bury the families after it', () => {
+    const preview = buildMentionPreview(
+      [
+        { type: 'integration', items: many(300) },
+        { type: 'workflow', items: [item('thermal-field')] },
+      ],
+      () => 5
+    )
+
+    expect(preview.filter((c) => c.type === 'integration')).toHaveLength(5)
+    expect(preview.map((c) => c.item.id)).toContain('thermal-field')
+  })
+
+  it('lets a family raise its own cap', () => {
+    const preview = buildMentionPreview(
+      [
+        { type: 'integration', items: many(10) },
+        { type: 'workflow', items: many(10) },
+      ],
+      (type) => (type === 'workflow' ? 2 : 5)
+    )
+
+    expect(preview.filter((c) => c.type === 'integration')).toHaveLength(5)
+    expect(preview.filter((c) => c.type === 'workflow')).toHaveLength(2)
+  })
+
+  it('keeps families in the order they were given, so headings stay contiguous', () => {
+    const preview = buildMentionPreview(
+      [
+        { type: 'integration', items: many(3) },
+        { type: 'workflow', items: many(3) },
+      ],
+      () => 5
+    )
+
+    const boundaries = preview.filter((c, i) => i > 0 && preview[i - 1].type !== c.type)
+    expect(boundaries).toHaveLength(1)
+    expect(preview.at(-1)?.type).toBe('workflow')
+  })
+
+  it('keeps a family shorter than the cap intact', () => {
+    const preview = buildMentionPreview([{ type: 'workflow', items: many(2) }], () => 5)
+    expect(preview).toHaveLength(2)
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.ts
@@ -92,3 +92,30 @@ export function withDesktopTabMentions(
     return group
   })
 }
+
+/** One row of the `@` list: an item plus the family it came from. */
+export interface ResourceMentionCandidate {
+  type: MothershipResourceType
+  item: AvailableItem
+}
+
+/**
+ * The rows an `@` list shows for an EMPTY query — a preview of what is mentionable,
+ * capped per family so no one family can bury the rest.
+ *
+ * `integration` carries 300+ near-identical rows and sorts FIRST, so while the cap
+ * defaulted to "uncapped" the preview was its entire catalog and no other family was
+ * reachable without scrolling past all of it. Capping is therefore the default and a
+ * family opts out by raising its own limit, not by omitting one.
+ *
+ * Only the empty-query preview is capped; {@link resourceMentionMatches} searches
+ * every family in full once the user types.
+ */
+export function buildMentionPreview(
+  groups: readonly ResourceMentionGroup[],
+  limitFor: (type: MothershipResourceType) => number
+): ResourceMentionCandidate[] {
+  return groups.flatMap(({ type, items }) =>
+    items.slice(0, limitFor(type)).map((item) => ({ type, item }))
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/skills-menu-dropdown/skills-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/skills-menu-dropdown/skills-menu-dropdown.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { cn, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@sim/emcn'
+import {
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  dropdownMenuRowClass,
+} from '@sim/emcn'
 import { AgentSkillsIcon, McpIcon } from '@/components/icons'
 import type { McpServer } from '@/hooks/queries/mcp'
 import type { SkillDefinition } from '@/hooks/queries/skills'
@@ -210,7 +216,8 @@ export const SkillsMenuDropdown = React.memo(
                     onMouseEnter={() => setActiveIndex(index)}
                     onClick={() => handleSelect(target)}
                     className={cn(
-                      'relative flex w-full min-w-0 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-left text-[var(--text-body)] text-caption outline-none transition-colors duration-0 [&>span]:min-w-0 [&>span]:truncate [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]',
+                      dropdownMenuRowClass,
+                      'w-full text-left',
                       /* `activeIndex` is the cursor, not a selection — hover surface. */
                       isActive && 'bg-[var(--surface-hover)]'
                     )}
@@ -221,7 +228,7 @@ export const SkillsMenuDropdown = React.memo(
                 )
               })
             ) : (
-              <div className='px-2 py-1.5 text-center text-[var(--text-tertiary)] text-caption'>
+              <div className='flex h-[28px] items-center justify-center px-2 text-[var(--text-muted)] text-caption'>
                 No skills or MCP servers
               </div>
             )}

--- a/apps/sim/app/workspace/[workspaceId]/tables/components/import-progress-menu/import-progress-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/components/import-progress-menu/import-progress-menu.tsx
@@ -79,7 +79,7 @@ export function ImportProgressMenu({ workspaceId, tableId }: ImportProgressMenuP
           </span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align='end' className='min-w-[320px] max-w-[420px] gap-0 p-1'>
+      <DropdownMenuContent align='end' className='min-w-[320px] max-w-[420px]'>
         {imports.map((row) => {
           const stage = getImportStage(row)
           const isReadyExport = row.jobType === 'export' && row.phase === 'ready' && row.hasResult

--- a/apps/sim/blocks/integration-matcher.ts
+++ b/apps/sim/blocks/integration-matcher.ts
@@ -46,6 +46,7 @@ function normalizeDisplayName(name: string): string {
 
 let cachedMatcher: IntegrationMatcher | null = null
 let cachedList: readonly IntegrationDescriptor[] | null = null
+let cachedPopularList: readonly IntegrationDescriptor[] | null = null
 
 /**
  * Drops the memoized matcher/list. Registered with the block cache-invalidator
@@ -55,6 +56,7 @@ let cachedList: readonly IntegrationDescriptor[] | null = null
 function clearIntegrationMatcherCache(): void {
   cachedMatcher = null
   cachedList = null
+  cachedPopularList = null
 }
 
 registerBlockCacheInvalidator(clearIntegrationMatcherCache)
@@ -141,4 +143,68 @@ export function listIntegrations(): readonly IntegrationDescriptor[] {
   const { byName } = getIntegrationMatcher()
   cachedList = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
   return cachedList
+}
+
+/**
+ * The integrations a surface should lead with when it can only show a handful,
+ * most-reached-for first.
+ *
+ * Keyed by NORMALIZED DISPLAY NAME rather than block type on purpose: the matcher
+ * dedups versioned blocks down to one descriptor per display name
+ * ({@link normalizeDisplayName}), so `gmail` and a future `gmail_v2` collapse to
+ * "Gmail" and only one of them is ever the canonical `blockType`. Ranking by name
+ * therefore survives a version bump that ranking by type would silently break —
+ * the entry would stop matching and the integration would drop out of the preview
+ * with nothing failing.
+ *
+ * Hand-curated, not derived. The landing page's `POPULAR_WORKFLOWS` is the other
+ * popularity signal in the app, but it is built from `getAllBlockMeta()` at module
+ * scope and so drags the entire block registry into whatever imports it — which is
+ * exactly what a client chat surface must not do.
+ */
+export const POPULAR_INTEGRATION_NAMES: readonly string[] = [
+  'Slack',
+  'Gmail',
+  'Notion',
+  'Linear',
+  'GitHub',
+  'Google Sheets',
+  'Google Drive',
+  'Google Calendar',
+  'Google Docs',
+  'Jira',
+  'Airtable',
+  'HubSpot',
+  'Salesforce',
+  'Discord',
+]
+
+const POPULAR_RANK = new Map(
+  POPULAR_INTEGRATION_NAMES.map((name, index) => [name.toLowerCase(), index])
+)
+
+/**
+ * Orders by {@link POPULAR_INTEGRATION_NAMES} rank first, then alphabetically.
+ * Exported for direct testing — the ordering rule needs no block registry.
+ */
+export function byIntegrationPopularity(a: { name: string }, b: { name: string }): number {
+  const unranked = POPULAR_RANK.size
+  const rankA = POPULAR_RANK.get(a.name.toLowerCase()) ?? unranked
+  const rankB = POPULAR_RANK.get(b.name.toLowerCase()) ?? unranked
+  return rankA === rankB ? a.name.localeCompare(b.name) : rankA - rankB
+}
+
+/**
+ * Every integration, the curated popular ones first (in
+ * {@link POPULAR_INTEGRATION_NAMES} order) and the rest alphabetically after.
+ *
+ * For surfaces that show a truncated preview — the `@`-mention list takes the first
+ * few — where plain alphabetical order means leading with whatever happens to sort
+ * first (1Password, Affinity, AgentMail) rather than anything a user is likely to
+ * want. {@link listIntegrations} stays alphabetical for surfaces that show them all.
+ */
+export function listIntegrationsByPopularity(): readonly IntegrationDescriptor[] {
+  if (cachedPopularList) return cachedPopularList
+  cachedPopularList = [...listIntegrations()].sort(byIntegrationPopularity)
+  return cachedPopularList
 }

--- a/apps/sim/blocks/integration-popularity.test.ts
+++ b/apps/sim/blocks/integration-popularity.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { byIntegrationPopularity, POPULAR_INTEGRATION_NAMES } from '@/blocks/integration-matcher'
+
+const sortNames = (names: string[]) =>
+  [...names]
+    .map((name) => ({ name }))
+    .sort(byIntegrationPopularity)
+    .map((i) => i.name)
+
+describe('byIntegrationPopularity', () => {
+  it('leads with curated integrations instead of whatever sorts first alphabetically', () => {
+    expect(sortNames(['1Password', 'Affinity', 'AgentMail', 'Slack'])[0]).toBe('Slack')
+  })
+
+  it('keeps the curated entries in their authored order, not alphabetical', () => {
+    const curated = POPULAR_INTEGRATION_NAMES.slice(0, 4)
+    expect(sortNames([...curated].reverse())).toEqual(curated)
+  })
+
+  it('sorts everything unranked alphabetically behind the curated set', () => {
+    expect(sortNames(['Zoom', 'Affinity', 'Slack'])).toEqual(['Slack', 'Affinity', 'Zoom'])
+  })
+
+  it('matches case-insensitively so a display-name casing change cannot silently unrank one', () => {
+    expect(sortNames(['Affinity', 'sLaCk'])[0]).toBe('sLaCk')
+  })
+})

--- a/packages/emcn/src/components/chip-dropdown/chip-dropdown.tsx
+++ b/packages/emcn/src/components/chip-dropdown/chip-dropdown.tsx
@@ -35,7 +35,7 @@ interface ChipDropdownOption {
   /**
    * Optional leading icon rendered inside the menu item. Auto-sized to
    * `size-[14px]` and tinted with `--text-icon` via the item's base classes
-   * (see `DROPDOWN_MENU_ITEM_BASE_CLASSES`).
+   * (see {@link dropdownMenuRowClass}).
    */
   icon?: ChipIcon
   /** Pre-rendered leading element (e.g. an avatar) — takes precedence over `icon`. */

--- a/packages/emcn/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/emcn/src/components/dropdown-menu/dropdown-menu.tsx
@@ -24,7 +24,7 @@ import * as React from 'react'
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import { Check, ChevronRight, Circle, Search } from '../../icons'
 import { cn } from '../../lib/cn'
-import { chipFieldSurfaceClass } from '../chip/chip-chrome'
+import { chipContentGap, chipFieldSurfaceClass } from '../chip/chip-chrome'
 import { InsideModalContext } from '../modal/modal'
 
 const ANIMATION_CLASSES =
@@ -36,6 +36,12 @@ const ANIMATION_CLASSES =
  * the surface note below). Every row (item, checkbox, radio, submenu trigger,
  * search field) composes these, so the rhythm cannot drift the way it did when
  * each row hardcoded its own height and radius.
+ *
+ * The icon↔label gap is {@link chipContentGap}, not a local literal. It was `gap-2`
+ * (8px) against the platform's 6px, and on the menu's 14px icons — narrower than the
+ * chip's 16px — the extra 2px read as the row's content drifting apart rather than as
+ * one icon/label pair. Importing the token is also what keeps a menu row and the
+ * sidebar chip it opens over from spacing their content differently.
  */
 const MENU_ROW_HEIGHT_CLASS = 'h-[28px]'
 const MENU_ROW_RADIUS_CLASS = 'rounded-lg'
@@ -113,9 +119,9 @@ function withEllipsizedLabel(children: React.ReactNode): React.ReactNode {
  * A menu is capped so a long data-driven list — every workflow, every folder —
  * scrolls instead of running the height of the screen. The cap has to clear the
  * tallest hand-authored action menu though, or an ordinary right-click menu
- * scrolls for the sake of a few pixels: the knowledge-base row menu is 247px
- * (7 rows x 28px + 3 separators x 13px + 12px padding), which the previous flat
- * 240px clipped while the 221px Files row menu next to it did not. 420px clears
+ * scrolls for the sake of a few pixels: the knowledge-base row menu is 231px
+ * (7 rows x 28px + 3 separators x 9px + 8px padding), which a flat 240px cap
+ * once clipped while the shorter Files row menu next to it did not. 420px clears
  * every action menu in the app with room for a couple more rows.
  *
  * `min()` with Radix's measured space then keeps the menu inside the viewport
@@ -137,8 +143,14 @@ const MENU_MAX_HEIGHT_CLASS = 'max-h-[min(420px,var(--radix-popper-available-hei
  * {@link Tooltip}). A menu that picks its own pair reads as a different family of
  * object next to the surfaces it opens over, so match the convention rather than
  * making the two corners strictly concentric.
+ *
+ * The 4px surface padding then makes them concentric anyway — 8px row + 4px pad is
+ * exactly the 12px surface corner, so a first or last row's rounding now tracks the
+ * corner it sits in instead of cutting across it. It was 6px, which both broke that
+ * and gave the menu a wider gutter than its own 8px row padding; two consumers had
+ * already overridden it back down to 4px by hand.
  */
-const CONTENT_BASE_CLASSES = `z-[var(--z-popover)] ${MENU_MAX_HEIGHT_CLASS} min-w-[8rem] origin-[--radix-dropdown-menu-content-transform-origin] overflow-y-auto overflow-x-hidden overscroll-none rounded-xl border border-[var(--border)] bg-[var(--bg)] p-1.5 text-[var(--text-body)] shadow-sm`
+const CONTENT_BASE_CLASSES = `z-[var(--z-popover)] ${MENU_MAX_HEIGHT_CLASS} min-w-[8rem] origin-[--radix-dropdown-menu-content-transform-origin] overflow-y-auto overflow-x-hidden overscroll-none rounded-xl border border-[var(--border)] bg-[var(--bg)] p-1 text-[var(--text-body)] shadow-sm`
 
 /**
  * Menu root. Inside a `ModalContent` (Radix modal dialog) the menu is forced
@@ -163,11 +175,7 @@ const DropdownMenuGroup = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Group>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Group>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Group
-    ref={ref}
-    className={cn('flex flex-col gap-0.5', className)}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Group ref={ref} className={cn('flex flex-col', className)} {...props} />
 ))
 DropdownMenuGroup.displayName = DropdownMenuPrimitive.Group.displayName
 
@@ -198,7 +206,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
         /* An open submenu keeps its trigger on the selected surface — including while
            the pointer is on it, so walking into the submenu doesn't drop the trigger
            back to the hover fill. */
-        `flex ${MENU_ROW_HEIGHT_CLASS} min-w-0 cursor-default select-none items-center gap-2 ${MENU_ROW_RADIUS_CLASS} px-2 text-[var(--text-body)] text-small outline-none ${MENU_ROW_TRANSITION_CLASS} ${MENU_ROW_HIGHLIGHT_CLASS} data-[state=open]:bg-[var(--surface-active)] data-[state=open]:focus:bg-[var(--surface-active)] ${MENU_ROW_SINGLE_LINE_CLASS} [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]`,
+        `flex ${MENU_ROW_HEIGHT_CLASS} min-w-0 cursor-default select-none items-center ${chipContentGap} ${MENU_ROW_RADIUS_CLASS} px-2 text-[var(--text-body)] text-small outline-none ${MENU_ROW_TRANSITION_CLASS} ${MENU_ROW_HIGHLIGHT_CLASS} data-[state=open]:bg-[var(--surface-active)] data-[state=open]:focus:bg-[var(--surface-active)] ${MENU_ROW_SINGLE_LINE_CLASS} [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]`,
         inset && 'pl-7',
         className
       )}
@@ -260,7 +268,18 @@ const DropdownMenuContent = React.forwardRef<
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
-const DROPDOWN_MENU_ITEM_BASE_CLASSES = `relative flex ${MENU_ROW_HEIGHT_CLASS} min-w-0 cursor-pointer select-none items-center gap-2 ${MENU_ROW_RADIUS_CLASS} px-2 text-[var(--text-body)] text-small outline-none ${MENU_ROW_TRANSITION_CLASS} data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ${MENU_ROW_SINGLE_LINE_CLASS} [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]`
+/**
+ * The canonical menu-row chrome, exported for the rare consumer that cannot use
+ * {@link DropdownMenuItem} itself.
+ *
+ * Radix tracks every `DropdownMenuItem` in a focus Collection, so a list that
+ * mounts and unmounts rows as a query narrows makes its FocusScope restore focus
+ * to the content root mid-keystroke. Such a list renders plain `<button role="menuitem">`
+ * elements instead — but it must still LOOK like a menu row, and hand-rolling that
+ * is how the `@`-mention list drifted to its own gap, radius, height and text size.
+ * Compose this instead of restating the literals.
+ */
+export const dropdownMenuRowClass = `relative flex ${MENU_ROW_HEIGHT_CLASS} min-w-0 cursor-pointer select-none items-center ${chipContentGap} ${MENU_ROW_RADIUS_CLASS} px-2 text-[var(--text-body)] text-small outline-none ${MENU_ROW_TRANSITION_CLASS} data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ${MENU_ROW_SINGLE_LINE_CLASS} [&_svg]:pointer-events-none [&_svg]:size-[14px] [&_svg]:shrink-0 [&_svg]:text-[var(--text-icon)]`
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
@@ -292,7 +311,7 @@ const DropdownMenuItem = React.forwardRef<
         <DropdownMenuPrimitive.Item
           ref={ref}
           className={cn(
-            DROPDOWN_MENU_ITEM_BASE_CLASSES,
+            dropdownMenuRowClass,
             stateClasses,
             'pr-[28px]',
             inset && 'pl-7',
@@ -312,7 +331,7 @@ const DropdownMenuItem = React.forwardRef<
   return (
     <DropdownMenuPrimitive.Item
       ref={ref}
-      className={cn(DROPDOWN_MENU_ITEM_BASE_CLASSES, stateClasses, inset && 'pl-7', className)}
+      className={cn(dropdownMenuRowClass, stateClasses, inset && 'pl-7', className)}
       asChild={asChild}
       {...props}
     >
@@ -397,6 +416,22 @@ const DropdownMenuRadioItem = React.forwardRef<
 ))
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
 
+/**
+ * Section heading above a group of rows.
+ *
+ * Composes {@link MENU_ROW_HEIGHT_CLASS} rather than padding to a height. It was
+ * `py-1.5` over `text-xs`, and nothing in the app sets a `line-height`, so its box
+ * resolved through the browser's default leading — roughly 25px, font-dependent,
+ * and the only child of the menu not on the 28px row grid. Every row beneath it
+ * therefore sat ~3px off that grid too.
+ *
+ * `text-caption` and `--text-muted` come from the platform's two other list
+ * headings — the command palette's group heading and the sidebar's section header
+ * — which both set a heading one step below their own rows in `--text-muted`. The
+ * menu's rows are `text-small`, so one step down is `text-caption`; `text-xs` was
+ * two. `--text-tertiary` was also darker than `--text-muted`, so the heading
+ * out-weighed the rows it introduces.
+ */
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
@@ -405,7 +440,11 @@ const DropdownMenuLabel = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
-    className={cn('px-2 py-1.5 text-[var(--text-tertiary)] text-xs', inset && 'pl-7', className)}
+    className={cn(
+      `flex ${MENU_ROW_HEIGHT_CLASS} items-center px-2 text-[var(--text-muted)] text-caption`,
+      inset && 'pl-7',
+      className
+    )}
     {...props}
   />
 ))
@@ -417,7 +456,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('my-1.5 h-px bg-[var(--border-1)]', className)}
+    className={cn('my-1 h-px bg-[var(--border-1)]', className)}
     {...props}
   />
 ))
@@ -444,7 +483,7 @@ const DropdownMenuSearchInput = React.forwardRef<
 
   /*
    * No horizontal margin: the field spans the same width as the rows beneath it,
-   * both inset only by the surface's `p-1.5`. It carried `mx-0.5` and so sat 2px
+   * both inset only by the surface's `p-1`. It carried `mx-0.5` and so sat 2px
    * narrower on each side. The vertical margins stay — the search field is a
    * sibling of the item groups, not a member of one, so no container gap
    * separates it from the first row.
@@ -452,7 +491,7 @@ const DropdownMenuSearchInput = React.forwardRef<
   return (
     <div
       className={cn(
-        `mt-0.5 mb-0.5 flex ${MENU_ROW_HEIGHT_CLASS} shrink-0 items-center gap-2 px-2`,
+        `mt-0.5 mb-0.5 flex ${MENU_ROW_HEIGHT_CLASS} shrink-0 items-center ${chipContentGap} px-2`,
         chipFieldSurfaceClass
       )}
     >

--- a/packages/emcn/src/components/index.ts
+++ b/packages/emcn/src/components/index.ts
@@ -121,6 +121,7 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  dropdownMenuRowClass,
 } from './dropdown-menu/dropdown-menu'
 export { Expandable, ExpandableContent } from './expandable/expandable'
 export { DashedDividerLine, FieldDivider } from './field-divider/field-divider'


### PR DESCRIPTION
## Summary

**Dropdown spacing** — the menu was spaced wider than the surfaces it opens over:
- Row icon↔label gap was a re-derived `gap-2` (8px); now composes `chipContentGap` (6px), the token the chips and resource rows already use. The menu's icons are 14px vs the chip's 16px, so the extra 2px read wider still.
- Surface padding `p-1.5` → `p-1`. An 8px row radius + 4px padding is exactly the 12px surface radius, so a first/last row's rounding now tracks its corner instead of cutting across it. Two consumers had already overridden this to `p-1` by hand — both overrides removed.
- Separator gutter 13px → 9px. Rows in the same group sit flush at 0px, so 13px made groups read as floating apart.
- `DropdownMenuLabel` padded to an uncontrolled, font-dependent height (nothing sets a `line-height`), sat two type steps below its rows, and used a colour heavier than the rows it introduces. Now composes the shared row height at `text-caption` / `--text-muted`, matching how the command palette and sidebar set their own section headings.
- Removed dead `gap-0.5` from `DropdownMenuGroup` (zero consumers) and the now-inert `gap-0` override it existed for.

**`@` mention list** — it rendered the entire integration catalogue:
- The per-family preview cap defaulted to uncapped, and `integration` is 300+ near-identical rows sorted *first*, so nothing else was reachable without scrolling past all of them. Capping is now the default (`MENTION_PREVIEW_DEFAULT_LIMIT`); a family opts out by raising its own limit. Typing a query still searches every family in full.
- Families are now labelled, so the list says what's mentionable instead of running as one flat alphabetical column.
- Capped to 280px rather than the 420px action-menu default — this one floats over the chat input.
- The integrations shown are curated popular ones rather than whatever sorts first alphabetically. Ranked by normalised display name, not block type, so a version bump can't silently unrank one.

**Shared chrome** — `dropdownMenuRowClass` is now exported. Both menus that render plain `<button role="menuitem">` (required: mounting/unmounting `DropdownMenuItem` makes Radix's FocusScope steal focus mid-keystroke) compose it instead of re-deriving row chrome. The `/` skills menu carried a byte-identical copy of the literal and was migrated too, so it doesn't diverge from the `@` menu beside it.

## Type of Change
- [x] Improvement

## Testing
Verified against the running app in both light and dark themes, measuring the rendered geometry off the live DOM rather than by eye.

- `bun run check:audits` — 32/32 pass
- `bun run lint` — 26/26 pass
- `bun run type-check` — clean in `apps/sim` and `packages/emcn`
- Tests: 53 pass in `apps/sim`, 92 in `packages/emcn`. 8 new cases covering the preview cap and the popularity comparator — each verified to fail when its fix is reverted.

Note: `check-block-registry.ts` reports a pre-existing `table_v2` / `outputColumns` subblock failure that reproduces on a clean `staging` checkout. Unrelated to this PR, which touches no block definitions.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)