### PR TITLE
chore(lint): turn on the rules that would have caught the dead code

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
@@ -795,9 +795,9 @@ export function SecretsManager() {
       }
     }
 
-    const validVariables = envVars
-      .filter((v) => v.key && v.value)
-      .reduce<Record<string, string>>((acc, { key, value }) => ({ ...acc, [key]: value }), {})
+    const validVariables = Object.fromEntries(
+      envVars.filter((v) => v.key && v.value).map(({ key, value }) => [key, value])
+    )
 
     const before = initialWorkspaceVarsRef.current
     const after = mergedWorkspaceVars

--- a/apps/sim/stores/workflows/workflow/store.ts
+++ b/apps/sim/stores/workflows/workflow/store.ts
@@ -580,15 +580,11 @@ export const useWorkflowStore = create<WorkflowStore>()(
         const activeWorkflowId = get().currentWorkflowId
         const mergedBlock = mergeSubblockState(get().blocks, activeWorkflowId || undefined, id)[id]
 
-        const newSubBlocks = Object.entries(mergedBlock.subBlocks).reduce(
-          (acc, [subId, subBlock]) => ({
-            ...acc,
-            [subId]: {
-              ...subBlock,
-              value: structuredClone(subBlock.value),
-            },
-          }),
-          {}
+        const newSubBlocks = Object.fromEntries(
+          Object.entries(mergedBlock.subBlocks).map(([subId, subBlock]) => [
+            subId,
+            { ...subBlock, value: structuredClone(subBlock.value) },
+          ])
         )
 
         // Remap condition/router IDs in the duplicated subBlocks

--- a/biome.json
+++ b/biome.json
@@ -134,12 +134,25 @@
         "noStaticOnlyClass": "off"
       },
       "performance": {
-        "noAccumulatingSpread": "off",
+        "noAccumulatingSpread": "error",
         "noDelete": "error",
         "noImgElement": "off"
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["packages/**"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedFunctionParameters": "error",
+            "noUnusedVariables": "error"
+          }
+        }
+      }
+    }
+  ],
   "javascript": {
     "formatter": {
       "jsxQuoteStyle": "single",

--- a/packages/testing/src/mocks/socket.mock.ts
+++ b/packages/testing/src/mocks/socket.mock.ts
@@ -40,7 +40,7 @@ export function createMockSocket(): IMockSocket {
     disconnected: false,
 
     // Core methods
-    emit: vi.fn((event: string, ..._args: any[]) => {
+    emit: vi.fn((_event: string, ..._args: any[]) => {
       return socket
     }),
 

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -471,7 +471,7 @@ export class SimStudioClient {
     try {
       const status = await this.getWorkflowStatus(workflowId)
       return status.isDeployed
-    } catch (error) {
+    } catch {
       return false
     }
   }

--- a/packages/workflow-persistence/src/subflow-helpers.ts
+++ b/packages/workflow-persistence/src/subflow-helpers.ts
@@ -78,7 +78,7 @@ export function generateLoopBlocks(blocks: Record<string, BlockState>): Record<s
 
   Object.entries(blocks)
     .filter(([_, block]) => block.type === 'loop')
-    .forEach(([id, block]) => {
+    .forEach(([id]) => {
       const loop = convertLoopBlockToLoop(id, blocks)
       if (loop) {
         loops[id] = loop
@@ -95,7 +95,7 @@ export function generateParallelBlocks(
 
   Object.entries(blocks)
     .filter(([_, block]) => block.type === 'parallel')
-    .forEach(([id, block]) => {
+    .forEach(([id]) => {
       const parallel = convertParallelBlockToParallel(id, blocks)
       if (parallel) {
         parallels[id] = parallel

--- a/packages/workflow-renderer/src/subflow/subflow-node-view.tsx
+++ b/packages/workflow-renderer/src/subflow/subflow-node-view.tsx
@@ -65,7 +65,14 @@ export interface SubflowNodeViewProps {
   isFocused: boolean
   /** Whether execution controls are active for this subflow. */
   isRunning?: boolean
-  /** Whether the parent workflow is executing. Holds every subflow action swell open. */
+  /**
+   * Whether the parent workflow is executing.
+   *
+   * Accepted and currently unread: `subflow-node.tsx` supplies it and nothing
+   * below consults it, so the hold-open behavior this once claimed is not
+   * implemented. Kept in the interface because the caller passes it — wire it up
+   * or stop passing it, but do not read this as working today.
+   */
   isWorkflowRunning?: boolean
   /** Whether this subflow participates in the current execution handoff. */
   isExecutionHighlighted?: boolean
@@ -326,7 +333,6 @@ export function SubflowNodeView({
   isLocked,
   isFocused,
   isRunning = false,
-  isWorkflowRunning = false,
   isExecutionHighlighted = false,
   diffStatus,
   nestingLevel,

--- a/packages/workflow-renderer/src/workflow-block/workflow-block-view.tsx
+++ b/packages/workflow-renderer/src/workflow-block/workflow-block-view.tsx
@@ -393,7 +393,14 @@ export interface WorkflowBlockViewProps {
   runPathStatus?: BlockRunStatus
   /** Whether execution controls are active for this block. */
   isRunning?: boolean
-  /** Whether the parent workflow is executing. Holds every block's action swell open. */
+  /**
+   * Whether the parent workflow is executing.
+   *
+   * Accepted and currently unread: `workflow-block.tsx` supplies it and nothing
+   * below consults it, so the hold-open behavior this once claimed is not
+   * implemented. Kept in the interface because the caller passes it — wire it up
+   * or stop passing it, but do not read this as working today.
+   */
   isWorkflowRunning?: boolean
   /** Whether this block participates in the current execution handoff. */
   isExecutionHighlighted?: boolean
@@ -521,7 +528,6 @@ export function WorkflowBlockView({
   ringStyles,
   runPathStatus,
   isRunning = false,
-  isWorkflowRunning = false,
   isExecutionHighlighted = false,
   Icon,
   iconBgColor,


### PR DESCRIPTION
Three lint rules were `"off"`, so nothing enforced them. I measured each, fixed the sites, and enabled them where the cost is bounded.

## What changed

| Rule | Violations | Action |
|---|---|---|
| `performance/noAccumulatingSpread` | **2** | fixed both → enabled repo-wide |
| `correctness/noUnusedVariables` + `noUnusedFunctionParameters` | 633 repo-wide, **6 under `packages/`** | fixed the 6 → enabled at `error` for `packages/**` |
| `suspicious/noDocumentCookie` | 3 | **not enabled** — see below |

## The accumulating spreads were real

Both are O(n²) reducers, now `Object.fromEntries`:

- `stores/workflows/workflow/store.ts` — rebuilds a block's `subBlocks` on **every block duplication**
- `secrets-manager.tsx` — rebuilds a `Record` from **every workspace env var**

## Why `packages/**` and not everywhere

`apps/sim` carries 627 of the 633. That is a sweep of its own, and a rule switched on with 627 outstanding warnings teaches people to scroll past it. Scoped to `packages/**`, the cost was 6 fixes and the coverage is 979 files, permanently.

**This is the rule class whose absence let #7019 happen** — eleven unread loggers, a whole unimported file, write-only locals. No gate could see any of it.

## One fix is narrower than it looks

Two of the six were `isWorkflowRunning` in `workflow-renderer`: destructured, never read, in both the block and subflow views. My first instinct was to delete the prop — that was wrong twice over, and type-check caught it:

- A **test** passes it (this package type-checks its tests; `apps/sim` doesn't)
- The **app** passes it, from `workflow-block.tsx:1243` and `subflow-node.tsx:78`

Its TSDoc claimed it *"holds every block's action swell open."* Nothing reads it, so **that behavior does not exist today.** Implementing it is a UX call — there is adjacent logic deliberately *not* pinning the toolbar during a handoff — and deleting the prop breaks two callers.

So only the unused binding goes, the prop stays in the interface, and the TSDoc now states the truth instead of describing behavior that isn't there. Wiring it up or dropping it from the callers is a follow-up for someone who knows the intended UX.

## Not enabled

- **`noDocumentCookie`** (3 sites, all in the sidebar store) — its fix is the `CookieStore` API, which is a browser-support decision, not a lint cleanup.
- **`useExhaustiveDependencies`** — 384 errors. Noted, not attempted.

## Verification

- All **26 workspaces** type-check
- `bun run lint:check` exits 0
- Both enabled rule sets report zero across their scopes
- 113 + 14 + 332 tests pass across `workflow-renderer`, `workflow-persistence`, `stores/workflows`, and settings
- Confirmed the rule can fail: reintroducing the spread turns `lint:check` red, restoring it goes green

One pre-existing `suppressions/unused` warning in `shell-layout.test.ts` is untouched — it is on staging too and unrelated.