### PR TITLE
fix(copilot): name a count-parallel's branch count `count` in the model's read view

### DIFF
--- a/apps/sim/lib/workflows/sanitization/json-sanitizer.test.ts
+++ b/apps/sim/lib/workflows/sanitization/json-sanitizer.test.ts
@@ -184,6 +184,58 @@ describe('sanitizeForCopilot product-gated block inputs', () => {
   })
 })
 
+describe('sanitizeForCopilot subflow config', () => {
+  /**
+   * The model's read view has to use the same field names as the write contract it is
+   * given, or an echoed-back edit is silently dropped. `components/blocks/parallel.json`
+   * declares `count`; `components/blocks/loop.json` declares `iterations`.
+   */
+  it("names a count-parallel's branch count `count`, matching the parallel write contract", () => {
+    const state = makeSingleBlockWorkflow('parallel-1', {
+      type: 'parallel',
+      name: 'Parallel 1',
+      enabled: true,
+      subBlocks: {},
+      data: { parallelType: 'count', count: 5 },
+    })
+
+    expect(sanitizeForCopilot(state).blocks['parallel-1'].inputs).toEqual({
+      parallelType: 'count',
+      count: 5,
+    })
+  })
+
+  it("names a for-loop's trip count `iterations`, matching the loop write contract", () => {
+    const state = makeSingleBlockWorkflow('loop-1', {
+      type: 'loop',
+      name: 'Loop 1',
+      enabled: true,
+      subBlocks: {},
+      data: { loopType: 'for', count: 3 },
+    })
+
+    expect(sanitizeForCopilot(state).blocks['loop-1'].inputs).toEqual({
+      loopType: 'for',
+      iterations: 3,
+    })
+  })
+
+  it('exports a collection parallel without a branch count', () => {
+    const state = makeSingleBlockWorkflow('parallel-2', {
+      type: 'parallel',
+      name: 'Parallel 2',
+      enabled: true,
+      subBlocks: {},
+      data: { parallelType: 'collection', collection: '<start.items>' },
+    })
+
+    expect(sanitizeForCopilot(state).blocks['parallel-2'].inputs).toEqual({
+      parallelType: 'collection',
+      collection: '<start.items>',
+    })
+  })
+})
+
 /** Builds a one-block workflow for webhook-URL synthesis tests. */
 function makeSingleBlockWorkflow(blockId: string, block: Record<string, unknown>): WorkflowState {
   return {

--- a/apps/sim/lib/workflows/sanitization/json-sanitizer.ts
+++ b/apps/sim/lib/workflows/sanitization/json-sanitizer.ts
@@ -591,7 +591,11 @@ export function sanitizeForCopilot(
         loopInputs.parallelType = parallelType
         // Only export fields relevant to the current parallelType
         if (parallelType === 'count' && block.data?.count !== undefined) {
-          loopInputs.iterations = block.data.count
+          // `count`, not `iterations`: the parallel schema the model is given names this
+          // field `count` and the edit path reads it back under that name. A loop's
+          // equivalent field really is called `iterations` on both sides — copying that
+          // line here made the model's read view disagree with its own write contract.
+          loopInputs.count = block.data.count
         }
         if (parallelType === 'collection' && block.data?.collection !== undefined) {
           loopInputs.collection = block.data.collection


### PR DESCRIPTION
`sanitizeForCopilot` builds the workflow JSON the model reads before editing. The loop and parallel branches disagreed about what to call a subflow's count.

| | write contract (model is told) | edit path reads | read view emitted |
|---|---|---|---|
| loop | `iterations` | `params.inputs.iterations` → `data.count` | `iterations` ✅ |
| parallel | `count` | `params.inputs.count` → `data.count` | **`iterations`** ❌ |

The parallel branch copied the loop's line without renaming the field. So the model was shown a branch count under a name its own write contract never defines. If it echoes that back, the value is dropped silently — neither `addSubflowConfig` (`editing/operations.ts:64`) nor the update path (`:168`) looks for `iterations` on a parallel.

**Scope.** Confined to the copilot read/edit round-trip (`edit-workflow/index.ts:131` returns this straight back to the model after every edit). `sanitizeForExport` is a different function and is unaffected — it preserves `state.blocks` wholesale, so user JSON export, superuser import, and admin folder backup/restore always carried the real `data.count`. I checked that specifically because "backup/restore loses data" would have made this far more serious than it is.

**Tests.** The sanitizer had zero `parallelType` coverage, which is how this drifted. Adds three cases pinning both contracts plus the collection variant. The parallel case fails against the old code (`expected { parallelType, iterations } to deeply equal { parallelType: 'count', count: 5 }`); the loop case passes before and after, confirming the loop path is untouched.

`bun run type-check` clean, all 33 audits pass, 204 tests across `sanitization`, `editing`, and `copilot/tools/server/workflow` green.
