### PR TITLE
fix(landing): harden cross-browser compatibility

### DIFF
--- a/apps/sim/app/(landing)/components/auth-modal/auth-modal.tsx
+++ b/apps/sim/app/(landing)/components/auth-modal/auth-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import {
+  cn,
   Loader,
   Modal,
   ModalClose,
@@ -22,6 +23,7 @@ import { getEnv, isFalsy } from '@/lib/core/config/env'
 import { isSsoEnabled } from '@/lib/core/config/env-flags'
 import { captureClientEvent } from '@/lib/posthog/client'
 import type { PostHogEventMap } from '@/lib/posthog/events'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { getBrandConfig } from '@/ee/whitelabeling'
 
 const logger = createLogger('AuthModal')
@@ -196,7 +198,12 @@ export function AuthModal({ children, defaultView = 'login', source }: AuthModal
                   className='h-[22px] w-auto shrink-0 object-contain'
                 />
                 <div className='flex flex-col gap-1 text-left'>
-                  <p className='text-[22px] text-[color-mix(in_srgb,var(--text-muted)_60%,transparent)] leading-[125%] tracking-[0.02em]'>
+                  <p
+                    className={cn(
+                      'text-[22px] leading-[125%] tracking-[0.02em]',
+                      colorMixFallbacks.mutedText60
+                    )}
+                  >
                     Start building.
                   </p>
                   <h2 className='text-[22px] text-[var(--text-primary)] leading-[110%] tracking-[-0.02em]'>

--- a/apps/sim/app/(landing)/components/hero/components/hero-visual/hero-visual.tsx
+++ b/apps/sim/app/(landing)/components/hero/components/hero-visual/hero-visual.tsx
@@ -300,7 +300,7 @@ const SEND_BUTTON_INK = {
  */
 const LANDING_LOADER_INK = {
   '--tl-grad-inner': 'var(--text-body)',
-  '--tl-grad-outer': 'var(--landing-loader-outer)',
+  '--tl-grad-outer': 'var(--thinking-loader-outer)',
   '--tl-glow': 'transparent',
 } as CSSProperties
 

--- a/apps/sim/app/(landing)/components/hero/components/hero-visual/hero-visual.tsx
+++ b/apps/sim/app/(landing)/components/hero/components/hero-visual/hero-visual.tsx
@@ -38,6 +38,7 @@ import {
   TYPE_MS_PER_ATOM,
   WORKFLOW_FOCUS_SCALE,
 } from '@/app/(landing)/components/hero/components/hero-visual/workflow-data'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 
 /**
  * Animated hero visual - the only client island in the hero, decorative and
@@ -299,7 +300,7 @@ const SEND_BUTTON_INK = {
  */
 const LANDING_LOADER_INK = {
   '--tl-grad-inner': 'var(--text-body)',
-  '--tl-grad-outer': 'color-mix(in srgb, var(--text-body) 76%, #fff)',
+  '--tl-grad-outer': 'var(--landing-loader-outer)',
   '--tl-glow': 'transparent',
 } as CSSProperties
 
@@ -1144,6 +1145,7 @@ export function HeroVisual() {
             // layer, so the slide + dock read as smooth sub-pixel motion instead of
             // jittering as the position pixel-snaps each frame.
             'pointer-events-none absolute top-0 left-0 z-20 transform-gpu transition-opacity duration-300 will-change-transform [transition-timing-function:cubic-bezier(0.23,1,0.32,1)]',
+            colorMixFallbacks.loaderOuter,
             loaderFading ? 'opacity-0' : 'opacity-100'
           )}
           style={{ transformOrigin: '0 0' }}

--- a/apps/sim/app/(landing)/components/navbar/components/logo-mark/logo-mark.tsx
+++ b/apps/sim/app/(landing)/components/navbar/components/logo-mark/logo-mark.tsx
@@ -19,7 +19,7 @@ interface LogoMarkProps {
  */
 const LOADER_INK = {
   '--tl-grad-inner': 'var(--text-body)',
-  '--tl-grad-outer': 'var(--landing-loader-outer)',
+  '--tl-grad-outer': 'var(--thinking-loader-outer)',
   '--tl-glow': 'transparent',
 } as CSSProperties
 

--- a/apps/sim/app/(landing)/components/navbar/components/logo-mark/logo-mark.tsx
+++ b/apps/sim/app/(landing)/components/navbar/components/logo-mark/logo-mark.tsx
@@ -3,6 +3,7 @@
 import { type CSSProperties, type ReactNode, useState } from 'react'
 import { cn } from '@sim/emcn'
 import { ThinkingLoader } from '@/components/ui'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 
 interface LogoMarkProps {
   /** Server-rendered Sim wordmark, shown by default. */
@@ -18,7 +19,7 @@ interface LogoMarkProps {
  */
 const LOADER_INK = {
   '--tl-grad-inner': 'var(--text-body)',
-  '--tl-grad-outer': 'color-mix(in srgb, var(--text-body) 76%, #fff)',
+  '--tl-grad-outer': 'var(--landing-loader-outer)',
   '--tl-glow': 'transparent',
 } as CSSProperties
 
@@ -35,7 +36,7 @@ export function LogoMark({ children }: LogoMarkProps) {
 
   return (
     <span
-      className='relative inline-flex items-center'
+      className={cn('relative inline-flex items-center', colorMixFallbacks.loaderOuter)}
       // Transform + its transition are inline on purpose: Tailwind's
       // `transition-transform` utility (its var-based transform composition)
       // prevents the scale from applying on this element, so the transition is

--- a/apps/sim/app/(landing)/components/navbar/components/mobile-nav/mobile-nav.tsx
+++ b/apps/sim/app/(landing)/components/navbar/components/mobile-nav/mobile-nav.tsx
@@ -10,6 +10,7 @@ import {
   NAVBAR_GLASS_SURFACE,
   useNavbarFrost,
 } from '@/app/(landing)/components/navbar/components/navbar-shell'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { DEMO_HREF, SIGNUP_HREF } from '@/app/(landing)/constants'
 
 /**
@@ -92,7 +93,10 @@ export function MobileNav({ stars }: MobileNavProps) {
           aria-hidden='true'
           tabIndex={-1}
           onClick={() => setOpen(false)}
-          className='fixed inset-0 top-full z-40 cursor-default bg-[color-mix(in_srgb,var(--text-primary)_8%,transparent)]'
+          className={cn(
+            'fixed inset-0 top-full z-40 cursor-default',
+            colorMixFallbacks.mobileBackdrop
+          )}
         />
       ) : null}
 

--- a/apps/sim/app/(landing)/components/navbar/components/nav-menu-chip/components/nav-menu-item/nav-menu-item.tsx
+++ b/apps/sim/app/(landing)/components/navbar/components/nav-menu-chip/components/nav-menu-item/nav-menu-item.tsx
@@ -26,7 +26,7 @@ const ROW_CLASS =
 const TITLE_CLASS = 'truncate text-[14px] text-[var(--text-body)]'
 const DESC_CLASS = 'text-[12px] text-[var(--text-muted)] leading-snug'
 const ARROW_CLASS =
-  'size-4 flex-shrink-0 -translate-x-1 text-[var(--text-icon)] opacity-0 transition-all group-hover/item:translate-x-0 group-hover/item:opacity-100 group-focus-visible/item:translate-x-0 group-focus-visible/item:opacity-100 motion-reduce:transition-none'
+  'size-4 flex-shrink-0 -translate-x-1 text-[var(--text-icon)] opacity-0 transition-[opacity,transform] group-hover/item:translate-x-0 group-hover/item:opacity-100 group-focus-visible/item:translate-x-0 group-focus-visible/item:opacity-100 motion-reduce:transition-none'
 
 export function NavMenuItem({ item, onSelect }: NavMenuItemProps) {
   const { title, description, href, external } = item

--- a/apps/sim/app/(landing)/components/navbar/components/navbar-shell/navbar-shell.tsx
+++ b/apps/sim/app/(landing)/components/navbar/components/navbar-shell/navbar-shell.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react'
 import { createContext, use, useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '@sim/emcn'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 
 /**
  * Frosted near-white surface for the scrolled bar - `--bg` at 92% + a strong 40px
@@ -10,8 +11,7 @@ import { cn } from '@sim/emcn'
  * dropdown sheet ({@link MobileNav}) wears the exact same glass as the bar and the
  * two can never drift.
  */
-export const NAVBAR_GLASS_SURFACE =
-  'bg-[color-mix(in_srgb,var(--bg)_92%,transparent)] backdrop-blur-2xl'
+export const NAVBAR_GLASS_SURFACE = cn(colorMixFallbacks.navbarGlass, 'backdrop-blur-2xl')
 
 interface NavbarFrostContextValue {
   /**

--- a/apps/sim/app/(landing)/components/shared/code-window-graphic/code-window-graphic.tsx
+++ b/apps/sim/app/(landing)/components/shared/code-window-graphic/code-window-graphic.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { cn } from '@sim/emcn'
 import styles from '@/app/(landing)/components/shared/code-window-graphic/code-window-graphic.module.css'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics'
 
 /** One inline run of code text inside a {@link CodeWindowGraphic} line. */
@@ -40,7 +41,7 @@ const SEGMENT_TONE_CLASS = {
 } as const
 
 /** Shared hairline ink for the window outline, header rule, and icon box. */
-const OUTLINE_INK = 'border-[color:color-mix(in_srgb,var(--text-muted-inverse)_45%,transparent)]'
+const OUTLINE_INK = colorMixFallbacks.inverseBorder45
 
 /**
  * The dark-tile outlined editor window shared by the platform pages' "from

--- a/apps/sim/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css
+++ b/apps/sim/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css
@@ -1,0 +1,115 @@
+.navbarGlass {
+  background-color: var(--bg);
+}
+
+.mobileBackdrop {
+  background-color: var(--text-primary);
+  opacity: 0.08;
+}
+
+.mutedText60 {
+  color: var(--text-muted);
+}
+
+.loaderOuter {
+  --landing-loader-outer: var(--text-body);
+}
+
+.inverseBorder45 {
+  border-color: var(--text-muted-inverse);
+}
+
+.inverseBackground45 {
+  background-color: var(--text-muted-inverse);
+}
+
+.mutedBackground35 {
+  background-color: var(--text-muted);
+}
+
+.mutedBorder60 {
+  border-color: var(--text-muted);
+}
+
+.inverseBorder22 {
+  border-color: var(--text-muted-inverse);
+}
+
+.inverseBorder35 {
+  border-color: var(--text-muted-inverse);
+}
+
+.inverseBorder70 {
+  border-color: var(--text-muted-inverse);
+}
+
+.mutedStroke35 {
+  stroke: var(--text-muted);
+}
+
+.inverseStroke28 {
+  stroke: var(--text-muted-inverse);
+}
+
+.inverseStroke45 {
+  stroke: var(--text-muted-inverse);
+}
+
+@supports (color: color-mix(in srgb, red, blue)) {
+  .navbarGlass {
+    background-color: color-mix(in srgb, var(--bg) 92%, transparent);
+  }
+
+  .mobileBackdrop {
+    background-color: color-mix(in srgb, var(--text-primary) 8%, transparent);
+    opacity: 1;
+  }
+
+  .mutedText60 {
+    color: color-mix(in srgb, var(--text-muted) 60%, transparent);
+  }
+
+  .loaderOuter {
+    --landing-loader-outer: color-mix(in srgb, var(--text-body) 76%, var(--white));
+  }
+
+  .inverseBorder45 {
+    border-color: color-mix(in srgb, var(--text-muted-inverse) 45%, transparent);
+  }
+
+  .inverseBackground45 {
+    background-color: color-mix(in srgb, var(--text-muted-inverse) 45%, transparent);
+  }
+
+  .mutedBackground35 {
+    background-color: color-mix(in srgb, var(--text-muted) 35%, transparent);
+  }
+
+  .mutedBorder60 {
+    border-color: color-mix(in srgb, var(--text-muted) 60%, transparent);
+  }
+
+  .inverseBorder22 {
+    border-color: color-mix(in srgb, var(--text-muted-inverse) 22%, transparent);
+  }
+
+  .inverseBorder35 {
+    border-color: color-mix(in srgb, var(--text-muted-inverse) 35%, transparent);
+  }
+
+  .inverseBorder70 {
+    border-color: color-mix(in srgb, var(--text-muted-inverse) 70%, transparent);
+  }
+
+  .mutedStroke35 {
+    stroke: color-mix(in srgb, var(--text-muted) 35%, transparent);
+  }
+
+  .inverseStroke28 {
+    stroke: color-mix(in srgb, var(--text-muted-inverse) 28%, transparent);
+  }
+
+  .inverseStroke45 {
+    stroke: color-mix(in srgb, var(--text-muted-inverse) 45%, transparent);
+  }
+}

--- a/apps/sim/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css
+++ b/apps/sim/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css
@@ -12,7 +12,7 @@
 }
 
 .loaderOuter {
-  --landing-loader-outer: var(--text-body);
+  --thinking-loader-outer: var(--text-body);
 }
 
 .inverseBorder45 {
@@ -70,7 +70,7 @@
   }
 
   .loaderOuter {
-    --landing-loader-outer: color-mix(in srgb, var(--text-body) 76%, var(--white));
+    --thinking-loader-outer: color-mix(in srgb, var(--text-body) 76%, var(--white));
   }
 
   .inverseBorder45 {

--- a/apps/sim/app/(landing)/demo/components/demo-booking/demo-booking.tsx
+++ b/apps/sim/app/(landing)/demo/components/demo-booking/demo-booking.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { type CSSProperties, useEffect, useRef, useState } from 'react'
+import { type CSSProperties, type RefObject, useEffect, useRef, useState } from 'react'
 import { chipBorderShadowRing, cn } from '@sim/emcn'
 import dynamic from 'next/dynamic'
 import { preconnect } from 'react-dom'
 import { DemoForm, type DemoLead } from '@/app/(landing)/demo/components/demo-form'
+import { applyLegacyInertFallback } from '@/app/(landing)/demo/components/legacy-inert-fallback'
 
 const importScheduler = () => import('@/app/(landing)/demo/components/demo-scheduler')
 
@@ -31,6 +32,14 @@ const DemoScheduler = dynamic(() => importScheduler().then((m) => m.DemoSchedule
   ssr: false,
   loading: () => null,
 })
+
+function useLegacyInertFallback(ref: RefObject<HTMLDivElement | null>, inert: boolean) {
+  useEffect(() => {
+    const node = ref.current
+    if (!inert || !node || 'inert' in HTMLElement.prototype) return
+    return applyLegacyInertFallback(node)
+  }, [inert, ref])
+}
 
 interface DemoBookingProps {
   /** Layout/placement classes (grid cell). Never chrome. */
@@ -59,7 +68,12 @@ export function DemoBooking({ className }: DemoBookingProps) {
   const [lead, setLead] = useState<DemoLead | null>(null)
   const [formHeight, setFormHeight] = useState<number>()
   const formRef = useRef<HTMLDivElement>(null)
+  const formPanelRef = useRef<HTMLDivElement>(null)
+  const schedulerPanelRef = useRef<HTMLDivElement>(null)
   const showScheduler = lead !== null
+
+  useLegacyInertFallback(formPanelRef, showScheduler)
+  useLegacyInertFallback(schedulerPanelRef, !showScheduler)
 
   useEffect(() => {
     const node = formRef.current
@@ -87,6 +101,7 @@ export function DemoBooking({ className }: DemoBookingProps) {
         style={{ transform: showScheduler ? 'translateX(-100%)' : undefined }}
       >
         <div
+          ref={formPanelRef}
           className='w-full min-w-0 shrink-0'
           inert={showScheduler}
           onFocusCapture={() => void preloadScheduler()}
@@ -95,7 +110,11 @@ export function DemoBooking({ className }: DemoBookingProps) {
             <DemoForm onComplete={setLead} />
           </div>
         </div>
-        <div className='h-full w-full min-w-0 shrink-0' inert={!showScheduler}>
+        <div
+          ref={schedulerPanelRef}
+          className='h-full w-full min-w-0 shrink-0'
+          inert={!showScheduler}
+        >
           {lead ? <DemoScheduler lead={lead} /> : null}
         </div>
       </div>

--- a/apps/sim/app/(landing)/demo/components/legacy-inert-fallback.test.ts
+++ b/apps/sim/app/(landing)/demo/components/legacy-inert-fallback.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest'
+import { applyLegacyInertFallback } from '@/app/(landing)/demo/components/legacy-inert-fallback'
+
+describe('applyLegacyInertFallback', () => {
+  it('removes descendants from interaction and restores their exact prior state', () => {
+    const panel = document.createElement('div')
+    panel.setAttribute('aria-hidden', 'false')
+    panel.style.pointerEvents = 'auto'
+    panel.innerHTML = `
+      <button>Continue</button>
+      <a href="/demo" tabindex="2">Demo</a>
+      <input disabled />
+    `
+
+    const button = panel.querySelector('button')
+    const link = panel.querySelector('a')
+    const disabledInput = panel.querySelector('input')
+    const restore = applyLegacyInertFallback(panel)
+
+    expect(panel.getAttribute('aria-hidden')).toBe('true')
+    expect(panel.style.pointerEvents).toBe('none')
+    expect(button?.getAttribute('tabindex')).toBe('-1')
+    expect(link?.getAttribute('tabindex')).toBe('-1')
+    expect(disabledInput?.getAttribute('tabindex')).toBeNull()
+
+    restore()
+
+    expect(panel.getAttribute('aria-hidden')).toBe('false')
+    expect(panel.style.pointerEvents).toBe('auto')
+    expect(button?.getAttribute('tabindex')).toBeNull()
+    expect(link?.getAttribute('tabindex')).toBe('2')
+  })
+})

--- a/apps/sim/app/(landing)/demo/components/legacy-inert-fallback.test.ts
+++ b/apps/sim/app/(landing)/demo/components/legacy-inert-fallback.test.ts
@@ -33,4 +33,21 @@ describe('applyLegacyInertFallback', () => {
     expect(button?.getAttribute('tabindex')).toBeNull()
     expect(link?.getAttribute('tabindex')).toBe('2')
   })
+
+  it('moves focus out of a panel before hiding it', () => {
+    const panel = document.createElement('div')
+    const button = document.createElement('button')
+    panel.append(button)
+    document.body.append(panel)
+    button.focus()
+
+    expect(document.activeElement).toBe(button)
+
+    const restore = applyLegacyInertFallback(panel)
+
+    expect(document.activeElement).not.toBe(button)
+
+    restore()
+    panel.remove()
+  })
 })

--- a/apps/sim/app/(landing)/demo/components/legacy-inert-fallback.ts
+++ b/apps/sim/app/(landing)/demo/components/legacy-inert-fallback.ts
@@ -21,6 +21,9 @@ export function applyLegacyInertFallback(node: HTMLElement): () => void {
   const previousAriaHidden = node.getAttribute('aria-hidden')
   const previousPointerEvents = node.style.pointerEvents
   const previousTabIndexes = new Map<HTMLElement, string | null>()
+  const activeElement = node.ownerDocument.activeElement
+
+  if (activeElement instanceof HTMLElement && node.contains(activeElement)) activeElement.blur()
 
   node.setAttribute('aria-hidden', 'true')
   node.style.pointerEvents = 'none'

--- a/apps/sim/app/(landing)/demo/components/legacy-inert-fallback.ts
+++ b/apps/sim/app/(landing)/demo/components/legacy-inert-fallback.ts
@@ -1,0 +1,43 @@
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]',
+].join(',')
+
+/**
+ * Mirrors the interaction-blocking parts of `inert` for Firefox 111, the only
+ * browser in Next's supported range without native support. Modern browsers
+ * never call this fallback.
+ */
+export function applyLegacyInertFallback(node: HTMLElement): () => void {
+  const previousAriaHidden = node.getAttribute('aria-hidden')
+  const previousPointerEvents = node.style.pointerEvents
+  const previousTabIndexes = new Map<HTMLElement, string | null>()
+
+  node.setAttribute('aria-hidden', 'true')
+  node.style.pointerEvents = 'none'
+
+  for (const element of node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)) {
+    previousTabIndexes.set(element, element.getAttribute('tabindex'))
+    element.setAttribute('tabindex', '-1')
+  }
+
+  return () => {
+    if (previousAriaHidden === null) node.removeAttribute('aria-hidden')
+    else node.setAttribute('aria-hidden', previousAriaHidden)
+    node.style.pointerEvents = previousPointerEvents
+
+    for (const [element, tabIndex] of previousTabIndexes) {
+      if (tabIndex === null) element.removeAttribute('tabindex')
+      else element.setAttribute('tabindex', tabIndex)
+    }
+  }
+}

--- a/apps/sim/app/(landing)/enterprise/components/feature-graphics/access-control-graphic.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/feature-graphics/access-control-graphic.tsx
@@ -1,5 +1,6 @@
 import { ChipTag, cn } from '@sim/emcn'
 import Image from 'next/image'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import styles from '@/app/(landing)/enterprise/components/feature-graphics/access-control-graphic.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics/feature-graphic-shell'
 
@@ -123,13 +124,10 @@ export function AccessControlGraphic() {
                 pathLength={1}
                 className={cn(
                   styles.edgeDraw,
-                  edge.emphasized ? styles.edgeDrawEmphasized : EDGE_DRAW_CLASSES[index]
+                  edge.emphasized ? styles.edgeDrawEmphasized : EDGE_DRAW_CLASSES[index],
+                  !edge.emphasized && colorMixFallbacks.mutedStroke35
                 )}
-                stroke={
-                  edge.emphasized
-                    ? 'var(--text-secondary)'
-                    : 'color-mix(in srgb, var(--text-muted) 35%, transparent)'
-                }
+                stroke={edge.emphasized ? 'var(--text-secondary)' : undefined}
                 strokeWidth='1'
               />
             ))}

--- a/apps/sim/app/(landing)/enterprise/components/feature-graphics/deploy-graphic.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/feature-graphics/deploy-graphic.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'react'
 import { ChipTag, chipContentLabelClass, chipGeometryClass, cn } from '@sim/emcn'
 import { CircleCheck, Lock } from '@sim/emcn/icons'
 import { ThinkingLoader } from '@/components/ui'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import styles from '@/app/(landing)/enterprise/components/feature-graphics/deploy-graphic.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics/feature-graphic-shell'
 
@@ -100,7 +101,12 @@ export function DeployGraphic({
           <ChipTag variant='mono'>{versionTag}</ChipTag>
         </div>
 
-        <span className='relative mt-1.5 min-h-3 w-px flex-1 overflow-hidden bg-[color:color-mix(in_srgb,var(--text-muted-inverse)_45%,transparent)]'>
+        <span
+          className={cn(
+            'relative mt-1.5 min-h-3 w-px flex-1 overflow-hidden',
+            colorMixFallbacks.inverseBackground45
+          )}
+        >
           <span className={styles.sweep} />
         </span>
 
@@ -116,11 +122,21 @@ export function DeployGraphic({
           </span>
         </span>
 
-        <span className='relative mt-2.5 mb-1.5 min-h-3 w-px flex-1 overflow-hidden bg-[color:color-mix(in_srgb,var(--text-muted-inverse)_45%,transparent)]'>
+        <span
+          className={cn(
+            'relative mt-2.5 mb-1.5 min-h-3 w-px flex-1 overflow-hidden',
+            colorMixFallbacks.inverseBackground45
+          )}
+        >
           <span className={cn(styles.sweep, styles.sweepLower)} />
         </span>
 
-        <div className='relative h-24 w-full rounded-t-xl border border-[color:color-mix(in_srgb,var(--text-muted-inverse)_45%,transparent)] border-b-0'>
+        <div
+          className={cn(
+            'relative h-24 w-full rounded-t-xl border border-b-0',
+            colorMixFallbacks.inverseBorder45
+          )}
+        >
           <span
             className={cn(
               '-inset-px absolute rounded-t-xl border border-[var(--text-inverse)] border-b-0',

--- a/apps/sim/app/(landing)/enterprise/components/feature-graphics/lifecycle-graphic.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/feature-graphics/lifecycle-graphic.tsx
@@ -1,5 +1,6 @@
 import { ChipTag, cn } from '@sim/emcn'
 import { Clock } from '@sim/emcn/icons'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics/feature-graphic-shell'
 import styles from '@/app/(landing)/enterprise/components/feature-graphics/lifecycle-graphic.module.css'
 
@@ -69,7 +70,7 @@ export function LifecycleGraphic() {
 
           <div className='flex gap-3'>
             <span className='flex w-2.5 justify-center'>
-              <span className='h-9 w-px bg-[color:color-mix(in_srgb,var(--text-muted)_35%,transparent)]' />
+              <span className={cn('h-9 w-px', colorMixFallbacks.mutedBackground35)} />
             </span>
           </div>
 
@@ -92,12 +93,17 @@ export function LifecycleGraphic() {
             <div key={version.label} className='flex flex-col'>
               <div className='flex gap-3'>
                 <span className='flex w-2.5 justify-center'>
-                  <span className='h-9 w-px bg-[color:color-mix(in_srgb,var(--text-muted)_35%,transparent)]' />
+                  <span className={cn('h-9 w-px', colorMixFallbacks.mutedBackground35)} />
                 </span>
               </div>
               <div className='flex items-center gap-3'>
                 <span className='flex w-2.5 justify-center'>
-                  <span className='size-2 rounded-full border border-[color:color-mix(in_srgb,var(--text-muted)_60%,transparent)] bg-[var(--surface-3)]' />
+                  <span
+                    className={cn(
+                      'size-2 rounded-full border bg-[var(--surface-3)]',
+                      colorMixFallbacks.mutedBorder60
+                    )}
+                  />
                 </span>
                 <span className='flex min-w-0 flex-1 items-center gap-2'>
                   <span className='text-[var(--text-muted)] text-small'>{version.label}</span>

--- a/apps/sim/app/(landing)/enterprise/components/feature-graphics/operations-teams-graphic.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/feature-graphics/operations-teams-graphic.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react'
 import { cn } from '@sim/emcn'
 import { ThinkingLoader } from '@/components/ui'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics/feature-graphic-shell'
 import styles from '@/app/(landing)/enterprise/components/feature-graphics/operations-teams-graphic.module.css'
 
@@ -118,14 +119,11 @@ const OUT_PATHS = {
   jira: 'M 140 155 C 140 184 224 178 224 206',
 } as const
 
-/** Faint-ink stroke for the resting wires (the deploy tile's guide-line grey, quieter). */
-const QUIET_STROKE = 'color-mix(in srgb, var(--text-muted-inverse) 28%, transparent)'
-
 /** Shared 1px outline ink for the tags, port dots, and router hub ring. */
-const OUTLINE_INK = 'border-[color:color-mix(in_srgb,var(--text-muted-inverse)_45%,transparent)]'
+const OUTLINE_INK = colorMixFallbacks.inverseBorder45
 
 /** Shared SVG props for a resting wire. */
-const WIRE_PROPS = { stroke: QUIET_STROKE, strokeWidth: '1' } as const
+const WIRE_PROPS = { className: colorMixFallbacks.inverseStroke28, strokeWidth: '1' } as const
 
 /** Shared SVG props for a traveling white request-pulse overlay on a wire. */
 const PULSE_PROPS = {

--- a/apps/sim/app/(landing)/enterprise/components/feature-graphics/rollback-graphic.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/feature-graphics/rollback-graphic.tsx
@@ -1,5 +1,6 @@
-import { Button, ChipTag } from '@sim/emcn'
+import { Button, ChipTag, cn } from '@sim/emcn'
 import { Undo } from '@sim/emcn/icons'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics/feature-graphic-shell'
 
 /**
@@ -71,7 +72,12 @@ export function RollbackGraphic() {
 
           <div className='flex'>
             <span className='relative flex h-[38px] w-2.5 shrink-0 justify-center'>
-              <span className='-top-[4px] -bottom-[24px] absolute w-px bg-[color:color-mix(in_srgb,var(--text-muted)_35%,transparent)]' />
+              <span
+                className={cn(
+                  '-top-[4px] -bottom-[24px] absolute w-px',
+                  colorMixFallbacks.mutedBackground35
+                )}
+              />
             </span>
           </div>
 
@@ -103,13 +109,23 @@ export function RollbackGraphic() {
 
           <div className='flex'>
             <span className='relative flex h-[28px] w-2.5 shrink-0 justify-center'>
-              <span className='-top-[24px] -bottom-[4px] absolute w-px bg-[color:color-mix(in_srgb,var(--text-muted)_35%,transparent)]' />
+              <span
+                className={cn(
+                  '-top-[24px] -bottom-[4px] absolute w-px',
+                  colorMixFallbacks.mutedBackground35
+                )}
+              />
             </span>
           </div>
 
           <div className='flex items-center gap-3'>
             <span className='flex w-2.5 shrink-0 justify-center'>
-              <span className='size-2 rounded-full border border-[color:color-mix(in_srgb,var(--text-muted)_60%,transparent)] bg-[var(--surface-3)]' />
+              <span
+                className={cn(
+                  'size-2 rounded-full border bg-[var(--surface-3)]',
+                  colorMixFallbacks.mutedBorder60
+                )}
+              />
             </span>
             <span className='flex min-w-0 flex-1 items-center gap-2'>
               <span className='text-[var(--text-muted)] text-small'>v2</span>

--- a/apps/sim/app/(landing)/enterprise/components/feature-graphics/standards-graphic.tsx
+++ b/apps/sim/app/(landing)/enterprise/components/feature-graphics/standards-graphic.tsx
@@ -1,5 +1,6 @@
 import { ChipTag, cn } from '@sim/emcn'
 import { ShieldCheck } from '@sim/emcn/icons'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics/feature-graphic-shell'
 import styles from '@/app/(landing)/enterprise/components/feature-graphics/standards-graphic.module.css'
 
@@ -86,8 +87,18 @@ export function StandardsGraphic({
       <div aria-hidden='true' className='absolute inset-0 pr-8 max-lg:pr-6'>
         <div className='relative h-full'>
           <div className='-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 h-[250px] w-[320px]'>
-            <div className='absolute top-0 left-[48px] size-[224px] rounded-full border border-[color:color-mix(in_srgb,var(--text-muted-inverse)_22%,transparent)] [mask-image:linear-gradient(to_bottom,black_30%,transparent_92%)]' />
-            <div className='absolute top-[36px] left-[84px] size-[152px] rounded-full border border-[color:color-mix(in_srgb,var(--text-muted-inverse)_35%,transparent)]' />
+            <div
+              className={cn(
+                'absolute top-0 left-[48px] size-[224px] rounded-full border [mask-image:linear-gradient(to_bottom,black_30%,transparent_92%)]',
+                colorMixFallbacks.inverseBorder22
+              )}
+            />
+            <div
+              className={cn(
+                'absolute top-[36px] left-[84px] size-[152px] rounded-full border',
+                colorMixFallbacks.inverseBorder35
+              )}
+            />
 
             <svg
               className='absolute inset-0'
@@ -141,21 +152,33 @@ export function StandardsGraphic({
               <path
                 d='M 90 112.5 L 122 112.5'
                 pathLength={1}
-                className={styles.connector}
-                stroke='color-mix(in srgb, var(--text-muted-inverse) 45%, transparent)'
+                className={cn(styles.connector, colorMixFallbacks.inverseStroke45)}
                 strokeWidth='1'
               />
               <path
                 d='M 198 112.5 L 230 112.5'
                 pathLength={1}
-                className={cn(styles.connector, styles.connectorTrailing)}
-                stroke='color-mix(in srgb, var(--text-muted-inverse) 45%, transparent)'
+                className={cn(
+                  styles.connector,
+                  styles.connectorTrailing,
+                  colorMixFallbacks.inverseStroke45
+                )}
                 strokeWidth='1'
               />
             </svg>
 
-            <span className='absolute top-[108px] left-[118px] size-2 rounded-full border border-[color:color-mix(in_srgb,var(--text-muted-inverse)_70%,transparent)] bg-[var(--text-secondary)]' />
-            <span className='absolute top-[108px] left-[194px] size-2 rounded-full border border-[color:color-mix(in_srgb,var(--text-muted-inverse)_70%,transparent)] bg-[var(--text-secondary)]' />
+            <span
+              className={cn(
+                'absolute top-[108px] left-[118px] size-2 rounded-full border bg-[var(--text-secondary)]',
+                colorMixFallbacks.inverseBorder70
+              )}
+            />
+            <span
+              className={cn(
+                'absolute top-[108px] left-[194px] size-2 rounded-full border bg-[var(--text-secondary)]',
+                colorMixFallbacks.inverseBorder70
+              )}
+            />
 
             <div
               className={cn(

--- a/apps/sim/app/(landing)/files/components/files-hero-loop.tsx
+++ b/apps/sim/app/(landing)/files/components/files-hero-loop.tsx
@@ -287,7 +287,7 @@ export function FilesHeroLoop() {
           <div className='min-h-0 flex-1 overflow-hidden'>
             <div
               className={cn(
-                'overflow-hidden transition-all duration-500 ease-out',
+                'overflow-hidden transition-[max-height,opacity] duration-500 ease-out',
                 dropped ? 'max-h-[40px] opacity-100' : 'max-h-0 opacity-0'
               )}
             >
@@ -304,7 +304,7 @@ export function FilesHeroLoop() {
               <div
                 key={row.name}
                 className={cn(
-                  'transition-all duration-300 ease-out',
+                  'transition-[opacity,transform] duration-300 ease-out',
                   index < rowCount ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0'
                 )}
               >

--- a/apps/sim/app/(landing)/knowledge/components/knowledge-hero-loop.tsx
+++ b/apps/sim/app/(landing)/knowledge/components/knowledge-hero-loop.tsx
@@ -229,7 +229,7 @@ export function KnowledgeHeroLoop() {
                     <tr
                       key={row.name}
                       className={cn(
-                        'transition-all duration-300 ease-out',
+                        'transition-[opacity,transform] duration-300 ease-out',
                         index < visibleRows
                           ? 'translate-y-0 opacity-100'
                           : '-translate-y-1 opacity-0'

--- a/apps/sim/app/(landing)/logs/components/feature-graphics/failure-alert-graphic.tsx
+++ b/apps/sim/app/(landing)/logs/components/feature-graphics/failure-alert-graphic.tsx
@@ -1,10 +1,11 @@
 import { cn } from '@sim/emcn'
 import { SlackIcon } from '@/components/icons'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics'
 import styles from '@/app/(landing)/logs/components/feature-graphics/failure-alert-graphic.module.css'
 
 /** Shared hairline ink for the run row, connector, and notification window. */
-const OUTLINE_INK = 'border-[color:color-mix(in_srgb,var(--text-muted-inverse)_45%,transparent)]'
+const OUTLINE_INK = colorMixFallbacks.inverseBorder45
 
 /**
  * A failure caught by alerting, told top to bottom as the deploy tile's
@@ -54,7 +55,7 @@ export function FailureAlertGraphic() {
         <span
           className={cn(
             'relative mt-2 mb-2 min-h-4 w-px flex-1 overflow-hidden',
-            'bg-[color:color-mix(in_srgb,var(--text-muted-inverse)_45%,transparent)]'
+            colorMixFallbacks.inverseBackground45
           )}
         >
           <span className={styles.sweep} />

--- a/apps/sim/app/(landing)/logs/components/feature-graphics/run-trace-graphic.tsx
+++ b/apps/sim/app/(landing)/logs/components/feature-graphics/run-trace-graphic.tsx
@@ -1,4 +1,5 @@
 import { cn, Library } from '@sim/emcn'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics'
 import styles from '@/app/(landing)/logs/components/feature-graphics/run-trace-graphic.module.css'
 
@@ -71,7 +72,7 @@ const BAR_TONE_CLASS = {
 } as const
 
 /** Shared hairline ink for the window outline, header rule, and icon box. */
-const OUTLINE_INK = 'border-[color:color-mix(in_srgb,var(--text-muted-inverse)_45%,transparent)]'
+const OUTLINE_INK = colorMixFallbacks.inverseBorder45
 
 /**
  * A run's block-by-block trace told inside the agent-code tile's dark

--- a/apps/sim/app/(landing)/workflows/components/feature-graphics/workflow-canvas-graphic.tsx
+++ b/apps/sim/app/(landing)/workflows/components/feature-graphics/workflow-canvas-graphic.tsx
@@ -1,4 +1,5 @@
 import { ChipTag, cn } from '@sim/emcn'
+import colorMixFallbacks from '@/app/(landing)/components/shared/color-mix-fallbacks/color-mix-fallbacks.module.css'
 import { FeatureGraphicShell } from '@/app/(landing)/enterprise/components/feature-graphics'
 import styles from '@/app/(landing)/workflows/components/feature-graphics/workflow-canvas-graphic.module.css'
 
@@ -74,8 +75,11 @@ export function WorkflowCanvasGraphic() {
                 key={path}
                 d={path}
                 pathLength={1}
-                className={cn(styles.edgeDraw, EDGE_DRAW_CLASSES[index])}
-                stroke='color-mix(in srgb, var(--text-muted) 35%, transparent)'
+                className={cn(
+                  styles.edgeDraw,
+                  EDGE_DRAW_CLASSES[index],
+                  colorMixFallbacks.mutedStroke35
+                )}
                 strokeWidth='1'
               />
             ))}


### PR DESCRIPTION
## Summary
- add feature-gated color fallbacks across landing visuals for older browser engines
- limit animated properties and add a Firefox 111 inert fallback without changing modern Chrome output

## Type of Change
- [x] Bug fix

## Testing
Tested with lint, 33 repository audits, type-check, focused Vitest coverage, production build, and Chromium/Firefox/WebKit landing smoke checks.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
