### PR TITLE
improvement(files): match the preview toolbar's height to the tab strip above it

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-toolbar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/preview-toolbar.tsx
@@ -30,7 +30,11 @@ export function PreviewToolbar({ navigation, zoom, className }: PreviewToolbarPr
   return (
     <div
       className={cn(
-        'flex shrink-0 items-center justify-between border-[var(--border)] border-b bg-[var(--surface-1)] px-2 py-1',
+        // Matches the resource tab strip stacked directly above it: a 40px
+        // content box over a 1px border. `py-1` around a 30px chip came to 39px,
+        // near enough to read as a mistake rather than as a different bar, and
+        // the chips themselves still sat taller than the 26px tabs.
+        'flex h-[41px] shrink-0 items-center justify-between border-[var(--border)] border-b bg-[var(--surface-1)] px-2',
         className
       )}
     >


### PR DESCRIPTION
## Summary
- Give the file preview toolbar the same height as the resource tab strip stacked directly above it. It had no height of its own — `py-1` around a 30px chip came to 39px against the strip's 41px, so two stacked bars sat two pixels apart, which reads as a mistake rather than as two different bars
- The toolbar now takes the same 40px content box over a 1px border, so its chips centre in the same band the tabs do
- One change covers all four previews that mount it — pdf, docx, pptx, and the zoomable image/svg surface — none of which override its height
- The shared 30px `chipGeometryClass` is untouched; this is the toolbar's own padding

## Type of Change
- [x] Improvement

## Testing
Tested manually

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
