### PR TITLE
fix(selectors): resolve shared environment references server-side

### DIFF
--- a/apps/sim/app/api/environment/route.test.ts
+++ b/apps/sim/app/api/environment/route.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment node
+ */
+import {
+  auditMock,
+  authMockFns,
+  createMockRequest,
+  dbChainMockFns,
+  environmentUtilsMockFns,
+  posthogServerMock,
+  resetDbChainMock,
+} from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockEncryptSecret, mockSyncPersonalEnvCredentialsForUser } = vi.hoisted(() => ({
+  mockEncryptSecret: vi.fn(),
+  mockSyncPersonalEnvCredentialsForUser: vi.fn(),
+}))
+
+vi.mock('@sim/audit', () => auditMock)
+vi.mock('@/lib/posthog/server', () => posthogServerMock)
+vi.mock('@/lib/core/security/encryption', () => ({
+  decryptSecret: vi.fn(),
+  encryptSecret: mockEncryptSecret,
+}))
+vi.mock('@/lib/credentials/environment', () => ({
+  syncPersonalEnvCredentialsForUser: mockSyncPersonalEnvCredentialsForUser,
+}))
+
+import { POST } from '@/app/api/environment/route'
+
+describe('POST /api/environment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+    authMockFns.mockGetSession.mockResolvedValue({
+      user: { id: 'user-1', name: 'Test User', email: 'test@example.com' },
+    })
+    mockEncryptSecret.mockResolvedValue({ encrypted: 'encrypted-value' })
+    mockSyncPersonalEnvCredentialsForUser.mockResolvedValue(undefined)
+  })
+
+  it('invalidates the effective environment cache immediately after the database update', async () => {
+    const response = await POST(
+      createMockRequest('POST', { variables: { JIRA_DOMAIN: 'example.atlassian.net' } })
+    )
+
+    expect(response.status).toBe(200)
+    expect(environmentUtilsMockFns.mockInvalidateEffectiveDecryptedEnvCache).toHaveBeenCalledWith({
+      userId: 'user-1',
+    })
+    expect(dbChainMockFns.onConflictDoUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      environmentUtilsMockFns.mockInvalidateEffectiveDecryptedEnvCache.mock.invocationCallOrder[0]
+    )
+    expect(
+      environmentUtilsMockFns.mockInvalidateEffectiveDecryptedEnvCache.mock.invocationCallOrder[0]
+    ).toBeLessThan(mockSyncPersonalEnvCredentialsForUser.mock.invocationCallOrder[0])
+  })
+})

--- a/apps/sim/app/api/environment/route.ts
+++ b/apps/sim/app/api/environment/route.ts
@@ -14,6 +14,7 @@ import { generateRequestId } from '@/lib/core/utils/request'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { syncPersonalEnvCredentialsForUser } from '@/lib/credentials/environment'
 import type { EnvironmentVariable } from '@/lib/environment/api'
+import { invalidateEffectiveDecryptedEnvCache } from '@/lib/environment/utils'
 import { captureServerEvent } from '@/lib/posthog/server'
 
 const logger = createLogger('EnvironmentAPI')
@@ -68,6 +69,8 @@ export const POST = withRouteHandler(async (req: NextRequest) => {
           updatedAt: new Date(),
         },
       })
