### PR TITLE
fix(knowledge): harden OCR and SharePoint ingestion limits

### DIFF
--- a/apps/sim/app/api/tools/mistral/parse/route.ts
+++ b/apps/sim/app/api/tools/mistral/parse/route.ts
@@ -9,13 +9,17 @@ import {
   validateUrlWithDNS,
 } from '@/lib/core/security/input-validation.server'
 import { generateRequestId } from '@/lib/core/utils/request'
+import { isPayloadSizeLimitError } from '@/lib/core/utils/stream-limits'
 import { withRouteHandler } from '@/lib/core/utils/with-route-handler'
 import { validateOpaqueModelInputProvenance } from '@/lib/execution/model-input-provenance'
+import { decodeDataUriWithinLimit } from '@/lib/file-parsers/data-uri'
+import { isFileParserError } from '@/lib/file-parsers/errors'
+import { MISTRAL_OCR_REQUEST_POLICY } from '@/lib/knowledge/documents/ocr-request-policy'
+import { readBoundedHttpErrorBody } from '@/lib/knowledge/documents/utils'
 import {
   isModelSafeWorkspaceFileKey,
   MODEL_UNSAFE_WORKSPACE_FILE_ERROR_MESSAGE,
 } from '@/lib/uploads/contexts/workspace/workspace-file-secret-provenance'
-import { MAX_BUFFERED_TRANSFER_BYTES } from '@/lib/uploads/shared/types'
 import {
   extractStorageKey,
   isInternalFileUrl,
@@ -160,7 +164,7 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           requestId,
           logger,
           {
-            maxBytes: MAX_BUFFERED_TRANSFER_BYTES,
+            maxBytes: MISTRAL_OCR_REQUEST_POLICY.maxBytes,
           }
         )
         base64 = buffer.toString('base64')
@@ -168,6 +172,35 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
           mimeType = contentType
         }
       }
+
+      let inlineBytes: number
+      try {
+        inlineBytes = base64.startsWith('data:')
+          ? decodeDataUriWithinLimit(base64, MISTRAL_OCR_REQUEST_POLICY.maxBytes).buffer.length
+          : Buffer.byteLength(base64, 'base64')
+      } catch (error) {
+        const status = isFileParserError(error) && error.code === 'complexity_limit' ? 413 : 400
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              status === 413
+                ? `File exceeds Mistral OCR's ${MISTRAL_OCR_REQUEST_POLICY.maxBytes.toLocaleString()}-byte request limit`
+                : getErrorMessage(error, 'Invalid inline file data'),
+          },
+          { status }
+        )
+      }
+      if (inlineBytes > MISTRAL_OCR_REQUEST_POLICY.maxBytes) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: `File exceeds Mistral OCR's ${MISTRAL_OCR_REQUEST_POLICY.maxBytes.toLocaleString()}-byte request limit`,
+          },
+          { status: 413 }
+        )
+      }
+
       const base64Payload = base64.startsWith('data:')
         ? base64
         : `data:${mimeType};base64,${base64}`
@@ -295,8 +328,11 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     )
 
     if (!mistralResponse.ok) {
-      const errorText = await mistralResponse.text()
-      logger.error(`[${requestId}] Mistral API error:`, errorText)
+      const errorText = await readBoundedHttpErrorBody(mistralResponse)
+      logger.error(`[${requestId}] Mistral API error`, {
+        status: mistralResponse.status,
+        diagnostic: errorText,
+      })
       return NextResponse.json(
         {
           success: false,
@@ -317,6 +353,16 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
   } catch (error) {
     const notReady = docNotReadyResponse(error)
     if (notReady) return notReady
+
+    if (isPayloadSizeLimitError(error)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `File exceeds Mistral OCR's ${MISTRAL_OCR_REQUEST_POLICY.maxBytes.toLocaleString()}-byte request limit`,
+        },
+        { status: 413 }
+      )
+    }
 
     logger.error(`[${requestId}] Error in Mistral parse:`, error)
 

--- a/apps/sim/connectors/sharepoint/sharepoint.test.ts
+++ b/apps/sim/connectors/sharepoint/sharepoint.test.ts
@@ -105,6 +105,29 @@ function rootChildren(driveId: string, items: unknown[]) {
   }
 }
 
+/** Builds a Graph pagination chain with an optional continuation beyond the final allowed page. */
+function paginatedRoutes(
+  initialUrl: string,
+  routePrefix: string,
+  pageCount: number,
+  continueAfterLast: boolean
+): Record<string, GraphRoute> {
+  const routes: Record<string, GraphRoute> = {}
+
+  for (let page = 0; page < pageCount; page++) {
+    const url = page === 0 ? initialUrl : `${GRAPH}/${routePrefix}/${page}`
+    const hasNextPage = page < pageCount - 1 || continueAfterLast
+    routes[url] = {
+      body: {
+        value: [],
+        ...(hasNextPage ? { '@odata.nextLink': `${GRAPH}/${routePrefix}/${page + 1}` } : {}),
+      },
+    }
+  }
+
+  return routes
+}
+
 function resolve(folderPath?: string) {
   return resolveFolderTarget('token', SITE_ID, SITE_URL, 'Contoso', folderPath)
 }
