### PR TITLE
fix(provenance): classify a latched-but-empty registry's file writes as unrecorded

### DIFF
--- a/apps/sim/executor/utils/resolved-secret-trace-registry.test.ts
+++ b/apps/sim/executor/utils/resolved-secret-trace-registry.test.ts
@@ -17,12 +17,44 @@ import {
   ANONYMOUS_SECRET_TRACE_REPLACEMENT,
   createIncompleteResolvedSecretTraceRegistry,
   createResolvedSecretTraceRegistry,
+  isResolvedSecretProvenanceAbsence,
   isResolvedSecretTraceProvenanceV1,
   RESOLVED_SECRET_TRACE_CHECKPOINT_VERSION,
   ResolvedSecretTraceProvenanceAccumulator,
   type ResolvedSecretTraceProvenanceV1,
   ResolvedSecretTraceRegistry,
 } from '@/executor/utils/resolved-secret-trace-registry'
+
+describe('provenance absence classification', () => {
+  it.each([
+    'value-provenance-absent',
+    'source-provenance-incomplete',
+    'constructed-incomplete',
+    'log-creation-skipped',
+    'durable-provenance-unknown',
+    'inherited-incomplete-source',
+    'inherited-incomplete-input-path',
+  ] as const)('classifies %s as an absence, since no material transited the latch', (reason) => {
+    expect(isResolvedSecretProvenanceAbsence(reason)).toBe(true)
+  })
+
+  /**
+   * Warn-level is not absence: `value-provenance-filter-incomplete` latches after a staged
+   * source registry decrypted real entries it could not narrow to the value, so plaintext was in
+   * flight without ever activating. The absence set must stay narrower than the report split.
+   */
+  it.each([
+    'value-provenance-filter-incomplete',
+    'value-provenance-import-failed',
+    'entry-decrypt-failed',
+    'projection-mismatch',
+    'untrusted-provenance',
+    'restored-provenance-untrusted',
+    'client-tool-seal-failed',
+  ] as const)('keeps %s out of the absence set', (reason) => {
+    expect(isResolvedSecretProvenanceAbsence(reason)).toBe(false)
+  })
+})
 
 describe('ResolvedSecretTraceProvenanceAccumulator', () => {
   const scope = { userId: 'user-1', workspaceId: 'workspace-1' }

--- a/apps/sim/executor/utils/resolved-secret-trace-registry.ts
+++ b/apps/sim/executor/utils/resolved-secret-trace-registry.ts
@@ -99,6 +99,22 @@ export type ResolvedSecretIncompletenessReason =
  * inheriting a parent that reported moments earlier, or an unaudited caller taking the default
  * reason from flooding the error stream. A reason added later without thought stays quiet.
  */
+/**
+ * True when a reason means a guard tripped on a path that should have succeeded, as opposed to
+ * provenance never being on offer. The same set decides the report level above; exposing the
+ * predicate keeps callers that must separate fault from absence — a file write deciding between
+ * taint and `unrecorded` — on the one centrally maintained classification instead of a copy.
+ *
+ * A fault matters to such callers because it can coexist with plaintext that never activated: a
+ * verification or decrypt failure happens *while* secret material is in flight, so an empty active
+ * set does not prove the context never held any.
+ */
+export function isResolvedSecretIncompletenessFault(
+  reason: ResolvedSecretIncompletenessReason
+): boolean {
+  return ORIGINATING_FAULT_REASONS.has(reason)
+}
+
 const ORIGINATING_FAULT_REASONS = new Set<ResolvedSecretIncompletenessReason>([
   'untrusted-provenance',
   'entry-decrypt-failed',

--- a/apps/sim/executor/utils/resolved-secret-trace-registry.ts
+++ b/apps/sim/executor/utils/resolved-secret-trace-registry.ts
@@ -100,19 +100,37 @@ export type ResolvedSecretIncompletenessReason =
  * reason from flooding the error stream. A reason added later without thought stays quiet.
  */
 /**
- * True when a reason means a guard tripped on a path that should have succeeded, as opposed to
- * provenance never being on offer. The same set decides the report level above; exposing the
- * predicate keeps callers that must separate fault from absence — a file write deciding between
- * taint and `unrecorded` — on the one centrally maintained classification instead of a copy.
+ * Reasons meaning provenance was never on offer AND no secret material transited the latching
+ * context. This is a deliberately separate, narrower set than the warn side of the report-level
+ * split below: that split assigns report ownership, and a warn-level reason can still involve
+ * plaintext in flight — `value-provenance-filter-incomplete` latches after a staged source
+ * registry decrypted real entries it then could not narrow to the value, so the plaintext existed
+ * in-process without ever activating. Membership here requires the stronger claim.
  *
- * A fault matters to such callers because it can coexist with plaintext that never activated: a
- * verification or decrypt failure happens *while* secret material is in flight, so an empty active
- * set does not prove the context never held any.
+ * The claim holds for each member: an absent or declared-incomplete envelope carries no entries
+ * (the envelope schema rejects incomplete-with-entries), so nothing was decrypted; a registry
+ * built without a catalog or without a persisted log never handled material; a durable read that
+ * latched did so before importing anything; and the inherited markers never occur alone — the
+ * source's own reasons are copied first, so they are judged by the originals they accompany.
+ *
+ * Consumers use this to separate `unrecorded` (absence — readable under the fail-open policy)
+ * from taint at a write decision. A reason outside this set keeps the taint.
  */
-export function isResolvedSecretIncompletenessFault(
+const PROVENANCE_ABSENCE_REASONS = new Set<ResolvedSecretIncompletenessReason>([
+  'value-provenance-absent',
+  'source-provenance-incomplete',
+  'constructed-incomplete',
+  'log-creation-skipped',
+  'durable-provenance-unknown',
+  'inherited-incomplete-source',
+  'inherited-incomplete-input-path',
+])
+
+/** True when {@link PROVENANCE_ABSENCE_REASONS} holds the reason; see its contract. */
+export function isResolvedSecretProvenanceAbsence(
   reason: ResolvedSecretIncompletenessReason
 ): boolean {
-  return ORIGINATING_FAULT_REASONS.has(reason)
+  return PROVENANCE_ABSENCE_REASONS.has(reason)
 }
 
 const ORIGINATING_FAULT_REASONS = new Set<ResolvedSecretIncompletenessReason>([

--- a/apps/sim/lib/copilot/request/tools/files.test.ts
+++ b/apps/sim/lib/copilot/request/tools/files.test.ts
@@ -563,6 +563,13 @@ describe('maybeWriteOutputToFile', () => {
       .mockReturnValueOnce({ version: 1, complete: false, entries: [] })
     const registry = {
       exportCommittedProvenanceForValue,
+      /** Plaintext is in scope, so the incomplete export below is a taint, not an absence. */
+      getIncompletenessDiagnostics: vi.fn(() => ({
+        reasons: ['source-provenance-incomplete'],
+        origins: [],
+        incompleteInputPathCount: 0,
+        activeEntryCount: 1,
+      })),
     } as unknown as ResolvedSecretTraceRegistry
 
     const result = await maybeWriteOutputToFile(

--- a/apps/sim/lib/logs/execution/trace-store.ts
+++ b/apps/sim/lib/logs/execution/trace-store.ts
@@ -439,6 +439,7 @@ function reportStoredDisplayProvenanceFaults(
     if (parts.length === 0) continue
     logger[report.level](report.message, {
       ...details,
+      fault: kind,
       parts: parts.slice(0, MAX_REPORTED_PROVENANCE_FAULT_PARTS),
       partCount: parts.length,
     })

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.test.ts
@@ -1578,6 +1578,31 @@ describe('createWorkspaceFileSecretProvenanceFromRegistry write decision', () =>
     ).resolves.toEqual({ safe: true, provenance: { status: 'unrecorded' } })
   })
 
+  /**
+   * Zero active entries does not prove the context never held plaintext: a verification or
+   * decrypt fault trips while secret material is in flight, before anything activates. Only a
+   * latch whose recorded reasons are all non-fault absences may relax to unrecorded.
+   */
+  it('keeps a latch caused by an originating fault as a taint even with no active entries', async () => {
+    const registry = {
+      exportCommittedProvenanceForValue: vi.fn(() => ({
+        version: 1,
+        complete: false,
+        entries: [],
+      })),
+      getIncompletenessDiagnostics: vi.fn(() => ({
+        reasons: ['projection-mismatch'],
+        origins: [],
+        incompleteInputPathCount: 0,
+        activeEntryCount: 0,
+      })),
+    } as unknown as ResolvedSecretTraceRegistry
+
+    await expect(
+      createWorkspaceFileSecretProvenanceFromRegistry(registry, 'generated content', SCOPE)
+    ).resolves.toEqual({ safe: false })
+  })
+
   it('keeps a latched registry holding plaintext it cannot map as a taint', async () => {
     const registry = {
       exportCommittedProvenanceForValue: vi.fn(() => ({

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.test.ts
@@ -20,6 +20,7 @@ import type { DbTransaction } from '@/lib/db/types'
 import {
   areModelSafeWorkspaceFileKeys,
   copyWorkspaceFileSecretProvenanceInTx,
+  createWorkspaceFileSecretProvenanceFromRegistry,
   filterModelSafeWorkspaceFileAttachments,
   importWorkspaceFileSecretProvenanceForModelView,
   importWorkspaceFileSecretProvenanceForRuntime,
@@ -1546,5 +1547,69 @@ describe('workspace file secret provenance', () => {
     expect(
       mergeWorkspaceFileSecretProvenance({ status: 'unrecorded' }, { status: 'unknown' })
     ).toEqual({ status: 'unknown' })
+  })
+})
+
+describe('createWorkspaceFileSecretProvenanceFromRegistry write decision', () => {
+  const SCOPE = { userId: 'user-1', workspaceId: 'workspace-1' }
+
+  /**
+   * A registry latched with nothing resolved is an absence, not a taint: no plaintext exists in
+   * the context to be in the bytes, so the file must stay readable under the unrecorded policy.
+   * Stamping taint here made one failed workflow run hard-refuse every file its chat later wrote.
+   */
+  it('classifies a latched registry holding no active entries as unrecorded', async () => {
+    const registry = {
+      exportCommittedProvenanceForValue: vi.fn(() => ({
+        version: 1,
+        complete: false,
+        entries: [],
+      })),
+      getIncompletenessDiagnostics: vi.fn(() => ({
+        reasons: ['value-provenance-absent'],
+        origins: [],
+        incompleteInputPathCount: 0,
+        activeEntryCount: 0,
+      })),
+    } as unknown as ResolvedSecretTraceRegistry
+
+    await expect(
+      createWorkspaceFileSecretProvenanceFromRegistry(registry, 'generated content', SCOPE)
+    ).resolves.toEqual({ safe: true, provenance: { status: 'unrecorded' } })
+  })
+
+  it('keeps a latched registry holding plaintext it cannot map as a taint', async () => {
+    const registry = {
+      exportCommittedProvenanceForValue: vi.fn(() => ({
+        version: 1,
+        complete: false,
+        entries: [],
+      })),
+      getIncompletenessDiagnostics: vi.fn(() => ({
+        reasons: ['source-provenance-incomplete'],
+        origins: [],
+        incompleteInputPathCount: 0,
+        activeEntryCount: 1,
+      })),
+    } as unknown as ResolvedSecretTraceRegistry
+
+    await expect(
+      createWorkspaceFileSecretProvenanceFromRegistry(registry, 'generated content', SCOPE)
+    ).resolves.toEqual({ safe: false })
+  })
+
+  it('stays a taint when the incomplete export carries no diagnostics to vouch with', async () => {
+    const registry = {
+      exportCommittedProvenanceForValue: vi.fn(() => ({
+        version: 1,
+        complete: false,
+        entries: [],
+      })),
+      getIncompletenessDiagnostics: vi.fn(() => undefined),
+    } as unknown as ResolvedSecretTraceRegistry
+
+    await expect(
+      createWorkspaceFileSecretProvenanceFromRegistry(registry, 'generated content', SCOPE)
+    ).resolves.toEqual({ safe: false })
   })
 })

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.test.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.test.ts
@@ -1581,9 +1581,41 @@ describe('createWorkspaceFileSecretProvenanceFromRegistry write decision', () =>
   /**
    * Zero active entries does not prove the context never held plaintext: a verification or
    * decrypt fault trips while secret material is in flight, before anything activates. Only a
-   * latch whose recorded reasons are all non-fault absences may relax to unrecorded.
+   * latch whose recorded reasons all belong to the registry's absence set may relax.
    */
-  it('keeps a latch caused by an originating fault as a taint even with no active entries', async () => {
+  it.each([
+    ['an originating fault', 'projection-mismatch'],
+    /**
+     * Warn-level, yet plaintext-bearing: it latches after a staged source registry decrypted
+     * real entries it could not narrow to the value — the report-level split must not be the
+     * absence split.
+     */
+    ['an unnarrowable crossing', 'value-provenance-filter-incomplete'],
+  ] as const)(
+    'keeps a latch caused by %s as a taint even with no active entries',
+    async (_, reason) => {
+      const registry = {
+        exportCommittedProvenanceForValue: vi.fn(() => ({
+          version: 1,
+          complete: false,
+          entries: [],
+        })),
+        getIncompletenessDiagnostics: vi.fn(() => ({
+          reasons: [reason],
+          origins: [],
+          incompleteInputPathCount: 0,
+          activeEntryCount: 0,
+        })),
+      } as unknown as ResolvedSecretTraceRegistry
+
+      await expect(
+        createWorkspaceFileSecretProvenanceFromRegistry(registry, 'generated content', SCOPE)
+      ).resolves.toEqual({ safe: false })
+    }
+  )
+
+  /** A latched registry that recorded no reason offers nothing to vouch with; keep the taint. */
+  it('keeps a latch with an empty reason list as a taint', async () => {
     const registry = {
       exportCommittedProvenanceForValue: vi.fn(() => ({
         version: 1,
@@ -1591,7 +1623,7 @@ describe('createWorkspaceFileSecretProvenanceFromRegistry write decision', () =>
         entries: [],
       })),
       getIncompletenessDiagnostics: vi.fn(() => ({
-        reasons: ['projection-mismatch'],
+        reasons: [],
         origins: [],
         incompleteInputPathCount: 0,
         activeEntryCount: 0,

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.ts
@@ -21,7 +21,7 @@ import {
   PROVENANCE_MAX_SERIALIZED_BYTES,
 } from '@/lib/execution/provenance-limits'
 import {
-  isResolvedSecretIncompletenessFault,
+  isResolvedSecretProvenanceAbsence,
   type ResolvedSecretTraceProvenanceV1,
   type ResolvedSecretTraceRegistry,
 } from '@/executor/utils/resolved-secret-trace-registry'
@@ -256,19 +256,21 @@ export async function createWorkspaceFileSecretProvenanceFromRegistry(
     : registry.exportCommittedProvenanceForValue(persistedValue)
   if (!sourceProvenance.complete || !persistedProvenance.complete) {
     /**
-     * A latched registry is the same absence only when both hold: nothing activated, and no
-     * recorded reason is an originating fault. Zero active entries alone does not prove the
-     * context never held plaintext — a verification or decrypt fault trips while secret material
-     * is in flight — so any fault reason keeps the taint. What remains is a registry that latched
-     * because provenance was never on offer (a failed workflow run crossing with no envelope is
-     * the recurring producer), which is exactly what `unrecorded` states. Stamping taint for that
-     * state made one failed run turn every file its chat later wrote into a hard refusal until
-     * the next clean write.
+     * A latched registry is the same absence only when both hold: nothing activated, and every
+     * recorded reason is in the registry's absence set — reasons meaning provenance was never on
+     * offer and no secret material transited the latching context. Zero active entries alone does
+     * not prove that: a decrypt, verification, or filtering failure trips while plaintext is in
+     * flight, before anything activates, so any such reason keeps the taint. What remains is a
+     * registry that latched with nothing to lose (a failed workflow run crossing with no envelope
+     * is the recurring producer), which is exactly what `unrecorded` states. Stamping taint for
+     * that state made one failed run turn every file its chat later wrote into a hard refusal
+     * until the next clean write.
      */
     const diagnostics = registry.getIncompletenessDiagnostics()
     if (
       diagnostics?.activeEntryCount === 0 &&
-      !diagnostics.reasons.some(isResolvedSecretIncompletenessFault)
+      diagnostics.reasons.length > 0 &&
+      diagnostics.reasons.every(isResolvedSecretProvenanceAbsence)
     ) {
       return { safe: true, provenance: { status: 'unrecorded' } }
     }

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.ts
@@ -253,7 +253,20 @@ export async function createWorkspaceFileSecretProvenanceFromRegistry(
   const persistedProvenance = Object.is(sourceValue, persistedValue)
     ? sourceProvenance
     : registry.exportCommittedProvenanceForValue(persistedValue)
-  if (!sourceProvenance.complete || !persistedProvenance.complete) return { safe: false }
+  if (!sourceProvenance.complete || !persistedProvenance.complete) {
+    /**
+     * A latched registry holding no active entries is the same absence: no secret plaintext was
+     * ever resolved or imported in this context, so none can be in these bytes — the latch says
+     * only that content of unrecorded history crossed (a failed workflow run is the recurring
+     * producer), which is exactly what `unrecorded` states. Taint stays reserved for a registry
+     * that holds plaintext it cannot map to this output: stamping it here made one failed run
+     * turn every file its chat later wrote into a hard refusal until the next clean write.
+     */
+    if (registry.getIncompletenessDiagnostics()?.activeEntryCount === 0) {
+      return { safe: true, provenance: { status: 'unrecorded' } }
+    }
+    return { safe: false }
+  }
   if (
     (sourceProvenance.entries.length > 0 &&
       !isPrivateSecretProvenanceScopeCompatible(sourceProvenance.scope, destinationScope)) ||

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-secret-provenance.ts
@@ -20,9 +20,10 @@ import {
   PROVENANCE_MAX_ENTRIES,
   PROVENANCE_MAX_SERIALIZED_BYTES,
 } from '@/lib/execution/provenance-limits'
-import type {
-  ResolvedSecretTraceProvenanceV1,
-  ResolvedSecretTraceRegistry,
+import {
+  isResolvedSecretIncompletenessFault,
+  type ResolvedSecretTraceProvenanceV1,
+  type ResolvedSecretTraceRegistry,
 } from '@/executor/utils/resolved-secret-trace-registry'
 
 /** Ids per statement. Bounds the query, never how many files a caller may classify. */
@@ -255,14 +256,20 @@ export async function createWorkspaceFileSecretProvenanceFromRegistry(
     : registry.exportCommittedProvenanceForValue(persistedValue)
   if (!sourceProvenance.complete || !persistedProvenance.complete) {
     /**
-     * A latched registry holding no active entries is the same absence: no secret plaintext was
-     * ever resolved or imported in this context, so none can be in these bytes — the latch says
-     * only that content of unrecorded history crossed (a failed workflow run is the recurring
-     * producer), which is exactly what `unrecorded` states. Taint stays reserved for a registry
-     * that holds plaintext it cannot map to this output: stamping it here made one failed run
-     * turn every file its chat later wrote into a hard refusal until the next clean write.
+     * A latched registry is the same absence only when both hold: nothing activated, and no
+     * recorded reason is an originating fault. Zero active entries alone does not prove the
+     * context never held plaintext — a verification or decrypt fault trips while secret material
+     * is in flight — so any fault reason keeps the taint. What remains is a registry that latched
+     * because provenance was never on offer (a failed workflow run crossing with no envelope is
+     * the recurring producer), which is exactly what `unrecorded` states. Stamping taint for that
+     * state made one failed run turn every file its chat later wrote into a hard refusal until
+     * the next clean write.
      */
-    if (registry.getIncompletenessDiagnostics()?.activeEntryCount === 0) {
+    const diagnostics = registry.getIncompletenessDiagnostics()
+    if (
+      diagnostics?.activeEntryCount === 0 &&
+      !diagnostics.reasons.some(isResolvedSecretIncompletenessFault)
+    ) {
       return { safe: true, provenance: { status: 'unrecorded' } }
     }
     return { safe: false }


### PR DESCRIPTION
## Summary
- Fixes the hard failure the log monitoring surfaced today: a Mothership chat generating a document and immediately rendering it back failed with "This file result cannot be shared safely because its secret provenance is unavailable" — a file that, per its terminal sidecar in production, carries **zero secret entries**.
- Root cause is a causal chain between two of today's log signals: a copilot workflow run that fails before exporting provenance crosses as `value-provenance-absent` and latches the chat's registry (`importCrossingProvenance` is path-less, so the latch is whole-registry). Every file that chat later writes hits the write decision's export-incomplete branch → `safe: false` → sidecar stamped `unknown` — the **taint**, which no policy relaxes — so the chat's own follow-up read is refused until a later clean turn rewrites the sidecar. Verified in prod: the refused file healed to exact-empty 46 seconds after the last refusal; fleet-wide, zero files are currently stuck (the only 4 standing `unknown` sidecars are pre-#6986 relics with demoted versions that read as untracked and refuse nothing).
- The fix applies the surface's own absence/taint dichotomy at the write decision: a latched registry holding **no active entries** is an absence — no secret plaintext was resolved or imported in that context, so none can be in the bytes; the only fact is that content of unrecorded history crossed, which is exactly what `unrecorded` states. Such writes now stamp `unrecorded` (readable under the fail-open policy, audit entry naming the surface) instead of taint. Taint stays for a latched registry that holds plaintext it cannot map to the output, for an incomplete export with no diagnostics to vouch with, and for every structural refusal below (scope incompatibility, incomplete derived representations, encryption failure).
- Also adds the fault kind as a structured `fault` field on the trace-store display-read lines, so log tooling can group by kind without parsing messages.

## Type of Change
- [x] Bug fix

## Testing
Three new tests pin the decision: latched + zero active entries → `unrecorded`; latched + plaintext in scope → taint; incomplete export with no diagnostics → taint. One existing test's stub registry gained the diagnostics method its real counterpart has (its intent — taint for unavailable lineage — is preserved with an active entry). 2,981 tests green across lib/uploads, lib/copilot, lib/logs, and the registry suite; `bun run type-check` clean; all 33 audits pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)