### PR TITLE
docs(library): update ai-agent-vs-chatbot

### DIFF
--- a/apps/sim/content/library/ai-agent-vs-chatbot/index.mdx
+++ b/apps/sim/content/library/ai-agent-vs-chatbot/index.mdx
@@ -1,216 +1,96 @@
 ---
 slug: ai-agent-vs-chatbot
 title: 'AI Agent vs Chatbot: Understanding the Differences'
-description: Understand the key differences between AI agents vs chatbots, from architecture to real-world use cases. Learn when to use each and how to choose the right approach for your workflows.
+description: 'Understand the key differences between AI agents vs chatbots, from architecture to real-world use cases. Learn when to use each and how to choose the right approach for your workflows.'
 date: 2026-06-28
-updated: 2026-07-23
+updated: 2026-08-27
 authors:
-  - emir
-readingTime: 13
+  - andrew
+readingTime: 6
 tags: [AI Agents, Chatbots, AI Workspace, Sim]
 ogImage: /library/ai-agent-vs-chatbot/cover.jpg
 canonical: https://www.sim.ai/library/ai-agent-vs-chatbot
 draft: false
 faq:
-  - q: "What is the difference between an AI agent and a chatbot?"
-    a: "A chatbot is a reactive system that matches user input to predefined responses using rules or basic NLP; it can only answer within its scripted boundaries. An AI agent is an autonomous system that reasons toward a goal, accesses external tools and data, retains memory across interactions, and executes multi-step actions with minimal human direction."
-  - q: "Can a chatbot become an AI agent?"
-    a: "Adding an LLM like GPT to a chatbot doesn't make it an agent — it makes it a chatbot with better language generation. True AI agents require a fundamentally different architecture: persistent memory (short-term and long-term), tool access for taking real actions across systems, and goal-directed planning that lets the system break down objectives into steps and execute them."
-  - q: "Are AI agents more expensive than chatbots?"
-    a: "AI agents can require more setup: integration with APIs and databases, memory configuration, LLM costs, and orchestration logic. But new tools like Sim make it easy to deploy a first agent in minutes. Once live, agents reduce manual overhead at scale — less time spent on repetitive multi-step processes, and fewer errors in cross-system workflows. For teams drowning in manual tasks or coordination, the ROI on an agent proves itself within months."
-  - q: "What are the best use cases for AI agents in 2026?"
-    a: "Common enterprise use cases include end-to-end support automation (resolving tickets without human escalation), data enrichment (pulling and combining data across CRMs, third-party sources, and internal databases), compliance workflows (monitoring regulatory requirements and flagging issues across documents), multi-system reporting (aggregating data from analytics, billing, and project platforms into actionable summaries), and employee or customer onboarding (coordinating account provisioning, training schedules, and documentation across multiple tools)."
-  - q: "How do I know if my team is ready to build AI agents?"
-    a: "Check for four things: clear workflows you want to automate with defined steps rather than a vague AI goal, the right access credentials to the systems involved (CRM, payment gateway, databases, communication tools), a chosen platform or framework such as a code-first tool like LangChain or a visual builder like Sim, and someone who will own the agent rollout and keep monitoring performance and expanding scope over time."
+  - q: "Do AI agents always produce more accurate answers than chatbots?"
+    a: "Answer accuracy is the degree to which a system's response is correct and supported by the available evidence. In [Sim](https://sim.ai), you can inspect each workflow step and control which instructions, data, and tools the model uses. This visibility helps you find the source of an error and improve the workflow without assuming that an agent is inherently more accurate than a chatbot."
+  - q: "Can a chatbot and an AI agent work together?"
+    a: "A hybrid application uses a chatbot for conversation and an AI agent for actions that require tools or multiple steps. Sim connects our [Chat interface](https://docs.sim.ai/execution/chat) to agent workflows you build in a visual workspace with connected integrations. You can give users one conversational interface while the agent handles work across connected applications."
+  - q: "Do I need to know how to code to build an AI agent?"
+    a: "A visual agent builder represents workflow logic as configurable blocks that connect models to tools, so you do not have to program every step. Sim provides a visual workspace for creating and testing these workflows. You can add code when needed without building the orchestration layer from scratch."
+  - q: "Can AI agents run with local models?"
+    a: "Local-model execution runs a model on infrastructure you control rather than through a hosted model provider. Sim supports Enterprise workflows that use local-model tools such as Ollama and also offers hosted access. This choice lets teams match deployment to their security, control, and infrastructure requirements."
+  - q: "How should an AI agent handle failed actions?"
+    a: "A fallback is a predefined response to an invalid, unavailable, or unsuccessful tool call. Sim lets you route a failed action to a retry, an approved alternative, human review, or a safe stop. These paths prevent the agent from continuing with unsupported data or taking an unapproved action."
 ---
 
