### PR TITLE
fix(landing): restore section heading weight

### DIFF
--- a/apps/sim/app/(landing)/components/solutions-page/components/solutions-card-row/components/solutions-card-row-header/solutions-card-row-header.tsx
+++ b/apps/sim/app/(landing)/components/solutions-page/components/solutions-card-row/components/solutions-card-row-header/solutions-card-row-header.tsx
@@ -21,7 +21,7 @@ export function SolutionsCardRowHeader({ row, headingId }: SolutionsCardRowHeade
     <div className='flex flex-col items-start gap-3 text-left'>
       <h2
         id={headingId}
-        className='max-w-[540px] text-balance font-medium text-[22px] text-[var(--text-primary)] leading-[1.3] max-sm:text-[20px]'
+        className='max-w-[540px] text-balance text-[22px] text-[var(--text-primary)] leading-[1.3] max-sm:text-[20px]'
       >
         {row.title}
       </h2>


### PR DESCRIPTION
## Summary
- restore shared landing section headings to their original regular weight
- keep card labels and unrelated landing typography unchanged

## Type of Change
- [x] Bug fix

## Testing
Tested manually on Workflows and Enterprise at desktop and mobile sizes. `bun run type-check`, `bun run lint`, block registry checks, and all 33 audits pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)