### PR TITLE
improvement(menus): one separator per menu, before the destructive action

### DIFF
--- a/.claude/rules/sim-list-ordering.md
+++ b/.claude/rules/sim-list-ordering.md
@@ -59,6 +59,15 @@ genuinely buys is a stop before the action you cannot undo.
 A second rule is justified only when a menu mixes genuinely different *scopes* — cell-level and
 table-level actions in one menu, say — not different verbs.
 
+**The one standing exception: menus that emulate a native menu.** The text-editor menu
+(`editor-context-menu.tsx`), the terminal menu (`terminal-context-menu.tsx`), and the browser
+page menu (`browser-session.tsx`) each mirror the OS menu the user already knows — clipboard
+banding (`Cut · Copy · Paste │ Select all`) is a convention every text field on their machine
+teaches them. These keep their native banding, and that is the *same* principle as the ordering
+rule above: mirror the surface the user already reads. The test is whether a real menu outside
+Sim taught them the grouping. Our own resource, row, and action menus have no such precedent —
+the toolbars they mirror are flat — so they take the single rule.
+
 **Both sides of every rule must be guaranteed non-empty.** Write the separator's guard out of
 the *exact* render conditions of the items around it, never a looser approximation:
 

--- a/.claude/rules/sim-list-ordering.md
+++ b/.claude/rules/sim-list-ordering.md
@@ -26,6 +26,54 @@ Left-to-right becomes top-to-bottom. A toolbar reading `Filter · Sort · Export
 
 Platform-only entries (desktop **Browser** and **Terminal**) trail the shared set rather than interleaving, so the common prefix is identical on every platform.
 
+## Grouping: one rule, before the destructive action
+
+Order is governed above. **Separators are governed here** — and the answer is: use at most one.
+
+Put a single `DropdownMenuSeparator` immediately before the destructive group (Delete, Leave,
+Close, Hide) and nowhere else. Everything above it runs uninterrupted in toolbar-mirroring order.
+
+```tsx
+// ✗ Bad — four semantic bands the user meets nowhere else
+Open in new tab │─── Rename, Lock │─── Duplicate, Export │─── Delete
+
+// ✓ Good — one rule, isolating the irreversible action
+Open in new tab, Rename, Lock, Duplicate, Export │─── Delete
+```
+
+**Why one.** No toolbar in this app renders a divider — every header is a flat
+`HEADER_ACTION_CLUSTER` (`gap-1`) chip row and every bulk action bar a flat `gap-[5px]` run. A
+menu banded into navigation / status / edit / copy / destructive therefore teaches a taxonomy
+that appears on no other surface, and because each band is conditional, the same action lands in
+a different group depending on which sibling items happen to be visible. The one thing a rule
+genuinely buys is a stop before the action you cannot undo.
+
+A second rule is justified only when a menu mixes genuinely different *scopes* — cell-level and
+table-level actions in one menu, say — not different verbs.
+
+**Both sides of every rule must be guaranteed non-empty.** Write the separator's guard out of
+the *exact* render conditions of the items around it, never a looser approximation:
+
+```tsx
+// ✗ Bad — `showLeave` alone, while the Leave item needs `showLeave && onLeave`.
+//         A caller passing showLeave from a permission check with a conditional
+//         onLeave renders a trailing rule under the last item.
+{hasActionsAbove && (showLeave || showDelete) && <DropdownMenuSeparator />}
+
+// ✓ Good — each term is the item's own condition, verbatim
+const hasDestructiveSection = (showLeave && onLeave) || showDelete
+{hasActionsAboveDestructive && hasDestructiveSection && <DropdownMenuSeparator />}
+```
+
+This is the failure that put a dangling rule at the bottom of the logs row menu, where two
+unconditional separators sat above conditional items.
+
+**Do not add a prop to move a rule.** The shared workflow context menu grew
+`groupNonDestructiveActions` and `separateNavigationAction` for this; between them they moved one
+separator for one caller, four of six branches were unreachable, and `separateNavigationAction`
+had no observable effect anywhere in the repo. Both are gone. A menu that wants different
+grouping wants the standard grouping.
+
 ## Encode the order once
 
 An order duplicated across surfaces is an order that will drift. Export **one** constant and sort by it — do not hand-maintain a matching literal per menu.

--- a/.claude/rules/sim-list-ordering.md
+++ b/.claude/rules/sim-list-ordering.md
@@ -26,12 +26,20 @@ Left-to-right becomes top-to-bottom. A toolbar reading `Filter · Sort · Export
 
 Platform-only entries (desktop **Browser** and **Terminal**) trail the shared set rather than interleaving, so the common prefix is identical on every platform.
 
-## Grouping: one rule, before the destructive action
+## Grouping: one rule, against the consequential group
 
 Order is governed above. **Separators are governed here** — and the answer is: use at most one.
 
