### PR TITLE
chore(tools): correct the bindable-subblock rationale

### DIFF
--- a/apps/sim/providers/tool-binding.ts
+++ b/apps/sim/providers/tool-binding.ts
@@ -21,11 +21,19 @@ export interface ToolResourceBinding {
  * Subblock types whose value identifies WHICH external resource an instance is bound to,
  * and that can be resolved to a name from Sim's own database.
  *
- * A deliberate subset of {@link SELECTOR_TYPES_HYDRATION_REQUIRED}: the selectors omitted here
- * (`file-selector`, `project-selector`, `folder-selector`, `channel-selector`, `sheet-selector`,
- * `document-selector`, `user-selector`) name resources that live in a third-party service, so
- * resolving one costs an OAuth round-trip. `table-selector` is omitted because table tools already
- * name their table through `toolEnrichment` — see `lib/table/llm/enrichment.ts`.
+ * A deliberate subset of `SELECTOR_TYPES_HYDRATION_REQUIRED` (`blocks/types.ts`), which lists the
+ * fourteen subblock types the editor hydrates into display names. The eleven omitted here fall into
+ * three groups:
+ *
+ * - `channel-selector`, `user-selector`, `file-selector`, `sheet-selector`, `folder-selector`,
+ *   `project-selector`, `document-selector` name resources that live in a third-party service, so
+ *   resolving one costs an OAuth round-trip rather than a local read.
+ * - `table-selector` needs no entry because table tools already name their table through
+ *   `toolEnrichment` — see `lib/table/llm/enrichment.ts`.
+ * - `variables-input`, `mcp-server-selector` and `mcp-tool-selector` do not identify a bound
+ *   resource at all here: variable assignments are not a resource, and an MCP tool's id already
+ *   embeds its server (`createMcpToolId`), so two MCP entries only collide when the server and
+ *   tool are identical and there is nothing left to distinguish.
  */
 export const BINDABLE_SUBBLOCK_KINDS: Partial<Record<SubBlockType, BoundResourceKind>> = {
   'oauth-input': 'credential',


### PR DESCRIPTION
## Summary
- Follow-up to #7079. The comment on `BINDABLE_SUBBLOCK_KINDS` listed seven of the eleven omitted subblock types and described all of them as third-party resources. Three aren't: `variables-input` isn't a bound resource, and `mcp-server-selector`/`mcp-tool-selector` don't need an entry because an MCP tool's id already embeds its server, so two MCP entries only collide when there's nothing left to distinguish.
- It also referenced `SELECTOR_TYPES_HYDRATION_REQUIRED` with a `{@link}` that can't resolve — the constant lives in `blocks/types.ts` and isn't imported here. Referenced by path instead, matching how the rest of the file cites other modules. Importing it would add a runtime edge to a client-reachable module for a doc link.

Comment-only; no behavior change.

## Type of Change
- [x] Chore

## Testing
`tsc` clean, 26 binding tests pass, lint clean, all 33 audits pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)