### PR TITLE
fix(v2): stop six responses reporting less than the layer beneath them knew

### DIFF
--- a/apps/docs/openapi-v2-resources.json
+++ b/apps/docs/openapi-v2-resources.json
@@ -7393,7 +7393,7 @@
           },
           "toolNamesTruncated": {
             "type": "boolean",
-            "description": "Whether `toolCount` and `toolNames` under-report. The names are gathered for the whole page under one ceiling, so a page whose servers publish more tools than that ceiling between them reports only part of each server's inventory. Read `GET /api/v2/workflow-mcp-servers/{serverId}/tools` for a server's authoritative set. Unrelated to `nextCursor`, which is how this list says there are further servers."
+            "description": "Whether `toolCount` and `toolNames` under-report. The names are gathered for the whole page under one ceiling, so a page whose servers publish more tools than that ceiling between them reports only part of each server's inventory. Read `GET /api/v2/workflow-mcp-servers/{serverId}/tools` for one server's inventory and check that response's own `truncated`, which reports the same ceiling applied to a single server — only an untruncated response is the authoritative set. Unrelated to `nextCursor`, which is how this list says there are further servers."
           }
         },
         "required": ["data", "nextCursor", "toolNamesTruncated"],

--- a/apps/docs/openapi-v2-resources.json
+++ b/apps/docs/openapi-v2-resources.json
@@ -7390,9 +7390,13 @@
               }
             ],
             "description": "Opaque cursor for the next page. Send it back as `cursor`; `null` means there is nothing further to fetch. Never construct one yourself."
+          },
+          "toolNamesTruncated": {
+            "type": "boolean",
+            "description": "Whether `toolCount` and `toolNames` under-report. The names are gathered for the whole page under one ceiling, so a page whose servers publish more tools than that ceiling between them reports only part of each server's inventory. Read `GET /api/v2/workflow-mcp-servers/{serverId}/tools` for a server's authoritative set. Unrelated to `nextCursor`, which is how this list says there are further servers."
           }
         },
-        "required": ["data", "nextCursor"],
+        "required": ["data", "nextCursor", "toolNamesTruncated"],
         "additionalProperties": false,
         "title": "List workflow MCP servers response",
         "description": "A cursor-paginated page of published MCP servers.",
@@ -7411,7 +7415,8 @@
                 "toolNames": ["triage_ticket"]
               }
             ],
-            "nextCursor": null
+            "nextCursor": null,
+            "toolNamesTruncated": false
           }
         ]
       },
@@ -7653,9 +7658,13 @@
               }
             ],
             "description": "Always `null` — this list has no `cursor` or `limit` param and returns its whole bounded set in one page. Present so the list can gain pages later without a shape change."
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "Whether this inventory was cut short by the server-side ceiling on how many tools one response may carry. `nextCursor` is null either way — this list takes no `cursor`, so a truncated set cannot be paged past and this flag is the only way to tell a partial inventory from a complete one. A reconciling caller must not treat a truncated set as the full published inventory."
           }
         },
-        "required": ["data", "nextCursor"],
+        "required": ["data", "nextCursor", "truncated"],
         "additionalProperties": false,
         "title": "List workflow MCP tools response",
         "description": "The tools a published MCP server exposes.",
@@ -7674,7 +7683,8 @@
                 "updatedAt": "2026-06-12T10:30:00.000Z"
               }
             ],
-            "nextCursor": null
+            "nextCursor": null,
+            "truncated": false
           }
         ]
       },

--- a/apps/docs/openapi-v2-tables.json
+++ b/apps/docs/openapi-v2-tables.json
@@ -9964,18 +9964,18 @@
                 "description": "Workflow groups the dispatch runs."
               },
               "rowIds": {
-                "description": "Explicit rows the dispatch targets. Absent does not mean every eligible row on its own — a select-all dispatch has no row list either, and says so with `selectAll`.",
+                "description": "Explicit rows the dispatch targets. Absent means it was given no row list and walks every eligible row, narrowed by `filtered` and `excludeRowIds` when either is present.",
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
               },
