### PR TITLE
fix(media): stop the ffmpeg output format from choosing its own path

### DIFF
--- a/apps/sim/lib/media/ffmpeg.test.ts
+++ b/apps/sim/lib/media/ffmpeg.test.ts
@@ -244,6 +244,44 @@ describe('runFfmpegOperation concat normalization target', () => {
   })
 })
 
+describe('runFfmpegOperation output format', () => {
+  const traversals = [
+    '../../../../../../../../tmp/pwned.mp4',
+    '../sibling.mp4',
+    'mp4/../../../etc/x',
+    '/etc/passwd',
+    'mp4\u0000.txt',
+  ]
+
+  for (const format of traversals) {
+    it(`refuses to build an output path from ${JSON.stringify(format)}`, async () => {
+      await expect(runFfmpegOperation('convert', [videoInput], { format })).rejects.toThrow(
+        /Unsupported output format/
+      )
+      // Rejected before FFmpeg is handed anything to write.
+      expect(saves.waiters.length).toBe(0)
+    })
+  }
+
+  it('refuses a traversal on extract_audio too', async () => {
+    await expect(
+      runFfmpegOperation('extract_audio', [videoInput], { format: '../../../tmp/pwned.mp3' })
+    ).rejects.toThrow(/Unsupported output format/)
+  })
+
+  it('still accepts ordinary container extensions', async () => {
+    for (const format of ['mp4', 'mp3', 'webm', 'm4a', 'flac', 'opus', 'gif', 'mkv']) {
+      const result = await runFfmpegOperation('convert', [videoInput], { format })
+      expect(result.ext).toBe(format)
+    }
+  })
+
+  it('lowercases before validating, so MP4 is still a valid target', async () => {
+    const result = await runFfmpegOperation('convert', [videoInput], { format: 'MP4' })
+    expect(result.ext).toBe('mp4')
+  })
+})
+
 describe('runFfmpegOperation process bounds', () => {
   it('kills a command that outlives the operation budget', async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })

--- a/apps/sim/lib/media/ffmpeg.ts
+++ b/apps/sim/lib/media/ffmpeg.ts
@@ -238,6 +238,34 @@ async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
   }
 }
 
+/**
+ * Extensions this module will build an output path from: letters and digits only.
+ *
+ * `format` reaches the tool as an unconstrained string and is the one
+ * caller-controlled value that becomes a path. Because the pattern admits no `.`
+ * and no separator, `out.${ext}` is always a single path segment, so the joined
+ * path cannot leave the temp directory — the containment is the pattern, not a
+ * second check that could drift away from it.
+ */
+const OUTPUT_EXT_PATTERN = /^[a-z0-9]{1,12}$/
+
+/**
+ * Resolve a temp-dir output path for a caller-supplied extension.
+ *
+ * Unvalidated, `path.join(dir, 'out.' + '../../../../tmp/x.mp4')` resolves to
+ * `/tmp/x.mp4`: FFmpeg writes wherever the traversal points, the bytes are
+ * attacker-influenced media, and the temp-directory cleanup never sees the file
+ * because it was never inside the directory being removed.
+ */
+function outputPathForExt(dir: string, ext: string): string {
+  if (!OUTPUT_EXT_PATTERN.test(ext)) {
+    throw new Error(
+      `Unsupported output format "${ext}" — use a plain extension such as mp4, mp3, wav, or gif`
+    )
+  }
+  return path.join(dir, `out.${ext}`)
+}
+
 async function writeInput(dir: string, file: MediaFile, index: number): Promise<string> {
   const ext = extFromMime(file.mimeType)
   const filePath = path.join(dir, `in-${index}.${ext}`)
@@ -807,7 +835,7 @@ async function extractAudio(
   options: FfmpegOptions
 ): Promise<FfmpegResult> {
   const ext = (options.format || 'mp3').toLowerCase()
-  const outputPath = path.join(dir, `out.${ext}`)
+  const outputPath = outputPathForExt(dir, ext)
   const command = ffmpeg(inputPath).noVideo()
   await runCommand(ctx, command, outputPath)
   return readOut(outputPath, ext)
@@ -821,7 +849,7 @@ async function convert(
 ): Promise<FfmpegResult> {
   if (!options.format) throw new Error('convert requires a target format')
   const ext = options.format.toLowerCase()
-  const outputPath = path.join(dir, `out.${ext}`)
+  const outputPath = outputPathForExt(dir, ext)
   await runCommand(ctx, ffmpeg(inputPath), outputPath)
   return readOut(outputPath, ext)
 }


### PR DESCRIPTION
## Summary

`convert` and `extract_audio` built their output path as ``path.join(dir, `out.${format}`)``, and `format` arrives from the tool as an unconstrained `{"type": "string"}` — no `pattern`, no `enum` — which the handler passes through untouched. A traversal in that string relocates the file FFmpeg writes.

Verified against a real FFmpeg binary rather than reasoned about:

```
format = "../../../../../../../../tmp/ffx-escaped.mp4"
  path.join(dir, "out." + format)  ->  /tmp/ffx-escaped.mp4
  result: 44,078-byte MP4 written outside the temp directory
```

The temp directory is removed with `fs.rm(dir, { recursive: true, force: true })` afterwards, which never sees that file — it was never inside the directory being removed. So the write also outlives the cleanup that is supposed to bound this tool's filesystem footprint.

The bytes are a transcode of a caller-supplied input, so the attacker influences the content as well as the destination, bounded only by what the app process can write. Reaching it needs nothing but workspace write permission, the same gate as the rest of the tool.

## Fix

Output extensions are letters and digits only, up to 12 characters. Because the pattern admits no `.` and no separator, ``out.${ext}`` is always a single path segment — containment follows from the validation itself rather than from a second check that could drift away from it.

Every ordinary target still works: `mp4`, `mp3`, `webm`, `m4a`, `flac`, `opus`, `gif`, `mkv`, and `MP4` still lowercases before validating.

## What is deliberately not changed

`trim` and `fade` also build paths from an extension, but theirs comes from `extFromMime`, which returns `mime.split('/')[1]` — that can never contain a separator, so those paths are already contained. Routing them through this stricter pattern would wrongly reject legitimate values like `x-msvideo` that the fallback produces for an unrecognized MIME type.

## Provenance

Found while tracing a report that targeted `escapeDrawtext` and `addText`. **That vulnerability is already fixed** — #6734 replaced the inline caption with `textfile=` plus `expansion=none`, and `escapeDrawtext` no longer exists — but the report's observation that the tool's string parameters are unconstrained still held for `format`, which is a path rather than a filtergraph.

## Verification

Six traversal cases pinned by tests — parent-relative, deep-relative, embedded `..`, absolute, and an embedded NUL — each confirmed to fail against the unfixed source before the fix was applied. Full suite: 1,789 tests across `lib/copilot` and `lib/media`, plus `tsc --noEmit`, `lint:check`, and the `api-validation` / `boundaries` / `client-boundary` / `utils` gates.

## Follow-ups, not in scope

- A `-protocol_whitelist` on FFmpeg inputs would stop a crafted *input container* from referencing external resources. No injection vector remains through the tool's own parameters, so this is defence in depth rather than a fix, and it needs care not to break the concat demuxer.
- `concat` is separately broken for any clip without an audio stream: it synthesizes silence with `-f lavfi`, but `lavfi` is a libavdevice *device* and fluent-ffmpeg validates `-f` against `ffmpeg -formats`, which does not list devices. Reproduced standalone; fix verified; wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)