### PR TITLE
fix(mothership): persist embedded workflow block positions

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-canvas-helpers.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-canvas-helpers.test.ts
@@ -4,11 +4,38 @@
 import { describe, expect, it } from 'vitest'
 import {
   getArrowNavigationDirection,
+  getWorkflowCanvasInteractionPolicy,
   isPositionalTriggerBlock,
   reconcileCanvasEdges,
   reconcileCanvasNodes,
   shouldHighlightContainerDropTarget,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-canvas-helpers'
+
+describe('getWorkflowCanvasInteractionPolicy', () => {
+  it('allows position changes and re-parenting in the editable workflow editor', () => {
+    expect(getWorkflowCanvasInteractionPolicy({ embedded: false, canEdit: true })).toEqual({
+      canDragNodes: true,
+      canReparentNodes: true,
+    })
+  })
+
+  it('allows position changes without re-parenting in an editable embedded canvas', () => {
+    expect(getWorkflowCanvasInteractionPolicy({ embedded: true, canEdit: true })).toEqual({
+      canDragNodes: true,
+      canReparentNodes: false,
+    })
+  })
+
+  it.each([false, true])(
+    'disables dragging when edit access is denied (embedded=%s)',
+    (embedded) => {
+      expect(getWorkflowCanvasInteractionPolicy({ embedded, canEdit: false })).toEqual({
+        canDragNodes: false,
+        canReparentNodes: false,
+      })
+    }
+  )
+})
 
 describe('getArrowNavigationDirection', () => {
   it('moves once for a fresh horizontal arrow press', () => {

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-canvas-helpers.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-canvas-helpers.ts
@@ -7,6 +7,22 @@ import type { BlockState } from '@/stores/workflows/workflow/types'
 
 export const SUBFLOW_DROP_TARGET_CLASS = 'subflow-node-drop-target'
 
+interface WorkflowCanvasInteractionPolicyInput {
+  embedded: boolean
+  canEdit: boolean
+}
+
+/** Separates position editing from structural re-parenting for embedded canvases. */
+export function getWorkflowCanvasInteractionPolicy({
+  embedded,
+  canEdit,
+}: WorkflowCanvasInteractionPolicyInput) {
+  return {
+    canDragNodes: canEdit,
+    canReparentNodes: canEdit && !embedded,
+  } as const
+}
+
 type ArrowNavigationEvent = Pick<
   KeyboardEvent,
   'key' | 'repeat' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/workflow.tsx
@@ -92,6 +92,7 @@ import {
   getEdgeSelectionContextId,
   getNodeSelectionContextId,
   getRunFromBlockDependencyState,
+  getWorkflowCanvasInteractionPolicy,
   getWorkflowLockToggleIds,
   isBlockProtected,
   isEdgeProtected,
@@ -732,6 +733,10 @@ const WorkflowContent = React.memo(
       }
       return userPermissions
     }, [userPermissions, currentWorkflow.isSnapshotView, workflowReadOnly])
+    const { canDragNodes, canReparentNodes } = getWorkflowCanvasInteractionPolicy({
+      embedded: embedded === true,
+      canEdit: effectivePermissions.canEdit === true,
+    })
     const {
       collaborativeBatchAddEdges,
       collaborativeBatchRemoveEdges,
@@ -2869,7 +2874,7 @@ const WorkflowContent = React.memo(
             parentId: block.data?.parentId,
             extent: block.data?.extent || undefined,
             dragHandle: '.workflow-drag-handle',
-            draggable: !workflowReadOnly && !isBlockProtected(block.id, blocks),
+            draggable: canDragNodes && !isBlockProtected(block.id, blocks),
             zIndex: depth,
             data: {
               ...block.data,
@@ -2914,7 +2919,7 @@ const WorkflowContent = React.memo(
           position,
           parentId: block.data?.parentId,
           dragHandle,
-          draggable: !workflowReadOnly && !isBlockProtected(block.id, blocks),
+          draggable: canDragNodes && !isBlockProtected(block.id, blocks),
           zIndex: cardZIndex,
           extent: (() => {
             // Clamp children to subflow body (exclude header)
@@ -2968,6 +2973,7 @@ const WorkflowContent = React.memo(
       isDebugging,
       getBlockConfig,
       embedded,
+      canDragNodes,
       workflowReadOnly,
       collaborativeSetBlockErrorEnabled,
       collaborativeBatchRemoveEdges,
@@ -3677,7 +3683,7 @@ const WorkflowContent = React.memo(
         // paths bail when potentialParentId still equals the drag-start parent, so
         // positions persist but a block can never be inserted into (or pulled out
         // of) a loop/parallel from the embedded view.
-        if (embedded) return
+        if (!canReparentNodes) return
 
         // Check if this is a starter block - starter blocks should never be in containers
         const isStarterBlock = node.data?.type === 'starter'
@@ -3804,7 +3810,7 @@ const WorkflowContent = React.memo(
         getNodes,
         potentialParentId,
         blocks,
-        embedded,
+        canReparentNodes,
         getNodeAbsolutePosition,
         getNodeDepth,
         isDescendantOf,
@@ -5172,16 +5178,14 @@ const WorkflowContent = React.memo(
                   multiSelectionKeyCode={embedded ? null : ['Meta', 'Control', 'Shift']}
                   nodesConnectable={!embedded && effectivePermissions.canEdit}
                   connectOnClick={false}
-                  nodesDraggable={!embedded && effectivePermissions.canEdit}
+                  nodesDraggable={canDragNodes}
                   draggable={false}
                   noWheelClassName='allow-scroll'
                   edgesFocusable={!embedded}
                   edgesUpdatable={!embedded && effectivePermissions.canEdit}
                   className={`workflow-container h-full bg-[var(--bg)] transition-opacity duration-150 ${reactFlowStyles} ${canvasOpacityClass} ${isHandMode ? 'canvas-mode-hand' : 'canvas-mode-cursor'}`}
-                  onNodeDrag={effectivePermissions.canEdit ? onNodeDrag : undefined}
-                  onNodeDragStop={
-                    !embedded && effectivePermissions.canEdit ? onNodeDragStop : undefined
-                  }
+                  onNodeDrag={canDragNodes ? onNodeDrag : undefined}
+                  onNodeDragStop={canDragNodes ? onNodeDragStop : undefined}
                   onSelectionDragStart={
                     effectivePermissions.canEdit ? onSelectionDragStart : undefined
                   }
@@ -5189,9 +5193,7 @@ const WorkflowContent = React.memo(
                   onSelectionDragStop={
                     effectivePermissions.canEdit ? onSelectionDragStop : undefined
                   }
-                  onNodeDragStart={
-                    !embedded && effectivePermissions.canEdit ? onNodeDragStart : undefined
-                  }
+                  onNodeDragStart={canDragNodes ? onNodeDragStart : undefined}
                   snapToGrid={snapToGrid}
                   snapGrid={snapGrid}
                   elevateEdgesOnSelect={false}


### PR DESCRIPTION
## Summary

Restores position persistence when an editable workflow is embedded as a Sim Chat resource.

The embedded canvas already allowed block movement visually, but it did not wire the drag start/stop lifecycle that records undo state and calls the existing collaborative batch-position operation. This PR makes the interaction policy explicit: editable embedded canvases can move blocks, but cannot structurally re-parent them; normal editable canvases retain both behaviors; read-only/locked/snapshot canvases retain neither.

No new API, persistence protocol, debounce, schema, or public type is introduced.

- Slack ticket and before recording: https://sim-ai.slack.com/archives/C093DF8MA21/p1786662044110359
- Root cause: embedded canvases set `nodesDraggable={false}` and omitted `onNodeDragStart`/`onNodeDragStop`, so React Flow could show transient movement without crossing the workflow's collaborative persistence boundary.
- Fix: reuse the existing drag-stop path and `collaborativeBatchUpdatePositions`, while continuing to skip embedded container-intersection/re-parenting logic.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

Automated validation on the latest `origin/staging` base:

- `bunx vitest run 'app/workspace/[workspaceId]/w/[workflowId]/utils/workflow-canvas-helpers.test.ts'` — 19 passed
- `bun run format:check` — passed
- `bun run lint:check` — passed (one pre-existing unused-suppression warning in `lib/workspace-files/shell-layout.test.ts`)
- `bun run check:audits` — 33/33 passed
- `bun run docs-manifest:check` — passed
- `bun run check:migrations origin/staging` — no new migrations
- `bunx turbo run type-check` — 26/26 tasks passed
- `bun run test` — 19/19 workspace tasks passed; `@sim/app` 2,212 files and 31,288 tests passed (3 files/46 tests skipped)
- CI-equivalent `bunx turbo run build --filter=@sim/app` with `.github/workflows/test-build.yml` environment values — passed
- `git diff --check` — passed

Browser verification used authenticated Chrome against dedicated local app/realtime processes on ports 3013/3014 and a disposable workflow/chat:

| Scenario | Result |
| --- | --- |
| Main-editor drag, live embedded update, and main-editor reload | Passed |
| Embedded drag and live main-editor update | Passed |
| Embedded reload and close/reopen | Passed |
| Open workflow in the main editor after embedded drag | Passed |
| Embedded drag over Loop changes position without changing Loop membership | Passed; persisted subflow membership remained unchanged |
| Normal-editor drop into Loop | Passed; collaborative parent update added the block to Loop membership |
| Embedded pan, double-click zoom, and Open workflow | Passed |
| Embedded selection editing, block editor opening, connections, and re-parenting remain unavailable | Passed |

The disposable workflow and chat were soft-deleted after verification.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

### 1. Embedded canvas immediately after the drag

<img width="1512" height="742" alt="Embedded workflow canvas immediately after dragging the Agent block" src="https://github.com/user-attachments/assets/8e4cc470-06f1-4ac1-8bb0-c96a845cc5a2" />

### 2. Same embedded position after reload

<img width="1512" height="742" alt="Embedded workflow canvas preserving the Agent position after reload" src="https://github.com/user-attachments/assets/3eaab98a-1dc6-4da2-ad5e-4e7dd6602306" />

### 3. Main editor showing the same persisted position

<img width="1512" height="798" alt="Main workflow editor showing the same persisted Agent position" src="https://github.com/user-attachments/assets/9845bbfa-7e12-4925-9414-0bc4aee500d9" />
