### PR TITLE
fix(ci): require a default export before treating a file as a route entry

### DIFF
--- a/scripts/check-tool-registry-boundary.ts
+++ b/scripts/check-tool-registry-boundary.ts
@@ -72,13 +72,39 @@ const ENTRY_FILENAMES = new Set([
   'error.tsx',
   'loading.tsx',
   'not-found.tsx',
+  'template.tsx',
+  'default.tsx',
 ])
+
+/**
+ * A default export, which every convention-composed entry must have — Next
+ * renders the default and nothing else.
+ *
+ * The filename alone is not enough. `[workspaceId]/components/error/error.tsx`
+ * is named like a boundary and is not one: it exports `ErrorShell` and
+ * `ErrorState` for the thirteen real boundaries to use, and Next would reject
+ * it as a boundary for having no default. Counting it as an entry both inflated
+ * the coverage number and would have recorded a shared component in the
+ * graph-weight baseline as though it were a route.
+ */
+const DEFAULT_EXPORT_RE =
+  /(?:^|\n)\s*export\s+default\b|(?:^|\n)\s*export\s*\{[^}]*\bas\s+default\b/
+
+function hasDefaultExport(file: string): boolean {
+  try {
+    return DEFAULT_EXPORT_RE.test(readFileSync(file, 'utf8'))
+  } catch {
+    return false
+  }
+}
 
 function collectEntries(dir: string, found: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name)
     if (entry.isDirectory()) collectEntries(full, found)
-    else if (ENTRY_FILENAMES.has(entry.name)) found.push(relative(APP, full))
+    else if (ENTRY_FILENAMES.has(entry.name) && hasDefaultExport(full)) {
+      found.push(relative(APP, full))
+    }
   }
   return found
 }

--- a/scripts/check-tool-registry-boundary.ts
+++ b/scripts/check-tool-registry-boundary.ts
@@ -86,9 +86,16 @@ const ENTRY_FILENAMES = new Set([
  * it as a boundary for having no default. Counting it as an entry both inflated
  * the coverage number and would have recorded a shared component in the
  * graph-weight baseline as though it were a route.
+ *
+ * All four declaring forms count — `export default …`, `export { default } from`,
+ * `export { default, … } from`, and `export { X as default }`. `export { default
+ * as X }` does not: it re-exports someone else's default under a name and leaves
+ * the module without one. Missing a form is the dangerous direction, since the
+ * entry would drop out of the walk and skip both the registry gate and the
+ * graph-weight ratchet silently.
  */
 const DEFAULT_EXPORT_RE =
-  /(?:^|\n)\s*export\s+default\b|(?:^|\n)\s*export\s*\{[^}]*\bas\s+default\b/
+  /(?:^|\n)\s*export\s+default\b|(?:^|\n)\s*export\s*\{[^}]*(?:\bas\s+default\b|\bdefault\s*[,}])/
 
 function hasDefaultExport(file: string): boolean {
   try {


### PR DESCRIPTION
Follow-up to #7026. Both points were raised in review there and I merged before reading them, so they land here.

## The filename was never the right test

#7026 added `error.tsx` to the entry filenames, and with it picked up `[workspaceId]/components/error/error.tsx` — named like a boundary, and not one:

```ts
export interface ErrorBoundaryProps { … }
export function ErrorShell(…) { … }
export function ErrorState(…) { … }
```

Named exports only. It is the shared helper the **thirteen real** boundaries render, and Next would reject it as a boundary for having no default export.

Counting it inflated the coverage number and — the part that would have bitten — recorded a shared component in the graph-weight baseline as though it were a route.

Every convention-composed entry must default-export the thing Next renders, so that is the discriminator now.

**Entry count 60 → 59.** All thirteen real `error.tsx` boundaries still walk; only the helper drops out.

## Completing the enumeration

Also adds `template.tsx` and `default.tsx`. Neither exists under `app/workspace` today, so this changes nothing right now — but the list claims to cover what Next composes, and leaving two out makes that claim false the day someone adds one. That is the same failure the surrounding TSDoc already warns about: *"A hardcoded list goes stale silently."*

## Verification

```
✓ tool registry stays out of 59 workspace page/layout graphs
error.tsx entries walked: 13
components/error/error.tsx: not present
```

## Credit

The non-route entry was Cursor's; the missing `template.tsx`/`default.tsx` was Greptile's. Both were correct.