### PR TITLE
fix: surface an unbilled run, and clamp the google-docs page cap

### DIFF
--- a/apps/sim/connectors/google-docs/google-docs.ts
+++ b/apps/sim/connectors/google-docs/google-docs.ts
@@ -304,7 +304,8 @@ export const googleDocsConnector: ConnectorConfig = {
 
     const maxDocs = sourceConfig.maxDocs ? Number(sourceConfig.maxDocs) : 0
     const previouslyFetched = (syncContext?.totalDocsFetched as number) ?? 0
-    const remaining = maxDocs > 0 ? maxDocs - previouslyFetched : 0
+    /** Last-page precision: never ask Drive for more files than the cap still allows. */
+    const remaining = maxDocs > 0 ? Math.max(0, maxDocs - previouslyFetched) : 0
     const pageSize = remaining > 0 ? Math.min(PAGE_SIZE, remaining) : PAGE_SIZE
 
     /**

--- a/apps/sim/lib/logs/execution/logger.ts
+++ b/apps/sim/lib/logs/execution/logger.ts
@@ -1399,7 +1399,16 @@ export class ExecutionLogger implements IExecutionLoggerService {
           actorUserId,
           exactBillingContext
         )
-      } catch {}
+      } catch (recordError) {
+        /* The safety net is the last thing between a completed run and an unbilled
+           one. Swallowing it left the only emitted line saying a notification check
+           had failed and was non-fatal. */
+        execLog.error('Failed to record execution usage — this run may be unbilled', {
+          error: recordError,
+          executionId,
+          workflowId: updatedLog.workflowId,
+        })
+      }
       execLog.warn('Usage threshold notification check failed (non-fatal)', { error: e })
     }
 


### PR DESCRIPTION
Two places where a failure is reported as something smaller than it is.

## A run that is never billed logs as a notification problem

`lib/logs/execution/logger.ts:1389`

```ts
} catch (e) {
  // Safety net: if a step above threw BEFORE the single record call, ensure
  // the run is still billed. Reconciliation is idempotent...
  try {
    await this.recordExecutionUsage(...)
  } catch {}
  execLog.warn('Usage threshold notification check failed (non-fatal)', { error: e })
}
```

The comment documents the *safety net*, not the bare `catch {}` inside it.

The outer `try` covers a `user` lookup, `recordExecutionUsage`, and the threshold-email calls. With a degraded database the lookup throws **before** the record call, the safety-net re-record hits the same degraded database and is swallowed, and the run is never billed. The only line emitted says the notification check failed and was non-fatal — true of the outer failure, badly wrong about the inner one.

That is the shape that keeps a revenue-losing incident out of alerting: the log asserts the opposite of what happened.

Now logs at `error` with the execution and workflow ids, saying the run may be unbilled. The outer `warn` still covers the email path it was written for.

## google-docs can ask Drive for a negative page

```ts
// google-slides.ts:301
/** Last-page precision: never ask Drive for more files than the cap still allows. */
const remaining = maxDocs > 0 ? Math.max(0, maxDocs - previouslyFetched) : 0

// google-docs.ts:307  — no clamp
const remaining = maxDocs > 0 ? maxDocs - previouslyFetched : 0
```

Both then run:

```ts
if (maxDocs > 0 && documents.length > remaining) documents = documents.slice(0, remaining)
```

A negative `remaining` makes that guard true for any non-empty page, and `slice` counts a negative end **from the end** — so it keeps the leading documents and drops the trailing ones, where the cap says to keep none. The wrong subset, silently, with `slicedSome` set.

Reachable when `maxDocs` is lowered while a sync cursor persists. `google-drive` guards the same case a different way (an early return when `previouslyFetched >= maxFiles`); `google-docs` had neither, and its `google-slides` twin carries the fix under a comment marking it deliberate — it just never propagated.

## Scope

The logging change is observability only. The clamp changes behavior exactly in the case that is currently wrong.

## Testing

1653 tests passing across `lib/logs` and `connectors`; `bun run type-check` clean.