### PR TITLE
refactor(renderer): drop the isWorkflowRunning prop the views never read

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/subflows/subflow-node.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/subflows/subflow-node.tsx
@@ -75,7 +75,6 @@ export const SubflowNodeComponent = memo(({ data, id, selected }: NodeProps<Subf
       isLocked={isLocked}
       isFocused={isFocused}
       isRunning={isRunning}
-      isWorkflowRunning={isWorkflowRunning}
       isExecutionHighlighted={isExecutionHighlighted}
       diffStatus={diffStatus}
       nestingLevel={nestingLevel}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/workflow-block/workflow-block.tsx
@@ -1240,7 +1240,6 @@ export const WorkflowBlock = memo(function WorkflowBlock({
       ringStyles={ringStyles}
       runPathStatus={runPathStatus}
       isRunning={isExecuting}
-      isWorkflowRunning={isWorkflowRunning}
       isExecutionHighlighted={isExecutionHighlighted}
       Icon={config.icon}
       iconBgColor={config.bgColor}

--- a/packages/workflow-renderer/src/subflow/subflow-node-view.tsx
+++ b/packages/workflow-renderer/src/subflow/subflow-node-view.tsx
@@ -65,15 +65,6 @@ export interface SubflowNodeViewProps {
   isFocused: boolean
   /** Whether execution controls are active for this subflow. */
   isRunning?: boolean
-  /**
-   * Whether the parent workflow is executing.
-   *
-   * Accepted and currently unread: `subflow-node.tsx` supplies it and nothing
-   * below consults it, so the hold-open behavior this once claimed is not
-   * implemented. Kept in the interface because the caller passes it — wire it up
-   * or stop passing it, but do not read this as working today.
-   */
-  isWorkflowRunning?: boolean
   /** Whether this subflow participates in the current execution handoff. */
   isExecutionHighlighted?: boolean
   /** Diff state when comparing workflow versions. */

--- a/packages/workflow-renderer/src/workflow-block/workflow-block-view-interaction.test.tsx
+++ b/packages/workflow-renderer/src/workflow-block/workflow-block-view-interaction.test.tsx
@@ -25,8 +25,7 @@ function createView(
   isRunning: boolean,
   isEnabled = true,
   isLocked = false,
-  isExecutionHighlighted = false,
-  isWorkflowRunning = false
+  isExecutionHighlighted = false
 ) {
   return (
     <ReactFlowProvider>
@@ -39,7 +38,6 @@ function createView(
         hasRing={false}
         ringStyles=''
         isRunning={isRunning}
-        isWorkflowRunning={isWorkflowRunning}
         isExecutionHighlighted={isExecutionHighlighted}
         Icon={TestIcon}
         iconBgColor='var(--surface-2)'
@@ -130,7 +128,7 @@ describe('WorkflowBlockView action menu', () => {
     mountedRoots.add(root)
     mountedHosts.add(host)
 
-    act(() => root.render(createView(false, true, false, false, true)))
+    act(() => root.render(createView(false, true, false, false)))
     flushAnimationFrames()
 
     const actionMenuRoot = host.querySelector<HTMLElement>('.group.relative')
@@ -149,7 +147,7 @@ describe('WorkflowBlockView action menu', () => {
     mountedRoots.add(root)
     mountedHosts.add(host)
 
-    act(() => root.render(createView(false, true, false, true, true)))
+    act(() => root.render(createView(false, true, false, true)))
     flushAnimationFrames()
 
     const actionMenuRoot = host.querySelector<HTMLElement>('.group.relative')

--- a/packages/workflow-renderer/src/workflow-block/workflow-block-view.tsx
+++ b/packages/workflow-renderer/src/workflow-block/workflow-block-view.tsx
@@ -393,15 +393,6 @@ export interface WorkflowBlockViewProps {
   runPathStatus?: BlockRunStatus
   /** Whether execution controls are active for this block. */
   isRunning?: boolean
-  /**
-   * Whether the parent workflow is executing.
-   *
-   * Accepted and currently unread: `workflow-block.tsx` supplies it and nothing
-   * below consults it, so the hold-open behavior this once claimed is not
-   * implemented. Kept in the interface because the caller passes it — wire it up
-   * or stop passing it, but do not read this as working today.
-   */
-  isWorkflowRunning?: boolean
   /** Whether this block participates in the current execution handoff. */
   isExecutionHighlighted?: boolean
   /** Block icon component and its background color. */


### PR DESCRIPTION
> Follow-up to #7037, which merged before this landed. In that PR I removed only the unused *binding* and kept the prop — that was half a fix, and the reasoning behind it was wrong.

## What I got wrong in #7037

I justified keeping the prop as "implementing it is a UX decision." That conflated two things:

- *Should the toolbar pin open during a run?* — a UX decision
- *Should we keep a prop that does nothing?* — not a UX decision, just dead code

Keeping it on the chance someone wants the behavior later is speculative generality. If the toolbar should pin open during a run, that gets implemented deliberately and the prop comes back **with logic behind it**.

## What was actually dead

`WorkflowBlockView` and `SubflowNodeView` both declared `isWorkflowRunning?: boolean`, both had it destructured, and **neither ever read it**. Its TSDoc claimed it *"holds every block's action swell open"* — a behavior that does not exist in either view.

Both are removed, along with the two call sites that fed them.

## What deliberately stays

The store subscription is **not** removed. `workflow-block.tsx:642` and `subflow-node.tsx:47` each pass the same value to **two** places:

| Consumer | Reads it? |
|---|---|
| `WorkflowBlockView` / `SubflowNodeView` | no — removed here |
| `ActionBar` | **yes — 28 reads** |

`ActionBar` is what the surrounding TSDoc is actually describing when it says the flag *"only swaps Run for Stop and disables mutations."* `workflow-edge-view` uses it as well (7 reads) and is untouched.

So the subscription earns its keep; only the dead second pass goes.

## A note on the test

`workflow-block-view-interaction.test.tsx` passed the flag in two cases to stage a workflow run. Since the view ignored it, **those two cases were never exercising the run state their names describe** — they pass on other logic. The argument is removed; the assertions are unchanged and still pass. Worth flagging for whoever owns that behavior.

## Verification

- All 26 workspaces type-check — this is what caught my first attempt, which deleted the prop while two callers and a test still passed it
- `bun run lint:check` exits 0
- 113 renderer tests, 636 across `app/workspace/w` and `stores/workflows`
- Remaining `isWorkflowRunning` references are exactly the live ones: `action-bar.tsx`, `workflow-edge-view.tsx`, `note-block.tsx`, and the two subscriptions

**Net −22 lines.**