### PR TITLE
improvement(blocks): document child workflow deployment behavior

### DIFF
--- a/apps/sim/blocks/blocks/workflow_input.ts
+++ b/apps/sim/blocks/blocks/workflow_input.ts
@@ -9,6 +9,7 @@ export const WorkflowInputBlock: BlockConfig = {
   bestPractices: `
   - Usually clarify/check if the user has tagged a workflow to use as the child workflow. Understand the child workflow to determine the logical position of this block in the workflow.
   - Remember, that the start point of the child workflow is the Start block.
+  - Which version of the child runs depends on how this workflow runs: manual/draft executions run the child's draft, while deployed executions run the child's active deployment. Deploy the child (and redeploy it after editing it) before deploying this workflow, otherwise the deployed run fails because the child is not deployed.
   `,
   category: 'blocks',
   docsLink: 'https://docs.sim.ai/workflows/blocks/workflow',


### PR DESCRIPTION
## Summary
- The Workflow block's `bestPractices` metadata explained how to pick and reason about the child workflow, but never covered deployment. Added a bullet stating that manual/draft parent executions run the child's draft while deployed parent executions run the child's active deployment, so the child must be deployed (and redeployed after edits) before the parent is.
- Matches the executor: `useDeployed = isCustomBlock || ctx.isDeployedContext` selects `loadChildWorkflowDeployed` vs `loadChildWorkflow`, and a deployed parent with an undeployed child throws `Child workflow is not deployed`.
- Fixed once in block metadata rather than in a Copilot-only prompt — `bestPractices` is serialized into the copilot block JSON and projected into the v2 catalog the CLI reads, so all consumers pick it up from the single source.

## Type of Change
- [x] Improvement

## Testing
Tested manually. `bun run lint`, `check:audits` (33/33), and the block-registry audit pass. Ran the focused consumer tests: `blocks/blocks.test.ts` (89), plus `projection-invariants`, `catalog-sweep`, and `vfs/serializers` (59).

No test added: no test in the repo asserts on `bestPractices` for any block, and this is prose metadata with no behavioral surface — a test here would only assert wording.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)