### PR TITLE
fix(imap): resolve mailbox selector contexts server-side

### DIFF
--- a/apps/sim/app/api/tools/imap/mailboxes/route.ts
+++ b/apps/sim/app/api/tools/imap/mailboxes/route.ts
@@ -2,20 +2,25 @@ import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { ImapFlow } from 'imapflow'
 import { type NextRequest, NextResponse } from 'next/server'
-import { imapMailboxesContract } from '@/lib/api/contracts/tools/imap'
+import {
+  imapMailboxesContract,
+  resolvedImapMailboxesBodySchema,
+} from '@/lib/api/contracts/tools/imap'
 import { getValidationErrorMessage, parseRequest } from '@/lib/api/server'
-import { getSession } from '@/lib/auth'
 import { validateDatabaseHost } from '@/lib/core/security/input-validation.server'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
+import {
+  authenticateSelectorRequest,
+  resolveAuthorizedSelectorContext,
+} from '@/lib/selectors/server/resolve-authorized-context'
 
 const logger = createLogger('ImapMailboxesAPI')
 
 export const POST = withRouteHandler(async (request: NextRequest) => {
-  const session = await getSession()
-  if (!session?.user?.id) {
-    return NextResponse.json({ success: false, message: 'Unauthorized' }, { status: 401 })
+  const authentication = await authenticateSelectorRequest(request)
+  if (!authentication.ok) {
+    return NextResponse.json({ error: authentication.error }, { status: authentication.status })
   }
-
   const parsed = await parseRequest(
     imapMailboxesContract,
     request,
@@ -40,10 +45,29 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     }
   )
   if (!parsed.success) return parsed.response
-  const { host, port, secure, username, password } = parsed.data.body
+  const { workflowId, ...context } = parsed.data.body
+
+  const resolution = await resolveAuthorizedSelectorContext(authentication.principal, {
+    workflowId,
+    context,
+  })
+  if (!resolution.ok) {
+    return NextResponse.json(
+      { success: false, message: resolution.error },
+      { status: resolution.status }
+    )
+  }
+  const validated = resolvedImapMailboxesBodySchema.safeParse(resolution.context)
+  if (!validated.success) {
+    return NextResponse.json(
+      { success: false, message: 'Invalid IMAP selector configuration' },
+      { status: 400 }
+    )
+  }
+  const { host, port, secure, username, password } = validated.data
 
   try {
-    const hostValidation = await validateDatabaseHost(host, 'host')
+    const hostValidation = await validateDatabaseHost(host, 'host', { logFailureDetails: false })
     if (!hostValidation.isValid) {
       return NextResponse.json({ success: false, message: hostValidation.error }, { status: 400 })
     }
@@ -94,17 +118,18 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
       throw error
     }
   } catch (error) {
-    const errorMessage = getErrorMessage(error, 'Unknown error')
-    logger.error('Error fetching IMAP mailboxes:', errorMessage)
-
-    let userMessage = 'Failed to connect to IMAP server. Please check your connection settings.'
-    if (
-      errorMessage.includes('AUTHENTICATIONFAILED') ||
-      errorMessage.includes('Invalid credentials')
-    ) {
-      userMessage = 'Invalid username or password. For Gmail, use an App Password.'
-    }
-
-    return NextResponse.json({ success: false, message: userMessage }, { status: 500 })
+    logger.error('Error fetching IMAP mailboxes')
+    const errorMessage = getErrorMessage(error)
+    const userMessage =
+      errorMessage.includes('AUTHENTICATIONFAILED') || errorMessage.includes('Invalid credentials')
+        ? 'Invalid username or password. For Gmail, use an App Password.'
+        : 'Failed to connect to IMAP server. Please check your connection settings.'
+    return NextResponse.json(
+      {
+        success: false,
+        message: userMessage,
+      },
+      { status: 500 }
+    )
   }
 })

