### PR TITLE
refactor: remove five more dead prop chains

### DIFF
--- a/apps/sim/app/(auth)/components/oauth-provider-checker.tsx
+++ b/apps/sim/app/(auth)/components/oauth-provider-checker.tsx
@@ -3,7 +3,6 @@ import {
   isGithubAuthDisabled,
   isGoogleAuthDisabled,
   isMicrosoftAuthDisabled,
-  isProd,
 } from '@/lib/core/config/env-flags'
 
 export async function getOAuthProviderStatus() {
@@ -16,5 +15,5 @@ export async function getOAuthProviderStatus() {
   const microsoftAvailable =
     !!(env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET) && !isMicrosoftAuthDisabled
 
-  return { githubAvailable, googleAvailable, microsoftAvailable, isProduction: isProd }
+  return { githubAvailable, googleAvailable, microsoftAvailable }
 }

--- a/apps/sim/app/(auth)/components/social-login-buttons.tsx
+++ b/apps/sim/app/(auth)/components/social-login-buttons.tsx
@@ -15,7 +15,6 @@ interface SocialLoginButtonsProps {
   googleAvailable: boolean
   microsoftAvailable: boolean
   callbackURL?: string
-  isProduction: boolean
   children?: ReactNode
 }
 
@@ -24,7 +23,6 @@ export function SocialLoginButtons({
   googleAvailable,
   microsoftAvailable,
   callbackURL = '/workspace',
-  isProduction,
   children,
 }: SocialLoginButtonsProps) {
   const [isGithubLoading, setIsGithubLoading] = useState(false)

--- a/apps/sim/app/(auth)/login/login-form.tsx
+++ b/apps/sim/app/(auth)/login/login-form.tsx
@@ -87,13 +87,11 @@ export default function LoginPage({
   githubAvailable,
   googleAvailable,
   microsoftAvailable,
-  isProduction,
   registrationDisabled,
 }: {
   githubAvailable: boolean
   googleAvailable: boolean
   microsoftAvailable: boolean
-  isProduction: boolean
   /** DISABLE_REGISTRATION. Hides the signup cross-link, which `/signup` blocks. */
   registrationDisabled: boolean
 }) {
@@ -430,7 +428,6 @@ export default function LoginPage({
             googleAvailable={googleAvailable}
             githubAvailable={githubAvailable}
             microsoftAvailable={microsoftAvailable}
-            isProduction={isProduction}
             callbackURL={callbackUrl}
           >
             {ssoEnabled && !hasOnlySSO && (

--- a/apps/sim/app/(auth)/login/page.tsx
+++ b/apps/sim/app/(auth)/login/page.tsx
@@ -12,8 +12,7 @@ export const metadata: Metadata = {
 export const dynamic = 'force-dynamic'
 
 export default async function LoginPage() {
-  const { githubAvailable, googleAvailable, microsoftAvailable, isProduction } =
-    await getOAuthProviderStatus()
+  const { githubAvailable, googleAvailable, microsoftAvailable } = await getOAuthProviderStatus()
 
   return (
     <Suspense fallback={<LoginLoading />}>
@@ -21,7 +20,6 @@ export default async function LoginPage() {
         githubAvailable={githubAvailable}
         googleAvailable={googleAvailable}
         microsoftAvailable={microsoftAvailable}
-        isProduction={isProduction}
         registrationDisabled={isRegistrationDisabled}
       />
     </Suspense>

--- a/apps/sim/app/(auth)/signup/page.tsx
+++ b/apps/sim/app/(auth)/signup/page.tsx
@@ -36,15 +36,13 @@ export default async function SignupPage({
     )
   }
 
-  const { githubAvailable, googleAvailable, microsoftAvailable, isProduction } =
-    await getOAuthProviderStatus()
+  const { githubAvailable, googleAvailable, microsoftAvailable } = await getOAuthProviderStatus()
 
   return (
     <SignupForm
       githubAvailable={githubAvailable}
       googleAvailable={googleAvailable}
       microsoftAvailable={microsoftAvailable}
-      isProduction={isProduction}
       emailSignupEnabled={!isEmailSignupDisabled}
       emailVerificationEnabled={isEmailVerificationEffectivelyEnabled()}
     />

--- a/apps/sim/app/(auth)/signup/signup-form.tsx
+++ b/apps/sim/app/(auth)/signup/signup-form.tsx
@@ -91,7 +91,6 @@ interface SignupFormProps {
   githubAvailable: boolean
   googleAvailable: boolean
   microsoftAvailable: boolean
-  isProduction: boolean
   emailSignupEnabled: boolean
   /** Server-derived: verification is enabled AND a mail provider is configured. */
   emailVerificationEnabled: boolean
@@ -101,7 +100,6 @@ function SignupFormContent({
   githubAvailable,
   googleAvailable,
   microsoftAvailable,
-  isProduction,
   emailSignupEnabled,
   emailVerificationEnabled,
 }: SignupFormProps) {
@@ -484,7 +482,6 @@ function SignupFormContent({
           googleAvailable={googleAvailable}
           microsoftAvailable={microsoftAvailable}
           callbackURL={redirectUrl || '/workspace'}
-          isProduction={isProduction}
         >
           {ssoEnabled && !hasOnlySSO && (
             <SSOLoginButton callbackURL={redirectUrl || '/workspace'} variant='outline' />
@@ -507,7 +504,6 @@ export default function SignupPage({
   githubAvailable,
   googleAvailable,
   microsoftAvailable,
-  isProduction,
   emailSignupEnabled,
   emailVerificationEnabled,
 }: SignupFormProps) {
@@ -519,7 +515,6 @@ export default function SignupPage({
         githubAvailable={githubAvailable}
         googleAvailable={googleAvailable}
         microsoftAvailable={microsoftAvailable}
-        isProduction={isProduction}
         emailSignupEnabled={emailSignupEnabled}
         emailVerificationEnabled={emailVerificationEnabled}
       />

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
@@ -218,7 +218,6 @@ export function usePromptEditor({
   const mentionMenu = useMentionMenu({
     message: value,
     selectedContexts: contextManagement.selectedContexts,
-    onContextSelect: addContextNotified,
     onMessageChange: commitValue,
   })
 

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-mention-menu.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-mention-menu.ts
@@ -7,8 +7,6 @@ interface UseMentionMenuProps {
   message: string
   /** Currently selected contexts */
   selectedContexts: ChatContext[]
-  /** Callback when a context is selected */
-  onContextSelect: (context: ChatContext) => void
   /** Callback when message changes */
   onMessageChange: (message: string) => void
 }
@@ -23,7 +21,6 @@ interface UseMentionMenuProps {
 export function useMentionMenu({
   message,
   selectedContexts,
-  onContextSelect,
   onMessageChange,
 }: UseMentionMenuProps) {
   // Refs

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/connection-blocks/components/field-item/field-item.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/connection-blocks/components/field-item/field-item.tsx
@@ -24,7 +24,6 @@ interface FieldItemProps {
   connection: ConnectedBlock
   field: SchemaField
   path: string
-  level: number
   hasChildren?: boolean
   isExpanded?: boolean
   onToggleExpand?: (path: string) => void
@@ -37,7 +36,6 @@ export function FieldItem({
   connection,
   field,
   path,
-  level,
   hasChildren,
   isExpanded,
   onToggleExpand,

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/connection-blocks/connection-blocks.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/connection-blocks/connection-blocks.tsx
@@ -27,7 +27,6 @@ interface ConnectionBlocksProps {
 interface FieldTreeNodesProps {
   fields: SchemaField[]
   parentPath: string
-  level: number
   connection: ConnectedBlock
   isFieldExpanded: (connectionId: string, fieldPath: string) => boolean
   onToggleFieldExpansion: (connectionId: string, fieldPath: string) => void
@@ -36,7 +35,6 @@ interface FieldTreeNodesProps {
 function FieldTreeNodes({
   fields,
   parentPath,
-  level,
   connection,
   isFieldExpanded,
   onToggleFieldExpansion,
@@ -52,7 +50,6 @@ function FieldTreeNodes({
           connection={connection}
           field={field}
           path={fieldPath}
-          level={level}
           hasChildren={hasChildren}
           isExpanded={expanded}
           onToggleExpand={(p) => onToggleFieldExpansion(connection.id, p)}
@@ -63,7 +60,6 @@ function FieldTreeNodes({
             <FieldTreeNodes
               fields={field.children!}
               parentPath={fieldPath}
-              level={level + 1}
               connection={connection}
               isFieldExpanded={isFieldExpanded}
               onToggleFieldExpansion={onToggleFieldExpansion}
@@ -152,7 +148,6 @@ function ConnectionItem({
           <FieldTreeNodes
             fields={fields}
             parentPath=''
-            level={0}
             connection={connection}
             isFieldExpanded={isFieldExpanded}
             onToggleFieldExpansion={onToggleFieldExpansion}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/grouped-checkbox-list/grouped-checkbox-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/grouped-checkbox-list/grouped-checkbox-list.tsx
@@ -35,23 +35,19 @@ function SelectedCountDisplay({ noneSelected, allSelected, count }: SelectedCoun
 interface GroupedCheckboxListProps {
   blockId: string
   subBlockId: string
-  title: string
   options: { label: string; id: string; group?: string }[]
   isPreview?: boolean
   subBlockValues: Record<string, any>
   disabled?: boolean
-  maxHeight?: number
 }
 
 export function GroupedCheckboxList({
   blockId,
   subBlockId,
-  title,
   options,
   isPreview = false,
   subBlockValues,
   disabled = false,
-  maxHeight = 400,
 }: GroupedCheckboxListProps) {
   const activeSearchTarget = useActiveSearchTarget()
   const [open, setOpen] = useState(false)

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/tag-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tag-dropdown/tag-dropdown.tsx
@@ -376,7 +376,6 @@ const buildNestedTagTree = (tags: string[], blockName: string): NestedTag[] => {
 interface NestedTagRendererProps {
   nestedTag: NestedTag
   group: NestedBlockTagGroup
-  flatTagList: Array<{ tag: string; group?: BlockTagGroup }>
   /** Map from tag string to index for O(1) lookups */
   flatTagIndexMap: Map<string, number>
   selectedIndex: number
@@ -403,7 +402,6 @@ interface FolderContentsProps extends NestedTagRendererProps {
  */
 const FolderContentsInner: React.FC<FolderContentsProps> = ({
   group,
-  flatTagList,
   flatTagIndexMap,
   selectedIndex,
   setSelectedIndex,
@@ -565,7 +563,6 @@ const FolderContents: React.FC<Omit<NestedTagRendererProps, never>> = (props) =>
 const NestedTagRenderer: React.FC<NestedTagRendererProps> = ({
   nestedTag,
   group,
-  flatTagList,
   flatTagIndexMap,
   selectedIndex,
   setSelectedIndex,
@@ -612,7 +609,6 @@ const NestedTagRenderer: React.FC<NestedTagRendererProps> = ({
         <FolderContents
           nestedTag={nestedTag}
           group={group}
-          flatTagList={flatTagList}
           flatTagIndexMap={flatTagIndexMap}
           selectedIndex={selectedIndex}
           setSelectedIndex={setSelectedIndex}
@@ -1633,9 +1629,9 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
         </PopoverAnchor>
         <KeyboardNavigationHandler
           visible={visible}
+          flatTagList={flatTagList}
           selectedIndex={selectedIndex}
           setSelectedIndex={setSelectedIndex}
-          flatTagList={flatTagList}
           nestedBlockTagGroups={nestedBlockTagGroups}
           handleTagSelect={handleTagSelect}
           onFolderEnter={() => {
@@ -1720,7 +1716,6 @@ export const TagDropdown: React.FC<TagDropdownProps> = ({
                             key={`${group.blockId}-${nestedTag.key}`}
                             nestedTag={nestedTag}
                             group={group}
-                            flatTagList={flatTagList}
                             flatTagIndexMap={flatTagIndexMap}
                             selectedIndex={selectedIndex}
                             setSelectedIndex={setSelectedIndex}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
@@ -844,12 +844,10 @@ function SubBlockComponent({
           <GroupedCheckboxList
             blockId={blockId}
             subBlockId={config.id}
-            title={config.title ?? ''}
             options={config.options as { label: string; id: string; group?: string }[]}
             isPreview={isPreview}
             subBlockValues={subBlockValues ?? {}}
             disabled={isDisabled}
-            maxHeight={config.maxHeight}
           />
         )
 

--- a/apps/sim/ee/custom-blocks/components/custom-block-detail.tsx
+++ b/apps/sim/ee/custom-blocks/components/custom-block-detail.tsx
@@ -85,9 +85,9 @@ export function CustomBlockDetail({ blockId, workspaceId, onBack }: CustomBlockD
     [blocks, blockId]
   )
 
-  const publish = usePublishCustomBlock(workspaceId)
-  const update = useUpdateCustomBlock(workspaceId)
-  const remove = useDeleteCustomBlock(workspaceId)
+  const publish = usePublishCustomBlock()
+  const update = useUpdateCustomBlock()
+  const remove = useDeleteCustomBlock()
 
   // Needed in both modes: the source picker (create) and the manage gate (edit).
   const { data: workspaces = [] } = useWorkspacesQuery()

--- a/apps/sim/hooks/queries/custom-blocks.ts
+++ b/apps/sim/hooks/queries/custom-blocks.ts
@@ -75,7 +75,7 @@ export function useCustomBlockUsageCounts(blockId?: string, options?: { enabled?
   })
 }
 
-export function usePublishCustomBlock(workspaceId?: string) {
+export function usePublishCustomBlock() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (body: PublishCustomBlockBody) => requestJson(publishCustomBlockContract, { body }),
@@ -85,7 +85,7 @@ export function usePublishCustomBlock(workspaceId?: string) {
   })
 }
 
-export function useUpdateCustomBlock(workspaceId?: string) {
+export function useUpdateCustomBlock() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: ({ id, ...body }: UpdateCustomBlockBody & { id: string }) =>
@@ -96,7 +96,7 @@ export function useUpdateCustomBlock(workspaceId?: string) {
   })
 }
 
-export function useDeleteCustomBlock(workspaceId?: string) {
+export function useDeleteCustomBlock() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (id: string) => requestJson(deleteCustomBlockContract, { params: { id } }),


### PR DESCRIPTION
> Continues #7040 (`isWorkflowRunning`), which merged before these were ready. Same shape throughout: a prop **declared**, **threaded through every layer by real callers**, and **never read** at the end.

Found by sweeping the unused-parameter list the rule in #7037 exposed, then verifying each by hand — which mattered, because a third of the candidates did not survive.

| # | Chain | Why it's worth removing |
|---|---|---|
| 1 | `FieldItem.level` | a depth counter recursed through an arbitrarily deep tree |
| 2 | `useMentionMenu({ onContextSelect })` | a **documented** callback the hook never fires |
| 3 | `SocialLoginButtons.isProduction` | required prop, 4-file chain, plus a now-unused return value |
| 4 | `GroupedCheckboxList.title` / `.maxHeight` | the component overrides both with hardcoded copy |
| 5 | `flatTagList` | an array carried alongside its own index map to a dead end |
| 6 | 3 × `useCustomBlock*(workspaceId)` | vestigial parameter on three mutation hooks |

## The two that are more than tidying

**`useMentionMenu({ onContextSelect })`** is a **required** prop carrying the TSDoc *"Callback when a context is selected"*. The hook never invokes it, so that contract is unimplemented — and a future caller would reasonably rely on it. Context selection works only because the caller invokes `addContextNotified` itself at five sites.

Only the dead hand-off goes. `addContextNotified` and the ref sinks behind it stay: they serve those five live calls.

**`FieldItem.level`** is a required `level: number` the component never reads, and `FieldTreeNodes` exists largely to thread it — declared, destructured, passed down, incremented `level={level + 1}` on every recursion from a `level={0}` seed. Indentation comes from the nested wrapper divs (`ml-1.5 pl-2.5`), so nothing renders differently.

## Notes on the rest

**`isProduction`** was a *required* prop on `SocialLoginButtons`, forwarded by both auth forms without either reading it. With the chain gone, `getOAuthProviderStatus`'s `isProduction` return had no consumer either — `/api/auth/providers` already takes just the three availability flags — so the return value and its `isProd` import went too. `verify-content.tsx` genuinely branches on it and is untouched.

**`GroupedCheckboxList`** renders hardcoded `Select PII Types to Detect` and `PII types` while accepting a `title` it ignores, so a block author setting `title` gets silence, and `maxHeight = 400` implies a scroll ceiling never applied. Separately worth knowing: the component's copy is PII-specific while its name and props present as generic. Renaming is a design call, not made here.

**`useCustomBlock*(workspaceId)`** looks like it was meant to narrow invalidation to `list(workspaceId)`, but `lists()` is the level CLAUDE.md's targeted-invalidation rule prescribes and is a correct superset. So the invalidation is right and the parameter is vestigial; narrowing the key would be a separate call with its own under-invalidation risk.

## Two claims that did not survive verification

- The three `useCustomBlock*` hooks were reported as having **zero callers** (dead exports). They have callers — the search behind that claim omitted `apps/sim/ee`.
- My own line patterns matched a **live** `flatTagList` on `KeyboardNavigationHandler` and a **live** `title` on `Switch`. `tsc` caught both before commit; both are restored and verified in the diff.

## Verification

- All 26 workspaces type-check; `bun run lint:check` exits 0
- 1087 tests across `app/workspace/home` + `/w`, 446 in `/w`, 210 across `hooks/queries` + `ee/custom-blocks`
- Every removal confirmed by grepping the receiver for the identifier: 2 occurrences (declaration + destructure) and nothing else

**Net −59 lines.**