### PR TITLE
fix(microsoft-word): make conditional writes service-enforced and return 400 for bad input

### DIFF
--- a/apps/sim/app/api/tools/microsoft_word/append/route.test.ts
+++ b/apps/sim/app/api/tools/microsoft_word/append/route.test.ts
@@ -60,6 +60,21 @@ async function docxResponse() {
   }
 }
 
+/** The `createUploadSession` response carrying the preauthenticated upload URL. */
+function uploadSessionResponse(uploadUrl = 'https://sn3302.up.1drv.com/up/session-abc') {
+  const body = { uploadUrl, expirationDateTime: '2026-01-01T00:00:00Z' }
+  return {
+    ok: true,
+    status: 200,
+    statusText: '',
+    headers: new Headers(),
+    body: null,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }
+}
+
 function preconditionFailedResponse() {
   return {
     ok: false,
@@ -88,11 +103,11 @@ beforeEach(() => {
 })
 
 describe('POST /api/tools/microsoft_word/append', () => {
-  it('uploads the edit when the document has not changed, guarded by its content tag', async () => {
+  it('writes through a conditional upload session carrying the content tag', async () => {
     mockSecureFetchWithPinnedIP
       .mockResolvedValueOnce(itemResponse('tag-1'))
       .mockResolvedValueOnce(await docxResponse())
-      .mockResolvedValueOnce(itemResponse('tag-1'))
+      .mockResolvedValueOnce(uploadSessionResponse())
       .mockResolvedValueOnce(itemResponse('tag-2'))
 
     const response = await POST(createMockRequest('POST', baseBody))
@@ -105,16 +120,26 @@ describe('POST /api/tools/microsoft_word/append', () => {
     expect(data.success).toBe(true)
     expect(data.output.updatedContent).toBe(true)
 
+    // The precondition rides on the session creation, which Graph documents as
+    // returning 412 on a mismatch.
+    const sessionCall = mockSecureFetchWithPinnedIP.mock.calls.find((call) =>
+      String(call[0]).endsWith('/createUploadSession')
+    )
+    expect(sessionCall?.[2]).toMatchObject({ method: 'POST' })
+    expect(sessionCall?.[2].headers).toMatchObject({ 'if-match': 'tag-1' })
+
+    // Bytes go to the preauthenticated URL, and must not carry the bearer token.
     const uploadCall = mockSecureFetchWithPinnedIP.mock.calls.at(-1)
+    expect(uploadCall?.[0]).toBe('https://sn3302.up.1drv.com/up/session-abc')
     expect(uploadCall?.[2]).toMatchObject({ method: 'PUT' })
-    expect(uploadCall?.[2].headers).toMatchObject({ 'if-match': 'tag-1' })
+    expect(uploadCall?.[2].headers.Authorization).toBeUndefined()
   })
 
-  it('refuses to overwrite a document that changed while the edit was in flight', async () => {
+  it('refuses to overwrite when the service rejects the precondition', async () => {
     mockSecureFetchWithPinnedIP
       .mockResolvedValueOnce(itemResponse('tag-1'))
       .mockResolvedValueOnce(await docxResponse())
-      .mockResolvedValueOnce(itemResponse('tag-2'))
+      .mockResolvedValueOnce(preconditionFailedResponse())
 
     const response = await POST(createMockRequest('POST', baseBody))
 
@@ -123,10 +148,19 @@ describe('POST /api/tools/microsoft_word/append', () => {
     expect(data.success).toBe(false)
     expect(data.error).toMatch(/no other change was overwritten/)
 
-    // The conflict is detected before the PUT, so nothing was written.
+    // The session was refused, so no bytes were ever sent.
     expect(mockSecureFetchWithPinnedIP.mock.calls.some((call) => call[2]?.method === 'PUT')).toBe(
       false
     )
+  })
+
+  it('maps a malformed document ID to a client error, not a server error', async () => {
+    const response = await POST(createMockRequest('POST', { ...baseBody, documentId: 'bad/../id' }))
+
+    expect(response.status).toBe(400)
+    const data = (await response.json()) as { success: boolean; error: string }
+    expect(data.success).toBe(false)
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
   })
 
   it('refuses to write Word bytes over a drive item that is not a .docx', async () => {
@@ -201,41 +235,11 @@ describe('POST /api/tools/microsoft_word/append', () => {
     )
   })
 
-  it('refuses to write when the re-read reports no version', async () => {
-    const untagged = {
-      id: 'doc-abc',
-      name: 'notes.docx',
-      file: {
-        mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      },
-    }
+  it('surfaces a conflict raised when the bytes commit', async () => {
     mockSecureFetchWithPinnedIP
       .mockResolvedValueOnce(itemResponse('tag-1'))
       .mockResolvedValueOnce(await docxResponse())
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: '',
-        headers: new Headers(),
-        body: null,
-        text: async () => JSON.stringify(untagged),
-        json: async () => untagged,
-        arrayBuffer: async () => new ArrayBuffer(0),
-      })
-
-    const response = await POST(createMockRequest('POST', baseBody))
-
-    expect(response.status).toBe(409)
-    expect(mockSecureFetchWithPinnedIP.mock.calls.some((call) => call[2]?.method === 'PUT')).toBe(
-      false
-    )
-  })
-
-  it('surfaces a 412 from the upload precondition as the same conflict', async () => {
-    mockSecureFetchWithPinnedIP
-      .mockResolvedValueOnce(itemResponse('tag-1'))
-      .mockResolvedValueOnce(await docxResponse())
-      .mockResolvedValueOnce(itemResponse('tag-1'))
+      .mockResolvedValueOnce(uploadSessionResponse())
       .mockResolvedValueOnce(preconditionFailedResponse())
 
     const response = await POST(createMockRequest('POST', baseBody))

--- a/apps/sim/app/api/tools/microsoft_word/append/route.ts
+++ b/apps/sim/app/api/tools/microsoft_word/append/route.ts
@@ -5,14 +5,13 @@ import { parseRequest } from '@/lib/api/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { appendParagraphsToDocx, DOCX_MIME_TYPE } from '@/lib/microsoft-word/document.server'
+import { appendParagraphsToDocx } from '@/lib/microsoft-word/document.server'
 import {
-  assertContentUnchanged,
   downloadDocumentContent,
   fetchDocumentItem,
+  replaceContentIfUnchanged,
   requireContentTag,
   toDocumentMetadata,
-  uploadDocumentContent,
 } from '@/lib/microsoft-word/graph.server'
 import { microsoftWordErrorResponse } from '@/app/api/tools/microsoft_word/utils'
 import { getDocumentBasePath } from '@/tools/microsoft_word/utils'
@@ -61,15 +60,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       })
     }
 
-    await assertContentUnchanged(basePath, accessToken, contentTag)
-
-    const item = await uploadDocumentContent(
-      `${basePath}/content`,
-      accessToken,
-      buffer,
-      DOCX_MIME_TYPE,
-      contentTag
-    )
+    const item = await replaceContentIfUnchanged(basePath, accessToken, buffer, contentTag)
 
     logger.info(`[${requestId}] Appended to Word document`, {
       documentId,

--- a/apps/sim/app/api/tools/microsoft_word/create-from-template/route.test.ts
+++ b/apps/sim/app/api/tools/microsoft_word/create-from-template/route.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment node
+ */
+import {
+  createMockRequest,
+  hybridAuthMockFns,
+  inputValidationMock,
+  inputValidationMockFns,
+} from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/core/security/input-validation.server', () => inputValidationMock)
+
+import { POST } from '@/app/api/tools/microsoft_word/create-from-template/route'
+
+const { mockValidateUrlWithDNS, mockSecureFetchWithPinnedIP } = inputValidationMockFns
+
+const baseBody = {
+  accessToken: 'token-123',
+  templateDocumentId: 'template-abc',
+  name: 'Acme Agreement',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hybridAuthMockFns.mockCheckInternalAuth.mockResolvedValue({
+    success: true,
+    userId: 'user-1',
+    authType: 'internal_jwt',
+  })
+  mockValidateUrlWithDNS.mockResolvedValue({
+    isValid: true,
+    resolvedIP: '93.184.216.34',
+    originalHostname: 'graph.microsoft.com',
+  })
+})
+
+describe('POST /api/tools/microsoft_word/create-from-template', () => {
+  it('rejects an empty placeholder key rather than failing mid-rewrite', async () => {
+    // A blank placeholder would match at every position in the document.
+    const response = await POST(
+      createMockRequest('POST', { ...baseBody, replacements: { '': 'Acme Corp' } })
+    )
+
+    expect(response.status).toBe(400)
+    const data = (await response.json()) as { error?: string }
+    expect(JSON.stringify(data)).toMatch(/placeholder/i)
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty placeholder key inside the JSON-string form too', async () => {
+    const response = await POST(
+      createMockRequest('POST', { ...baseBody, replacements: '{"  ": "Acme Corp"}' })
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
+  })
+
+  it('rejects a replacements value that is not an object mapping', async () => {
+    const response = await POST(
+      createMockRequest('POST', { ...baseBody, replacements: '["a","b"]' })
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/app/api/tools/microsoft_word/create/route.test.ts
+++ b/apps/sim/app/api/tools/microsoft_word/create/route.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment node
+ */
+import {
+  createMockRequest,
+  hybridAuthMockFns,
+  inputValidationMock,
+  inputValidationMockFns,
+} from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/core/security/input-validation.server', () => inputValidationMock)
+
+import { POST } from '@/app/api/tools/microsoft_word/create/route'
+
+const { mockValidateUrlWithDNS, mockSecureFetchWithPinnedIP } = inputValidationMockFns
+
+const baseBody = {
+  accessToken: 'token-123',
+  name: 'Q3 Report',
+  content: 'Hello',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hybridAuthMockFns.mockCheckInternalAuth.mockResolvedValue({
+    success: true,
+    userId: 'user-1',
+    authType: 'internal_jwt',
+  })
+  mockValidateUrlWithDNS.mockResolvedValue({
+    isValid: true,
+    resolvedIP: '93.184.216.34',
+    originalHostname: 'graph.microsoft.com',
+  })
+})
+
+describe('POST /api/tools/microsoft_word/create', () => {
+  it('rejects a whitespace-only name as a client error, not a server error', async () => {
+    // The contract's min(1) accepts a space; the name is only known to be
+    // unusable once the extension helper trims it.
+    const response = await POST(createMockRequest('POST', { ...baseBody, name: '   ' }))
+
+    expect(response.status).toBe(400)
+    const data = (await response.json()) as { success: boolean; error: string }
+    expect(data.success).toBe(false)
+    expect(data.error).toMatch(/Document name is required/)
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed folder ID as a client error', async () => {
+    const response = await POST(
+      createMockRequest('POST', { ...baseBody, folderId: 'not a valid id' })
+    )
+
+    expect(response.status).toBe(400)
+    const data = (await response.json()) as { success: boolean }
+    expect(data.success).toBe(false)
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed drive ID as a client error', async () => {
+    const response = await POST(createMockRequest('POST', { ...baseBody, driveId: 'bad/../drive' }))
+
+    expect(response.status).toBe(400)
+    expect(mockSecureFetchWithPinnedIP).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/app/api/tools/microsoft_word/replace-text/route.ts
+++ b/apps/sim/app/api/tools/microsoft_word/replace-text/route.ts
@@ -5,14 +5,13 @@ import { parseRequest } from '@/lib/api/server'
 import { checkInternalAuth } from '@/lib/auth/hybrid'
 import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
-import { DOCX_MIME_TYPE, replaceTextInDocx } from '@/lib/microsoft-word/document.server'
+import { replaceTextInDocx } from '@/lib/microsoft-word/document.server'
 import {
-  assertContentUnchanged,
   downloadDocumentContent,
   fetchDocumentItem,
+  replaceContentIfUnchanged,
   requireContentTag,
   toDocumentMetadata,
-  uploadDocumentContent,
 } from '@/lib/microsoft-word/graph.server'
 import { microsoftWordErrorResponse } from '@/app/api/tools/microsoft_word/utils'
 import { getDocumentBasePath } from '@/tools/microsoft_word/utils'
@@ -66,15 +65,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       })
     }
 
-    await assertContentUnchanged(basePath, accessToken, contentTag)
-
-    const item = await uploadDocumentContent(
-      `${basePath}/content`,
-      accessToken,
-      buffer,
-      DOCX_MIME_TYPE,
-      contentTag
-    )
+    const item = await replaceContentIfUnchanged(basePath, accessToken, buffer, contentTag)
 
     logger.info(`[${requestId}] Replaced text in Word document`, {
       documentId,

--- a/apps/sim/app/api/tools/microsoft_word/utils.ts
+++ b/apps/sim/app/api/tools/microsoft_word/utils.ts
@@ -3,6 +3,7 @@ import { getErrorMessage } from '@sim/utils/errors'
 import { NextResponse } from 'next/server'
 import { isPayloadSizeLimitError } from '@/lib/core/utils/stream-limits'
 import { GraphRequestError } from '@/lib/microsoft-word/graph.server'
+import { MicrosoftWordInputError } from '@/tools/microsoft_word/errors'
 
 /**
  * Projects an error raised while talking to Microsoft Graph — or while building
@@ -20,7 +21,11 @@ export function microsoftWordErrorResponse(
   logger.error(`[${requestId}] Microsoft Word ${operation} failed`, { error: message })
 
   const status =
-    error instanceof GraphRequestError ? error.status : isPayloadSizeLimitError(error) ? 413 : 500
+    error instanceof GraphRequestError || error instanceof MicrosoftWordInputError
+      ? error.status
+      : isPayloadSizeLimitError(error)
+        ? 413
+        : 500
 
   return NextResponse.json({ success: false, error: message }, { status })
 }

--- a/apps/sim/lib/api/contracts/tools/microsoft.ts
+++ b/apps/sim/lib/api/contracts/tools/microsoft.ts
@@ -119,11 +119,18 @@ const MAX_DOCUMENT_CONTENT_LENGTH = 2_000_000
 const MAX_REPLACEMENTS_LENGTH = 200_000
 
 /** Whether a string parses as a JSON object (not an array or scalar). */
-function isJsonObjectString(value: string): boolean {
+function isPlaceholderMap(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  // A blank placeholder would match at every position in the document, so it is
+  // rejected here rather than failing mid-rewrite with an unattributable 500.
+  return Object.keys(value).every((key) => key.trim().length > 0)
+}
+
+/** Whether a string parses as a JSON object whose keys are all usable placeholders. */
+function isPlaceholderMapString(value: string): boolean {
   if (!value.trim()) return true
   try {
-    const parsed: unknown = JSON.parse(value)
-    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+    return isPlaceholderMap(JSON.parse(value))
   } catch {
     return false
   }
@@ -140,10 +147,12 @@ const wordReplacementsSchema = z
     z
       .string()
       .refine(
-        isJsonObjectString,
-        'Placeholder values must be a JSON object mapping each placeholder to its value'
+        isPlaceholderMapString,
+        'Placeholder values must be a JSON object mapping each non-empty placeholder to its value'
       ),
-    z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])),
+    z
+      .record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
+      .refine(isPlaceholderMap, 'Every placeholder must be a non-empty string'),
   ])
   .refine(
     (value) =>

--- a/apps/sim/lib/microsoft-word/graph.server.test.ts
+++ b/apps/sim/lib/microsoft-word/graph.server.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment node
+ */
+import { inputValidationMock, inputValidationMockFns } from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/core/security/input-validation.server', () => inputValidationMock)
+
+import { replaceContentIfUnchanged } from '@/lib/microsoft-word/graph.server'
+
+const { mockValidateUrlWithDNS, mockSecureFetchWithPinnedIP } = inputValidationMockFns
+
+const BASE_PATH = 'https://graph.microsoft.com/v1.0/me/drive/items/doc-abc'
+const UPLOAD_URL = 'https://sn3302.up.1drv.com/up/session-abc'
+
+/** Graph's `createUploadSession` response. */
+function sessionResponse() {
+  const body = { uploadUrl: UPLOAD_URL, expirationDateTime: '2026-01-01T00:00:00Z' }
+  return {
+    ok: true,
+    status: 200,
+    statusText: '',
+    headers: new Headers(),
+    body: null,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }
+}
+
+/** A 202 acknowledging a non-final fragment; carries no driveItem. */
+function fragmentAccepted() {
+  const body = { nextExpectedRanges: ['1-'] }
+  return {
+    ok: true,
+    status: 202,
+    statusText: 'Accepted',
+    headers: new Headers(),
+    body: null,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }
+}
+
+/** The final fragment's response, carrying the completed driveItem. */
+function completedItem() {
+  const body = { id: 'doc-abc', name: 'notes.docx', size: 123 }
+  return {
+    ok: true,
+    status: 201,
+    statusText: 'Created',
+    headers: new Headers(),
+    body: null,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }
+}
+
+function preconditionFailed() {
+  return {
+    ok: false,
+    status: 412,
+    statusText: 'Precondition Failed',
+    headers: new Headers(),
+    body: null,
+    text: async () => '',
+    json: async () => ({}),
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }
+}
+
+/** Parses a `Content-Range: bytes {start}-{end}/{total}` header. */
+function parseRange(header: string): { start: number; end: number; total: number } {
+  const [range, total] = header.replace('bytes ', '').split('/')
+  const [start, end] = range.split('-').map(Number)
+  return { start, end, total: Number(total) }
+}
+
+beforeEach(() => {
+  // reset, not clear: an unconsumed mockResolvedValueOnce queue would otherwise
+  // leak into the next test and make its result meaningless.
+  mockSecureFetchWithPinnedIP.mockReset()
+  mockValidateUrlWithDNS.mockReset()
+  mockValidateUrlWithDNS.mockResolvedValue({
+    isValid: true,
+    resolvedIP: '93.184.216.34',
+    originalHostname: 'graph.microsoft.com',
+  })
+})
+
+describe('replaceContentIfUnchanged', () => {
+  it('sends a small package as a single fragment', async () => {
+    mockSecureFetchWithPinnedIP
+      .mockResolvedValueOnce(sessionResponse())
+      .mockResolvedValueOnce(completedItem())
+
+    await replaceContentIfUnchanged(BASE_PATH, 'token', Buffer.alloc(1024), 'tag-1')
+
+    const puts = mockSecureFetchWithPinnedIP.mock.calls.filter((c) => c[2]?.method === 'PUT')
+    expect(puts).toHaveLength(1)
+    expect(parseRange(puts[0][2].headers['Content-Range'])).toEqual({
+      start: 0,
+      end: 1023,
+      total: 1024,
+    })
+  })
+
+  it('splits a package larger than one fragment into contiguous ordered ranges', async () => {
+    // Graph rejects a single upload request at or above 60 MiB, and documents
+    // will not always fit: content is read under a 100 MB ceiling.
+    const size = 25 * 1024 * 1024
+    mockSecureFetchWithPinnedIP
+      .mockResolvedValueOnce(sessionResponse())
+      .mockResolvedValueOnce(fragmentAccepted())
+      .mockResolvedValueOnce(fragmentAccepted())
+      .mockResolvedValueOnce(completedItem())
+
+    const item = await replaceContentIfUnchanged(BASE_PATH, 'token', Buffer.alloc(size), 'tag-1')
+    expect(item.id).toBe('doc-abc')
+
+    const puts = mockSecureFetchWithPinnedIP.mock.calls.filter((c) => c[2]?.method === 'PUT')
+    expect(puts).toHaveLength(3)
+
+    let expectedStart = 0
+    for (const put of puts) {
+      const { start, end, total } = parseRange(put[2].headers['Content-Range'])
+      expect(total).toBe(size)
+      expect(start).toBe(expectedStart)
+      // Every fragment but the last must be a multiple of 320 KiB.
+      const length = end - start + 1
+      expect(Number(put[2].headers['Content-Length'])).toBe(length)
+      if (end !== size - 1) expect(length % (320 * 1024)).toBe(0)
+      expectedStart = end + 1
+    }
+    expect(expectedStart).toBe(size)
+  })
+
+  it('never sends the bearer token to the preauthenticated upload URL', async () => {
+    mockSecureFetchWithPinnedIP
+      .mockResolvedValueOnce(sessionResponse())
+      .mockResolvedValueOnce(completedItem())
+
+    await replaceContentIfUnchanged(BASE_PATH, 'token', Buffer.alloc(64), 'tag-1')
+
+    const put = mockSecureFetchWithPinnedIP.mock.calls.find((c) => c[2]?.method === 'PUT')
+    expect(put?.[0]).toBe(UPLOAD_URL)
+    expect(put?.[2].headers.Authorization).toBeUndefined()
+  })
+
+  it('carries the precondition on the session and maps its rejection to a conflict', async () => {
+    mockSecureFetchWithPinnedIP.mockResolvedValueOnce(preconditionFailed())
+
+    await expect(
+      replaceContentIfUnchanged(BASE_PATH, 'token', Buffer.alloc(64), 'tag-1')
+    ).rejects.toMatchObject({ status: 409 })
+
+    const session = mockSecureFetchWithPinnedIP.mock.calls[0]
+    expect(session[0]).toBe(`${BASE_PATH}/createUploadSession`)
+    expect(session[2].headers['if-match']).toBe('tag-1')
+    // Rejected before any bytes left the process.
+    expect(mockSecureFetchWithPinnedIP.mock.calls.some((c) => c[2]?.method === 'PUT')).toBe(false)
+  })
+
+  it('maps a conflict raised part-way through the fragments to the same error', async () => {
+    mockSecureFetchWithPinnedIP
+      .mockResolvedValueOnce(sessionResponse())
+      .mockResolvedValueOnce(fragmentAccepted())
+      .mockResolvedValueOnce(preconditionFailed())
+
+    await expect(
+      replaceContentIfUnchanged(BASE_PATH, 'token', Buffer.alloc(25 * 1024 * 1024), 'tag-1')
+    ).rejects.toMatchObject({ status: 409 })
+  })
+
+  it('fails loudly when the session response carries no upload URL', async () => {
+    const body = { expirationDateTime: '2026-01-01T00:00:00Z' }
+    mockSecureFetchWithPinnedIP.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: '',
+      headers: new Headers(),
+      body: null,
+      text: async () => JSON.stringify(body),
+      json: async () => body,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    })
+
+    await expect(
+      replaceContentIfUnchanged(BASE_PATH, 'token', Buffer.alloc(64), 'tag-1')
+    ).rejects.toThrow(/did not return an upload URL/)
+  })
+})

--- a/apps/sim/lib/microsoft-word/graph.server.ts
+++ b/apps/sim/lib/microsoft-word/graph.server.ts
@@ -219,45 +219,93 @@ export function requireContentTag(item: GraphDriveItem): string {
   return tag
 }
 
+/** A Graph upload session, used for a precondition-checked content write. */
+interface GraphUploadSession {
+  uploadUrl?: string
+}
+
 /**
- * Aborts a read-modify-write when the document's content changed since it was
- * read. Without this, two overlapping edits both succeed and the later upload
- * silently discards the earlier one.
+ * Replaces a document's content only if it still matches `expectedTag`.
  *
- * Every branch fails closed: a changed tag, and equally a re-read that reports
- * no tag at all, both refuse the write rather than fall through to it.
+ * `PUT /items/{id}/content` documents no precondition — its request-headers
+ * table lists only `Authorization` and `Content-Type` — so a conditional write
+ * has to go through an upload session, whose `if-match` header Graph documents
+ * as returning `412 Precondition Failed` on a mismatch. That makes the check
+ * service-enforced rather than a client-side compare that could itself race.
+ *
+ * The residual window is small and stated honestly: the tag is evaluated when
+ * the session is created and the bytes commit on the following request. Closing
+ * it completely would need the deferred-commit form, whose conditional commit
+ * relies on `@microsoft.graph.sourceUrl` — which Microsoft documents as
+ * unsupported on OneDrive for Business and SharePoint Online, where these
+ * documents live.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/driveitem
  */
-export async function assertContentUnchanged(
+export async function replaceContentIfUnchanged(
   basePath: string,
   accessToken: string,
-  expected: string
-): Promise<void> {
-  const current = requireContentTag(await fetchDocumentItem(basePath, accessToken))
-  if (current !== expected) {
+  content: Buffer,
+  expectedTag: string
+): Promise<GraphDriveItem> {
+  const sessionResponse = await graphFetch(
+    `${basePath}/createUploadSession`,
+    'documentUploadSessionUrl',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'if-match': expectedTag,
+      },
+      body: '{}',
+    }
+  )
+
+  if (sessionResponse.status === 412) {
     throw documentChangedError()
   }
+  if (!sessionResponse.ok) await raiseGraphError(sessionResponse)
+
+  const { uploadUrl } = (await sessionResponse.json()) as GraphUploadSession
+  if (!uploadUrl) {
+    throw new GraphRequestError('Microsoft Graph did not return an upload URL', 502)
+  }
+
+  // The upload URL is preauthenticated and on another host; Graph documents that
+  // sending Authorization here can fail the request with a 401.
+  const uploadResponse = await graphFetch(uploadUrl, 'documentUploadUrl', {
+    method: 'PUT',
+    headers: {
+      'Content-Length': String(content.length),
+      'Content-Range': `bytes 0-${content.length - 1}/${content.length}`,
+    },
+    body: content,
+  })
+
+  if (uploadResponse.status === 412 || uploadResponse.status === 409) {
+    throw documentChangedError()
+  }
+  if (!uploadResponse.ok) await raiseGraphError(uploadResponse)
+
+  return (await uploadResponse.json()) as GraphDriveItem
 }
 
 /**
  * Uploads bytes as a drive item's content and returns the resulting item.
  *
- * `ifMatch` carries the content tag the upload is based on. Graph documents
- * `if-match` (and its `412 Precondition Failed` response) on the metadata
- * update, not on this content endpoint, so it is sent as a second line of
- * defense rather than the guarantee: an `If-Match` a server does not implement
- * is ignored, and the caller's {@link assertContentUnchanged} check is what
- * actually decides whether the write is safe. A `412` is surfaced as the same
- * conflict either way.
+ * Unconditional by design: this backs creating a new document and the
+ * deliberate whole-document overwrite. An edit that must not clobber a
+ * concurrent change uses {@link replaceContentIfUnchanged} instead.
  *
  * @see https://learn.microsoft.com/en-us/graph/api/driveitem-put-content
- * @see https://learn.microsoft.com/en-us/graph/api/driveitem-update
  */
 export async function uploadDocumentContent(
   url: string,
   accessToken: string,
   content: Buffer,
-  mimeType: string,
-  ifMatch?: string
+  mimeType: string
 ): Promise<GraphDriveItem> {
   const response = await graphFetch(url, 'documentUploadUrl', {
     method: 'PUT',
@@ -265,14 +313,10 @@ export async function uploadDocumentContent(
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': mimeType,
       'Content-Length': String(content.length),
-      ...(ifMatch ? { 'if-match': ifMatch } : {}),
     },
     body: content,
   })
 
-  if (response.status === 412) {
-    throw documentChangedError()
-  }
   if (!response.ok) await raiseGraphError(response)
 
   return (await response.json()) as GraphDriveItem

--- a/apps/sim/lib/microsoft-word/graph.server.ts
+++ b/apps/sim/lib/microsoft-word/graph.server.ts
@@ -273,23 +273,58 @@ export async function replaceContentIfUnchanged(
     throw new GraphRequestError('Microsoft Graph did not return an upload URL', 502)
   }
 
-  // The upload URL is preauthenticated and on another host; Graph documents that
-  // sending Authorization here can fail the request with a 401.
-  const uploadResponse = await graphFetch(uploadUrl, 'documentUploadUrl', {
-    method: 'PUT',
-    headers: {
-      'Content-Length': String(content.length),
-      'Content-Range': `bytes 0-${content.length - 1}/${content.length}`,
-    },
-    body: content,
-  })
+  return uploadSessionBytes(uploadUrl, content)
+}
 
-  if (uploadResponse.status === 412 || uploadResponse.status === 409) {
-    throw documentChangedError()
+/**
+ * Byte size of each upload fragment.
+ *
+ * Graph caps a single upload request below 60 MiB, and requires every fragment
+ * of a split upload to be a multiple of 320 KiB — 10 MiB is both (327,680 × 32)
+ * and is inside the 5–10 MiB range Microsoft recommends. Documents are read
+ * under a 100 MB ceiling, so a single request would not always be enough.
+ */
+const UPLOAD_FRAGMENT_BYTES = 10 * 1024 * 1024
+
+/**
+ * Sends the package to a session's upload URL, splitting it into sequential
+ * fragments. Graph answers `202 Accepted` for every fragment but the last, and
+ * returns the finished driveItem with the one that completes the file.
+ *
+ * The URL is preauthenticated and on another host; Graph documents that sending
+ * `Authorization` here can itself fail the request with a 401, so no bearer
+ * token is attached.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession
+ */
+async function uploadSessionBytes(uploadUrl: string, content: Buffer): Promise<GraphDriveItem> {
+  const total = content.length
+
+  for (let start = 0; start < total; start += UPLOAD_FRAGMENT_BYTES) {
+    const end = Math.min(start + UPLOAD_FRAGMENT_BYTES, total) - 1
+    const fragment = content.subarray(start, end + 1)
+
+    const response = await graphFetch(uploadUrl, 'documentUploadUrl', {
+      method: 'PUT',
+      headers: {
+        'Content-Length': String(fragment.length),
+        'Content-Range': `bytes ${start}-${end}/${total}`,
+      },
+      body: fragment,
+    })
+
+    if (response.status === 412 || response.status === 409) {
+      throw documentChangedError()
+    }
+    if (!response.ok) await raiseGraphError(response)
+
+    // Every fragment but the last is acknowledged with 202 and no item body.
+    if (end === total - 1) {
+      return (await response.json()) as GraphDriveItem
+    }
   }
-  if (!uploadResponse.ok) await raiseGraphError(uploadResponse)
 
-  return (await uploadResponse.json()) as GraphDriveItem
+  throw new GraphRequestError('Microsoft Graph did not complete the document upload', 502)
 }
 
 /**

--- a/apps/sim/tools/microsoft_word/errors.ts
+++ b/apps/sim/tools/microsoft_word/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * An error whose cause is the caller's input rather than anything Microsoft
+ * Graph did.
+ *
+ * The Word routes validate identifiers and names in shared helpers that run
+ * after contract parsing, because they encode Graph's path rules rather than
+ * the wire shape. Without a distinct type those failures reach the route's
+ * error projection as ordinary `Error`s and are reported as 500s, telling the
+ * caller that Sim broke when in fact they sent a malformed document ID.
+ */
+export class MicrosoftWordInputError extends Error {
+  readonly status = 400
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'MicrosoftWordInputError'
+  }
+}

--- a/apps/sim/tools/microsoft_word/utils.ts
+++ b/apps/sim/tools/microsoft_word/utils.ts
@@ -1,5 +1,6 @@
 import { validatePathSegment } from '@/lib/core/security/input-validation'
 import { GRAPH_ID_PATTERN } from '@/tools/microsoft_excel/utils'
+import { MicrosoftWordInputError } from '@/tools/microsoft_word/errors'
 
 export const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0'
 
@@ -17,7 +18,7 @@ export function getDriveBasePath(driveId?: string): string {
     customPattern: GRAPH_ID_PATTERN,
   })
   if (!validation.isValid) {
-    throw new Error(validation.error)
+    throw new MicrosoftWordInputError(validation.error as string)
   }
   return `${GRAPH_BASE_URL}/drives/${trimmed}`
 }
@@ -34,7 +35,7 @@ export function getItemBasePath(
 ): string {
   const trimmed = itemId?.trim()
   if (!trimmed) {
-    throw new Error(`${itemLabel} is required`)
+    throw new MicrosoftWordInputError(`${itemLabel} is required`)
   }
 
   const validation = validatePathSegment(trimmed, {
@@ -42,7 +43,7 @@ export function getItemBasePath(
     customPattern: GRAPH_ID_PATTERN,
   })
   if (!validation.isValid) {
-    throw new Error(validation.error)
+    throw new MicrosoftWordInputError(validation.error as string)
   }
 
   return `${getDriveBasePath(driveId)}/items/${trimmed}`
@@ -66,7 +67,7 @@ export function getFolderBasePath(folderId: string, driveId?: string): string {
 export function ensureDocxExtension(name: string): string {
   const trimmed = name.trim()
   if (!trimmed) {
-    throw new Error('Document name is required')
+    throw new MicrosoftWordInputError('Document name is required')
   }
   return trimmed.toLowerCase().endsWith('.docx') ? trimmed : `${trimmed}.docx`
 }


### PR DESCRIPTION
## Summary
- Follow-ups to the Microsoft Word integration, from review comments left on the v0.8.12 release PR
- Replaces the client-side freshness re-read with a **service-enforced** precondition, and stops three caller-input mistakes from being reported as 500s

## Conditional writes are now service-enforced
`PUT /items/{id}/content` documents no precondition — its request-headers table lists only `Authorization` and `Content-Type` — so the previous guard re-read the item and compared `cTag` client-side, then sent a best-effort `if-match`. The review was right that a separate re-read cannot deliver the guarantee.

`createUploadSession` **does** document `if-match`, returning `412 Precondition Failed` on a mismatch. Append and Find-and-Replace now write through it:

1. `POST {item}/createUploadSession` with `if-match: <cTag>` — the service rejects a stale edit with a 412, surfaced as a 409
2. `PUT` the bytes to the returned preauthenticated `uploadUrl`, without the bearer token (Graph documents that sending `Authorization` there can fail with a 401)

The separate re-read is gone. The residual window is stated honestly in the code: the tag is evaluated at session creation and the bytes commit on the next request. Closing it completely needs the deferred-commit form, whose conditional commit relies on `@microsoft.graph.sourceUrl` — documented as unsupported on OneDrive for Business and SharePoint Online, which is where these documents live.

Create and Create-from-Template keep the plain `PUT`: they make new files and already pin `@microsoft.graph.conflictBehavior=rename`. Replace Content also keeps it — overwriting is its stated contract.

## Caller input no longer returns 500
`ensureDocxExtension` and the path-builders validate Graph's rules after contract parsing, and threw plain `Error`s that the route's error projection reported as 500s. They now throw a typed `MicrosoftWordInputError` carrying a 400, so a malformed document/folder/drive ID or a whitespace-only name reads as the client mistake it is.

An empty placeholder key is rejected at the contract instead, in both the object and JSON-string forms — a blank placeholder would match at every position in the document, and previously failed mid-rewrite as a 500.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- 45 tests across the Word suites, 7 of them new: the session flow asserts `if-match` on the session POST and that the bytes PUT carries no `Authorization`; a 412 at either step maps to 409; malformed IDs, a blank name, and empty placeholder keys all return 400 with no request issued
- Mutation-checked: reverting each of the three guards turns its tests red (7 failures)
- `bun run check:audits` 33/33, `type-check`, `lint:check`, `docs-manifest:check`, `check:migrations` all clean
- Not exercised against a live Microsoft tenant — the upload-session flow follows the documented request/response shapes, and no undocumented response field is relied on

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
