### PR TITLE
fix(landing): refresh workspace sidebar preview

### DIFF
--- a/apps/sim/app/(landing)/components/shared/hero-loop-shell/hero-loop-shell.tsx
+++ b/apps/sim/app/(landing)/components/shared/hero-loop-shell/hero-loop-shell.tsx
@@ -10,6 +10,8 @@ import { DESIGN, useDesignScale } from '@/app/(landing)/hooks/use-design-scale'
 interface HeroLoopShellProps {
   /** Workspace name in the sidebar header chip. */
   workspaceName?: string
+  /** Viewer name shown in the sidebar profile footer. */
+  profileName?: string
   /** Recent-chat entries in the sidebar - four fill the design height. */
   chats: readonly string[]
   /** Deployed-workflow entries in the sidebar - five fill the design height. */
@@ -30,6 +32,7 @@ interface HeroLoopShellProps {
  */
 export function HeroLoopShell({
   workspaceName = 'Brightwave',
+  profileName = 'Morgan',
   chats,
   workflows,
   activeNav,
@@ -49,6 +52,7 @@ export function HeroLoopShell({
       >
         <EnterpriseSidebar
           workspaceName={workspaceName}
+          profileName={profileName}
           chats={chats}
           workflows={workflows}
           activeNav={activeNav}

--- a/apps/sim/app/(landing)/enterprise/components/enterprise-platform-loop/enterprise-platform-loop.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/enterprise-platform-loop/enterprise-platform-loop.tsx
@@ -96,6 +96,7 @@ export function EnterprisePlatformLoop({
   return (
     <HeroLoopShell
       workspaceName={content.workspaceName}
+      profileName={content.profileName}
       chats={content.sidebarChats}
       workflows={content.sidebarWorkflows}
     >

--- a/apps/sim/app/(landing)/enterprise/components/enterprise-platform-loop/enterprise-sidebar.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/enterprise-platform-loop/enterprise-sidebar.tsx
@@ -1,16 +1,22 @@
 import { memo } from 'react'
-import { ChevronDown, cn, Home, Library } from '@sim/emcn'
 import {
-  Calendar,
+  ChipChevronDown,
+  chipContentIconClass,
+  chipContentLabelClass,
+  chipVariants,
+  cn,
+} from '@sim/emcn'
+import {
   Database,
-  File,
+  Files,
   HelpCircle,
+  Home,
   Integration,
+  Library,
   MoreHorizontal,
   PanelLeft,
   Plus,
   Search,
-  Settings,
   Table,
 } from '@sim/emcn/icons'
 import Image from 'next/image'
@@ -21,9 +27,8 @@ import {
 
 const WORKSPACE_NAV = [
   { label: 'Tables', icon: Table },
-  { label: 'Files', icon: File },
-  { label: 'Knowledge base', icon: Database },
-  { label: 'Scheduled tasks', icon: Calendar },
+  { label: 'Files', icon: Files },
+  { label: 'Knowledge bases', icon: Database },
   { label: 'Logs', icon: Library },
 ] as const
 
@@ -36,14 +41,9 @@ interface IconRowProps {
 /** A sidebar nav row with a leading icon, like the real workspace sidebar. */
 function IconRow({ icon: Icon, label, active = false }: IconRowProps) {
   return (
-    <div
-      className={cn(
-        'mx-0.5 flex h-[28px] items-center gap-2 rounded-[8px] px-2',
-        active && 'bg-[var(--surface-active)]'
-      )}
-    >
-      <Icon className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
-      <span className='truncate text-[13px] text-[var(--text-body)]'>{label}</span>
+    <div className={chipVariants({ active, fullWidth: true })}>
+      <Icon className={chipContentIconClass} />
+      <span className={chipContentLabelClass}>{label}</span>
     </div>
   )
 }
@@ -51,8 +51,8 @@ function IconRow({ icon: Icon, label, active = false }: IconRowProps) {
 /** A bare text row - the real sidebar's chat and workflow entries. */
 function TextRow({ label }: { label: string }) {
   return (
-    <div className='mx-0.5 flex h-[28px] items-center rounded-[8px] px-2'>
-      <span className='truncate text-[13px] text-[var(--text-body)]'>{label}</span>
+    <div className={chipVariants({ fullWidth: true })}>
+      <span className={chipContentLabelClass}>{label}</span>
     </div>
   )
 }
@@ -61,7 +61,7 @@ function TextRow({ label }: { label: string }) {
 function SectionLabel({ label, actions }: { label: string; actions?: boolean }) {
   return (
     <div className='flex items-center justify-between px-4 pb-1.5'>
-      <span className='text-[12px] text-[var(--text-icon)]'>{label}</span>
+      <span className='text-[var(--text-muted)] text-caption'>{label}</span>
       {actions && (
         <span className='flex items-center gap-2 text-[var(--text-icon)]'>
           <MoreHorizontal className='size-[14px]' />
@@ -75,6 +75,8 @@ function SectionLabel({ label, actions }: { label: string; actions?: boolean }) 
 export interface EnterpriseSidebarProps {
   /** Workspace name in the header chip. Defaults to the enterprise workspace. */
   workspaceName?: string
+  /** Viewer name shown in the profile footer. Defaults to the enterprise persona. */
+  profileName?: string
   /** Recent-chat entries - four fill the design height. Defaults enterprise. */
   chats?: readonly string[]
   /** Deployed-workflow entries - five fill the design height. Defaults enterprise. */
@@ -91,30 +93,26 @@ export interface EnterpriseSidebarProps {
  * The Brightwave workspace sidebar, rendered live (the homepage loop keeps its
  * baked-screenshot sidebar; the enterprise loop draws its own so the content
  * can read like a large tenured deployment): the workspace header, New chat /
- * Search / Integrations, a filled-out Chats history, the Workspace nav, a full
- * Workflows section, and the Help / Settings footer. Purely decorative -
+ * Integrations, a filled-out Chats history, the Workspace nav, a full
+ * Workflows section, and the profile / Help footer. Purely decorative -
  * hover/click behavior is owned by the parent's `pointer-events-none` frame.
- * The workspace name and the chat / workflow entries are injectable so each
- * solutions hero can read like that team's workspace; defaults keep the
+ * The workspace and profile names plus the chat / workflow entries are injectable
+ * so each solutions hero can read like that team's workspace; defaults keep the
  * enterprise page exactly as it renders today. Memoized - the sidebar is
  * fully static per props, and every consuming loop re-renders on each clock
  * tick with stable sidebar props.
  */
 export const EnterpriseSidebar = memo(function EnterpriseSidebar({
   workspaceName = 'Brightwave',
+  profileName = 'Morgan',
   chats = SIDEBAR_CHATS,
   workflows = SIDEBAR_WORKFLOWS,
   activeNav,
 }: EnterpriseSidebarProps = {}) {
   return (
-    <div className='flex h-full w-[249px] flex-shrink-0 flex-col bg-[var(--surface-1)] pt-3'>
-      {/* Workspace header, matching the real product's WorkspaceHeader chip
-          (borderless `chipVariants()` geometry: h-[30px] rounded-lg px-2 with
-          mx-0.5, 16px logo, text-sm name, 14px chevron) and therefore the
-          homepage's baked sidebar pixels - logo + name + chevron as a bare
-          row, panel toggle right-aligned outside it. */}
+    <div className='flex h-full w-[238px] flex-shrink-0 flex-col bg-[var(--surface-1)] pt-3'>
       <div className='flex flex-shrink-0 items-center justify-between px-2'>
-        <div className='mx-0.5 flex h-[30px] min-w-0 items-center gap-2 rounded-lg px-2'>
+        <div className={cn(chipVariants(), 'min-w-0 flex-1')}>
           {/* The exact Brightwave mark the homepage capture seeds
               (`readme-tour-capture` sets `logoUrl: '/landing/rivian-logo.svg'`),
               so both platform previews show the same company logo. */}
@@ -125,30 +123,36 @@ export const EnterpriseSidebar = memo(function EnterpriseSidebar({
             height={16}
             className='size-[16px] flex-shrink-0 rounded-sm'
           />
-          <span className='min-w-0 truncate text-[var(--text-body)] text-sm'>{workspaceName}</span>
-          <ChevronDown className='size-[14px] flex-shrink-0 text-[var(--text-icon)]' />
+          <span className={chipContentLabelClass}>{workspaceName}</span>
+          <ChipChevronDown />
         </div>
-        <PanelLeft className='mr-1.5 size-[16px] flex-shrink-0 text-[var(--text-icon)]' />
+        <div className='flex h-[30px] w-[65px] flex-shrink-0 items-center gap-[1px]'>
+          <span className={chipVariants()}>
+            <Search className={chipContentIconClass} />
+          </span>
+          <span className={chipVariants()}>
+            <PanelLeft className={chipContentIconClass} />
+          </span>
+        </div>
       </div>
 
-      <div className='mt-2.5 flex flex-shrink-0 flex-col gap-0.5 px-2'>
+      <div className='mt-4 flex flex-shrink-0 flex-col gap-[1px] px-2'>
         <IconRow icon={Home} label='New chat' active={!activeNav} />
-        <IconRow icon={Search} label='Search' />
         <IconRow icon={Integration} label='Integrations' />
       </div>
 
-      <div className='mt-3.5 flex flex-shrink-0 flex-col'>
+      <div className='mt-4 flex flex-shrink-0 flex-col'>
         <SectionLabel label='Chats' />
-        <div className='flex flex-col gap-0.5 px-2'>
+        <div className='flex flex-col gap-[1px] px-2'>
           {chats.map((chat) => (
             <TextRow key={chat} label={chat} />
           ))}
         </div>
       </div>
 
-      <div className='mt-3.5 flex flex-shrink-0 flex-col'>
+      <div className='mt-4 flex flex-shrink-0 flex-col'>
         <SectionLabel label='Workspace' />
-        <div className='flex flex-col gap-0.5 px-2'>
+        <div className='flex flex-col gap-[1px] px-2'>
           {WORKSPACE_NAV.map((item) => (
             <IconRow
               key={item.label}
@@ -160,18 +164,27 @@ export const EnterpriseSidebar = memo(function EnterpriseSidebar({
         </div>
       </div>
 
-      <div className='flex min-h-0 flex-1 flex-col overflow-hidden pt-3.5'>
+      <div className='flex min-h-0 flex-1 flex-col overflow-hidden pt-4'>
         <SectionLabel label='Workflows' actions />
-        <div className='flex flex-col gap-0.5 px-2'>
+        <div className='flex flex-col gap-[1px] px-2'>
           {workflows.map((workflow) => (
             <TextRow key={workflow} label={workflow} />
           ))}
         </div>
       </div>
 
-      <div className='flex flex-shrink-0 flex-col gap-0.5 px-2 pt-[9px] pb-2'>
-        <IconRow icon={HelpCircle} label='Help' />
-        <IconRow icon={Settings} label='Settings' />
+      <div className='flex flex-shrink-0 items-center border-t px-2 pt-[9px] pb-2'>
+        <div className='flex min-w-0 flex-1'>
+          <div className={cn(chipVariants(), 'min-w-0 max-w-full')}>
+            <span className='flex size-[16px] flex-shrink-0 items-center justify-center rounded-full bg-[var(--surface-4)] text-[var(--text-body)] text-micro leading-none'>
+              {profileName.charAt(0).toUpperCase()}
+            </span>
+            <span className={chipContentLabelClass}>{profileName}</span>
+          </div>
+        </div>
+        <span className={cn(chipVariants(), 'flex-shrink-0')}>
+          <HelpCircle className={chipContentIconClass} />
+        </span>
       </div>
     </div>
   )

--- a/apps/sim/app/(landing)/enterprise/components/enterprise-platform-loop/stage-data.ts
+++ b/apps/sim/app/(landing)/enterprise/components/enterprise-platform-loop/stage-data.ts
@@ -157,6 +157,8 @@ export type EnterpriseLoopPhase = 'idle' | 'typing' | 'typed' | 'dispatch' | 're
 export interface EnterpriseLoopContent {
   /** Workspace name shown in the sidebar header. */
   workspaceName: string
+  /** Viewer name shown in the sidebar profile footer. */
+  profileName: string
   /** The new-chat greeting, personalized like the real workspace Home. */
   greeting: string
   /** Composer placeholder shown before the prompt types out. */
@@ -182,6 +184,7 @@ export interface EnterpriseLoopContent {
 /** The enterprise hero's own loop content - the parametrized loop's default. */
 export const ENTERPRISE_LOOP_CONTENT: EnterpriseLoopContent = {
   workspaceName: 'Brightwave',
+  profileName: 'Morgan',
   greeting: ENTERPRISE_GREETING,
   placeholder: COMPOSER_PLACEHOLDER,
   prompt: ENTERPRISE_PROMPT,

--- a/apps/sim/app/(landing)/knowledge/components/knowledge-hero-loop.tsx
+++ b/apps/sim/app/(landing)/knowledge/components/knowledge-hero-loop.tsx
@@ -162,7 +162,7 @@ export function KnowledgeHeroLoop() {
   })
 
   return (
-    <HeroLoopShell chats={SIDEBAR_CHATS} workflows={SIDEBAR_WORKFLOWS} activeNav='Knowledge base'>
+    <HeroLoopShell chats={SIDEBAR_CHATS} workflows={SIDEBAR_WORKFLOWS} activeNav='Knowledge bases'>
       <div className='h-full w-full overflow-hidden rounded-[6px] border border-[var(--border)] bg-[var(--bg)]'>
         <div
           className={cn(

--- a/apps/sim/app/(landing)/solutions/compliance/components/compliance-hero-loop.tsx
+++ b/apps/sim/app/(landing)/solutions/compliance/components/compliance-hero-loop.tsx
@@ -15,6 +15,7 @@ import type { EnterpriseLoopContent } from '@/app/(landing)/enterprise/component
  */
 const COMPLIANCE_LOOP_CONTENT: EnterpriseLoopContent = {
   workspaceName: 'Brightwave GRC',
+  profileName: 'Dana',
   greeting: 'What should we get done, Dana?',
   placeholder: 'Ask Sim to automate a process.',
   prompt:

--- a/apps/sim/app/(landing)/solutions/engineering/components/engineering-hero-loop.tsx
+++ b/apps/sim/app/(landing)/solutions/engineering/components/engineering-hero-loop.tsx
@@ -15,6 +15,7 @@ import type { EnterpriseLoopContent } from '@/app/(landing)/enterprise/component
  */
 const ENGINEERING_LOOP_CONTENT: EnterpriseLoopContent = {
   workspaceName: 'Brightwave Engineering',
+  profileName: 'Alex',
   greeting: 'What should we get done, Alex?',
   placeholder: 'Ask Sim to automate a process.',
   prompt:

--- a/apps/sim/app/(landing)/solutions/finance/components/finance-hero-loop.tsx
+++ b/apps/sim/app/(landing)/solutions/finance/components/finance-hero-loop.tsx
@@ -14,6 +14,7 @@ import type { EnterpriseLoopContent } from '@/app/(landing)/enterprise/component
  */
 const FINANCE_LOOP_CONTENT: EnterpriseLoopContent = {
   workspaceName: 'Brightwave Finance',
+  profileName: 'Elena',
   greeting: 'What should we get done, Elena?',
   placeholder: 'Ask Sim to automate a process.',
   prompt:

--- a/apps/sim/app/(landing)/solutions/hr/components/hr-hero-loop.tsx
+++ b/apps/sim/app/(landing)/solutions/hr/components/hr-hero-loop.tsx
@@ -14,6 +14,7 @@ import type { EnterpriseLoopContent } from '@/app/(landing)/enterprise/component
  */
 const HR_LOOP_CONTENT: EnterpriseLoopContent = {
   workspaceName: 'Brightwave HR',
+  profileName: 'Sam',
   greeting: 'What should we get done, Sam?',
   placeholder: 'Ask Sim to automate a process.',
   prompt:

--- a/apps/sim/app/(landing)/solutions/it/components/it-hero-loop.tsx
+++ b/apps/sim/app/(landing)/solutions/it/components/it-hero-loop.tsx
@@ -14,6 +14,7 @@ import type { EnterpriseLoopContent } from '@/app/(landing)/enterprise/component
  */
 const IT_LOOP_CONTENT: EnterpriseLoopContent = {
   workspaceName: 'Brightwave IT',
+  profileName: 'Priya',
   greeting: 'What should we get done, Priya?',
   placeholder: 'Ask Sim to automate a process.',
   prompt:

--- a/apps/sim/app/(landing)/solutions/sales/components/sales-hero-loop.tsx
+++ b/apps/sim/app/(landing)/solutions/sales/components/sales-hero-loop.tsx
@@ -21,6 +21,7 @@ import type { EnterpriseLoopContent } from '@/app/(landing)/enterprise/component
  */
 const SALES_LOOP_CONTENT: EnterpriseLoopContent = {
   workspaceName: 'Brightwave Sales',
+  profileName: 'Marcus',
   greeting: 'What should we get done, Marcus?',
   placeholder: 'Ask Sim to automate a process.',
   prompt:


### PR DESCRIPTION
## Summary
- Update landing workspace previews to match the current sidebar navigation and chip styling
- Remove scheduled tasks and replace the legacy footer with the profile and Help layout

## Type of Change
- [x] Bug fix

## Testing
- Tested manually at 1440px and 1024px
- `bun run lint`
- `bun run apps/sim/scripts/check-block-registry.ts origin/staging`
- `bun run check:audits`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)