### PR TITLE
feat(providers): add OrcaRouter as a named provider

### DIFF
--- a/apps/docs/content/docs/en/workflows/blocks/agent.mdx
+++ b/apps/docs/content/docs/en/workflows/blocks/agent.mdx
@@ -25,7 +25,7 @@ Answer in two sentences, cite the doc you used, and never guess a price.
 
 ### Model
 
-The model that runs the step. Defaults to `claude-sonnet-4-6`. Type or pick any model from OpenAI, Anthropic, Google, xAI, Groq, Cerebras, DeepSeek, Azure, AWS Bedrock, Google Vertex, or OpenRouter, or a local model through Ollama or VLLM.
+The model that runs the step. Defaults to `claude-sonnet-4-6`. Type or pick any model from OpenAI, Anthropic, Google, xAI, Groq, Cerebras, DeepSeek, Azure, AWS Bedrock, Google Vertex, OpenRouter, or [OrcaRouter](https://www.orcarouter.ai), or a local model through Ollama or VLLM.
 
 ### Files
 
@@ -139,7 +139,7 @@ The Agent reads the message from Start with `<start.input>` and returns a result
 - **Use a response format when a downstream block needs specific fields.** It guarantees the shape, and you read each field as `<agent.field>`.
 
 <FAQ items={[
-  { question: "What LLM providers does the Agent block support?", answer: "OpenAI, Anthropic, Google (Gemini), xAI (Grok), DeepSeek, Groq, Cerebras, Azure OpenAI, Azure Anthropic, Google Vertex AI, AWS Bedrock, OpenRouter, and local models via Ollama or VLLM. Type or select any supported model from the model combobox." },
+  { question: "What LLM providers does the Agent block support?", answer: "OpenAI, Anthropic, Google (Gemini), xAI (Grok), DeepSeek, Groq, Cerebras, Azure OpenAI, Azure Anthropic, Google Vertex AI, AWS Bedrock, OpenRouter, [OrcaRouter](https://www.orcarouter.ai), and local models via Ollama or VLLM. Type or select any supported model from the model combobox." },
   { question: "What are the memory options for the Agent block?", answer: "Four modes: None (no memory, each run is independent), Conversation (full history keyed by a conversation ID), Sliding window by messages (the N most recent messages), and Sliding window by tokens (messages up to a token budget). Memory needs a conversation ID to persist across runs." },
   { question: "What is the difference between the tool usage controls (Auto, Force, None)?", answer: "In Auto, the model decides when to call a tool based on context. In Force, the model must call the tool on every run. In None, the tool is hidden from the model and never sent, which disables it without removing it from the block." },
   { question: "How does the Response Format work?", answer: "It enforces structured output by providing a JSON Schema. When set, the model's response is constrained to match the schema exactly, and each field is read directly by downstream blocks using <agent.fieldName>. Without a response format, the agent returns its standard outputs: content, model, tokens, and toolCalls." },

--- a/apps/sim/.env.example
+++ b/apps/sim/.env.example
@@ -94,6 +94,7 @@ CRON_SECRET=your_cron_secret # Use `openssl rand -hex 32` to generate. Authentic
 # LITELLM_BASE_URL=http://localhost:4000 # Base URL for your LiteLLM proxy (OpenAI-compatible)
 # LITELLM_API_KEY=                       # Optional bearer token if your LiteLLM proxy requires auth
 # OPENROUTER_API_KEY=                    # Optional self-hosted fallback for OpenAI knowledge-base embeddings
+# ORCAROUTER_API_KEY=                    # Optional OrcaRouter API key for model listing and inference
 # NEXT_PUBLIC_FORCE_HOSTED=true          # Dev only: treat this instance as hosted Sim (sim-auto pool, platform keys); ignored in production builds
 # FIREWORKS_API_KEY=                     # Optional Fireworks AI API key for model listing and inference
 # FIREWORKS_API_KEY_1=                   # Optional Fireworks API key for rotation (hosted deployments)

--- a/apps/sim/app/api/providers/orcarouter/models/route.ts
+++ b/apps/sim/app/api/providers/orcarouter/models/route.ts
@@ -1,0 +1,71 @@
+import { createLogger } from '@sim/logger'
+import { getErrorMessage } from '@sim/utils/errors'
+import { type NextRequest, NextResponse } from 'next/server'
+import { providerModelsResponseSchema } from '@/lib/api/contracts/providers'
+import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import { filterBlacklistedModels, isProviderBlacklisted } from '@/providers/utils'
+
+const logger = createLogger('OrcaRouterModelsAPI')
+
+interface OrcaRouterModel {
+  id: string
+  supported_endpoint_types?: string[]
+}
+
+interface OrcaRouterResponse {
+  data: OrcaRouterModel[]
+}
+
+/**
+ * Enumerates the public OrcaRouter model catalog. OrcaRouter is an
+ * OpenAI-compatible gateway that routes across many upstream providers, so its
+ * `/v1/models` endpoint (like OpenRouter's) is public — no key needed to list.
+ * Chat models are filtered to those exposing chat completions.
+ */
+export const GET = withRouteHandler(async (_request: NextRequest) => {
+  if (isProviderBlacklisted('orcarouter')) {
+    logger.info('OrcaRouter provider is blacklisted, returning empty models')
+    return NextResponse.json({ models: [], modelInfo: {} })
+  }
+
+  try {
+    const response = await fetch('https://api.orcarouter.ai/v1/models', {
+      headers: { 'Content-Type': 'application/json' },
+      next: { revalidate: 300 },
+    })
+
+    if (!response.ok) {
+      logger.warn('Failed to fetch OrcaRouter models', {
+        status: response.status,
+        statusText: response.statusText,
+      })
+      return NextResponse.json({ models: [], modelInfo: {} })
+    }
+
+    const data: OrcaRouterResponse = await response.json()
+
+    const allModels: string[] = []
+    for (const model of data.data ?? []) {
+      const endpoints = model.supported_endpoint_types ?? []
+      // OrcaRouter exposes chat completions through the OpenAI-compatible
+      // endpoint (`openai`); models without an endpoint list default to included.
+      if (endpoints.length > 0 && !endpoints.includes('openai')) continue
+      allModels.push(`orcarouter/${model.id}`)
+    }
+
+    const uniqueModels = Array.from(new Set(allModels))
+    const models = filterBlacklistedModels(uniqueModels)
+
+    logger.info('Successfully fetched OrcaRouter models', {
+      count: models.length,
+      filtered: uniqueModels.length - models.length,
+    })
+
+    return NextResponse.json(providerModelsResponseSchema.parse({ models, modelInfo: {} }))
+  } catch (error) {
+    logger.error('Error fetching OrcaRouter models', {
+      error: getErrorMessage(error, 'Unknown error'),
+    })
+    return NextResponse.json({ models: [], modelInfo: {} })
+  }
+})

--- a/apps/sim/app/workspace/[workspaceId]/providers/provider-models-loader.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/providers/provider-models-loader.tsx
@@ -11,6 +11,7 @@ import {
   updateOllamaCloudProviderModels,
   updateOllamaProviderModels,
   updateOpenRouterProviderModels,
+  updateOrcaRouterProviderModels,
   updateTogetherProviderModels,
   updateVLLMProviderModels,
 } from '@/providers/utils'
@@ -45,6 +46,8 @@ function useSyncProvider(provider: ProviderName, workspaceId?: string) {
         if (data.modelInfo) {
           setOpenRouterModelInfo(data.modelInfo)
         }
+      } else if (provider === 'orcarouter') {
+        void updateOrcaRouterProviderModels(data.models)
       } else if (provider === 'fireworks') {
         void updateFireworksProviderModels(data.models)
       } else if (provider === 'together') {
@@ -76,6 +79,7 @@ export function ProviderModelsLoader() {
   useSyncProvider('vllm')
   useSyncProvider('litellm')
   useSyncProvider('openrouter')
+  useSyncProvider('orcarouter')
   useSyncProvider('fireworks', workspaceId)
   useSyncProvider('together', workspaceId)
   useSyncProvider('baseten', workspaceId)

--- a/apps/sim/blocks/utils.test.ts
+++ b/apps/sim/blocks/utils.test.ts
@@ -26,6 +26,7 @@ const { mockProviders } = vi.hoisted(() => ({
       vllm: { models: [] as string[], isLoading: false },
       litellm: { models: [] as string[], isLoading: false },
       openrouter: { models: [] as string[], isLoading: false },
+      orcarouter: { models: [] as string[], isLoading: false },
       fireworks: { models: [] as string[], isLoading: false },
     },
   },
@@ -109,6 +110,7 @@ describe('getApiKeyCondition / shouldRequireApiKeyForModel', () => {
       vllm: { models: [], isLoading: false },
       litellm: { models: [], isLoading: false },
       openrouter: { models: [], isLoading: false },
+      orcarouter: { models: [], isLoading: false },
       fireworks: { models: [], isLoading: false },
     }
     mockGetHostedModels.mockReturnValue([])

--- a/apps/sim/blocks/utils.ts
+++ b/apps/sim/blocks/utils.ts
@@ -62,6 +62,7 @@ export function getModelOptions() {
   const vllmModels = providersState.providers.vllm.models
   const litellmModels = providersState.providers.litellm.models
   const openrouterModels = providersState.providers.openrouter.models
+  const orcarouterModels = providersState.providers.orcarouter.models
   const fireworksModels = providersState.providers.fireworks.models
   const togetherModels = providersState.providers.together.models
   const basetenModels = providersState.providers.baseten.models
@@ -73,6 +74,7 @@ export function getModelOptions() {
       ...vllmModels,
       ...litellmModels,
       ...openrouterModels,
+      ...orcarouterModels,
       ...fireworksModels,
       ...togetherModels,
       ...basetenModels,

--- a/apps/sim/components/icons.tsx
+++ b/apps/sim/components/icons.tsx
@@ -5135,6 +5135,22 @@ export function TogetherIcon(props: SVGProps<SVGSVGElement>) {
   )
 }
 
+export function OrcaRouterIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      fill='currentColor'
+      fillRule='evenodd'
+      height='1em'
+      viewBox='0 0 24 24'
+      width='1em'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path d='M4 4h6.5v6.5H4V4zm9.5 0H20v6.5h-6.5V4zM4 13.5h6.5V20H4v-6.5zm9.5 0H20V20h-6.5v-6.5zM5.5 5.5v3.5h3.5V5.5H5.5zM15 5.5V9h3.5V5.5H15zM5.5 15v3.5H9V15H5.5zM15 15v3.5h3.5V15H15z' />
+    </svg>
+  )
+}
+
 export function BasetenIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/apps/sim/hooks/queries/providers.ts
+++ b/apps/sim/hooks/queries/providers.ts
@@ -11,6 +11,7 @@ import {
   getOllamaProviderModelsContract,
   getOpenRouterEmbeddingModelsContract,
   getOpenRouterProviderModelsContract,
+  getOrcaRouterProviderModelsContract,
   getTogetherProviderModelsContract,
   getVllmProviderModelsContract,
   type ProviderModelsResponse,
@@ -73,6 +74,8 @@ async function requestProviderModels(
       return requestJson(getLitellmProviderModelsContract, { signal })
     case 'openrouter':
       return requestJson(getOpenRouterProviderModelsContract, { signal })
+    case 'orcarouter':
+      return requestJson(getOrcaRouterProviderModelsContract, { signal })
     case 'openrouter-embeddings':
       return requestJson(getOpenRouterEmbeddingModelsContract, { signal })
     case 'fireworks':

--- a/apps/sim/lib/api-key/byok.ts
+++ b/apps/sim/lib/api-key/byok.ts
@@ -322,6 +322,27 @@ export async function getApiKeyWithBYOK(
     return { apiKey: PROVIDER_PLACEHOLDER_KEY, isBYOK: false }
   }
 
+  const isOrcaRouterModel =
+    provider === 'orcarouter' ||
+    useProvidersStore.getState().providers.orcarouter.models.includes(model)
+  if (isOrcaRouterModel) {
+    if (workspaceId) {
+      const byokResult = await getBYOKKey(workspaceId, 'orcarouter')
+      if (byokResult) {
+        logger.info('Using BYOK key for OrcaRouter', {
+          model,
+          workspaceId,
+          scope: byokResult.scope,
+        })
+        return byokResult
+      }
+    }
+    if (userProvidedKey) {
+      return { apiKey: userProvidedKey, isBYOK: false }
+    }
+    throw new Error(`API key is required for OrcaRouter ${model}`)
+  }
+
   if (provider === 'azure-openai') {
     return { apiKey: userProvidedKey || env.AZURE_OPENAI_API_KEY || '', isBYOK: false }
   }

--- a/apps/sim/lib/api/contracts/byok-keys.ts
+++ b/apps/sim/lib/api/contracts/byok-keys.ts
@@ -14,6 +14,7 @@ export const byokProviderIdSchema = z.enum([
   'together',
   'baseten',
   'ollama-cloud',
+  'orcarouter',
   'falai',
   'firecrawl',
   'exa',

--- a/apps/sim/lib/api/contracts/providers.ts
+++ b/apps/sim/lib/api/contracts/providers.ts
@@ -268,6 +268,15 @@ export const getOpenRouterProviderModelsContract = defineRouteContract({
   },
 })
 
+export const getOrcaRouterProviderModelsContract = defineRouteContract({
+  method: 'GET',
+  path: '/api/providers/orcarouter/models',
+  response: {
+    mode: 'json',
+    schema: providerModelsResponseSchema,
+  },
+})
+
 export const getOpenRouterEmbeddingModelsContract = defineRouteContract({
   method: 'GET',
   path: '/api/providers/openrouter/embeddings/models',

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -243,6 +243,7 @@ export const env = createEnv({
     OPENAI_API_KEY_2:                      z.string().min(1).optional(),           // Additional OpenAI API key for load balancing
     OPENAI_API_KEY_3:                      z.string().min(1).optional(),           // Additional OpenAI API key for load balancing
     OPENROUTER_API_KEY:                    z.string().min(1).optional(),           // OpenRouter API key; self-hosted fallback for OpenAI knowledge-base embeddings
+    ORCAROUTER_API_KEY:                    z.string().min(1).optional(),           // OrcaRouter API key; optional self-hosted fallback for model listing and inference
     MISTRAL_API_KEY:                       z.string().min(1).optional(),           // Mistral AI API key
     ANTHROPIC_API_KEY_1:                   z.string().min(1).optional(),           // Primary Anthropic Claude API key
     ANTHROPIC_API_KEY_2:                   z.string().min(1).optional(),           // Additional Anthropic API key for load balancing

--- a/apps/sim/providers/attachments.ts
+++ b/apps/sim/providers/attachments.ts
@@ -26,6 +26,7 @@ export type AttachmentProvider =
   | 'google'
   | 'bedrock'
   | 'openrouter'
+  | 'orcarouter'
   | 'mistral'
   | 'groq'
   | 'fireworks'
@@ -164,6 +165,7 @@ const PROVIDER_SUPPORTED_LABELS: Record<AttachmentProvider, string> = {
   google: 'images, audio, video, PDFs, and text documents through Gemini inlineData',
   bedrock: 'Bedrock Converse image, document, and video content blocks',
   openrouter: 'images and PDFs through OpenRouter multimodal message parts',
+  orcarouter: 'images and PDFs through OrcaRouter multimodal message parts',
   mistral: 'images through image_url message parts',
   groq: 'images through image_url message parts on multimodal models',
   fireworks: 'images through image_url message parts on vision models',
@@ -188,6 +190,7 @@ export function getAttachmentProvider(providerId: ProviderId | string): Attachme
   if (providerId === 'google' || providerId === 'vertex') return 'google'
   if (providerId === 'bedrock') return 'bedrock'
   if (providerId === 'openrouter') return 'openrouter'
+  if (providerId === 'orcarouter') return 'orcarouter'
   if (providerId === 'mistral') return 'mistral'
   if (providerId === 'groq') return 'groq'
   if (providerId === 'fireworks') return 'fireworks'
@@ -306,7 +309,8 @@ export function isProviderAttachmentFilenameModelBound(
     providerId === 'openai' ||
     provider === 'anthropic' ||
     provider === 'bedrock' ||
-    provider === 'openrouter'
+    provider === 'openrouter' ||
+    provider === 'orcarouter'
   )
 }
 
@@ -401,6 +405,7 @@ function isMimeTypeSupportedByProvider(
         (contentType === 'video' && BEDROCK_VIDEO_FORMATS.has(extension))
       )
     case 'openrouter':
+    case 'orcarouter':
       return isImageMimeType(mimeType) || mimeType === PDF_MIME_TYPE
     case 'mistral':
     case 'groq':

--- a/apps/sim/providers/models.test.ts
+++ b/apps/sim/providers/models.test.ts
@@ -73,6 +73,7 @@ const DYNAMIC_PROVIDERS = new Set([
   'vllm',
   'litellm',
   'openrouter',
+  'orcarouter',
   'fireworks',
   'together',
   'baseten',

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -26,6 +26,7 @@ import {
   OllamaIcon,
   OpenAIIcon,
   OpenRouterIcon,
+  OrcaRouterIcon,
   SakanaIcon,
   TogetherIcon,
   VertexIcon,
@@ -261,6 +262,22 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     defaultModel: '',
     modelPatterns: [/^openrouter\//],
     icon: OpenRouterIcon,
+    isReseller: true,
+    capabilities: {
+      temperature: { min: 0, max: 2 },
+      toolUsageControl: true,
+    },
+    contextInformationAvailable: false,
+    models: [],
+  },
+  orcarouter: {
+    id: 'orcarouter',
+    fileAttachment: { maxBytes: 50 * 1024 * 1024, strategy: 'remote-url' },
+    name: 'OrcaRouter',
+    description: 'Unified access to many models via OrcaRouter',
+    defaultModel: '',
+    modelPatterns: [/^orcarouter\//],
+    icon: OrcaRouterIcon,
     isReseller: true,
     capabilities: {
       temperature: { min: 0, max: 2 },
@@ -4038,6 +4055,7 @@ export const DYNAMIC_MODEL_PROVIDERS = [
   'vllm',
   'litellm',
   'openrouter',
+  'orcarouter',
   'fireworks',
   'together',
   'baseten',
@@ -4395,6 +4413,18 @@ export function updateOllamaCloudModels(models: string[]): void {
 
 export function updateOpenRouterModels(models: string[]): void {
   PROVIDER_DEFINITIONS.openrouter.models = models.map((modelId) => ({
+    id: modelId,
+    pricing: {
+      input: 0,
+      output: 0,
+      updatedAt: new Date().toISOString().split('T')[0],
+    },
+    capabilities: {},
+  }))
+}
+
+export function updateOrcaRouterModels(models: string[]): void {
+  PROVIDER_DEFINITIONS.orcarouter.models = models.map((modelId) => ({
     id: modelId,
     pricing: {
       input: 0,

--- a/apps/sim/providers/orcarouter/index.test.ts
+++ b/apps/sim/providers/orcarouter/index.test.ts
@@ -1,0 +1,285 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StreamingExecution } from '@/executor/types'
+
+const {
+  mockCreate,
+  mockSupportsNativeStructuredOutputs,
+  mockPrepareToolsWithUsageControl,
+  mockExecuteTool,
+} = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+  mockSupportsNativeStructuredOutputs: vi.fn(),
+  mockPrepareToolsWithUsageControl: vi.fn(),
+  mockExecuteTool: vi.fn(),
+}))
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(
+    class {
+      chat = { completions: { create: mockCreate } }
+    }
+  ),
+}))
+
+vi.mock('@/providers', () => ({ MAX_TOOL_ITERATIONS: 5 }))
+
+vi.mock('@/providers/models', () => ({
+  getProviderFileAttachment: vi
+    .fn()
+    .mockReturnValue({ maxBytes: 10 * 1024 * 1024, strategy: 'inline' }),
+  INLINE_ATTACHMENT_MAX_BYTES: 10 * 1024 * 1024,
+  getProviderModels: vi.fn().mockReturnValue([]),
+  getProviderDefaultModel: vi.fn().mockReturnValue(''),
+}))
+
+vi.mock('@/providers/attachments', () => ({
+  formatMessagesForProvider: vi.fn((messages) => messages),
+}))
+
+vi.mock('@/providers/orcarouter/utils', () => ({
+  supportsNativeStructuredOutputs: mockSupportsNativeStructuredOutputs,
+  createReadableStreamFromOpenAIStream: vi.fn(
+    () => new ReadableStream({ start: (controller) => controller.close() })
+  ),
+  checkForForcedToolUsage: vi.fn(() => ({ hasUsedForcedTool: false, usedForcedTools: [] })),
+}))
+
+vi.mock('@/providers/trace-enrichment', () => ({
+  enrichLastModelSegmentFromChatCompletions: vi.fn(),
+}))
+
+vi.mock('@/providers/utils', () => ({
+  isFunctionToolCall: (toolCall: unknown) =>
+    typeof toolCall === 'object' &&
+    toolCall !== null &&
+    'function' in toolCall &&
+    (toolCall as { function?: unknown }).function != null,
+  calculateCost: vi.fn().mockReturnValue({ input: 0, output: 0, total: 0 }),
+  generateSchemaInstructions: vi.fn(() => 'SCHEMA_INSTRUCTIONS'),
+  prepareToolExecution: vi.fn(() => ({ toolParams: { x: 1 }, executionParams: { x: 1 } })),
+  prepareToolsWithUsageControl: mockPrepareToolsWithUsageControl,
+  sumToolCosts: vi.fn().mockReturnValue(0),
+}))
+
+vi.mock('@/tools', () => ({ executeTool: mockExecuteTool }))
+
+import { orcarouterProvider } from '@/providers/orcarouter/index'
+import { ProviderError } from '@/providers/types'
+
+const textResponse = (content: string) => ({
+  choices: [{ message: { content, tool_calls: [] } }],
+  usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+})
+
+const toolCallResponse = (
+  assistant: { content?: string | null; reasoning_content?: string } = {}
+) => ({
+  choices: [
+    {
+      message: {
+        content: assistant.content ?? null,
+        ...(assistant.reasoning_content !== undefined
+          ? { reasoning_content: assistant.reasoning_content }
+          : {}),
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'my_tool', arguments: '{"x":1}' } },
+        ],
+      },
+    },
+  ],
+  usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+})
+
+const toolDef = {
+  id: 'my_tool',
+  name: 'my_tool',
+  description: '',
+  params: {},
+  parameters: { type: 'object', properties: {}, required: [] },
+}
+
+const callBody = (index: number) => mockCreate.mock.calls[index][0]
+const lastCallBody = () => mockCreate.mock.calls.at(-1)?.[0]
+
+describe('orcarouterProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSupportsNativeStructuredOutputs.mockResolvedValue(true)
+    mockPrepareToolsWithUsageControl.mockImplementation((tools) => ({
+      tools,
+      toolChoice: 'auto',
+      forcedTools: [],
+    }))
+    mockExecuteTool.mockResolvedValue({ success: true, output: { ok: true } })
+  })
+
+  const baseRequest = {
+    model: 'orcarouter/auto',
+    systemPrompt: 'You are helpful.',
+    messages: [{ role: 'user' as const, content: 'Hello' }],
+    apiKey: 'sk-orca-test-key',
+  }
+
+  it('throws when the API key is missing', async () => {
+    await expect(
+      orcarouterProvider.executeRequest({ ...baseRequest, apiKey: undefined })
+    ).rejects.toThrow('API key is required for OrcaRouter')
+  })
+
+  it('strips the orcarouter/ prefix and reports the catalog id', async () => {
+    mockCreate.mockResolvedValueOnce(textResponse('hi there'))
+
+    const result = await orcarouterProvider.executeRequest(baseRequest)
+
+    expect(callBody(0).model).toBe('auto')
+    expect(result).toMatchObject({
+      content: 'hi there',
+      model: 'orcarouter/auto',
+      tokens: { input: 10, output: 5, total: 15 },
+    })
+  })
+
+  it('wraps API errors in a ProviderError', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(orcarouterProvider.executeRequest(baseRequest)).rejects.toBeInstanceOf(
+      ProviderError
+    )
+  })
+
+  it('streams directly when there are no tools', async () => {
+    mockCreate.mockResolvedValueOnce({})
+
+    const result = await orcarouterProvider.executeRequest({ ...baseRequest, stream: true })
+
+    expect(lastCallBody()).toMatchObject({ stream: true, stream_options: { include_usage: true } })
+    expect(result).toHaveProperty('stream')
+    expect(result).toHaveProperty('execution')
+  })
+
+  it('sends a json_schema response_format when native is supported', async () => {
+    mockCreate.mockResolvedValueOnce(textResponse('{}'))
+
+    await orcarouterProvider.executeRequest({
+      ...baseRequest,
+      responseFormat: { name: 'my_schema', schema: { type: 'object' }, strict: true },
+    })
+
+    expect(lastCallBody().response_format).toEqual({
+      type: 'json_schema',
+      json_schema: { name: 'my_schema', schema: { type: 'object' } },
+    })
+    expect(lastCallBody().response_format.json_schema).not.toHaveProperty('strict')
+  })
+
+  it('falls back to json_object with prompt instructions when native is unsupported', async () => {
+    mockSupportsNativeStructuredOutputs.mockResolvedValue(false)
+    mockCreate.mockResolvedValueOnce(textResponse('{}'))
+
+    await orcarouterProvider.executeRequest({
+      ...baseRequest,
+      responseFormat: { name: 'my_schema', schema: { type: 'object' } },
+    })
+
+    expect(lastCallBody().response_format).toEqual({ type: 'json_object' })
+    expect(lastCallBody().messages.at(-1)).toEqual({
+      role: 'user',
+      content: 'SCHEMA_INSTRUCTIONS',
+    })
+  })
+
+  it('defers response_format to a final call when tools are active', async () => {
+    mockCreate
+      .mockResolvedValueOnce(textResponse('intermediate'))
+      .mockResolvedValueOnce(textResponse('{"done":true}'))
+
+    await orcarouterProvider.executeRequest({
+      ...baseRequest,
+      responseFormat: { name: 'my_schema', schema: { type: 'object' } },
+      tools: [toolDef],
+    })
+
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+    expect(callBody(0).response_format).toBeUndefined()
+    expect(callBody(0).tools).toBeDefined()
+    expect(callBody(1).response_format).toEqual({
+      type: 'json_schema',
+      json_schema: { name: 'my_schema', schema: { type: 'object' } },
+    })
+    expect(callBody(1).tools).toBeUndefined()
+  })
+
+  it('runs the tool loop and threads tool results back into the conversation', async () => {
+    mockCreate
+      .mockResolvedValueOnce(toolCallResponse())
+      .mockResolvedValueOnce(textResponse('final answer'))
+
+    const result = await orcarouterProvider.executeRequest({ ...baseRequest, tools: [toolDef] })
+
+    expect(mockExecuteTool).toHaveBeenCalledWith('my_tool', { x: 1 }, expect.anything())
+    expect(result).toMatchObject({ content: 'final answer' })
+    expect((result as { toolCalls?: unknown[] }).toolCalls).toHaveLength(1)
+
+    const followUpMessages = callBody(1).messages
+    expect(followUpMessages).toContainEqual(
+      expect.objectContaining({ role: 'assistant', tool_calls: expect.any(Array) })
+    )
+    expect(followUpMessages).toContainEqual(
+      expect.objectContaining({ role: 'tool', tool_call_id: 'call_1' })
+    )
+  })
+
+  it('replays assistant content and reasoning_content on the second request', async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        toolCallResponse({
+          content: 'I will use the tool.',
+          reasoning_content: 'Need the tool result.',
+        })
+      )
+      .mockResolvedValueOnce(textResponse('final answer'))
+
+    await orcarouterProvider.executeRequest({ ...baseRequest, tools: [toolDef] })
+
+    expect(
+      callBody(1).messages.find((message: { role: string }) => message.role === 'assistant')
+    ).toEqual({
+      role: 'assistant',
+      content: 'I will use the tool.',
+      reasoning_content: 'Need the tool result.',
+      tool_calls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'my_tool', arguments: '{"x":1}' },
+        },
+      ],
+    })
+  })
+
+  it('streams the settled tool-loop answer without a duplicate provider request', async () => {
+    mockCreate.mockResolvedValueOnce(toolCallResponse()).mockResolvedValueOnce(textResponse('done'))
+
+    const result = (await orcarouterProvider.executeRequest({
+      ...baseRequest,
+      stream: true,
+      tools: [toolDef],
+    })) as StreamingExecution
+
+    expect(mockCreate).toHaveBeenCalledTimes(2)
+    expect(result.execution.output).toMatchObject({
+      content: 'done',
+      tokens: { input: 18, output: 9, total: 27 },
+      toolCalls: { count: 1 },
+    })
+    const reader = result.stream.getReader()
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: { type: 'text_delta', text: 'done', turn: 'final' },
+    })
+    await expect(reader.read()).resolves.toEqual({ done: true, value: undefined })
+  })
+})

--- a/apps/sim/providers/orcarouter/index.ts
+++ b/apps/sim/providers/orcarouter/index.ts
@@ -1,0 +1,669 @@
+import { createLogger } from '@sim/logger'
+import { getErrorMessage, toError } from '@sim/utils/errors'
+import { isRecordLike } from '@sim/utils/object'
+import OpenAI from 'openai'
+import type { ChatCompletionCreateParamsStreaming } from 'openai/resources/chat/completions'
+import type { StreamingExecution } from '@/executor/types'
+import { MAX_TOOL_ITERATIONS } from '@/providers'
+import { formatMessagesForProvider } from '@/providers/attachments'
+import { getProviderDefaultModel, getProviderModels } from '@/providers/models'
+import { createOpenAICompatAssistantHistory } from '@/providers/openai-compat/assistant-history'
+import {
+  checkForForcedToolUsage,
+  createReadableStreamFromOpenAIStream,
+  supportsNativeStructuredOutputs,
+} from '@/providers/orcarouter/utils'
+import { executeProviderTool } from '@/providers/runtime-context'
+import { createSettledAgentEventStream } from '@/providers/stream-events'
+import { createStreamingExecution } from '@/providers/streaming-execution'
+import { isAbortError, parseToolArguments } from '@/providers/streaming-tool-loop-shared'
+import { adaptOpenAIChatToolSchema } from '@/providers/tool-schema-adapter'
+import { enrichLastModelSegmentFromChatCompletions } from '@/providers/trace-enrichment'
+import { openAICompatTransport } from '@/providers/transport'
+import type {
+  FunctionCallResponse,
+  Message,
+  ProviderConfig,
+  ProviderRequest,
+  ProviderResponse,
+  TimeSegment,
+} from '@/providers/types'
+import { ProviderError } from '@/providers/types'
+import {
+  calculateCost,
+  generateSchemaInstructions,
+  isFunctionToolCall,
+  prepareToolExecution,
+  prepareToolsWithUsageControl,
+  sumToolCosts,
+} from '@/providers/utils'
+
+const logger = createLogger('OrcaRouterProvider')
+
+/**
+ * Applies structured output configuration to a payload based on model capabilities.
+ * Uses native json_schema for supported models, falls back to json_object with prompt instructions.
+ */
+async function applyResponseFormat(
+  targetPayload: any,
+  messages: any[],
+  responseFormat: any,
+  model: string
+): Promise<any[]> {
+  const useNative = await supportsNativeStructuredOutputs(model)
+
+  if (useNative) {
+    logger.info('Using native structured outputs for OrcaRouter model', { model })
+    targetPayload.response_format = {
+      type: 'json_schema',
+      json_schema: {
+        name: responseFormat.name || 'response_schema',
+        schema: responseFormat.schema || responseFormat,
+      },
+    }
+    return messages
+  }
+
+  logger.info('Using json_object mode with prompt instructions for OrcaRouter model', { model })
+  const schema = responseFormat.schema || responseFormat
+  const schemaInstructions = generateSchemaInstructions(schema, responseFormat.name)
+  targetPayload.response_format = { type: 'json_object' }
+  return [...messages, { role: 'user', content: schemaInstructions }]
+}
+
+export const orcarouterProvider: ProviderConfig = {
+  id: 'orcarouter',
+  name: 'OrcaRouter',
+  description: 'Unified access to many models via OrcaRouter',
+  version: '1.0.0',
+  models: getProviderModels('orcarouter'),
+  defaultModel: getProviderDefaultModel('orcarouter'),
+
+  executeRequest: async (
+    request: ProviderRequest
+  ): Promise<ProviderResponse | StreamingExecution> => {
+    if (!request.apiKey) {
+      throw new Error('API key is required for OrcaRouter')
+    }
+
+    const client = new OpenAI({
+      ...openAICompatTransport(),
+      apiKey: request.apiKey,
+      baseURL: 'https://api.orcarouter.ai/v1',
+    })
+
+    const requestedModel = request.model.replace(/^orcarouter\//, '')
+
+    logger.info('Preparing OrcaRouter request', {
+      model: requestedModel,
+      hasSystemPrompt: !!request.systemPrompt,
+      hasMessages: !!request.messages?.length,
+      hasTools: !!request.tools?.length,
+      toolCount: request.tools?.length || 0,
+      hasResponseFormat: !!request.responseFormat,
+      stream: !!request.stream,
+    })
+
+    const allMessages: Message[] = []
+
+    if (request.systemPrompt) {
+      allMessages.push({ role: 'system', content: request.systemPrompt })
+    }
+
+    if (request.context) {
+      allMessages.push({ role: 'user', content: request.context })
+    }
+
+    if (request.messages) {
+      allMessages.push(...request.messages)
+    }
+    const formattedMessages = formatMessagesForProvider(allMessages, 'orcarouter') as Message[]
+
+    const tools = request.tools?.length
+      ? request.tools.map((tool) => adaptOpenAIChatToolSchema(tool))
+      : undefined
+
+    const payload: any = {
+      model: requestedModel,
+      messages: formattedMessages,
+    }
+
+    if (request.temperature !== undefined) payload.temperature = request.temperature
+    if (request.maxTokens != null) payload.max_tokens = request.maxTokens
+
+    let preparedTools: ReturnType<typeof prepareToolsWithUsageControl> | null = null
+    let hasActiveTools = false
+    if (tools?.length) {
+      preparedTools = prepareToolsWithUsageControl(tools, request.tools, logger, 'orcarouter')
+      const { tools: filteredTools, toolChoice } = preparedTools
+      if (filteredTools?.length && toolChoice) {
+        payload.tools = filteredTools
+        payload.tool_choice = toolChoice
+        hasActiveTools = true
+      }
+    }
+
+    const providerStartTime = Date.now()
+    const providerStartTimeISO = new Date(providerStartTime).toISOString()
+
+    try {
+      if (request.responseFormat && !hasActiveTools) {
+        payload.messages = await applyResponseFormat(
+          payload,
+          payload.messages,
+          request.responseFormat,
+          requestedModel
+        )
+      }
+
+      if (request.stream && (!tools || tools.length === 0 || !hasActiveTools)) {
+        const streamingParams: ChatCompletionCreateParamsStreaming = {
+          ...payload,
+          stream: true,
+          stream_options: { include_usage: true },
+        }
+        const streamResponse = await client.chat.completions.create(
+          streamingParams,
+          request.abortSignal ? { signal: request.abortSignal } : undefined
+        )
+
+        const streamingResult = createStreamingExecution({
+          // Echo the catalog id, never the wire name: it is the billing and
+          // logging identity (cost policy, ledger row, trace span, model
+          // breakdown) the way every other Sim-hosted provider reports it.
+          model: request.model,
+          providerStartTime,
+          providerStartTimeISO,
+          timing: { kind: 'simple', segmentName: request.model },
+          initialTokens: { input: 0, output: 0, total: 0 },
+          initialCost: { input: 0, output: 0, total: 0 },
+          streamFormat: 'agent-events-v1',
+          createStream: ({ output, finalizeTiming }) =>
+            createReadableStreamFromOpenAIStream(streamResponse, (content, usage) => {
+              output.content = content
+              output.tokens = {
+                input: usage.prompt_tokens,
+                output: usage.completion_tokens,
+                total: usage.total_tokens,
+              }
+
+              // Pricing keys on the catalog id (orcarouter/<name>), not the wire
+              // name — static hosted entries price; dynamic ids stay unpriced.
+              const costResult = calculateCost(
+                request.model,
+                usage.prompt_tokens,
+                usage.completion_tokens
+              )
+              output.cost = {
+                input: costResult.input,
+                output: costResult.output,
+                total: costResult.total,
+              }
+
+              finalizeTiming()
+            }),
+        })
+
+        return streamingResult
+      }
+
+      const initialCallTime = Date.now()
+      const originalToolChoice = payload.tool_choice
+      const forcedTools = preparedTools?.forcedTools || []
+      let usedForcedTools: string[] = []
+
+      let currentResponse = await client.chat.completions.create(
+        payload,
+        request.abortSignal ? { signal: request.abortSignal } : undefined
+      )
+      const firstResponseTime = Date.now() - initialCallTime
+
+      let content = currentResponse.choices[0]?.message?.content || ''
+      const tokens = {
+        input: currentResponse.usage?.prompt_tokens || 0,
+        output: currentResponse.usage?.completion_tokens || 0,
+        total: currentResponse.usage?.total_tokens || 0,
+      }
+      const toolCalls: FunctionCallResponse[] = []
+      const toolResults: Record<string, unknown>[] = []
+      const currentMessages = [...formattedMessages]
+      let iterationCount = 0
+      let modelTime = firstResponseTime
+      let toolsTime = 0
+      let hasUsedForcedTool = false
+      const timeSegments: TimeSegment[] = [
+        {
+          type: 'model',
+          name: request.model,
+          startTime: initialCallTime,
+          endTime: initialCallTime + firstResponseTime,
+          duration: firstResponseTime,
+        },
+      ]
+
+      const forcedToolResult = checkForForcedToolUsage(
+        currentResponse,
+        originalToolChoice,
+        forcedTools,
+        usedForcedTools
+      )
+      hasUsedForcedTool = forcedToolResult.hasUsedForcedTool
+      usedForcedTools = forcedToolResult.usedForcedTools
+
+      while (iterationCount < MAX_TOOL_ITERATIONS) {
+        if (currentResponse.choices[0]?.message?.content) {
+          content = currentResponse.choices[0].message.content
+        }
+
+        const toolCallsInResponse =
+          currentResponse.choices[0]?.message?.tool_calls?.filter(isFunctionToolCall)
+
+        enrichLastModelSegmentFromChatCompletions(
+          timeSegments,
+          currentResponse,
+          toolCallsInResponse,
+          { model: request.model, provider: 'orcarouter' }
+        )
+
+        if (!toolCallsInResponse || toolCallsInResponse.length === 0) {
+          break
+        }
+
+        const toolsStartTime = Date.now()
+
+        const toolExecutionPromises = toolCallsInResponse.map(async (toolCall) => {
+          const toolCallStartTime = Date.now()
+          const toolName = toolCall.function.name
+
+          try {
+            const toolArgs = parseToolArguments(toolCall.function.arguments, toolName)
+            const tool = request.tools?.find((t) => t.id === toolName)
+
+            if (!tool) {
+              const toolCallEndTime = Date.now()
+              return {
+                toolCall,
+                toolName,
+                toolParams: {},
+                result: {
+                  success: false,
+                  output: undefined,
+                  error: `Tool "${toolName}" is not available`,
+                },
+                startTime: toolCallStartTime,
+                endTime: toolCallEndTime,
+                duration: toolCallEndTime - toolCallStartTime,
+              }
+            }
+
+            const { toolParams, executionParams } = prepareToolExecution(
+              tool,
+              toolArgs,
+              request,
+              toolCall.id
+            )
+            const { rawResponse, modelResponse } = await executeProviderTool(
+              toolName,
+              executionParams,
+              {
+                signal: request.abortSignal,
+              }
+            )
+            const toolCallEndTime = Date.now()
+
+            return {
+              toolCall,
+              toolName,
+              toolParams,
+              result: rawResponse,
+              modelResult: modelResponse,
+              startTime: toolCallStartTime,
+              endTime: toolCallEndTime,
+              duration: toolCallEndTime - toolCallStartTime,
+            }
+          } catch (error) {
+            if (isAbortError(error) || request.abortSignal?.aborted) {
+              throw error
+            }
+            const toolCallEndTime = Date.now()
+            logger.error('Error processing tool call (OrcaRouter):', {
+              error: toError(error).message,
+              toolName,
+            })
+
+            return {
+              toolCall,
+              toolName,
+              toolParams: {},
+              result: {
+                success: false,
+                output: undefined,
+                error: getErrorMessage(error, 'Tool execution failed'),
+              },
+              startTime: toolCallStartTime,
+              endTime: toolCallEndTime,
+              duration: toolCallEndTime - toolCallStartTime,
+            }
+          }
+        })
+
+        const executionResults = await Promise.all(toolExecutionPromises)
+        const assistantMessage = currentResponse.choices[0]?.message
+        if (assistantMessage) {
+          currentMessages.push(
+            createOpenAICompatAssistantHistory({
+              message: assistantMessage,
+              toolCalls: toolCallsInResponse,
+              reasoningFields: ['reasoning_content'],
+            })
+          )
+        }
+
+        for (const executionResult of executionResults) {
+          const { toolCall, toolName, toolParams, result, startTime, endTime, duration } =
+            executionResult
+          const modelResult =
+            'modelResult' in executionResult ? (executionResult.modelResult ?? result) : result
+
+          timeSegments.push({
+            type: 'tool',
+            name: toolName,
+            startTime: startTime,
+            endTime: endTime,
+            duration: duration,
+            toolCallId: toolCall.id,
+          })
+
+          let resultContent: unknown
+          if (result.success) {
+            if (isRecordLike(result.output)) {
+              toolResults.push(result.output)
+            }
+            resultContent = result.output ?? null
+          } else {
+            resultContent = {
+              error: true,
+              message: result.error || 'Tool execution failed',
+              tool: toolName,
+            }
+          }
+          const modelResultContent = modelResult.success
+            ? (modelResult.output ?? null)
+            : {
+                error: true,
+                message: modelResult.error || 'Tool execution failed',
+                tool: toolName,
+              }
+
+          toolCalls.push({
+            name: toolName,
+            arguments: toolParams,
+            startTime: new Date(startTime).toISOString(),
+            endTime: new Date(endTime).toISOString(),
+            duration: duration,
+            result: resultContent,
+            success: result.success,
+          })
+
+          currentMessages.push({
+            role: 'tool',
+            tool_call_id: toolCall.id,
+            content: JSON.stringify(modelResultContent),
+          })
+        }
+
+        const thisToolsTime = Date.now() - toolsStartTime
+        toolsTime += thisToolsTime
+
+        const nextPayload = {
+          ...payload,
+          messages: currentMessages,
+        }
+
+        if (typeof originalToolChoice === 'object' && hasUsedForcedTool && forcedTools.length > 0) {
+          const remainingTools = forcedTools.filter((tool) => !usedForcedTools.includes(tool))
+          if (remainingTools.length > 0) {
+            nextPayload.tool_choice = { type: 'function', function: { name: remainingTools[0] } }
+          } else {
+            nextPayload.tool_choice = 'auto'
+          }
+        }
+
+        const nextModelStartTime = Date.now()
+        currentResponse = await client.chat.completions.create(
+          nextPayload,
+          request.abortSignal ? { signal: request.abortSignal } : undefined
+        )
+        const nextForcedToolResult = checkForForcedToolUsage(
+          currentResponse,
+          nextPayload.tool_choice,
+          forcedTools,
+          usedForcedTools
+        )
+        hasUsedForcedTool = nextForcedToolResult.hasUsedForcedTool
+        usedForcedTools = nextForcedToolResult.usedForcedTools
+        const nextModelEndTime = Date.now()
+        const thisModelTime = nextModelEndTime - nextModelStartTime
+        timeSegments.push({
+          type: 'model',
+          name: request.model,
+          startTime: nextModelStartTime,
+          endTime: nextModelEndTime,
+          duration: thisModelTime,
+        })
+        modelTime += thisModelTime
+        if (currentResponse.choices[0]?.message?.content) {
+          content = currentResponse.choices[0].message.content
+        }
+        if (currentResponse.usage) {
+          tokens.input += currentResponse.usage.prompt_tokens || 0
+          tokens.output += currentResponse.usage.completion_tokens || 0
+          tokens.total += currentResponse.usage.total_tokens || 0
+        }
+        iterationCount++
+      }
+
+      if (iterationCount === MAX_TOOL_ITERATIONS) {
+        const pendingToolCalls =
+          currentResponse.choices[0]?.message?.tool_calls?.filter(isFunctionToolCall)
+        enrichLastModelSegmentFromChatCompletions(timeSegments, currentResponse, pendingToolCalls, {
+          model: request.model,
+          provider: 'orcarouter',
+        })
+
+        if (pendingToolCalls?.length && !(request.responseFormat && hasActiveTools)) {
+          const finalPayload: any = {
+            ...payload,
+            messages: [...currentMessages],
+            tool_choice: 'none',
+          }
+
+          if (request.responseFormat) {
+            finalPayload.messages = await applyResponseFormat(
+              finalPayload,
+              finalPayload.messages,
+              request.responseFormat,
+              requestedModel
+            )
+          }
+
+          const finalStartTime = Date.now()
+          const finalResponse = await client.chat.completions.create(
+            finalPayload,
+            request.abortSignal ? { signal: request.abortSignal } : undefined
+          )
+          const finalEndTime = Date.now()
+          const finalDuration = finalEndTime - finalStartTime
+
+          timeSegments.push({
+            type: 'model',
+            name: 'Final answer after tool iteration limit',
+            startTime: finalStartTime,
+            endTime: finalEndTime,
+            duration: finalDuration,
+          })
+          modelTime += finalDuration
+
+          if (finalResponse.choices[0]?.message?.content) {
+            content = finalResponse.choices[0].message.content
+          }
+          if (finalResponse.usage) {
+            tokens.input += finalResponse.usage.prompt_tokens || 0
+            tokens.output += finalResponse.usage.completion_tokens || 0
+            tokens.total += finalResponse.usage.total_tokens || 0
+          }
+
+          enrichLastModelSegmentFromChatCompletions(
+            timeSegments,
+            finalResponse,
+            finalResponse.choices[0]?.message?.tool_calls?.filter(isFunctionToolCall),
+            { model: request.model, provider: 'orcarouter' }
+          )
+        }
+      }
+
+      if (request.responseFormat && hasActiveTools) {
+        const finalPayload: any = {
+          model: payload.model,
+          messages: [...currentMessages],
+        }
+        if (payload.temperature !== undefined) {
+          finalPayload.temperature = payload.temperature
+        }
+        if (payload.max_tokens !== undefined) {
+          finalPayload.max_tokens = payload.max_tokens
+        }
+
+        finalPayload.messages = await applyResponseFormat(
+          finalPayload,
+          finalPayload.messages,
+          request.responseFormat,
+          requestedModel
+        )
+
+        const finalStartTime = Date.now()
+        const finalResponse = await client.chat.completions.create(
+          finalPayload,
+          request.abortSignal ? { signal: request.abortSignal } : undefined
+        )
+        const finalEndTime = Date.now()
+        const finalDuration = finalEndTime - finalStartTime
+
+        timeSegments.push({
+          type: 'model',
+          name: 'Final structured response',
+          startTime: finalStartTime,
+          endTime: finalEndTime,
+          duration: finalDuration,
+        })
+        modelTime += finalDuration
+
+        if (finalResponse.choices[0]?.message?.content) {
+          content = finalResponse.choices[0].message.content
+        }
+        if (finalResponse.usage) {
+          tokens.input += finalResponse.usage.prompt_tokens || 0
+          tokens.output += finalResponse.usage.completion_tokens || 0
+          tokens.total += finalResponse.usage.total_tokens || 0
+        }
+
+        enrichLastModelSegmentFromChatCompletions(
+          timeSegments,
+          finalResponse,
+          finalResponse.choices[0]?.message?.tool_calls?.filter(isFunctionToolCall),
+          { model: request.model, provider: 'orcarouter' }
+        )
+      }
+
+      if (request.stream) {
+        // Pricing keys on the catalog id (orcarouter/<name>), not the wire name.
+        const accumulatedCost = calculateCost(request.model, tokens.input, tokens.output)
+        const toolCost = sumToolCosts(toolResults)
+        const finalCost = {
+          input: accumulatedCost.input,
+          output: accumulatedCost.output,
+          toolCost: toolCost || undefined,
+          total: accumulatedCost.total + toolCost,
+        }
+
+        const streamingResult = createStreamingExecution({
+          model: request.model,
+          providerStartTime,
+          providerStartTimeISO,
+          timing: {
+            kind: 'accumulated',
+            modelTime,
+            toolsTime,
+            firstResponseTime,
+            iterations: timeSegments.filter((segment) => segment.type === 'model').length,
+            timeSegments,
+          },
+          initialTokens: { input: tokens.input, output: tokens.output, total: tokens.total },
+          initialCost: finalCost,
+          toolCalls:
+            toolCalls.length > 0 ? { list: toolCalls, count: toolCalls.length } : undefined,
+          streamFormat: 'agent-events-v1',
+          createStream: ({ output, finalizeTiming }) => {
+            output.content = content
+            output.tokens = { input: tokens.input, output: tokens.output, total: tokens.total }
+            output.cost = finalCost
+            finalizeTiming()
+            return createSettledAgentEventStream(content)
+          },
+        })
+
+        return streamingResult
+      }
+
+      const providerEndTime = Date.now()
+      const providerEndTimeISO = new Date(providerEndTime).toISOString()
+      const totalDuration = providerEndTime - providerStartTime
+
+      return {
+        content,
+        model: request.model,
+        tokens,
+        toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+        toolResults: toolResults.length > 0 ? toolResults : undefined,
+        timing: {
+          startTime: providerStartTimeISO,
+          endTime: providerEndTimeISO,
+          duration: totalDuration,
+          modelTime: modelTime,
+          toolsTime: toolsTime,
+          firstResponseTime: firstResponseTime,
+          iterations: timeSegments.filter((segment) => segment.type === 'model').length,
+          timeSegments: timeSegments,
+        },
+      }
+    } catch (error) {
+      const providerEndTime = Date.now()
+      const providerEndTimeISO = new Date(providerEndTime).toISOString()
+      const totalDuration = providerEndTime - providerStartTime
+
+      const errorDetails: Record<string, any> = {
+        error: toError(error).message,
+        duration: totalDuration,
+      }
+      if (error && typeof error === 'object') {
+        const err = error as any
+        if (err.status) errorDetails.status = err.status
+        if (err.code) errorDetails.code = err.code
+        if (err.type) errorDetails.type = err.type
+        if (err.error?.message) errorDetails.providerMessage = err.error.message
+        if (err.error?.metadata) errorDetails.metadata = err.error.metadata
+      }
+
+      logger.error('Error in OrcaRouter request:', errorDetails)
+      if (isAbortError(error) || request.abortSignal?.aborted) {
+        throw error
+      }
+
+      throw new ProviderError(toError(error).message, {
+        startTime: providerStartTimeISO,
+        endTime: providerEndTimeISO,
+        duration: totalDuration,
+      })
+    }
+  },
+}

--- a/apps/sim/providers/orcarouter/utils.ts
+++ b/apps/sim/providers/orcarouter/utils.ts
@@ -1,0 +1,49 @@
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions'
+import type { CompletionUsage } from 'openai/resources/completions'
+import { createOpenAICompatibleAgentEventStream } from '@/providers/openai-compat/stream-events'
+import type { AgentStreamEvent } from '@/providers/stream-events'
+import { checkForForcedToolUsageOpenAI } from '@/providers/utils'
+
+/**
+ * OrcaRouter is an OpenAI-compatible gateway that routes across many upstream
+ * providers, so native `json_schema` support varies per upstream model. Use the
+ * broadly supported JSON-object mode for all models to avoid 400s.
+ */
+export async function supportsNativeStructuredOutputs(_modelId: string): Promise<boolean> {
+  return false
+}
+
+/**
+ * Creates an agent-events stream from an OrcaRouter streaming response.
+ * Uses the shared OpenAI-compatible agent event streaming utility.
+ */
+export function createReadableStreamFromOpenAIStream(
+  openaiStream: AsyncIterable<ChatCompletionChunk>,
+  onComplete?: (content: string, usage: CompletionUsage, thinking?: string) => void
+): ReadableStream<AgentStreamEvent> {
+  return createOpenAICompatibleAgentEventStream(openaiStream, {
+    providerName: 'OrcaRouter',
+    onComplete: onComplete
+      ? (result) => onComplete(result.content, result.usage, result.thinking)
+      : undefined,
+  })
+}
+
+/**
+ * Checks if a forced tool was used in an OrcaRouter response.
+ * Uses the shared OpenAI-compatible forced tool usage helper.
+ */
+export function checkForForcedToolUsage(
+  response: any,
+  toolChoice: string | { type: string; function?: { name: string }; name?: string; any?: any },
+  forcedTools: string[],
+  usedForcedTools: string[]
+): { hasUsedForcedTool: boolean; usedForcedTools: string[] } {
+  return checkForForcedToolUsageOpenAI(
+    response,
+    toolChoice,
+    'OrcaRouter',
+    forcedTools,
+    usedForcedTools
+  )
+}

--- a/apps/sim/providers/registry.ts
+++ b/apps/sim/providers/registry.ts
@@ -18,6 +18,7 @@ import { ollamaProvider } from '@/providers/ollama'
 import { ollamaCloudProvider } from '@/providers/ollama-cloud'
 import { openaiProvider } from '@/providers/openai'
 import { openRouterProvider } from '@/providers/openrouter'
+import { orcarouterProvider } from '@/providers/orcarouter'
 import { sakanaProvider } from '@/providers/sakana'
 import { togetherProvider } from '@/providers/together'
 import type { ProviderConfig, ProviderId } from '@/providers/types'
@@ -48,6 +49,7 @@ const providerRegistry: Record<ProviderId, ProviderConfig> = {
   mistral: mistralProvider,
   'azure-openai': azureOpenAIProvider,
   openrouter: openRouterProvider,
+  orcarouter: orcarouterProvider,
   fireworks: fireworksProvider,
   together: togetherProvider,
   baseten: basetenProvider,

--- a/apps/sim/providers/types.ts
+++ b/apps/sim/providers/types.ts
@@ -21,6 +21,7 @@ export type ProviderId =
   | 'ollama'
   | 'ollama-cloud'
   | 'openrouter'
+  | 'orcarouter'
   | 'fireworks'
   | 'together'
   | 'baseten'

--- a/apps/sim/providers/utils.ts
+++ b/apps/sim/providers/utils.ts
@@ -181,6 +181,7 @@ export const providers: Record<ProviderId, ProviderMetadata> = {
   mistral: buildProviderMetadata('mistral'),
   bedrock: buildProviderMetadata('bedrock'),
   openrouter: buildProviderMetadata('openrouter'),
+  orcarouter: buildProviderMetadata('orcarouter'),
   fireworks: buildProviderMetadata('fireworks'),
   together: buildProviderMetadata('together'),
   baseten: buildProviderMetadata('baseten'),
@@ -207,6 +208,12 @@ export async function updateOpenRouterProviderModels(models: string[]): Promise<
   const { updateOpenRouterModels } = await import('@/providers/models')
   updateOpenRouterModels(models)
   providers.openrouter.models = getProviderModelsFromDefinitions('openrouter')
+}
+
+export async function updateOrcaRouterProviderModels(models: string[]): Promise<void> {
+  const { updateOrcaRouterModels } = await import('@/providers/models')
+  updateOrcaRouterModels(models)
+  providers.orcarouter.models = getProviderModelsFromDefinitions('orcarouter')
 }
 
 export async function updateFireworksProviderModels(models: string[]): Promise<void> {
@@ -242,6 +249,7 @@ export function getBaseModelProviders(): Record<string, ProviderId> {
         providerId !== 'vllm' &&
         providerId !== 'litellm' &&
         providerId !== 'openrouter' &&
+        providerId !== 'orcarouter' &&
         providerId !== 'fireworks' &&
         providerId !== 'together' &&
         providerId !== 'baseten'

--- a/apps/sim/stores/providers/store.ts
+++ b/apps/sim/stores/providers/store.ts
@@ -12,6 +12,7 @@ export const useProvidersStore = create<ProvidersStore>((set, get) => ({
     vllm: { models: [], isLoading: false },
     litellm: { models: [], isLoading: false },
     openrouter: { models: [], isLoading: false },
+    orcarouter: { models: [], isLoading: false },
     fireworks: { models: [], isLoading: false },
     together: { models: [], isLoading: false },
     baseten: { models: [], isLoading: false },

--- a/apps/sim/stores/providers/types.ts
+++ b/apps/sim/stores/providers/types.ts
@@ -4,6 +4,7 @@ export type ProviderName =
   | 'vllm'
   | 'litellm'
   | 'openrouter'
+  | 'orcarouter'
   | 'fireworks'
   | 'together'
   | 'baseten'

--- a/apps/sim/tools/types.ts
+++ b/apps/sim/tools/types.ts
@@ -17,6 +17,7 @@ export type BYOKProviderId =
   | 'together'
   | 'baseten'
   | 'ollama-cloud'
+  | 'orcarouter'
   | 'falai'
   | 'firecrawl'
   | 'exa'

--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -9,8 +9,8 @@ const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
 const BASELINE = {
-  totalRoutes: 1162,
-  zodRoutes: 1162,
+  totalRoutes: 1163,
+  zodRoutes: 1163,
   nonZodRoutes: 0,
 } as const
 


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a first-class named provider in Sim's model picker, mirroring the existing OpenRouter integration. OrcaRouter is an OpenAI-compatible gateway (`https://api.orcarouter.ai/v1`, key prefix `sk-orca-`) that routes across many upstream providers — the same shape as OpenRouter, so it fits the existing reseller-provider wiring with no new architectural surface.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

- **New `orcarouter` provider** (`apps/sim/providers/orcarouter/`): OpenAI-compatible chat completions with the full tool loop and streaming, using the same shared streaming/tool helpers as the other OpenAI-compatible providers. Targets `https://api.orcarouter.ai/v1` via the OpenAI SDK.
- **Model catalog route** (`apps/sim/app/api/providers/orcarouter/models/route.ts`): enumerates the public OrcaRouter `/v1/models` catalog (like OpenRouter's, no key required to list), filtering to chat-capable models.
- **Full registration** across the provider registry, `ProviderId`/`ProviderName`/`BYOKProviderId` unions, `PROVIDER_DEFINITIONS` + `DYNAMIC_MODEL_PROVIDERS`, provider metadata, attachment support (images + PDFs), the providers store, the model-list loader, and the query/contract wiring.
- **BYOK key resolution** for `orcarouter` keys, with workspace/org key support.
- **Docs**: Agent block provider list now mentions OrcaRouter.

Models are typed as `orcarouter/<id>` and appear in the model combobox automatically via the catalog route.

## Testing

- `vitest` — all provider, blocks, stores, contracts, and api-provider tests pass: **2807 tests across 194 files** (including a new 10-test `orcarouterProvider` suite).
- `tsc --noEmit` — clean.
- `biome check` — clean on all changed files.
- `check:api-validation` — passes (baseline route count bumped 1162 → 1163 for the new route).
- L3 live verification against the OrcaRouter API:
  - `GET https://api.orcarouter.ai/v1/models` → `200`
  - `POST https://api.orcarouter.ai/v1/chat/completions` with `model: "orcarouter/auto"` → `200`, returned `ORCA-LIVE-OK` (routed to `gemini-3.1-flash-lite`).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the Contributor License Agreement (CLA)

Disclosure: I'm an engineer on the OrcaRouter team.