-You've deployed a chatbot. It answers the easy stuff fine: store hours, password resets, order status checks. Then a customer shows up with something slightly more complex: a refund tied to a promotional code, a shipping update across two orders, a billing question that requires pulling data from your CRM. The chatbot stalls. It loops. It punts to a human agent. Nearly one in five consumers who have used AI for customer service saw no benefit from the experience, according to the Qualtrics 2026 Customer Experience Trends Report.
+## TL;DR
 
-The market isn't helping with clarity: vendors slap "AI agent" on glorified decision trees and call rule-based bots "intelligent assistants." The term "AI agent" gets thrown around loosely, and the resulting confusion costs companies money.
+- A chatbot responds to user messages within a defined conversation.
+- An AI agent pursues a goal by deciding what steps to take and completing actions.
+- AI agents can use retained context and external tools to manage multi-step work with less user direction.
+- Use a chatbot for predictable conversations and an agent for tasks that require decisions or actions.
+- [Sim](https://sim.ai) combines [Chat](https://docs.sim.ai/execution/chat) with more than [1,000 integrations](https://sim.ai/integrations) in a visual workspace for building agent-chatbot hybrids.
 
-Chatbots and AI agents are fundamentally different architectures. They're built differently, they reason differently, they act differently. One follows a script. The other pursues a goal. Understanding the difference shapes whether you waste six months on the wrong tool or deploy something that moves the needle from day one.
+We last verified the article on August 27, 2026.
 
-We'll walk through what each one is, how they work under the hood, a direct side-by-side comparison, a decision framework for choosing the right tool, and a look at hybrid approaches where both work together. By the end, you'll know exactly which architecture fits your problem.
+## AI agents vs. chatbots: key differences
 
-## The Short Version
+A chatbot is a conversational interface that responds to user messages, usually within a predefined flow or a single exchange. An AI agent is a goal-directed system that uses external tools to complete tasks with limited user guidance. [Anthropic defines an agent](https://www.anthropic.com/research/measuring-agent-autonomy) as an AI system equipped with tools that let it take actions, like running code, calling APIs, or messaging other agents.
 
-- **Chatbots follow scripts:** They match user input to predefined responses using rules or basic NLP, handling FAQs and simple lookups well but breaking down when conversations go off-script.
-- **AI agents pursue goals:** They combine LLMs, memory, tool access, and planning to reason through multi-step tasks, make decisions, and take actions across systems with minimal human direction.
-- **The dividing lines are autonomy, memory, and tool use:** If a system can't remember context, access external tools, or adjust its approach mid-task, it's a chatbot, regardless of what it's marketed as.
-- **Chatbots aren't inferior; they're scoped:** For high-volume FAQ handling, appointment booking, and lead qualification, a well-built chatbot is the right call. Don't over-engineer.
-- **You don't have to build from scratch:** Visual agent builders like Sim let teams design, deploy, and iterate on agent workflows without writing orchestration code from the ground up.
+AI agents can direct more of the work than chatbots. A chatbot waits for each prompt and returns a response, while an AI agent can plan a sequence of steps and adjust the plan after evaluating each result. An agent can also retain relevant context across steps or sessions and act through connected software, such as by searching a database or updating a CRM.
 
-## What Is a Chatbot?
+A hybrid product combines a chatbot interface with an AI agent. A conversational interface may collect a request, while an agent works behind it to complete a multi-step task. Treat a hybrid as an AI agent when it can choose and execute steps outside the conversation while preserving relevant context.
 
-A chatbot is software designed to simulate conversation. At its core, it takes user input, matches that input against a set of predefined rules, decision trees, or basic natural language processing (NLP) patterns, and returns a scripted response. The interaction model is reactive: the user asks, the chatbot answers within the bounds of what it's been programmed to say.
+## When to use a chatbot vs. an AI agent
 
-### Two flavors, same ceiling
+Choose based on how much work your product must complete beyond answering a user. A chatbot fits predictable conversations, while an AI agent fits tasks that require independent decisions and actions across connected systems.
 
-Rule-based chatbots are the simplest form. They follow rigid decision trees: if the user says X, respond with Y. Think of the IVR menus of the chat world. "Press 1 for billing, press 2 for shipping." They're predictable, easy to build, and cheap to run. But the moment a user asks something outside the tree, the bot can hit a wall.
-
-NLP-enhanced chatbots add a layer of language understanding. They can parse intent ("I want to return something") and extract entities ("order #12345") to route the conversation more flexibly. They feel smarter because they handle variations in phrasing. But they're still reactive and script-bound; they don't reason, they don't plan, and they don't take actions outside their predefined flows.
-
-### What chatbots do well
-
-Chatbots are excellent at:
-
-- **High-volume FAQ handling:** Store hours, return policies, pricing questions, password resets. Consistent answers, zero wait time.
-- **Simple transactional lookups:** Order status, account balance, appointment availability. If the answer lives in one system and requires one query, chatbots handle it fast.
-- **Lead qualification with basic routing:** "What's your company size?" "What product are you interested in?" Route to the right sales rep.
-- **Fast deployment, low cost:** A rule-based chatbot can go live in days. NLP-enhanced versions can take a few weeks. Neither requires a dedicated engineering team to maintain.
-
-### Where chatbots break
-
-The ceiling shows up fast when complexity increases. Consider two scenarios:
-
-**Scenario A: "Where is my order?"**
-
-The chatbot asks for the order number, queries the tracking system, and returns a status. Clean, fast, done. This is a chatbot's sweet spot.
-
-**Scenario B: "I want to return this item, get a refund to my original payment method, and update my shipping address for future orders."**
-
-Now the chatbot needs to initiate a return flow, process a refund through the payment system, and update the customer's profile in a separate database. That's three systems, conditional logic (is the item eligible for return? was it purchased within the return window?), and an action sequence that depends on real-time data. Most chatbots will either punt this to a human, ask the customer to complete each step separately, or get stuck looping through a flow that wasn't designed for multi-step requests.
-
-## What Is an AI Agent?
-
-An AI agent is an autonomous system that perceives context, reasons toward a goal, makes decisions, and executes actions across tools and systems, with minimal human direction. Where a chatbot waits for input and responds from a script, an agent receives an objective and figures out how to accomplish it.
-
-### The components that make agents different
-
-Four architectural elements separate AI agents from chatbots:
-
-- **LLMs for reasoning:** The agent uses a large language model as its "brain" to interpret context, break down complex requests into sub-tasks, and decide what to do next.
-- **Memory (short-term and long-term):** Short-term memory tracks the current conversation and task state. Long-term memory retains information across sessions: past interactions, user preferences, and resolved tickets.
-- **Tool access:** Agents connect to APIs, databases, CRMs, payment systems, email services, and other external tools. They can update a record, trigger a workflow, send a notification, or query multiple systems in sequence.
-- **A feedback and learning loop:** Agents can evaluate the results of their actions, adjust their approach when something doesn't work, and improve over time based on outcomes.
-
-### What agents do that chatbots can't
-
-AI agents handle multi-step task completion, cross-system coordination, dynamic decision-making mid-task, and proactive action. They don't wait for you to tell them each step; they plan the sequence, execute it, and verify the result.
-
-Let's revisit the refund example from the chatbot section. Same customer, same request: "I want to return this item, get a refund, and update my shipping address."
-
-Here's how an AI agent handles it:
-
-- Verifies the customer's identity by pulling account data from the CRM
-- Checks return eligibility by querying the order management system for purchase date, item condition policy, and return window status
-- Initiates the return by creating a return authorization in the fulfillment system
-- Processes the refund by triggering the payment gateway to reverse the charge to the original payment method
-- Updates the shipping address in the customer profile database
-- Notifies the finance team by logging the refund in the accounting system
-- Sends a confirmation email to the customer with return instructions and the updated address
-
-### A common misconception worth clearing up
-
-Bolting GPT onto a chatbot doesn't make it an AI agent. An LLM-powered chatbot can generate more natural-sounding responses and handle a wider range of questions, but without memory, tool access, and goal-directed planning, it's still fundamentally reactive. An AI agent is not a chatbot. Nor is it a smarter search engine. True agents reason, remember, act, and adapt.
-
-## AI Agent vs Chatbot: Side-by-Side Comparison
-
-The table below breaks down how each architecture works across the dimensions that matter most when you're deciding what to build or buy.
-
-| Dimension | Chatbot | AI Agent |
+| Criterion | Use a chatbot | Use an AI agent |
 | --- | --- | --- |
-| Primary function | Answers questions from predefined scripts or NLP-matched patterns | Pursues goals by reasoning, planning, and executing multi-step tasks |
-| Decision-making | Rule-based or intent-matching; follows fixed logic | Dynamic; evaluates context, weighs options, and adjusts approach mid-task |
-| Memory | Session-only (forgets after conversation ends) | Short-term (task state) and long-term (cross-session context, user history) |
-| Tool/system access | Limited or none; may query one data source | Connects to APIs, databases, CRMs, payment systems, and external services |
-| Handles multi-step tasks | Poorly; breaks down when requests span multiple systems or require conditional logic | Core strength: plans and executes task sequences across systems |
-| Learning over time | No, responses are static unless manually updated | Yes, adjusts based on outcomes, feedback, and accumulated context |
-| Setup complexity | Low; can deploy in days to weeks | Higher; requires integration with tools, memory configuration, and orchestration |
-| Best for | FAQs, simple lookups, lead qualification, and appointment booking | End-to-end support resolution, cross-system workflows, automated reporting, and complex onboarding |
+| Task complexity | Simple questions and guided interactions | Complex tasks with changing requirements |
+| Tool access | No external tools or limited lookups | Actions across connected applications and databases |
+| Workflow length | One response or a short exchange | Multiple dependent steps |
+| Context needs | Current conversation is sufficient | Past activity must inform later decisions |
+| Predictability | Responses should follow fixed paths | The AI agent must choose the next step |
+| Human oversight | A person handles exceptions | The AI agent handles routine exceptions within set limits |
+| Risk level | Errors have limited consequences | Sensitive actions need approval, and every action needs controlled permissions plus an audit record |
 
-### The three rows that matter most
+Ask whether your product can finish the job in one bounded exchange. If it must review an intermediate result before choosing the next action, use an agent with task-specific permissions and approval controls.
 
-If you take one thing from this comparison, focus on autonomy, memory, and tool use. These are the clearest dividing lines.
+## Chatbots and AI agents side by side
 
-Autonomy determines whether the system can figure out how to accomplish a goal or whether you have to pre-script every possible path. Chatbots need you to anticipate every conversation branch. Agents interpret the goal and plan their own route.
+An agent's orchestration loop can complete more work than a chatbot's bounded response loop, but it also adds tool permissions, variable costs, latency, and additional failure paths. These operational tradeoffs affect how each system handles data, testing, monitoring, and safeguards.
 
-Memory determines whether the system treats every interaction as brand new or builds on past context. A customer who called last week about a billing issue shouldn't have to re-explain the problem this week.
-
-Tool use determines whether the system can take action or only provide information. Chatbots tell you what to do. Agents do it for you: updating records, triggering workflows, and coordinating across systems.
-
-## When to Use a Chatbot vs. an AI Agent
-
-This isn't a "chatbots are bad, agents are good" conversation. Chatbots are the right tool for specific jobs, and deploying an AI agent where a chatbot would suffice is like hiring a senior engineer to update a spreadsheet. The goal is to match the tool to the task.
-
-### Where chatbots shine
-
-- **FAQ and knowledge base deflection:** If the majority of your support tickets are "what's your return policy?" or "how do I reset my password?", a chatbot handles this all day without breaking a sweat.
-- **Appointment booking with fixed rules:** Dental office, salon, repair service. The variables are simple: available time slots, service type, and customer name. No conditional logic required.
-- **Order status lookups:** Single-system queries with a predictable response. The customer provides an order number, and the chatbot returns tracking info.
-- **Lead qualification with simple routing:** Collecting firmographic data (company size, industry, budget range) and routing to the right sales rep based on predefined criteria.
-- **Website navigation assistance:** "Where do I find your pricing page?" "How do I contact support?" Directional, low-complexity.
-
-### Where AI agents earn their keep
-
-- **Automated reporting pipelines:** Aggregating data from multiple platforms (analytics, billing, project management), generating a summary, and distributing it to stakeholders on a schedule.
-- **Multi-system data enrichment:** Pulling data from your CRM, enriching it with third-party sources, scoring it, and updating the record; all triggered by a single event.
-- **Code review and release automation:** Scanning pull requests, checking for issues, running tests, and coordinating the release pipeline across tools like GitHub, Jira, and Slack.
-- **Complex onboarding workflows:** New employee onboarding that involves provisioning accounts, sending welcome sequences, scheduling training, and updating multiple internal systems.
-- **End-to-end customer support resolution:** The customer's issue spans returns, refunds, account updates, and follow-up scheduling. The agent resolves it in one pass.
-
-### Decision criteria at a glance
-
-| Scenario | Recommended Tool | Why |
+| Comparison dimension | Chatbot | AI agent |
 | --- | --- | --- |
-| Answering common product questions | Chatbot | Responses are static and predictable; no cross-system action needed |
-| Processing a return that involves a refund, inventory update, and customer notification | AI Agent | Requires multi-step actions across payment, inventory, and CRM systems |
-| Booking a demo meeting with a prospect | Chatbot | Fixed logic: check calendar availability, collect contact info, confirm |
-| Enriching a lead record with firmographic and intent data from multiple sources | AI Agent | Requires querying and writing to multiple APIs in sequence |
-| Routing a support ticket to the right department | Chatbot | Simple classification based on keywords or category selection |
-| Generating a weekly performance report from three data platforms | AI Agent | Requires aggregation, analysis, and distribution across tools |
+| Software architecture | A chatbot sends each user message through a predefined response flow or language model call. | An AI agent combines a model with an orchestration loop that uses the result of each selected action to determine the next step. |
+| Data handling | A chatbot usually reads the current conversation and approved reference material to produce a response. | An AI agent may read and write data across connected applications, so each tool needs scoped permissions and validation rules. |
+| Cost and latency profile | A chatbot often completes one model request per exchange, which makes response time and usage easier to estimate. | An AI agent may make several model and tool calls for one request, which increases variable cost and response time. |
+| Common failure modes | A chatbot can misread intent and produce an unsupported answer. | An AI agent can select the wrong tool or continue acting on incorrect data. |
+| Testing and monitoring | Chatbot testing checks response quality and whether retrieval and routing work correctly. | Agent testing must verify each tool choice against its permissions and expected outcome. |
+| Operational safeguards | A chatbot can restrict responses with filtered retrieval and clear escalation rules. | An AI agent needs strict action limits and logs of every tool call. Require approval for sensitive operations. |
 
-### Signals that you need an agent
+## Why combine a chatbot with an AI agent
 
-If any of these describe your situation, a chatbot probably won't cut it:
+When users need one interface for both answers and actions, combining a chatbot with an AI agent separates the work between them. The chatbot clarifies the request and presents the result, while the agent retains relevant context, chooses workflow steps, and calls approved systems. This division lets each layer use controls suited to its role.
 
-- The task requires data from more than one system
-- The task has branching logic that changes based on real-time context (not just predefined rules)
-- The task requires taking an action, not just providing information
-- The task needs to remember context across sessions; the user shouldn't have to repeat themselves every time
+Production conversations and actions require different controls. A user may submit an ambiguous request, so the conversational layer can confirm the account or desired outcome before an agent proceeds. After confirmation, the agent can operate within permissions you define and pause for approval before a sensitive action.
 
-## The Hybrid Approach: When You Need Both
+With limited agent autonomy, one interface can handle both simple and complex requests. A chatbot can answer a policy question directly, but a refund request may require an agent to retrieve an order and assess eligibility. An employee can approve the refund before the agent issues it.
 
-In production, many effective deployments don't choose between chatbots and AI agents. They use both in a layered architecture where each handles the work it's built for.
+[Sim's visual workspace](https://sim.ai) lets you build this hybrid. You can connect a conversational entry point to workflow branches that call tools after gathering the required information. Separate branches handle approval requests. Our [1,000+ integrations](https://sim.ai/integrations) connect those branches to the business applications that store the relevant records and execute the actions.
 
-### The pattern
+For example, Sim Chat can collect an order number before a workflow retrieves the matching purchase through an integration. The workflow can then apply refund rules and request approval when those rules require it. Chat returns the final status to the user after the workflow completes. For more patterns in this area, see the [best AI agents for customer support automation](https://www.sim.ai/library/best-ai-agents-for-customer-support-automation).
 
-The chatbot sits on the front line. It handles tier-1 volume: FAQs, routing, simple confirmations, and basic lookups. It's fast, cheap, and consistent. The moment a request crosses a complexity threshold, the chatbot hands off to an AI agent that can reason, access tools, and resolve the issue end-to-end.
+## Building your own agent-chatbot hybrid with Sim
 
-Think of it like a support team. The chatbot is your first-response rep who handles the quick wins. The AI agent is your senior specialist who steps in when the problem requires investigation, cross-system access, and judgment.
+Sim's conversational layer gathers intent, the visual workflow routes the request, and connected tools perform approved actions. Configure those layers in five steps:
 
-### The build consideration
+1. Start with [Sim's Chat feature](https://docs.sim.ai/execution/chat). Chat gives users one place to submit a request and review the agent's response without exposing the workflow behind it.
+2. Use Sim's visual workspace to [build the workflow](https://www.sim.ai/library/how-to-create-an-ai-agent) and configure instructions and routes for each request type. Specify when the agent should ask for clarification instead of acting.
+3. Connect the services the agent needs through [Sim's integration library](https://sim.ai/integrations). For example, the workflow can retrieve a customer record and update a support ticket after Chat confirms the user's intent.
+4. Choose between using [Sim's hosted access](https://sim.ai/pricing) and bringing your own API key (BYOK). Enterprise access also supports local-model workflows such as Ollama.
+5. Before publishing, test how the workflow responds when required information is missing or a tool is unavailable. Confirm that the workflow seeks human approval before restricted actions.
 
-This hybrid model doesn't work with duct tape. It requires an orchestration layer: something that manages the handoff between the chatbot and agent, passes full conversation context, and routes based on defined complexity triggers. Without it, you get the worst of both worlds: a chatbot that can't escalate gracefully and an agent that receives incomplete context.
-
-This is where an agent workspace or workflow builder becomes critical. You need a system that can define escalation rules, pass structured data between layers, and give your team visibility into what's happening at each stage.
-
-## How to Build an AI Agent (Without Starting From Scratch)
-
-Most content about AI agents stops at the "what" and never gets to the "how." You're left understanding the concept but with no clear path to building one. That gap is where teams stall: they know they need an agent, but the engineering lift feels enormous.
-
-### Two build paths
-
-Code-first frameworks like LangChain and CrewAI give you full control. You define the agent's reasoning chain, tool connections, memory management, and orchestration logic in code. The upside is flexibility and power. The downside is that you need engineers who understand both LLM application architecture and your business logic. Building, testing, and iterating takes time, and maintenance is ongoing.
-
-Visual/no-code agent builders take a different approach. They let teams design agent workflows through drag-and-drop interfaces, connecting LLMs, memory, APIs, and business tools without writing orchestration code from scratch. The tradeoff is less granular control for significantly faster deployment and lower maintenance overhead. For most business teams, this is the faster path to production.
-
-### What a visual agent workspace looks like
-
-A visual agent builder gives you a canvas where each node represents a step in the workflow: an LLM call for reasoning, an API call to pull data, a conditional branch, a tool action, and an output. You wire these together, configure each node's parameters, and deploy the workflow as a live agent that can be triggered via chat, API, webhook, or on a schedule.
-
-Sim is one example of this approach, an open-source AI agent workspace where teams build agent workflows visually, connecting over 1,000 integrations and multiple LLMs through a drag-and-drop canvas. It supports processing blocks (AI agents, API calls, custom functions), logic blocks (conditional branching, loops, routers), and output blocks (responses, evaluators). Workflows can run synchronously via API for real-time interactions or asynchronously via webhooks and scheduled triggers for background processes.
-
-The point isn't that visual builders replace code-first approaches. It's that they remove the orchestration overhead so your team can focus on the business logic: what the agent should do, not how to wire the plumbing.
-
-## The Bottom Line
-
-The AI agent vs chatbot distinction comes down to architecture. Chatbots react to inputs within predefined boundaries. AI agents reason toward goals, access tools, remember context, and take action across systems. They're different tools for different jobs, and teams often use both.
-
-If your workflow requires multi-step reasoning, cross-system coordination, or actions that go beyond surfacing information, you need an agent, or a hybrid setup where the chatbot handles the front door and the agent handles the resolution.
-
-AI agents are moving from experimental to expected across enterprise teams, and the adoption curve is steep. For your team, the question isn't whether to bring agents in; it's where to start.
-
-Pick one workflow that's currently breaking down: reports that take hours to compile manually, and employee onboarding sequences that require five people to coordinate. Build an agent for that, prove ROI, then expand from there.
-
-For the adjacent comparison, [AI agents vs RPA](/library/ai-agents-vs-rpa) covers rule-based automation rather than conversational tools. If you've decided an agent is what you need, [10 AI agent ideas](/library/ai-agent-ideas) has starting points, [how to build AI agents](/library/how-to-create-an-ai-agent) walks through the first one, and [the best AI agents for customer support automation](/library/best-ai-agents-for-customer-support-automation) goes deep on the support use case specifically.
+[Explore Sim's visual workspace](https://sim.ai) to build, test, and publish an agent-chatbot hybrid with the integrations and approval steps your workflow requires. If you need a starting point, these [AI agent ideas](https://www.sim.ai/library/ai-agent-ideas) cover a range of workflow patterns.

--- a/apps/sim/content/library/ai-agent-vs-chatbot/index.mdx
+++ b/apps/sim/content/library/ai-agent-vs-chatbot/index.mdx
@@ -1,7 +1,7 @@
 ---
 slug: ai-agent-vs-chatbot
 title: 'AI Agent vs Chatbot: Understanding the Differences'
-description: 'Understand the key differences between AI agents vs chatbots, from architecture to real-world use cases. Learn when to use each and how to choose the right approach for your workflows.'
+description: Understand the key differences between AI agents vs chatbots, from architecture to real-world use cases. Learn when to use each and how to choose the right approach for your workflows.
 date: 2026-06-28
 updated: 2026-08-27
 authors:


### PR DESCRIPTION
Content update to `apps/sim/content/library/ai-agent-vs-chatbot`: UPDATE the existing library post at apps/sim/content/library/ai-agent-vs-chatbot/index.mdx. A full replacement article IS supplied in the `article` input.

PRECEDENCE — READ THIS FIRST. These operator instructions override your standing body rules where they conflict. Specifically:
- Your "post must end up with 3-5 internal links to related existing Sim library entries" rule must be satisfied ONLY inside the sections listed under CHANGE #3 below. Do NOT insert internal links into any section marked KEEP. If you cannot reach 3 library links within the permitted sections, report that instead of inserting links elsewhere.
- Do NOT rewrite the frontmatter `description` unless the supplied body makes it inaccurate. Recompute `readingTime` only, and preserve `date` byte-identically.
- On a previous run you added links into sections the operator had frozen. Do not repeat that.

KEEP — do not alter these at all:
- The TL;DR bullets and the "We last verified..." line (the supplied article already updates the date to August 27, 2026 — that specific change is intended).
- The "When to use a chatbot vs. an AI agent" decision table.
- The "Chatbots and AI agents side by side" comparison table.
- The FAQ content (concise, definitional — carry all 5 Q&As into frontmatter `faq` verbatim).
- The Anthropic citation in the "key differences" section (https://www.anthropic.com/research/measuring-agent-autonomy) — verified, keep it inline exactly where it is.

CHANGE #1 — de-templating, "Why combine a chatbot with an AI agent" section. The supplied article still has three consecutive paragraphs opening with the same declarative-claim-then-explain pattern: "Combine a chatbot with an AI agent when...", "Conversation and action require different controls...", "Limited agent autonomy lets one interface...". Vary those three openings so they do not share one formula. Preserve the meaning, the facts, and the paragraph order — this is a rephrasing of sentence openings, not a rewrite of the argument. Do not add new claims.

CHANGE #2 — de-templating, "Building your own agent-chatbot hybrid with Sim" section. The construction "In Sim..." appears three or more times across this section and the one above it ("In Sim, the conversational layer gathers intent...", "In Sim's visual workspace, build the workflow..."). A content grader flagged this specifically as templated. Vary or cut the repeats so "In Sim" is not the opening construction more than once. Again: rephrasing only, no new claims, keep all five numbered steps and their substance intact.

CHANGE #3 — internal links. The links in the supplied article have ALREADY been swapped to verified deeper URLs (sim.ai/integrations, sim.ai/pricing, docs.sim.ai/execution/chat). Use the supplied article's links as-is. Link changes are permitted ONLY in these sections: the TL;DR bullet, the "Why combine" section, the "Building your own hybrid" section (including step 4), and the FAQ. This is also where you must satisfy your 3-5 internal-library-link requirement — add sim.ai/library links only in those sections, and only after verifying each target folder exists under apps/sim/content/library/.

CHANGE #4 — verify, do not change: step 4 of the "Building your own hybrid" list reads "Choose between using Sim's hosted access and bringing your own API key (BYOK). Enterprise access also supports local-model workflows such as Ollama." This must continue to scope Ollama/local models to Enterprise access only. It currently reads correctly. Confirm the final file still scopes it that way and do not loosen it. The same applies to the "Can AI agents run with local models?" FAQ answer.

Nothing needs deletion. All changes are rephrasing and linking, not structural.

- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)