### PR TITLE
fix(terminal): keep running-command tooltips concise

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session.test.ts
@@ -9,7 +9,44 @@ import {
   terminalFontSizeForZoom,
   terminalSelectionLabel,
   terminalSelectionSnapshot,
+  terminalTooltip,
 } from '@/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session'
+
+describe('terminal tab tooltips', () => {
+  it('summarizes a long compound heredoc command by its foreground program', () => {
+    const running = `mkdir -p ~/.doordash-bot/bin && cat > ~/.doordash-bot/bin/dd-cli-mock <<'EOF'
+#!/usr/bin/env node
+const carts = new Map()
+process.stdout.write(JSON.stringify([...carts]))
+EOF
+chmod +x ~/.doordash-bot/bin/dd-cli-mock && echo '--- smoke test ---' && ~/.doordash-bot/bin/dd-cli-mock submit mock_123`
+    const tooltip = terminalTooltip({
+      terminalId: 'terminal-1',
+      title: 'mkdir',
+      cwd: '/Users/emirkarabeg',
+      running,
+      interactive: false,
+      active: false,
+    })
+
+    expect(tooltip).toBe('/Users/emirkarabeg — dd-cli-mock')
+    expect(tooltip).not.toContain('const carts')
+  })
+
+  it('preserves the working-directory tooltip for idle terminals', () => {
+    const idleTab = {
+      terminalId: 'terminal-1',
+      title: 'sim',
+      cwd: '/Users/emirkarabeg/sim',
+      running: null,
+      interactive: false,
+      active: true,
+    }
+
+    expect(terminalTooltip(idleTab)).toBe('/Users/emirkarabeg/sim')
+    expect(terminalTooltip({ ...idleTab, cwd: null })).toBe('Terminal')
+  })
+})
 
 describe('suspended terminal resource lifecycle', () => {
   it('does not remove a resource when administrative suspension clears its PTYs', () => {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session.tsx
@@ -114,10 +114,10 @@ function hideMountedMenuSurfaces(): void {
  */
 const COMMAND_SETTLE_MS = 1_000
 
-/** Full working directory, plus whatever the shell is running in it. */
-function terminalTooltip(tab: TerminalTabState): string {
+/** Full working directory, plus a concise name for whatever the shell is running. */
+export function terminalTooltip(tab: TerminalTabState): string {
   const where = tab.cwd ?? 'Terminal'
-  return tab.running ? `${where} — ${tab.running}` : where
+  return tab.running ? `${where} — ${describeRunningCommand(tab.running)}` : where
 }
 
 function sameIds(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
@@ -902,8 +902,8 @@ export function TerminalSession({ visible, scopeId }: TerminalSessionProps) {
         id: tab.terminalId,
         title: counts.get(label) === 1 ? label : `${label} ${occurrence}`,
         // The label is a basename, and the tab may be running something it
-        // is not naming yet, so hovering gives the whole picture: where the
-        // shell is, and what it is doing there.
+        // is not naming yet, so hovering identifies the working directory and
+        // foreground program without exposing the literal command.
         tooltip: terminalTooltip(tab),
         icon: (
           <TerminalTabIcon


### PR DESCRIPTION
## Summary

- Show the terminal working directory and a concise foreground program name in terminal-tab tooltips.
- Keep the literal running command unchanged in terminal state and scrollback, where it remains selectable and copyable.
- Add regression coverage for the long compound heredoc command reported in Slack and the existing idle-terminal fallbacks.

Slack issue: https://sim-ai.slack.com/archives/C093DF8MA21/p1786758187764159

The oversized tooltip was caused by passing the complete literal command into a short, non-interactive tooltip. Its existing width cap then wrapped document-length commands into a viewport-height column. This fixes the semantic input at the terminal call site by reusing `describeRunningCommand`; it does not change the shared tooltip primitive or affect browser/resource-tab tooltip behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing

- Focused terminal-session test: 10 passed.
- `@sim/terminal-protocol` tests: 9 passed.
- Full monorepo test suite: 18 workspace tasks passed; Sim app reported 2,166 passing test files and 30,775 passing tests.
- Full monorepo type-check passed.
- Full monorepo lint check passed with one unrelated existing unused-suppression warning in `lib/workspace-files/shell-layout.test.ts`.
- API-validation audit passed.
- Source-built Electron manual QA against the local renderer:
  - Ran a 900-character multiline heredoc in one of two terminal tabs.
  - Keyboard-focused the running tab and verified the tooltip was `/Users/billleoutsakos — python3` rather than the literal heredoc.
  - Verified the tooltip remained compact in a narrow split terminal pane and in both dark and light themes.
  - Verified the full command remained visible in terminal scrollback and that selecting it enabled the existing Copy action.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

The original oversized-tooltip screenshot is in the linked Slack thread. Manual QA was completed in both dark and light themes using the source-built desktop app.