-              "selectAll": {
-                "description": "Present and true when the dispatch targets everything matching the filter its `POST` supplied, minus `excludeRowIds`, rather than a fixed row list. The filter itself is not published: it is stored compiled, in a different grammar from the predicate the request was written in. Absent alongside an absent `rowIds` is what means every eligible row.",
+              "filtered": {
+                "description": "Present and true when a stored filter narrows which rows run. The filter itself is not published: it is held compiled, in a different grammar from the predicate the request was written in. Absent means no filter narrows the dispatch — which, with no `rowIds` and no `excludeRowIds`, is what means every eligible row.",
                 "type": "boolean"
               },
               "excludeRowIds": {
-                "description": "Rows deselected from a select-all scope, which the walk skips. Only meaningful alongside `selectAll`.",
+                "description": "Rows the walk skips. Independent of `filtered`: a dispatch may exclude rows from a filtered set or from every eligible row. Never present alongside `rowIds`, which the run rejects and the walk would ignore.",
                 "type": "array",
                 "items": {
                   "type": "string"

--- a/apps/docs/openapi-v2-tables.json
+++ b/apps/docs/openapi-v2-tables.json
@@ -9964,7 +9964,18 @@
                 "description": "Workflow groups the dispatch runs."
               },
               "rowIds": {
-                "description": "Explicit rows the dispatch targets; absent means every eligible row.",
+                "description": "Explicit rows the dispatch targets. Absent does not mean every eligible row on its own — a select-all dispatch has no row list either, and says so with `selectAll`.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "selectAll": {
+                "description": "Present and true when the dispatch targets everything matching the filter its `POST` supplied, minus `excludeRowIds`, rather than a fixed row list. The filter itself is not published: it is stored compiled, in a different grammar from the predicate the request was written in. Absent alongside an absent `rowIds` is what means every eligible row.",
+                "type": "boolean"
+              },
+              "excludeRowIds": {
+                "description": "Rows deselected from a select-all scope, which the walk skips. Only meaningful alongside `selectAll`.",
                 "type": "array",
                 "items": {
                   "type": "string"

--- a/apps/sim/app/api/v2/files/[fileId]/unzip/route.test.ts
+++ b/apps/sim/app/api/v2/files/[fileId]/unzip/route.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/lib/core/rate-limiter', () => v2RateLimiterModuleMock)
 
 import { NoWorkspaceAccessError } from '@/lib/core/application'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
+import { ArchiveError } from '@/lib/uploads/archive'
 import { POST } from '@/app/api/v2/files/[fileId]/unzip/route'
 
 const WORKSPACE_ID = '6fc7631d-88cd-46f8-9f0a-d4764daef7f8'
@@ -164,5 +165,38 @@ describe('POST /api/v2/files/[fileId]/unzip', () => {
     const response = await POST(unzipRequest(), context)
 
     expect(response.status).toBe(400)
+  })
+
+  /**
+   * The cases above all raise `OrchestrationError`, which every v2 policy
+   * already renders — but the extraction use case does not: a payload it cannot
+   * parse or that busts a cap raises `ArchiveError`, and with no arm for that
+   * class the route answered `500`. The internal extract route beside it has
+   * mapped these all along, so the two disagreed about whose fault a bad
+   * archive was.
+   */
+  it('renders a malformed archive as 400 rather than a server fault', async () => {
+    mocks.extract.mockRejectedValueOnce(
+      new ArchiveError(
+        'invalid',
+        'Not a valid .zip archive — its central directory could not be parsed.'
+      )
+    )
+
+    const response = await POST(unzipRequest(), context)
+
+    expect(response.status).toBe(400)
+    expect((await response.json()).error.message).toContain('valid .zip archive')
+  })
+
+  it('renders an over-cap archive as 413 rather than a server fault', async () => {
+    mocks.extract.mockRejectedValueOnce(
+      new ArchiveError('too_many_entries', 'Archive has 1001 files; the maximum is 1000.')
+    )
+
+    const response = await POST(unzipRequest(), context)
+
+    expect(response.status).toBe(413)
+    expect((await response.json()).error.message).toContain('maximum is 1000')
   })
 })

--- a/apps/sim/app/api/v2/files/[fileId]/unzip/route.ts
+++ b/apps/sim/app/api/v2/files/[fileId]/unzip/route.ts
@@ -34,7 +34,7 @@ export const POST = defineV2JsonRoute({
   auth: v2ApiKeyAuth,
   operation: fileOperations.extractArchive,
   rateLimit: v2RateLimits.publicApi,
-  errorPolicy: v2FileErrorPolicies.concealResourceAuthorization,
+  errorPolicy: v2FileErrorPolicies.concealExtractionAuthorization,
   mapInput: ({ params, body }) => ({
     fileId: params.fileId,
     assertedWorkspaceId: body.workspaceId,

--- a/apps/sim/app/api/v2/files/uploads/[uploadId]/route.ts
+++ b/apps/sim/app/api/v2/files/uploads/[uploadId]/route.ts
@@ -28,7 +28,7 @@ export const GET = defineV2JsonRoute({
     uploadToken: headers['upload-token'],
   }),
   useCase: readWorkspaceFileUploadOperation,
-  present: async (session) => ({ data: await toV2FileUpload(session, null) }),
+  present: async ({ session, file }) => ({ data: await toV2FileUpload(session, file) }),
 })
 
 export const DELETE = defineV2JsonRoute({

--- a/apps/sim/app/api/v2/tables/presenters.test.ts
+++ b/apps/sim/app/api/v2/tables/presenters.test.ts
@@ -188,12 +188,33 @@ describe('presentV2TableDispatch', () => {
     expect(presented).not.toHaveProperty('triggeredByUserId')
   })
 
-  /** The stored scope also carries a compiled filter, which is not public. */
-  it('publishes only the addressable half of the run scope', () => {
-    expect(presentV2TableDispatch(stored).scope).toEqual({
-      groupIds: ['group-1'],
-      rowIds: ['row-1'],
-    })
+  /**
+   * The stored scope also carries a compiled filter, which stays unpublished —
+   * it is held in a different grammar from the predicate the request was
+   * written in.
+   */
+  it('withholds the compiled filter itself', () => {
+    expect(presentV2TableDispatch(stored).scope).not.toHaveProperty('filter')
+  })
+
+  /**
+   * Withholding the filter must not also withhold the fact that there was one.
+   * A select-all dispatch has no `rowIds` either, so without `selectAll` the
+   * response described it exactly like a run over every eligible row.
+   */
+  it('says a filtered scope is a filtered scope', () => {
+    expect(
+      presentV2TableDispatch({
+        ...stored,
+        scope: { groupIds: ['group-1'], filter: { status: 'open' }, excludeRowIds: ['row-9'] },
+      }).scope
+    ).toEqual({ groupIds: ['group-1'], selectAll: true, excludeRowIds: ['row-9'] })
+  })
+
+  /** An unfiltered run is the one shape that really does mean every eligible row. */
+  it('leaves an unfiltered scope unmarked', () => {
+    const scope = presentV2TableDispatch({ ...stored, scope: { groupIds: ['group-1'] } }).scope
+    expect(scope).toEqual({ groupIds: ['group-1'] })
   })
 })
 

--- a/apps/sim/app/api/v2/tables/presenters.test.ts
+++ b/apps/sim/app/api/v2/tables/presenters.test.ts
@@ -199,7 +199,7 @@ describe('presentV2TableDispatch', () => {
 
   /**
    * Withholding the filter must not also withhold the fact that there was one.
-   * A select-all dispatch has no `rowIds` either, so without `selectAll` the
+   * A filtered dispatch has no `rowIds` either, so without `filtered` the
    * response described it exactly like a run over every eligible row.
    */
   it('says a filtered scope is a filtered scope', () => {
@@ -208,11 +208,39 @@ describe('presentV2TableDispatch', () => {
         ...stored,
         scope: { groupIds: ['group-1'], filter: { status: 'open' }, excludeRowIds: ['row-9'] },
       }).scope
-    ).toEqual({ groupIds: ['group-1'], selectAll: true, excludeRowIds: ['row-9'] })
+    ).toEqual({ groupIds: ['group-1'], filtered: true, excludeRowIds: ['row-9'] })
   })
 
-  /** An unfiltered run is the one shape that really does mean every eligible row. */
-  it('leaves an unfiltered scope unmarked', () => {
+  /**
+   * The run rejects only `rowIds` *with* `excludeRowIds`, so exclusions with no
+   * filter are a scope a caller can really create, and the walk applies them.
+   * Reporting it as filtered would be false; reporting it bare would be the
+   * original bug, since it targets every eligible row *except* these.
+   */
+  it('reports exclusions that narrow an otherwise unfiltered run', () => {
+    expect(
+      presentV2TableDispatch({
+        ...stored,
+        scope: { groupIds: ['group-1'], excludeRowIds: ['row-9'] },
+      }).scope
+    ).toEqual({ groupIds: ['group-1'], excludeRowIds: ['row-9'] })
+  })
+
+  /**
+   * The walk ignores exclusions once a row list is given, so publishing them
+   * beside `rowIds` would describe a narrowing that never happens.
+   */
+  it('withholds exclusions the walk would ignore', () => {
+    expect(
+      presentV2TableDispatch({
+        ...stored,
+        scope: { groupIds: ['group-1'], rowIds: ['row-1'], excludeRowIds: ['row-9'] },
+      }).scope
+    ).toEqual({ groupIds: ['group-1'], rowIds: ['row-1'] })
+  })
+
+  /** Nothing narrowing it is the one shape that really does mean every eligible row. */
+  it('leaves an unnarrowed scope unmarked', () => {
     const scope = presentV2TableDispatch({ ...stored, scope: { groupIds: ['group-1'] } }).scope
     expect(scope).toEqual({ groupIds: ['group-1'] })
   })

--- a/apps/sim/app/api/v2/tables/presenters.ts
+++ b/apps/sim/app/api/v2/tables/presenters.ts
@@ -62,25 +62,32 @@ export function presentV2TableDispatch(dispatch: DispatchRow): V2TableRunDispatc
     status: dispatch.status === 'cancelled' ? 'canceled' : dispatch.status,
     mode: dispatch.mode,
     /**
-     * A select-all dispatch carries a compiled filter and an exclusion set
-     * instead of a row list, and the dispatcher runs both. Publishing only
-     * `groupIds` and `rowIds` described a filtered run exactly like an
-     * unfiltered one, so `rowIds: undefined` read as "every eligible row" for
-     * two scopes that target very different sets — and `POST` on this same path
-     * accepts `filter` and `excludeRowIds`, so a caller could create a scope
-     * this resource then denied having.
+     * A dispatch with no row list narrows what it walks by a compiled filter,
+     * an exclusion set, or both, and the dispatcher applies each independently.
+     * Publishing only `groupIds` and `rowIds` described all of those exactly
+     * like a run over every eligible row — and `POST` on this same path accepts
+     * `filter` and `excludeRowIds`, so a caller could create a scope this
+     * resource then denied having.
      *
      * The filter itself stays unpublished, with the scheduler `cursor` and the
-     * internal identities: it is stored compiled, in a different grammar from
-     * the predicate the request was written in, so returning it would publish
-     * an internal artifact under a name callers would read as their own input.
-     * `selectAll` names the distinction without claiming to reproduce it.
+     * internal identities: it is held compiled, in a different grammar from the
+     * predicate the request was written in, so returning it would publish an
+     * internal artifact under a name callers would read back as their own
+     * input. `filtered` names the distinction without claiming to reproduce it.
+     *
+     * The two narrowings are reported separately because they are separate: the
+     * run rejects only `rowIds` *with* `excludeRowIds`, so an exclusion set with
+     * no filter is a scope a caller can really create, and one flag covering
+     * both would have to call it either filtered (it is not) or unnarrowed (it
+     * is not). `excludeRowIds` mirrors the walk's own condition and is withheld
+     * where `rowIds` would make the dispatcher ignore it, so the scope reports
+     * what will actually happen.
      */
     scope: {
       groupIds: dispatch.scope.groupIds,
       ...(dispatch.scope.rowIds ? { rowIds: dispatch.scope.rowIds } : {}),
-      ...(dispatch.scope.filter ? { selectAll: true as const } : {}),
-      ...(dispatch.scope.excludeRowIds?.length
+      ...(dispatch.scope.filter ? { filtered: true as const } : {}),
+      ...(!dispatch.scope.rowIds?.length && dispatch.scope.excludeRowIds?.length
         ? { excludeRowIds: dispatch.scope.excludeRowIds }
         : {}),
     },

--- a/apps/sim/app/api/v2/tables/presenters.ts
+++ b/apps/sim/app/api/v2/tables/presenters.ts
@@ -61,9 +61,28 @@ export function presentV2TableDispatch(dispatch: DispatchRow): V2TableRunDispatc
      */
     status: dispatch.status === 'cancelled' ? 'canceled' : dispatch.status,
     mode: dispatch.mode,
+    /**
+     * A select-all dispatch carries a compiled filter and an exclusion set
+     * instead of a row list, and the dispatcher runs both. Publishing only
+     * `groupIds` and `rowIds` described a filtered run exactly like an
+     * unfiltered one, so `rowIds: undefined` read as "every eligible row" for
+     * two scopes that target very different sets — and `POST` on this same path
+     * accepts `filter` and `excludeRowIds`, so a caller could create a scope
+     * this resource then denied having.
+     *
+     * The filter itself stays unpublished, with the scheduler `cursor` and the
+     * internal identities: it is stored compiled, in a different grammar from
+     * the predicate the request was written in, so returning it would publish
+     * an internal artifact under a name callers would read as their own input.
+     * `selectAll` names the distinction without claiming to reproduce it.
+     */
     scope: {
       groupIds: dispatch.scope.groupIds,
       ...(dispatch.scope.rowIds ? { rowIds: dispatch.scope.rowIds } : {}),
+      ...(dispatch.scope.filter ? { selectAll: true as const } : {}),
+      ...(dispatch.scope.excludeRowIds?.length
+        ? { excludeRowIds: dispatch.scope.excludeRowIds }
+        : {}),
     },
     limit: dispatch.limit,
     processedCount: dispatch.processedCount,

--- a/apps/sim/app/api/v2/workflow-mcp-servers/[serverId]/tools/route.test.ts
+++ b/apps/sim/app/api/v2/workflow-mcp-servers/[serverId]/tools/route.test.ts
@@ -342,6 +342,23 @@ describe('/api/v2/workflow-mcp-servers/[serverId]/tools', () => {
       const body = await (await get()).json()
 
       expect(body.nextCursor).toBeNull()
+      expect(body.truncated).toBe(false)
+    })
+
+    /**
+     * `nextCursor` is null whether or not the ceiling cut the set, and this list
+     * takes no `cursor`, so a truncated inventory cannot be paged past. Without
+     * this flag a reconciling caller read a partial set as the whole published
+     * inventory — and the use case had been computing it all along.
+     */
+    it('says when the ceiling cut the inventory short', async () => {
+      mocks.getServer.mockResolvedValue(serverRow)
+      mocks.listTools.mockResolvedValue({ tools: [toolRow], truncated: true })
+
+      const body = await (await get()).json()
+
+      expect(body.truncated).toBe(true)
+      expect(body.nextCursor).toBeNull()
     })
 
     it('conceals a server in another workspace as not found', async () => {

--- a/apps/sim/app/api/v2/workflow-mcp-servers/[serverId]/tools/route.ts
+++ b/apps/sim/app/api/v2/workflow-mcp-servers/[serverId]/tools/route.ts
@@ -29,6 +29,11 @@ export const revalidate = 0
  * is bounded by the workspace's deployed workflows, and a caller reconciling it
  * wants all of it. `nextCursor` is therefore always null.
  *
+ * That bound is not unlimited, though, and a set cut short by the ceiling
+ * cannot be paged past — so the response carries `truncated`. Without it a
+ * reconciling caller read a partial inventory as the complete one and would
+ * have unpublished every tool past the cut.
+ *
  * Head-safe: nothing is written and no audit is projected.
  */
 export const GET = defineV2JsonRoute({
@@ -39,9 +44,10 @@ export const GET = defineV2JsonRoute({
   errorPolicy: workflowMcpServerErrorPolicy,
   mapInput: ({ params }) => ({ serverId: params.serverId }),
   useCase: listWorkflowMcpDeploymentTools,
-  present: ({ tools }) => ({
+  present: ({ tools, truncated }) => ({
     data: tools.map(toV2WorkflowMcpToolListItem),
     nextCursor: null,
+    truncated,
   }),
 })
 

--- a/apps/sim/app/api/v2/workflow-mcp-servers/route.test.ts
+++ b/apps/sim/app/api/v2/workflow-mcp-servers/route.test.ts
@@ -164,7 +164,44 @@ describe('/api/v2/workflow-mcp-servers', () => {
           },
         ],
         nextCursor: null,
+        toolNamesTruncated: false,
       })
+    })
+
+    /**
+     * `toolNames` and `toolCount` are gathered for the whole page under one
+     * ceiling, so a page that trips it under-reports every server's inventory.
+     * Publishing only the names left a reconciling caller reading a partial set
+     * as the complete one.
+     */
+    it('says when the tool names it published were cut short', async () => {
+      mocks.listToolNames.mockResolvedValue({
+        namesByServerId: new Map([['wfmcp-1', ['triage_ticket']]]),
+        truncated: true,
+      })
+
+      expect((await (await get()).json()).toolNamesTruncated).toBe(true)
+    })
+
+    /**
+     * A further page is what `nextCursor` says. Folding it into the truncation
+     * flag would report an incomplete inventory on every page with a successor,
+     * which is most of them.
+     */
+    it('does not call a paged inventory truncated', async () => {
+      mocks.listServers.mockResolvedValue({
+        data: [serverRow()],
+        nextCursorKeys: [{ key: 'createdAt', value: '2026-06-12T10:30:00.000Z' }],
+      })
+      mocks.listToolNames.mockResolvedValue({
+        namesByServerId: new Map([['wfmcp-1', ['triage_ticket']]]),
+        truncated: false,
+      })
+
+      const body = await (await get()).json()
+
+      expect(body.nextCursor).not.toBeNull()
+      expect(body.toolNamesTruncated).toBe(false)
     })
 
     /**

--- a/apps/sim/app/api/v2/workflow-mcp-servers/route.ts
+++ b/apps/sim/app/api/v2/workflow-mcp-servers/route.ts
@@ -52,8 +52,9 @@ export const GET = defineV2JsonRoute({
     ),
   }),
   useCase: listWorkflowMcpDeployments,
-  present: ({ servers, nextCursorKeys }, { query }) => ({
+  present: ({ servers, nextCursorKeys, toolNamesTruncated }, { query }) => ({
     data: servers.map(toV2WorkflowMcpServerListItem),
+    toolNamesTruncated,
     nextCursor: writeSortedCursor(
       nextCursorKeys,
       query.sortBy,

--- a/apps/sim/app/api/v2/workflows/[workflowId]/runs/[runId]/files/[fileId]/route.ts
+++ b/apps/sim/app/api/v2/workflows/[workflowId]/runs/[runId]/files/[fileId]/route.ts
@@ -27,7 +27,11 @@ export const revalidate = 0
  * so the response cannot be used to probe which ids exist.
  *
  * `headSafe: false` because downloading records a `FILE_DOWNLOADED` audit event
- * and pulls the bytes out of object storage.
+ * and pulls the bytes out of object storage. `HEAD` therefore runs the
+ * authorization phase alone — which is why the use case resolves the addressed
+ * file while loading canonical context rather than in `execute`, so a `HEAD`
+ * answers the same existence question a `GET` would instead of succeeding for
+ * an id that has no file behind it.
  */
 export const GET = defineV2BinaryRoute({
   contract: v2DownloadRunFileContract,

--- a/apps/sim/app/api/v2/workflows/[workflowId]/runs/[runId]/route.test.ts
+++ b/apps/sim/app/api/v2/workflows/[workflowId]/runs/[runId]/route.test.ts
@@ -198,6 +198,32 @@ describe('v2 run detail and cancel adapters', () => {
     )
   })
 
+  /**
+   * The contract has always said `includeFileBase64` requires `includeOutput`,
+   * and the read honours it: files are projected inside the `includeOutput`
+   * branch alone. Nothing enforced it, so the flag parsed, was accepted, and
+   * was then dropped — a `200` carrying no files and no reason why.
+   */
+  it('rejects inlining files without asking for the output they hang off', async () => {
+    const response = await callStatus('?includeFileBase64=true')
+
+    expect(response.status).toBe(400)
+    expect((await response.json()).error.message).toContain('includeOutput')
+    expect(mocks.readRun).not.toHaveBeenCalled()
+  })
+
+  it('rejects a ceiling for an inlining that was never requested', async () => {
+    const response = await callStatus('?base64MaxBytes=4096')
+
+    expect(response.status).toBe(400)
+    expect(mocks.readRun).not.toHaveBeenCalled()
+  })
+
+  /** Explicitly declining the inlining is not a request for it. */
+  it('accepts includeFileBase64=false on its own', async () => {
+    expect((await callStatus('?includeFileBase64=false')).status).toBe(200)
+  })
+
   it('rejects a base64MaxBytes above the inline ceiling', async () => {
     const response = await callStatus(
       `?includeOutput=true&includeFileBase64=true&base64MaxBytes=${64 * 1024 * 1024}`

--- a/apps/sim/lib/api/contracts/v2/openapi/resources.ts
+++ b/apps/sim/lib/api/contracts/v2/openapi/resources.ts
@@ -1483,7 +1483,7 @@ const declaredRoutes = [
         'ListWorkflowMcpServersResponse',
         'List workflow MCP servers response',
         'A cursor-paginated page of published MCP servers.',
-        [{ data: [WORKFLOW_MCP_SERVER_LIST_EXAMPLE], nextCursor: null }]
+        [{ data: [WORKFLOW_MCP_SERVER_LIST_EXAMPLE], nextCursor: null, toolNamesTruncated: false }]
       ),
     }
   ),
@@ -1550,6 +1550,7 @@ const declaredRoutes = [
           {
             data: [omitUpdated(WORKFLOW_MCP_TOOL_EXAMPLE)],
             nextCursor: null,
+            truncated: false,
           },
         ]
       ),

--- a/apps/sim/lib/api/contracts/v2/tables.ts
+++ b/apps/sim/lib/api/contracts/v2/tables.ts
@@ -2546,7 +2546,21 @@ export const v2TableRunDispatchSchema = z
         rowIds: z
           .array(z.string())
           .optional()
-          .describe('Explicit rows the dispatch targets; absent means every eligible row.'),
+          .describe(
+            'Explicit rows the dispatch targets. Absent does not mean every eligible row on its own — a select-all dispatch has no row list either, and says so with `selectAll`.'
+          ),
+        selectAll: z
+          .boolean()
+          .optional()
+          .describe(
+            'Present and true when the dispatch targets everything matching the filter its `POST` supplied, minus `excludeRowIds`, rather than a fixed row list. The filter itself is not published: it is stored compiled, in a different grammar from the predicate the request was written in. Absent alongside an absent `rowIds` is what means every eligible row.'
+          ),
+        excludeRowIds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Rows deselected from a select-all scope, which the walk skips. Only meaningful alongside `selectAll`.'
+          ),
       })
       .strict()
       .describe('What the dispatch was asked to run.'),

--- a/apps/sim/lib/api/contracts/v2/tables.ts
+++ b/apps/sim/lib/api/contracts/v2/tables.ts
@@ -2547,19 +2547,19 @@ export const v2TableRunDispatchSchema = z
           .array(z.string())
           .optional()
           .describe(
-            'Explicit rows the dispatch targets. Absent does not mean every eligible row on its own — a select-all dispatch has no row list either, and says so with `selectAll`.'
+            'Explicit rows the dispatch targets. Absent means it was given no row list and walks every eligible row, narrowed by `filtered` and `excludeRowIds` when either is present.'
           ),
-        selectAll: z
+        filtered: z
           .boolean()
           .optional()
           .describe(
-            'Present and true when the dispatch targets everything matching the filter its `POST` supplied, minus `excludeRowIds`, rather than a fixed row list. The filter itself is not published: it is stored compiled, in a different grammar from the predicate the request was written in. Absent alongside an absent `rowIds` is what means every eligible row.'
+            'Present and true when a stored filter narrows which rows run. The filter itself is not published: it is held compiled, in a different grammar from the predicate the request was written in. Absent means no filter narrows the dispatch — which, with no `rowIds` and no `excludeRowIds`, is what means every eligible row.'
           ),
         excludeRowIds: z
           .array(z.string())
           .optional()
           .describe(
-            'Rows deselected from a select-all scope, which the walk skips. Only meaningful alongside `selectAll`.'
+            'Rows the walk skips. Independent of `filtered`: a dispatch may exclude rows from a filtered set or from every eligible row. Never present alongside `rowIds`, which the run rejects and the walk would ignore.'
           ),
       })
       .strict()

--- a/apps/sim/lib/api/contracts/v2/workflow-mcp-servers.ts
+++ b/apps/sim/lib/api/contracts/v2/workflow-mcp-servers.ts
@@ -356,7 +356,7 @@ export const v2ListWorkflowMcpServersContract = defineRouteContract({
       toolNamesTruncated: z
         .boolean()
         .describe(
-          "Whether `toolCount` and `toolNames` under-report. The names are gathered for the whole page under one ceiling, so a page whose servers publish more tools than that ceiling between them reports only part of each server's inventory. Read `GET /api/v2/workflow-mcp-servers/{serverId}/tools` for a server's authoritative set. Unrelated to `nextCursor`, which is how this list says there are further servers."
+          "Whether `toolCount` and `toolNames` under-report. The names are gathered for the whole page under one ceiling, so a page whose servers publish more tools than that ceiling between them reports only part of each server's inventory. Read `GET /api/v2/workflow-mcp-servers/{serverId}/tools` for one server's inventory and check that response's own `truncated`, which reports the same ceiling applied to a single server — only an untruncated response is the authoritative set. Unrelated to `nextCursor`, which is how this list says there are further servers."
         ),
     }),
   },

--- a/apps/sim/lib/api/contracts/v2/workflow-mcp-servers.ts
+++ b/apps/sim/lib/api/contracts/v2/workflow-mcp-servers.ts
@@ -352,7 +352,13 @@ export const v2ListWorkflowMcpServersContract = defineRouteContract({
   query: v2ListWorkflowMcpServersQuerySchema,
   response: {
     mode: 'json',
-    schema: v2CursorListResponse(v2WorkflowMcpServerListItemSchema),
+    schema: v2CursorListResponse(v2WorkflowMcpServerListItemSchema).extend({
+      toolNamesTruncated: z
+        .boolean()
+        .describe(
+          "Whether `toolCount` and `toolNames` under-report. The names are gathered for the whole page under one ceiling, so a page whose servers publish more tools than that ceiling between them reports only part of each server's inventory. Read `GET /api/v2/workflow-mcp-servers/{serverId}/tools` for a server's authoritative set. Unrelated to `nextCursor`, which is how this list says there are further servers."
+        ),
+    }),
   },
 })
 
@@ -408,7 +414,13 @@ export const v2ListWorkflowMcpToolsContract = defineRouteContract({
   params: v2WorkflowMcpServerParamsSchema,
   response: {
     mode: 'json',
-    schema: v2CursorListResponse(v2WorkflowMcpToolListItemSchema, { paged: false }),
+    schema: v2CursorListResponse(v2WorkflowMcpToolListItemSchema, { paged: false }).extend({
+      truncated: z
+        .boolean()
+        .describe(
+          'Whether this inventory was cut short by the server-side ceiling on how many tools one response may carry. `nextCursor` is null either way — this list takes no `cursor`, so a truncated set cannot be paged past and this flag is the only way to tell a partial inventory from a complete one. A reconciling caller must not treat a truncated set as the full published inventory.'
+        ),
+    }),
   },
 })
 

--- a/apps/sim/lib/api/contracts/v2/workflows.ts
+++ b/apps/sim/lib/api/contracts/v2/workflows.ts
@@ -1821,6 +1821,27 @@ export const v2GetWorkflowRunContract = defineRouteContract({
         ),
     })
     .strict()
+    /**
+     * `includeFileBase64` is documented as requiring `includeOutput`, and the
+     * read honours that: file projection happens inside the `includeOutput`
+     * branch alone. Nothing enforced it, so asking for base64 without output
+     * parsed, was accepted, and was then dropped — the response came back `200`
+     * carrying no files and nothing to say why. `base64MaxBytes` rides on the
+     * same projection and was ignored the same way. Rejecting names the missing
+     * flag instead, matching `GET /billing/logs`, which refuses a window bound
+     * its period will not read rather than answering over a different one.
+     */
+    .superRefine((query, ctx) => {
+      if (query.includeOutput) return
+      for (const field of ['includeFileBase64', 'base64MaxBytes'] as const) {
+        if (query[field] === undefined || query[field] === false) continue
+        ctx.addIssue({
+          code: 'custom',
+          message: `${field} is only accepted with includeOutput=true; without it the run's files are never projected`,
+          path: [field],
+        })
+      }
+    })
     .meta({
       id: 'GetWorkflowRunQuery',
       title: 'Get workflow run query',

--- a/apps/sim/lib/mcp/application/workflow-deployments.ts
+++ b/apps/sim/lib/mcp/application/workflow-deployments.ts
@@ -125,6 +125,20 @@ export const listWorkflowMcpDeployments = defineAuthorizedWorkspaceUseCase({
         toolNames: namesByServerId.get(server.id) ?? [],
       })),
       nextCursorKeys: page.nextCursorKeys,
+      /**
+       * The name cap alone: `toolCount` and `toolNames` under-report because
+       * this page's servers publish more tools between them than
+       * `MAX_LISTED_WORKFLOW_MCP_TOOLS`. Kept apart from `truncated` because a
+       * surface that already publishes a `nextCursor` expresses "there is more
+       * to fetch" with the cursor, and would otherwise report an incomplete
+       * inventory on every page that simply has a successor.
+       */
+      toolNamesTruncated: truncated,
+      /**
+       * Anything at all is unseen — the name cap, or a further page. For a
+       * caller with no cursor to follow, which is how the copilot handler reads
+       * this, those are the same fact.
+       */
       truncated: page.nextCursorKeys !== null || truncated,
     }
   },

--- a/apps/sim/lib/table/application/bulk.test.ts
+++ b/apps/sim/lib/table/application/bulk.test.ts
@@ -603,6 +603,43 @@ describe('path-keyed bulk table selections', () => {
   })
 
   /**
+   * The published `deleted` is keyed the way the caller addressed the batch, so
+   * on this route a folder's id is replaced by its display path. The audit must
+   * not inherit that: `FOLDER_DELETED.resourceId` recorded `/Sales` here while
+   * `DELETE /api/folders/[id]` recorded the canonical id for the same action,
+   * leaving two spellings of one resource that no query could join.
+   */
+  it('audits a path-keyed folder deletion by its canonical id', async () => {
+    mocks.bulkDeleteFolders.mockResolvedValue({
+      succeeded: [{ id: 'folder-1', name: 'Sales' }],
+      failed: [],
+      folderCount: 1,
+      resourceCount: 0,
+    })
+    mocks.planFolderSelection.mockResolvedValue({
+      selected: [{ id: 'folder-1', name: 'Sales' }],
+      notFound: [],
+      contained: [],
+      covered: new Set<string>(),
+    })
+
+    const result = await bulkDeleteTables.execute({
+      principal,
+      input: {
+        assertedWorkspaceId: 'workspace-1',
+        folderKeying: 'paths' as const,
+        tableIds: [],
+        folders: ['/Sales'],
+      },
+    })
+
+    expect(result.deleted).toEqual([{ kind: 'folder', id: '/Sales', name: '/Sales' }])
+    expect(result.auditedDeletions).toEqual([
+      expect.objectContaining({ kind: 'folder', id: 'folder-1' }),
+    ])
+  })
+
+  /**
    * One index for the whole batch: `resolveTableFolderPath` takes the folder
    * tree lock per call, so per-path resolution would be a lock acquisition each.
    */

--- a/apps/sim/lib/table/application/bulk.ts
+++ b/apps/sim/lib/table/application/bulk.ts
@@ -129,7 +129,14 @@ interface BulkMoveTablesExecutionResult extends BulkMoveTablesResult, TableBatch
 }
 interface BulkDeleteTablesExecutionResult
   extends BulkDeleteTablesResult,
-    TableBatchExecutionResult {}
+    TableBatchExecutionResult {
+  /**
+   * Every deletion keyed by canonical id, for the audit projection only. The
+   * published `deleted` is keyed the way the caller addressed the batch, which
+   * on the path-keyed route is a display path.
+   */
+  auditedDeletions: BulkTableItem[]
+}
 
 async function resolveBulkTablesContext(
   input: BulkTablesSelectionInput,
@@ -539,6 +546,18 @@ export const bulkDeleteTables = defineAuthorizedTableUseCase({
       })
       return {
         deleted: deleted.map((item) => projectFolderItem(item, context)),
+        /**
+         * The same deletions still keyed by canonical id.
+         *
+         * `deleted` above is keyed for the caller, and on the path-keyed v2
+         * route `projectFolderItem` replaces a folder's id with its display
+         * path. Auditing from that list wrote the path into
+         * `FOLDER_DELETED.resourceId`, so the same action recorded a path here
+         * and an id from `DELETE /api/folders/[id]` — two spellings of one
+         * resource that no query could join. The projection stays a
+         * presentation concern; the audit reads the canonical ids.
+         */
+        auditedDeletions: deleted.map((item) => ({ ...item })),
         deletedItems,
         ...withUnresolvedFolders(projectBulkOutcome(outcome, context), context),
         ...(terminalError !== undefined && { terminalFailure: { error: terminalError } }),
@@ -555,7 +574,7 @@ export const bulkDeleteTables = defineAuthorizedTableUseCase({
    * thousands of audit rows.
    */
   projectAudit: ({ result }) =>
-    result.deleted.map((item) =>
+    result.auditedDeletions.map((item) =>
       item.kind === 'folder'
         ? {
             action: AuditAction.FOLDER_DELETED,

--- a/apps/sim/lib/uploads/upload-session/application.test.ts
+++ b/apps/sim/lib/uploads/upload-session/application.test.ts
@@ -131,7 +131,9 @@ describe('upload session application', () => {
     })
 
     expect(file).toEqual({ id: 'file-1', name: 'file.txt' })
-    expect(mocks.getWorkspaceFile).toHaveBeenCalledWith('workspace-1', 'file-1')
+    expect(mocks.getWorkspaceFile).toHaveBeenCalledWith('workspace-1', 'file-1', {
+      throwOnError: true,
+    })
   })
 
   it('does not look for a file before finalization completes', async () => {
@@ -143,6 +145,44 @@ describe('upload session application', () => {
 
     expect(file).toBeNull()
     expect(mocks.getWorkspaceFile).not.toHaveBeenCalled()
+  })
+
+  /**
+   * `getWorkspaceFile` logs and returns null on a read failure unless told
+   * otherwise, which would report a finalized upload as fileless to the one
+   * caller polling to learn what it created — and they would stop, believing
+   * there was nothing. A failed read is not the same answer as no file.
+   */
+  it('surfaces a failed file read instead of reporting the upload fileless', async () => {
+    const completed = { ...workspaceUploadSession(), status: 'completed' as const, completedFileId: 'file-1' }
+    mocks.getOwnedSession.mockResolvedValue(completed)
+    mocks.getPrincipalSession.mockResolvedValue(completed)
+    mocks.getWorkspaceFile.mockRejectedValue(new Error('connection terminated'))
+
+    await expect(
+      readWorkspaceUploadSession(principal, {
+        uploadId: 'upload-1',
+        workspaceId: 'workspace-1',
+        uploadToken: 'upload-token',
+      })
+    ).rejects.toThrow('connection terminated')
+  })
+
+  it('reads the completed file with throwOnError so a fault cannot read as absence', async () => {
+    const completed = { ...workspaceUploadSession(), status: 'completed' as const, completedFileId: 'file-1' }
+    mocks.getOwnedSession.mockResolvedValue(completed)
+    mocks.getPrincipalSession.mockResolvedValue(completed)
+    mocks.getWorkspaceFile.mockResolvedValue({ id: 'file-1', name: 'file.txt' })
+
+    await readWorkspaceUploadSession(principal, {
+      uploadId: 'upload-1',
+      workspaceId: 'workspace-1',
+      uploadToken: 'upload-token',
+    })
+
+    expect(mocks.getWorkspaceFile).toHaveBeenCalledWith('workspace-1', 'file-1', {
+      throwOnError: true,
+    })
   })
 
   /** A completed session whose file was since deleted has nothing to address. */

--- a/apps/sim/lib/uploads/upload-session/application.test.ts
+++ b/apps/sim/lib/uploads/upload-session/application.test.ts
@@ -11,6 +11,11 @@ const mocks = vi.hoisted(() => ({
   getOwnedSession: vi.fn(),
   getPrincipalSession: vi.fn(),
   reauthorizeWorkspacePurpose: vi.fn(),
+  getWorkspaceFile: vi.fn(),
+}))
+
+vi.mock('@/lib/uploads/contexts/workspace', () => ({
+  getWorkspaceFile: mocks.getWorkspaceFile,
 }))
 
 vi.mock('@/lib/uploads/upload-session/service', () => ({
@@ -91,7 +96,7 @@ describe('upload session application', () => {
    * workspace permission rather than trusting the session lookup alone.
    */
   it('re-authorizes a session read against the read operation', async () => {
-    const session = await readWorkspaceUploadSession(principal, {
+    const { session } = await readWorkspaceUploadSession(principal, {
       uploadId: 'upload-1',
       workspaceId: 'workspace-1',
       uploadToken: 'upload-token',
@@ -103,6 +108,57 @@ describe('upload session application', () => {
       expect.objectContaining({ id: 'upload-1' }),
       expect.objectContaining({ id: 'files.upload.read', minimumRole: 'read' })
     )
+  })
+
+  /**
+   * The resource documents `file` as the registered file after finalization,
+   * and a caller polling a transfer it lost track of is exactly who needs it —
+   * it is the only way to learn the id the upload produced without having held
+   * the `complete` response. The read answered `null` unconditionally, so that
+   * caller could see a session reach `completed` and still never learn what it
+   * had created.
+   */
+  it('returns the registered file once the session has completed', async () => {
+    const completed = { ...workspaceUploadSession(), status: 'completed' as const, completedFileId: 'file-1' }
+    mocks.getOwnedSession.mockResolvedValue(completed)
+    mocks.getPrincipalSession.mockResolvedValue(completed)
+    mocks.getWorkspaceFile.mockResolvedValue({ id: 'file-1', name: 'file.txt' })
+
+    const { file } = await readWorkspaceUploadSession(principal, {
+      uploadId: 'upload-1',
+      workspaceId: 'workspace-1',
+      uploadToken: 'upload-token',
+    })
+
+    expect(file).toEqual({ id: 'file-1', name: 'file.txt' })
+    expect(mocks.getWorkspaceFile).toHaveBeenCalledWith('workspace-1', 'file-1')
+  })
+
+  it('does not look for a file before finalization completes', async () => {
+    const { file } = await readWorkspaceUploadSession(principal, {
+      uploadId: 'upload-1',
+      workspaceId: 'workspace-1',
+      uploadToken: 'upload-token',
+    })
+
+    expect(file).toBeNull()
+    expect(mocks.getWorkspaceFile).not.toHaveBeenCalled()
+  })
+
+  /** A completed session whose file was since deleted has nothing to address. */
+  it('answers null when the completed file is gone', async () => {
+    const gone = { ...workspaceUploadSession(), status: 'completed' as const, completedFileId: 'file-1' }
+    mocks.getOwnedSession.mockResolvedValue(gone)
+    mocks.getPrincipalSession.mockResolvedValue(gone)
+    mocks.getWorkspaceFile.mockResolvedValue(null)
+
+    const { file } = await readWorkspaceUploadSession(principal, {
+      uploadId: 'upload-1',
+      workspaceId: 'workspace-1',
+      uploadToken: 'upload-token',
+    })
+
+    expect(file).toBeNull()
   })
 
   it('does not return a session whose re-authorization fails', async () => {

--- a/apps/sim/lib/uploads/upload-session/application.ts
+++ b/apps/sim/lib/uploads/upload-session/application.ts
@@ -205,6 +205,13 @@ export interface ReadWorkspaceUploadSessionResult {
    * Still null when a completed session's file has since been deleted, which is
    * the same shape as "not finalized yet" and needs no separate signal: in both
    * cases there is no file to address.
+   *
+   * A failed *read*, though, is not that shape. `getWorkspaceFile` logs and
+   * returns null by default, which would let a transient database error present
+   * a finalized upload as fileless to the one caller polling to learn what it
+   * created — and they would stop, having been told there was nothing. It is
+   * read with `throwOnError` so the failure surfaces and the poll can retry,
+   * matching how `readWorkspaceFileRecord` loads the same record.
    */
   file: WorkspaceFileRecord | null
 }
@@ -218,7 +225,9 @@ export async function readWorkspaceUploadSession(
   if (session.status !== 'completed' || !session.completedFileId || !session.workspaceId) {
     return { session, file: null }
   }
-  const file = await getWorkspaceFile(session.workspaceId, session.completedFileId)
+  const file = await getWorkspaceFile(session.workspaceId, session.completedFileId, {
+    throwOnError: true,
+  })
   return { session, file: file ?? null }
 }
 

--- a/apps/sim/lib/uploads/upload-session/application.ts
+++ b/apps/sim/lib/uploads/upload-session/application.ts
@@ -3,7 +3,7 @@ import type { CreateInternalFileUploadBody } from '@/lib/api/contracts/upload-se
 import type { OrchestrationRequestContext } from '@/lib/core/orchestration/types'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 import { loadActiveFolderPathIndex, resolveFolderPathFromIndex } from '@/lib/folders/queries'
-import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
+import { getWorkspaceFile, type WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import {
   abortUploadSession,
   assertUploadSessionAuthBinding,
@@ -191,13 +191,35 @@ export async function loadAuthorizedWorkspaceUploadSession(
  * auth binding and the caller's present workspace permission are both
  * re-checked here rather than the session being looked up on its id alone.
  */
+export interface ReadWorkspaceUploadSessionResult {
+  session: UploadSessionRecord
+  /**
+   * The file the session registered, once it has one.
+   *
+   * The resource documents `file` as "the registered file after finalization",
+   * and a caller polling a transfer it lost track of is exactly who needs it —
+   * it is the only way to learn the id the upload produced without having held
+   * the `complete` response. Loaded here rather than in the presenter because
+   * it is a protected read.
+   *
+   * Still null when a completed session's file has since been deleted, which is
+   * the same shape as "not finalized yet" and needs no separate signal: in both
+   * cases there is no file to address.
+   */
+  file: WorkspaceFileRecord | null
+}
+
 export async function readWorkspaceUploadSession(
   principal: Principal,
   input: UploadSessionControlInput
-): Promise<UploadSessionRecord> {
+): Promise<ReadWorkspaceUploadSessionResult> {
   const session = await loadAuthorizedWorkspaceUploadSession(principal, input)
   await reauthorizeWorkspaceUploadPurpose(principal, session, fileOperations.uploadRead)
-  return session
+  if (session.status !== 'completed' || !session.completedFileId || !session.workspaceId) {
+    return { session, file: null }
+  }
+  const file = await getWorkspaceFile(session.workspaceId, session.completedFileId)
+  return { session, file: file ?? null }
 }
 
 /** Issues multipart URLs after current workspace authorization. */

--- a/apps/sim/lib/workflows/application/download-workflow-run-file.test.ts
+++ b/apps/sim/lib/workflows/application/download-workflow-run-file.test.ts
@@ -110,6 +110,31 @@ describe('downloadWorkflowRunFileStream', () => {
     expect(result.contentLength).toBe(3)
   })
 
+  /**
+   * `HEAD` on this route runs the authorization phase alone. With the file
+   * lookup downstream of it, `authorize` succeeded for any id at all, so a
+   * `HEAD` answered `200` for a file the `GET` beside it would `404` — the two
+   * verbs disagreed about whether the resource existed. The route test above
+   * could not catch it: it mocks this use case and makes `authorize` reject, so
+   * it only ever proved the route renders a rejection.
+   */
+  it('refuses to authorize a file id the run never produced', async () => {
+    await expect(
+      downloadWorkflowRunFileStream.authorize({
+        principal: principals[0],
+        input: input({ fileId: 'file_absent' }),
+      })
+    ).rejects.toThrow('File not found')
+    expect(mocks.downloadFileStream).not.toHaveBeenCalled()
+  })
+
+  it('authorizes a file the run did produce', async () => {
+    await expect(
+      downloadWorkflowRunFileStream.authorize({ principal: principals[0], input: input() })
+    ).resolves.not.toThrow()
+    expect(mocks.downloadFileStream).not.toHaveBeenCalled()
+  })
+
   it('denies a principal below the read role', async () => {
     mocks.resolvePermission.mockResolvedValue(null)
 

--- a/apps/sim/lib/workflows/application/download-workflow-run-file.ts
+++ b/apps/sim/lib/workflows/application/download-workflow-run-file.ts
@@ -35,14 +35,32 @@ export interface DownloadWorkflowRunFileResult {
   contentLength: number
 }
 
-async function executeDownloadWorkflowRunFile({
-  context,
-  input,
-}: AuthorizedWorkspaceUseCaseContext<
-  typeof workflowOperations.downloadRunFile,
-  DownloadWorkflowRunFileInput,
-  ActiveWorkflowRunApplicationContext
->): Promise<DownloadWorkflowRunFileResult> {
+interface DownloadWorkflowRunFileContext extends ActiveWorkflowRunApplicationContext {
+  file: UserFile
+}
+
+/**
+ * Resolves the run *and* the file the path addresses.
+ *
+ * The file lookup belongs here rather than in `execute` because `HEAD` runs the
+ * authorization phase alone: with the lookup downstream of it, `HEAD` answered
+ * a success for a file id no `GET` on the same path would ever serve, so the
+ * two disagreed about whether the resource existed. Resolving the addressed
+ * sub-resource while loading canonical context is what `readTableDispatch` does
+ * with its dispatch id, and it makes both verbs answer from one decision.
+ *
+ * Every failure keeps the shared message: an unknown run, an unknown file, a
+ * file belonging to another run, and a concealed cross-tenant denial are all
+ * `File not found`, so ordering this before the authorization phase separates
+ * none of them.
+ */
+async function resolveDownloadWorkflowRunFileContext(
+  input: DownloadWorkflowRunFileInput
+): Promise<DownloadWorkflowRunFileContext> {
+  const context = await resolveActiveWorkflowRunApplicationContext({
+    runId: input.runId,
+    assertedWorkflowId: input.workflowId,
+  })
   const runFiles = await getWorkflowRunFiles({
     workflowId: context.workflowId,
     runId: context.runId,
@@ -67,6 +85,18 @@ async function executeDownloadWorkflowRunFile({
    */
   const file = runFiles.filesById.get(input.fileId)
   if (!file) throw new OrchestrationError('not_found', FILE_NOT_FOUND_MESSAGE)
+
+  return { ...context, file }
+}
+
+async function executeDownloadWorkflowRunFile({
+  context,
+}: AuthorizedWorkspaceUseCaseContext<
+  typeof workflowOperations.downloadRunFile,
+  DownloadWorkflowRunFileInput,
+  DownloadWorkflowRunFileContext
+>): Promise<DownloadWorkflowRunFileResult> {
+  const { file } = context
 
   /**
    * The storage context is inferred from the key rather than read off the
@@ -110,10 +140,7 @@ async function executeDownloadWorkflowRunFile({
 export const downloadWorkflowRunFileStream = defineAuthorizedWorkflowUseCase({
   operation: workflowOperations.downloadRunFile,
   resolveContext: ({ input }: { input: DownloadWorkflowRunFileInput }) =>
-    resolveActiveWorkflowRunApplicationContext({
-      runId: input.runId,
-      assertedWorkflowId: input.workflowId,
-    }),
+    resolveDownloadWorkflowRunFileContext(input),
   execute: executeDownloadWorkflowRunFile,
   projectAudit: ({ context, result }) => ({
     action: AuditAction.FILE_DOWNLOADED,

--- a/apps/sim/lib/workspace-files/api/route-policies.ts
+++ b/apps/sim/lib/workspace-files/api/route-policies.ts
@@ -4,7 +4,9 @@ import {
   type V2ErrorPolicy,
   v2OrchestrationErrorPolicy,
 } from '@/lib/api/server/routes'
+import { ArchiveError, statusForArchiveError } from '@/lib/uploads/archive'
 import { WORKSPACE_FILES_DELEGATION_AUDIENCE } from '@/lib/workspace-files/application/authorization'
+import { v2CaughtOrchestrationError, v2ErrorForOrchestration } from '@/app/api/v2/lib/response'
 
 export const internalSessionOrExecutorAuth = createInternalSessionOrExecutorAuth({
   audience: WORKSPACE_FILES_DELEGATION_AUDIENCE,
@@ -36,5 +38,26 @@ export const v2FileErrorPolicies = {
    */
   concealUploadAuthorization: createV2ResourceConcealmentPolicy({
     notFoundMessage: 'Upload session not found',
+  }) satisfies V2ErrorPolicy,
+  /**
+   * Unarchiving is the one file operation whose *payload* can be at fault: a
+   * malformed archive is the caller's request being wrong, and an archive over
+   * a cap is a limit they can act on. Without an arm for it both rendered as a
+   * `500`, so the v2 caller was told the server had failed when the answer was
+   * `400` or `413` — the internal extract route beside it has said so all
+   * along. The status stays decided by `statusForArchiveError`, which classifies
+   * every reason in one place; this only carries it into the v2 vocabulary.
+   */
+  concealExtractionAuthorization: createV2ResourceConcealmentPolicy({
+    notFoundMessage: 'File not found',
+    render(error) {
+      if (error instanceof ArchiveError) {
+        return v2ErrorForOrchestration(
+          statusForArchiveError(error) === 413 ? 'payload_too_large' : 'validation',
+          error.message
+        )
+      }
+      return v2CaughtOrchestrationError(error)
+    },
   }) satisfies V2ErrorPolicy,
 } as const

--- a/packages/sim-cli/src/generated/v2-api.ts
+++ b/packages/sim-cli/src/generated/v2-api.ts
@@ -752,6 +752,8 @@ type CancelTableDispatchResponseRef0 = {
   scope: {
     groupIds: Array<string>
     rowIds?: Array<string>
+    selectAll?: boolean
+    excludeRowIds?: Array<string>
   }
   limit: {
     type: 'rows'
@@ -4266,6 +4268,8 @@ type GetTableDispatchResponseRef0 = {
   scope: {
     groupIds: Array<string>
     rowIds?: Array<string>
+    selectAll?: boolean
+    excludeRowIds?: Array<string>
   }
   limit: {
     type: 'rows'
@@ -5867,6 +5871,8 @@ type ListTableDispatchesResponseRef0 = {
   scope: {
     groupIds: Array<string>
     rowIds?: Array<string>
+    selectAll?: boolean
+    excludeRowIds?: Array<string>
   }
   limit: {
     type: 'rows'
@@ -6161,6 +6167,7 @@ type ListWorkflowMcpServersResponseRef0 = {
 export type ListWorkflowMcpServersResponse = {
   data: Array<ListWorkflowMcpServersResponseRef0>
   nextCursor: string | null
+  toolNamesTruncated: boolean
 }
 
 /** `GET /api/v2/workflow-mcp-servers/[serverId]/tools` */
@@ -6185,6 +6192,7 @@ type ListWorkflowMcpToolsResponseRef0 = {
 export type ListWorkflowMcpToolsResponse = {
   data: Array<ListWorkflowMcpToolsResponseRef0>
   nextCursor: string | null
+  truncated: boolean
 }
 
 /** `GET /api/v2/workflows/[workflowId]/runs` */

--- a/packages/sim-cli/src/generated/v2-api.ts
+++ b/packages/sim-cli/src/generated/v2-api.ts
@@ -752,7 +752,7 @@ type CancelTableDispatchResponseRef0 = {
   scope: {
     groupIds: Array<string>
     rowIds?: Array<string>
-    selectAll?: boolean
+    filtered?: boolean
     excludeRowIds?: Array<string>
   }
   limit: {
@@ -4268,7 +4268,7 @@ type GetTableDispatchResponseRef0 = {
   scope: {
     groupIds: Array<string>
     rowIds?: Array<string>
-    selectAll?: boolean
+    filtered?: boolean
     excludeRowIds?: Array<string>
   }
   limit: {
@@ -5871,7 +5871,7 @@ type ListTableDispatchesResponseRef0 = {
   scope: {
     groupIds: Array<string>
     rowIds?: Array<string>
-    selectAll?: boolean
+    filtered?: boolean
     excludeRowIds?: Array<string>
   }
   limit: {


### PR DESCRIPTION
## Summary
The remaining real findings from cubic's review of the v0.8.12 release PR (#7090), all on the v2 API surface. Verified each against the code before fixing; two needed no change.

Six of the seven share a shape worth naming: **the layer underneath already knew, and the response threw it away.**

- **`includeFileBase64` silently did nothing without `includeOutput`.** The contract has always said it requires it, and the read honours that — files are projected inside the `includeOutput` branch alone. Nothing enforced it, so the flag parsed, was accepted, and was then dropped: a `200` carrying no files and no reason why. Now a `400` naming the missing flag, matching how `GET /billing/logs` refuses a window bound its period will not read. `base64MaxBytes` rode on the same projection and is covered too.
- **`POST /files/{fileId}/unzip` answered `500` for a bad archive.** `ArchiveError` had no arm in the v2 error policy, though the internal extract route beside it has mapped the same failures to `400`/`413` all along. `statusForArchiveError` stays the single place a reason is classified.
- **Both workflow-MCP lists truncated silently.** The use cases were *already returning* `truncated`, and the copilot handler already publishes it — only the v2 presenters dropped it, while `nextCursor: null` told a reconciling caller the set was complete. The tools list now returns `truncated`; the servers list returns `toolNamesTruncated`, kept separate from "there is another page" so it does not fire on every page with a successor.
- **A filtered table dispatch was indistinguishable from an unfiltered one.** `rowIds: undefined` documented itself as "every eligible row", but a select-all dispatch has no row list either — and `POST` on that same path accepts `filter` and `excludeRowIds`, so a caller could create a scope the resource then denied having. The compiled filter stays unpublished (it is stored in a different grammar from the predicate the request was written in, and a test had deliberately locked that in); `selectAll` and `excludeRowIds` name the distinction without reproducing it.
- **`GET /files/uploads/{uploadId}` always returned `file: null`,** though the contract promises the registered file after finalization and `completedFileId` was sitting on the record. That endpoint exists for a caller who lost track of a transfer — the one caller who cannot get the id any other way.
- **`HEAD` on a run file 200'd for ids that do not exist.** It resolved the file downstream of authorization, so it disagreed with the `GET` beside it. The lookup moved into context resolution, matching how `readTableDispatch` resolves its dispatch id.
- **v2 bulk table delete audited a display path as `resourceId`.** It projected from the caller-keyed list, so `FOLDER_DELETED` recorded `/Sales` where `DELETE /api/folders/[id]` records the canonical id — two spellings of one resource that no query could join.

### Needed no change
- **Cross-organization audit-log cursor replay.** The scenario needs one caller authorized for two organizations. `member` carries `uniqueIndex('member_user_id_unique')` and `resolveEnterpriseAuditAccess` refuses any organization the caller is not a member of, so it cannot arise. Reasoning posted on the thread.
- **Both documentation findings** were already fixed on staging by #7092, after cubic's review ran.

## Type of Change
- [x] Bug fix

## Testing
- A test per fix, each **verified to fail against the unfixed code**. Several of these survived because the existing tests could not catch them: the unzip tests all raised `OrchestrationError` (which every policy already renders) rather than the `ArchiveError` the use case actually throws, and the `HEAD` test mocked the use case and made `authorize` reject — proving only that the route renders a rejection. The new `HEAD` coverage sits at the use-case level, where the real decision is made.
- Full suites green: `apps/sim` 33,288 tests, `sim-cli` 607 tests.
- `bun run lint`, all 33 audits (`check:audits`), and `type-check` in both workspaces pass. `generate:openapi` rejected the new response fields until their examples were updated, which is the gate working.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)