### PR TITLE
fix(ci): skip the diff-based audits on branch creation instead of guessing a base

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,18 +14,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      # The diff-based audits below need a base commit to read, and the default
-      # depth of 1 clones a single commit with no parent. They normally fetch
-      # their base by SHA (see "Resolve base ref"), so this depth only covers the
-      # `HEAD~1` fallback — but without it that fallback resolves to nothing.
-      #
-      # Worth stating because the failure was invisible for so long: the migration
-      # audit read the resulting `git diff` failure as "no migrations changed" and
-      # exited 0, so it had never actually run on a push build.
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          fetch-depth: 2
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -114,39 +104,43 @@ jobs:
 
           echo "✅ All env flags are properly configured"
 
-      # One fetch for both base-ref audits, and no `|| true`: a swallowed fetch leaves
-      # the base ref absent, which neither audit can tell apart from a branch that
-      # changed nothing. The block-registry check at least degrades to a visible
-      # `⚠ … skipping` line; the migration audit printed `✓ No new migrations to
-      # check` and exited 0, clearing the only guard on production DDL.
-      #
-      # Depth stays at 1 — without a merge-base the migration audit diffs the two
-      # tips, which under `--diff-filter=AM` is exactly the migrations new here.
       # Resolved once for both diff-based audits, and never with `|| true`: a
       # swallowed fetch leaves the base absent, which neither audit can tell apart
-      # from a branch that changed nothing.
+      # from a branch that changed nothing. That is how the migration audit came
+      # to print `✓ No new migrations to check` and exit 0 on every push build,
+      # having read nothing — and it is the only guard on production DDL.
       #
       # On push the base is `github.event.before`, the tip the branch had before
-      # this push — not `HEAD~1`, which names only the last commit and would let a
-      # multi-commit push slip every earlier commit's migrations past the audit.
-      # It is fetched by SHA at depth 1; the audits diff two tips and need no
-      # common ancestry. An all-zero `before` means the branch is new and has no
-      # predecessor to diff, so `HEAD~1` remains the fallback there.
+      # this push. It is fetched by SHA at depth 1, so the checkout needs no extra
+      # history; the audits diff two tips and need no common ancestry between them.
+      #
+      # A push that creates the branch reports an all-zero `before` and genuinely
+      # has no predecessor, so the audits skip with a notice rather than falling
+      # back to a commit. Auditing one commit while reporting on the whole push is
+      # the failure this step exists to remove.
       - name: Resolve base ref for diff-based audits
         id: audit_base
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch --depth=1 origin "${{ github.base_ref }}"
             echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ github.event.before }}" ] &&
-               [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+          elif [ -z "${{ github.event.before }}" ] ||
+               [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            # No predecessor to diff against. All-zero means the push created the
+            # branch; empty means this was not a push at all — `workflow_dispatch`
+            # carries no push payload, and dropping that guard would run
+            # `git fetch origin ""` and fail the job. Say so and let the audits
+            # skip: naming a commit here would audit that one commit while
+            # reporting on the whole push.
+            echo "::notice::No preceding commit to diff against; skipping the diff-based audits."
+            echo "ref=" >> "$GITHUB_OUTPUT"
+          else
             git fetch --depth=1 origin "${{ github.event.before }}"
             echo "ref=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check block registry invariants
+        if: steps.audit_base.outputs.ref != ''
         run: bun run apps/sim/scripts/check-block-registry.ts "${{ steps.audit_base.outputs.ref }}"
 
       - name: Lint code
@@ -162,6 +156,7 @@ jobs:
         run: bun run docs-manifest:check
 
       - name: Migration safety (zero-downtime) audit
+        if: steps.audit_base.outputs.ref != ''
         run: bun run check:migrations "${{ steps.audit_base.outputs.ref }}"
 
       # Every workspace, not just realtime. packages/emcn, packages/utils,


### PR DESCRIPTION
> Follow-up to #7033, which merged with a Greptile P1 thread still open. This closes it.

## The finding

> **Branch creation audits only tip** — when the first push creates `main`, `staging`, or `dev` with multiple commits, the all-zero `github.event.before` selects `HEAD~1`, so both audits inspect only the final commit.

Correct. It is the same failure #7033 set out to remove — a partial audit reported as a complete one — one case further along.

## Why there is no base to substitute

Nothing precedes a branch-creating push. The alternatives are both wrong:

- **`HEAD~1`** audits one arbitrary commit and reports on the whole push.
- **The whole history** would lint every migration ever written; `--all` mode already exits 1 on this repo for exactly that reason.

So the audits now **skip, and say so**:

```
::notice::Branch created — no preceding commit to diff against; skipping the diff-based audits.
```

A stated skip is honest. A partial audit wearing a green check is what this whole line of work exists to stop.

## Reachability

Only by deleting and recreating `main`, `staging` or `dev` — the three branches the push trigger covers, all of which exist. This closes a gap, not an incident, and I'd rather say that plainly than dress it up.

## It makes #7033 smaller

`fetch-depth: 2` existed solely to give the `HEAD~1` fallback something to resolve to. With the fallback gone its only consumer goes too, and since `before` is fetched by SHA the checkout returns to its default depth — untouched, as it was before #7033.

**Net −9 lines against #7033.**

## Verification

- `HEAD~1` no longer appears anywhere in the workflow
- Both audits still pass against a raw SHA base (`exit=0`)
- YAML parses; both audit steps carry the same `if: steps.audit_base.outputs.ref != ''` guard, so they cannot diverge on when they run