@@ -319,6 +342,51 @@ describe('resolveFolderTarget', () => {
 
     await expect(resolve('00 IWW Library')).rejects.toThrow(
       /Failed to open the default document library/
+    )
+  })
+
+  it('surfaces a terminal document-library listing failure', async () => {
+    mockGraph({
+      ...defaultDriveRoute,
+      [`${GRAPH}/sites/${SITE_ID}/drives?$select=id,name,webUrl`]: {
+        status: 503,
+        body: { error: { message: 'Service unavailable' } },
+      },
+    })
+
+    await expect(resolve('Missing')).rejects.toThrow(
+      /Failed to list SharePoint document libraries: 503/
+    )
+  })
+
+  it('rejects a document-library listing that continues beyond its safety limit', async () => {
+    const initialUrl = `${GRAPH}/sites/${SITE_ID}/drives?$select=id,name,webUrl`
+    mockGraph({
+      ...defaultDriveRoute,
+      ...paginatedRoutes(initialUrl, 'drive-pages', 20, true),
+    })
+
+    await expect(resolve('Missing')).rejects.toThrow(
+      /document-library listing exceeded the 20-page safety limit/
+    )
+  })
+
+  it('surfaces a 404 encountered while traversing a folder collection', async () => {
+    mockGraph({ ...defaultDriveRoute, ...sitesDrivesRoute })
+
+    await expect(resolve('Missing')).rejects.toThrow(/Failed to list folder contents: 404/)
+  })
+
+  it('rejects a folder listing that continues beyond its safety limit', async () => {
+    const initialUrl = `${GRAPH}/drives/${DEFAULT_DRIVE_ID}/root/children?$top=200&$select=id,name,folder`
+    mockGraph({
+      ...defaultDriveRoute,
+      ...sitesDrivesRoute,
+      ...paginatedRoutes(initialUrl, 'folder-pages', 50, true),
+    })
+
+    await expect(resolve('Missing')).rejects.toThrow(
+      /folder listing exceeded the 50-page safety limit/
     )
   })
 