-Put a single `DropdownMenuSeparator` immediately before the destructive group (Delete, Leave,
-Close, Hide) and nowhere else. Everything above it runs uninterrupted in toolbar-mirroring order.
+Put a single `DropdownMenuSeparator` against the **consequential group** — the actions that
+delete, detach, or change a run — and nowhere else. Everything on the other side of it runs
+uninterrupted in toolbar-mirroring order.
+
+That group trails in almost every menu, so in practice the rule reads "one rule immediately
+before Delete / Leave / Close / Hide". It leads in exactly one place: the **logs row menu**,
+where `Retry` and `Cancel Run` are the primary actions on a failed run and sit at the top, with
+the rule beneath them. Ordering follows the surface (see "The rule" above); the separator simply
+fences whichever end the consequential group occupies. A menu whose consequential actions are
+merely *disabled* still gets no extra rule — `disabled` is not a group.
 
 ```tsx
 // ✗ Bad — four semantic bands the user meets nowhere else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,9 @@ Co-locate a `search-params.ts` per feature exporting the parser map (single sour
 
 A list orders itself the way the user already reads the same things somewhere else. Resource menus (`+` attach, `@` mention, resource-tab `+`) mirror the **sidebar** top-down; a row or root **context menu** mirrors that surface's **toolbar**, left-to-right becoming top-to-bottom; tab strips mirror their nav. Platform-only entries (desktop Browser, Terminal) trail the shared set.
 
-Encode the order in ONE exported constant and sort by it — never a hand-maintained literal per menu (`RESOURCE_MENU_ORDER` / `byResourceMenuOrder` in `home/components/mothership-view/components/resource-registry`). Render mixed item kinds in a single ordered pass; emitting all submenu-backed families and then all flat ones silently pins every submenu to the top no matter what the constant says. Divergence is allowed only for search ranking, user-controlled ordering, and recency. Full rule in `.claude/rules/sim-list-ordering.md`.
+Encode the order in ONE exported constant and sort by it — never a hand-maintained literal per menu (`RESOURCE_MENU_ORDER` / `byResourceMenuOrder` in `home/components/mothership-view/components/resource-registry`). Render mixed item kinds in a single ordered pass; emitting all submenu-backed families and then all flat ones silently pins every submenu to the top no matter what the constant says. Divergence is allowed only for search ranking, user-controlled ordering, and recency.
+
+**Grouping**: at most ONE `DropdownMenuSeparator` per menu, immediately before the destructive group (Delete/Leave/Close/Hide). No toolbar in the app renders a divider, so multi-band menus teach a taxonomy that exists on no other surface. Build each separator's guard from the EXACT render conditions of the items on both sides — a looser guard is what leaves a dangling rule when its group is conditional. Never add a prop to move a rule. Full rule in `.claude/rules/sim-list-ordering.md`.
 
 ## Styling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,7 +388,7 @@ A list orders itself the way the user already reads the same things somewhere el
 
 Encode the order in ONE exported constant and sort by it — never a hand-maintained literal per menu (`RESOURCE_MENU_ORDER` / `byResourceMenuOrder` in `home/components/mothership-view/components/resource-registry`). Render mixed item kinds in a single ordered pass; emitting all submenu-backed families and then all flat ones silently pins every submenu to the top no matter what the constant says. Divergence is allowed only for search ranking, user-controlled ordering, and recency.
 
-**Grouping**: at most ONE `DropdownMenuSeparator` per menu, immediately before the destructive group (Delete/Leave/Close/Hide). No toolbar in the app renders a divider, so multi-band menus teach a taxonomy that exists on no other surface. Build each separator's guard from the EXACT render conditions of the items on both sides — a looser guard is what leaves a dangling rule when its group is conditional. Never add a prop to move a rule. Full rule in `.claude/rules/sim-list-ordering.md`.
+**Grouping**: at most ONE `DropdownMenuSeparator` per menu, fencing the consequential group — immediately before Delete/Leave/Close/Hide in almost every menu, and immediately after Retry/Cancel Run in the logs row menu, where those lead. No toolbar in the app renders a divider, so multi-band menus teach a taxonomy that exists on no other surface. Build each separator's guard from the EXACT render conditions of the items on both sides — a looser guard is what leaves a dangling rule when its group is conditional. Never add a prop to move a rule. Full rule in `.claude/rules/sim-list-ordering.md`.
 
 ## Styling
 

--- a/apps/sim/app/workspace/[workspaceId]/components/folders/folder-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/folders/folder-context-menu.tsx
@@ -91,7 +91,6 @@ export const FolderContextMenu = memo(function FolderContextMenu({
         )}
         {canEdit && (
           <>
-            <DropdownMenuSeparator />
             <DropdownMenuItem onSelect={onRename}>
               <Pencil />
               Rename

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-row-context-menu/file-row-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-row-context-menu/file-row-context-menu.tsx
@@ -55,6 +55,16 @@ export const FileRowContextMenu = memo(function FileRowContextMenu({
 }: FileRowContextMenuProps) {
   const isMultiSelect = selectedCount > 1
 
+  /**
+   * Everything that can render above `Delete`: Open/Pin need a single selection,
+   * Download needs its handler, and the edit trio needs `canEdit` — so a multi-select
+   * with no download and only a move target leaves `Move to` alone above the rule.
+   *
+   * @see `.claude/rules/sim-list-ordering.md` — one rule, before the destructive group.
+   */
+  const hasActionsAboveDestructive =
+    !isMultiSelect || !!onDownload || (!!onMove && !!moveOptions && moveOptions.length > 0)
+
   return (
     <DropdownMenu open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
       <DropdownMenuTrigger asChild>
@@ -91,7 +101,6 @@ export const FileRowContextMenu = memo(function FileRowContextMenu({
         )}
         {canEdit && (
           <>
-            <DropdownMenuSeparator />
             {!isMultiSelect && (
               <DropdownMenuItem onSelect={onRename}>
                 <Pencil />
@@ -120,6 +129,7 @@ export const FileRowContextMenu = memo(function FileRowContextMenu({
                 </DropdownMenuSubContent>
               </DropdownMenuSub>
             )}
+            {hasActionsAboveDestructive && <DropdownMenuSeparator />}
             <DropdownMenuItem onSelect={onDelete}>
               <Trash />
               {isMultiSelect ? `Delete ${selectedCount} items` : 'Delete'}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/files-list-context-menu/files-list-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/files-list-context-menu/files-list-context-menu.tsx
@@ -48,7 +48,7 @@ export const FilesListContextMenu = memo(function FilesListContextMenu({
         {onUploadFile && (
           <DropdownMenuItem disabled={disableUpload} onSelect={onUploadFile}>
             <Upload />
-            Upload file
+            Upload
           </DropdownMenuItem>
         )}
         {onCreateFolder && (

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-tab-strip.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/browser-session/browser-tab-strip.tsx
@@ -216,9 +216,7 @@ export function BrowserTabStrip({
           onOpenInNewTab={openTabInExternalBrowser}
           openInNewTabLabel='Open in External Browser'
           openInNewTabPosition='last'
-          separateNavigationAction
           showOpenInNewTab={Boolean(contextTab?.url && contextTab.url !== 'about:blank')}
-          groupNonDestructiveActions
           onTogglePin={
             contextTab ? () => onSetTabPinned(contextTab.tabId, !contextTab.pinned) : undefined
           }

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/chunk-context-menu/chunk-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/chunk-context-menu/chunk-context-menu.tsx
@@ -71,7 +71,6 @@ export function ChunkContextMenu({
   const hasEditSection = !isMultiSelect && (!!onEdit || !!onCopyContent)
   const hasStateSection = !!onToggleEnabled
   const hasDestructiveSection = !!onDelete
-  /** @see `.claude/rules/sim-list-ordering.md` — one rule, before the destructive group. */
   const hasActionsAboveDestructive = hasNavigationSection || hasEditSection || hasStateSection
 
   return (

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/chunk-context-menu/chunk-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/chunk-context-menu/chunk-context-menu.tsx
@@ -71,6 +71,8 @@ export function ChunkContextMenu({
   const hasEditSection = !isMultiSelect && (!!onEdit || !!onCopyContent)
   const hasStateSection = !!onToggleEnabled
   const hasDestructiveSection = !!onDelete
+  /** @see `.claude/rules/sim-list-ordering.md` — one rule, before the destructive group. */
+  const hasActionsAboveDestructive = hasNavigationSection || hasEditSection || hasStateSection
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
@@ -102,11 +104,6 @@ export function ChunkContextMenu({
                 Open in new tab
               </DropdownMenuItem>
             )}
-            {hasNavigationSection &&
-              (hasEditSection || hasStateSection || hasDestructiveSection) && (
-                <DropdownMenuSeparator />
-              )}
-
             {!isMultiSelect && onEdit && (
               <DropdownMenuItem disabled={disableEdit} onSelect={onEdit}>
                 <Pencil />
@@ -119,10 +116,6 @@ export function ChunkContextMenu({
                 Copy content
               </DropdownMenuItem>
             )}
-            {hasEditSection && (hasStateSection || hasDestructiveSection) && (
-              <DropdownMenuSeparator />
-            )}
-
             {onToggleEnabled && (
               <DropdownMenuItem disabled={disableToggleEnabled} onSelect={onToggleEnabled}>
                 <Eye />
@@ -130,7 +123,7 @@ export function ChunkContextMenu({
               </DropdownMenuItem>
             )}
 
-            {hasStateSection && hasDestructiveSection && <DropdownMenuSeparator />}
+            {hasActionsAboveDestructive && hasDestructiveSection && <DropdownMenuSeparator />}
             {onDelete && (
               <DropdownMenuItem disabled={disableDelete} onSelect={onDelete}>
                 <Trash />

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/chunk-context-menu/chunk-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/[documentId]/components/chunk-context-menu/chunk-context-menu.tsx
@@ -33,7 +33,7 @@ interface ChunkContextMenuProps {
 
 /**
  * Context menu for chunks table.
- * Shows chunk actions when right-clicking a row, or "Create chunk" when right-clicking empty space.
+ * Shows chunk actions when right-clicking a row, or "New chunk" when right-clicking empty space.
  * Supports batch operations when multiple chunks are selected.
  */
 export function ChunkContextMenu({
@@ -135,7 +135,7 @@ export function ChunkContextMenu({
           onAddChunk && (
             <DropdownMenuItem disabled={disableAddChunk} onSelect={onAddChunk}>
               <Plus />
-              Create chunk
+              New chunk
             </DropdownMenuItem>
           )
         )}

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/document-context-menu/document-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/document-context-menu/document-context-menu.tsx
@@ -141,7 +141,7 @@ export function DocumentContextMenu({
           onAddDocument && (
             <DropdownMenuItem disabled={disableAddDocument} onSelect={onAddDocument}>
               <Plus />
-              Add document
+              New documents
             </DropdownMenuItem>
           )
         )}

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/document-context-menu/document-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/document-context-menu/document-context-menu.tsx
@@ -71,6 +71,8 @@ export function DocumentContextMenu({
   const hasEditSection = !isMultiSelect && (!!onRename || !!onViewTags)
   const hasStateSection = !!onToggleEnabled
   const hasDestructiveSection = !!onDelete
+  /** @see `.claude/rules/sim-list-ordering.md` — one rule, before the destructive group. */
+  const hasActionsAboveDestructive = hasNavigationSection || hasEditSection || hasStateSection
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
@@ -108,11 +110,6 @@ export function DocumentContextMenu({
                 Open source
               </DropdownMenuItem>
             )}
-            {hasNavigationSection &&
-              (hasEditSection || hasStateSection || hasDestructiveSection) && (
-                <DropdownMenuSeparator />
-              )}
-
             {!isMultiSelect && onRename && (
               <DropdownMenuItem disabled={disableRename} onSelect={onRename}>
                 <Pencil />
@@ -125,10 +122,6 @@ export function DocumentContextMenu({
                 Tags
               </DropdownMenuItem>
             )}
-            {hasEditSection && (hasStateSection || hasDestructiveSection) && (
-              <DropdownMenuSeparator />
-            )}
-
             {onToggleEnabled && (
               <DropdownMenuItem disabled={disableToggleEnabled} onSelect={onToggleEnabled}>
                 <Eye />
@@ -136,7 +129,7 @@ export function DocumentContextMenu({
               </DropdownMenuItem>
             )}
 
-            {hasStateSection && hasDestructiveSection && <DropdownMenuSeparator />}
+            {hasActionsAboveDestructive && hasDestructiveSection && <DropdownMenuSeparator />}
             {onDelete && (
               <DropdownMenuItem disabled={disableDelete} onSelect={onDelete}>
                 <Trash />

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/document-context-menu/document-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/document-context-menu/document-context-menu.tsx
@@ -71,7 +71,6 @@ export function DocumentContextMenu({
   const hasEditSection = !isMultiSelect && (!!onRename || !!onViewTags)
   const hasStateSection = !!onToggleEnabled
   const hasDestructiveSection = !!onDelete
-  /** @see `.claude/rules/sim-list-ordering.md` — one rule, before the destructive group. */
   const hasActionsAboveDestructive = hasNavigationSection || hasEditSection || hasStateSection
 
   return (

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/knowledge-base-context-menu/knowledge-base-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/knowledge-base-context-menu/knowledge-base-context-menu.tsx
@@ -75,7 +75,6 @@ export const KnowledgeBaseContextMenu = memo(function KnowledgeBaseContextMenu({
   const hasMoveSection = !disableEdit && !!onMove && !!moveOptions && moveOptions.length > 0
   const hasEditSection = (showEdit && !!onEdit) || hasMoveSection
   const hasDestructiveSection = showDelete && !!onDelete
-  /** @see `.claude/rules/sim-list-ordering.md` — one rule, before the destructive group. */
   const hasActionsAboveDestructive = hasNavigationSection || hasInfoSection || hasEditSection
 
   return (

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/components/knowledge-base-context-menu/knowledge-base-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/components/knowledge-base-context-menu/knowledge-base-context-menu.tsx
@@ -75,6 +75,8 @@ export const KnowledgeBaseContextMenu = memo(function KnowledgeBaseContextMenu({
   const hasMoveSection = !disableEdit && !!onMove && !!moveOptions && moveOptions.length > 0
   const hasEditSection = (showEdit && !!onEdit) || hasMoveSection
   const hasDestructiveSection = showDelete && !!onDelete
+  /** @see `.claude/rules/sim-list-ordering.md` — one rule, before the destructive group. */
+  const hasActionsAboveDestructive = hasNavigationSection || hasInfoSection || hasEditSection
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
@@ -104,10 +106,6 @@ export const KnowledgeBaseContextMenu = memo(function KnowledgeBaseContextMenu({
             Open in new tab
           </DropdownMenuItem>
         )}
-        {hasNavigationSection && (hasInfoSection || hasEditSection || hasDestructiveSection) && (
-          <DropdownMenuSeparator />
-        )}
-
         {showViewTags && onViewTags && (
           <DropdownMenuItem onSelect={onViewTags}>
             <TagIcon />
@@ -126,8 +124,6 @@ export const KnowledgeBaseContextMenu = memo(function KnowledgeBaseContextMenu({
             {pinned ? 'Unpin' : 'Pin'}
           </DropdownMenuItem>
         )}
-        {hasInfoSection && (hasEditSection || hasDestructiveSection) && <DropdownMenuSeparator />}
-
         {showEdit && onEdit && (
           <DropdownMenuItem disabled={disableEdit} onSelect={onEdit}>
             <Pencil />
@@ -147,7 +143,7 @@ export const KnowledgeBaseContextMenu = memo(function KnowledgeBaseContextMenu({
           </DropdownMenuSub>
         )}
 
-        {hasEditSection && hasDestructiveSection && <DropdownMenuSeparator />}
+        {hasActionsAboveDestructive && hasDestructiveSection && <DropdownMenuSeparator />}
         {showDelete && onDelete && (
           <DropdownMenuItem disabled={disableDelete} onSelect={onDelete}>
             <Trash />

--- a/apps/sim/app/workspace/[workspaceId]/logs/components/log-row-context-menu/log-row-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/logs/components/log-row-context-menu/log-row-context-menu.tsx
@@ -103,23 +103,18 @@ export const LogRowContextMenu = memo(function LogRowContextMenu({
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
         {isRetryable && (
-          <>
-            <DropdownMenuItem onSelect={onRetryExecution} disabled={isRetryPending}>
-              <Redo />
-              {isRetryPending ? 'Retrying...' : 'Retry'}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
+          <DropdownMenuItem onSelect={onRetryExecution} disabled={isRetryPending}>
+            <Redo />
+            {isRetryPending ? 'Retrying...' : 'Retry'}
+          </DropdownMenuItem>
         )}
         {showCancelAction && (
-          <>
-            <DropdownMenuItem onSelect={onCancelExecution} disabled={isStopping}>
-              <X />
-              {isStopping ? 'Stopping…' : 'Cancel Run'}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
+          <DropdownMenuItem onSelect={onCancelExecution} disabled={isStopping}>
+            <X />
+            {isStopping ? 'Stopping…' : 'Cancel Run'}
+          </DropdownMenuItem>
         )}
+        {(isRetryable || showCancelAction) && <DropdownMenuSeparator />}
         <DropdownMenuItem disabled={!hasExecutionId} onSelect={onCopyExecutionId}>
           <Duplicate />
           Copy Run ID
@@ -128,8 +123,6 @@ export const LogRowContextMenu = memo(function LogRowContextMenu({
           <Link />
           Copy Link
         </DropdownMenuItem>
-
-        <DropdownMenuSeparator />
         <DropdownMenuItem disabled={!hasOpenableWorkflow} onSelect={onOpenWorkflow}>
           <SquareArrowUpRight />
           Open Workflow
@@ -138,8 +131,6 @@ export const LogRowContextMenu = memo(function LogRowContextMenu({
           <Eye />
           Open Snapshot
         </DropdownMenuItem>
-
-        <DropdownMenuSeparator />
         {!isFilteredByThisWorkflow && (
           <DropdownMenuItem disabled={!hasWorkflow} onSelect={onToggleWorkflowFilter}>
             <ListFilter />

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/context-menu/context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/context-menu/context-menu.tsx
@@ -169,13 +169,10 @@ export function ContextMenu({
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
         {onAddToChat && (
-          <>
-            <DropdownMenuItem onSelect={onAddToChat}>
-              <Blimp />
-              {addToChatLabel}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
+          <DropdownMenuItem onSelect={onAddToChat}>
+            <Blimp />
+            {addToChatLabel}
+          </DropdownMenuItem>
         )}
         {contextMenu.columnName && canEditCell && (
           <DropdownMenuItem disabled={disableEdit} onSelect={onEditCell}>

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
@@ -160,34 +160,31 @@ export function ColumnOptionsMenu({
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
         {showRunActions && (
-          <>
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <PlayOutline />
-                Run
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                {showRunSelected && (
-                  <DropdownMenuItem onSelect={() => onRunColumnSelected?.()}>
-                    {`Run ${selectedRowCount} selected ${selectedRowCount === 1 ? 'row' : 'rows'}`}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <PlayOutline />
+              Run
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {showRunSelected && (
+                <DropdownMenuItem onSelect={() => onRunColumnSelected?.()}>
+                  {`Run ${selectedRowCount} selected ${selectedRowCount === 1 ? 'row' : 'rows'}`}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem onSelect={() => onRunColumnAll?.()}>
+                {runLabels.all}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onRunColumnIncomplete?.()}>
+                {runLabels.incomplete}
+              </DropdownMenuItem>
+              {onRunColumnLimited &&
+                LIMITED_RUN_PRESETS.map((max) => (
+                  <DropdownMenuItem key={max} onSelect={() => onRunColumnLimited(max)}>
+                    {runLabels.limited(max)}
                   </DropdownMenuItem>
-                )}
-                <DropdownMenuItem onSelect={() => onRunColumnAll?.()}>
-                  {runLabels.all}
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => onRunColumnIncomplete?.()}>
-                  {runLabels.incomplete}
-                </DropdownMenuItem>
-                {onRunColumnLimited &&
-                  LIMITED_RUN_PRESETS.map((max) => (
-                    <DropdownMenuItem key={max} onSelect={() => onRunColumnLimited(max)}>
-                      {runLabels.limited(max)}
-                    </DropdownMenuItem>
-                  ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-            <DropdownMenuSeparator />
-          </>
+                ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
         )}
         {/* Sort leads the column-scoped block: the options bar reads Filter ·
             Sort · Columns, and this menu carries no Filter item, so Sort is the
@@ -217,7 +214,6 @@ export function ColumnOptionsMenu({
               <ArrowDown />
               Sort descending
             </DropdownMenuItem>
-            <DropdownMenuSeparator />
           </>
         )}
         {onViewWorkflow && (
@@ -236,7 +232,6 @@ export function ColumnOptionsMenu({
             {isPinned ? 'Unpin column' : 'Pin column'}
           </DropdownMenuItem>
         )}
-        <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => onInsertLeft(column.key)}>
           <ArrowLeft />
           Insert column left

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
@@ -44,6 +44,12 @@ const LIMITED_RUN_PRESETS = [10, 1000] as const
 /** Labels for the table-scoped run items. With an active filter the run is
  *  scoped to matching rows, so the labels say "filtered rows" to make the
  *  narrowed target visible. Shared by both menu surfaces. */
+/**
+ * Incomplete before all, matching the action bar and the row context menu, which both
+ * present Play (empty or failed) ahead of Refresh (every row). These two menus read the
+ * same four run actions the user already met on the action bar, so they must not invert
+ * the pair — see `.claude/rules/sim-list-ordering.md`.
+ */
 function runMenuLabels(hasActiveFilter: boolean) {
   const rows = hasActiveFilter ? 'filtered rows' : 'rows'
   return {
@@ -171,11 +177,11 @@ export function ColumnOptionsMenu({
                   {`Run ${selectedRowCount} selected ${selectedRowCount === 1 ? 'row' : 'rows'}`}
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem onSelect={() => onRunColumnAll?.()}>
-                {runLabels.all}
-              </DropdownMenuItem>
               <DropdownMenuItem onSelect={() => onRunColumnIncomplete?.()}>
                 {runLabels.incomplete}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onRunColumnAll?.()}>
+                {runLabels.all}
               </DropdownMenuItem>
               {onRunColumnLimited &&
                 LIMITED_RUN_PRESETS.map((max) => (
@@ -510,10 +516,10 @@ export function WorkflowGroupMetaCell({
                   {`Run ${selectedCount} selected ${selectedCount === 1 ? 'row' : 'rows'}`}
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem onSelect={handleRunAll}>{runLabels.all}</DropdownMenuItem>
               <DropdownMenuItem onSelect={handleRunIncomplete}>
                 {runLabels.incomplete}
               </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleRunAll}>{runLabels.all}</DropdownMenuItem>
               {LIMITED_RUN_PRESETS.map((max) => (
                 <DropdownMenuItem key={max} onSelect={() => handleRunLimited(max)}>
                   {runLabels.limited(max)}

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/headers/workflow-group-meta-cell.tsx
@@ -180,15 +180,15 @@ export function ColumnOptionsMenu({
               <DropdownMenuItem onSelect={() => onRunColumnIncomplete?.()}>
                 {runLabels.incomplete}
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => onRunColumnAll?.()}>
-                {runLabels.all}
-              </DropdownMenuItem>
               {onRunColumnLimited &&
                 LIMITED_RUN_PRESETS.map((max) => (
                   <DropdownMenuItem key={max} onSelect={() => onRunColumnLimited(max)}>
                     {runLabels.limited(max)}
                   </DropdownMenuItem>
                 ))}
+              <DropdownMenuItem onSelect={() => onRunColumnAll?.()}>
+                {runLabels.all}
+              </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
         )}
@@ -519,12 +519,12 @@ export function WorkflowGroupMetaCell({
               <DropdownMenuItem onSelect={handleRunIncomplete}>
                 {runLabels.incomplete}
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={handleRunAll}>{runLabels.all}</DropdownMenuItem>
               {LIMITED_RUN_PRESETS.map((max) => (
                 <DropdownMenuItem key={max} onSelect={() => handleRunLimited(max)}>
                   {runLabels.limited(max)}
                 </DropdownMenuItem>
               ))}
+              <DropdownMenuItem onSelect={handleRunAll}>{runLabels.all}</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/apps/sim/app/workspace/[workspaceId]/tables/components/table-context-menu/table-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/components/table-context-menu/table-context-menu.tsx
@@ -114,8 +114,6 @@ export function TableContextMenu({
             </DropdownMenuSubContent>
           </DropdownMenuSub>
         )}
-        {(onViewSchema || onRename || onImportCsv || onExportCsv || onMove) &&
-          (onCopyId || onTogglePin || onDelete) && <DropdownMenuSeparator />}
         {onTogglePin && (
           <DropdownMenuItem onSelect={onTogglePin}>
             <Pin />
@@ -128,7 +126,14 @@ export function TableContextMenu({
             Copy ID
           </DropdownMenuItem>
         )}
-        {(onCopyId || onTogglePin) && onDelete && <DropdownMenuSeparator />}
+        {(onViewSchema ||
+          onRename ||
+          onImportCsv ||
+          onExportCsv ||
+          onMove ||
+          onCopyId ||
+          onTogglePin) &&
+          onDelete && <DropdownMenuSeparator />}
         {onDelete && (
           <DropdownMenuItem disabled={disableDelete} onSelect={onDelete}>
             <Trash />

--- a/apps/sim/app/workspace/[workspaceId]/tables/components/table-context-menu/table-context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/components/table-context-menu/table-context-menu.tsx
@@ -57,6 +57,23 @@ export function TableContextMenu({
   disableImport = false,
   disableExport = false,
 }: TableContextMenuProps) {
+  /**
+   * `Move to` needs a NON-EMPTY `moveOptions`, not just the handler — the looser
+   * `onMove` alone draws the rule with nothing above it for a table whose other
+   * actions are all absent and whose move list is empty.
+   *
+   * @see `.claude/rules/sim-list-ordering.md` — one rule, before the destructive
+   * group, with both sides built from the items' exact render conditions.
+   */
+  const hasActionsAboveDestructive =
+    onViewSchema ||
+    onRename ||
+    onImportCsv ||
+    onExportCsv ||
+    (onMove && moveOptions && moveOptions.length > 0) ||
+    onCopyId ||
+    onTogglePin
+
   return (
     <DropdownMenu open={isOpen} onOpenChange={(open) => !open && onClose()} modal={false}>
       <DropdownMenuTrigger asChild>
@@ -126,14 +143,7 @@ export function TableContextMenu({
             Copy ID
           </DropdownMenuItem>
         )}
-        {(onViewSchema ||
-          onRename ||
-          onImportCsv ||
-          onExportCsv ||
-          onMove ||
-          onCopyId ||
-          onTogglePin) &&
-          onDelete && <DropdownMenuSeparator />}
+        {hasActionsAboveDestructive && onDelete && <DropdownMenuSeparator />}
         {onDelete && (
           <DropdownMenuItem disabled={disableDelete} onSelect={onDelete}>
             <Trash />

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.test.tsx
@@ -138,15 +138,6 @@ describe('sidebar context menu dismissal', () => {
   })
 })
 
-/**
- * Separator invariants. The menu carries exactly one rule, immediately before the
- * destructive group, and it may never render with an empty group on either side —
- * see the grouping section of `.claude/rules/sim-list-ordering.md`.
- *
- * These pin the shape the flag matrix used to get wrong: `showLeave` in the rule's
- * guard without the `&& onLeave` its item requires produced a trailing rule under
- * the last item, and nothing covered it.
- */
 describe('separators', () => {
   function renderWith(props: Partial<React.ComponentProps<typeof ContextMenu>>) {
     ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -169,7 +160,6 @@ describe('separators', () => {
     )
   }
 
-  /** Menu children in render order, each as 'sep' or its label. */
   function menuShape(): string[] {
     const content = document.querySelector('[role="menu"]')
     if (!content) return []

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.test.tsx
@@ -137,3 +137,118 @@ describe('sidebar context menu dismissal', () => {
     expect(onClose).toHaveBeenCalled()
   })
 })
+
+/**
+ * Separator invariants. The menu carries exactly one rule, immediately before the
+ * destructive group, and it may never render with an empty group on either side —
+ * see the grouping section of `.claude/rules/sim-list-ordering.md`.
+ *
+ * These pin the shape the flag matrix used to get wrong: `showLeave` in the rule's
+ * guard without the `&& onLeave` its item requires produced a trailing rule under
+ * the last item, and nothing covered it.
+ */
+describe('separators', () => {
+  function renderWith(props: Partial<React.ComponentProps<typeof ContextMenu>>) {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() =>
+      root?.render(
+        <ContextMenu
+          isOpen
+          position={{ x: 10, y: 10 }}
+          menuRef={{ current: null }}
+          onClose={() => {}}
+          onDelete={() => {}}
+          showRename={false}
+          showDuplicate={false}
+          {...props}
+        />
+      )
+    )
+  }
+
+  /** Menu children in render order, each as 'sep' or its label. */
+  function menuShape(): string[] {
+    const content = document.querySelector('[role="menu"]')
+    if (!content) return []
+    return Array.from(content.children).map((el) =>
+      el.getAttribute('role') === 'separator' ? 'sep' : (el.textContent ?? '')
+    )
+  }
+
+  it('puts its one rule directly before the destructive action', () => {
+    renderWith({ showRename: true, onRename: () => {}, showDelete: true })
+    const shape = menuShape()
+    expect(shape.filter((s) => s === 'sep')).toHaveLength(1)
+    expect(shape[shape.indexOf('sep') + 1]).toBe('Delete')
+  })
+
+  it('renders no rule when nothing precedes the destructive action', () => {
+    renderWith({ showDelete: true })
+    expect(menuShape()).toEqual(['Delete'])
+  })
+
+  it('renders no rule when there is no destructive action', () => {
+    renderWith({ showRename: true, onRename: () => {}, showDelete: false })
+    const shape = menuShape()
+    expect(shape).not.toContain('sep')
+    expect(shape).toEqual(['Rename'])
+  })
+
+  it('never trails a rule when showLeave is set without an onLeave handler', () => {
+    renderWith({
+      showRename: true,
+      onRename: () => {},
+      showLeave: true,
+      onLeave: undefined,
+      showDelete: false,
+    })
+    const shape = menuShape()
+    expect(shape.at(-1)).not.toBe('sep')
+    expect(shape).toEqual(['Rename'])
+  })
+
+  it('draws the rule for Leave when its handler is present', () => {
+    renderWith({
+      showRename: true,
+      onRename: () => {},
+      showLeave: true,
+      onLeave: () => {},
+      showDelete: false,
+    })
+    expect(menuShape()).toEqual(['Rename', 'sep', 'Leave'])
+  })
+
+  it('never renders two rules back to back across a broad flag sweep', () => {
+    const noop = () => {}
+    for (const showOpenInNewTab of [true, false]) {
+      for (const showPin of [true, false]) {
+        for (const showLock of [true, false]) {
+          for (const showExport of [true, false]) {
+            for (const showDelete of [true, false]) {
+              act(() => root?.unmount())
+              container?.remove()
+              renderWith({
+                showOpenInNewTab,
+                onOpenInNewTab: noop,
+                showPin,
+                onTogglePin: noop,
+                showLock,
+                onToggleLock: noop,
+                showExport,
+                onExport: noop,
+                showDelete,
+              })
+              const shape = menuShape()
+              expect(shape.filter((s) => s === 'sep').length).toBeLessThanOrEqual(1)
+              expect(shape.at(0)).not.toBe('sep')
+              expect(shape.at(-1)).not.toBe('sep')
+            }
+          }
+        }
+      }
+    }
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
@@ -185,6 +185,9 @@ export function ContextMenu({
    * rendered a trailing rule under the last item.
    */
   const hasActionsAboveDestructive =
+    /* No `openInNewTabPosition` term: the item renders in the 'first' slot or the
+       'last' one, and the prop is a closed two-value union, so `showOpenInNewTab &&
+       onOpenInNewTab` already means exactly "the nav item renders somewhere above". */
     (showOpenInNewTab && onOpenInNewTab) ||
     (showMarkAsRead && onMarkAsRead) ||
     (showMarkAsUnread && onMarkAsUnread) ||

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
@@ -165,29 +165,7 @@ export function ContextMenu({
   showUploadLogo = false,
   disableUploadLogo = false,
 }: ContextMenuProps) {
-  /**
-   * One rule, immediately before the destructive group — see the menu-grouping
-   * section of `.claude/rules/sim-list-ordering.md`.
-   *
-   * This menu previously carried four semantic bands (navigation / status / edit /
-   * copy / destructive) behind up to five separators. No toolbar in the app renders
-   * a divider — every header is a flat `gap-1` chip row — so those bands taught a
-   * taxonomy the user met nowhere else, and each caller's flag combination banded
-   * the same action differently (Pin alone here, Pin beside Duplicate there). Order
-   * still mirrors the surface's toolbar, which is what the ordering rule actually
-   * requires; only the rules between groups are gone.
-   *
-   * Every term below is the exact render condition of the item it stands for, so a
-   * separator can never outlive the group on either side of it. `showLeave` was the
-   * one asymmetric term — it omitted `&& onLeave`, so a caller passing `showLeave`
-   * from a permission check with a conditional `onLeave` (the `x ? fn : undefined`
-   * shape used for `onDuplicate`/`onTogglePin`/`onCloseTab` elsewhere) would have
-   * rendered a trailing rule under the last item.
-   */
   const hasActionsAboveDestructive =
-    /* No `openInNewTabPosition` term: the item renders in the 'first' slot or the
-       'last' one, and the prop is a closed two-value union, so `showOpenInNewTab &&
-       onOpenInNewTab` already means exactly "the nav item renders somewhere above". */
     (showOpenInNewTab && onOpenInNewTab) ||
     (showMarkAsRead && onMarkAsRead) ||
     (showMarkAsUnread && onMarkAsUnread) ||

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workflow-list/components/context-menu/context-menu.tsx
@@ -35,8 +35,6 @@ interface ContextMenuProps {
   onOpenInNewTab?: () => void
   openInNewTabLabel?: string
   openInNewTabPosition?: 'first' | 'last'
-  separateNavigationAction?: boolean
-  groupNonDestructiveActions?: boolean
   onMarkAsRead?: () => void
   onMarkAsUnread?: () => void
   onTogglePin?: () => void
@@ -121,8 +119,6 @@ export function ContextMenu({
   onOpenInNewTab,
   openInNewTabLabel = 'Open in new tab',
   openInNewTabPosition = 'first',
-  separateNavigationAction = false,
-  groupNonDestructiveActions = false,
   onMarkAsRead,
   onMarkAsUnread,
   onTogglePin,
@@ -169,18 +165,43 @@ export function ContextMenu({
   showUploadLogo = false,
   disableUploadLogo = false,
 }: ContextMenuProps) {
-  const hasNavigationSection = showOpenInNewTab && onOpenInNewTab
-  const hasStatusSection =
+  /**
+   * One rule, immediately before the destructive group — see the menu-grouping
+   * section of `.claude/rules/sim-list-ordering.md`.
+   *
+   * This menu previously carried four semantic bands (navigation / status / edit /
+   * copy / destructive) behind up to five separators. No toolbar in the app renders
+   * a divider — every header is a flat `gap-1` chip row — so those bands taught a
+   * taxonomy the user met nowhere else, and each caller's flag combination banded
+   * the same action differently (Pin alone here, Pin beside Duplicate there). Order
+   * still mirrors the surface's toolbar, which is what the ordering rule actually
+   * requires; only the rules between groups are gone.
+   *
+   * Every term below is the exact render condition of the item it stands for, so a
+   * separator can never outlive the group on either side of it. `showLeave` was the
+   * one asymmetric term — it omitted `&& onLeave`, so a caller passing `showLeave`
+   * from a permission check with a conditional `onLeave` (the `x ? fn : undefined`
+   * shape used for `onDuplicate`/`onTogglePin`/`onCloseTab` elsewhere) would have
+   * rendered a trailing rule under the last item.
+   */
+  const hasActionsAboveDestructive =
+    (showOpenInNewTab && onOpenInNewTab) ||
     (showMarkAsRead && onMarkAsRead) ||
     (showMarkAsUnread && onMarkAsUnread) ||
-    (showPin && onTogglePin)
-  const hasEditSection =
+    (showPin && onTogglePin) ||
     (showRename && onRename) ||
     (showCreate && onCreate) ||
     (showCreateFolder && onCreateFolder) ||
     (showLock && onToggleLock) ||
-    (showUploadLogo && onUploadLogo)
-  const hasCopySection = (showDuplicate && onDuplicate) || (showExport && onExport)
+    (showUploadLogo && onUploadLogo) ||
+    (showDuplicate && onDuplicate) ||
+    (showExport && onExport)
+  const hasDestructiveSection =
+    (showLeave && onLeave) ||
+    showDelete ||
+    (showCloseTab && onCloseTab) ||
+    onCloseOtherTabs ||
+    onCloseTabsToRight
 
   /**
    * Only the "Rename" item should trigger the `onCloseAutoFocus` refocus below —
@@ -237,11 +258,6 @@ export function ContextMenu({
             {openInNewTabLabel}
           </DropdownMenuItem>
         )}
-        {openInNewTabPosition === 'first' &&
-          (!groupNonDestructiveActions || separateNavigationAction) &&
-          hasNavigationSection &&
-          (hasStatusSection || hasEditSection || hasCopySection) && <DropdownMenuSeparator />}
-
         {showMarkAsRead && onMarkAsRead && (
           <DropdownMenuItem
             disabled={disableMarkAsRead}
@@ -277,10 +293,6 @@ export function ContextMenu({
             {isPinned ? 'Unpin' : 'Pin'}
           </DropdownMenuItem>
         )}
-        {!groupNonDestructiveActions && hasStatusSection && (hasEditSection || hasCopySection) && (
-          <DropdownMenuSeparator />
-        )}
-
         {showRename && onRename && (
           <DropdownMenuItem
             disabled={disableRename}
@@ -343,9 +355,6 @@ export function ContextMenu({
           </DropdownMenuItem>
         )}
 
-        {!groupNonDestructiveActions && hasEditSection && hasCopySection && (
-          <DropdownMenuSeparator />
-        )}
         {showDuplicate && onDuplicate && (
           <DropdownMenuItem
             disabled={disableDuplicate}
@@ -370,10 +379,6 @@ export function ContextMenu({
             Export
           </DropdownMenuItem>
         )}
-        {openInNewTabPosition === 'last' &&
-          (!groupNonDestructiveActions || separateNavigationAction) &&
-          hasNavigationSection &&
-          (hasStatusSection || hasEditSection || hasCopySection) && <DropdownMenuSeparator />}
         {openInNewTabPosition === 'last' && showOpenInNewTab && onOpenInNewTab && (
           <DropdownMenuItem
             onSelect={() => {
@@ -386,12 +391,7 @@ export function ContextMenu({
           </DropdownMenuItem>
         )}
 
-        {(hasNavigationSection || hasStatusSection || hasEditSection || hasCopySection) &&
-          (showLeave ||
-            showDelete ||
-            (showCloseTab && onCloseTab) ||
-            onCloseOtherTabs ||
-            onCloseTabsToRight) && <DropdownMenuSeparator />}
+        {hasActionsAboveDestructive && hasDestructiveSection && <DropdownMenuSeparator />}
         {showLeave && onLeave && (
           <DropdownMenuItem
             disabled={disableLeave}


### PR DESCRIPTION
## Summary

Context menus banded themselves into semantic groups — navigation / status / edit / copy / destructive — behind **2–4 separators each**. **No toolbar in the app renders a divider**: every header is a flat `HEADER_ACTION_CLUSTER` (`gap-1`) chip row, every bulk action bar a flat `gap-[5px]` run. So the bands taught a taxonomy the user meets on no other surface, and since each band is conditional, the same action landed in a different group depending on which siblings were visible — `Pin` sat alone in one caller of the shared workflow menu and beside `Duplicate` in another.

Every menu now carries **at most one rule, immediately before the destructive group**. Order is untouched, so the toolbar-mirroring that `.claude/rules/sim-list-ordering.md` actually requires is unaffected.

| Menu | Before | After |
|---|---|---|
| Shared workflow/folder/chat/workspace/tab | 5 separator slots | 1 |
| Logs row | 4 | 1 |
| Column options | 4 | 1 |
| Knowledge base / document / chunk rows | 3 each | 1 each |
| Tables list row, table detail row | 2 each | 1 each |
| Files row | 2 (one at a permission boundary) | 1 (moved to before `Delete`) |

### Two separator bugs fixed

- **Logs row menu — user-visible today.** Two unconditional separators sat above conditional items, so a log already filtered by its workflow with no active filters ended on a dangling rule.
- **Shared workflow menu — latent.** The destructive rule was guarded on `showLeave` alone while the Leave item requires `showLeave && onLeave`. A caller passing `showLeave` from a permission check with a conditional `onLeave` — the `x ? fn : undefined` shape already used for `onDuplicate`/`onTogglePin`/`onCloseTab` at other call sites — would trail a rule under the last item. Every term in both guards is now the exact render condition of the item it stands for.

### Dead flags removed

`groupNonDestructiveActions` and `separateNavigationAction`. Between them they moved one separator for one caller (the browser tab strip), four of six reachable branches had no caller, and `separateNavigationAction` had **no observable effect anywhere in the repo** — its only caller set it to cancel out the other flag it also set.

### Rule documented

`.claude/rules/sim-list-ordering.md` governed order but said nothing about grouping, which is why this drifted per-file with nothing to converge on. Adds a grouping section: one rule before the destructive group, build each guard from the exact render conditions on both sides, and never add a prop to move a rule.

## Type of Change
- [x] Improvement
- [x] Bug fix

## Testing
The separator matrix was previously untested — the existing test only covered Radix focus dismissal, which is how the `showLeave` asymmetry survived. Added invariants: the rule sits directly before the destructive action, no rule when either side would be empty, the `showLeave`-without-handler case, and a 32-combination flag sweep asserting no menu ever renders two rules, a leading rule, or a trailing rule. Verified the `showLeave` test fails when the old guard is restored.

- `bun run check:audits` — 32/32 pass
- `bun run lint` — 26/26 pass
- `bun run type-check` — clean
- Tests: 1014 pass across the touched areas (sidebar, logs, tables, knowledge, files)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)