### PR TITLE
feat(providers): add GLM-5.3 and GLM-5.3-Flash to Z.ai

### DIFF
--- a/apps/docs/content/docs/en/workflows/blocks/agent.mdx
+++ b/apps/docs/content/docs/en/workflows/blocks/agent.mdx
@@ -119,7 +119,7 @@ Live tool-call chips stream for **OpenAI, Anthropic, Azure Anthropic, Google, Ve
 | Groq | Full thinking deltas | `groq/openai/gpt-oss-120b`, `groq/openai/gpt-oss-20b`, `groq/openai/gpt-oss-safeguard-20b`, `groq/qwen/qwen3.6-27b` |
 | Meta | Not streamed | `muse-spark-1.1` |
 | Kimi | Full thinking deltas | `kimi-k2.6` |
-| Z.ai | Full thinking deltas | `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5-air` |
+| Z.ai | Full thinking deltas | `glm-5.3`, `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5-air` |
 
 {/* agent-stream-capabilities:end */}
 

--- a/apps/sim/providers/models.test.ts
+++ b/apps/sim/providers/models.test.ts
@@ -253,6 +253,8 @@ describe('zai provider definition', () => {
   const zai = PROVIDER_DEFINITIONS.zai
 
   const expectedModels = [
+    { id: 'glm-5.3', contextWindow: 1000000 },
+    { id: 'glm-5.3-flash', contextWindow: 1000000 },
     { id: 'glm-5.2', contextWindow: 1000000 },
     { id: 'glm-5.1', contextWindow: 200000 },
     { id: 'glm-5', contextWindow: 200000 },

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -2889,6 +2889,41 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     },
     models: [
       {
+        id: 'glm-5.3',
+        pricing: {
+          input: 1.4,
+          output: 4.4,
+          updatedAt: '2026-08-26',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 1 },
+          toolUsageControl: true,
+          maxOutputTokens: 131072,
+          reasoningEffort: {
+            values: ['low', 'high', 'max'],
+          },
+        },
+        contextWindow: 1000000,
+        releaseDate: '2026-08-14',
+        recommended: true,
+      },
+      {
+        id: 'glm-5.3-flash',
+        pricing: {
+          input: 0.15,
+          output: 0.5,
+          updatedAt: '2026-08-26',
+        },
+        capabilities: {
+          temperature: { min: 0, max: 1 },
+          toolUsageControl: true,
+          maxOutputTokens: 131072,
+        },
+        contextWindow: 1000000,
+        releaseDate: '2026-08-26',
+        speedOptimized: true,
+      },
+      {
         id: 'glm-5.2',
         pricing: {
           input: 1.4,
@@ -2905,7 +2940,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1000000,
         releaseDate: '2026-06-13',
-        recommended: true,
       },
       {
         id: 'glm-5.1',


### PR DESCRIPTION
## Summary
- Add `glm-5.3` (1M context, 131k max output, $1.40/$4.40 per 1M) with reasoning-effort levels `low`/`high`/`max` — reasoning is always on for this model, so no thinking on/off toggle
- Add `glm-5.3-flash` (1M context, 131k max output, $0.15/$0.50 per 1M), marked `speedOptimized`
- Move `recommended` from `glm-5.2` to `glm-5.3`
- Update the Z.ai model-list assertion and regenerate the agent-block streamed-thinking table

Flash pricing uses Z.ai's list rate, not the current 50% promo ($0.075/$0.25) that expires 2026-09-09 — otherwise the entry would silently under-bill once the promo ends.

`glm-5.3-flash` intentionally omits `reasoningEffort`: Z.ai's docs recommend `reasoning_effort: max` for it but never publish the allowed values, so the effort selector stays hidden rather than offering guessed levels.

## Type of Change
- [x] New feature

## Testing
Tested manually. `bun run lint`, `bun run type-check`, `bun run check:audits` (33/33 including `agent-stream-docs:check` and `check:api-validation:strict`), and `providers/models.test.ts` (38/38) all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)