--- a/apps/sim/connectors/sharepoint/sharepoint.ts
+++ b/apps/sim/connectors/sharepoint/sharepoint.ts
@@ -425,9 +425,9 @@ async function listChildFolders(
 
   for (let page = 0; page < MAX_CHILD_PAGES_PER_SEGMENT; page++) {
     const response = await graphGet(url, accessToken, retryOptions)
-    if (response.status === 404) break
     if (!response.ok) {
-      throw new Error(`Failed to list folder contents: ${response.status}`)
+      const errorText = await readBoundedHttpErrorBody(response)
+      throw new Error(`Failed to list folder contents: ${response.status} – ${errorText}`)
     }
 
     const rawData: unknown = await response.json()
@@ -455,11 +455,16 @@ async function listChildFolders(
       rawData['@odata.nextLink'] === undefined
         ? undefined
         : assertMicrosoftGraphNextLink(rawData['@odata.nextLink'])
-    if (!nextLink) break
+    if (!nextLink) return folders
+    if (page === MAX_CHILD_PAGES_PER_SEGMENT - 1) {
+      throw new Error(
+        `SharePoint folder listing exceeded the ${MAX_CHILD_PAGES_PER_SEGMENT}-page safety limit`
+      )
+    }
     url = nextLink
   }
 
-  return folders
+  throw new Error('SharePoint folder listing ended unexpectedly')
 }
 
 /**
@@ -668,15 +673,25 @@ async function listSiteDrives(
 
   for (let page = 0; page < MAX_DRIVE_PAGES; page++) {
     const response = await graphGet(url, accessToken, retryOptions)
-    if (!response.ok) break
+    if (!response.ok) {
+      const errorText = await readBoundedHttpErrorBody(response)
+      throw new Error(
+        `Failed to list SharePoint document libraries: ${response.status} – ${errorText}`
+      )
+    }
     const data = parseDriveListResponse(await response.json())
     drives.push(...data.value)
     const nextLink = data['@odata.nextLink']
-    if (!nextLink) break
+    if (!nextLink) return drives
+    if (page === MAX_DRIVE_PAGES - 1) {
+      throw new Error(
+        `SharePoint document-library listing exceeded the ${MAX_DRIVE_PAGES}-page safety limit`
+      )
+    }
     url = nextLink
   }
 
-  return drives
+  throw new Error('SharePoint document-library listing ended unexpectedly')
 }
 
 /**

--- a/apps/sim/lib/knowledge/documents/document-processor.ts
+++ b/apps/sim/lib/knowledge/documents/document-processor.ts
@@ -30,9 +30,18 @@ import {
   PermanentDocumentProcessingError,
 } from '@/lib/knowledge/documents/document-processing-error'
 import {
+  getAzureMistralOcrRequestPolicy,
+  MISTRAL_OCR_REQUEST_POLICY,
+  type OcrRequestPolicy,
+} from '@/lib/knowledge/documents/ocr-request-policy'
+import {
   resolveParserExtension,
   resolveStoredArtifactExtension,
 } from '@/lib/knowledge/documents/parser-extension'
+import {
+  buildLargestFittingPdfChunk,
+  type PdfOcrChunk,
+} from '@/lib/knowledge/documents/pdf-ocr-chunking'
 import { assessPdfTextLayer } from '@/lib/knowledge/documents/pdf-text-layer'
 import { retryWithExponentialBackoff } from '@/lib/knowledge/documents/utils'
 import {
@@ -54,18 +63,10 @@ const TIMEOUTS = {
   MISTRAL_OCR_API: 120000,
 } as const
 
-const DEFAULT_OCR_CHUNK_CONCURRENCY = 2
 const MAX_OCR_PDF_PAGES = 10_000
-const MAX_OCR_PDF_CHUNKS = 10
 const MAX_OCR_SPLIT_BYTES = 2 * MAX_FILE_SIZE
 const MAX_OCR_RESPONSE_BYTES = 32 * 1024 * 1024
 const MAX_OCR_OUTPUT_TEXT_BYTES = 20 * 1024 * 1024
-
-/**
- * Two concurrent OCR chunks keep the source, split-buffer, response, and
- * extracted-text ceilings inside one worker's aggregate memory budget.
- */
-const MAX_CONCURRENT_CHUNKS = DEFAULT_OCR_CHUNK_CONCURRENCY
 
 type OCRResult = {
   success: boolean
@@ -90,8 +91,6 @@ const LEGACY_FORMAT_REPLACEMENTS: Record<string, string> = {
   xls: 'XLSX',
 }
 
-const MISTRAL_MAX_PAGES = 1000
-
 async function getPdfPageCount(buffer: Buffer): Promise<number> {
   let pdf: Awaited<ReturnType<typeof import('unpdf')['getDocumentProxy']>> | undefined
   try {
@@ -100,36 +99,19 @@ async function getPdfPageCount(buffer: Buffer): Promise<number> {
     pdf = await getDocumentProxy(uint8Array)
     return pdf.numPages
   } catch (error) {
-    logger.warn('Failed to get PDF page count:', error)
-    return 0
+    logger.warn('Primary PDF page-count parser failed', {
+      errorType: toError(error).name,
+    })
+    try {
+      return (await PDFDocument.load(buffer)).getPageCount()
+    } catch (fallbackError) {
+      logger.warn('Fallback PDF page-count parser failed', {
+        errorType: toError(fallbackError).name,
+      })
+      return 0
+    }
   } finally {
     await pdf?.destroy().catch(() => {})
-  }
-}
-
-interface PdfChunk {
-  buffer: Buffer
-  startPage: number
-  endPage: number
-}
-
-async function buildPdfChunk(
-  sourcePdf: PDFDocument,
-  startPage: number,
-  endPage: number
-): Promise<PdfChunk> {
-  const outputPdf = await PDFDocument.create()
-  const pageIndices = Array.from(
-    { length: endPage - startPage + 1 },
-    (_, index) => startPage + index
-  )
-  const copiedPages = await outputPdf.copyPages(sourcePdf, pageIndices)
-  for (const page of copiedPages) outputPdf.addPage(page)
-
-  return {
-    buffer: Buffer.from(await outputPdf.save()),
-    startPage,
-    endPage,
   }
 }
 
@@ -476,20 +458,10 @@ async function handleFileForOCR(
 
   if (isExternalHttps) {
     if (mimeType === 'application/pdf') {
-      logger.info(`handleFileForOCR: Downloading external PDF to check page count`)
-      try {
-        const buffer = await downloadFileWithTimeout(fileUrl, userId)
-        logger.info(`handleFileForOCR: Downloaded external PDF: ${buffer.length} bytes`)
-        return { httpsUrl: fileUrl, buffer }
-      } catch (error) {
-        logger.warn(
-          `handleFileForOCR: Failed to download external PDF for page count check, proceeding without batching`,
-          {
-            errorType: toError(error).name,
-          }
-        )
-        return { httpsUrl: fileUrl, buffer: undefined }
-      }
+      logger.info('handleFileForOCR: Downloading external PDF for OCR admission')
+      const buffer = await downloadFileWithTimeout(fileUrl, userId)
+      logger.info('handleFileForOCR: Downloaded external PDF', { bytes: buffer.length })
+      return { httpsUrl: fileUrl, buffer }
     }
     logger.info(`handleFileForOCR: Using external URL directly`)
     return { httpsUrl: fileUrl, buffer: undefined }
@@ -672,6 +644,12 @@ async function makeOCRRequest(
     }
 
     if (!response.ok) {
+      if (response.status === 413) {
+        throw new PermanentDocumentProcessingError(
+          'document_complexity_limit',
+          'The OCR provider rejected this document because the request was too large. Split or optimize the document and retry.'
+        )
+      }
       throw new APIError(`OCR failed: ${response.status}`, response.status)
     }
 
@@ -703,6 +681,7 @@ async function parseWithAzureMistralOCR(
   )
 
   const fileBuffer = await downloadFileForBase64(fileUrl, userId)
+  const requestPolicy = getAzureMistralOcrRequestPolicy(env.OCR_AZURE_MODEL_NAME!)
 
   try {
     /**
@@ -713,7 +692,7 @@ async function parseWithAzureMistralOCR(
      */
     const content =
       mimeType === 'application/pdf'
-        ? await ocrPdfInChunks(fileBuffer, 'azure-mistral', filename, (chunk) => {
+        ? await ocrPdfInChunks(fileBuffer, 'azure-mistral', filename, requestPolicy, (chunk) => {
             const pageCount = chunk.endPage - chunk.startPage + 1
             return recognizeWithAzureOCR(
               chunk.buffer,
@@ -831,12 +810,18 @@ async function parseWithMistralOCR(
     logger.info('PDF page count resolved', { pageCount })
   }
 
-  const needsBatching = pageCount > MISTRAL_MAX_PAGES
+  const needsBatching =
+    Boolean(buffer) &&
+    (pageCount > MISTRAL_OCR_REQUEST_POLICY.maxPages ||
+      buffer!.length > MISTRAL_OCR_REQUEST_POLICY.maxBytes)
 
   if (needsBatching && buffer) {
-    logger.info(
-      `PDF has ${pageCount} pages, exceeds limit of ${MISTRAL_MAX_PAGES}. Splitting and processing in chunks.`
-    )
+    logger.info('PDF exceeds a Mistral OCR request limit; splitting into bounded chunks', {
+      bytes: buffer.length,
+      pageCount,
+      maxBytes: MISTRAL_OCR_REQUEST_POLICY.maxBytes,
+      maxPages: MISTRAL_OCR_REQUEST_POLICY.maxPages,
+    })
     return processMistralOCRInBatches(filename, apiKey, buffer, userId, cloudUrl)
   }
 
@@ -892,16 +877,19 @@ async function executeMistralOCRRequest(
 async function processChunk(
   chunk: { buffer: Buffer; startPage: number; endPage: number },
   chunkIndex: number,
-  totalChunks: number,
   filename: string,
   apiKey: string,
   userId?: string
 ): Promise<string> {
   const chunkPageCount = chunk.endPage - chunk.startPage + 1
 
-  logger.info(
-    `Processing chunk ${chunkIndex + 1}/${totalChunks} (pages ${chunk.startPage + 1}-${chunk.endPage + 1}, ${chunkPageCount} pages)`
-  )
+  logger.info('Processing OCR chunk', {
+    chunk: chunkIndex + 1,
+    startPage: chunk.startPage + 1,
+    endPage: chunk.endPage + 1,
+    pages: chunkPageCount,
+    bytes: chunk.buffer.length,
+  })
 
   let uploadedKey: string | null = null
 
@@ -962,10 +950,10 @@ async function processChunk(
 
     const content = result.output?.content ?? ''
     assertOcrOutputTextWithinLimit(content)
-    logger.info(`Chunk ${chunkIndex + 1}/${totalChunks} completed successfully`)
+    logger.info(`Chunk ${chunkIndex + 1} completed successfully`)
     return content
   } catch (error) {
-    logger.error(`Chunk ${chunkIndex + 1}/${totalChunks} failed:`, {
+    logger.error(`Chunk ${chunkIndex + 1} failed:`, {
       errorType: toError(error).name,
     })
     throw error
@@ -986,11 +974,11 @@ async function processChunk(
 /**
  * Runs a PDF through OCR a chunk at a time and stitches the pages back together.
  *
- * A provider that caps how many pages one request may carry needs the document
- * split, and both providers cap at the same limit — so the splitting, the
- * concurrency, the ordering and the partial-failure rule live here once rather
- * than being restated per provider, where they had already drifted into one
- * provider chunking and the other refusing anything over the cap.
+ * A provider that caps how many pages or bytes one request may carry needs the
+ * document split according to its own policy. The splitting, concurrency,
+ * ordering, and partial-failure rule live here once rather than being restated
+ * per provider, where they had already drifted into one provider chunking and
+ * the other refusing anything over the cap.
  *
  * A document is indexed whole or not at all: if any chunk fails, the document
  * fails, because a partial result reports success while page ranges are missing
@@ -1000,21 +988,16 @@ async function ocrPdfInChunks(
   pdfBuffer: Buffer,
   provider: string,
   filename: string,
-  recognize: (
-    chunk: { buffer: Buffer; startPage: number; endPage: number },
-    chunkIndex: number,
-    totalChunks: number
-  ) => Promise<string | null>
+  policy: OcrRequestPolicy,
+  recognize: (chunk: PdfOcrChunk, chunkIndex: number) => Promise<string | null>
 ): Promise<string> {
   const detectedPageCount = await getPdfPageCount(pdfBuffer)
 
   /**
-   * Splitting has to load the document, which an encrypted or malformed PDF will
-   * refuse. That must not decide whether the file reaches OCR at all: those are
-   * exactly the documents with no readable text layer, so OCR is their only route,
-   * and the provider may well accept bytes that a local parser would not. When the
-   * split fails the document is sent whole and the page cap is left to the
-   * provider — the behaviour before it was chunked.
+   * An encrypted or malformed PDF may be acceptable to the provider even when
+   * pdf-lib cannot load it. It can still be sent whole when its measured bytes
+   * and known page count fit the request policy. Once a known limit is exceeded,
+   * however, sending it unsplit would knowingly violate the provider contract.
    */
   let sourcePdf: PDFDocument | null = null
   let totalPages = detectedPageCount
@@ -1022,27 +1005,44 @@ async function ocrPdfInChunks(
     sourcePdf = await PDFDocument.load(pdfBuffer)
     totalPages = sourcePdf.getPageCount()
   } catch (error) {
-    logger.info('PDF could not be split for OCR, sending it whole', {
+    logger.info('PDF could not be loaded for OCR splitting', {
       provider,
       error: toError(error).message,
     })
   }
 
-  const requiresSplitting = sourcePdf !== null && totalPages > MISTRAL_MAX_PAGES
-  const chunkCount = requiresSplitting ? Math.ceil(totalPages / MISTRAL_MAX_PAGES) : 1
-  if (totalPages > MAX_OCR_PDF_PAGES || chunkCount > MAX_OCR_PDF_CHUNKS) {
+  if (totalPages > MAX_OCR_PDF_PAGES) {
     throw new PermanentDocumentProcessingError(
       'document_complexity_limit',
       `This PDF has ${totalPages.toLocaleString()} pages, exceeding the safe OCR limit of ${MAX_OCR_PDF_PAGES.toLocaleString()}. Split it into smaller files and retry.`
     )
   }
 
-  logger.info('Splitting PDF for OCR', {
+  const minimumChunkCount = totalPages > 0 ? Math.ceil(totalPages / policy.maxPages) : 1
+  if (minimumChunkCount > policy.maxChunks) {
+    throw new PermanentDocumentProcessingError(
+      'document_complexity_limit',
+      `This PDF requires at least ${minimumChunkCount.toLocaleString()} OCR requests, exceeding the safe limit of ${policy.maxChunks.toLocaleString()}. Split it into smaller files and retry.`
+    )
+  }
+
+  const requiresSplitting = pdfBuffer.length > policy.maxBytes || totalPages > policy.maxPages
+  if (requiresSplitting && (!sourcePdf || totalPages === 0)) {
+    throw new PermanentDocumentProcessingError(
+      'document_complexity_limit',
+      `This PDF exceeds the OCR provider's per-request limit and could not be split safely. Split or optimize the PDF and retry.`
+    )
+  }
+
+  logger.info('OCR PDF request policy resolved', {
     provider,
+    bytes: pdfBuffer.length,
     totalPages,
-    chunks: chunkCount,
-    maxPagesPerChunk: MISTRAL_MAX_PAGES,
-    concurrency: MAX_CONCURRENT_CHUNKS,
+    requiresSplitting,
+    maxBytesPerRequest: policy.maxBytes,
+    maxPagesPerRequest: policy.maxPages,
+    maxChunks: policy.maxChunks,
+    concurrency: policy.concurrency,
   })
 
   type ChunkOutcome =
@@ -1053,16 +1053,34 @@ async function ocrPdfInChunks(
   const outcomes: ChunkOutcome[] = []
   let cumulativeSplitBytes = 0
   let cumulativeOutputBytes = 0
+  let nextPage = 0
+  let nextChunkIndex = 0
+  let wholeDocumentPending = !requiresSplitting
 
-  for (let i = 0; i < chunkCount; i += MAX_CONCURRENT_CHUNKS) {
-    const batchEnd = Math.min(i + MAX_CONCURRENT_CHUNKS, chunkCount)
-    const batch: PdfChunk[] = []
-    for (let index = i; index < batchEnd; index++) {
-      let chunk: PdfChunk
-      if (requiresSplitting && sourcePdf) {
-        const startPage = index * MISTRAL_MAX_PAGES
-        const endPage = Math.min(startPage + MISTRAL_MAX_PAGES - 1, totalPages - 1)
-        chunk = await buildPdfChunk(sourcePdf, startPage, endPage)
+  while (wholeDocumentPending || nextPage < totalPages) {
+    const batch: Array<{ chunk: PdfOcrChunk; index: number }> = []
+
+    if (wholeDocumentPending) {
+      batch.push({
+        chunk: {
+          buffer: pdfBuffer,
+          startPage: 0,
+          endPage: totalPages > 0 ? totalPages - 1 : -1,
+        },
+        index: nextChunkIndex++,
+      })
+      wholeDocumentPending = false
+      nextPage = totalPages
+    } else {
+      for (let slot = 0; slot < policy.concurrency && nextPage < totalPages; slot++) {
+        if (nextChunkIndex >= policy.maxChunks) {
+          throw new PermanentDocumentProcessingError(
+            'document_complexity_limit',
+            `Byte-aware OCR splitting requires more than the safe limit of ${policy.maxChunks.toLocaleString()} requests. Split or optimize the PDF and retry.`
+          )
+        }
+
+        const chunk = await buildLargestFittingPdfChunk(sourcePdf!, nextPage, totalPages, policy)
         cumulativeSplitBytes += chunk.buffer.length
         if (cumulativeSplitBytes > MAX_OCR_SPLIT_BYTES) {
           throw new PermanentDocumentProcessingError(
@@ -1070,21 +1088,16 @@ async function ocrPdfInChunks(
             `Splitting this PDF for OCR exceeded the safe cumulative limit of ${MAX_OCR_SPLIT_BYTES.toLocaleString()} bytes. Split it into smaller files and retry.`
           )
         }
-      } else {
-        chunk = {
-          buffer: pdfBuffer,
-          startPage: 0,
-          endPage: totalPages > 0 ? totalPages - 1 : -1,
-        }
+
+        batch.push({ chunk, index: nextChunkIndex++ })
+        nextPage = chunk.endPage + 1
       }
-      batch.push(chunk)
     }
 
     const batchResults = await Promise.all(
-      batch.map(async (chunk, batchIndex): Promise<ChunkOutcome> => {
-        const index = i + batchIndex
+      batch.map(async ({ chunk, index }): Promise<ChunkOutcome> => {
         try {
-          const content = await recognize(chunk, index, chunkCount)
+          const content = await recognize(chunk, index)
           return content && content.trim().length > 0
             ? { index, kind: 'content', content }
             : { index, kind: 'empty' }
@@ -1110,6 +1123,8 @@ async function ocrPdfInChunks(
     }
     outcomes.push(...batchResults)
   }
+
+  const chunkCount = outcomes.length
 
   const failures = outcomes.filter(
     (outcome): outcome is Extract<ChunkOutcome, { kind: 'failure' }> => outcome.kind === 'failure'
@@ -1158,8 +1173,12 @@ async function processMistralOCRInBatches(
   processingMethod: 'mistral-ocr'
   cloudUrl?: string
 }> {
-  const content = await ocrPdfInChunks(pdfBuffer, 'mistral', filename, (chunk, index, total) =>
-    processChunk(chunk, index, total, filename, apiKey, userId)
+  const content = await ocrPdfInChunks(
+    pdfBuffer,
+    'mistral',
+    filename,
+    MISTRAL_OCR_REQUEST_POLICY,
+    (chunk, index) => processChunk(chunk, index, filename, apiKey, userId)
   )
 
   return { content, processingMethod: 'mistral-ocr', cloudUrl }

--- a/apps/sim/lib/knowledge/documents/ocr-request-policy.test.ts
+++ b/apps/sim/lib/knowledge/documents/ocr-request-policy.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  getAzureMistralOcrRequestPolicy,
+  MISTRAL_OCR_REQUEST_POLICY,
+} from '@/lib/knowledge/documents/ocr-request-policy'
+
+describe('OCR request policies', () => {
+  it('uses Mistral hosted OCR limits without binary-megabyte inflation', () => {
+    expect(MISTRAL_OCR_REQUEST_POLICY).toMatchObject({
+      maxBytes: 50_000_000,
+      maxPages: 1000,
+      concurrency: 2,
+    })
+  })
+
+  it('preserves the historical Azure model envelope', () => {
+    expect(getAzureMistralOcrRequestPolicy('mistral-ocr-2503')).toMatchObject({
+      maxBytes: 50_000_000,
+      maxPages: 1000,
+      concurrency: 1,
+    })
+    expect(getAzureMistralOcrRequestPolicy('mistral-ocr')).toMatchObject({
+      maxBytes: 50_000_000,
+      maxPages: 1000,
+      concurrency: 1,
+    })
+  })
+
+  it('uses the stricter current Azure envelope for current and unknown models', () => {
+    for (const modelName of [
+      'mistral-document-ai-2512',
+      'mistral-ocr-4-0',
+      'custom-deployment-name',
+    ]) {
+      expect(getAzureMistralOcrRequestPolicy(modelName)).toMatchObject({
+        maxBytes: 30_000_000,
+        maxPages: 30,
+        concurrency: 1,
+      })
+    }
+  })
+})

--- a/apps/sim/lib/knowledge/documents/ocr-request-policy.ts
+++ b/apps/sim/lib/knowledge/documents/ocr-request-policy.ts
@@ -1,0 +1,45 @@
+export interface OcrRequestPolicy {
+  readonly maxBytes: number
+  readonly maxPages: number
+  readonly maxChunks: number
+  readonly concurrency: number
+}
+
+/** Mistral's hosted OCR request limits for uploaded documents. */
+export const MISTRAL_OCR_REQUEST_POLICY: OcrRequestPolicy = {
+  maxBytes: 50_000_000,
+  maxPages: 1000,
+  maxChunks: 10,
+  concurrency: 2,
+}
+
+/** Current Azure-hosted Mistral Document AI request limits. */
+const AZURE_MISTRAL_CURRENT_REQUEST_POLICY: OcrRequestPolicy = {
+  maxBytes: 30_000_000,
+  maxPages: 30,
+  maxChunks: 10,
+  concurrency: 1,
+}
+
+/** Historical Azure Mistral OCR deployments accepted the direct-provider envelope. */
+const AZURE_MISTRAL_LEGACY_REQUEST_POLICY: OcrRequestPolicy = {
+  maxBytes: 50_000_000,
+  maxPages: 1000,
+  maxChunks: 10,
+  concurrency: 1,
+}
+
+const AZURE_MISTRAL_LEGACY_MODEL_NAMES = new Set(['mistral-ocr', 'mistral-ocr-2503'])
+
+/**
+ * Resolves Azure's model-specific OCR envelope. Azure deployments can use a
+ * custom deployment name, so only the repository's established legacy alias and
+ * the historical model ID receive the older, larger envelope. Every other name
+ * uses the stricter current contract and therefore cannot overrun a documented
+ * current-model limit.
+ */
+export function getAzureMistralOcrRequestPolicy(modelName: string): OcrRequestPolicy {
+  return AZURE_MISTRAL_LEGACY_MODEL_NAMES.has(modelName.trim().toLowerCase())
+    ? AZURE_MISTRAL_LEGACY_REQUEST_POLICY
+    : AZURE_MISTRAL_CURRENT_REQUEST_POLICY
+}

--- a/apps/sim/lib/knowledge/documents/ocr-request-policy.ts
+++ b/apps/sim/lib/knowledge/documents/ocr-request-policy.ts
@@ -6,28 +6,28 @@ export interface OcrRequestPolicy {
 }
 
 /** Mistral's hosted OCR request limits for uploaded documents. */
-export const MISTRAL_OCR_REQUEST_POLICY: OcrRequestPolicy = {
+export const MISTRAL_OCR_REQUEST_POLICY = {
   maxBytes: 50_000_000,
   maxPages: 1000,
   maxChunks: 10,
   concurrency: 2,
-}
+} as const satisfies OcrRequestPolicy
 
 /** Current Azure-hosted Mistral Document AI request limits. */
-const AZURE_MISTRAL_CURRENT_REQUEST_POLICY: OcrRequestPolicy = {
+const AZURE_MISTRAL_CURRENT_REQUEST_POLICY = {
   maxBytes: 30_000_000,
   maxPages: 30,
   maxChunks: 10,
   concurrency: 1,
-}
+} as const satisfies OcrRequestPolicy
 
 /** Historical Azure Mistral OCR deployments accepted the direct-provider envelope. */
-const AZURE_MISTRAL_LEGACY_REQUEST_POLICY: OcrRequestPolicy = {
+const AZURE_MISTRAL_LEGACY_REQUEST_POLICY = {
   maxBytes: 50_000_000,
   maxPages: 1000,
   maxChunks: 10,
   concurrency: 1,
-}
+} as const satisfies OcrRequestPolicy
 
 const AZURE_MISTRAL_LEGACY_MODEL_NAMES = new Set(['mistral-ocr', 'mistral-ocr-2503'])
 

--- a/apps/sim/lib/knowledge/documents/pdf-ocr-chunking.test.ts
+++ b/apps/sim/lib/knowledge/documents/pdf-ocr-chunking.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment node
+ */
+import { PDFDocument, StandardFonts } from 'pdf-lib'
+import { describe, expect, it } from 'vitest'
+import { PermanentDocumentProcessingError } from '@/lib/knowledge/documents/document-processing-error'
+import type { OcrRequestPolicy } from '@/lib/knowledge/documents/ocr-request-policy'
+import { buildLargestFittingPdfChunk } from '@/lib/knowledge/documents/pdf-ocr-chunking'
+
+async function createSourcePdf(pageCount: number): Promise<PDFDocument> {
+  const pdf = await PDFDocument.create()
+  const font = await pdf.embedFont(StandardFonts.Helvetica)
+  for (let page = 0; page < pageCount; page++) {
+    pdf.addPage().drawText(`Unique OCR test page ${page + 1} ${'x'.repeat(page * 40)}`, { font })
+  }
+  return pdf
+}
+
+function policy(overrides: Partial<OcrRequestPolicy> = {}): OcrRequestPolicy {
+  return {
+    maxBytes: 1_000_000,
+    maxPages: 1000,
+    maxChunks: 10,
+    concurrency: 2,
+    ...overrides,
+  }
+}
+
+describe('buildLargestFittingPdfChunk', () => {
+  it('obeys the page ceiling while retaining a contiguous range', async () => {
+    const source = await createSourcePdf(5)
+
+    const chunk = await buildLargestFittingPdfChunk(source, 1, 5, policy({ maxPages: 2 }))
+
+    expect(chunk.startPage).toBe(1)
+    expect(chunk.endPage).toBe(2)
+  })
+
+  it('shrinks a chunk until its serialized bytes fit', async () => {
+    const source = await createSourcePdf(3)
+    const onePage = await buildLargestFittingPdfChunk(source, 0, 3, policy({ maxPages: 1 }))
+    const twoPages = await buildLargestFittingPdfChunk(source, 0, 3, policy({ maxPages: 2 }))
+    expect(twoPages.buffer.length).toBeGreaterThan(onePage.buffer.length)
+
+    const maxBytes = twoPages.buffer.length - 1
+    const chunk = await buildLargestFittingPdfChunk(source, 0, 3, policy({ maxBytes, maxPages: 3 }))
+
+    expect(chunk.buffer.length).toBeLessThanOrEqual(maxBytes)
+    expect(chunk.endPage).toBeLessThan(2)
+  })
+
+  it('permanently rejects a page that cannot fit by itself', async () => {
+    const source = await createSourcePdf(1)
+    const onePage = await buildLargestFittingPdfChunk(source, 0, 1, policy())
+
+    const failure = buildLargestFittingPdfChunk(
+      source,
+      0,
+      1,
+      policy({ maxBytes: onePage.buffer.length - 1 })
+    )
+
+    await expect(failure).rejects.toBeInstanceOf(PermanentDocumentProcessingError)
+    await expect(failure).rejects.toThrow(/Page 1 cannot fit/)
+  })
+})

--- a/apps/sim/lib/knowledge/documents/pdf-ocr-chunking.ts
+++ b/apps/sim/lib/knowledge/documents/pdf-ocr-chunking.ts
@@ -1,0 +1,67 @@
+import { PDFDocument } from 'pdf-lib'
+import { PermanentDocumentProcessingError } from '@/lib/knowledge/documents/document-processing-error'
+import type { OcrRequestPolicy } from '@/lib/knowledge/documents/ocr-request-policy'
+
+export interface PdfOcrChunk {
+  buffer: Buffer
+  startPage: number
+  endPage: number
+}
+
+async function buildPdfChunk(
+  sourcePdf: PDFDocument,
+  startPage: number,
+  endPage: number
+): Promise<PdfOcrChunk> {
+  const outputPdf = await PDFDocument.create()
+  const pageIndices = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, index) => startPage + index
+  )
+  const copiedPages = await outputPdf.copyPages(sourcePdf, pageIndices)
+  for (const page of copiedPages) outputPdf.addPage(page)
+
+  return {
+    buffer: Buffer.from(await outputPdf.save()),
+    startPage,
+    endPage,
+  }
+}
+
+/**
+ * Builds the largest contiguous chunk that satisfies both the request's page
+ * and serialized-byte ceilings. Every candidate is measured after serialization
+ * because source PDF size is not a safe proxy for an extracted range's size.
+ */
+export async function buildLargestFittingPdfChunk(
+  sourcePdf: PDFDocument,
+  startPage: number,
+  totalPages: number,
+  policy: OcrRequestPolicy
+): Promise<PdfOcrChunk> {
+  let lowEndPage = startPage
+  let highEndPage = Math.min(startPage + policy.maxPages - 1, totalPages - 1)
+  let bestEndPage: number | null = null
+
+  while (lowEndPage <= highEndPage) {
+    const candidateEndPage = Math.floor((lowEndPage + highEndPage) / 2)
+    const candidate = await buildPdfChunk(sourcePdf, startPage, candidateEndPage)
+
+    if (candidate.buffer.length <= policy.maxBytes) {
+      bestEndPage = candidateEndPage
+      lowEndPage = candidateEndPage + 1
+    } else {
+      highEndPage = candidateEndPage - 1
+    }
+  }
+
+  if (bestEndPage !== null) {
+    const chunk = await buildPdfChunk(sourcePdf, startPage, bestEndPage)
+    if (chunk.buffer.length <= policy.maxBytes) return chunk
+  }
+
+  throw new PermanentDocumentProcessingError(
+    'document_complexity_limit',
+    `Page ${startPage + 1} cannot fit within the OCR provider's ${policy.maxBytes.toLocaleString()}-byte request limit. Split or optimize the PDF and retry.`
+  )
+}

--- a/apps/sim/lib/knowledge/documents/pdf-ocr-triage.test.ts
+++ b/apps/sim/lib/knowledge/documents/pdf-ocr-triage.test.ts
@@ -180,6 +180,16 @@ describe('PDF OCR triage', () => {
 
     await expect(parse()).rejects.toThrow('OCR provider returned no page results')
   })
+
+  it('classifies an OCR request-size rejection as a permanent document failure', async () => {
+    mockParseBuffer.mockResolvedValue({ content: '', metadata: {} })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 413 })))
+
+    const error = await parse().catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(PermanentDocumentProcessingError)
+    expect(error).toMatchObject({ code: 'document_complexity_limit' })
+  })
 })
 
 describe('Azure OCR chunking', () => {
@@ -215,6 +225,31 @@ describe('Azure OCR chunking', () => {
 
     expect(result.metadata.processingMethod).toBe('mistral-ocr')
     // 1001 pages against a 1000-page request cap: two chunks, two requests.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the current Azure model 30-page request envelope', async () => {
+    Object.assign(env, {
+      OCR_PROVIDER: 'azure-mistral',
+      OCR_AZURE_API_KEY: 'key',
+      OCR_AZURE_ENDPOINT: 'https://example.openai.azure.com',
+      OCR_AZURE_MODEL_NAME: 'mistral-document-ai-2512',
+    })
+    mockParseBuffer.mockResolvedValue({ content: '', metadata: {} })
+    mockDownload.mockResolvedValue(await pdfOfPages(31))
+    let request = 0
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      const pageCount = request++ === 0 ? 30 : 1
+      return new Response(
+        JSON.stringify({ pages: ocrPages(pageCount), usage_info: { pages_processed: pageCount } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await parse()
+
+    expect(result.metadata.processingMethod).toBe('mistral-ocr')
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
   /**


### PR DESCRIPTION
## Summary
- enforce provider-specific OCR byte and page limits with bounded PDF splitting
- fail explicitly when SharePoint pagination is incomplete or a collection request fails
- surface permanent request-size failures without indexing partial results

## Type of Change
- [x] Bug fix

## Testing
- 342 focused knowledge-document and SharePoint tests pass
- repository lint, block-registry validation, and all 33 CI audits pass
- generated artifacts are current

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)