--- a/apps/sim/app/api/tools/imap/mailboxes/server-resolved-selector.test.ts
+++ b/apps/sim/app/api/tools/imap/mailboxes/server-resolved-selector.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @vitest-environment node
+ */
+import { createMockRequest } from '@sim/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  authenticate: vi.fn(),
+  resolveContext: vi.fn(),
+  validateDatabaseHost: vi.fn(),
+  imapConstruct: vi.fn(),
+  imapConnect: vi.fn(),
+  imapList: vi.fn(),
+  imapLogout: vi.fn(),
+}))
+
+vi.mock('@/lib/selectors/server/resolve-authorized-context', () => ({
+  authenticateSelectorRequest: mocks.authenticate,
+  resolveAuthorizedSelectorContext: mocks.resolveContext,
+}))
+
+vi.mock('@/lib/core/security/input-validation.server', () => ({
+  validateDatabaseHost: mocks.validateDatabaseHost,
+}))
+
+vi.mock('imapflow', () => ({
+  ImapFlow: class MockImapFlow {
+    constructor(config: unknown) {
+      mocks.imapConstruct(config)
+    }
+
+    connect = mocks.imapConnect
+    list = mocks.imapList
+    logout = mocks.imapLogout
+  },
+}))
+
+import { POST as listMailboxes } from '@/app/api/tools/imap/mailboxes/route'
+
+function request(body: unknown) {
+  return createMockRequest('POST', body, {}, 'http://localhost:3000/api/tools/imap/mailboxes')
+}
+
+const wireBody = {
+  workflowId: 'workflow-1',
+  host: '{{IMAP_HOST}}',
+  port: '{{IMAP_PORT}}',
+  secure: '{{IMAP_TLS}}',
+  username: '{{IMAP_USERNAME}}',
+  password: '{{IMAP_PASSWORD}}',
+}
+
+describe('server-resolved IMAP mailbox selector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.authenticate.mockResolvedValue({
+      ok: true,
+      principal: { kind: 'session', userId: 'viewer-1', sessionId: 'session-1' },
+    })
+    mocks.resolveContext.mockResolvedValue({
+      ok: true,
+      context: {
+        host: 'imap.example.com',
+        port: '993',
+        secure: 'true',
+        username: 'mailbox@example.com',
+        password: 'resolved-password',
+      },
+      requesterUserId: 'viewer-1',
+      workspaceId: 'workspace-1',
+    })
+    mocks.validateDatabaseHost.mockResolvedValue({
+      isValid: true,
+      resolvedIP: '203.0.113.10',
+    })
+    mocks.imapConnect.mockResolvedValue(undefined)
+    mocks.imapList.mockResolvedValue([
+      { path: 'Archive', name: 'Archive', delimiter: '/' },
+      { path: 'INBOX', name: 'INBOX', delimiter: '/' },
+    ])
+    mocks.imapLogout.mockResolvedValue(undefined)
+  })
+
+  it('authenticates before parsing malformed requests', async () => {
+    mocks.authenticate.mockResolvedValue({ ok: false, status: 401, error: 'Unauthorized' })
+
+    const response = await listMailboxes(request({}))
+
+    expect(response.status).toBe(401)
+    expect(mocks.resolveContext).not.toHaveBeenCalled()
+  })
+
+  it('passes every raw connection field to the resolver and maps sorted mailboxes', async () => {
+    const response = await listMailboxes(request(wireBody))
+
+    expect(await response.json()).toEqual({
+      success: true,
+      mailboxes: [
+        { path: 'INBOX', name: 'INBOX', delimiter: '/' },
+        { path: 'Archive', name: 'Archive', delimiter: '/' },
+      ],
+    })
+    expect(mocks.resolveContext).toHaveBeenCalledWith(expect.anything(), {
+      workflowId: 'workflow-1',
+      context: {
+        host: '{{IMAP_HOST}}',
+        port: '{{IMAP_PORT}}',
+        secure: '{{IMAP_TLS}}',
+        username: '{{IMAP_USERNAME}}',
+        password: '{{IMAP_PASSWORD}}',
+      },
+    })
+    expect(mocks.validateDatabaseHost).toHaveBeenCalledWith('imap.example.com', 'host', {
+      logFailureDetails: false,
+    })
+    expect(mocks.imapConstruct).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: '203.0.113.10',
+        servername: 'imap.example.com',
+        port: 993,
+        secure: true,
+        auth: { user: 'mailbox@example.com', pass: 'resolved-password' },
+      })
+    )
+    expect(mocks.imapLogout).toHaveBeenCalledOnce()
+  })
+
+  it('short-circuits inaccessible references before DNS or provider access', async () => {
+    mocks.resolveContext.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: 'Unable to resolve selector configuration',
+    })
+
+    const response = await listMailboxes(request(wireBody))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      success: false,
+      message: 'Unable to resolve selector configuration',
+    })
+    expect(mocks.validateDatabaseHost).not.toHaveBeenCalled()
+    expect(mocks.imapConstruct).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid resolved port/TLS values before DNS or provider access', async () => {
+    mocks.resolveContext.mockResolvedValue({
+      ok: true,
+      context: {
+        host: 'imap.example.com',
+        port: 'invalid',
+        secure: 'invalid',
+        username: 'mailbox@example.com',
+        password: 'resolved-password',
+      },
+      requesterUserId: 'viewer-1',
+      workspaceId: 'workspace-1',
+    })
+
+    const response = await listMailboxes(request(wireBody))
+
+    expect(response.status).toBe(400)
+    expect(mocks.validateDatabaseHost).not.toHaveBeenCalled()
+    expect(mocks.imapConstruct).not.toHaveBeenCalled()
+  })
+
+  it('sanitizes provider connection failures and logs out best-effort', async () => {
+    mocks.imapConnect.mockRejectedValue(
+      new Error('connection failed with resolved-password and imap.example.com')
+    )
+
+    const response = await listMailboxes(request(wireBody))
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body).toEqual({
+      success: false,
+      message: 'Failed to connect to IMAP server. Please check your connection settings.',
+    })
+    expect(mocks.imapLogout).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/sim/hooks/selectors/providers/imap/selectors.ts
+++ b/apps/sim/hooks/selectors/providers/imap/selectors.ts
@@ -9,34 +9,23 @@ export const imapSelectors = {
    * not a stored credential the server can resolve by id — the user types the connection in,
    * so the parameters travel on the context.
    *
-   * **The password is deliberately absent from the query key.** A query key identifies a
-   * resource; a credential authorizes access to it. `oauthCredential` is safe in a key because
-   * it is only an id, but a typed password is a secret, and React Query keys are held in cache
-   * and surfaced by devtools. Host, port, TLS and username already identify the mailbox list
-   * uniquely — the password only proves the caller may read it, and it rides the request body
-   * exactly as it did before.
-   *
-   * The consequence is intentional: correcting a wrong password re-runs the request (the
-   * previous attempt failed and cached nothing), while changing ONLY the password on an
-   * otherwise identical connection reuses the cached list, which is the same list.
+   * **Connection fields are deliberately absent from the query key.** React Query keys are
+   * retained in browser memory and surfaced by devtools, so server-resolved dependencies are
+   * represented by the shared opaque revision instead of their literal or referenced values.
    */
   'imap.mailboxes': {
     key: 'imap.mailboxes',
     contracts: [imapMailboxesContract],
+    serverResolvedContextFields: ['host', 'port', 'secure', 'username', 'password'],
     staleTime: SELECTOR_STALE,
-    getQueryKey: ({ context }: SelectorQueryArgs) => [
-      'selectors',
-      'imap.mailboxes',
-      context.host ?? 'none',
-      context.port ?? 'default',
-      context.secure ?? 'default',
-      context.username ?? 'none',
-    ],
-    enabled: ({ context }) => Boolean(context.host && context.username && context.password),
+    getQueryKey: () => ['selectors', 'imap.mailboxes'],
+    enabled: ({ context }) =>
+      Boolean(context.host && context.username && context.password && context.workflowId),
     fetchList: async ({ context, signal }: SelectorQueryArgs) => {
       if (!context.host || !context.username || !context.password) return []
       const data = await requestJson(imapMailboxesContract, {
         body: {
+          workflowId: context.workflowId!,
           host: context.host,
           port: context.port,
           secure: context.secure,

--- a/apps/sim/hooks/selectors/providers/imap/server-resolved-context.test.ts
+++ b/apps/sim/hooks/selectors/providers/imap/server-resolved-context.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ requestJson: vi.fn() }))
+
+vi.mock('@/lib/api/client/request', () => ({ requestJson: mocks.requestJson }))
+
+import { imapSelectors } from '@/hooks/selectors/providers/imap/selectors'
+
+describe('IMAP server-resolved selector context', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('opts every connection field into server resolution', () => {
+    expect(imapSelectors['imap.mailboxes']?.serverResolvedContextFields).toEqual([
+      'host',
+      'port',
+      'secure',
+      'username',
+      'password',
+    ])
+  })
+
+  it('forwards raw references and maps mailbox options', async () => {
+    const definition = imapSelectors['imap.mailboxes']!
+    const context = {
+      workflowId: 'workflow-1',
+      host: '{{IMAP_HOST}}',
+      port: '{{IMAP_PORT}}',
+      secure: '{{IMAP_TLS}}',
+      username: '{{IMAP_USERNAME}}',
+      password: '{{IMAP_PASSWORD}}',
+    }
+    mocks.requestJson.mockResolvedValue({
+      success: true,
+      mailboxes: [{ path: 'INBOX', name: 'Inbox', delimiter: '/' }],
+    })
+
+    expect(await definition.fetchList!({ key: 'imap.mailboxes', context })).toEqual([
+      { id: 'INBOX', label: 'Inbox' },
+    ])
+    expect(mocks.requestJson.mock.calls[0][1].body).toEqual(context)
+  })
+
+  it('requires a workflow and keeps connection plaintext out of base query keys', () => {
+    const definition = imapSelectors['imap.mailboxes']!
+    const context = {
+      workspaceId: 'workspace-1',
+      workflowId: 'workflow-1',
+      host: 'private-imap.example.com',
+      port: '993',
+      secure: 'true',
+      username: 'private-user@example.com',
+      password: 'imap-literal-secret',
+    }
+    const key = definition.getQueryKey!({ key: 'imap.mailboxes', context })
+
+    expect(definition.enabled?.({ key: 'imap.mailboxes', context })).toBe(true)
+    expect(
+      definition.enabled?.({
+        key: 'imap.mailboxes',
+        context: { ...context, workflowId: undefined },
+      })
+    ).toBe(false)
+    for (const secret of [
+      'private-imap.example.com',
+      'private-user@example.com',
+      'imap-literal-secret',
+    ]) {
+      expect(JSON.stringify(key)).not.toContain(secret)
+    }
+  })
+})

--- a/apps/sim/lib/api/contracts/tools/imap.server-resolved.test.ts
+++ b/apps/sim/lib/api/contracts/tools/imap.server-resolved.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  imapMailboxesBodySchema,
+  resolvedImapMailboxesBodySchema,
+} from '@/lib/api/contracts/tools/imap'
+
+describe('IMAP selector contracts', () => {
+  it('accepts literal or exact-reference values for every connection field', () => {
+    for (const useReferences of [false, true]) {
+      expect(
+        imapMailboxesBodySchema.safeParse({
+          workflowId: 'workflow-1',
+          host: useReferences ? '{{IMAP_HOST}}' : 'imap.example.com',
+          port: useReferences ? '{{IMAP_PORT}}' : 993,
+          secure: useReferences ? '{{IMAP_TLS}}' : true,
+          username: useReferences ? '{{IMAP_USERNAME}}' : 'mailbox@example.com',
+          password: useReferences ? '{{IMAP_PASSWORD}}' : 'literal-password',
+        }).success
+      ).toBe(true)
+    }
+  })
+
+  it.each([
+    ['993', 'true', 993, true],
+    ['143', 'false', 143, false],
+    [undefined, undefined, 993, true],
+  ])('coerces resolved port %s and TLS %s', (port, secure, expectedPort, expectedSecure) => {
+    expect(
+      resolvedImapMailboxesBodySchema.parse({
+        host: 'imap.example.com',
+        port,
+        secure,
+        username: 'mailbox@example.com',
+        password: 'resolved-password',
+      })
+    ).toMatchObject({ port: expectedPort, secure: expectedSecure })
+  })
+
+  it('rejects invalid resolved port and TLS values', () => {
+    expect(
+      resolvedImapMailboxesBodySchema.safeParse({
+        host: 'imap.example.com',
+        port: 'invalid',
+        secure: 'invalid',
+        username: 'mailbox@example.com',
+        password: 'resolved-password',
+      }).success
+    ).toBe(false)
+  })
+})

--- a/apps/sim/lib/api/contracts/tools/imap.ts
+++ b/apps/sim/lib/api/contracts/tools/imap.ts
@@ -21,12 +21,25 @@ export const imapMailboxesResponseSchema = z.object({
 })
 
 export const imapMailboxesBodySchema = z.object({
+  workflowId: z.string().min(1, 'Workflow ID is required'),
   host: z.string().min(1),
-  port: z.preprocess((value) => value || 993, z.coerce.number().int().positive()),
-  secure: z.preprocess((value) => value ?? true, z.boolean()),
+  port: z.union([z.string(), z.number()]).optional(),
+  secure: z.union([z.string(), z.boolean()]).optional(),
   username: z.string().min(1),
   password: z.string().min(1),
 })
+
+export const resolvedImapMailboxesBodySchema = imapMailboxesBodySchema
+  .omit({ workflowId: true })
+  .extend({
+    port: z.preprocess((value) => value || 993, z.coerce.number().int().positive()),
+    secure: z.preprocess((value) => {
+      if (value === undefined || value === null || value === '') return true
+      if (value === 'true') return true
+      if (value === 'false') return false
+      return value
+    }, z.boolean()),
+  })
 
 export const imapMailboxesContract = defineRouteContract({
   method: 'POST',

--- a/apps/sim/lib/core/security/input-validation.server.ts
+++ b/apps/sim/lib/core/security/input-validation.server.ts
@@ -194,7 +194,8 @@ export async function validateAndPinProxyUrl(
  */
 export async function validateDatabaseHost(
   host: string | null | undefined,
-  paramName = 'host'
+  paramName = 'host',
+  options: { logFailureDetails?: boolean } = {}
 ): Promise<AsyncValidationResult> {
   if (!host) {
     return { isValid: false, error: `${paramName} is required` }
@@ -217,11 +218,13 @@ export async function validateDatabaseHost(
       : addresses.find((candidate) => isPrivateIp(candidate))
 
     if (blockedAddress !== undefined) {
-      logger.warn('Database host resolves to blocked IP address', {
-        paramName,
-        hostname: host,
-        resolvedIP: blockedAddress,
-      })
+      if (options.logFailureDetails !== false) {
+        logger.warn('Database host resolves to blocked IP address', {
+          paramName,
+          hostname: host,
+          resolvedIP: blockedAddress,
+        })
+      }
       return {
         isValid: false,
         error: `${paramName} resolves to a blocked IP address`,
@@ -234,11 +237,13 @@ export async function validateDatabaseHost(
       originalHostname: host,
     }
   } catch (error) {
-    logger.warn('DNS lookup failed for database host', {
-      paramName,
-      hostname: host,
-      error: toError(error).message,
-    })
+    if (options.logFailureDetails !== false) {
+      logger.warn('DNS lookup failed for database host', {
+        paramName,
+        hostname: host,
+        error: toError(error).message,
+      })
+    }
     return {
       isValid: false,
       error: `${paramName} hostname could not be resolved`,


### PR DESCRIPTION
> Stacked on #7095. Review the diff against the PR1 branch. Do not merge until #7095 lands and this PR is rebased and retargeted to staging.

## Summary

- Migrate the IMAP Mailbox selector to PR1's authorized server-side context resolver.
- Resolve host, port, TLS, username, and password only after workflow authorization.
- Split wire acceptance from resolved coercion/validation and suppress DNS logging for secret-derived host values.
- Keep IMAP route, contract, validation option, selector wiring, and behavior-focused tests isolated in this PR.

## Security behavior

- Successful personal/workspace environment mutations invalidate mounted selector, canvas-label, and workflow-search caches through PR1, so an unchanged `{{KEY}}` refetches without exposing its value.
- IMAP direct-secret selectors require an authorized active workflow.
- The browser sends literals or exact references; resolved credentials remain server-only.
- Missing and inaccessible references return the same sanitized error and short-circuit before IMAP client construction.
- Secret-derived host validation avoids logging resolved host plaintext.
- Query keys contain opaque dependency revisions rather than connection plaintext.

## Focused coverage

- Server resolution of host, port, TLS, username, and password.
- Wire/resolved validation and coercion.
- Inaccessible-reference, DNS, and provider short-circuiting.
- Sanitized connection failures, cleanup, mailbox mapping, and concise base-key privacy.

## Verification

- Provider-focused Vitest: 3 files, 13 tests passed.
- App type-check passed.
- Root lint/format, strict API validation, client-boundary, React Query, and `git diff --check` passed on the combined stack.
- Combined full repository tests passed: 19/19 tasks; app 2,365 files passed, 3 skipped; 34,824 tests passed, 46 skipped.
- Combined focused selector suite: 28 files, 153 tests passed.
- All ten pairwise child diff intersections are empty.

## Browser verification

- After the freshness restack, a combined Jira smoke confirmed exact raw references still reach dedicated selector routes and provider/authorization failures stay sanitized. The exact mounted same-reference mutation is covered by PR1's real QueryClient regression because this local account cannot edit Secrets through the UI.
- A disposable IMAP workflow selector preserved literal, personal-reference, and shared-reference host, port, username, and password values; the password remained masked.
- Each input family reached the selector route and returned sanitized failures without echoing reference-derived values. TLS exact-reference coercion remains covered by route/contract tests.
- No secret-derived DNS or connection value appeared in server logs.
- The disposable workflow was deleted afterward.

