### PR TITLE
fix(ci): stop failing the API audit for adding a compliant route

### DIFF
--- a/scripts/check-api-validation-contracts.ts
+++ b/scripts/check-api-validation-contracts.ts
@@ -8,6 +8,17 @@ const CONTRACTS_DIR = path.join(ROOT, 'apps/sim/lib/api/contracts')
 const QUERY_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/queries')
 const SELECTOR_HOOKS_DIR = path.join(ROOT, 'apps/sim/hooks/selectors')
 
+/**
+ * `totalRoutes` is reported, never gated.
+ *
+ * The invariant worth holding is that every route is contract-backed, and
+ * `nonZodRoutes` states exactly that: it is 0, and rises the moment a route ships
+ * without one. Failing on the total as well meant a fully compliant new route
+ * still turned CI red, fixable only by editing the number here. A ratchet
+ * survives on the habit of never bumping it casually, and a gate that must be
+ * bumped to add a compliant route teaches precisely the opposite habit — on a
+ * file whose other seven baselines depend on that habit holding.
+ */
 const BASELINE = {
   totalRoutes: 1162,
   zodRoutes: 1162,
@@ -1373,9 +1384,6 @@ async function main() {
   if (!checkOnly) return
 
   const failures: string[] = []
-  if (totalRoutes > BASELINE.totalRoutes) {
-    failures.push(`route count increased from ${BASELINE.totalRoutes} to ${totalRoutes}`)
-  }
   if (nonZodRoutes > BASELINE.nonZodRoutes) {
     failures.push(
       `non-Zod routes increased from ${BASELINE.nonZodRoutes} to ${nonZodRoutes} (${zodRoutes} Zod-backed routes)`


### PR DESCRIPTION
## The next route fails CI regardless of quality

`BASELINE.totalRoutes` is 1162 and the repo has exactly 1162 routes. The gate is:

```ts
if (totalRoutes > BASELINE.totalRoutes) {
  failures.push(`route count increased from ${BASELINE.totalRoutes} to ${totalRoutes}`)
}
```

Route 1163 turns CI red whether or not it is contract-backed. Reproduced by dropping the baseline by one:

```
API validation audit failed:
  - route count increased from 1161 to 1162
```

## It gates nothing the other counters miss

Live output: `total routes: 1162 / Zod-backed: 1162 / non-Zod: 0`.

The invariant worth holding is *every route has a contract*, and `nonZodRoutes` states exactly that — it is 0 and rises the moment a route ships without one. With `zodRoutes === totalRoutes`, the total carries no information the other two counters don't.

## What it adds instead is a bad habit

The only way past this failure is editing the number. This file holds **seven other baselines** — `routeZodImports`, `routeLocalSchemaConstructors`, `clientHookZodImports` and the rest — and every one of them works only while nobody bumps a baseline casually.

A gate you must bump to add a *compliant* route trains exactly the reflex that erodes the gates that matter.

## Change

The total is still printed as a metric. It is no longer a failure condition. Nothing else moves.

## Verified both directions

| Scenario | Before | After |
|---|---|---|
| Compliant new route (`total` over baseline, `nonZod` still 0) | ❌ red | ✅ passes |
| Route with no contract (`nonZod` rises) | ❌ red | ❌ red |

The second was checked by lowering `nonZodRoutes` to `-1`, which correctly produced `non-Zod routes increased from -1 to 0 (1162 Zod-backed routes)` and exit 1.

`check:api-validation` and `check:api-validation:strict` both exit 0 on the restored file.