### PR TITLE
fix(ci): give push builds the parent commit their audits diff against

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,8 +14,18 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # The diff-based audits below need a base commit to read, and the default
+      # depth of 1 clones a single commit with no parent. They normally fetch
+      # their base by SHA (see "Resolve base ref"), so this depth only covers the
+      # `HEAD~1` fallback — but without it that fallback resolves to nothing.
+      #
+      # Worth stating because the failure was invisible for so long: the migration
+      # audit read the resulting `git diff` failure as "no migrations changed" and
+      # exited 0, so it had never actually run on a push build.
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 2
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -112,18 +122,32 @@ jobs:
       #
       # Depth stays at 1 — without a merge-base the migration audit diffs the two
       # tips, which under `--diff-filter=AM` is exactly the migrations new here.
-      - name: Fetch base ref for diff-based audits
-        if: github.event_name == 'pull_request'
-        run: git fetch --depth=1 origin "${{ github.base_ref }}"
-
-      - name: Check block registry invariants
+      # Resolved once for both diff-based audits, and never with `|| true`: a
+      # swallowed fetch leaves the base absent, which neither audit can tell apart
+      # from a branch that changed nothing.
+      #
+      # On push the base is `github.event.before`, the tip the branch had before
+      # this push — not `HEAD~1`, which names only the last commit and would let a
+      # multi-commit push slip every earlier commit's migrations past the audit.
+      # It is fetched by SHA at depth 1; the audits diff two tips and need no
+      # common ancestry. An all-zero `before` means the branch is new and has no
+      # predecessor to diff, so `HEAD~1` remains the fallback there.
+      - name: Resolve base ref for diff-based audits
+        id: audit_base
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="origin/${{ github.base_ref }}"
+            git fetch --depth=1 origin "${{ github.base_ref }}"
+            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.before }}" ] &&
+               [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            git fetch --depth=1 origin "${{ github.event.before }}"
+            echo "ref=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
           else
-            BASE_REF="HEAD~1"
+            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
           fi
-          bun run apps/sim/scripts/check-block-registry.ts "$BASE_REF"
+
+      - name: Check block registry invariants
+        run: bun run apps/sim/scripts/check-block-registry.ts "${{ steps.audit_base.outputs.ref }}"
 
       - name: Lint code
         run: bun run lint:check
@@ -138,13 +162,7 @@ jobs:
         run: bun run docs-manifest:check
 
       - name: Migration safety (zero-downtime) audit
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="origin/${{ github.base_ref }}"
-          else
-            BASE_REF="HEAD~1"
-          fi
-          bun run check:migrations "$BASE_REF"
+        run: bun run check:migrations "${{ steps.audit_base.outputs.ref }}"
 
       # Every workspace, not just realtime. packages/emcn, packages/utils,
       # apps/desktop and apps/docs had no type check in CI at all; apps/sim's


### PR DESCRIPTION
> Unblocks the failing `staging` push build surfacing on the v0.8.11 release PR (#7032).

## What is failing

```
✗ Migration safety check could not run.
  Cannot diff against 'HEAD~1'. The ref is missing, or was fetched without
  enough history for a merge-base.
```

## Why

`actions/checkout` in the audit job sets no `fetch-depth`, so it defaults to **1** — a single-commit clone in which **`HEAD~1` does not resolve**. Both diff-based audits use `HEAD~1` as their base on push events, so neither has ever had a base to read.

Proven in a two-commit repo:

```
depth=1:  git rev-parse HEAD~1  → does not resolve
depth=2:  git rev-parse HEAD~1  → d73c984…   git diff HEAD~1 HEAD → f
```

## This is #7022 doing its job, uncomfortably

Before #7022 the audit answered that failure with `✓ No new migrations to check` and exit 0. **It had never actually run on a push build** — the green was a report about what it could see, not about the migrations.

#7022 made it say it cannot run rather than claim success, and the first push build after it merged said exactly that. The bug is the missing history; #7022 only stopped it being invisible.

The block-registry check has the identical input and reports `⚠ Could not diff against base ref — skipping`. Visible, so it never blocked anything — and equally never ran on push.

## Fix

`fetch-depth: 2` on the audit job's checkout. That is the minimum that makes `HEAD~1` name something, and on this repo's push events (squash merges) `HEAD~1..HEAD` is exactly the merged change.

Only the `Lint and Test` job changes. `Build App` keeps its depth-1 checkout — it does no diffing and a deeper fetch would slow it for nothing.

## Verification

Both audits against `HEAD~1` on a checkout with history:

```
✓ No new migrations to check.                exit=0
✓ Integration meta coverage check passed
✓ Sunset replacedBy check passed             exit=0
```

Since both already run on every PR against `origin/<base>`, and a push to `staging` carries the same content that just passed as a PR, neither should newly fail — they will simply run for the first time.