### PR TITLE
fix(sandbox): upgrade isolated-vm to 6.2.0

### DIFF
--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -184,7 +184,7 @@
     "input-otp": "^1.4.2",
     "ioredis": "^5.6.0",
     "ipaddr.js": "2.3.0",
-    "isolated-vm": "6.1.2",
+    "isolated-vm": "6.2.0",
     "jose": "6.0.11",
     "js-tiktoken": "1.0.21",
     "js-yaml": "4.3.1",

--- a/bun.lock
+++ b/bun.lock
@@ -288,7 +288,7 @@
         "input-otp": "^1.4.2",
         "ioredis": "^5.6.0",
         "ipaddr.js": "2.3.0",
-        "isolated-vm": "6.1.2",
+        "isolated-vm": "6.2.0",
         "jose": "6.0.11",
         "js-tiktoken": "1.0.21",
         "js-yaml": "4.3.1",
@@ -3309,7 +3309,7 @@
 
     "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
-    "isolated-vm": ["isolated-vm@6.1.2", "", { "dependencies": { "node-gyp-build": "^4.8.4" } }, "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A=="],
+    "isolated-vm": ["isolated-vm@6.2.0", "", { "dependencies": { "node-gyp-build": "^4.8.4" } }, "sha512-UuSlxSHWt2QuJ5WvBhzlIJx2VVZN/a44SqBbEZFKNdvuSyhOvhmyDo8SQ+njVbhnh/njoL/aW0bUTiFYlpweGQ=="],
 
     "isomorphic-unfetch": ["isomorphic-unfetch@3.1.0", "", { "dependencies": { "node-fetch": "^2.6.1", "unfetch": "^4.2.0" } }, "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q=="],
 


### PR DESCRIPTION
## Summary
- Upgrade isolated-vm from 6.1.2 to the patched 6.2.0 release
- Refresh the lockfile integrity entry for the sandbox escape fix

## Type of Change
- [x] Bug fix

## Testing
- Compiled isolated-vm 6.2.0 against Node.js 24
- Verified function and task worker execution, Reference-backed timers, broker calls, and binary finalization
- `bunx vitest run lib/execution/isolated-vm-worker-hardening.test.ts lib/execution/isolated-vm.test.ts` (15 tests)
- `bun run lint`
- `bun run apps/sim/scripts/check-block-registry.ts origin/staging`
- `bun run check:audits` (33 audits)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
