### PR TITLE
refactor: replace hand-rolled utilities and dead code with the shared forms

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -289,14 +289,8 @@ export const PlusMenuDropdown = React.memo(
       <DropdownMenu open={open} onOpenChange={handleOpenChange}>
         <DropdownMenuTrigger asChild>
           <div
-            style={{
-              position: 'fixed',
-              left: anchorPos?.left ?? 0,
-              top: anchorPos?.top ?? 0,
-              width: 0,
-              height: 0,
-              pointerEvents: 'none',
-            }}
+            className='pointer-events-none fixed size-0'
+            style={{ left: anchorPos?.left ?? 0, top: anchorPos?.top ?? 0 }}
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/skills-menu-dropdown/skills-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/skills-menu-dropdown/skills-menu-dropdown.tsx
@@ -182,14 +182,8 @@ export const SkillsMenuDropdown = React.memo(
       <DropdownMenu open={open} onOpenChange={handleOpenChange}>
         <DropdownMenuTrigger asChild>
           <div
-            style={{
-              position: 'fixed',
-              left: anchorPos?.left ?? 0,
-              top: anchorPos?.top ?? 0,
-              width: 0,
-              height: 0,
-              pointerEvents: 'none',
-            }}
+            className='pointer-events-none fixed size-0'
+            style={{ left: anchorPos?.left ?? 0, top: anchorPos?.top ?? 0 }}
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/skill-input/skill-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/skill-input/skill-input.tsx
@@ -44,12 +44,17 @@ export function SkillInput({
   const [editingSkillId, setEditingSkillId] = useState<string | null>(null)
   const [editingSkillSnapshot, setEditingSkillSnapshot] = useState<SkillDefinition | null>(null)
 
+  const skillsById = useMemo(
+    () => new Map(workspaceSkills.map((skill) => [skill.id, skill])),
+    [workspaceSkills]
+  )
+
   // Prefer the live query cache so the modal reflects concurrent edits, but
   // fall back to the click-time snapshot when a background refetch drops the
   // skill — otherwise the modal would close mid-edit and silently discard the
   // draft; saving surfaces the real server error instead.
   const editingSkill = editingSkillId
-    ? (workspaceSkills.find((s) => s.id === editingSkillId) ?? editingSkillSnapshot)
+    ? (skillsById.get(editingSkillId) ?? editingSkillSnapshot)
     : null
 
   const selectedSkills: StoredSkill[] = useMemo(() => {
@@ -119,10 +124,10 @@ export function SkillInput({
 
   const resolveSkillName = useCallback(
     (stored: StoredSkill): string => {
-      const found = workspaceSkills.find((s) => s.id === stored.skillId)
+      const found = skillsById.get(stored.skillId)
       return found?.name ?? stored.name ?? stored.skillId
     },
-    [workspaceSkills]
+    [skillsById]
   )
 
   return (
@@ -141,7 +146,7 @@ export function SkillInput({
 
         {selectedSkills.length > 0 &&
           selectedSkills.map((stored, index) => {
-            const fullSkill = workspaceSkills.find((s) => s.id === stored.skillId)
+            const fullSkill = skillsById.get(stored.skillId)
             const skillName = resolveSkillName(stored)
             const workflowSearchHighlight = getWorkflowSearchLabelHighlight({
               activeSearchTarget,

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -520,7 +520,7 @@ export const ToolInput = memo(function ToolInput({
   // subBlock): shown in the picker but greyed out with a tooltip instead of added.
   const blockType = useWorkflowStore(useCallback((state) => state.blocks[blockId]?.type, [blockId]))
   const unsupportedToolTypes = useMemo<readonly ('mcp' | 'custom-tool')[]>(() => {
-    const block = getBlock(blockType)
+    const block = blockType ? getBlock(blockType) : undefined
     return block?.subBlocks.find((sb) => sb.id === subBlockId)?.unsupportedToolTypes ?? []
   }, [blockType, subBlockId])
   const mcpUnsupported = unsupportedToolTypes.includes('mcp')

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -520,7 +520,7 @@ export const ToolInput = memo(function ToolInput({
   // subBlock): shown in the picker but greyed out with a tooltip instead of added.
   const blockType = useWorkflowStore(useCallback((state) => state.blocks[blockId]?.type, [blockId]))
   const unsupportedToolTypes = useMemo<readonly ('mcp' | 'custom-tool')[]>(() => {
-    const block = getAllBlocks().find((b) => b.type === blockType)
+    const block = getBlock(blockType)
     return block?.subBlocks.find((sb) => sb.id === subBlockId)?.unsupportedToolTypes ?? []
   }, [blockType, subBlockId])
   const mcpUnsupported = unsupportedToolTypes.includes('mcp')
@@ -529,9 +529,8 @@ export const ToolInput = memo(function ToolInput({
   // Look up credential type for reactive condition filtering (e.g. service account detection).
   // Uses canonical resolution so the active field (basic vs advanced) is respected.
   const toolCredentialId = useMemo(() => {
-    const allBlocks = getAllBlocks()
     for (const [toolIndex, tool] of selectedTools.entries()) {
-      const blockConfig = allBlocks.find((b: { type: string }) => b.type === tool.type)
+      const blockConfig = getBlock(tool.type)
       if (!blockConfig?.subBlocks) continue
       // canonical-index-unscoped: a nested tool resolves against `tool.params`, which only ever
       // holds action-surface values — a tool is never invoked in trigger mode.

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -530,7 +530,7 @@ export const ToolInput = memo(function ToolInput({
   // Uses canonical resolution so the active field (basic vs advanced) is respected.
   const toolCredentialId = useMemo(() => {
     for (const [toolIndex, tool] of selectedTools.entries()) {
-      const blockConfig = getBlock(tool.type)
+      const blockConfig = tool.type ? getBlock(tool.type) : undefined
       if (!blockConfig?.subBlocks) continue
       // canonical-index-unscoped: a nested tool resolves against `tool.params`, which only ever
       // holds action-surface values — a tool is never invoked in trigger mode.

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/panel.tsx
@@ -640,13 +640,10 @@ export const Panel = memo(function Panel() {
     setIsMenuOpen(false)
   }, [collaborativeBatchToggleLocked])
 
-  // Compute run button state
-  const canRun = userPermissions.canRead // Running only requires read permissions
+  const canRun = userPermissions.canRead
   const isLoadingPermissions = userPermissions.isLoading
-  const hasValidationErrors = false // TODO: Add validation logic if needed
-  const isWorkflowBlocked = isExecuting || hasValidationErrors
   const isButtonDisabled =
-    !isExecuting && (isUsageGateLoading || isWorkflowBlocked || (!canRun && !isLoadingPermissions))
+    !isExecuting && (isUsageGateLoading || (!canRun && !isLoadingPermissions))
 
   /**
    * Register global keyboard shortcuts using the central commands registry.

--- a/apps/sim/blocks/blocks/fireflies.ts
+++ b/apps/sim/blocks/blocks/fireflies.ts
@@ -1,3 +1,4 @@
+import { omit } from '@sim/utils/object'
 import { FirefliesIcon } from '@/components/icons'
 import { resolveHttpsUrlFromFileInput } from '@/lib/uploads/utils/file-utils'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
@@ -698,9 +699,7 @@ Return ONLY the summary text - no quotes, no labels.`,
 const firefliesV2SubBlocks = (FirefliesBlock.subBlocks || []).filter(
   (subBlock) => subBlock.id !== 'audioUrl'
 )
-const firefliesV2Inputs = FirefliesBlock.inputs
-  ? Object.fromEntries(Object.entries(FirefliesBlock.inputs).filter(([key]) => key !== 'audioUrl'))
-  : {}
+const firefliesV2Inputs = FirefliesBlock.inputs ? omit(FirefliesBlock.inputs, ['audioUrl']) : {}
 
 export const FirefliesV2Block: BlockConfig<FirefliesResponse> = {
   ...FirefliesBlock,

--- a/apps/sim/blocks/blocks/grain.ts
+++ b/apps/sim/blocks/blocks/grain.ts
@@ -1,3 +1,4 @@
+import { omit } from '@sim/utils/object'
 import { GrainIcon } from '@/components/icons'
 import type { BlockConfig, BlockMeta } from '@/blocks/types'
 import { AuthMode, IntegrationType } from '@/blocks/types'
@@ -758,7 +759,7 @@ export const GrainV2Block: BlockConfig = {
     },
   },
   inputs: {
-    ...Object.fromEntries(Object.entries(GrainBlock.inputs).filter(([key]) => key !== 'viewId')),
+    ...omit(GrainBlock.inputs, ['viewId']),
     apiKey: { type: 'string', description: 'Grain API key (Personal or Workspace Access Token)' },
     hookType: { type: 'string', description: 'Grain event type for the webhook' },
     hookInclude: {

--- a/apps/sim/blocks/blocks/stt.ts
+++ b/apps/sim/blocks/blocks/stt.ts
@@ -1,3 +1,4 @@
+import { omit } from '@sim/utils/object'
 import { STTIcon } from '@/components/icons'
 import { AuthMode, type BlockConfig, IntegrationType } from '@/blocks/types'
 import { createVersionedToolSelector, normalizeFileInput } from '@/blocks/utils'
@@ -368,9 +369,7 @@ export const SttBlock: BlockConfig<SttBlockResponse> = {
   },
 }
 
-const sttV2Inputs = SttBlock.inputs
-  ? Object.fromEntries(Object.entries(SttBlock.inputs).filter(([key]) => key !== 'audioUrl'))
-  : {}
+const sttV2Inputs = SttBlock.inputs ? omit(SttBlock.inputs, ['audioUrl']) : {}
 const sttV2SubBlocks = (SttBlock.subBlocks || []).filter((subBlock) => subBlock.id !== 'audioUrl')
 
 export const SttV2Block: BlockConfig<SttBlockResponse> = {

--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -32,7 +32,7 @@ import { selectModelBoundFileInputPaths } from '@/lib/uploads/utils/model-input'
 import { hydrateUserFilesWithBase64 } from '@/lib/uploads/utils/user-file-base64.server'
 import { resolveCustomBlockToolBinding } from '@/lib/workflows/custom-blocks/operations'
 import { getCustomToolById } from '@/lib/workflows/custom-tools/operations'
-import { getAllBlocks } from '@/blocks'
+import { getAllBlocks, getBlock } from '@/blocks'
 import { assembleCustomBlockInputMapping, isCustomBlockType } from '@/blocks/custom/build-config'
 import type { BlockOutput } from '@/blocks/types'
 import { normalizeFileInput } from '@/blocks/utils'
@@ -857,7 +857,7 @@ export class AgentBlockHandler implements BlockHandler {
     )
     if (tool.type === 'mcp' || tool.type === 'custom-tool') return alignedParams
 
-    const blockInputs = getAllBlocks().find((block) => block.type === tool.type)?.inputs
+    const blockInputs = tool.type ? getBlock(tool.type)?.inputs : undefined
     return prepareResolvedSecretProjectedInputs(alignedParams, blockInputs, formattedParams)
   }
 

--- a/apps/sim/executor/handlers/api/api-handler.ts
+++ b/apps/sim/executor/handlers/api/api-handler.ts
@@ -58,7 +58,7 @@ export class ApiBlockHandler implements BlockHandler {
             if (trimmedBody.startsWith('{') || trimmedBody.startsWith('[')) {
               processedInputs.body = JSON.parse(trimmedBody)
             }
-          } catch (e) {}
+          } catch {}
         } else if (processedInputs.body === null) {
           processedInputs.body = undefined
         }

--- a/apps/sim/executor/utils.ts
+++ b/apps/sim/executor/utils.ts
@@ -113,7 +113,7 @@ export class StreamingResponseFormatProcessor implements ResponseFormatStreamPro
 
         return null
       }
-    } catch (e) {}
+    } catch {}
 
     const openBraces = (buffer.match(/\{/g) || []).length
     const closeBraces = (buffer.match(/\}/g) || []).length
@@ -138,7 +138,7 @@ export class StreamingResponseFormatProcessor implements ResponseFormatStreamPro
 
           return null
         }
-      } catch (e) {}
+      } catch {}
     }
 
     return null

--- a/apps/sim/executor/utils/errors.ts
+++ b/apps/sim/executor/utils/errors.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@sim/utils/errors'
 import { HttpError } from '@/lib/core/utils/http-error'
 import type { ExecutionContext, ExecutionResult } from '@/executor/types'
 import type { SerializedBlock } from '@/serializer/types'
@@ -49,8 +50,7 @@ export interface BlockExecutionErrorDetails {
  * every block boundary.
  */
 export function buildBlockExecutionError(details: BlockExecutionErrorDetails): Error {
-  const errorMessage =
-    details.error instanceof Error ? details.error.message : String(details.error)
+  const errorMessage = getErrorMessage(details.error)
   const blockName = details.block.metadata?.name || details.block.id
   const blockType = details.block.metadata?.id || 'unknown'
 

--- a/apps/sim/hooks/selectors/providers/google/selectors.ts
+++ b/apps/sim/hooks/selectors/providers/google/selectors.ts
@@ -1,6 +1,10 @@
 import { requestJson } from '@/lib/api/client/request'
 import * as selectorContracts from '@/lib/api/contracts/selectors'
-import { ensureCredential, SELECTOR_STALE } from '@/hooks/selectors/providers/shared'
+import {
+  ensureCredential,
+  SELECTOR_SEARCH_STALE,
+  SELECTOR_STALE,
+} from '@/hooks/selectors/providers/shared'
 import type { SelectorDefinition, SelectorKey, SelectorQueryArgs } from '@/hooks/selectors/types'
 
 export const googleSelectors = {
@@ -101,7 +105,7 @@ export const googleSelectors = {
       selectorContracts.googleDriveFilesSelectorContract,
       selectorContracts.googleDriveFileSelectorContract,
     ],
-    staleTime: 15 * 1000,
+    staleTime: SELECTOR_SEARCH_STALE,
     getQueryKey: ({ context, search }: SelectorQueryArgs) => [
       'selectors',
       'google.drive',

--- a/apps/sim/hooks/selectors/providers/jira/selectors.ts
+++ b/apps/sim/hooks/selectors/providers/jira/selectors.ts
@@ -1,7 +1,12 @@
 import { requestJson } from '@/lib/api/client/request'
 import * as selectorContracts from '@/lib/api/contracts/selectors'
 import { fetchOAuthToken } from '@/hooks/selectors/helpers'
-import { ensureCredential, ensureDomain, SELECTOR_STALE } from '@/hooks/selectors/providers/shared'
+import {
+  ensureCredential,
+  ensureDomain,
+  SELECTOR_SEARCH_STALE,
+  SELECTOR_STALE,
+} from '@/hooks/selectors/providers/shared'
 import type { SelectorDefinition, SelectorKey, SelectorQueryArgs } from '@/hooks/selectors/types'
 
 export const jiraSelectors = {
@@ -71,7 +76,7 @@ export const jiraSelectors = {
       selectorContracts.jiraIssuesSelectorContract,
       selectorContracts.jiraIssueSelectorContract,
     ],
-    staleTime: 15 * 1000,
+    staleTime: SELECTOR_SEARCH_STALE,
     getQueryKey: ({ context, search }: SelectorQueryArgs) => [
       'selectors',
       'jira.issues',

--- a/apps/sim/hooks/selectors/providers/shared.ts
+++ b/apps/sim/hooks/selectors/providers/shared.ts
@@ -2,6 +2,15 @@ import type { SelectorContext, SelectorKey } from '@/hooks/selectors/types'
 
 export const SELECTOR_STALE = 60 * 1000
 
+/**
+ * Stale window for selectors whose result set is search-backed.
+ *
+ * Shorter than {@link SELECTOR_STALE} because the query key carries the search
+ * term, so a stale entry is a stale answer to a question the user is still
+ * typing rather than a stale copy of a stable list.
+ */
+export const SELECTOR_SEARCH_STALE = 15 * 1000
+
 export const ensureCredential = (context: SelectorContext, key: SelectorKey): string => {
   if (!context.oauthCredential) {
     throw new Error(`Missing credential for selector ${key}`)

--- a/apps/sim/hooks/selectors/providers/shared.ts
+++ b/apps/sim/hooks/selectors/providers/shared.ts
@@ -3,11 +3,13 @@ import type { SelectorContext, SelectorKey } from '@/hooks/selectors/types'
 export const SELECTOR_STALE = 60 * 1000
 
 /**
- * Stale window for selectors whose result set is search-backed.
+ * The shorter stale window carried by `google.drive`, `jira.issues` and
+ * `webflow.items`, whose listings turn over faster than {@link SELECTOR_STALE}
+ * assumes.
  *
- * Shorter than {@link SELECTOR_STALE} because the query key carries the search
- * term, so a stale entry is a stale answer to a question the user is still
- * typing rather than a stale copy of a stable list.
+ * Not every search-backed selector uses it — several still sit on
+ * {@link SELECTOR_STALE} — so treat this as the value those three share rather
+ * than a rule about search.
  */
 export const SELECTOR_SEARCH_STALE = 15 * 1000
 

--- a/apps/sim/hooks/selectors/providers/webflow/selectors.ts
+++ b/apps/sim/hooks/selectors/providers/webflow/selectors.ts
@@ -1,6 +1,10 @@
 import { requestJson } from '@/lib/api/client/request'
 import * as selectorContracts from '@/lib/api/contracts/selectors'
-import { ensureCredential, SELECTOR_STALE } from '@/hooks/selectors/providers/shared'
+import {
+  ensureCredential,
+  SELECTOR_SEARCH_STALE,
+  SELECTOR_STALE,
+} from '@/hooks/selectors/providers/shared'
 import type { SelectorDefinition, SelectorKey, SelectorQueryArgs } from '@/hooks/selectors/types'
 
 export const webflowSelectors = {
@@ -59,7 +63,7 @@ export const webflowSelectors = {
   'webflow.items': {
     key: 'webflow.items',
     contracts: [selectorContracts.webflowItemsSelectorContract],
-    staleTime: 15 * 1000,
+    staleTime: SELECTOR_SEARCH_STALE,
     getQueryKey: ({ context, search }: SelectorQueryArgs) => [
       'selectors',
       'webflow.items',

--- a/apps/sim/lib/workflows/subblocks/display.ts
+++ b/apps/sim/lib/workflows/subblocks/display.ts
@@ -556,13 +556,15 @@ export function resolveSkillsLabel(
   if (subBlock?.type !== 'skill-input') return null
   if (!Array.isArray(rawValue) || rawValue.length === 0) return null
 
+  const skillsById = new Map(skills.map((skill) => [skill.id, skill]))
+
   const names = rawValue
     .map((skill: unknown) => {
       if (!skill || typeof skill !== 'object') return null
       const s = skill as { skillId?: string; name?: string }
 
       if (s.skillId) {
-        const found = skills.find((candidate) => candidate.id === s.skillId)
+        const found = skillsById.get(s.skillId)
         if (found?.name) return found.name
       }
       if (typeof s.name === 'string' && s.name) return s.name


### PR DESCRIPTION
> Stacked on #7015. Review that first; this PR's base is `deslop-codebase`, and it should be retargeted to `staging` once #7015 merges.

## What

Sites that hand-roll something the repo already mandates, plus the dead code around them. Each was verified equivalent before changing, not pattern-matched:

| Replaced | With | Where |
|---|---|---|
| `Object.fromEntries(Object.entries(x).filter(...))` | `omit()` | `blocks/blocks/{stt,fireflies,grain}.ts` |
| `error instanceof Error ? error.message : String(error)` | `getErrorMessage()` | `executor/utils/errors.ts:53` |
| `getAllBlocks().find((b) => b.type === x)` | `getBlock()` | `tool-input.tsx` ×2, `agent-handler.ts` |
| `.find()`-by-id in a loop | a `Map` index | `skill-input.tsx` ×3, `display.ts` |
| `15 * 1000` ×3 | `SELECTOR_SEARCH_STALE` | `{jira,google,webflow}/selectors.ts` |
| static inline `style` | Tailwind classes | `{plus,skills}-menu-dropdown.tsx` |
| `catch (e) {}` | `catch {}` | `api-handler.ts`, `executor/utils.ts` ×2 |

`omit()` also recovers the `Omit<T, K>` typing that `Object.fromEntries` erases to a bare index signature.

`getAllBlocks()` is not memoised — each call built a fresh 336-element array before scanning it. `getBlock` is an O(1) registry index. `agent-handler`'s call ran per tool during execution; `tool-input`'s ran inside a loop over selected tools.

`panel.tsx` loses a `TODO`-stubbed `const hasValidationErrors = false` and the `isWorkflowBlocked` term built on it. That term was dead twice over — it reduced to `isExecuting`, and the enclosing expression is already guarded by `!isExecuting`, so the disjunct could only ever be reached as `false`.

## Two things the review caught

**`getBlock` is not a drop-in for `.find()`.** It normalizes via `type.replace(...)`, so it *throws* on `undefined` where `.find()` returned `undefined` harmlessly. Both call sites are reachable without a type — `tool-input` reads `state.blocks[blockId]?.type`, undefined once the block is deleted while the panel is mounted. `Record` indexing hid that from the compiler; it would have thrown during render. Both are now guarded. The compiler did catch the `agent-handler` one.

**`providers/utils.ts:683` deliberately keeps its `getAllBlocks().find(...)`.** It takes the registry as an *injected dependency* so a client-reachable module never imports it. Reaching for `getBlock` there would cross that boundary, so it was left alone.

## Scope

Behavior-preserving throughout — no user-visible change intended. The `SELECTOR_SEARCH_STALE` constant preserves the three sites' existing 15s window rather than folding them into the 60s `SELECTOR_STALE`; its doc describes what those three callers share rather than asserting a rule about search, since several other search-backed selectors still sit on the longer window.

## Testing

- 7019 tests passing across `executor`, `blocks`, `hooks`, `lib/workflows/subblocks`, `app/workspace`
- `bun run type-check` clean; `bun run check:api-validation` passes

## Provenance

Found by running [mattpocock/skills](https://github.com/mattpocock/skills) over the codebase. Worth noting what the audit did *not* find: the repo's mandated-utility rules are already ~95% enforced — zero `@ts-ignore`, zero `JSON.parse(JSON.stringify(`, and 52 of 60 non-test double-casts already carry their required annotation.