+
+    invalidateEffectiveDecryptedEnvCache({ userId: session.user.id })
 
     await syncPersonalEnvCredentialsForUser({
       userId: session.user.id,

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-tool-event.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-tool-event.test.ts
@@ -118,16 +118,16 @@ describe('tool events (dispatch → model + side effects)', () => {
     {
       scope: 'personal',
       output: { scope: 'personal' },
-      environmentQueryKey: environmentKeys.personal(),
+      environmentQueryKeys: [environmentKeys.personal(), environmentKeys.workspaces()],
     },
     {
       scope: 'workspace',
       output: { scope: 'workspace', workspaceId: 'workspace-from-result' },
-      environmentQueryKey: environmentKeys.workspace('workspace-from-result'),
+      environmentQueryKeys: [environmentKeys.workspace('workspace-from-result')],
     },
   ])(
     'refreshes the $scope environment before selector caches after Copilot saves secrets',
-    async ({ output, environmentQueryKey }) => {
+    async ({ output, environmentQueryKeys }) => {
       const deps = makeStreamLoopDeps()
       const invalidateQueries = vi.mocked(deps.queryClient.invalidateQueries)
       invalidateQueries.mockResolvedValue(undefined)
@@ -139,9 +139,11 @@ describe('tool events (dispatch → model + side effects)', () => {
         toolResult('environment-1', true, SetEnvironmentVariables.id, output)
       )
 
-      await vi.waitFor(() => expect(invalidateQueries).toHaveBeenCalledTimes(5))
+      await vi.waitFor(() =>
+        expect(invalidateQueries).toHaveBeenCalledTimes(environmentQueryKeys.length + 4)
+      )
       expect(invalidateQueries.mock.calls.map(([filters]) => filters?.queryKey)).toEqual([
-        environmentQueryKey,
+        ...environmentQueryKeys,
         environmentDependentSelectorKeys.primary,
         environmentDependentSelectorKeys.dynamicDetails,
         environmentDependentSelectorKeys.workflowDetails,

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-tool-event.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-tool-event.test.ts
@@ -15,8 +15,11 @@ vi.mock(
   () => ({ invalidateResourceQueries: vi.fn() })
 )
 
+import { SetEnvironmentVariables } from '@/lib/copilot/generated/tool-catalog-v1'
 import type { PersistedStreamEventEnvelope } from '@/lib/copilot/request/session/contract'
 import type { FilePreviewSession } from '@/lib/copilot/request/session/file-preview-session-contract'
+import { environmentKeys } from '@/hooks/queries/environment'
+import { environmentDependentSelectorKeys } from '@/hooks/selectors/cache-invalidation'
 import { dispatchStreamEvent } from './dispatch-stream-event'
 import { createStreamLoopContext, type StreamLoopContext } from './stream-context'
 import { makeStreamLoopDeps, ref } from './stream-test-helpers'
@@ -38,7 +41,7 @@ function toolEnv(payload: Record<string, unknown>): PersistedStreamEventEnvelope
 const toolCall = (id: string, name = 'my_tool') =>
   toolEnv({ phase: 'call', executor: 'go', mode: 'sync', toolCallId: id, toolName: name })
 
-const toolResult = (id: string, success: boolean, name = 'my_tool') =>
+const toolResult = (id: string, success: boolean, name = 'my_tool', output?: unknown) =>
   toolEnv({
     phase: 'result',
     executor: 'go',
@@ -47,6 +50,7 @@ const toolResult = (id: string, success: boolean, name = 'my_tool') =>
     toolName: name,
     success,
     status: success ? 'success' : 'error',
+    ...(output === undefined ? {} : { output }),
   })
 
 const workspaceFileCall = (id: string) =>
@@ -108,6 +112,61 @@ describe('tool events (dispatch → model + side effects)', () => {
     dispatchStreamEvent(ctx, toolCall('tc-3'))
     dispatchStreamEvent(ctx, toolResult('tc-3', false))
     expect(toolNode(ctx, 'tc-3').status).toBe('error')
+  })
+
+  it.each([
+    {
+      scope: 'personal',
+      output: { scope: 'personal' },
+      environmentQueryKey: environmentKeys.personal(),
+    },
+    {
+      scope: 'workspace',
+      output: { scope: 'workspace', workspaceId: 'workspace-from-result' },
+      environmentQueryKey: environmentKeys.workspace('workspace-from-result'),
+    },
+  ])(
+    'refreshes the $scope environment before selector caches after Copilot saves secrets',
+    async ({ output, environmentQueryKey }) => {
+      const deps = makeStreamLoopDeps()
+      const invalidateQueries = vi.mocked(deps.queryClient.invalidateQueries)
+      invalidateQueries.mockResolvedValue(undefined)
+      const ctx = createStreamLoopContext(deps)
+
+      dispatchStreamEvent(ctx, toolCall('environment-1', SetEnvironmentVariables.id))
+      dispatchStreamEvent(
+        ctx,
+        toolResult('environment-1', true, SetEnvironmentVariables.id, output)
+      )
+
+      await vi.waitFor(() => expect(invalidateQueries).toHaveBeenCalledTimes(5))
+      expect(invalidateQueries.mock.calls.map(([filters]) => filters?.queryKey)).toEqual([
+        environmentQueryKey,
+        environmentDependentSelectorKeys.primary,
+        environmentDependentSelectorKeys.dynamicDetails,
+        environmentDependentSelectorKeys.workflowDetails,
+        environmentDependentSelectorKeys.workflowReplacementOptions,
+      ])
+    }
+  )
+
+  it('does not refresh environment or selector caches when Copilot secret storage fails', async () => {
+    const deps = makeStreamLoopDeps()
+    const invalidateQueries = vi.mocked(deps.queryClient.invalidateQueries)
+    invalidateQueries.mockResolvedValue(undefined)
+    const ctx = createStreamLoopContext(deps)
+
+    dispatchStreamEvent(ctx, toolCall('environment-failed', SetEnvironmentVariables.id))
+    dispatchStreamEvent(
+      ctx,
+      toolResult('environment-failed', false, SetEnvironmentVariables.id, {
+        scope: 'workspace',
+        workspaceId: 'workspace-from-result',
+      })
+    )
+    await Promise.resolve()
+
+    expect(invalidateQueries).not.toHaveBeenCalled()
   })
 
   // The client starts terminal/browser/workflow tools straight off the call

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-tool-event.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-tool-event.ts
@@ -4,7 +4,11 @@ import {
   MothershipStreamV1ToolPhase,
   MothershipStreamV1ToolStatus,
 } from '@/lib/copilot/generated/mothership-stream-v1'
-import { ApplyFileEdit, PrepareFileEdit } from '@/lib/copilot/generated/tool-catalog-v1'
+import {
+  ApplyFileEdit,
+  PrepareFileEdit,
+  SetEnvironmentVariables,
+} from '@/lib/copilot/generated/tool-catalog-v1'
 import type { PersistedStreamEventEnvelope } from '@/lib/copilot/request/session/contract'
 import {
   extractResourcesFromToolResult,
@@ -26,8 +30,10 @@ import {
   type ToolNode,
 } from '@/app/workspace/[workspaceId]/home/hooks/stream/turn-model'
 import { deploymentKeys } from '@/hooks/queries/deployments'
+import { environmentKeys } from '@/hooks/queries/environment'
 import { folderKeys } from '@/hooks/queries/utils/folder-keys'
 import { invalidateWorkflowLists } from '@/hooks/queries/utils/invalidate-workflow-lists'
+import { invalidateEnvironmentDependentSelectorQueries } from '@/hooks/selectors/cache-invalidation'
 
 type ToolEvent = Extract<PersistedStreamEventEnvelope, { type: 'tool' }>
 
@@ -69,6 +75,23 @@ function runToolResultSideEffects(ctx: StreamLoopContext, node: ToolNode): void 
     // `rm` archives, so the archived list moves too — and the shared helper also
     // refreshes the workflow selector lists that `@`-mentions and pickers read.
     void invalidateWorkflowLists(deps.queryClient, deps.workspaceId, ['active', 'archived'])
+  }
+
+  if (name === SetEnvironmentVariables.id && isSuccess) {
+    const out = output as Record<string, unknown> | undefined
+    const isPersonal = out?.scope === 'personal'
+    const workspaceId = typeof out?.workspaceId === 'string' ? out.workspaceId : deps.workspaceId
+
+    void (async () => {
+      if (isPersonal) {
+        await deps.queryClient.invalidateQueries({ queryKey: environmentKeys.personal() })
+      } else {
+        await deps.queryClient.invalidateQueries({
+          queryKey: environmentKeys.workspace(workspaceId),
+        })
+      }
+      await invalidateEnvironmentDependentSelectorQueries(deps.queryClient)
+    })()
   }
 
   const extractedResources =

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-tool-event.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/stream/handle-tool-event.ts
@@ -84,7 +84,10 @@ function runToolResultSideEffects(ctx: StreamLoopContext, node: ToolNode): void 
 
     void (async () => {
       if (isPersonal) {
-        await deps.queryClient.invalidateQueries({ queryKey: environmentKeys.personal() })
+        await Promise.all([
+          deps.queryClient.invalidateQueries({ queryKey: environmentKeys.personal() }),
+          deps.queryClient.invalidateQueries({ queryKey: environmentKeys.workspaces() }),
+        ])
       } else {
         await deps.queryClient.invalidateQueries({
           queryKey: environmentKeys.workspace(workspaceId),

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ConnectorConfigField } from '@/connectors/types'
+import type { SelectorDefinition, SelectorKey } from '@/hooks/selectors/types'
+
+const { getSelectorDefinitionMock, useSelectorOptionsMock } = vi.hoisted(() => ({
+  getSelectorDefinitionMock: vi.fn(),
+  useSelectorOptionsMock: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    isFetchingMore: false,
+    hasMore: false,
+    truncated: false,
+    error: null,
+  })),
+}))
+
+vi.mock('@sim/emcn', () => ({ ChipCombobox: () => null }))
+vi.mock('@sim/emcn/icons', () => ({ Loader: () => null }))
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ workspaceId: 'workspace-1', id: 'knowledge-1' }),
+}))
+vi.mock('@/hooks/selectors/registry', () => ({
+  getSelectorDefinition: getSelectorDefinitionMock,
+}))
+vi.mock('@/hooks/selectors/use-selector-query', () => ({
+  useSelectorOptions: useSelectorOptionsMock,
+  useSelectorOptionDetail: () => ({ data: null }),
+  useSelectorOptionDetails: () => [],
+}))
+vi.mock('@/hooks/use-debounce', () => ({ useDebounce: (value: string) => value }))
+
+import { ConnectorSelectorField } from '@/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field'
+
+let root: Root | null = null
+
+afterEach(() => {
+  act(() => root?.unmount())
+  root = null
+  document.body.innerHTML = ''
+  vi.clearAllMocks()
+})
+
+describe('ConnectorSelectorField cache scope', () => {
+  it('changes only when a server-resolved selector dependency changes', () => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    const definition = {
+      key: 'jira.projects' as SelectorKey,
+      serverResolvedContextFields: ['domain'],
+      getQueryKey: () => ['selectors', 'jira.projects'],
+      fetchList: async () => [],
+    } as SelectorDefinition
+    getSelectorDefinitionMock.mockReturnValue(definition)
+
+    const domainField: ConnectorConfigField = {
+      id: 'domain-field',
+      title: 'Domain',
+      type: 'short-input',
+      canonicalParamId: 'domain',
+      mode: 'basic',
+    }
+    const projectField = {
+      id: 'project',
+      title: 'Project',
+      type: 'selector',
+      selectorKey: definition.key,
+      dependsOn: ['domain-field'],
+    } satisfies ConnectorConfigField & { selectorKey: SelectorKey }
+    const configFields = [domainField, projectField]
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    const render = (domain: string, unrelated: string) => {
+      act(() =>
+        root?.render(
+          <ConnectorSelectorField
+            field={projectField}
+            value=''
+            onChange={vi.fn()}
+            credentialId='credential-1'
+            sourceConfig={{ 'domain-field': domain, unrelated }}
+            configFields={configFields}
+            canonicalModes={{ domain: 'basic' }}
+          />
+        )
+      )
+      return useSelectorOptionsMock.mock.calls.at(-1)?.[1].context.selectorCacheScope
+    }
+
+    const initial = render('{{JIRA_DOMAIN}}', 'first')
+    const afterUnrelatedEdit = render('{{JIRA_DOMAIN}}', 'second')
+    const afterDependencyEdit = render('{{OTHER_DOMAIN}}', 'second')
+
+    expect(initial).toEqual(expect.any(String))
+    expect(afterUnrelatedEdit).toBe(initial)
+    expect(afterDependencyEdit).not.toBe(initial)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useState } from 'react'
 import { ChipCombobox, type ComboboxOption } from '@sim/emcn'
 import { Loader } from '@sim/emcn/icons'
-import { generateShortId } from '@sim/utils/id'
 import { useParams } from 'next/navigation'
 import { SEARCH_DEBOUNCE_MS } from '@/lib/url-state'
 import { SELECTOR_CONTEXT_FIELDS } from '@/lib/workflows/subblocks/context'
@@ -13,6 +12,10 @@ import type {
   ConfigFieldValue,
 } from '@/app/workspace/[workspaceId]/knowledge/[id]/hooks/use-connector-config-fields'
 import type { ConnectorConfigField } from '@/connectors/types'
+import {
+  createSelectorCacheScopeRegistry,
+  scopeServerResolvedSelectorContext,
+} from '@/hooks/selectors/context-resolution'
 import { getSelectorDefinition } from '@/hooks/selectors/registry'
 import type { SelectorContext, SelectorKey } from '@/hooks/selectors/types'
 import {
@@ -46,15 +49,12 @@ export function ConnectorSelectorField({
   const params = useParams<{ workspaceId: string; id: string }>()
   const isMulti = Boolean(field.multi)
   const [searchTerm, setSearchTerm] = useState('')
-  const selectorCacheScope = useMemo(
-    () => generateShortId(),
-    [field.id, field.selectorKey, credentialId, sourceConfig]
-  )
+  const definition = getSelectorDefinition(field.selectorKey)
+  const selectorCacheScopes = useMemo(() => createSelectorCacheScopeRegistry(), [])
 
   const context = useMemo<SelectorContext>(() => {
     const ctx: SelectorContext = {
       workspaceId: params.workspaceId,
-      selectorCacheScope,
     }
     if (credentialId) ctx.oauthCredential = credentialId
     if (field.mimeType) ctx.mimeType = field.mimeType
@@ -69,7 +69,7 @@ export function ConnectorSelectorField({
       }
     }
 
-    return ctx
+    return scopeServerResolvedSelectorContext(definition, ctx, selectorCacheScopes)
   }, [
     credentialId,
     field.mimeType,
@@ -78,7 +78,8 @@ export function ConnectorSelectorField({
     configFields,
     canonicalModes,
     params.workspaceId,
-    selectorCacheScope,
+    definition,
+    selectorCacheScopes,
   ])
 
   const depsResolved = useMemo(() => {
@@ -126,7 +127,7 @@ export function ConnectorSelectorField({
    * implementations resolve a record by id, where a partial keystroke is a guaranteed
    * failed upstream request rather than an empty result.
    */
-  const resolvesUnknownIds = Boolean(getSelectorDefinition(field.selectorKey).resolvesUnknownIds)
+  const resolvesUnknownIds = Boolean(definition.resolvesUnknownIds)
   const debouncedSearch = useDebounce(searchTerm.trim(), SEARCH_DEBOUNCE_MS)
   const { data: searchedOption } = useSelectorOptionDetail(field.selectorKey, {
     context,

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/connector-selector-field/connector-selector-field.tsx
@@ -3,6 +3,8 @@
 import { useMemo, useState } from 'react'
 import { ChipCombobox, type ComboboxOption } from '@sim/emcn'
 import { Loader } from '@sim/emcn/icons'
+import { generateShortId } from '@sim/utils/id'
+import { useParams } from 'next/navigation'
 import { SEARCH_DEBOUNCE_MS } from '@/lib/url-state'
 import { SELECTOR_CONTEXT_FIELDS } from '@/lib/workflows/subblocks/context'
 import { getDependsOnFields } from '@/lib/workflows/subblocks/dependencies'
@@ -41,11 +43,19 @@ export function ConnectorSelectorField({
   canonicalModes,
   disabled,
 }: ConnectorSelectorFieldProps) {
+  const params = useParams<{ workspaceId: string; id: string }>()
   const isMulti = Boolean(field.multi)
   const [searchTerm, setSearchTerm] = useState('')
+  const selectorCacheScope = useMemo(
+    () => generateShortId(),
+    [field.id, field.selectorKey, credentialId, sourceConfig]
+  )
 
   const context = useMemo<SelectorContext>(() => {
-    const ctx: SelectorContext = {}
+    const ctx: SelectorContext = {
+      workspaceId: params.workspaceId,
+      selectorCacheScope,
+    }
     if (credentialId) ctx.oauthCredential = credentialId
     if (field.mimeType) ctx.mimeType = field.mimeType
 
@@ -60,7 +70,16 @@ export function ConnectorSelectorField({
     }
 
     return ctx
-  }, [credentialId, field.mimeType, field.dependsOn, sourceConfig, configFields, canonicalModes])
+  }, [
+    credentialId,
+    field.mimeType,
+    field.dependsOn,
+    sourceConfig,
+    configFields,
+    canonicalModes,
+    params.workspaceId,
+    selectorCacheScope,
+  ])
 
   const depsResolved = useMemo(() => {
     if (!field.dependsOn) return true

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-selector-setup.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/hooks/use-selector-setup.ts
@@ -1,11 +1,15 @@
 'use client'
 
 import { useMemo } from 'react'
+import { generateShortId } from '@sim/utils/id'
 import { useParams } from 'next/navigation'
-import { SELECTOR_CONTEXT_FIELDS } from '@/lib/workflows/subblocks/context'
 import type { SubBlockConfig } from '@/blocks/types'
-import { extractEnvVarName, isEnvVarReference, isReference } from '@/executor/constants'
 import { usePersonalEnvironment } from '@/hooks/queries/environment'
+import {
+  applySelectorDependenciesToContext,
+  resolveSelectorDependencyValues,
+} from '@/hooks/selectors/context-resolution'
+import { getSelectorDefinition } from '@/hooks/selectors/registry'
 import type { SelectorContext, SelectorKey } from '@/hooks/selectors/types'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useDependsOnGate } from './use-depends-on-gate'
@@ -35,6 +39,15 @@ export function useSelectorSetup(
 
   const { data: envVariables = {} } = usePersonalEnvironment()
 
+  const selectorKey = (subBlock.selectorKey ?? null) as SelectorKey | null
+  const serverResolvedContextFields = useMemo(
+    () =>
+      new Set<keyof SelectorContext>(
+        selectorKey ? (getSelectorDefinition(selectorKey).serverResolvedContextFields ?? []) : []
+      ),
+    [selectorKey]
+  )
+
   const { finalDisabled, dependencyValues, canonicalIndex } = useDependsOnGate(
     blockId,
     subBlock,
@@ -43,42 +56,33 @@ export function useSelectorSetup(
 
   const [impersonateUserEmail] = useSubBlockValue<string | null>(blockId, 'impersonateUserEmail')
 
+  const selectorCacheScope = useMemo(
+    () => generateShortId(),
+    [blockId, subBlock.id, selectorKey, dependencyValues]
+  )
+
   const resolvedDependencyValues = useMemo(() => {
-    const resolved: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(dependencyValues)) {
-      if (value === null || value === undefined) {
-        resolved[key] = value
-        continue
-      }
-      const str = String(value)
-      if (isEnvVarReference(str)) {
-        const varName = extractEnvVarName(str)
-        resolved[key] = envVariables[varName]?.value || undefined
-      } else {
-        resolved[key] = value
-      }
-    }
-    return resolved
-  }, [dependencyValues, envVariables])
+    return resolveSelectorDependencyValues({
+      dependencyValues,
+      personalEnvironment: envVariables,
+      canonicalIndex,
+      serverResolvedContextFields,
+    })
+  }, [dependencyValues, envVariables, canonicalIndex, serverResolvedContextFields])
 
   const selectorContext = useMemo<SelectorContext>(() => {
     const context: SelectorContext = {
       workflowId,
       workspaceId: workspaceId || undefined,
+      selectorCacheScope,
       mimeType: subBlock.mimeType,
     }
 
-    for (const [depKey, value] of Object.entries(resolvedDependencyValues)) {
-      if (value === null || value === undefined) continue
-      const strValue = String(value)
-      if (!strValue) continue
-      if (isReference(strValue)) continue
-
-      const canonicalParamId = canonicalIndex.canonicalIdBySubBlockId[depKey] ?? depKey
-      if (SELECTOR_CONTEXT_FIELDS.has(canonicalParamId as keyof SelectorContext)) {
-        context[canonicalParamId as keyof SelectorContext] = strValue
-      }
-    }
+    applySelectorDependenciesToContext({
+      context,
+      dependencyValues: resolvedDependencyValues,
+      canonicalIndex,
+    })
 
     if (context.oauthCredential && impersonateUserEmail) {
       context.impersonateUserEmail = impersonateUserEmail
@@ -90,12 +94,13 @@ export function useSelectorSetup(
     canonicalIndex,
     workflowId,
     workspaceId,
+    selectorCacheScope,
     subBlock.mimeType,
     impersonateUserEmail,
   ])
 
   return {
-    selectorKey: (subBlock.selectorKey ?? null) as SelectorKey | null,
+    selectorKey,
     selectorContext,
     allowSearch: subBlock.selectorAllowSearch ?? true,
     disabled: finalDisabled || !subBlock.selectorKey,

--- a/apps/sim/ee/workspace-forking/components/fork-sync/dependent-field-selector.tsx
+++ b/apps/sim/ee/workspace-forking/components/fork-sync/dependent-field-selector.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react'
 import { ChipCombobox, type ComboboxOption, Loader } from '@sim/emcn'
+import { generateShortId } from '@sim/utils/id'
 import { dependentFieldNoun } from '@/ee/workspace-forking/components/fork-sync/dependent-field-noun'
 import type { SelectorContext, SelectorKey } from '@/hooks/selectors/types'
 import { useSelectorOptions } from '@/hooks/selectors/use-selector-query'
@@ -31,11 +32,13 @@ export function DependentFieldSelector({
   onChange,
   title,
 }: DependentFieldSelectorProps) {
+  const dependencyIdentity = JSON.stringify(context)
+  const selectorCacheScope = useMemo(() => generateShortId(), [selectorKey, dependencyIdentity])
   const selectorContext = useMemo<SelectorContext>(() => {
-    const ctx: SelectorContext = {}
+    const ctx: SelectorContext = { selectorCacheScope }
     Object.assign(ctx, context)
     return ctx
-  }, [context])
+  }, [context, selectorCacheScope])
 
   const { data: options = [], isLoading } = useSelectorOptions(selectorKey, {
     context: selectorContext,

--- a/apps/sim/hooks/queries/dynamic-subblock-options.test.tsx
+++ b/apps/sim/hooks/queries/dynamic-subblock-options.test.tsx
@@ -19,7 +19,10 @@ import {
   dynamicSubBlockOptionKeys,
   useDynamicSubBlockOptionDisplayName,
 } from '@/hooks/queries/dynamic-subblock-options'
-import type { SelectorDefinition, SelectorKey } from '@/hooks/selectors/types'
+import type { SelectorDefinition, SelectorKey, SelectorQueryArgs } from '@/hooks/selectors/types'
+import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
+import { useSubBlockStore } from '@/stores/workflows/subblock/store'
+import { useWorkflowStore } from '@/stores/workflows/workflow/store'
 
 /** Any registered key; the hook only uses it to look the definition up. */
 const SELECTOR_KEY = 'workspace.credentialGroups' as SelectorKey
@@ -30,6 +33,7 @@ function mockDefinition(definition: Partial<SelectorDefinition>) {
 
 interface HookHarness<T> {
   result: () => T
+  queryClient: QueryClient
   unmount: () => void
 }
 
@@ -55,6 +59,7 @@ function renderHookWithClient<T>(useHook: () => T): HookHarness<T> {
 
   return {
     result: () => latest,
+    queryClient,
     unmount: () => act(() => root.unmount()),
   }
 }
@@ -70,6 +75,9 @@ describe('useDynamicSubBlockOptionDisplayName', () => {
 
   afterEach(() => {
     mounted.splice(0).forEach((unmount) => unmount())
+    useWorkflowRegistry.setState({ activeWorkflowId: null })
+    useWorkflowStore.setState({ blocks: {} })
+    useSubBlockStore.setState({ workflowValues: {} })
     vi.clearAllMocks()
   })
 
@@ -146,5 +154,87 @@ describe('useDynamicSubBlockOptionDisplayName', () => {
     expect(keyFor(undefined)).not.toEqual(keyFor('group-1'))
     expect(keyFor('group-1')).not.toEqual(keyFor('group-2'))
     expect(keyFor('group-1')).toEqual(keyFor('group-1'))
+  })
+
+  it('scopes server-resolved detail hydration without keying raw dependencies', async () => {
+    const fetchById = vi.fn(async ({ context, detailId }: SelectorQueryArgs) => {
+      if (context.domain === 'DYNAMIC_PRIVATE_SENTINEL_B') {
+        throw new Error('tenant B is unavailable')
+      }
+      return { id: detailId as string, label: 'Tenant A project' }
+    })
+    mockDefinition({
+      key: SELECTOR_KEY,
+      serverResolvedContextFields: ['domain'],
+      getQueryKey: () => ['selectors', SELECTOR_KEY],
+      fetchById,
+    })
+    const subBlock = {
+      id: 'projectId',
+      title: 'Project',
+      type: 'project-selector',
+      selectorKey: SELECTOR_KEY,
+    } satisfies SubBlockConfig
+
+    useWorkflowRegistry.setState({ activeWorkflowId: 'workflow-1' })
+    useWorkflowStore.setState({
+      blocks: {
+        'block-1': {
+          id: 'block-1',
+          type: 'jira',
+          subBlocks: {},
+          data: {},
+        } as never,
+      },
+    })
+    useSubBlockStore.setState({
+      workflowValues: {
+        'workflow-1': {
+          'block-1': {
+            credential: 'credential-1',
+            domain: 'DYNAMIC_PRIVATE_SENTINEL_A',
+          },
+        },
+      },
+    })
+
+    const hook = renderHookWithClient(() =>
+      useDynamicSubBlockOptionDisplayName({
+        workspaceId: 'workspace-1',
+        blockId: 'block-1',
+        subBlock,
+        value: 'project-1',
+      })
+    )
+    mounted.push(hook.unmount)
+
+    await waitForResult(() => expect(hook.result()).toBe('Tenant A project'))
+
+    act(() => {
+      useSubBlockStore.setState({
+        workflowValues: {
+          'workflow-1': {
+            'block-1': {
+              credential: 'credential-1',
+              domain: 'DYNAMIC_PRIVATE_SENTINEL_B',
+            },
+          },
+        },
+      })
+    })
+
+    await waitForResult(() => expect(fetchById).toHaveBeenCalledTimes(2))
+    await waitForResult(() => expect(hook.result()).toBeNull())
+
+    const contexts = fetchById.mock.calls.map(([args]) => args.context)
+    expect(contexts[0].selectorCacheScope).not.toBe(contexts[1].selectorCacheScope)
+    expect(
+      JSON.stringify(
+        hook.queryClient
+          .getQueryCache()
+          .getAll()
+          .map((query) => query.queryKey)
+      )
+    ).not.toContain('DYNAMIC_PRIVATE_SENTINEL')
   })
 })

--- a/apps/sim/hooks/queries/dynamic-subblock-options.ts
+++ b/apps/sim/hooks/queries/dynamic-subblock-options.ts
@@ -3,8 +3,13 @@ import { useQueries } from '@tanstack/react-query'
 import { buildSelectorContextFromBlock } from '@/lib/workflows/subblocks/context'
 import { summarizeNames } from '@/lib/workflows/subblocks/display'
 import type { SubBlockConfig } from '@/blocks/types'
+import {
+  createSelectorCacheScopeRegistry,
+  scopeServerResolvedSelectorContext,
+} from '@/hooks/selectors/context-resolution'
 import { getSelectorDefinition } from '@/hooks/selectors/registry'
 import type { SelectorContext } from '@/hooks/selectors/types'
+import { getScopedSelectorQueryKey } from '@/hooks/selectors/use-selector-query'
 import { useWorkflowRegistry } from '@/stores/workflows/registry/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
 import { useWorkflowStore } from '@/stores/workflows/workflow/store'
@@ -62,6 +67,7 @@ export function useDynamicSubBlockOptionDisplayName({
   subBlock,
   value,
 }: UseDynamicSubBlockOptionDisplayNameArgs): string | null {
+  const selectorCacheScopes = useMemo(() => createSelectorCacheScopeRegistry(), [])
   const optionIds = useMemo(() => getResolvableOptionIds(value), [value])
   // Label resolution follows the option source: a selector's own `fetchById`. There is no
   // per-block resolver any more, so a selector without one simply renders the raw id.
@@ -93,6 +99,14 @@ export function useDynamicSubBlockOptionDisplayName({
     })
   }, [block, liveValues, activeWorkflowId, workspaceId])
 
+  const scopedResolverContext = useMemo(
+    () =>
+      definition
+        ? scopeServerResolvedSelectorContext(definition, resolverContext, selectorCacheScopes)
+        : resolverContext,
+    [definition, resolverContext, selectorCacheScopes]
+  )
+
   /**
    * The selector's own key for this context. Reusing it means the cache is scoped by exactly
    * what the selector reads — no second list of context fields to keep in step, and it stays
@@ -100,8 +114,13 @@ export function useDynamicSubBlockOptionDisplayName({
    */
   const selectorScope = useMemo(
     () =>
-      definition ? definition.getQueryKey({ key: definition.key, context: resolverContext }) : [],
-    [definition, resolverContext]
+      definition
+        ? getScopedSelectorQueryKey(definition, {
+            key: definition.key,
+            context: scopedResolverContext,
+          })
+        : [],
+    [definition, scopedResolverContext]
   )
   const canResolve = Boolean(blockId && fetchById && optionIds.length > 0)
 
@@ -121,7 +140,7 @@ export function useDynamicSubBlockOptionDisplayName({
             }
             return fetchById({
               key: definition.key,
-              context: resolverContext,
+              context: scopedResolverContext,
               detailId: optionId,
               signal,
             })

--- a/apps/sim/hooks/queries/dynamic-subblock-options.ts
+++ b/apps/sim/hooks/queries/dynamic-subblock-options.ts
@@ -3,6 +3,7 @@ import { useQueries } from '@tanstack/react-query'
 import { buildSelectorContextFromBlock } from '@/lib/workflows/subblocks/context'
 import { summarizeNames } from '@/lib/workflows/subblocks/display'
 import type { SubBlockConfig } from '@/blocks/types'
+import { environmentDependentSelectorKeys } from '@/hooks/selectors/cache-invalidation'
 import {
   createSelectorCacheScopeRegistry,
   scopeServerResolvedSelectorContext,
@@ -18,7 +19,7 @@ export const DYNAMIC_SUBBLOCK_OPTION_STALE_TIME = 30 * 1000
 
 export const dynamicSubBlockOptionKeys = {
   all: ['dynamic-subblock-options'] as const,
-  details: () => [...dynamicSubBlockOptionKeys.all, 'detail'] as const,
+  details: () => environmentDependentSelectorKeys.dynamicDetails,
   /**
    * `selectorScope` is the selector's OWN query key for this context — every context field its
    * result depends on, named by the selector rather than restated here. Without it a label

--- a/apps/sim/hooks/queries/environment.test.tsx
+++ b/apps/sim/hooks/queries/environment.test.tsx
@@ -1,21 +1,33 @@
 /**
  * @vitest-environment jsdom
  */
-import { act } from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createRoot } from 'react-dom/client'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, type ReactNode } from 'react'
+import { sleep } from '@sim/utils/helpers'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockFetchWorkspaceEnvironment } = vi.hoisted(() => ({
+const { mockFetchWorkspaceEnvironment, mockRequestJson } = vi.hoisted(() => ({
   mockFetchWorkspaceEnvironment: vi.fn(),
+  mockRequestJson: vi.fn(),
 }))
+
+vi.mock('@/lib/api/client/request', () => ({ requestJson: mockRequestJson }))
 
 vi.mock('@/lib/environment/api', () => ({
   fetchPersonalEnvironment: vi.fn(),
   fetchWorkspaceEnvironment: mockFetchWorkspaceEnvironment,
 }))
 
-import { useWorkspaceEnvironment } from '@/hooks/queries/environment'
+import type { QueryKey } from '@tanstack/react-query'
+import {
+  environmentKeys,
+  useRemoveWorkspaceEnvironment,
+  useSavePersonalEnvironment,
+  useUpsertWorkspaceEnvironment,
+  useWorkspaceEnvironment,
+} from '@/hooks/queries/environment'
+import { environmentDependentSelectorKeys } from '@/hooks/selectors/cache-invalidation'
 
 function renderWorkspaceEnvironment(workspaceId: string, enabled?: boolean) {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -41,9 +53,111 @@ function renderWorkspaceEnvironment(workspaceId: string, enabled?: boolean) {
   return () => act(() => root.unmount())
 }
 
-afterEach(() => {
+interface CacheQueryFns {
+  environment: ReturnType<typeof vi.fn>
+  primary: ReturnType<typeof vi.fn>
+  dynamicDetails: ReturnType<typeof vi.fn>
+  workflowDetails: ReturnType<typeof vi.fn>
+  workflowReplacementOptions: ReturnType<typeof vi.fn>
+  unrelated: ReturnType<typeof vi.fn>
+}
+
+function createCacheQueryFns(): CacheQueryFns {
+  return {
+    environment: vi.fn().mockResolvedValue('environment'),
+    primary: vi.fn().mockResolvedValue('primary'),
+    dynamicDetails: vi.fn().mockResolvedValue('dynamic'),
+    workflowDetails: vi.fn().mockResolvedValue('workflow-detail'),
+    workflowReplacementOptions: vi.fn().mockResolvedValue('workflow-options'),
+    unrelated: vi.fn().mockResolvedValue('unrelated'),
+  }
+}
+
+function renderMutationWithCaches<T>(
+  useMutationHook: () => T,
+  environmentQueryKey: QueryKey,
+  queryFns: CacheQueryFns
+): { result: () => T; unmount: () => void } {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+      mutations: { retry: false },
+    },
+  })
+  const container = document.createElement('div')
+  const root: Root = createRoot(container)
+  let latest: T
+
+  function Probe() {
+    useQuery({ queryKey: environmentQueryKey, queryFn: queryFns.environment })
+    useQuery({
+      queryKey: [...environmentDependentSelectorKeys.primary, 'jira.projects', 'scope'],
+      queryFn: queryFns.primary,
+    })
+    useQuery({
+      queryKey: [...environmentDependentSelectorKeys.dynamicDetails, 'jira.project', 'scope'],
+      queryFn: queryFns.dynamicDetails,
+    })
+    useQuery({
+      queryKey: [...environmentDependentSelectorKeys.workflowDetails, 'jira.projects', 'scope'],
+      queryFn: queryFns.workflowDetails,
+    })
+    useQuery({
+      queryKey: [
+        ...environmentDependentSelectorKeys.workflowReplacementOptions,
+        'jira.projects',
+        'scope',
+      ],
+      queryFn: queryFns.workflowReplacementOptions,
+    })
+    useQuery({ queryKey: ['unrelated-user-data'], queryFn: queryFns.unrelated })
+    latest = useMutationHook()
+    return null
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+
+  act(() => {
+    root.render(
+      <Wrapper>
+        <Probe />
+      </Wrapper>
+    )
+  })
+
+  return {
+    result: () => latest,
+    unmount: () => act(() => root.unmount()),
+  }
+}
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve()
+      await sleep(0)
+    }
+  })
+}
+
+function expectOnlyEnvironmentAndSelectorCachesRefetched(queryFns: CacheQueryFns) {
+  expect(queryFns.environment).toHaveBeenCalledTimes(2)
+  expect(queryFns.primary).toHaveBeenCalledTimes(2)
+  expect(queryFns.dynamicDetails).toHaveBeenCalledTimes(2)
+  expect(queryFns.workflowDetails).toHaveBeenCalledTimes(2)
+  expect(queryFns.workflowReplacementOptions).toHaveBeenCalledTimes(2)
+  expect(queryFns.unrelated).toHaveBeenCalledTimes(1)
+}
+
+beforeEach(() => {
   vi.clearAllMocks()
+  mockRequestJson.mockResolvedValue({ success: true })
 })
+
+afterEach(() => vi.restoreAllMocks())
 
 describe('useWorkspaceEnvironment', () => {
   it('does not run without a workspace ID even when the caller enables it', () => {
@@ -58,5 +172,88 @@ describe('useWorkspaceEnvironment', () => {
 
     expect(mockFetchWorkspaceEnvironment).not.toHaveBeenCalled()
     unmount()
+  })
+})
+
+describe('environment mutation selector freshness', () => {
+  it('refetches every selector-bearing cache after a successful personal save', async () => {
+    const queryFns = createCacheQueryFns()
+    const view = renderMutationWithCaches(
+      useSavePersonalEnvironment,
+      environmentKeys.personal(),
+      queryFns
+    )
+    await flush()
+
+    await act(async () => {
+      await view.result().mutateAsync({ variables: { DOMAIN: 'new-value' } })
+    })
+    await flush()
+
+    expectOnlyEnvironmentAndSelectorCachesRefetched(queryFns)
+    view.unmount()
+  })
+
+  it.each([
+    {
+      name: 'upsert',
+      useMutationHook: useUpsertWorkspaceEnvironment,
+      variables: { workspaceId: 'workspace-1', variables: { DOMAIN: 'new-value' } },
+    },
+    {
+      name: 'removal',
+      useMutationHook: useRemoveWorkspaceEnvironment,
+      variables: { workspaceId: 'workspace-1', keys: ['DOMAIN'] },
+    },
+  ])('refetches every selector-bearing cache after a successful workspace $name', async (test) => {
+    const queryFns = createCacheQueryFns()
+    const view = renderMutationWithCaches(
+      test.useMutationHook,
+      environmentKeys.workspace('workspace-1'),
+      queryFns
+    )
+    await flush()
+
+    await act(async () => {
+      const mutation = view.result() as {
+        mutateAsync: (variables: unknown) => Promise<unknown>
+      }
+      await mutation.mutateAsync(test.variables)
+    })
+    await flush()
+
+    expectOnlyEnvironmentAndSelectorCachesRefetched(queryFns)
+    view.unmount()
+  })
+
+  it('does not invalidate selector caches after a failed environment mutation', async () => {
+    const requestError = new Error('save failed')
+    mockRequestJson.mockRejectedValueOnce(requestError)
+    const queryFns = createCacheQueryFns()
+    const view = renderMutationWithCaches(
+      useSavePersonalEnvironment,
+      environmentKeys.personal(),
+      queryFns
+    )
+    await flush()
+
+    let caught: unknown
+    await act(async () => {
+      try {
+        await view.result().mutateAsync({ variables: { DOMAIN: 'new-value' } })
+      } catch (error) {
+        caught = error
+      }
+    })
+    await flush()
+
+    expect(caught).toBe(requestError)
+    expect(queryFns.environment).toHaveBeenCalledTimes(2)
+    expect(queryFns.primary).toHaveBeenCalledTimes(1)
+    expect(queryFns.dynamicDetails).toHaveBeenCalledTimes(1)
+    expect(queryFns.workflowDetails).toHaveBeenCalledTimes(1)
+    expect(queryFns.workflowReplacementOptions).toHaveBeenCalledTimes(1)
+    expect(queryFns.unrelated).toHaveBeenCalledTimes(1)
+    view.unmount()
   })
 })

--- a/apps/sim/hooks/queries/environment.ts
+++ b/apps/sim/hooks/queries/environment.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/api/contracts'
 import type { WorkspaceEnvironmentData } from '@/lib/environment/api'
 import { fetchPersonalEnvironment, fetchWorkspaceEnvironment } from '@/lib/environment/api'
+import { invalidateEnvironmentDependentSelectorQueries } from '@/hooks/selectors/cache-invalidation'
 
 const logger = createLogger('EnvironmentQueries')
 
@@ -75,11 +76,12 @@ export function useSavePersonalEnvironment() {
 
       logger.info('Saved personal environment variables')
     },
-    onSettled: async () => {
+    onSettled: async (_data, error) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: environmentKeys.personal() }),
         queryClient.invalidateQueries({ queryKey: environmentKeys.workspaces() }),
       ])
+      if (!error) await invalidateEnvironmentDependentSelectorQueries(queryClient)
     },
   })
 }
@@ -103,10 +105,12 @@ export function useUpsertWorkspaceEnvironment() {
       logger.info(`Upserted workspace environment variables for workspace: ${workspaceId}`)
       return data
     },
-    onSettled: (_data, _error, variables) =>
-      queryClient.invalidateQueries({
+    onSettled: async (_data, error, variables) => {
+      await queryClient.invalidateQueries({
         queryKey: environmentKeys.workspace(variables.workspaceId),
-      }),
+      })
+      if (!error) await invalidateEnvironmentDependentSelectorQueries(queryClient)
+    },
   })
 }
 
@@ -129,9 +133,11 @@ export function useRemoveWorkspaceEnvironment() {
       logger.info(`Removed ${keys.length} workspace environment keys for workspace: ${workspaceId}`)
       return data
     },
-    onSettled: (_data, _error, variables) =>
-      queryClient.invalidateQueries({
+    onSettled: async (_data, error, variables) => {
+      await queryClient.invalidateQueries({
         queryKey: environmentKeys.workspace(variables.workspaceId),
-      }),
+      })
+      if (!error) await invalidateEnvironmentDependentSelectorQueries(queryClient)
+    },
   })
 }

--- a/apps/sim/hooks/queries/workflow-search-replace.test.ts
+++ b/apps/sim/hooks/queries/workflow-search-replace.test.ts
@@ -5,9 +5,12 @@ import { describe, expect, it } from 'vitest'
 import type { WorkflowSearchMatch } from '@/lib/workflows/search-replace/types'
 import {
   buildWorkflowSearchMcpToolReplacementOptions,
+  buildWorkflowSearchSelectorScope,
   flattenWorkflowSearchReplacementOptions,
   workflowSearchReplaceKeys,
 } from '@/hooks/queries/workflow-search-replace'
+import { createSelectorCacheScopeRegistry } from '@/hooks/selectors/context-resolution'
+import type { SelectorDefinition, SelectorKey } from '@/hooks/selectors/types'
 
 function createMcpToolMatch(serverId?: string): WorkflowSearchMatch {
   return {
@@ -106,6 +109,59 @@ describe('workflowSearchReplaceKeys', () => {
       'gmail.labels',
       '{"oauthCredential":"credential-1","workspaceId":"workspace-1"}',
     ])
+  })
+
+  it('uses opaque scoped identities for server-resolved selectors', () => {
+    const revisions = ['revision-a', 'revision-b'][Symbol.iterator]()
+    const registry = createSelectorCacheScopeRegistry(() => revisions.next().value ?? 'unexpected')
+    const definition = {
+      key: 'jira.projects' as SelectorKey,
+      serverResolvedContextFields: ['domain'],
+      getQueryKey: () => ['selectors', 'jira.projects', 'credential-1'],
+    } as SelectorDefinition
+
+    const first = buildWorkflowSearchSelectorScope(
+      definition,
+      {
+        workspaceId: 'workspace-1',
+        workflowId: 'workflow-1',
+        domain: 'WORKFLOW_SEARCH_PRIVATE_SENTINEL_A',
+      },
+      registry
+    )
+    const changed = buildWorkflowSearchSelectorScope(
+      definition,
+      {
+        workspaceId: 'workspace-1',
+        workflowId: 'workflow-1',
+        domain: 'WORKFLOW_SEARCH_PRIVATE_SENTINEL_B',
+      },
+      registry
+    )
+
+    expect(first.identity).not.toEqual(changed.identity)
+    expect(JSON.stringify(first.identity)).not.toContain('WORKFLOW_SEARCH_PRIVATE_SENTINEL')
+    expect(first.context).toMatchObject({
+      domain: 'WORKFLOW_SEARCH_PRIVATE_SENTINEL_A',
+      selectorCacheScope: 'revision-a',
+    })
+  })
+
+  it('retains serialized context identity for legacy selectors', () => {
+    const definition = {
+      key: 'gmail.labels' as SelectorKey,
+      getQueryKey: () => ['selectors', 'gmail.labels'],
+    } as SelectorDefinition
+    const context = { oauthCredential: 'credential-1', workspaceId: 'workspace-1' }
+
+    const scoped = buildWorkflowSearchSelectorScope(
+      definition,
+      context,
+      createSelectorCacheScopeRegistry(() => 'unused')
+    )
+
+    expect(scoped.context).toBe(context)
+    expect(scoped.identity).toBe('{"oauthCredential":"credential-1","workspaceId":"workspace-1"}')
   })
 })
 

--- a/apps/sim/hooks/queries/workflow-search-replace.ts
+++ b/apps/sim/hooks/queries/workflow-search-replace.ts
@@ -35,6 +35,7 @@ import {
   fetchOAuthCredentials,
 } from '@/hooks/queries/oauth/oauth-credentials'
 import { collectDuplicateNames, disambiguateLabelByFolder } from '@/hooks/queries/utils/folder-tree'
+import { environmentDependentSelectorKeys } from '@/hooks/selectors/cache-invalidation'
 import {
   createSelectorCacheScopeRegistry,
   type SelectorCacheScopeRegistry,
@@ -102,7 +103,7 @@ export const workflowSearchReplaceKeys = {
     [...workflowSearchReplaceKeys.replacementOptions(), 'mcp-tool', workspaceId ?? ''] as const,
   knowledgeReplacementOptions: (workspaceId?: string) =>
     [...workflowSearchReplaceKeys.replacementOptions(), 'knowledge', workspaceId ?? ''] as const,
-  selectorDetails: () => [...workflowSearchReplaceKeys.resourceDetails(), 'selector'] as const,
+  selectorDetails: () => environmentDependentSelectorKeys.workflowDetails,
   selectorDetail: (
     selectorKey?: string,
     contextIdentity?: string | readonly unknown[],
@@ -119,8 +120,7 @@ export const workflowSearchReplaceKeys = {
     contextIdentity?: string | readonly unknown[]
   ) =>
     [
-      ...workflowSearchReplaceKeys.replacementOptions(),
-      'selector',
+      ...environmentDependentSelectorKeys.workflowReplacementOptions,
       selectorKey ?? '',
       contextIdentity ?? '',
     ] as const,

--- a/apps/sim/hooks/queries/workflow-search-replace.ts
+++ b/apps/sim/hooks/queries/workflow-search-replace.ts
@@ -35,8 +35,19 @@ import {
   fetchOAuthCredentials,
 } from '@/hooks/queries/oauth/oauth-credentials'
 import { collectDuplicateNames, disambiguateLabelByFolder } from '@/hooks/queries/utils/folder-tree'
+import {
+  createSelectorCacheScopeRegistry,
+  type SelectorCacheScopeRegistry,
+  scopeServerResolvedSelectorContext,
+} from '@/hooks/selectors/context-resolution'
 import { getSelectorDefinition, loadAllSelectorOptions } from '@/hooks/selectors/registry'
-import type { SelectorKey, SelectorOption } from '@/hooks/selectors/types'
+import type {
+  SelectorContext,
+  SelectorDefinition,
+  SelectorKey,
+  SelectorOption,
+} from '@/hooks/selectors/types'
+import { getScopedSelectorQueryKey } from '@/hooks/selectors/use-selector-query'
 import type { WorkflowFolder } from '@/stores/folders/types'
 
 /** Stable identity while a folder list loads, so `select` isn't re-keyed on it. */
@@ -92,19 +103,26 @@ export const workflowSearchReplaceKeys = {
   knowledgeReplacementOptions: (workspaceId?: string) =>
     [...workflowSearchReplaceKeys.replacementOptions(), 'knowledge', workspaceId ?? ''] as const,
   selectorDetails: () => [...workflowSearchReplaceKeys.resourceDetails(), 'selector'] as const,
-  selectorDetail: (selectorKey?: string, contextKey?: string, value?: string) =>
+  selectorDetail: (
+    selectorKey?: string,
+    contextIdentity?: string | readonly unknown[],
+    value?: string
+  ) =>
     [
       ...workflowSearchReplaceKeys.selectorDetails(),
       selectorKey ?? '',
-      contextKey ?? '',
+      contextIdentity ?? '',
       value ?? '',
     ] as const,
-  selectorReplacementOptions: (selectorKey?: string, contextKey?: string) =>
+  selectorReplacementOptions: (
+    selectorKey?: string,
+    contextIdentity?: string | readonly unknown[]
+  ) =>
     [
       ...workflowSearchReplaceKeys.replacementOptions(),
       'selector',
       selectorKey ?? '',
-      contextKey ?? '',
+      contextIdentity ?? '',
     ] as const,
 }
 
@@ -137,6 +155,25 @@ function uniqueMatches(
 
 function selectorContextKey(match: WorkflowSearchMatch): string {
   return stableStringifyWorkflowSearchValue(match.resource?.selectorContext ?? {})
+}
+
+export function buildWorkflowSearchSelectorScope(
+  definition: SelectorDefinition,
+  context: SelectorContext,
+  registry: SelectorCacheScopeRegistry
+): { context: SelectorContext; identity: string | readonly unknown[] } {
+  if (!definition.serverResolvedContextFields?.length) {
+    return { context, identity: stableStringifyWorkflowSearchValue(context) }
+  }
+
+  const scopedContext = scopeServerResolvedSelectorContext(definition, context, registry)
+  return {
+    context: scopedContext,
+    identity: getScopedSelectorQueryKey(definition, {
+      key: definition.key,
+      context: scopedContext,
+    }),
+  }
 }
 
 function uniqueSelectorDetailMatches(matches: WorkflowSearchMatch[]): WorkflowSearchMatch[] {
@@ -378,18 +415,22 @@ export function useWorkflowSearchMcpToolDetails(
 
 export function useWorkflowSearchSelectorDetails(matches: WorkflowSearchMatch[]) {
   const selectorMatches = useMemo(() => uniqueSelectorDetailMatches(matches), [matches])
+  const cacheScopes = useMemo(() => createSelectorCacheScopeRegistry(), [])
 
   return useQueries({
     queries: selectorMatches.map((match) => {
       const selectorKey = match.resource?.selectorKey as SelectorKey
-      const context = match.resource?.selectorContext ?? {}
-      const contextKey = selectorContextKey(match)
       const definition = getSelectorDefinition(selectorKey)
+      const { context, identity } = buildWorkflowSearchSelectorScope(
+        definition,
+        match.resource?.selectorContext ?? {},
+        cacheScopes
+      )
       const queryArgs = { key: selectorKey, context, detailId: match.rawValue }
       const baseEnabled = definition.enabled ? definition.enabled(queryArgs) : true
 
       return {
-        queryKey: workflowSearchReplaceKeys.selectorDetail(selectorKey, contextKey, match.rawValue),
+        queryKey: workflowSearchReplaceKeys.selectorDetail(selectorKey, identity, match.rawValue),
         queryFn: async ({ signal }: { signal: AbortSignal }): Promise<SelectorOption | null> => {
           if (definition.fetchById) {
             return definition.fetchById({ ...queryArgs, signal })
@@ -652,18 +693,22 @@ export function useWorkflowSearchMcpToolReplacementOptions(
 
 export function useWorkflowSearchSelectorReplacementOptions(matches: WorkflowSearchMatch[]) {
   const selectorGroups = useMemo(() => uniqueSelectorOptionGroups(matches), [matches])
+  const cacheScopes = useMemo(() => createSelectorCacheScopeRegistry(), [])
 
   return useQueries({
     queries: selectorGroups.map((match) => {
       const selectorKey = match.resource?.selectorKey as SelectorKey
-      const context = match.resource?.selectorContext ?? {}
-      const contextKey = selectorContextKey(match)
       const definition = getSelectorDefinition(selectorKey)
+      const { context, identity } = buildWorkflowSearchSelectorScope(
+        definition,
+        match.resource?.selectorContext ?? {},
+        cacheScopes
+      )
       const queryArgs = { key: selectorKey, context }
       const baseEnabled = definition.enabled ? definition.enabled(queryArgs) : true
 
       return {
-        queryKey: workflowSearchReplaceKeys.selectorReplacementOptions(selectorKey, contextKey),
+        queryKey: workflowSearchReplaceKeys.selectorReplacementOptions(selectorKey, identity),
         queryFn: ({ signal }: { signal: AbortSignal }) =>
           loadAllSelectorOptions(definition, { ...queryArgs, signal }),
         enabled: Boolean(selectorKey && baseEnabled),

--- a/apps/sim/hooks/selectors/cache-invalidation.ts
+++ b/apps/sim/hooks/selectors/cache-invalidation.ts
@@ -1,0 +1,29 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+/**
+ * Browser cache prefixes whose results can depend on server-resolved selector context.
+ * Keep the factories and invalidation path on the same constants so a new selector cache
+ * cannot silently miss environment-change invalidation.
+ */
+export const environmentDependentSelectorKeys = {
+  primary: ['selectors'] as const,
+  dynamicDetails: ['dynamic-subblock-options', 'detail'] as const,
+  workflowDetails: ['workflow-search-replace', 'resource-detail', 'selector'] as const,
+  workflowReplacementOptions: [
+    'workflow-search-replace',
+    'replacement-options',
+    'selector',
+  ] as const,
+}
+
+/** Refetch mounted selector consumers after an environment value changes behind an opaque key. */
+export async function invalidateEnvironmentDependentSelectorQueries(queryClient: QueryClient) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: environmentDependentSelectorKeys.primary }),
+    queryClient.invalidateQueries({ queryKey: environmentDependentSelectorKeys.dynamicDetails }),
+    queryClient.invalidateQueries({ queryKey: environmentDependentSelectorKeys.workflowDetails }),
+    queryClient.invalidateQueries({
+      queryKey: environmentDependentSelectorKeys.workflowReplacementOptions,
+    }),
+  ])
+}

--- a/apps/sim/hooks/selectors/context-resolution.test.ts
+++ b/apps/sim/hooks/selectors/context-resolution.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import type { CanonicalIndex } from '@/lib/workflows/subblocks/visibility'
+import {
+  applySelectorDependenciesToContext,
+  resolveSelectorDependencyValues,
+} from '@/hooks/selectors/context-resolution'
+import type { SelectorContext } from '@/hooks/selectors/types'
+
+const canonicalIndex: CanonicalIndex = {
+  groupsById: {},
+  canonicalIdBySubBlockId: {
+    domainInput: 'domain',
+    tokenInput: 'oauthCredential',
+  },
+}
+
+describe('selector dependency context resolution', () => {
+  it('preserves exact references for opted-in canonical fields', () => {
+    const result = resolveSelectorDependencyValues({
+      dependencyValues: { domainInput: '{{SHARED_DOMAIN}}' },
+      personalEnvironment: { SHARED_DOMAIN: { value: 'personal.example.com' } },
+      canonicalIndex,
+      serverResolvedContextFields: new Set<keyof SelectorContext>(['domain']),
+    })
+
+    expect(result).toEqual({ domainInput: '{{SHARED_DOMAIN}}' })
+  })
+
+  it('retains personal browser resolution for non-opted fields', () => {
+    const result = resolveSelectorDependencyValues({
+      dependencyValues: { tokenInput: '{{PERSONAL_TOKEN}}' },
+      personalEnvironment: { PERSONAL_TOKEN: { value: 'personal-plaintext' } },
+      canonicalIndex,
+      serverResolvedContextFields: new Set(),
+    })
+
+    expect(result).toEqual({ tokenInput: 'personal-plaintext' })
+  })
+
+  it('keeps embedded interpolation unchanged for opted-in fields', () => {
+    const result = resolveSelectorDependencyValues({
+      dependencyValues: { domainInput: 'https://{{DOMAIN}}' },
+      personalEnvironment: { DOMAIN: { value: 'plaintext.example.com' } },
+      canonicalIndex,
+      serverResolvedContextFields: new Set<keyof SelectorContext>(['domain']),
+    })
+
+    expect(result).toEqual({ domainInput: 'https://{{DOMAIN}}' })
+  })
+
+  it('maps preserved references into context and excludes runtime block outputs', () => {
+    const context = applySelectorDependenciesToContext({
+      context: { workflowId: 'workflow-1' },
+      dependencyValues: {
+        domainInput: '{{SHARED_DOMAIN}}',
+        tokenInput: '<runtime.block.output>',
+      },
+      canonicalIndex,
+    })
+
+    expect(context).toEqual({ workflowId: 'workflow-1', domain: '{{SHARED_DOMAIN}}' })
+  })
+})

--- a/apps/sim/hooks/selectors/context-resolution.test.ts
+++ b/apps/sim/hooks/selectors/context-resolution.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from 'vitest'
 import type { CanonicalIndex } from '@/lib/workflows/subblocks/visibility'
 import {
   applySelectorDependenciesToContext,
+  createSelectorCacheScopeRegistry,
   resolveSelectorDependencyValues,
+  scopeServerResolvedSelectorContext,
 } from '@/hooks/selectors/context-resolution'
-import type { SelectorContext } from '@/hooks/selectors/types'
+import type { SelectorContext, SelectorDefinition, SelectorKey } from '@/hooks/selectors/types'
 
 const canonicalIndex: CanonicalIndex = {
   groupsById: {},
@@ -62,5 +64,43 @@ describe('selector dependency context resolution', () => {
     })
 
     expect(context).toEqual({ workflowId: 'workflow-1', domain: '{{SHARED_DOMAIN}}' })
+  })
+
+  it('assigns stable opaque revisions without exposing raw dependency values', () => {
+    const revisions = ['revision-a', 'revision-b'][Symbol.iterator]()
+    const registry = createSelectorCacheScopeRegistry(() => revisions.next().value ?? 'unexpected')
+    const definition = {
+      key: 'jira.projects' as SelectorKey,
+      serverResolvedContextFields: ['domain'],
+    } as SelectorDefinition
+
+    const first = scopeServerResolvedSelectorContext(
+      definition,
+      { domain: 'private-a.example.com' },
+      registry
+    )
+    const repeated = scopeServerResolvedSelectorContext(
+      definition,
+      { domain: 'private-a.example.com' },
+      registry
+    )
+    const changed = scopeServerResolvedSelectorContext(
+      definition,
+      { domain: 'private-b.example.com' },
+      registry
+    )
+
+    expect(first.selectorCacheScope).toBe('revision-a')
+    expect(repeated.selectorCacheScope).toBe('revision-a')
+    expect(changed.selectorCacheScope).toBe('revision-b')
+    expect(first.selectorCacheScope).not.toContain('private-a.example.com')
+  })
+
+  it('leaves legacy selector contexts unchanged', () => {
+    const registry = createSelectorCacheScopeRegistry(() => 'unused')
+    const definition = { key: 'gmail.labels' as SelectorKey } as SelectorDefinition
+    const context = { oauthCredential: 'credential-1' }
+
+    expect(scopeServerResolvedSelectorContext(definition, context, registry)).toBe(context)
   })
 })

--- a/apps/sim/hooks/selectors/context-resolution.ts
+++ b/apps/sim/hooks/selectors/context-resolution.ts
@@ -1,0 +1,60 @@
+import { SELECTOR_CONTEXT_FIELDS } from '@/lib/workflows/subblocks/context'
+import type { CanonicalIndex } from '@/lib/workflows/subblocks/visibility'
+import { extractEnvVarName, isEnvVarReference, isReference } from '@/executor/constants'
+import type { SelectorContext } from '@/hooks/selectors/types'
+
+interface PersonalEnvironmentValue {
+  value?: string
+}
+
+/** Preserves opted-in environment references and keeps legacy personal resolution elsewhere. */
+export function resolveSelectorDependencyValues(input: {
+  dependencyValues: Record<string, unknown>
+  personalEnvironment: Record<string, PersonalEnvironmentValue>
+  canonicalIndex: CanonicalIndex
+  serverResolvedContextFields: ReadonlySet<keyof SelectorContext>
+}): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input.dependencyValues)) {
+    if (value === null || value === undefined) {
+      resolved[key] = value
+      continue
+    }
+
+    const stringValue = String(value)
+    if (!isEnvVarReference(stringValue)) {
+      resolved[key] = value
+      continue
+    }
+
+    const canonicalParamId = input.canonicalIndex.canonicalIdBySubBlockId[key] ?? key
+    if (input.serverResolvedContextFields.has(canonicalParamId as keyof SelectorContext)) {
+      resolved[key] = stringValue
+      continue
+    }
+
+    const variableName = extractEnvVarName(stringValue)
+    resolved[key] = input.personalEnvironment[variableName]?.value || undefined
+  }
+  return resolved
+}
+
+/** Adds eligible dependencies to selector context while excluding runtime block references. */
+export function applySelectorDependenciesToContext(input: {
+  context: SelectorContext
+  dependencyValues: Record<string, unknown>
+  canonicalIndex: CanonicalIndex
+}): SelectorContext {
+  for (const [dependencyKey, value] of Object.entries(input.dependencyValues)) {
+    if (value === null || value === undefined) continue
+    const stringValue = String(value)
+    if (!stringValue || isReference(stringValue)) continue
+
+    const canonicalParamId =
+      input.canonicalIndex.canonicalIdBySubBlockId[dependencyKey] ?? dependencyKey
+    if (SELECTOR_CONTEXT_FIELDS.has(canonicalParamId as keyof SelectorContext)) {
+      input.context[canonicalParamId as keyof SelectorContext] = stringValue
+    }
+  }
+  return input.context
+}

--- a/apps/sim/hooks/selectors/context-resolution.ts
+++ b/apps/sim/hooks/selectors/context-resolution.ts
@@ -1,10 +1,56 @@
+import { generateShortId } from '@sim/utils/id'
 import { SELECTOR_CONTEXT_FIELDS } from '@/lib/workflows/subblocks/context'
 import type { CanonicalIndex } from '@/lib/workflows/subblocks/visibility'
 import { extractEnvVarName, isEnvVarReference, isReference } from '@/executor/constants'
-import type { SelectorContext } from '@/hooks/selectors/types'
+import type { SelectorContext, SelectorDefinition } from '@/hooks/selectors/types'
 
 interface PersonalEnvironmentValue {
   value?: string
+}
+
+export interface SelectorCacheScopeRegistry {
+  getScope(definition: SelectorDefinition, context: SelectorContext): string | undefined
+}
+
+/**
+ * Keeps raw dependency identity private while assigning stable opaque cache revisions.
+ *
+ * The raw signature exists only inside this component-lifetime registry. It is never returned,
+ * hashed into a key, or exposed to React Query. Repeated contexts reuse a revision; changing any
+ * server-resolved dependency receives a new one.
+ */
+export function createSelectorCacheScopeRegistry(
+  createScope: () => string = generateShortId
+): SelectorCacheScopeRegistry {
+  const scopes = new Map<string, string>()
+
+  return {
+    getScope(definition, context) {
+      const fields = definition.serverResolvedContextFields
+      if (!fields?.length) return undefined
+
+      const privateIdentity = JSON.stringify([
+        definition.key,
+        ...fields.map((field) => [field, context[field] ?? null]),
+      ])
+      const existing = scopes.get(privateIdentity)
+      if (existing) return existing
+
+      const scope = createScope()
+      scopes.set(privateIdentity, scope)
+      return scope
+    },
+  }
+}
+
+/** Adds an opaque revision only to selectors that opt into server-resolved context. */
+export function scopeServerResolvedSelectorContext(
+  definition: SelectorDefinition,
+  context: SelectorContext,
+  registry: SelectorCacheScopeRegistry
+): SelectorContext {
+  const selectorCacheScope = registry.getScope(definition, context)
+  return selectorCacheScope ? { ...context, selectorCacheScope } : context
 }
 
 /** Preserves opted-in environment references and keeps legacy personal resolution elsewhere. */

--- a/apps/sim/hooks/selectors/query-keys.ts
+++ b/apps/sim/hooks/selectors/query-keys.ts
@@ -1,5 +1,7 @@
+import { environmentDependentSelectorKeys } from '@/hooks/selectors/cache-invalidation'
+
 export const selectorKeys = {
-  all: ['selectors'] as const,
+  all: environmentDependentSelectorKeys.primary,
   simWorkflowsPrefix: (workspaceId: string) =>
     [...selectorKeys.all, 'sim.workflows', workspaceId] as const,
   simWorkflows: (workspaceId: string, excludeWorkflowId?: string) =>

--- a/apps/sim/hooks/selectors/selector-cache-scope.test.ts
+++ b/apps/sim/hooks/selectors/selector-cache-scope.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment node
+ */
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import type { SelectorContext, SelectorDefinition } from '@/hooks/selectors/types'
+import { getScopedSelectorQueryKey } from '@/hooks/selectors/use-selector-query'
+
+const definition: SelectorDefinition = {
+  key: 'jira.projects',
+  serverResolvedContextFields: ['domain'],
+  getQueryKey: () => ['selectors', 'synthetic.serverResolved'],
+  fetchList: async () => [],
+}
+
+function scopedKey(context: SelectorContext) {
+  return getScopedSelectorQueryKey(definition, {
+    key: definition.key,
+    context,
+  })
+}
+
+describe('server-resolved selector cache scope', () => {
+  it('keeps dependency revisions in separate real QueryClient entries without keying plaintext', () => {
+    const queryClient = new QueryClient()
+    const firstKey = scopedKey({
+      domain: 'first-secret.example.com',
+      workspaceId: 'workspace-1',
+      workflowId: 'workflow-1',
+      selectorCacheScope: 'revision-1',
+    })
+    const secondKey = scopedKey({
+      domain: 'second-secret.example.com',
+      workspaceId: 'workspace-1',
+      workflowId: 'workflow-1',
+      selectorCacheScope: 'revision-2',
+    })
+
+    queryClient.setQueryData(firstKey, ['first-result'])
+    queryClient.setQueryData(secondKey, ['second-result'])
+
+    expect(queryClient.getQueryData(firstKey)).toEqual(['first-result'])
+    expect(queryClient.getQueryData(secondKey)).toEqual(['second-result'])
+    expect(firstKey).not.toEqual(secondKey)
+    expect(JSON.stringify([firstKey, secondKey])).not.toContain('first-secret.example.com')
+    expect(JSON.stringify([firstKey, secondKey])).not.toContain('second-secret.example.com')
+  })
+
+  it('partitions identical references by workspace, workflow, and opaque dependency revision', () => {
+    const firstKey = scopedKey({
+      domain: '{{DOMAIN}}',
+      workspaceId: 'workspace-1',
+      workflowId: 'workflow-1',
+      selectorCacheScope: 'revision-1',
+    })
+    const otherWorkflowKey = scopedKey({
+      domain: '{{DOMAIN}}',
+      workspaceId: 'workspace-1',
+      workflowId: 'workflow-2',
+      selectorCacheScope: 'revision-1',
+    })
+    const otherWorkspaceKey = scopedKey({
+      domain: '{{DOMAIN}}',
+      workspaceId: 'workspace-2',
+      workflowId: 'workflow-1',
+      selectorCacheScope: 'revision-1',
+    })
+    const changedDependencyKey = scopedKey({
+      domain: '{{DOMAIN}}',
+      workspaceId: 'workspace-1',
+      workflowId: 'workflow-1',
+      selectorCacheScope: 'revision-2',
+    })
+
+    expect(
+      new Set(
+        [firstKey, otherWorkflowKey, otherWorkspaceKey, changedDependencyKey].map(JSON.stringify)
+      )
+    ).toHaveLength(4)
+  })
+
+  it('leaves non-opted selectors on their existing query keys', () => {
+    const legacyDefinition: SelectorDefinition = {
+      key: 'jira.projects',
+      getQueryKey: () => ['selectors', 'legacy'],
+      fetchList: async () => [],
+    }
+
+    expect(
+      getScopedSelectorQueryKey(legacyDefinition, {
+        key: legacyDefinition.key,
+        context: {
+          workspaceId: 'workspace-1',
+          workflowId: 'workflow-1',
+          selectorCacheScope: 'revision-1',
+        },
+      })
+    ).toEqual(['selectors', 'legacy'])
+  })
+})

--- a/apps/sim/hooks/selectors/types.ts
+++ b/apps/sim/hooks/selectors/types.ts
@@ -107,6 +107,8 @@ export interface SelectorOption {
 export interface SelectorContext {
   workspaceId?: string
   workflowId?: string
+  /** Browser-only opaque cache partition; never sent over the wire. */
+  selectorCacheScope?: string
   oauthCredential?: string
   serviceId?: string
   domain?: string
@@ -195,6 +197,13 @@ interface SelectorPageArgs extends SelectorQueryArgs {
 export interface SelectorDefinition {
   key: SelectorKey
   contracts?: readonly AnyApiRouteContract[]
+  /**
+   * Context fields whose environment references must remain opaque in the browser.
+   * The matching selector route resolves them only after authorizing the workflow
+   * (and credential, when applicable), so shared-secret plaintext never enters
+   * React state, query keys, or request payloads.
+   */
+  serverResolvedContextFields?: readonly (keyof SelectorContext)[]
   getQueryKey: (args: SelectorQueryArgs) => QueryKey
   /**
    * Loads the full option list in a single call. Required unless `fetchPage` is

--- a/apps/sim/hooks/selectors/use-selector-query.ts
+++ b/apps/sim/hooks/selectors/use-selector-query.ts
@@ -5,6 +5,7 @@ import { extractEnvVarName, isEnvVarReference, isReference } from '@/executor/co
 import { usePersonalEnvironment } from '@/hooks/queries/environment'
 import { getSelectorDefinition, mergeOption } from '@/hooks/selectors/registry'
 import type {
+  SelectorDefinition,
   SelectorKey,
   SelectorOption,
   SelectorPage,
@@ -44,6 +45,19 @@ const logger = createLogger('SelectorQuery')
 
 const EMPTY_PAGE: SelectorPage = { items: [], nextCursor: undefined }
 
+/** Partitions authorization-sensitive selector caches without keying on secret values. */
+export function getScopedSelectorQueryKey(definition: SelectorDefinition, args: SelectorQueryArgs) {
+  const baseKey = definition.getQueryKey(args)
+  if (!definition.serverResolvedContextFields?.length) return baseKey
+  return [
+    ...baseKey,
+    'authorized-scope',
+    args.context.workspaceId ?? 'none',
+    args.context.workflowId ?? 'none',
+    args.context.selectorCacheScope ?? 'none',
+  ]
+}
+
 /**
  * Safety bound on the background auto-drain. Real dropdowns settle in a handful
  * of pages; this only trips for pathological result sets and prevents an
@@ -79,7 +93,7 @@ export function useSelectorOptions(
   const supportsPagination = Boolean(definition.fetchPage)
 
   const flatQuery = useQuery<SelectorOption[]>({
-    queryKey: definition.getQueryKey(queryArgs),
+    queryKey: getScopedSelectorQueryKey(definition, queryArgs),
     queryFn: ({ signal }) =>
       definition.fetchList?.({ ...queryArgs, signal }) ?? Promise.resolve([]),
     enabled: !supportsPagination && isEnabled,
@@ -87,7 +101,7 @@ export function useSelectorOptions(
   })
 
   const pagedQuery = useInfiniteQuery<SelectorPage>({
-    queryKey: [...definition.getQueryKey(queryArgs), 'paged'],
+    queryKey: [...getScopedSelectorQueryKey(definition, queryArgs), 'paged'],
     queryFn: ({ pageParam, signal }) => {
       if (!definition.fetchPage) return Promise.resolve(EMPTY_PAGE)
       return definition.fetchPage({
@@ -201,7 +215,11 @@ export function useSelectorOptionDetail(
     canResolveDetail
 
   const query = useQuery<SelectorOption | null>({
-    queryKey: [...definition.getQueryKey(queryArgs), 'detail', resolvedDetailId ?? 'none'],
+    queryKey: [
+      ...getScopedSelectorQueryKey(definition, queryArgs),
+      'detail',
+      resolvedDetailId ?? 'none',
+    ],
     queryFn: ({ signal }) => definition.fetchById!({ ...queryArgs, signal }),
     enabled,
     staleTime: definition.staleTime ?? DEFAULT_SELECTOR_DETAIL_STALE_TIME,
@@ -242,7 +260,7 @@ export function useSelectorOptionDetails(
       const queryArgs: SelectorQueryArgs = { key, context: args.context, detailId }
       const canResolveDetail = definition.fetchById !== undefined
       return {
-        queryKey: [...definition.getQueryKey(queryArgs), 'detail', detailId],
+        queryKey: [...getScopedSelectorQueryKey(definition, queryArgs), 'detail', detailId],
         queryFn: ({ signal }: { signal: AbortSignal }) =>
           definition.fetchById!({ ...queryArgs, signal }),
         enabled:

--- a/apps/sim/hooks/use-selector-display-name.ts
+++ b/apps/sim/hooks/use-selector-display-name.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { generateShortId } from '@sim/utils/id'
 import { summarizeNames } from '@/lib/workflows/subblocks/display'
 import type { SubBlockConfig } from '@/blocks/types'
 import { resolveSelectorForSubBlock } from '@/hooks/selectors/resolution'
@@ -106,7 +107,8 @@ export function useSelectorDisplayName({
   const context = resolution?.context ?? {}
   const enabled = Boolean(key && hasSelection)
   const resolvedKey: SelectorKey = (key ?? 'slack.channels') as SelectorKey
-  const resolvedContext = enabled ? context : {}
+  const selectorCacheScope = useMemo(() => generateShortId(), [resolution])
+  const resolvedContext = enabled ? { ...context, selectorCacheScope } : {}
 
   const { data: options = [], isFetching: listLoading } = useSelectorOptions(resolvedKey, {
     context: resolvedContext,

--- a/apps/sim/lib/api/contracts/selectors/cloudwatch.ts
+++ b/apps/sim/lib/api/contracts/selectors/cloudwatch.ts
@@ -64,6 +64,11 @@ export const cloudwatchLogStreamsSelectorContract = definePostSelector(
     .passthrough()
 )
 
+export const cloudwatchSelectorContractsByPath = {
+  '/api/tools/cloudwatch/describe-log-groups': cloudwatchLogGroupsSelectorContract,
+  '/api/tools/cloudwatch/describe-log-streams': cloudwatchLogStreamsSelectorContract,
+} as const
+
 export type CloudwatchLogGroupsSelectorResponse = ContractJsonResponse<
   typeof cloudwatchLogGroupsSelectorContract
 >

--- a/apps/sim/lib/api/contracts/selectors/confluence.ts
+++ b/apps/sim/lib/api/contracts/selectors/confluence.ts
@@ -399,6 +399,12 @@ export const confluencePageSelectorContract = definePostSelector(
   z.object({ id: z.string(), title: z.string() }).passthrough()
 )
 
+export const confluenceSelectorContractsByPath = {
+  '/api/tools/confluence/selector-spaces': confluenceSpacesSelectorContract,
+  '/api/tools/confluence/pages': confluencePagesSelectorContract,
+  '/api/tools/confluence/page': confluencePageSelectorContract,
+} as const
+
 export const confluenceUpdatePageContract = defineConfluencePutContract(
   '/api/tools/confluence/page',
   confluenceUpdatePageBodySchema

--- a/apps/sim/lib/api/contracts/selectors/index.ts
+++ b/apps/sim/lib/api/contracts/selectors/index.ts
@@ -25,15 +25,8 @@ import {
   clickupSpacesSelectorContract,
   clickupWorkspacesSelectorContract,
 } from '@/lib/api/contracts/selectors/clickup'
-import {
-  cloudwatchLogGroupsSelectorContract,
-  cloudwatchLogStreamsSelectorContract,
-} from '@/lib/api/contracts/selectors/cloudwatch'
-import {
-  confluencePageSelectorContract,
-  confluencePagesSelectorContract,
-  confluenceSpacesSelectorContract,
-} from '@/lib/api/contracts/selectors/confluence'
+import { cloudwatchSelectorContractsByPath } from '@/lib/api/contracts/selectors/cloudwatch'
+import { confluenceSelectorContractsByPath } from '@/lib/api/contracts/selectors/confluence'
 import {
   gmailLabelSelectorContract,
   gmailLabelsSelectorContract,
@@ -168,7 +161,7 @@ export const selectorContractsByPath = {
   '/api/tools/clickup/spaces': clickupSpacesSelectorContract,
   '/api/tools/clickup/folders': clickupFoldersSelectorContract,
   '/api/tools/clickup/lists': clickupListsSelectorContract,
-  '/api/tools/confluence/selector-spaces': confluenceSpacesSelectorContract,
+  ...confluenceSelectorContractsByPath,
   '/api/tools/jsm/selector-servicedesks': jsmServiceDesksSelectorContract,
   '/api/tools/jsm/selector-requesttypes': jsmRequestTypesSelectorContract,
   '/api/tools/google_tasks/task-lists': googleTasksTaskListsSelectorContract,
@@ -215,8 +208,6 @@ export const selectorContractsByPath = {
   '/api/tools/netsuite/objects': netsuiteObjectsSelectorContract,
   '/api/tools/linear/teams': linearTeamsSelectorContract,
   '/api/tools/linear/projects': linearProjectsSelectorContract,
-  '/api/tools/confluence/pages': confluencePagesSelectorContract,
-  '/api/tools/confluence/page': confluencePageSelectorContract,
   '/api/tools/onedrive/files': onedriveFilesSelectorContract,
   '/api/tools/onedrive/folder': onedriveFolderSelectorContract,
   '/api/tools/onedrive/folders': onedriveFoldersSelectorContract,
@@ -231,8 +222,7 @@ export const selectorContractsByPath = {
   '/api/tools/webflow/sites': webflowSitesSelectorContract,
   '/api/tools/webflow/collections': webflowCollectionsSelectorContract,
   '/api/tools/webflow/items': webflowItemsSelectorContract,
-  '/api/tools/cloudwatch/describe-log-groups': cloudwatchLogGroupsSelectorContract,
-  '/api/tools/cloudwatch/describe-log-streams': cloudwatchLogStreamsSelectorContract,
+  ...cloudwatchSelectorContractsByPath,
 } as const
 
 export type SelectorContractPath = keyof typeof selectorContractsByPath

--- a/apps/sim/lib/atlassian/discovery.test.ts
+++ b/apps/sim/lib/atlassian/discovery.test.ts
@@ -123,6 +123,19 @@ describe('resolveAtlassianCloudId', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('omits provider response bodies from selector discovery errors', async () => {
+    fetchMock.mockResolvedValue(failure(403, { marker: 'provider-body-secret-marker' }))
+
+    const error = await resolveAtlassianCloudId(
+      options({
+        retryOptions: { ...FAST, omitResponseBodyFromErrors: true },
+      })
+    ).catch((caught) => caught as Error)
+
+    expect(error.message).toBe('Failed to fetch Jira accessible resources: 403')
+    expect(error.message).not.toContain('provider-body-secret-marker')
+  })
+
   it('does not pin a failure in the cache', async () => {
     fetchMock.mockResolvedValueOnce(failure(403, { message: 'nope' }))
     await expect(resolveAtlassianCloudId(options({ retryOptions: FAST }))).rejects.toThrow()

--- a/apps/sim/lib/atlassian/discovery.test.ts
+++ b/apps/sim/lib/atlassian/discovery.test.ts
@@ -136,6 +136,27 @@ describe('resolveAtlassianCloudId', () => {
     expect(error.message).not.toContain('provider-body-secret-marker')
   })
 
+  it('omits malformed successful response bodies from selector discovery errors', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: vi
+        .fn()
+        .mockRejectedValue(new SyntaxError('invalid provider-body-secret-marker JSON payload')),
+    })
+
+    const error = await resolveAtlassianCloudId(
+      options({
+        retryOptions: { ...FAST, omitResponseBodyFromErrors: true },
+      })
+    ).catch((caught) => caught as Error)
+
+    expect(error.message).toBe('Failed to fetch Jira accessible resources: invalid JSON response')
+    expect(error.message).not.toContain('provider-body-secret-marker')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('does not pin a failure in the cache', async () => {
     fetchMock.mockResolvedValueOnce(failure(403, { message: 'nope' }))
     await expect(resolveAtlassianCloudId(options({ retryOptions: FAST }))).rejects.toThrow()

--- a/apps/sim/lib/atlassian/discovery.test.ts
+++ b/apps/sim/lib/atlassian/discovery.test.ts
@@ -124,7 +124,14 @@ describe('resolveAtlassianCloudId', () => {
   })
 
   it('omits provider response bodies from selector discovery errors', async () => {
-    fetchMock.mockResolvedValue(failure(403, { marker: 'provider-body-secret-marker' }))
+    const cancel = vi.fn().mockResolvedValue(undefined)
+    fetchMock.mockResolvedValue(
+      createMockResponse({
+        status: 403,
+        json: { marker: 'provider-body-secret-marker' },
+        body: { cancel },
+      })
+    )
 
     const error = await resolveAtlassianCloudId(
       options({
@@ -134,6 +141,7 @@ describe('resolveAtlassianCloudId', () => {
 
     expect(error.message).toBe('Failed to fetch Jira accessible resources: 403')
     expect(error.message).not.toContain('provider-body-secret-marker')
+    expect(cancel).toHaveBeenCalledOnce()
   })
 
   it('omits malformed successful response bodies from selector discovery errors', async () => {

--- a/apps/sim/lib/atlassian/discovery.ts
+++ b/apps/sim/lib/atlassian/discovery.ts
@@ -172,7 +172,14 @@ export function fetchAtlassianDiscoveryJson<T>(
         throw error
       }
 
-      return (await response.json()) as T
+      try {
+        return (await response.json()) as T
+      } catch (error) {
+        if (omitResponseBodyFromErrors) {
+          throw new Error(`${failureLabel}: invalid JSON response`)
+        }
+        throw error
+      }
     },
     { ...ATLASSIAN_DISCOVERY_RETRY_OPTIONS, ...effectiveRetryOptions }
   )

--- a/apps/sim/lib/atlassian/discovery.ts
+++ b/apps/sim/lib/atlassian/discovery.ts
@@ -161,6 +161,13 @@ export function fetchAtlassianDiscoveryJson<T>(
       })
 
       if (!response.ok) {
+        if (omitResponseBodyFromErrors) {
+          try {
+            await response.body?.cancel()
+          } catch {
+            // Releasing an unread provider body is best-effort; the public error stays sanitized.
+          }
+        }
         const errorDetail = omitResponseBodyFromErrors
           ? ''
           : ` - ${(await response.text()) || response.statusText}`

--- a/apps/sim/lib/atlassian/discovery.ts
+++ b/apps/sim/lib/atlassian/discovery.ts
@@ -102,12 +102,20 @@ interface AccessibleResource {
   url: string
 }
 
+export interface AtlassianDiscoveryRetryOptions extends RetryOptions {
+  /**
+   * Selector routes set this to avoid putting provider-controlled response
+   * bodies into thrown errors, which the shared retry helper intentionally logs.
+   */
+  omitResponseBodyFromErrors?: boolean
+}
+
 interface ResolveAtlassianCloudIdOptions {
   domain: string
   accessToken: string
   /** Product name woven into the failure messages, e.g. `Jira` or `Confluence`. */
   product: string
-  retryOptions?: RetryOptions
+  retryOptions?: AtlassianDiscoveryRetryOptions
 }
 
 const cloudIdCache = createAtlassianDiscoveryCache()
@@ -141,8 +149,9 @@ export function fetchAtlassianDiscoveryJson<T>(
   url: string,
   headers: Record<string, string>,
   failureLabel: string,
-  retryOptions?: RetryOptions
+  retryOptions?: AtlassianDiscoveryRetryOptions
 ): Promise<T> {
+  const { omitResponseBodyFromErrors = false, ...effectiveRetryOptions } = retryOptions ?? {}
   return retryWithExponentialBackoff(
     async () => {
       const response = await fetch(url, {
@@ -152,10 +161,10 @@ export function fetchAtlassianDiscoveryJson<T>(
       })
 
       if (!response.ok) {
-        const errorText = await response.text()
-        const error: HTTPError = new Error(
-          `${failureLabel}: ${response.status} - ${errorText || response.statusText}`
-        )
+        const errorDetail = omitResponseBodyFromErrors
+          ? ''
+          : ` - ${(await response.text()) || response.statusText}`
+        const error: HTTPError = new Error(`${failureLabel}: ${response.status}${errorDetail}`)
         error.status = response.status
         error.statusText = response.statusText
         const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'))
@@ -165,14 +174,14 @@ export function fetchAtlassianDiscoveryJson<T>(
 
       return (await response.json()) as T
     },
-    { ...ATLASSIAN_DISCOVERY_RETRY_OPTIONS, ...retryOptions }
+    { ...ATLASSIAN_DISCOVERY_RETRY_OPTIONS, ...effectiveRetryOptions }
   )
 }
 
 function fetchAccessibleResources(
   accessToken: string,
   product: string,
-  retryOptions: RetryOptions | undefined
+  retryOptions: AtlassianDiscoveryRetryOptions | undefined
 ): Promise<AccessibleResource[]> {
   return fetchAtlassianDiscoveryJson<AccessibleResource[]>(
     ACCESSIBLE_RESOURCES_URL,
@@ -232,7 +241,10 @@ export async function resolveAtlassianCloudId(
   options: ResolveAtlassianCloudIdOptions
 ): Promise<string> {
   const { domain, accessToken, product, retryOptions } = options
-  const key = atlassianDiscoveryKey(normalizeAtlassianSiteUrl(domain), accessToken)
+  const errorMode = retryOptions?.omitResponseBodyFromErrors
+    ? 'sanitized-errors'
+    : 'standard-errors'
+  const key = `${atlassianDiscoveryKey(normalizeAtlassianSiteUrl(domain), accessToken)}:${errorMode}`
 
   return cloudIdCache.resolve(key, async () =>
     selectAtlassianCloudId(

--- a/apps/sim/lib/selectors/application/atlassian-credential.test.ts
+++ b/apps/sim/lib/selectors/application/atlassian-credential.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getServiceAccountSecret: vi.fn(),
+  providerMatches: vi.fn(),
+  refreshToken: vi.fn(),
+  resolveAccount: vi.fn(),
+}))
+
+vi.mock('@/lib/oauth/credential-service', () => ({
+  getAtlassianServiceAccountSecret: mocks.getServiceAccountSecret,
+  refreshAccessTokenIfNeeded: mocks.refreshToken,
+  resolveOAuthAccountId: mocks.resolveAccount,
+}))
+vi.mock('@/lib/selectors/application/credential-provider', () => ({
+  selectorCredentialMatchesService: mocks.providerMatches,
+}))
+
+import { resolveAtlassianSelectorCredential } from '@/lib/selectors/application/atlassian-credential'
+
+describe('resolveAtlassianSelectorCredential', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.providerMatches.mockResolvedValue(true)
+    mocks.resolveAccount.mockResolvedValue({
+      providerId: 'atlassian',
+      credentialId: 'credential-1',
+    })
+    mocks.refreshToken.mockResolvedValue('oauth-access-token')
+  })
+
+  it('binds a credential to the requested integration before reading or refreshing secrets', async () => {
+    mocks.providerMatches.mockResolvedValue(false)
+
+    const result = await resolveAtlassianSelectorCredential({
+      credentialId: 'credential-1',
+      credentialOwnerUserId: 'owner-1',
+      requestId: 'request-1',
+      serviceId: 'jira',
+    })
+
+    expect(result).toBeNull()
+    expect(mocks.providerMatches).toHaveBeenCalledWith({
+      credentialId: 'credential-1',
+      credentialOwnerUserId: 'owner-1',
+      serviceId: 'jira',
+    })
+    expect(mocks.resolveAccount).not.toHaveBeenCalled()
+    expect(mocks.getServiceAccountSecret).not.toHaveBeenCalled()
+    expect(mocks.refreshToken).not.toHaveBeenCalled()
+  })
+
+  it('refreshes an OAuth token only after provider binding succeeds', async () => {
+    const result = await resolveAtlassianSelectorCredential({
+      credentialId: 'credential-1',
+      credentialOwnerUserId: 'owner-1',
+      requestId: 'request-1',
+      serviceId: 'confluence',
+    })
+
+    expect(result).toEqual({ accessToken: 'oauth-access-token' })
+    expect(mocks.refreshToken).toHaveBeenCalledWith('credential-1', 'owner-1', 'request-1')
+  })
+
+  it('reads an Atlassian service account only after provider binding succeeds', async () => {
+    mocks.resolveAccount.mockResolvedValue({
+      providerId: 'atlassian-service-account',
+      credentialId: 'service-account-1',
+    })
+    mocks.getServiceAccountSecret.mockResolvedValue({
+      apiToken: 'service-account-token',
+      cloudId: 'cloud-1',
+    })
+
+    const result = await resolveAtlassianSelectorCredential({
+      credentialId: 'credential-1',
+      credentialOwnerUserId: 'owner-1',
+      requestId: 'request-1',
+      serviceId: 'jira',
+    })
+
+    expect(result).toEqual({ accessToken: 'service-account-token', cloudId: 'cloud-1' })
+    expect(mocks.getServiceAccountSecret).toHaveBeenCalledWith('service-account-1')
+    expect(mocks.refreshToken).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/lib/selectors/application/atlassian-credential.ts
+++ b/apps/sim/lib/selectors/application/atlassian-credential.ts
@@ -1,0 +1,34 @@
+import {
+  getAtlassianServiceAccountSecret,
+  refreshAccessTokenIfNeeded,
+  resolveOAuthAccountId,
+} from '@/lib/oauth/credential-service'
+import { ATLASSIAN_SERVICE_ACCOUNT_PROVIDER_ID } from '@/lib/oauth/types'
+import { selectorCredentialMatchesService } from '@/lib/selectors/application/credential-provider'
+
+export async function resolveAtlassianSelectorCredential(input: {
+  credentialId: string
+  credentialOwnerUserId: string
+  requestId: string
+  serviceId: 'jira' | 'confluence'
+}): Promise<{ accessToken: string; cloudId?: string } | null> {
+  const providerMatches = await selectorCredentialMatchesService({
+    credentialId: input.credentialId,
+    credentialOwnerUserId: input.credentialOwnerUserId,
+    serviceId: input.serviceId,
+  })
+  if (!providerMatches) return null
+
+  const resolved = await resolveOAuthAccountId(input.credentialId)
+  if (resolved?.providerId === ATLASSIAN_SERVICE_ACCOUNT_PROVIDER_ID && resolved.credentialId) {
+    const secret = await getAtlassianServiceAccountSecret(resolved.credentialId)
+    return { accessToken: secret.apiToken, cloudId: secret.cloudId }
+  }
+
+  const accessToken = await refreshAccessTokenIfNeeded(
+    input.credentialId,
+    input.credentialOwnerUserId,
+    input.requestId
+  )
+  return accessToken ? { accessToken } : null
+}

--- a/apps/sim/lib/selectors/application/credential-provider.test.ts
+++ b/apps/sim/lib/selectors/application/credential-provider.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment node
+ */
+import { account, credential } from '@sim/db/schema'
+import {
+  dbChainMock,
+  dbChainMockFns,
+  drizzleOrmMock,
+  hasMockCondition,
+  queueTableRows,
+  resetDbChainMock,
+} from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@sim/db', () => dbChainMock)
+vi.mock('drizzle-orm', () => drizzleOrmMock)
+
+import { selectorCredentialMatchesService } from '@/lib/selectors/application/credential-provider'
+
+describe('selectorCredentialMatchesService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDbChainMock()
+  })
+
+  it.each([
+    ['OAuth', 'jira', 'jira', true],
+    ['Atlassian service account', 'atlassian-service-account', 'confluence', true],
+    ['Slack custom bot', 'slack-custom-bot', 'slack', true],
+    ['unrelated provider', 'pipedrive', 'slack', false],
+  ])(
+    'binds a stored %s provider to the requested service',
+    async (_, providerId, serviceId, ok) => {
+      queueTableRows(credential, [{ accountId: null, providerId }])
+
+      await expect(
+        selectorCredentialMatchesService({
+          credentialId: 'credential-1',
+          credentialOwnerUserId: 'owner-1',
+          serviceId,
+        })
+      ).resolves.toBe(ok)
+
+      expect(dbChainMockFns.from).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('falls back to an owner-scoped legacy account provider', async () => {
+    queueTableRows(credential, [])
+    queueTableRows(account, [{ providerId: 'slack' }])
+
+    await expect(
+      selectorCredentialMatchesService({
+        credentialId: 'legacy-account-1',
+        credentialOwnerUserId: 'owner-1',
+        serviceId: 'slack',
+      })
+    ).resolves.toBe(true)
+
+    const accountWhere = dbChainMockFns.where.mock.calls.at(-1)?.[0]
+    expect(
+      hasMockCondition(
+        accountWhere,
+        (condition) =>
+          condition.type === 'eq' &&
+          condition.left === account.id &&
+          condition.right === 'legacy-account-1'
+      )
+    ).toBe(true)
+    expect(
+      hasMockCondition(
+        accountWhere,
+        (condition) =>
+          condition.type === 'eq' &&
+          condition.left === account.userId &&
+          condition.right === 'owner-1'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects a legacy account with no owner-matched provider row', async () => {
+    queueTableRows(credential, [])
+    queueTableRows(account, [])
+
+    await expect(
+      selectorCredentialMatchesService({
+        credentialId: 'legacy-account-1',
+        credentialOwnerUserId: 'owner-1',
+        serviceId: 'slack',
+      })
+    ).resolves.toBe(false)
+  })
+})

--- a/apps/sim/lib/selectors/application/credential-provider.ts
+++ b/apps/sim/lib/selectors/application/credential-provider.ts
@@ -1,0 +1,31 @@
+import { db } from '@sim/db'
+import { account, credential } from '@sim/db/schema'
+import { and, eq } from 'drizzle-orm'
+import { credentialProviderMatchesService, getServiceConfigByServiceId } from '@/lib/oauth/utils'
+
+/** Checks selector credential/provider binding without loading token plaintext. */
+export async function selectorCredentialMatchesService(input: {
+  credentialId: string
+  credentialOwnerUserId: string
+  serviceId: string
+}): Promise<boolean> {
+  const [credentialRow] = await db
+    .select({ accountId: credential.accountId, providerId: credential.providerId })
+    .from(credential)
+    .where(eq(credential.id, input.credentialId))
+    .limit(1)
+
+  let providerId = credentialRow?.providerId ?? null
+  const accountId = credentialRow?.accountId ?? input.credentialId
+  if (!providerId) {
+    const [accountRow] = await db
+      .select({ providerId: account.providerId })
+      .from(account)
+      .where(and(eq(account.id, accountId), eq(account.userId, input.credentialOwnerUserId)))
+      .limit(1)
+    providerId = accountRow?.providerId ?? null
+  }
+
+  const service = getServiceConfigByServiceId(input.serviceId)
+  return Boolean(providerId && service && credentialProviderMatchesService(providerId, service))
+}

--- a/apps/sim/lib/selectors/application/resolve-authorized-context.test.ts
+++ b/apps/sim/lib/selectors/application/resolve-authorized-context.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  authorizeCredential: vi.fn(),
+  authorizeWorkspace: vi.fn(),
+  getEnvironment: vi.fn(),
+  loadWorkspace: vi.fn(),
+  resolveWorkflow: vi.fn(),
+}))
+
+vi.mock('@/lib/auth/credential-access', () => ({
+  authorizeCredentialUseForAuth: mocks.authorizeCredential,
+}))
+vi.mock('@/lib/core/application', () => ({
+  authorizeWorkspaceOperation: mocks.authorizeWorkspace,
+  defineWorkspaceOperation: vi.fn((operation) => operation),
+}))
+vi.mock('@/lib/environment/utils', () => ({
+  getEffectiveDecryptedEnv: mocks.getEnvironment,
+}))
+vi.mock('@/lib/workflows/application/context', () => ({
+  resolveActiveWorkflowApplicationContext: mocks.resolveWorkflow,
+}))
+vi.mock('@/lib/workspaces/application/workspace-context', () => ({
+  loadActiveWorkspaceApplicationContext: mocks.loadWorkspace,
+}))
+
+import { resolveAuthorizedSelectorContextForPrincipal } from '@/lib/selectors/application/resolve-authorized-context'
+
+const sessionPrincipal = {
+  kind: 'session',
+  userId: 'viewer-1',
+  sessionId: 'session-1',
+} as const
+const delegatedPrincipal = {
+  kind: 'delegated',
+  service: 'executor',
+  subjectUserId: 'viewer-1',
+  delegationContext: { kind: 'workflow_execution', workflowId: 'workflow-1' },
+} as never
+
+describe('resolveAuthorizedSelectorContextForPrincipal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolveWorkflow.mockResolvedValue({
+      workspaceId: 'workspace-1',
+      workflowId: 'workflow-1',
+    })
+    mocks.loadWorkspace.mockResolvedValue({ workspaceId: 'workspace-1' })
+    mocks.authorizeWorkspace.mockResolvedValue(undefined)
+    mocks.authorizeCredential.mockResolvedValue({
+      ok: true,
+      workspaceId: 'workspace-1',
+      credentialOwnerUserId: 'owner-1',
+    })
+    mocks.getEnvironment.mockResolvedValue({
+      PERSONAL_DOMAIN: 'personal.example.com',
+      SHARED_DOMAIN: 'shared.example.com',
+      COLLISION: 'workspace-wins',
+    })
+  })
+
+  it('passes literals through after workflow authorization', async () => {
+    const result = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      workflowId: 'workflow-1',
+      context: { domain: 'literal.example.com' },
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      requesterUserId: 'viewer-1',
+      workspaceId: 'workspace-1',
+      context: { domain: 'literal.example.com' },
+    })
+  })
+
+  it.each([
+    ['personal', '{{PERSONAL_DOMAIN}}', 'personal.example.com'],
+    ['accessible workspace/shared', '{{SHARED_DOMAIN}}', 'shared.example.com'],
+    ['workspace-over-personal effective value', '{{COLLISION}}', 'workspace-wins'],
+  ])('resolves an exact %s reference', async (_label, reference, expected) => {
+    const result = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      workflowId: 'workflow-1',
+      context: { arbitraryFutureField: reference },
+    })
+
+    expect(result).toMatchObject({ ok: true, context: { arbitraryFutureField: expected } })
+  })
+
+  it('does not interpolate embedded references', async () => {
+    const result = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      workflowId: 'workflow-1',
+      context: { domain: 'https://{{SHARED_DOMAIN}}' },
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      context: { domain: 'https://{{SHARED_DOMAIN}}' },
+    })
+  })
+
+  it('makes missing and inaccessible references indistinguishable without plaintext leakage', async () => {
+    const missing = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      workflowId: 'workflow-1',
+      context: { domain: '{{MISSING_DOMAIN}}' },
+    })
+    const inaccessible = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      workflowId: 'workflow-1',
+      context: { domain: '{{INACCESSIBLE_DOMAIN}}' },
+    })
+
+    expect(missing).toEqual(inaccessible)
+    expect(missing).toEqual({
+      ok: false,
+      status: 400,
+      error: 'Unable to resolve selector configuration',
+    })
+    expect(JSON.stringify(missing)).not.toContain('MISSING_DOMAIN')
+    expect(JSON.stringify(inaccessible)).not.toContain('INACCESSIBLE_DOMAIN')
+    expect(JSON.stringify(inaccessible)).not.toContain('shared.example.com')
+  })
+
+  it('rejects archived or unreadable workflows before environment access', async () => {
+    mocks.resolveWorkflow.mockRejectedValue(new Error('Workflow is archived'))
+
+    const result = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      workflowId: 'workflow-1',
+      context: { domain: '{{SHARED_DOMAIN}}' },
+    })
+
+    expect(result).toEqual({ ok: false, status: 403, error: 'Unauthorized' })
+    expect(mocks.getEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('requires credential use authorization in the canonical workflow workspace', async () => {
+    mocks.authorizeCredential.mockResolvedValue({ ok: false, error: 'Credential not found' })
+
+    const result = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      workflowId: 'workflow-1',
+      credentialId: 'credential-1',
+      context: { domain: '{{SHARED_DOMAIN}}' },
+    })
+
+    expect(result).toEqual({ ok: false, status: 403, error: 'Credential not found' })
+    expect(mocks.getEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('rejects a credential authorized for a different workspace', async () => {
+    mocks.authorizeCredential.mockResolvedValue({
+      ok: true,
+      workspaceId: 'workspace-2',
+      credentialOwnerUserId: 'owner-1',
+    })
+
+    const result = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      workflowId: 'workflow-1',
+      credentialId: 'credential-1',
+      context: { domain: '{{SHARED_DOMAIN}}' },
+    })
+
+    expect(result).toEqual({ ok: false, status: 403, error: 'Unauthorized' })
+    expect(mocks.getEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('allows a session knowledge connector to derive workspace scope from its credential', async () => {
+    const result = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      credentialId: 'credential-1',
+      context: { domain: '{{SHARED_DOMAIN}}' },
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      workspaceId: 'workspace-1',
+      context: { domain: 'shared.example.com' },
+    })
+    expect(mocks.authorizeCredential).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'viewer-1' }),
+      { credentialId: 'credential-1' }
+    )
+    expect(mocks.loadWorkspace).toHaveBeenCalledWith('workspace-1')
+  })
+
+  it('requires a workflow for workflowless direct-secret requests', async () => {
+    const result = await resolveAuthorizedSelectorContextForPrincipal(sessionPrincipal, {
+      context: { token: '{{SLACK_TOKEN}}' },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: 'Unable to resolve selector configuration',
+    })
+    expect(mocks.getEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('does not permit delegated principals to derive workflowless credential scope', async () => {
+    const result = await resolveAuthorizedSelectorContextForPrincipal(delegatedPrincipal, {
+      credentialId: 'credential-1',
+      context: {},
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: 'Unable to resolve selector configuration',
+    })
+    expect(mocks.authorizeCredential).not.toHaveBeenCalled()
+  })
+
+  it('passes exact workflow scope to delegated authorization', async () => {
+    await resolveAuthorizedSelectorContextForPrincipal(delegatedPrincipal, {
+      workflowId: 'workflow-1',
+      context: {},
+    })
+
+    const options = mocks.authorizeWorkspace.mock.calls[0][3]
+    expect(options.delegation.audience).toBe('sim:selectors')
+    expect(options.delegation.isWithinScope(delegatedPrincipal)).toBe(true)
+    expect(
+      options.delegation.isWithinScope({
+        ...delegatedPrincipal,
+        delegationContext: { kind: 'workflow_execution', workflowId: 'workflow-2' },
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/sim/lib/selectors/application/resolve-authorized-context.ts
+++ b/apps/sim/lib/selectors/application/resolve-authorized-context.ts
@@ -1,0 +1,160 @@
+import {
+  type DelegatedPrincipal,
+  type Principal,
+  requirePrincipalSubjectUserId,
+} from '@sim/auth/principal'
+import {
+  authorizeCredentialUseForAuth,
+  type CredentialAccessResult,
+} from '@/lib/auth/credential-access'
+import { type AuthResult, AuthType } from '@/lib/auth/hybrid'
+import { authorizeWorkspaceOperation, defineWorkspaceOperation } from '@/lib/core/application'
+import { getEffectiveDecryptedEnv } from '@/lib/environment/utils'
+import { resolveActiveWorkflowApplicationContext } from '@/lib/workflows/application/context'
+import { loadActiveWorkspaceApplicationContext } from '@/lib/workspaces/application/workspace-context'
+import { resolveEnvVarReferences } from '@/executor/utils/reference-validation'
+
+const SAFE_RESOLUTION_ERROR = 'Unable to resolve selector configuration'
+const SELECTOR_DELEGATION_AUDIENCE = 'sim:selectors'
+
+export const selectorContextOperation = defineWorkspaceOperation({
+  id: 'selectors.context.resolve',
+  minimumRole: 'read',
+  workspaceApiKey: 'deny',
+  principalKinds: ['session', 'delegated'],
+  delegatedServices: ['executor'],
+})
+
+export type AuthorizedSelectorContextResult<T extends Record<string, unknown>> =
+  | {
+      ok: true
+      context: T
+      requesterUserId: string
+      workspaceId: string
+      credentialAccess?: CredentialAccessResult
+    }
+  | { ok: false; status: number; error: string }
+
+function authResultForPrincipal(principal: Principal): AuthResult {
+  return {
+    success: true,
+    userId: requirePrincipalSubjectUserId(principal),
+    authType: principal.kind === 'session' ? AuthType.SESSION : AuthType.INTERNAL_JWT,
+  }
+}
+
+function selectorDelegationWithinScope(
+  principal: DelegatedPrincipal,
+  workflowId: string | undefined
+): boolean {
+  if (!workflowId) return false
+  const delegationContext = (principal as { delegationContext?: unknown }).delegationContext
+  return (
+    typeof delegationContext === 'object' &&
+    delegationContext !== null &&
+    'kind' in delegationContext &&
+    delegationContext.kind === 'workflow_execution' &&
+    'workflowId' in delegationContext &&
+    delegationContext.workflowId === workflowId
+  )
+}
+
+/**
+ * Authorizes a selector request before resolving exact `{{KEY}}` references.
+ * Workflowless requests are restricted to session principals whose authorized
+ * credential supplies canonical workspace scope.
+ */
+export async function resolveAuthorizedSelectorContextForPrincipal<
+  T extends Record<string, unknown>,
+>(
+  principal: Principal,
+  input: {
+    workflowId?: string
+    credentialId?: string
+    context: T
+  }
+): Promise<AuthorizedSelectorContextResult<T>> {
+  let credentialAccess: CredentialAccessResult | undefined
+
+  try {
+    const requesterUserId = requirePrincipalSubjectUserId(principal)
+    const auth = authResultForPrincipal(principal)
+    let workspaceId: string
+    let workspaceContext
+
+    if (input.workflowId) {
+      const workflowContext = await resolveActiveWorkflowApplicationContext({
+        workflowId: input.workflowId,
+      })
+      workspaceId = workflowContext.workspaceId
+      workspaceContext = workflowContext
+    } else {
+      if (principal.kind !== 'session' || !input.credentialId) {
+        return { ok: false, status: 400, error: SAFE_RESOLUTION_ERROR }
+      }
+      credentialAccess = await authorizeCredentialUseForAuth(auth, {
+        credentialId: input.credentialId,
+      })
+      if (!credentialAccess.ok || !credentialAccess.workspaceId) {
+        return {
+          ok: false,
+          status: 403,
+          error: credentialAccess.error || 'Unauthorized',
+        }
+      }
+      workspaceId = credentialAccess.workspaceId
+      workspaceContext = await loadActiveWorkspaceApplicationContext(workspaceId)
+      if (!workspaceContext) return { ok: false, status: 403, error: 'Unauthorized' }
+    }
+
+    await authorizeWorkspaceOperation(principal, selectorContextOperation, workspaceContext, {
+      delegation: {
+        audience: SELECTOR_DELEGATION_AUDIENCE,
+        isWithinScope: (delegatedPrincipal) =>
+          selectorDelegationWithinScope(delegatedPrincipal, input.workflowId),
+      },
+    })
+
+    if (input.credentialId && !credentialAccess) {
+      credentialAccess = await authorizeCredentialUseForAuth(auth, {
+        credentialId: input.credentialId,
+        workflowId: input.workflowId,
+      })
+      if (!credentialAccess.ok || !credentialAccess.workspaceId) {
+        return {
+          ok: false,
+          status: 403,
+          error: credentialAccess.error || 'Unauthorized',
+        }
+      }
+      if (credentialAccess.workspaceId !== workspaceId) {
+        return { ok: false, status: 403, error: 'Unauthorized' }
+      }
+    }
+
+    let context: T
+    try {
+      const environment = await getEffectiveDecryptedEnv(requesterUserId, workspaceId)
+      context = resolveEnvVarReferences(input.context, environment, {
+        allowEmbedded: false,
+        resolveExactMatch: true,
+        onMissing: 'throw',
+        deep: true,
+      }) as T
+    } catch {
+      return { ok: false, status: 400, error: SAFE_RESOLUTION_ERROR }
+    }
+
+    return {
+      ok: true,
+      context,
+      requesterUserId,
+      workspaceId,
+      credentialAccess,
+    }
+  } catch {
+    return { ok: false, status: 403, error: 'Unauthorized' }
+  }
+}
+
+export { SELECTOR_DELEGATION_AUDIENCE }

--- a/apps/sim/lib/selectors/server/provider-errors.test.ts
+++ b/apps/sim/lib/selectors/server/provider-errors.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  resolveSelectorProviderValue,
+  selectorProviderFailure,
+} from '@/lib/selectors/server/provider-errors'
+
+describe('selectorProviderFailure', () => {
+  it.each([
+    [
+      401,
+      {
+        error: 'Atlassian rejected this credential. Reconnect it and try again.',
+        status: 401,
+        authRequired: true,
+      },
+    ],
+    [403, { error: 'Atlassian denied selector access.', status: 403 }],
+    [
+      429,
+      {
+        error: 'Atlassian rate-limited selector discovery. Try again shortly.',
+        status: 429,
+      },
+    ],
+    [400, { error: 'Atlassian selector discovery failed.', status: 502 }],
+    [500, { error: 'Atlassian selector discovery failed.', status: 502 }],
+  ])('maps provider status %s to its stable public failure', (input, expected) => {
+    expect(selectorProviderFailure('Atlassian', input)).toEqual(expected)
+  })
+
+  it('sanitizes a provider discovery exception without serializing its body marker', async () => {
+    const providerError = Object.assign(new Error('provider-body-secret-marker'), { status: 429 })
+
+    const result = await resolveSelectorProviderValue('Jira', async () => {
+      throw providerError
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      failure: {
+        error: 'Jira rate-limited selector discovery. Try again shortly.',
+        status: 429,
+      },
+      upstreamStatus: 429,
+    })
+    expect(JSON.stringify(result)).not.toContain('provider-body-secret-marker')
+  })
+})

--- a/apps/sim/lib/selectors/server/provider-errors.ts
+++ b/apps/sim/lib/selectors/server/provider-errors.ts
@@ -1,0 +1,68 @@
+export interface SelectorProviderFailure {
+  error: string
+  status: number
+  authRequired?: true
+}
+
+export type SelectorAtlassianProvider =
+  | 'Atlassian'
+  | 'Jira'
+  | 'Confluence'
+  | 'Jira Service Management'
+
+/** Keeps provider-controlled discovery bodies out of selector errors and retry logs. */
+export const SELECTOR_ATLASSIAN_DISCOVERY_OPTIONS = {
+  omitResponseBodyFromErrors: true,
+} as const
+
+function providerStatusFromError(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object' || !('status' in error)) return undefined
+  const status = error.status
+  return typeof status === 'number' && Number.isInteger(status) ? status : undefined
+}
+
+/** Maps provider failures to stable selector-safe responses without reading response bodies. */
+export function selectorProviderFailure(
+  provider: SelectorAtlassianProvider,
+  status: number
+): SelectorProviderFailure {
+  if (status === 401) {
+    return {
+      error: `${provider} rejected this credential. Reconnect it and try again.`,
+      status: 401,
+      authRequired: true,
+    }
+  }
+  if (status === 403) {
+    return { error: `${provider} denied selector access.`, status: 403 }
+  }
+  if (status === 429) {
+    return { error: `${provider} rate-limited selector discovery. Try again shortly.`, status: 429 }
+  }
+  return { error: `${provider} selector discovery failed.`, status: 502 }
+}
+
+export type SelectorProviderValueResult<T> =
+  | { ok: true; value: T }
+  | {
+      ok: false
+      failure: SelectorProviderFailure
+      upstreamStatus?: number
+    }
+
+/** Converts provider discovery exceptions into a safe value boundary. */
+export async function resolveSelectorProviderValue<T>(
+  provider: SelectorAtlassianProvider,
+  resolve: () => Promise<T>
+): Promise<SelectorProviderValueResult<T>> {
+  try {
+    return { ok: true, value: await resolve() }
+  } catch (error) {
+    const upstreamStatus = providerStatusFromError(error)
+    return {
+      ok: false,
+      failure: selectorProviderFailure(provider, upstreamStatus ?? 502),
+      upstreamStatus,
+    }
+  }
+}

--- a/apps/sim/lib/selectors/server/resolve-authorized-context.test.ts
+++ b/apps/sim/lib/selectors/server/resolve-authorized-context.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  createAuth: vi.fn(),
+  resolveForPrincipal: vi.fn(),
+  UnauthenticatedError: class InternalUnauthenticatedError extends Error {},
+}))
+
+vi.mock('@/lib/api/server/routes', () => ({
+  createInternalSessionOrExecutorAuth: mocks.createAuth.mockReturnValue({
+    authenticate: mocks.authenticate,
+  }),
+  InternalUnauthenticatedError: mocks.UnauthenticatedError,
+}))
+vi.mock('@/lib/selectors/application/resolve-authorized-context', () => ({
+  SELECTOR_DELEGATION_AUDIENCE: 'sim:selectors',
+  resolveAuthorizedSelectorContextForPrincipal: mocks.resolveForPrincipal,
+}))
+
+import { authenticateSelectorRequest } from '@/lib/selectors/server/resolve-authorized-context'
+
+const principal = { kind: 'session', userId: 'viewer-1', sessionId: 'session-1' } as const
+
+describe('selector request authentication adapter', () => {
+  beforeEach(() => {
+    mocks.authenticate.mockReset()
+    mocks.resolveForPrincipal.mockReset()
+  })
+
+  it('authenticates with the selector audience and returns the Principal', async () => {
+    mocks.authenticate.mockResolvedValue(principal)
+
+    await expect(authenticateSelectorRequest({} as never)).resolves.toEqual({
+      ok: true,
+      principal,
+    })
+    expect(mocks.createAuth).toHaveBeenCalledWith({ audience: 'sim:selectors' })
+  })
+
+  it('returns a sanitized 401 when authentication fails', async () => {
+    mocks.authenticate.mockRejectedValue(new mocks.UnauthenticatedError('Unauthorized'))
+
+    await expect(authenticateSelectorRequest({} as never)).resolves.toEqual({
+      ok: false,
+      status: 401,
+      error: 'Unauthorized',
+    })
+  })
+})

--- a/apps/sim/lib/selectors/server/resolve-authorized-context.ts
+++ b/apps/sim/lib/selectors/server/resolve-authorized-context.ts
@@ -1,0 +1,45 @@
+import type { Principal } from '@sim/auth/principal'
+import type { NextRequest } from 'next/server'
+import {
+  createInternalSessionOrExecutorAuth,
+  InternalUnauthenticatedError,
+} from '@/lib/api/server/routes'
+import {
+  type AuthorizedSelectorContextResult,
+  resolveAuthorizedSelectorContextForPrincipal,
+  SELECTOR_DELEGATION_AUDIENCE,
+} from '@/lib/selectors/application/resolve-authorized-context'
+
+const selectorRequestAuth = createInternalSessionOrExecutorAuth({
+  audience: SELECTOR_DELEGATION_AUDIENCE,
+})
+
+export type SelectorRequestAuthenticationResult =
+  | { ok: true; principal: Principal }
+  | { ok: false; status: 401; error: string }
+
+/** Authenticates selector requests before request parsing or protected work. */
+export async function authenticateSelectorRequest(
+  request: NextRequest
+): Promise<SelectorRequestAuthenticationResult> {
+  try {
+    return { ok: true, principal: await selectorRequestAuth.authenticate(request, {}) }
+  } catch (error) {
+    if (error instanceof InternalUnauthenticatedError) {
+      return { ok: false, status: 401, error: error.message }
+    }
+    throw error
+  }
+}
+
+/** Enters the surface-neutral selector-context application operation. */
+export async function resolveAuthorizedSelectorContext<T extends Record<string, unknown>>(
+  principal: Principal,
+  input: {
+    workflowId?: string
+    credentialId?: string
+    context: T
+  }
+): Promise<AuthorizedSelectorContextResult<T>> {
+  return resolveAuthorizedSelectorContextForPrincipal(principal, input)
+}

--- a/apps/sim/stores/index.test.ts
+++ b/apps/sim/stores/index.test.ts
@@ -8,11 +8,11 @@ const mocks = vi.hoisted(() => ({
   clearWorkflow: vi.fn(),
   consolePersist: vi.fn(),
   executionReset: vi.fn(),
-  queryRemove: vi.fn(),
+  queryClear: vi.fn(),
 }))
 
 vi.mock('@/app/_shell/providers/get-query-client', () => ({
-  getQueryClient: () => ({ removeQueries: mocks.queryRemove }),
+  getQueryClient: () => ({ clear: mocks.queryClear }),
 }))
 vi.mock('@/stores/execution', () => ({
   useExecutionStore: { getState: () => ({ reset: mocks.executionReset }) },
@@ -34,15 +34,14 @@ vi.mock('@/stores/workflows/workflow/store', () => ({
   useWorkflowStore: { getState: () => ({ clear: mocks.clearWorkflow }) },
 }))
 
-import { selectorKeys } from '@/hooks/selectors/query-keys'
 import { resetAllStores } from '@/stores'
 
 describe('resetAllStores', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('removes all authorization-sensitive selector queries on user-data reset', () => {
+  it('clears every server-state query on user-data reset', () => {
     resetAllStores()
 
-    expect(mocks.queryRemove).toHaveBeenCalledWith({ queryKey: selectorKeys.all })
+    expect(mocks.queryClear).toHaveBeenCalledOnce()
   })
 })

--- a/apps/sim/stores/index.test.ts
+++ b/apps/sim/stores/index.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  clearSubBlocks: vi.fn(),
+  clearWorkflow: vi.fn(),
+  consolePersist: vi.fn(),
+  executionReset: vi.fn(),
+  queryRemove: vi.fn(),
+}))
+
+vi.mock('@/app/_shell/providers/get-query-client', () => ({
+  getQueryClient: () => ({ removeQueries: mocks.queryRemove }),
+}))
+vi.mock('@/stores/execution', () => ({
+  useExecutionStore: { getState: () => ({ reset: mocks.executionReset }) },
+}))
+vi.mock('@/stores/mothership-drafts/store', () => ({
+  useMothershipDraftsStore: { setState: vi.fn() },
+}))
+vi.mock('@/stores/terminal', () => ({
+  consolePersistence: { persist: mocks.consolePersist },
+  useTerminalConsoleStore: { setState: vi.fn() },
+}))
+vi.mock('@/stores/workflows/registry/store', () => ({
+  useWorkflowRegistry: { setState: vi.fn() },
+}))
+vi.mock('@/stores/workflows/subblock/store', () => ({
+  useSubBlockStore: { getState: () => ({ clear: mocks.clearSubBlocks }) },
+}))
+vi.mock('@/stores/workflows/workflow/store', () => ({
+  useWorkflowStore: { getState: () => ({ clear: mocks.clearWorkflow }) },
+}))
+
+import { selectorKeys } from '@/hooks/selectors/query-keys'
+import { resetAllStores } from '@/stores'
+
+describe('resetAllStores', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('removes all authorization-sensitive selector queries on user-data reset', () => {
+    resetAllStores()
+
+    expect(mocks.queryRemove).toHaveBeenCalledWith({ queryKey: selectorKeys.all })
+  })
+})

--- a/apps/sim/stores/index.ts
+++ b/apps/sim/stores/index.ts
@@ -2,8 +2,6 @@
 
 import { createLogger } from '@sim/logger'
 import { getQueryClient } from '@/app/_shell/providers/get-query-client'
-import { environmentKeys } from '@/hooks/queries/environment'
-import { selectorKeys } from '@/hooks/selectors/query-keys'
 import { useExecutionStore } from '@/stores/execution'
 import { useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
 import { consolePersistence, useTerminalConsoleStore } from '@/stores/terminal'
@@ -33,8 +31,7 @@ export const resetAllStores = () => {
   })
   useWorkflowStore.getState().clear()
   useSubBlockStore.getState().clear()
-  getQueryClient().removeQueries({ queryKey: environmentKeys.all })
-  getQueryClient().removeQueries({ queryKey: selectorKeys.all })
+  getQueryClient().clear()
   useExecutionStore.getState().reset()
   useTerminalConsoleStore.setState({
     workflowEntries: {},

--- a/apps/sim/stores/index.ts
+++ b/apps/sim/stores/index.ts
@@ -3,6 +3,7 @@
 import { createLogger } from '@sim/logger'
 import { getQueryClient } from '@/app/_shell/providers/get-query-client'
 import { environmentKeys } from '@/hooks/queries/environment'
+import { selectorKeys } from '@/hooks/selectors/query-keys'
 import { useExecutionStore } from '@/stores/execution'
 import { useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
 import { consolePersistence, useTerminalConsoleStore } from '@/stores/terminal'
@@ -33,6 +34,7 @@ export const resetAllStores = () => {
   useWorkflowStore.getState().clear()
   useSubBlockStore.getState().clear()
   getQueryClient().removeQueries({ queryKey: environmentKeys.all })
+  getQueryClient().removeQueries({ queryKey: selectorKeys.all })
   useExecutionStore.getState().reset()
   useTerminalConsoleStore.setState({
     workflowEntries: {},

--- a/apps/sim/tools/jira/utils.ts
+++ b/apps/sim/tools/jira/utils.ts
@@ -1,6 +1,8 @@
 import { createLogger } from '@sim/logger'
-import { resolveAtlassianCloudId } from '@/lib/atlassian/discovery'
-import type { RetryOptions } from '@/lib/knowledge/documents/utils'
+import {
+  type AtlassianDiscoveryRetryOptions,
+  resolveAtlassianCloudId,
+} from '@/lib/atlassian/discovery'
 import { fetchWithRetry } from '@/lib/knowledge/documents/utils'
 
 const logger = createLogger('JiraUtils')
@@ -250,7 +252,7 @@ export function normalizeJiraWorklogTimestamp(value: string): string {
 export function getJiraCloudId(
   domain: string,
   accessToken: string,
-  retryOptions?: RetryOptions
+  retryOptions?: AtlassianDiscoveryRetryOptions
 ): Promise<string> {
   return resolveAtlassianCloudId({ domain, accessToken, product: 'Jira', retryOptions })
 }


### PR DESCRIPTION
## Summary

Adds the shared, authorized infrastructure for dependent selectors whose context may contain environment-secret references. This PR contains no Jira, Confluence, JSM, Slack, CloudWatch, or IMAP selector migration; those are independent sibling PRs stacked on this branch.

The browser carries literals or opaque exact `{{KEY}}` references only. Authorized resolution happens server-side, and resolved shared-secret plaintext never enters selector query keys, responses, or client state.

Shared infrastructure in this PR:

- `serverResolvedContextFields` metadata and exact-reference preservation
- Principal-based workflow/credential authorization
- active readable workflow scope, delegated executor scope, and session-only workflowless credential scope
- canonical workspace derivation and workflow/credential workspace agreement
- effective environment resolution with workspace-over-personal precedence and existing shared-secret membership filtering
- credential provider matching before token or service-account secret access
- cache partitioning by workspace, workflow, and opaque dependency revision
- knowledge-connector cache revisions derived only from each selector server-resolved dependency fields, so unrelated connector edits do not churn selector identity
- successful personal/workspace environment mutations refresh their environment query first, then invalidate primary selectors, canvas detail labels, and workflow-search selector caches without changing opaque query keys
- successful Copilot personal-secret updates refresh both personal and workspace-environment queries; Copilot workspace-secret updates refresh the canonical workspace query before the same selector invalidation
- complete selector-query reset during user-data reset
- shared Atlassian credential binding, sanitized discovery mode, provider-error mapping, and provider-owned selector contract map composition used by the Jira/Confluence and JSM children

Slack report: https://sim-ai.slack.com/archives/C093DF8MA21/p1786822370070229

## Security invariant

- Route adapters authenticate before parsing and reuse the authenticated session or executor principal.
- Workflow selectors require an active workflow the principal may read.
- Workflowless selectors require a session principal and an authorized credential; direct-secret selectors still require a workflow.
- Credential-backed requests use existing credential-use authorization and enforce workflow/credential workspace agreement.
- Provider compatibility is checked before token refresh or service-account secret access.
- Only exact whole-value references resolve; missing and inaccessible references return the same sanitized error.
- Resolved values never return to the browser or enter logs/query keys.
- Atlassian provider response bodies are neither returned nor logged; sanitized non-2xx bodies are best-effort cancelled without inspection.
- Personal environment writes immediately evict the server's effective-environment cache; failed browser mutations do not invalidate selector caches.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Focused coverage

- Literal passthrough; exact personal/shared references; workspace precedence; missing/inaccessible equivalence; exact-reference-only behavior.
- Active/archived workflow authorization, delegated scope, workflowless credential scope, workflow/credential workspace agreement, and direct-secret workflow enforcement.
- OAuth and Atlassian service-account provider binding plus mismatch denial before secret/provider access.
- Direct database-adapter coverage for OAuth, Atlassian and Slack service accounts, incompatible providers, and owner-scoped legacy accounts.
- One real QueryClient suite for opaque revisions, workspace/workflow separation, plaintext exclusion, and unchanged legacy keys.
- Real QueryClient mutation coverage for personal saves, workspace upserts/removals, all four selector cache families, unrelated-query isolation, and failed-mutation behavior.
- Immediate personal effective-environment cache eviction after the database write.
- User-data reset removes the entire selector query namespace.
- Server adapter authentication success/failure and the `sim:selectors` delegation audience.
- Exact public provider-error mappings without incidental implementation assertions.

## Verification

Verified after rebuilding on the latest `origin/staging`:

- Focused shared Vitest: 15 files, 95 tests passed.
- Provider-focused combined selector suites: 15 files, 75 tests passed.
- Full root suite on the final combined head: 19/19 tasks; app 2,368 files passed, 3 skipped; 34,842 tests passed, 46 skipped.
- App and root type-checks passed.
- Root `lint:check` and `format:check` passed. Lint reports one unrelated existing unused-suppression warning in `shell-layout.test.ts`.
- Strict API validation passed: 1,213/1,213 routes Zod-backed.
- Client-boundary and React Query audits passed.
- `git diff --check` passed.

The final review follow-up adds behavior-level regressions for connector dependency-scoped cache identity, Copilot personal/workspace secret-update invalidation, and sanitized Atlassian response cancellation without duplicating provider matrices.

## Combined browser acceptance

- Jira, Confluence, JSM, CloudWatch, Slack, and IMAP selector forms preserved literals and exact personal/shared references across the browser boundary.
- Existing Slack OAuth loaded real channel options in both a workflow and a workflowless knowledge connector.
- Changing between two deterministic invalid Slack direct tokens produced separate requests; an exact runtime block reference produced no selector request.
- CloudWatch and IMAP deterministic invalid inputs reached their dedicated selector routes and returned sanitized failures without echoing secrets.
- No selector-specific console warnings appeared and no plaintext secret values appeared in keys, responses, or server logs.
- Disposable workflow and knowledge-base data were deleted afterward; the existing Slack workflow was restored.
- Freshness follow-up smoke sent an exact missing Jira domain reference to the dedicated Project/Issue routes and surfaced only the sanitized `Credential not found` response. The temporary blocks and values were undone, and reload confirmed the workflow returned to its original Start-only state.
- The exact mounted same-reference mutation is covered by the real QueryClient regression because this local account cannot edit Secrets through the UI.

## Intentional scope

- Exact whole-value references only; embedded interpolation is unchanged.
- Runtime tool routes, block definitions, database schemas, runtime environment resolution, and chained resource-ID selectors are unchanged.
- Provider selector migrations remain in independent child PRs.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No selector-specific warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Stacked children

Each child is a draft sibling based directly on this PR's tip. Review each diff against `fix/server-resolved-selector-context`; do not merge a child until #7095 lands and that child is rebased and retargeted to `staging`.

- #7122 — Jira Project/Issue and Confluence Space/Page selectors
- #7114 — JSM Service Desk and Request Type selectors
- #7115 — Slack Channel/User selectors and direct-token handling
- #7116 — CloudWatch Log Group/Stream selectors
- #7117 — IMAP Mailbox selector


