### PR TITLE
fix(knowledge): stabilize skipped connector documents

### DIFF
--- a/apps/sim/lib/knowledge/connectors/sync-engine.test.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.test.ts
@@ -515,6 +515,23 @@ describe('classifyExternalDoc', () => {
     ).toEqual({ type: 'update', existingId: 'doc-1' })
   })
 
+  it('uses the same skip replacement rule after deferred hydration', async () => {
+    const { shouldReplaceExistingWithSkippedDocument } = await import(
+      '@/lib/knowledge/connectors/sync-engine'
+    )
+
+    expect(shouldReplaceExistingWithSkippedDocument({ storageKey: null }, {})).toBe(true)
+    expect(shouldReplaceExistingWithSkippedDocument({ storageKey: 'kb/indexed.txt' }, {})).toBe(
+      false
+    )
+    expect(
+      shouldReplaceExistingWithSkippedDocument(
+        { storageKey: 'kb/indexed.txt' },
+        { skippedExistingDisposition: 'replace' }
+      )
+    ).toBe(true)
+  })
+
   it('replaces stale indexed content for an authoritative skip', async () => {
     const { classifyExternalDoc } = await import('@/lib/knowledge/connectors/sync-engine')
 

--- a/apps/sim/lib/knowledge/connectors/sync-engine.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.ts
@@ -454,6 +454,13 @@ type DocClassification =
   | { type: 'unchanged' }
   | { type: 'drop' }
 
+export function shouldReplaceExistingWithSkippedDocument(
+  existing: { storageKey?: string | null },
+  skipped: Pick<ExternalDocument, 'skippedExistingDisposition'>
+): boolean {
+  return existing.storageKey === null || skipped.skippedExistingDisposition === 'replace'
+}
+
 /**
  * Decides what a listed external document becomes during reconciliation.
  *
@@ -487,7 +494,7 @@ export function classifyExternalDoc(
 ): DocClassification {
   if (extDoc.skippedReason) {
     if (!existing) return { type: 'skip' }
-    return existing.storageKey === null || extDoc.skippedExistingDisposition === 'replace'
+    return shouldReplaceExistingWithSkippedDocument(existing, extDoc)
       ? { type: 'skip', existingId: existing.id }
       : { type: 'unchanged' }
   }
@@ -2377,7 +2384,8 @@ export async function executeSync(
                   extDoc: mergeHydratedSkippedDocument(op.extDoc, fullDoc),
                 })
               } else if (op.type === 'update') {
-                if (fullDoc.skippedExistingDisposition === 'replace') {
+                const existing = priorByExternalId.get(op.extDoc.externalId)
+                if (existing && shouldReplaceExistingWithSkippedDocument(existing, fullDoc)) {
                   skipOps.push({
                     type: 'skip',
                     existingId: op.existingId,


### PR DESCRIPTION
## Summary

- reuse the same replacement rule for listing-time and hydration-time skipped documents
- persist a rediscovered skip when the existing row is already a content-less failed placeholder
- keep last-known-good indexed content unless a connector explicitly declares the skip authoritative
- preserve every existing retry path, including same-hash placeholder hydration

## Production evidence

A production GitHub sync reported previously recorded binary placeholders as source failures after the ingestion hardening rollout. Trigger traces showed successful listing and processing dispatch, while persisted state showed the reported failures were existing binary placeholders rather than GitHub API or child-processing failures. The hydration path rediscovered an intentional binary skip but, unlike the equivalent listing-time path, treated the content-less existing row as an unverified indexed refresh.

## Why this is minimal

The correction extracts the existing skip-replacement predicate and reuses it after deferred hydration. Existing content-less placeholders continue to rehydrate so providers with weak or absent modification metadata can recover. A rediscovered intentional skip is persisted and counted as `docsSkipped`; indexed last-known-good content is still retained unless the connector opts into authoritative replacement. No provider-specific suppression, retry change, or alert filtering is added.

## Validation

- 45 connector/sync test files, 1,416 tests passed
- monorepo lint passed (one unrelated pre-existing unused suppression warning)
- monorepo type-check passed (26 tasks)
- all 33 repository audits passed
- block registry audit passed
- agent-stream docs and skills generators were idempotent

No schema or migration changes.