### PR TITLE
fix(chat): conceal a missing deployment the way an unreachable one is

### DIFF
--- a/apps/sim/app/api/chat/error-policy.ts
+++ b/apps/sim/app/api/chat/error-policy.ts
@@ -37,9 +37,27 @@ export function createInternalChatDeploymentErrorPolicy(fallback: string): Inter
         }
         const classified = asOrchestrationError(error)
         if (!classified) return null
+        /**
+         * A not-found is concealed wherever it came from, not only when the
+         * concealment policy rewrites an authorization failure into one.
+         *
+         * The domain answers an absent deployment with its own wording, so the
+         * editor received `Chat deployment not found` for a deployment that is
+         * not there and `Chat not found or access denied` for one it may not
+         * reach — two 404s a caller can tell apart, which is the existence
+         * oracle this policy exists to close. The `code` is derived from the
+         * message, so leaving the message alone leaked it twice over.
+         *
+         * Every `not_found` reachable here means the same thing: the chat
+         * deployment is not available to this caller. None of them carries a
+         * distinction worth preserving at the cost of the one they must not
+         * make.
+         */
+        const message =
+          classified.code === 'not_found' ? CHAT_NOT_FOUND_MESSAGE : classified.message
         return internalErrorResponse(statusForOrchestrationError(classified.code), {
-          error: classified.message,
-          code: legacyCode(classified.message),
+          error: message,
+          code: legacyCode(message),
         })
       },
       unhandled() {

--- a/apps/sim/app/api/chat/manage/[id]/route.test.ts
+++ b/apps/sim/app/api/chat/manage/[id]/route.test.ts
@@ -242,6 +242,38 @@ describe('internal chat deployment routes', () => {
       expect(response.status).toBe(404)
     })
 
+    /**
+     * Both tests above assert only the status, which is what let the two 404s
+     * drift apart: the domain answered an absent deployment with its own
+     * wording while the concealment policy rewrote an unreachable one, so the
+     * body — and the `code` derived from it — told a caller which of the two it
+     * had hit. Comparing the responses is the assertion that keeps them one
+     * answer.
+     */
+    it('answers a missing and an unreachable deployment identically', async () => {
+      mocks.getChatDeploymentWithWorkspace.mockResolvedValue(null)
+      const missing = await GET(
+        new NextRequest(`http://localhost:3000/api/chat/manage/${CHAT_ID}`),
+        params
+      )
+      const missingBody = await missing.json()
+
+      mocks.getChatDeploymentWithWorkspace.mockResolvedValue({
+        chat: chatRow(),
+        workspaceId: WORKSPACE_ID,
+      })
+      mocks.resolvePermission.mockResolvedValue(null)
+      const unreachable = await GET(
+        new NextRequest(`http://localhost:3000/api/chat/manage/${CHAT_ID}`),
+        params
+      )
+      const unreachableBody = await unreachable.json()
+
+      expect(missing.status).toBe(unreachable.status)
+      expect(missingBody).toEqual(unreachableBody)
+      expect(missingBody.error).toBe('Chat not found or access denied')
+    })
+
     it('refuses a workspace member below admin the gate configuration', async () => {
       mocks.resolvePermission.mockResolvedValue('read')
 


### PR DESCRIPTION
## Summary
From the v0.8.12 release review (#7090). The internal chat error policy documents that a missing deployment and one in an unreachable workspace "must stay indistinguishable" — and they were not.

- The policy rewrites a cross-tenant authorization failure to `Chat not found or access denied`, but the domain answers an absent deployment with its own `Chat deployment not found`, which the projection passed straight through. Two 404s a caller can tell apart is exactly the existence oracle the concealment exists to close.
- The legacy `code` is derived from the message (`legacyCode`), so the difference leaked on both the `error` and `code` fields.
- Every `not_found` reachable through this policy means the same thing — the deployment is not available to this caller — so all of them now render as the concealed message. None of the alternatives (`context.ts`, `update-chat-deployment.ts`, the two undeploy paths) carries a distinction worth preserving at the cost of the one they must not make.

## Type of Change
- [x] Bug fix

## Testing
- The two existing 404 tests asserted only `response.status`, which is how the bodies drifted apart unnoticed. The new test compares the two responses directly and asserts the concealed wording; it goes red against the unfixed policy.
- Full `apps/sim` suite green: 34,539 tests.
- `bun run lint`, all 33 audits (`check:audits`), and `type-check` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)