### PR TITLE
refactor(tables): add column type extension points

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-config-sidebar.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-config-sidebar.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/app/workspace/[workspaceId]/tables/[tableId]/components/sidebar-fields'
 import { useAddTableColumn, useUpdateColumn } from '@/hooks/queries/tables'
 import { SelectOptionsEditor } from '../select-field'
-import { PLAIN_COLUMN_TYPE_OPTIONS } from './column-types'
+import { columnTypeOptionsForTable } from './column-types'
 
 /** Whether a column type carries an option set. */
 function isSelectType(type: ColumnDefinition['type']): boolean {
@@ -52,6 +52,7 @@ interface ColumnConfigSidebarProps {
   onClose: () => void
   /** Existing column record for `mode: 'edit'`; ignored otherwise. */
   existingColumn: ColumnDefinition | null
+  allColumns: readonly ColumnDefinition[]
   workspaceId: string
   tableId: string
   /** Notify parent of a rename so it can rewrite local `columnOrder` /
@@ -102,6 +103,7 @@ function ColumnConfigBody({
   config,
   onClose,
   existingColumn,
+  allColumns,
   workspaceId,
   tableId,
   onColumnRename,
@@ -274,11 +276,14 @@ function ColumnConfigBody({
             <div className='flex flex-col gap-[9.5px]'>
               <RequiredLabel>Type</RequiredLabel>
               <ChipCombobox
-                options={PLAIN_COLUMN_TYPE_OPTIONS.map((o) => ({
-                  label: o.label,
-                  value: o.type,
-                  icon: o.icon,
-                }))}
+                options={columnTypeOptionsForTable(allColumns, existingColumn)
+                  .filter((option) => option.type !== 'workflow')
+                  .map((option) => ({
+                    label: option.label,
+                    value: option.type,
+                    icon: option.icon,
+                    disabled: option.disabledReason !== undefined,
+                  }))}
                 value={typeInput}
                 onChange={(v) => setTypeInput(v as ColumnDefinition['type'])}
                 placeholder='Select type'

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-type-limits.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-type-limits.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { COLUMN_TYPE_REGISTRY } from '@/lib/table/column-types'
+import {
+  COLUMN_TYPE_OPTIONS,
+  columnTypeOptionsForTable,
+} from '@/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-types'
+
+const option = COLUMN_TYPE_OPTIONS.find((candidate) => candidate.type === 'string')
+if (!option) throw new Error('String column type option is missing')
+const originalMaxPerTable = option.maxPerTable
+const definition = COLUMN_TYPE_REGISTRY.string
+const originalDefinitionMaxPerTable = definition.maxPerTable
+
+afterEach(() => {
+  if (originalMaxPerTable === undefined) {
+    Reflect.deleteProperty(option, 'maxPerTable')
+  } else {
+    option.maxPerTable = originalMaxPerTable
+  }
+
+  if (originalDefinitionMaxPerTable === undefined) {
+    Reflect.deleteProperty(definition, 'maxPerTable')
+  } else {
+    Object.assign(definition, { maxPerTable: originalDefinitionMaxPerTable })
+  }
+})
+
+describe('column type picker limits', () => {
+  it('keeps a limited type visible but disables it once the limit is reached', () => {
+    option.maxPerTable = 1
+    Object.assign(definition, { maxPerTable: 1 })
+
+    const result = columnTypeOptionsForTable([{ name: 'first', type: 'string' }])
+    const stringOption = result.find((candidate) => candidate.type === 'string')
+
+    expect(stringOption?.disabledReason).toBe('Only one Text column allowed per table')
+  })
+
+  it('keeps the current type selectable while editing its existing column', () => {
+    option.maxPerTable = 1
+    Object.assign(definition, { maxPerTable: 1 })
+    const currentColumn = { name: 'first', type: 'string' } as const
+
+    const result = columnTypeOptionsForTable([currentColumn], currentColumn)
+    const stringOption = result.find((candidate) => candidate.type === 'string')
+
+    expect(stringOption?.disabledReason).toBeUndefined()
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-types.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-types.ts
@@ -52,8 +52,8 @@ export function columnTypeOptionsForTable(
   return COLUMN_TYPE_OPTIONS.map((option) => {
     if (option.type === 'workflow') return option
     if (currentColumn?.type === option.type) return option
-    if (!wouldExceedColumnTypeLimit(columns, option.type, 1)) return option
     if (option.maxPerTable === undefined) return option
+    if (!wouldExceedColumnTypeLimit(columns, option.type, 1)) return option
     return {
       ...option,
       disabledReason: columnTypeLimitMessage(option.label, option.maxPerTable),

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-types.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/column-types.ts
@@ -1,19 +1,21 @@
 import type React from 'react'
 import { PlayOutline } from '@sim/emcn/icons'
 import type { ColumnDefinition } from '@/lib/table'
-import { ALL_COLUMN_TYPES } from '@/lib/table/column-types'
+import { ALL_COLUMN_TYPES, wouldExceedColumnTypeLimit } from '@/lib/table/column-types'
 
 /**
  * UI-only column type. `'workflow'` is the virtual entry users pick from the
  * "+ New column" dropdown to spawn a workflow group; the resulting columns are
  * stored as scalar types under the hood (none carry `'workflow'`).
  */
-type SidebarColumnType = ColumnDefinition['type'] | 'workflow'
+export type SidebarColumnType = ColumnDefinition['type'] | 'workflow'
 
-interface ColumnTypeOption {
+export interface ColumnTypeOption {
   type: SidebarColumnType
   label: string
   icon: React.ComponentType<{ className?: string }>
+  maxPerTable?: number
+  disabledReason?: string
 }
 
 /**
@@ -26,9 +28,35 @@ export const COLUMN_TYPE_OPTIONS: ColumnTypeOption[] = [
     type: definition.id,
     label: definition.label,
     icon: definition.icon,
+    maxPerTable: definition.maxPerTable,
   })),
   { type: 'workflow', label: 'Workflow', icon: PlayOutline },
 ]
 
-/** Plain column types (no workflow). Used by `<ColumnConfigSidebar>`'s type combobox in edit mode. */
-export const PLAIN_COLUMN_TYPE_OPTIONS = COLUMN_TYPE_OPTIONS.filter((o) => o.type !== 'workflow')
+/** Plain column types (no workflow). Used by the column type combobox in edit mode. */
+export const PLAIN_COLUMN_TYPE_OPTIONS = COLUMN_TYPE_OPTIONS.filter(
+  (option) => option.type !== 'workflow'
+)
+
+function columnTypeLimitMessage(label: string, maxPerTable: number): string {
+  return maxPerTable === 1
+    ? `Only one ${label} column allowed per table`
+    : `Only ${maxPerTable} ${label} columns allowed per table`
+}
+
+/** Picker entries with unavailable cardinality-limited types marked as disabled. */
+export function columnTypeOptionsForTable(
+  columns: readonly ColumnDefinition[],
+  currentColumn?: ColumnDefinition | null
+): ColumnTypeOption[] {
+  return COLUMN_TYPE_OPTIONS.map((option) => {
+    if (option.type === 'workflow') return option
+    if (currentColumn?.type === option.type) return option
+    if (!wouldExceedColumnTypeLimit(columns, option.type, 1)) return option
+    if (option.maxPerTable === undefined) return option
+    return {
+      ...option,
+      disabledReason: columnTypeLimitMessage(option.label, option.maxPerTable),
+    }
+  })
+}

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/index.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-config-sidebar/index.ts
@@ -1,3 +1,9 @@
 export type { ColumnConfig } from './column-config-sidebar'
 export { ColumnConfigSidebar } from './column-config-sidebar'
-export { COLUMN_TYPE_OPTIONS, PLAIN_COLUMN_TYPE_OPTIONS } from './column-types'
+export {
+  COLUMN_TYPE_OPTIONS,
+  type ColumnTypeOption,
+  columnTypeOptionsForTable,
+  PLAIN_COLUMN_TYPE_OPTIONS,
+  type SidebarColumnType,
+} from './column-types'

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-dropdown/column-dropdown.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-dropdown/column-dropdown.test.tsx
@@ -29,6 +29,7 @@ describe('ColumnDropdown', () => {
     act(() => {
       root.render(
         <ColumnDropdown
+          columns={[]}
           trigger='header'
           disabled={false}
           onPickType={vi.fn()}

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-dropdown/column-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/column-dropdown/column-dropdown.tsx
@@ -10,15 +10,17 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Plus,
+  Tooltip,
 } from '@sim/emcn'
 import { Sparkles } from '@sim/emcn/icons'
 import type { ColumnDefinition } from '@/lib/table'
-import { COLUMN_TYPE_OPTIONS } from '../column-config-sidebar'
+import { type ColumnTypeOption, columnTypeOptionsForTable } from '../column-config-sidebar'
 
 const CELL_HEADER =
   'border-[var(--border)] border-r border-b bg-[var(--bg)] px-2 py-[7px] text-left align-middle'
 
 interface ColumnDropdownProps {
+  columns: readonly ColumnDefinition[]
   /** `'header'` renders the page-header trigger (subtle Button); `'inline-header'` renders
    *  the in-table column-header `<th>` trigger. Same dropdown content either way. */
   trigger: 'header' | 'inline-header'
@@ -36,12 +38,49 @@ interface ColumnDropdownProps {
   onBlocked: () => void
 }
 
+interface ColumnTypeMenuItemProps {
+  option: ColumnTypeOption
+  onSelect: () => void
+}
+
+function ColumnTypeMenuItem({ option, onSelect }: ColumnTypeMenuItemProps) {
+  const Icon = option.icon
+  const item = (
+    <DropdownMenuItem
+      aria-disabled={option.disabledReason ? true : undefined}
+      className={
+        option.disabledReason ? 'cursor-not-allowed opacity-50 focus:bg-transparent' : undefined
+      }
+      onSelect={(event) => {
+        if (option.disabledReason) {
+          event.preventDefault()
+          return
+        }
+        onSelect()
+      }}
+    >
+      <Icon className='size-[14px] text-[var(--text-icon)]' />
+      {option.label}
+    </DropdownMenuItem>
+  )
+
+  if (!option.disabledReason) return item
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>{item}</Tooltip.Trigger>
+      <Tooltip.Content>{option.disabledReason}</Tooltip.Content>
+    </Tooltip.Root>
+  )
+}
+
 /**
  * "+ New column" dropdown — the single entry point for creating a column.
  * Lists every column type plus "Workflow" and "Enrichments"; picking a type
  * opens the right sidebar pre-seeded.
  */
 export function ColumnDropdown({
+  columns,
   trigger,
   disabled,
   onPickType,
@@ -86,18 +125,12 @@ export function ColumnDropdown({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
       <DropdownMenuContent align='start' side='bottom' sideOffset={4}>
-        {COLUMN_TYPE_OPTIONS.map((option) => {
-          const Icon = option.icon
+        {columnTypeOptionsForTable(columns).map((option) => {
           const onSelect =
             option.type === 'workflow'
               ? onPickWorkflow
               : () => onPickType(option.type as ColumnDefinition['type'])
-          return (
-            <DropdownMenuItem key={option.type} onSelect={onSelect}>
-              <Icon className='size-[14px] text-[var(--text-icon)]' />
-              {option.label}
-            </DropdownMenuItem>
-          )
+          return <ColumnTypeMenuItem key={option.type} option={option} onSelect={onSelect} />
         })}
         <DropdownMenuItem onSelect={onPickEnrichment}>
           <Sparkles className='size-[14px] text-[var(--text-icon)]' />

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -4864,6 +4864,7 @@ export function TableGrid({
                       })}
                       {userPermissions.canEdit && (
                         <ColumnDropdown
+                          columns={columns}
                           trigger='inline-header'
                           disabled={addColumnMutation.isPending}
                           blocked={!canMutateSchema}

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/table.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/table.tsx
@@ -1373,6 +1373,7 @@ export function Table({
   const canMutateSchema = userPermissions.canEdit && !tableData?.locks.schemaLocked
   const createTrigger = userPermissions.canEdit ? (
     <ColumnDropdown
+      columns={columns}
       trigger='header'
       disabled={false}
       blocked={!canMutateSchema}
@@ -1645,6 +1646,7 @@ export function Table({
       <ColumnConfigSidebar
         config={columnConfig}
         onClose={onCloseSlideout}
+        allColumns={columns}
         existingColumn={
           columnConfig?.mode === 'edit'
             ? (columns.find((c) => getColumnId(c) === columnConfig.columnName) ?? null)

--- a/apps/sim/lib/table/column-types/extension-points.test.ts
+++ b/apps/sim/lib/table/column-types/extension-points.test.ts
@@ -69,6 +69,20 @@ describe('column type extension points', () => {
     ).toBe('stored-value')
   })
 
+  it('preserves an intentional null from source normalization', () => {
+    Object.assign(definition, {
+      valueForConversion: () => null,
+    })
+
+    expect(
+      valueForTypeConversion(
+        'stored-value',
+        { name: 'source', type: 'string' },
+        { name: 'target', type: 'number' }
+      )
+    ).toBeNull()
+  })
+
   it('lets a type own CSV import coercion', () => {
     Object.assign(definition, {
       coerceImport: (value: unknown) => `imported:${String(value)}`,

--- a/apps/sim/lib/table/column-types/extension-points.test.ts
+++ b/apps/sim/lib/table/column-types/extension-points.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  COLUMN_TYPE_REGISTRY,
+  validateColumnTypeLimits,
+  valueForTypeConversion,
+  wouldExceedColumnTypeLimit,
+} from '@/lib/table/column-types'
+import { coerceValue } from '@/lib/table/import'
+import type { ColumnDefinition } from '@/lib/table/types'
+
+const definition = COLUMN_TYPE_REGISTRY.string
+const originalMaxPerTable = definition.maxPerTable
+const originalCoerceImport = definition.coerceImport
+const originalValueForConversion = definition.valueForConversion
+
+function restoreOptionalProperty(
+  key: 'maxPerTable' | 'coerceImport' | 'valueForConversion',
+  value: unknown
+) {
+  if (value === undefined) {
+    Reflect.deleteProperty(definition, key)
+    return
+  }
+  Object.assign(definition, { [key]: value })
+}
+
+afterEach(() => {
+  restoreOptionalProperty('maxPerTable', originalMaxPerTable)
+  restoreOptionalProperty('coerceImport', originalCoerceImport)
+  restoreOptionalProperty('valueForConversion', originalValueForConversion)
+})
+
+describe('column type extension points', () => {
+  it('enforces registry-declared per-table limits', () => {
+    Object.assign(definition, { maxPerTable: 1 })
+    const columns: ColumnDefinition[] = [
+      { name: 'first', type: 'string' },
+      { name: 'second', type: 'string' },
+    ]
+
+    expect(wouldExceedColumnTypeLimit(columns.slice(0, 1), 'string', 1)).toBe(true)
+    expect(validateColumnTypeLimits(columns)).toEqual([
+      `A table can have at most 1 ${definition.label} column`,
+    ])
+  })
+
+  it('lets the source type normalize a value before conversion', () => {
+    Object.assign(definition, {
+      valueForConversion: (_value: unknown, target: ColumnDefinition) =>
+        target.type === 'number' ? 42 : 'unchanged',
+    })
+
+    expect(
+      valueForTypeConversion(
+        'stored-value',
+        { name: 'source', type: 'string' },
+        { name: 'target', type: 'number' }
+      )
+    ).toBe(42)
+    expect(
+      valueForTypeConversion(
+        'stored-value',
+        { name: 'source', type: 'number' },
+        { name: 'target', type: 'string' }
+      )
+    ).toBe('stored-value')
+  })
+
+  it('lets a type own CSV import coercion', () => {
+    Object.assign(definition, {
+      coerceImport: (value: unknown) => `imported:${String(value)}`,
+    })
+
+    expect(coerceValue('raw', 'string')).toBe('imported:raw')
+  })
+})

--- a/apps/sim/lib/table/column-types/extension-points.test.ts
+++ b/apps/sim/lib/table/column-types/extension-points.test.ts
@@ -8,18 +8,13 @@ import {
   valueForTypeConversion,
   wouldExceedColumnTypeLimit,
 } from '@/lib/table/column-types'
-import { coerceValue } from '@/lib/table/import'
 import type { ColumnDefinition } from '@/lib/table/types'
 
 const definition = COLUMN_TYPE_REGISTRY.string
 const originalMaxPerTable = definition.maxPerTable
-const originalCoerceImport = definition.coerceImport
 const originalValueForConversion = definition.valueForConversion
 
-function restoreOptionalProperty(
-  key: 'maxPerTable' | 'coerceImport' | 'valueForConversion',
-  value: unknown
-) {
+function restoreOptionalProperty(key: 'maxPerTable' | 'valueForConversion', value: unknown) {
   if (value === undefined) {
     Reflect.deleteProperty(definition, key)
     return
@@ -29,7 +24,6 @@ function restoreOptionalProperty(
 
 afterEach(() => {
   restoreOptionalProperty('maxPerTable', originalMaxPerTable)
-  restoreOptionalProperty('coerceImport', originalCoerceImport)
   restoreOptionalProperty('valueForConversion', originalValueForConversion)
 })
 
@@ -81,13 +75,5 @@ describe('column type extension points', () => {
         { name: 'target', type: 'number' }
       )
     ).toBeNull()
-  })
-
-  it('lets a type own CSV import coercion', () => {
-    Object.assign(definition, {
-      coerceImport: (value: unknown) => `imported:${String(value)}`,
-    })
-
-    expect(coerceValue('raw', 'string')).toBe('imported:raw')
   })
 })

--- a/apps/sim/lib/table/column-types/index.ts
+++ b/apps/sim/lib/table/column-types/index.ts
@@ -14,6 +14,7 @@ export * from '@/lib/table/column-types/registry'
 export type {
   CoerceResult,
   ColumnCellEditor,
+  ColumnImportCoerceOptions,
   ColumnType,
   ColumnTypeDefinition,
   TypeSpecificColumnKey,

--- a/apps/sim/lib/table/column-types/index.ts
+++ b/apps/sim/lib/table/column-types/index.ts
@@ -14,7 +14,6 @@ export * from '@/lib/table/column-types/registry'
 export type {
   CoerceResult,
   ColumnCellEditor,
-  ColumnImportCoerceOptions,
   ColumnType,
   ColumnTypeDefinition,
   TypeSpecificColumnKey,

--- a/apps/sim/lib/table/column-types/registry.ts
+++ b/apps/sim/lib/table/column-types/registry.ts
@@ -90,6 +90,15 @@ export function isValueCompatible(value: unknown, target: ColumnDefinition): boo
   return definition.coerce(value as JsonValue, target).ok
 }
 
+/** Applies source-owned normalization before a value is converted to another type. */
+export function valueForTypeConversion(
+  value: JsonValue,
+  source: ColumnDefinition,
+  target: ColumnDefinition
+): JsonValue {
+  return columnTypeOf(source).valueForConversion?.(value, target) ?? value
+}
+
 /** This type's own metadata errors; types carrying no metadata report none. */
 export function validateTypeMetadata(column: ColumnDefinition): string[] {
   return columnTypeOf(column).validateDefinition?.(column) ?? []
@@ -114,4 +123,32 @@ export function typeMetadataOf(column: ColumnDefinition): Partial<ColumnDefiniti
 /** Wire operators a column accepts, or `null` for "all operators". */
 export function filterOperatorsFor(column: ColumnDefinition): ReadonlySet<string> | null {
   return columnTypeOf(column).filterOperatorsFor?.(column) ?? null
+}
+
+/** Schema-level cardinality errors declared by column type definitions. */
+export function validateColumnTypeLimits(columns: readonly ColumnDefinition[]): string[] {
+  const errors: string[] = []
+  for (const definition of ALL_COLUMN_TYPES) {
+    if (definition.maxPerTable === undefined) continue
+    if (wouldExceedColumnTypeLimit(columns, definition.id)) {
+      errors.push(`A table can have at most ${definition.maxPerTable} ${definition.label} column`)
+    }
+  }
+  return errors
+}
+
+/** Whether adding columns of a type would exceed its registry-declared table limit. */
+export function wouldExceedColumnTypeLimit(
+  columns: readonly ColumnDefinition[],
+  type: ColumnType,
+  additionalColumns = 0
+): boolean {
+  const definition = COLUMN_TYPE_REGISTRY[type]
+  if (definition.maxPerTable === undefined) return false
+
+  const count = columns.reduce(
+    (total, column) => total + (column.type === type ? 1 : 0),
+    additionalColumns
+  )
+  return count > definition.maxPerTable
 }

--- a/apps/sim/lib/table/column-types/registry.ts
+++ b/apps/sim/lib/table/column-types/registry.ts
@@ -96,7 +96,8 @@ export function valueForTypeConversion(
   source: ColumnDefinition,
   target: ColumnDefinition
 ): JsonValue {
-  return columnTypeOf(source).valueForConversion?.(value, target) ?? value
+  const normalized = columnTypeOf(source).valueForConversion?.(value, target)
+  return normalized === undefined ? value : normalized
 }
 
 /** This type's own metadata errors; types carrying no metadata report none. */

--- a/apps/sim/lib/table/column-types/types.ts
+++ b/apps/sim/lib/table/column-types/types.ts
@@ -20,6 +20,7 @@
  */
 
 import type React from 'react'
+import type { NormalizeDateCellOptions } from '@/lib/table/dates'
 import type { ColumnDefinition, JsonValue } from '@/lib/table/types'
 
 /**
@@ -67,11 +68,17 @@ export type TypeSpecificColumnKey = (typeof TYPE_SPECIFIC_COLUMN_KEYS)[number]
 /** Result of coercing a raw value toward a column's declared type. */
 export type CoerceResult = { ok: true; value: JsonValue } | { ok: false }
 
+export interface ColumnImportCoerceOptions extends NormalizeDateCellOptions {
+  currencyCode?: string
+}
+
 export interface ColumnTypeDefinition {
   readonly id: ColumnType
 
   /** Human label in the type picker, column header menu, and docs. */
   readonly label: string
+  /** Maximum columns of this type a table may contain. Omitted when unlimited. */
+  readonly maxPerTable?: number
   /** Type icon. A component reference only — never invoked server-side. */
   readonly icon: React.ComponentType<{ className?: string }>
   /**
@@ -157,7 +164,17 @@ export interface ColumnTypeDefinition {
    * implementation — the server calls it before persisting and the grid calls
    * it to fill the optimistic cache, so the two can no longer disagree.
    */
-  coerce(value: JsonValue, column: ColumnDefinition): CoerceResult
+  coerce(
+    value: JsonValue,
+    column: ColumnDefinition,
+    context?: NormalizeDateCellOptions
+  ): CoerceResult
+
+  /** CSV-specific coercion when invalid input must survive for row-level validation. */
+  coerceImport?(value: unknown, options?: ColumnImportCoerceOptions): Exclude<JsonValue, Date>
+
+  /** Source-owned normalization applied before checking or rewriting a type conversion. */
+  valueForConversion?(value: JsonValue, target: ColumnDefinition): JsonValue
 
   /** Validates a stored cell's shape. Returns an error message, or null when valid. */
   validateCell(value: JsonValue, column: ColumnDefinition): string | null
@@ -203,7 +220,11 @@ export interface ColumnTypeDefinition {
   formatForDisplay(value: unknown, column: ColumnDefinition): string
 
   /** Stored value → the text an editor input starts with. */
-  formatForInput(value: unknown, column: ColumnDefinition): string
+  formatForInput(
+    value: unknown,
+    column: ColumnDefinition,
+    context?: NormalizeDateCellOptions
+  ): string
 
   /**
    * Metadata stamped onto a newly created column of this type, so the schema

--- a/apps/sim/lib/table/column-types/types.ts
+++ b/apps/sim/lib/table/column-types/types.ts
@@ -68,10 +68,6 @@ export type TypeSpecificColumnKey = (typeof TYPE_SPECIFIC_COLUMN_KEYS)[number]
 /** Result of coercing a raw value toward a column's declared type. */
 export type CoerceResult = { ok: true; value: JsonValue } | { ok: false }
 
-export interface ColumnImportCoerceOptions extends NormalizeDateCellOptions {
-  currencyCode?: string
-}
-
 export interface ColumnTypeDefinition {
   readonly id: ColumnType
 
@@ -169,9 +165,6 @@ export interface ColumnTypeDefinition {
     column: ColumnDefinition,
     context?: NormalizeDateCellOptions
   ): CoerceResult
-
-  /** CSV-specific coercion when invalid input must survive for row-level validation. */
-  coerceImport?(value: unknown, options?: ColumnImportCoerceOptions): Exclude<JsonValue, Date>
 
   /** Source-owned normalization applied before checking or rewriting a type conversion. */
   valueForConversion?(value: JsonValue, target: ColumnDefinition): JsonValue

--- a/apps/sim/lib/table/columns/retype-cell.test.ts
+++ b/apps/sim/lib/table/columns/retype-cell.test.ts
@@ -2,12 +2,24 @@
  * @vitest-environment node
  */
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { COLUMN_TYPE_REGISTRY } from '@/lib/table/column-types'
 import { retypeCellRewrite } from '@/lib/table/columns/service'
 import type { ColumnDefinition } from '@/lib/table/types'
 
 const column = (over: Partial<ColumnDefinition>): ColumnDefinition =>
   ({ name: 'col', type: 'string', ...over }) as ColumnDefinition
+
+const sourceDefinition = COLUMN_TYPE_REGISTRY.string
+const originalValueForConversion = sourceDefinition.valueForConversion
+
+afterEach(() => {
+  if (originalValueForConversion === undefined) {
+    Reflect.deleteProperty(sourceDefinition, 'valueForConversion')
+    return
+  }
+  Object.assign(sourceDefinition, { valueForConversion: originalValueForConversion })
+})
 
 describe('retypeCellRewrite', () => {
   it('preserves an empty string the target type can hold', () => {
@@ -30,6 +42,29 @@ describe('retypeCellRewrite', () => {
     expect(retypeCellRewrite('42', column({ type: 'number' }))).toEqual({ value: 42 })
     expect(retypeCellRewrite(7, column({ type: 'string' }))).toEqual({ value: '7' })
     expect(retypeCellRewrite('true', column({ type: 'boolean' }))).toEqual({ value: true })
+  })
+
+  it('writes back null produced by source normalization', () => {
+    Object.assign(sourceDefinition, { valueForConversion: () => null })
+
+    expect(
+      retypeCellRewrite('stored-value', column({ type: 'number' }), column({ type: 'string' }))
+    ).toEqual({ value: null })
+  })
+
+  it('coerces source-normalized values into select storage', () => {
+    Object.assign(sourceDefinition, { valueForConversion: () => 'Choice' })
+
+    expect(
+      retypeCellRewrite(
+        'stored-value',
+        column({
+          type: 'select',
+          options: [{ id: 'opt_choice', name: 'Choice' }],
+        }),
+        column({ type: 'string' })
+      )
+    ).toEqual({ value: 'opt_choice' })
   })
 
   it('skips a cell whose stored value already matches the coercion', () => {

--- a/apps/sim/lib/table/columns/service.ts
+++ b/apps/sim/lib/table/columns/service.ts
@@ -777,6 +777,8 @@ export function retypeCellRewrite(
     ? valueForTypeConversion(value as JsonValue, source, target)
     : (value as JsonValue)
 
+  if (effective === null) return { value: null }
+
   if (!isValueCompatibleWithColumn(effective, target)) {
     // Incompatible non-blanks never reach here: the compatibility scan already
     // refused the whole conversion for them.
@@ -919,6 +921,7 @@ export async function updateColumnType(
       const isSelectType = data.newType === 'select'
       const targetOptions = data.options ?? column.options ?? []
       const targetMultiple = data.multiple ?? column.multiple
+      const sourceNormalizesConversion = columnTypeOf(column).valueForConversion !== undefined
       // Leaving `select` behind: stored cells hold option ids, which mean nothing
       // once the column is text/number/etc. Check compatibility against the option
       // NAME — that's what the cell will actually become (migrated below).
@@ -1035,9 +1038,7 @@ export async function updateColumnType(
         resolved: new Map<string, JsonValue>(),
       }
       await migrationFrom(column.type)?.(migrationContext)
-      if (isSelectType) {
-        await migrationTo(data.newType)?.(migrationContext)
-      } else {
+      if (!isSelectType || sourceNormalizesConversion) {
         let rewriteAfterId: string | undefined
         while (true) {
           const rows = await readColumnRetypePage(
@@ -1064,6 +1065,9 @@ export async function updateColumnType(
           rewriteAfterId = rows.at(-1)?.id
           if (rows.length < retypeScanBatchSize) break
         }
+      }
+      if (isSelectType) {
+        await migrationTo(data.newType)?.(migrationContext)
       }
 
       // A `unique` arriving with this retype is validated HERE, against the values

--- a/apps/sim/lib/table/columns/service.ts
+++ b/apps/sim/lib/table/columns/service.ts
@@ -27,6 +27,7 @@ import {
   columnTypeOf,
   isValueCompatible,
   TYPE_SPECIFIC_COLUMN_KEYS,
+  valueForTypeConversion,
 } from '@/lib/table/column-types'
 import {
   migrationFrom,
@@ -767,17 +768,22 @@ export function applyPendingRename(
  */
 export function retypeCellRewrite(
   value: unknown,
-  target: ColumnDefinition
+  target: ColumnDefinition,
+  source?: ColumnDefinition
 ): { value: JsonValue } | null {
   if (value === null || value === undefined) return null
 
-  if (!isValueCompatibleWithColumn(value, target)) {
+  const effective = source
+    ? valueForTypeConversion(value as JsonValue, source, target)
+    : (value as JsonValue)
+
+  if (!isValueCompatibleWithColumn(effective, target)) {
     // Incompatible non-blanks never reach here: the compatibility scan already
     // refused the whole conversion for them.
-    return value === '' ? { value: null } : null
+    return effective === '' ? { value: null } : null
   }
 
-  const coerced = columnTypeById(target.type).coerce(value as JsonValue, target)
+  const coerced = columnTypeById(target.type).coerce(effective, target)
   if (coerced.ok && !Object.is(coerced.value, value)) return { value: coerced.value }
   return null
 }
@@ -944,6 +950,12 @@ export async function updateColumnType(
         isSelectType,
         targetMultiple: !!targetMultiple,
       })
+      const renamedColumns = schema.columns.map((c, i) => (i === columnIndex ? convertedColumn : c))
+      const updatedColumns = renamedColumns.map((c, i) =>
+        i === columnIndex ? applyPendingRename(renamedColumns, columnIndex, data.newName) : c
+      )
+      const updatedSchema: TableSchema = { ...schema, columns: updatedColumns }
+      assertValidSchema(updatedSchema, table.metadata?.columnOrder)
 
       let incompatibleCount = 0
       let blankCount = 0
@@ -972,7 +984,7 @@ export async function updateColumnType(
 
           const effective = convertingAwayFromSelect
             ? selectValueForConversion(column, value)
-            : value
+            : valueForTypeConversion(value as JsonValue, column, convertedColumn)
 
           if (!isValueCompatibleWithColumn(effective, convertedColumn)) {
             if (effective === null || effective === '') {
@@ -1000,11 +1012,6 @@ export async function updateColumnType(
         )
       }
 
-      const renamedColumns = schema.columns.map((c, i) => (i === columnIndex ? convertedColumn : c))
-      const updatedColumns = renamedColumns.map((c, i) =>
-        i === columnIndex ? applyPendingRename(renamedColumns, columnIndex, data.newName) : c
-      )
-
       const columnValidation = validateColumnDefinition(updatedColumns[columnIndex])
       if (!columnValidation.valid) {
         throw new OrchestrationError(
@@ -1013,7 +1020,6 @@ export async function updateColumnType(
         )
       }
 
-      const updatedSchema: TableSchema = { ...schema, columns: updatedColumns }
       const now = new Date()
 
       // Cell rewrites are owned by the column-type registry, keyed by direction.
@@ -1045,7 +1051,7 @@ export async function updateColumnType(
           if (rows.length === 0) break
           const coercedByRowId = new Map<string, JsonValue>()
           for (const row of rows) {
-            const rewrite = retypeCellRewrite(row.value, convertedColumn)
+            const rewrite = retypeCellRewrite(row.value, convertedColumn, column)
             if (rewrite) coercedByRowId.set(row.id, rewrite.value)
           }
           await writeBackCoercedCells(

--- a/apps/sim/lib/table/import.ts
+++ b/apps/sim/lib/table/import.ts
@@ -15,7 +15,6 @@ import type { Options as CsvParseOptions } from 'csv-parse'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 import { getColumnId } from '@/lib/table/column-keys'
 import type { ColumnType } from '@/lib/table/column-types'
-import { columnTypeById } from '@/lib/table/column-types'
 import { parseCurrencyInput } from '@/lib/table/currency'
 import { type NormalizeDateCellOptions, normalizeDateCellValue } from '@/lib/table/dates'
 import type { ColumnDefinition, RowData, TableSchema } from '@/lib/table/types'
@@ -482,8 +481,6 @@ export function coerceValue(
   options?: NormalizeDateCellOptions & { currencyCode?: string }
 ): string | number | boolean | null | Record<string, unknown> | unknown[] {
   if (value === null || value === undefined || value === '') return null
-  const definition = columnTypeById(colType)
-  if (definition.coerceImport) return definition.coerceImport(value, options)
 
   switch (colType) {
     case 'number': {

--- a/apps/sim/lib/table/import.ts
+++ b/apps/sim/lib/table/import.ts
@@ -15,6 +15,7 @@ import type { Options as CsvParseOptions } from 'csv-parse'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 import { getColumnId } from '@/lib/table/column-keys'
 import type { ColumnType } from '@/lib/table/column-types'
+import { columnTypeById } from '@/lib/table/column-types'
 import { parseCurrencyInput } from '@/lib/table/currency'
 import { type NormalizeDateCellOptions, normalizeDateCellValue } from '@/lib/table/dates'
 import type { ColumnDefinition, RowData, TableSchema } from '@/lib/table/types'
@@ -481,6 +482,9 @@ export function coerceValue(
   options?: NormalizeDateCellOptions & { currencyCode?: string }
 ): string | number | boolean | null | Record<string, unknown> | unknown[] {
   if (value === null || value === undefined || value === '') return null
+  const definition = columnTypeById(colType)
+  if (definition.coerceImport) return definition.coerceImport(value, options)
+
   switch (colType) {
     case 'number': {
       const n = Number(value)

--- a/apps/sim/lib/table/schema-invariants.ts
+++ b/apps/sim/lib/table/schema-invariants.ts
@@ -11,6 +11,7 @@
 
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 import { getColumnId } from '@/lib/table/column-keys'
+import { validateColumnTypeLimits } from '@/lib/table/column-types'
 import type { TableSchema, WorkflowGroup } from '@/lib/table/types'
 
 /**
@@ -19,7 +20,7 @@ import type { TableSchema, WorkflowGroup } from '@/lib/table/types'
  * etc. Returns a list of human-readable errors (empty if valid).
  */
 export function validateSchema(schema: TableSchema, columnOrder: string[] | undefined): string[] {
-  const errors: string[] = []
+  const errors = validateColumnTypeLimits(schema.columns)
   // Group refs and columnOrder hold stable column ids (not display names).
   const columnsById = new Map(schema.columns.map((c) => [getColumnId(c), c]))
   const groups = schema.workflowGroups ?? []

--- a/apps/sim/lib/table/service.ts
+++ b/apps/sim/lib/table/service.ts
@@ -828,6 +828,7 @@ export async function addTableColumnsWithTx(
     ...table.schema,
     columns: [...table.schema.columns, ...additions],
   }
+  assertValidSchema(updatedSchema, table.metadata?.columnOrder)
   const now = new Date()
 
   await trx

--- a/apps/sim/lib/table/validation.ts
+++ b/apps/sim/lib/table/validation.ts
@@ -14,6 +14,7 @@ import {
   columnTypeOf,
   isColumnType,
   TYPE_SPECIFIC_COLUMN_KEYS,
+  validateColumnTypeLimits,
   validateTypeMetadata,
 } from '@/lib/table/column-types'
 import {
@@ -243,6 +244,8 @@ export function validateTableSchema(schema: TableSchema): ValidationResult {
   if (uniqueNames.size !== columnNames.length) {
     errors.push('Duplicate column names found')
   }
+
+  errors.push(...validateColumnTypeLimits(schema.columns))
 
   return { valid: errors.length === 0, errors }
 }


### PR DESCRIPTION
## Summary

Column types can now declare table-wide cardinality limits and source-owned conversion normalization in the registry. Generic validation, retyping, and picker code consumes those declarations, so limited types can integrate without adding one-off branches to each table surface.

This is PR 1 of 4 in the row-expiration stack. [PR #7071](https://github.com/simstudioai/sim/pull/7071) uses these hooks to add the Expiration column; [PR #7072](https://github.com/simstudioai/sim/pull/7072) hardens shared timezone conversion; [PR #7161](https://github.com/simstudioai/sim/pull/7161) adds row-delete triggers.

CSV import coercion deliberately remains in the existing import switch because imports preserve invalid raw values for descriptive row-level errors. Existing column types keep unlimited cardinality and identity conversion by default.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: Internal refactor

## Testing

- Focused tests cover registry-defined limits, source-aware conversion, explicit `null` handling, select migrations, schema validation, and both column pickers.
- Verified limited types remain visible but disabled with a reason, while the current type remains selectable during an edit.
- At the restacked stack tip, 29 focused test files pass with 453 tests.
- `bun run type-check`, `bun run lint:check`, `bun run check:api-validation`, and `bun run check:migrations origin/staging` pass.
- Review focus: registry defaults must preserve every existing column type's behavior.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

No screenshots captured. Component tests cover the disabled picker state introduced by the generic cardinality hook.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This PR adds internal extension points whose defaults preserve existing column behavior; the feature PRs above own runtime rollout and monitoring.
