### PR TITLE
fix(workflow): highlight references in code previews

### DIFF
--- a/apps/sim/lib/workflows/sanitization/references.test.ts
+++ b/apps/sim/lib/workflows/sanitization/references.test.ts
@@ -86,5 +86,7 @@ describe('containsReference', () => {
   it('returns false for stray brackets that are not references', () => {
     expect(containsReference('a < b')).toBe(false)
     expect(containsReference('<123>')).toBe(false)
+    expect(containsReference('value <limit && value>max')).toBe(false)
+    expect(containsReference('a<b<c>d')).toBe(false)
   })
 })

--- a/apps/sim/lib/workflows/sanitization/references.ts
+++ b/apps/sim/lib/workflows/sanitization/references.ts
@@ -1,83 +1,14 @@
+import {
+  findWorkflowReferenceTokens,
+  isLikelyWorkflowReferenceSegment,
+  splitWorkflowReferenceSegment,
+} from '@sim/utils/workflow-references'
 import { normalizeName, REFERENCE } from '@/executor/constants'
 
 export const SYSTEM_REFERENCE_PREFIXES = new Set(['loop', 'parallel', 'variable'])
 
-const INVALID_REFERENCE_CHARS = /[+*/=<>!]/
-
-const LEADING_REFERENCE_PATTERN = /^[<>=!\s]*$/
-
-export function splitReferenceSegment(
-  segment: string
-): { leading: string; reference: string } | null {
-  if (!segment.startsWith(REFERENCE.START) || !segment.endsWith(REFERENCE.END)) {
-    return null
-  }
-
-  const lastOpenBracket = segment.lastIndexOf(REFERENCE.START)
-  if (lastOpenBracket === -1) {
-    return null
-  }
-
-  const leading = lastOpenBracket > 0 ? segment.slice(0, lastOpenBracket) : ''
-  const reference = segment.slice(lastOpenBracket)
-
-  if (!reference.startsWith(REFERENCE.START) || !reference.endsWith(REFERENCE.END)) {
-    return null
-  }
-
-  return { leading, reference }
-}
-
-export function isLikelyReferenceSegment(segment: string): boolean {
-  const split = splitReferenceSegment(segment)
-  if (!split) {
-    return false
-  }
-
-  const { leading, reference } = split
-
-  if (leading && !LEADING_REFERENCE_PATTERN.test(leading)) {
-    return false
-  }
-
-  const inner = reference.slice(REFERENCE.START.length, -REFERENCE.END.length)
-
-  if (!inner) {
-    return false
-  }
-
-  if (inner.startsWith(' ')) {
-    return false
-  }
-
-  if (inner.match(/^\s*[<>=!]+\s*$/) || inner.match(/\s[<>=!]+\s/)) {
-    return false
-  }
-
-  if (inner.match(/^[<>=!]+\s/)) {
-    return false
-  }
-
-  if (inner.includes(REFERENCE.PATH_DELIMITER)) {
-    const dotIndex = inner.indexOf(REFERENCE.PATH_DELIMITER)
-    const beforeDot = inner.substring(0, dotIndex)
-    const afterDot = inner.substring(dotIndex + REFERENCE.PATH_DELIMITER.length)
-
-    if (afterDot.includes(' ')) {
-      return false
-    }
-
-    if (INVALID_REFERENCE_CHARS.test(beforeDot) || INVALID_REFERENCE_CHARS.test(afterDot)) {
-      return false
-    }
-  } else if (INVALID_REFERENCE_CHARS.test(inner) || inner.match(/^\d+$/) || inner.match(/\s\d/)) {
-    return false
-  }
-
-  return true
-}
-
-const ENV_VAR_PATTERN = new RegExp(`\\${REFERENCE.ENV_VAR_START}[^}]+\\${REFERENCE.ENV_VAR_END}`)
+export const splitReferenceSegment = splitWorkflowReferenceSegment
+export const isLikelyReferenceSegment = isLikelyWorkflowReferenceSegment
 
 /**
  * Whether a subblock value carries a `<block.path>` / `<variable.name>` reference or a
@@ -89,7 +20,7 @@ export function containsReference(value: unknown): boolean {
   if (typeof value !== 'string' || !value) {
     return false
   }
-  return extractReferencePrefixes(value).length > 0 || ENV_VAR_PATTERN.test(value)
+  return findWorkflowReferenceTokens(value).length > 0
 }
 
 export function extractReferencePrefixes(value: string): Array<{ raw: string; prefix: string }> {
@@ -97,38 +28,16 @@ export function extractReferencePrefixes(value: string): Array<{ raw: string; pr
     return []
   }
 
-  const referencePattern = new RegExp(`${REFERENCE.START}[^${REFERENCE.END}]+${REFERENCE.END}`, 'g')
-  const matches = value.match(referencePattern)
-  if (!matches) {
-    return []
-  }
-
   const references: Array<{ raw: string; prefix: string }> = []
 
-  for (const match of matches) {
-    const split = splitReferenceSegment(match)
-    if (!split) {
-      continue
-    }
-
-    if (split.leading && !LEADING_REFERENCE_PATTERN.test(split.leading)) {
-      continue
-    }
-
-    const referenceSegment = split.reference
-
-    if (!isLikelyReferenceSegment(referenceSegment)) {
-      continue
-    }
-
-    const inner = referenceSegment.slice(REFERENCE.START.length, -REFERENCE.END.length)
+  for (const token of findWorkflowReferenceTokens(value)) {
+    if (token.kind !== 'workflow') continue
+    const inner = token.value.slice(REFERENCE.START.length, -REFERENCE.END.length)
     const [rawPrefix] = inner.split(REFERENCE.PATH_DELIMITER)
-    if (!rawPrefix) {
-      continue
-    }
+    if (!rawPrefix) continue
 
     const normalized = normalizeName(rawPrefix)
-    references.push({ raw: referenceSegment, prefix: normalized })
+    references.push({ raw: token.value, prefix: normalized })
   }
 
   return references

--- a/packages/emcn/src/components/code/code.css
+++ b/packages/emcn/src/components/code/code.css
@@ -73,9 +73,10 @@
   color: #dc2626;
 }
 
-/* Blue accents for <var> and {{ENV}} placeholders - light mode */
-.code-editor-theme.code-editor-theme .text-blue-500 {
-  color: #1d4ed8;
+/* Platform accent for <workflow.reference> and {{ENV}} placeholders */
+.code-editor-theme.code-editor-theme [data-code-reference],
+.code-editor-theme.code-editor-theme .token [data-code-reference] {
+  color: var(--brand-secondary);
 }
 
 /**
@@ -141,11 +142,6 @@
 
 .dark .code-editor-theme.code-editor-theme .token.deleted {
   color: #f87171;
-}
-
-/* Blue accents for <var> and {{ENV}} placeholders - dark mode */
-.dark .code-editor-theme.code-editor-theme .text-blue-500 {
-  color: #35b6ff;
 }
 
 /* Ensure transparent backgrounds */

--- a/packages/emcn/src/components/code/code.css
+++ b/packages/emcn/src/components/code/code.css
@@ -8,6 +8,14 @@
  * to override PrismJS defaults without !important.
  */
 
+.code-editor-theme.code-editor-theme {
+  --code-reference: #1d4ed8;
+}
+
+.dark .code-editor-theme.code-editor-theme {
+  --code-reference: #35b6ff;
+}
+
 /**
  * Light mode token colors - Cursor style with Sim vibrancy
  */
@@ -76,7 +84,7 @@
 /* Platform accent for <workflow.reference> and {{ENV}} placeholders */
 .code-editor-theme.code-editor-theme [data-code-reference],
 .code-editor-theme.code-editor-theme .token [data-code-reference] {
-  color: var(--brand-secondary);
+  color: var(--code-reference);
 }
 
 /**

--- a/packages/emcn/src/components/code/code.test.tsx
+++ b/packages/emcn/src/components/code/code.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { sleep } from '@sim/utils/helpers'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { Code } from './code'
+
+let root: Root | null = null
+let host: HTMLDivElement | null = null
+
+beforeEach(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  if (root) act(() => root?.unmount())
+  host?.remove()
+  root = null
+  host = null
+})
+
+describe('Code.Viewer workflow references', () => {
+  it('renders dollar replacement sequences literally', async () => {
+    await act(async () => {
+      root?.render(
+        <Code.Viewer
+          code={'const secret = {{SECRET_$&_$$}}\nconst output = <block.$$>'}
+          language='javascript'
+          highlightWorkflowReferences
+        />
+      )
+      await sleep(1)
+    })
+
+    expect(
+      Array.from(host?.querySelectorAll('[data-code-reference]') ?? [], (node) => node.textContent)
+    ).toEqual(['{{SECRET_$&_$$}}', '<block.$$>'])
+  })
+
+  it('preserves reference accents when gutter search highlighting is active', async () => {
+    await act(async () => {
+      root?.render(
+        <Code.Viewer
+          code='const result = <block.output>'
+          language='javascript'
+          showGutter
+          searchQuery='result'
+          highlightWorkflowReferences
+        />
+      )
+      await sleep(1)
+    })
+
+    expect(host?.querySelector('[data-code-reference]')?.textContent).toBe('<block.output>')
+    expect(host?.querySelector('[data-search-match]')?.textContent).toBe('result')
+  })
+})

--- a/packages/emcn/src/components/code/code.tsx
+++ b/packages/emcn/src/components/code/code.tsx
@@ -154,7 +154,7 @@ function highlightCodeReferences(
   for (const { original, placeholder } of placeholders) {
     highlighted = highlighted.replace(
       placeholder,
-      `<span data-code-reference="">${escapeHtml(original)}</span>`
+      () => `<span data-code-reference="">${escapeHtml(original)}</span>`
     )
   }
   return highlighted
@@ -1270,7 +1270,7 @@ const ViewerInner = memo(function ViewerInner({
     }
 
     return visibleLineIndices.map((idx) => {
-      let html = highlightOrEscape(prism, displayLines[idx], language)
+      let html = highlightOrEscape(prism, displayLines[idx], language, highlightWorkflowReferences)
       const matchCounter = { count: cumulativeMatches[idx] }
       html = applySearchHighlighting(html, searchQuery, currentMatchIndex, matchCounter)
       return { lineNumber: idx + 1, html: html || '&nbsp;' }

--- a/packages/emcn/src/components/code/code.tsx
+++ b/packages/emcn/src/components/code/code.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { findWorkflowReferenceTokens } from '@sim/utils/workflow-references'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronRight } from '../../icons'
 import { cn } from '../../lib/cn'
@@ -105,10 +106,58 @@ function escapeHtml(text: string): string {
  * @param language - The language key (e.g. `json`, `javascript`, `python`)
  * @returns Highlighted HTML, or escaped plaintext as a fallback
  */
-function highlightOrEscape(prism: PrismModule | null, text: string, language: string): string {
-  if (!prism) return escapeHtml(text)
-  const grammar = prism.languages[language] || prism.languages.javascript
-  return prism.highlight(text, grammar, language)
+function highlightOrEscape(
+  prism: PrismModule | null,
+  text: string,
+  language: string,
+  highlightWorkflowReferences = false
+): string {
+  const highlightSource = (source: string) => {
+    if (!prism) return escapeHtml(source)
+    const grammar = prism.languages[language] || prism.languages.javascript
+    return prism.highlight(source, grammar, language)
+  }
+
+  return highlightWorkflowReferences
+    ? highlightCodeReferences(text, highlightSource)
+    : highlightSource(text)
+}
+
+interface CodeReferencePlaceholder {
+  original: string
+  placeholder: string
+}
+
+function highlightCodeReferences(
+  source: string,
+  highlightSource: (source: string) => string
+): string {
+  const placeholders: CodeReferencePlaceholder[] = []
+  let cursor = 0
+  let maskedSource = ''
+
+  const maskReference = (original: string) => {
+    let placeholder = `__SIM_CODE_REFERENCE_${placeholders.length}__`
+    while (source.includes(placeholder)) placeholder += '_'
+    placeholders.push({ original, placeholder })
+    return placeholder
+  }
+
+  for (const token of findWorkflowReferenceTokens(source)) {
+    maskedSource += source.slice(cursor, token.start)
+    maskedSource += maskReference(token.value)
+    cursor = token.end
+  }
+  maskedSource += source.slice(cursor)
+
+  let highlighted = highlightSource(maskedSource)
+  for (const { original, placeholder } of placeholders) {
+    highlighted = highlighted.replace(
+      placeholder,
+      `<span data-code-reference="">${escapeHtml(original)}</span>`
+    )
+  }
+  return highlighted
 }
 
 /**
@@ -817,6 +866,8 @@ interface CodeViewerProps {
   className?: string
   /** Visual density for read-only code. */
   density?: CodeViewerDensity
+  /** Highlight Sim `{{ENV}}` and `<block.output>` references with the platform accent. */
+  highlightWorkflowReferences?: boolean
   /** Left padding offset (useful for terminal alignment) */
   paddingLeft?: number
   /** Inline styles for the gutter (e.g., to override background) */
@@ -905,6 +956,7 @@ type ViewerInnerProps = {
   className?: string
   /** Visual density for read-only code. */
   density: CodeViewerDensity
+  highlightWorkflowReferences: boolean
   /** Left padding offset in pixels */
   paddingLeft: number
   /** Custom styles for the gutter */
@@ -933,6 +985,7 @@ const VirtualizedViewerInner = memo(function VirtualizedViewerInner({
   language,
   className,
   density,
+  highlightWorkflowReferences,
   paddingLeft,
   gutterStyle,
   wrapText,
@@ -995,7 +1048,7 @@ const VirtualizedViewerInner = memo(function VirtualizedViewerInner({
     const hasSearch = searchQuery?.trim()
 
     return visibleLineIndices.map((idx) => {
-      let html = highlightOrEscape(prism, displayLines[idx], language)
+      let html = highlightOrEscape(prism, displayLines[idx], language, highlightWorkflowReferences)
 
       if (hasSearch && searchQuery) {
         const result = applySearchHighlightingToLine(
@@ -1013,6 +1066,7 @@ const VirtualizedViewerInner = memo(function VirtualizedViewerInner({
     prism,
     displayLines,
     language,
+    highlightWorkflowReferences,
     visibleLineIndices,
     searchQuery,
     currentMatchIndex,
@@ -1149,6 +1203,7 @@ const ViewerInner = memo(function ViewerInner({
   language,
   className,
   density,
+  highlightWorkflowReferences,
   paddingLeft,
   gutterStyle,
   wrapText,
@@ -1208,7 +1263,9 @@ const ViewerInner = memo(function ViewerInner({
     if (!searchQuery?.trim()) {
       return visibleLineIndices.map((idx) => ({
         lineNumber: idx + 1,
-        html: highlightOrEscape(prism, displayLines[idx], language) || '&nbsp;',
+        html:
+          highlightOrEscape(prism, displayLines[idx], language, highlightWorkflowReferences) ||
+          '&nbsp;',
       }))
     }
 
@@ -1222,6 +1279,7 @@ const ViewerInner = memo(function ViewerInner({
     prism,
     displayLines,
     language,
+    highlightWorkflowReferences,
     visibleLineIndices,
     searchQuery,
     currentMatchIndex,
@@ -1231,14 +1289,22 @@ const ViewerInner = memo(function ViewerInner({
   // Pre-compute simple highlighted code (for no-gutter mode)
   const highlightedCode = useMemo(() => {
     const visibleCode = visibleLineIndices.map((idx) => displayLines[idx]).join('\n')
-    let html = highlightOrEscape(prism, visibleCode, language)
+    let html = highlightOrEscape(prism, visibleCode, language, highlightWorkflowReferences)
 
     if (searchQuery?.trim()) {
       const matchCounter = { count: 0 }
       html = applySearchHighlighting(html, searchQuery, currentMatchIndex, matchCounter)
     }
     return html
-  }, [prism, displayLines, language, visibleLineIndices, searchQuery, currentMatchIndex])
+  }, [
+    prism,
+    displayLines,
+    language,
+    highlightWorkflowReferences,
+    visibleLineIndices,
+    searchQuery,
+    currentMatchIndex,
+  ])
 
   const whitespaceClass = wrapText ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'
 
@@ -1358,6 +1424,7 @@ function Viewer({
   language = 'json',
   className,
   density = 'default',
+  highlightWorkflowReferences = false,
   paddingLeft = 0,
   gutterStyle,
   wrapText = false,
@@ -1374,6 +1441,7 @@ function Viewer({
     language,
     className,
     density,
+    highlightWorkflowReferences,
     paddingLeft,
     gutterStyle,
     wrapText,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -61,6 +61,10 @@
     "./sandbox-references": {
       "types": "./src/sandbox-references.ts",
       "default": "./src/sandbox-references.ts"
+    },
+    "./workflow-references": {
+      "types": "./src/workflow-references.ts",
+      "default": "./src/workflow-references.ts"
     }
   },
   "scripts": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -42,3 +42,10 @@ export {
   sanitizeValueForJsonb,
   truncate,
 } from './string'
+export {
+  findWorkflowReferenceTokens,
+  isLikelyWorkflowReferenceSegment,
+  splitWorkflowReferenceSegment,
+  type WorkflowReferenceToken,
+  type WorkflowReferenceTokenKind,
+} from './workflow-references'

--- a/packages/utils/src/workflow-references.test.ts
+++ b/packages/utils/src/workflow-references.test.ts
@@ -1,0 +1,37 @@
+import {
+  findWorkflowReferenceTokens,
+  isLikelyWorkflowReferenceSegment,
+  splitWorkflowReferenceSegment,
+} from '@sim/utils/workflow-references'
+import { describe, expect, it } from 'vitest'
+
+describe('workflow references', () => {
+  it('separates comparison prefixes from the final reference', () => {
+    expect(splitWorkflowReferenceSegment('<= <block.output>')).toEqual({
+      leading: '<= ',
+      reference: '<block.output>',
+    })
+  })
+
+  it('distinguishes references from comparisons and numeric angle brackets', () => {
+    expect(isLikelyWorkflowReferenceSegment('<block.output>')).toBe(true)
+    expect(isLikelyWorkflowReferenceSegment('<parameter>')).toBe(true)
+    expect(isLikelyWorkflowReferenceSegment('< limit && total >')).toBe(false)
+    expect(isLikelyWorkflowReferenceSegment('<123>')).toBe(false)
+  })
+
+  it('finds environment and workflow tokens without treating comparisons as references', () => {
+    const source = [
+      'const secret = {{SECRET_NAME_REF}}',
+      'const result = <blockOutput.field>',
+      'const comparison = count < limit && total > 0',
+    ].join('\n')
+
+    expect(findWorkflowReferenceTokens(source).map(({ kind, value }) => ({ kind, value }))).toEqual(
+      [
+        { kind: 'environment', value: '{{SECRET_NAME_REF}}' },
+        { kind: 'workflow', value: '<blockOutput.field>' },
+      ]
+    )
+  })
+})

--- a/packages/utils/src/workflow-references.test.ts
+++ b/packages/utils/src/workflow-references.test.ts
@@ -34,4 +34,21 @@ describe('workflow references', () => {
       ]
     )
   })
+
+  it('rejects compact boolean and nested comparison expressions', () => {
+    expect(findWorkflowReferenceTokens('value <limit && value>max')).toEqual([])
+    expect(findWorkflowReferenceTokens('value<limit||value>max')).toEqual([])
+    expect(findWorkflowReferenceTokens('a<b<c>d')).toEqual([])
+  })
+
+  it('retains a reference after a comparison prefix', () => {
+    expect(findWorkflowReferenceTokens('value < <block.output>')).toEqual([
+      {
+        kind: 'workflow',
+        value: '<block.output>',
+        start: 8,
+        end: 22,
+      },
+    ])
+  })
 })

--- a/packages/utils/src/workflow-references.test.ts
+++ b/packages/utils/src/workflow-references.test.ts
@@ -51,4 +51,23 @@ describe('workflow references', () => {
       },
     ])
   })
+
+  it('scans long runs of opening brackets while preserving final reference offsets', () => {
+    expect(findWorkflowReferenceTokens(`${'<'.repeat(10_000)}value>`)).toEqual([
+      {
+        kind: 'workflow',
+        value: '<value>',
+        start: 9_999,
+        end: 10_006,
+      },
+    ])
+    expect(findWorkflowReferenceTokens(`${'<'.repeat(10_000)}<block.output>`)).toEqual([
+      {
+        kind: 'workflow',
+        value: '<block.output>',
+        start: 10_000,
+        end: 10_014,
+      },
+    ])
+  })
 })

--- a/packages/utils/src/workflow-references.ts
+++ b/packages/utils/src/workflow-references.ts
@@ -1,0 +1,79 @@
+const REFERENCE_START = '<'
+const REFERENCE_END = '>'
+const REFERENCE_PATH_DELIMITER = '.'
+const INVALID_REFERENCE_CHARS = /[+*/=<>!]/
+const LEADING_REFERENCE_PATTERN = /^[<>=!\s]*$/
+const ENV_REFERENCE_PATTERN = /\{\{[^{}\r\n]+\}\}/g
+const ANGLE_REFERENCE_PATTERN = /<[^<>\r\n]+>/g
+
+export type WorkflowReferenceTokenKind = 'environment' | 'workflow'
+
+export interface WorkflowReferenceToken {
+  kind: WorkflowReferenceTokenKind
+  value: string
+  start: number
+  end: number
+}
+
+/** Separates comparison characters before the final `<workflow.reference>` segment. */
+export function splitWorkflowReferenceSegment(
+  segment: string
+): { leading: string; reference: string } | null {
+  if (!segment.startsWith(REFERENCE_START) || !segment.endsWith(REFERENCE_END)) return null
+
+  const lastOpenBracket = segment.lastIndexOf(REFERENCE_START)
+  if (lastOpenBracket === -1) return null
+
+  const leading = lastOpenBracket > 0 ? segment.slice(0, lastOpenBracket) : ''
+  const reference = segment.slice(lastOpenBracket)
+  if (!reference.startsWith(REFERENCE_START) || !reference.endsWith(REFERENCE_END)) return null
+
+  return { leading, reference }
+}
+
+/** Distinguishes Sim workflow references from comparison expressions and stray angle brackets. */
+export function isLikelyWorkflowReferenceSegment(segment: string): boolean {
+  const split = splitWorkflowReferenceSegment(segment)
+  if (!split) return false
+
+  const { leading, reference } = split
+  if (leading && !LEADING_REFERENCE_PATTERN.test(leading)) return false
+
+  const inner = reference.slice(REFERENCE_START.length, -REFERENCE_END.length)
+  if (!inner || inner.startsWith(' ')) return false
+  if (/^\s*[<>=!]+\s*$/.test(inner) || /\s[<>=!]+\s/.test(inner)) return false
+  if (/^[<>=!]+\s/.test(inner)) return false
+
+  const dotIndex = inner.indexOf(REFERENCE_PATH_DELIMITER)
+  if (dotIndex !== -1) {
+    const beforeDot = inner.slice(0, dotIndex)
+    const afterDot = inner.slice(dotIndex + REFERENCE_PATH_DELIMITER.length)
+    return (
+      !afterDot.includes(' ') &&
+      !INVALID_REFERENCE_CHARS.test(beforeDot) &&
+      !INVALID_REFERENCE_CHARS.test(afterDot)
+    )
+  }
+
+  return !INVALID_REFERENCE_CHARS.test(inner) && !/^\d+$/.test(inner) && !/\s\d/.test(inner)
+}
+
+/** Finds non-overlapping `{{ENV}}` and `<workflow.reference>` tokens in source order. */
+export function findWorkflowReferenceTokens(source: string): WorkflowReferenceToken[] {
+  const tokens: WorkflowReferenceToken[] = []
+
+  for (const match of source.matchAll(ENV_REFERENCE_PATTERN)) {
+    const start = match.index
+    tokens.push({ kind: 'environment', value: match[0], start, end: start + match[0].length })
+  }
+
+  for (const match of source.matchAll(ANGLE_REFERENCE_PATTERN)) {
+    const start = match.index
+    const end = start + match[0].length
+    if (!isLikelyWorkflowReferenceSegment(match[0])) continue
+    if (tokens.some((token) => start < token.end && end > token.start)) continue
+    tokens.push({ kind: 'workflow', value: match[0], start, end })
+  }
+
+  return tokens.sort((left, right) => left.start - right.start)
+}

--- a/packages/utils/src/workflow-references.ts
+++ b/packages/utils/src/workflow-references.ts
@@ -1,10 +1,10 @@
 const REFERENCE_START = '<'
 const REFERENCE_END = '>'
 const REFERENCE_PATH_DELIMITER = '.'
-const INVALID_REFERENCE_CHARS = /[+*/=<>!]/
+const INVALID_REFERENCE_CHARS = /[+*/=<>!&|]/
 const LEADING_REFERENCE_PATTERN = /^[<>=!\s]*$/
 const ENV_REFERENCE_PATTERN = /\{\{[^{}\r\n]+\}\}/g
-const ANGLE_REFERENCE_PATTERN = /<[^<>\r\n]+>/g
+const ANGLE_REFERENCE_PATTERN = /<[^>\r\n]+>/g
 
 export type WorkflowReferenceTokenKind = 'environment' | 'workflow'
 
@@ -68,11 +68,12 @@ export function findWorkflowReferenceTokens(source: string): WorkflowReferenceTo
   }
 
   for (const match of source.matchAll(ANGLE_REFERENCE_PATTERN)) {
-    const start = match.index
-    const end = start + match[0].length
-    if (!isLikelyWorkflowReferenceSegment(match[0])) continue
+    const split = splitWorkflowReferenceSegment(match[0])
+    if (!split || !isLikelyWorkflowReferenceSegment(match[0])) continue
+    const start = match.index + split.leading.length
+    const end = start + split.reference.length
     if (tokens.some((token) => start < token.end && end > token.start)) continue
-    tokens.push({ kind: 'workflow', value: match[0], start, end })
+    tokens.push({ kind: 'workflow', value: split.reference, start, end })
   }
 
   return tokens.sort((left, right) => left.start - right.start)

--- a/packages/utils/src/workflow-references.ts
+++ b/packages/utils/src/workflow-references.ts
@@ -4,7 +4,6 @@ const REFERENCE_PATH_DELIMITER = '.'
 const INVALID_REFERENCE_CHARS = /[+*/=<>!&|]/
 const LEADING_REFERENCE_PATTERN = /^[<>=!\s]*$/
 const ENV_REFERENCE_PATTERN = /\{\{[^{}\r\n]+\}\}/g
-const ANGLE_REFERENCE_PATTERN = /<[^>\r\n]+>/g
 
 export type WorkflowReferenceTokenKind = 'environment' | 'workflow'
 
@@ -67,13 +66,29 @@ export function findWorkflowReferenceTokens(source: string): WorkflowReferenceTo
     tokens.push({ kind: 'environment', value: match[0], start, end: start + match[0].length })
   }
 
-  for (const match of source.matchAll(ANGLE_REFERENCE_PATTERN)) {
-    const split = splitWorkflowReferenceSegment(match[0])
-    if (!split || !isLikelyWorkflowReferenceSegment(match[0])) continue
-    const start = match.index + split.leading.length
-    const end = start + split.reference.length
-    if (tokens.some((token) => start < token.end && end > token.start)) continue
-    tokens.push({ kind: 'workflow', value: split.reference, start, end })
+  let candidateStart = -1
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]
+    if (character === REFERENCE_START && candidateStart === -1) {
+      candidateStart = index
+      continue
+    }
+    if (character === '\r' || character === '\n') {
+      candidateStart = -1
+      continue
+    }
+    if (character !== REFERENCE_END || candidateStart === -1) continue
+
+    const candidate = source.slice(candidateStart, index + REFERENCE_END.length)
+    const split = splitWorkflowReferenceSegment(candidate)
+    if (split && isLikelyWorkflowReferenceSegment(candidate)) {
+      const start = candidateStart + split.leading.length
+      const end = start + split.reference.length
+      if (!tokens.some((token) => start < token.end && end > token.start)) {
+        tokens.push({ kind: 'workflow', value: split.reference, start, end })
+      }
+    }
+    candidateStart = -1
   }
 
   return tokens.sort((left, right) => left.start - right.start)

--- a/packages/workflow-renderer/src/lib/code-hover-card.tsx
+++ b/packages/workflow-renderer/src/lib/code-hover-card.tsx
@@ -175,6 +175,7 @@ export function CodeHoverCard({ preview, className, children }: CodeHoverCardPro
           code={preview.code}
           language={preview.language}
           density='compact'
+          highlightWorkflowReferences
           className='max-h-[min(16rem,calc(100vh-2rem))] min-h-0 rounded-none border-0 bg-[var(--bg)] shadow-none dark:bg-[var(--bg)]'
         />
       </PopoverContent>

--- a/packages/workflow-renderer/src/lib/overflow-span-mount.test.tsx
+++ b/packages/workflow-renderer/src/lib/overflow-span-mount.test.tsx
@@ -121,6 +121,44 @@ describe('OverflowSpan code preview', () => {
     expect(document.querySelector('[data-code-hover-card]')).toBeNull()
   })
 
+  it('accents environment and block-output references without treating comparisons as references', () => {
+    const code = [
+      'const secret = {{SECRET_NAME_REF}}',
+      'const result = <blockOutput.field>',
+      'const comparison = count < limit && total > 0',
+    ].join('\n')
+    act(() => {
+      root?.render(
+        <OverflowSpan
+          value='const secret...'
+          className='truncate'
+          codePreview={{ code, language: 'javascript' }}
+        />
+      )
+    })
+
+    const trigger = host?.querySelector<HTMLElement>('span')
+    if (!trigger) throw new Error('Overflow trigger did not render')
+    Object.defineProperties(trigger, {
+      clientWidth: { configurable: true, value: 50 },
+      scrollWidth: { configurable: true, value: 200 },
+    })
+
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      vi.advanceTimersByTime(300)
+    })
+
+    const references = document.querySelectorAll('[data-code-hover-card] [data-code-reference]')
+    expect(Array.from(references, (reference) => reference.textContent)).toEqual([
+      '{{SECRET_NAME_REF}}',
+      '<blockOutput.field>',
+    ])
+    expect(document.querySelector('[data-code-hover-card]')).toHaveTextContent(
+      'count < limit && total > 0'
+    )
+  })
+
   it('opens from the keyboard and keeps the preview available while it is focused', () => {
     act(() => {
       root?.render(


### PR DESCRIPTION
## Summary
- highlight Sim environment and workflow references in code hover previews
- share one workflow-reference tokenizer between sanitization and Code.Viewer
- preserve comparison expressions as ordinary code

## Type of Change
- [x] Bug fix

## Testing
- bun run lint
- bun run lint:check
- bun run check:audits (31 aggregate checks passed; the final client-boundary scan passed standalone after the aggregate coordinator stalled)
- 22 focused Vitest assertions for tokenization, sanitization, and tooltip rendering
- type-checks for @sim/utils, @sim/emcn, and @sim/workflow-renderer

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm this PR targets staging and contains only the intended change