### PR TITLE
improvement(pricing): list Sandboxes as a Max and Enterprise feature

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/upgrade/components/comparison-table/comparison-data.ts
+++ b/apps/sim/app/workspace/[workspaceId]/upgrade/components/comparison-table/comparison-data.ts
@@ -194,6 +194,10 @@ export const COMPARISON_SECTIONS: ComparisonSection[] = [
         values: [false, false, true, true],
       },
       {
+        label: 'Sandboxes',
+        values: [false, false, true, true],
+      },
+      {
         label: 'Slack Connect',
         values: [false, false, SLACK, SLACK],
       },

--- a/apps/sim/app/workspace/[workspaceId]/upgrade/plan-configs.ts
+++ b/apps/sim/app/workspace/[workspaceId]/upgrade/plan-configs.ts
@@ -37,7 +37,7 @@ export const PRO_PLAN_FEATURES: readonly string[] = [
 export const MAX_PLAN_FEATURES: readonly string[] = [
   `${DEFAULT_BILLING_CONCURRENCY_LIMITS.team.toLocaleString('en-US')} concurrent executions`,
   'Invite teammates',
-  'Sim Mailer & KB Live Sync',
+  'Sim Mailer, KB Live Sync & Sandboxes',
   'Highest rate limits',
   'Expanded storage & tables',
 ]


### PR DESCRIPTION
## Summary
- Add a `Sandboxes` row to the shared pricing comparison `Features` section, available on Max and Enterprise
- Sandboxes gate on the same Max-or-Enterprise entitlement as Sim Mailer and KB Live Sync (`hasWorkspaceSandboxAccess` → `hasMaxTierWorkspaceAccess`), so the row sits with them above the Enterprise-only block
- One row covers all three surfaces that read `COMPARISON_SECTIONS`: the public pricing cards, the in-app upgrade comparison table, and the `WebApplication.featureList` JSON-LD on `/pricing`
- Update the Max upgrade card bullet to `Sim Mailer, KB Live Sync & Sandboxes` so the summary card matches the full table

## Type of Change
- [x] Improvement

## Testing
Tested manually. Biome check passes on both changed files; the rest of the audit suite was not run in this worktree (dependencies are not installed here) — the diff is data-literal only, with no generator inputs touched.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
