### PR TITLE
fix(settings): report a failed settings write instead of reporting success

### DIFF
--- a/apps/sim/app/api/users/me/settings/route.test.ts
+++ b/apps/sim/app/api/users/me/settings/route.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment node
+ */
+import { createMockRequest, dbChainMockFns, resetDbChainMock } from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetSession } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  auth: { api: { getSession: vi.fn() } },
+  getSession: mockGetSession,
+}))
+
+import { PATCH } from '@/app/api/users/me/settings/route'
+
+describe('PATCH /api/users/me/settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+    mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
+  })
+
+  it('reports success when the write lands', async () => {
+    const response = await PATCH(createMockRequest('PATCH', { theme: 'dark' }))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ success: true })
+  })
+
+  /**
+   * The regression this guards: the catch answered `{ success: true }` with 200, so
+   * `useUpdateGeneralSetting`'s optimistic rollback in `onError` could never run —
+   * a failed write showed as applied until the next refetch, including for
+   * consent-shaped settings the user believes they changed.
+   */
+  it('reports failure when the write throws', async () => {
+    dbChainMockFns.insert.mockImplementationOnce(() => {
+      throw new Error('connection terminated unexpectedly')
+    })
+
+    const response = await PATCH(createMockRequest('PATCH', { theme: 'dark' }))
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).not.toMatchObject({ success: true })
+  })
+})

--- a/apps/sim/app/api/users/me/settings/route.ts
+++ b/apps/sim/app/api/users/me/settings/route.ts
@@ -74,6 +74,10 @@ export const PATCH = withRouteHandler(async (request: NextRequest) => {
     return NextResponse.json({ success: true }, { status: 200 })
   } catch (error: any) {
     logger.error(`[${requestId}] Settings update error`, error)
-    return NextResponse.json({ success: true }, { status: 200 })
+    /* The client mutation is optimistic: it writes the new value into the cache in
+       `onMutate` and restores it in `onError`. Answering 200 here left that rollback
+       unreachable, so a failed write showed as applied until the next refetch —
+       including for consent-shaped settings the user believes they changed. */
+    return NextResponse.json({ error: 'Failed to update settings' }, { status: 500 })
   }
 })


### PR DESCRIPTION
## The route cannot fail

`app/api/users/me/settings/route.ts:75`

```ts
} catch (error: any) {
  logger.error(`[${requestId}] Settings update error`, error)
  return NextResponse.json({ success: true }, { status: 200 })
}
```

A failed upsert is answered exactly like a successful one.

## Which makes the client's rollback unreachable

`useUpdateGeneralSetting` (`hooks/queries/general-settings.ts:166`) is a full optimistic mutation:

- `onMutate` writes the new value into the cache and calls `syncThemeToNextThemes`
- `onError` restores `context.previousSettings` and re-syncs the theme

`requestJson` throws `ApiClientError` only on a non-2xx. Since the route always answered 200, **`onError` could never run** — the rollback and its theme re-sync are dead code.

## What the user sees

The upsert throws (pool exhaustion, a conflict on `settings.userId`, a replica failover). The UI applies the change. Nothing is persisted. `onSettled` invalidates, the refetch returns the old value, and the setting quietly reverts with no error anywhere.

For a consent-shaped setting — telemetry, email opt-out — the user believes they opted out and did not.

## The fix

The catch returns 500, which is what the mutation was already written to handle. No client change needed.

## Deliberately not changed

`GET` still falls back to `defaultUserSettings` on error, also at 200. Failing it would take the settings page down on a transient read, and whether that trade is right is a separate judgement from this one. Worth noting it compounds the above — a failing GET makes the post-write refetch show defaults — but the write path is the one making a false claim.

## Testing

A route test drives the failure through the real handler rather than asserting on a mock:

```
✓ reports success when the write lands
✓ reports failure when the write throws
```

Verified it can fail — restoring the `200` turns the second case red with `expected 200 to be 500`.

`bun run type-check` clean; 41 tests passing across `app/api/users` and the settings hook.