### PR TITLE
fix(ci): walk every route entry the workspace app composes

### DIFF
--- a/scripts/check-tool-registry-boundary.ts
+++ b/scripts/check-tool-registry-boundary.ts
@@ -46,19 +46,33 @@ const APP = join(ROOT, 'apps/sim')
 const FORBIDDEN = join(APP, 'tools/registry.ts')
 
 /**
- * Root the guard walks: every `page.tsx` and `layout.tsx` under the workspace app.
+ * Root the guard walks: every route entry Next.js composes under the workspace app.
  *
  * Discovered rather than listed. A hardcoded list goes stale silently — the
  * first version of this guard named `app/workspace/layout.tsx` as "the shared
  * shell", but that file only wraps `SocketProvider`; the real shell is
  * `app/workspace/[workspaceId]/layout.tsx`, which was never checked.
  *
- * Layouts must be enumerated separately because Next.js composes them by
- * convention — a page does not `import` its layout, so walking pages alone never
- * reaches layout modules even though every route pays for them.
+ * Every filename here is composed by convention rather than imported, so each
+ * must be enumerated: a page does not `import` its layout, its error boundary,
+ * or its loading state, yet the route pays for all of them. `error.tsx` in
+ * particular is always a Client Component — Next requires it — so a registry
+ * edge there lands in the browser bundle as surely as one from a page.
+ *
+ * The root stays at `app/workspace`. Widening it to `app` reports
+ * `(interfaces)/resume/[workflowId]/[executionId]/page.tsx`, which is a Server
+ * Component (`runtime = 'nodejs'`, `force-dynamic`) whose `PauseResumeManager`
+ * import resolves server-side and never reaches a client bundle. This guard
+ * cannot tell the two apart, so it stays where the premise holds.
  */
 const ENTRY_ROOT = 'app/workspace'
-const ENTRY_FILENAMES = new Set(['page.tsx', 'layout.tsx'])
+const ENTRY_FILENAMES = new Set([
+  'page.tsx',
+  'layout.tsx',
+  'error.tsx',
+  'loading.tsx',
+  'not-found.tsx',
+])
 
 function collectEntries(dir: string, found: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {


### PR DESCRIPTION
## The gap

`check-tool-registry-boundary.ts` collected two entry filenames:

```ts
const ENTRY_FILENAMES = new Set(['page.tsx', 'layout.tsx'])
```

Next composes three more by convention — `error.tsx`, `loading.tsx`, `not-found.tsx`. **26 exist under `app/workspace` and none was walked.**

The guard's own TSDoc already makes the argument for including them: layouts are enumerated separately *"because Next.js composes them by convention — a page does not `import` its layout"*. That reasoning covers error boundaries and loading states identically.

`error.tsx` matters most: Next **requires** it to be a Client Component, so a registry edge there lands in the browser bundle exactly as one from a page does.

## Result

Coverage goes from **34 entry graphs to 60**. Nothing new is reported — the hole was unexploited. This closes it before it costs something, at no price.

## The root stays at `app/workspace`

Widening `ENTRY_ROOT` to `app` looks tempting and is wrong. It reports:

```
❌ app/(interfaces)/resume/[workflowId]/[executionId]/page.tsx can reach @/tools/registry via:
     lib/workflows/executor/human-in-the-loop-manager.ts → ... → tools/registry.ts
```

That page is a **Server Component** (`runtime = 'nodejs'`, `dynamic = 'force-dynamic'`, `async` with `await params`). Its `PauseResumeManager` import resolves server-side and never reaches a client bundle, so the registry costs nothing there.

The guard cannot distinguish a server entry from a client one — its premise is "everything a route entry imports ships to the browser", which holds across `app/workspace` and not across `app`. Recorded in the TSDoc so the next person to consider widening it does not have to rediscover this.

## Testing

`bun run scripts/check-tool-registry-boundary.ts` → `✓ tool registry stays out of 60 workspace page/layout graphs` (was 34).

## Provenance

From an audit of the repo's custom gates for blind spots. Two sibling claims in the same report were **false positives** and are not fixed here: the walker was said to follow no re-exports (it applies `REEXPORT_RE` alongside three other patterns at line 151, covering `export * from`, `export * as ns from`, and `export { … } from`), and the root was said to need widening (above).