### PR TITLE
chore(copilot): sync load_slide_layout into the tool catalog

### DIFF
--- a/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
@@ -71,6 +71,7 @@ export interface ToolCatalogEntry {
     | 'load_deployment'
     | 'load_integration_tool'
     | 'load_skill'
+    | 'load_slide_layout'
     | 'manage_credential'
     | 'manage_custom_tool'
     | 'manage_knowledge_base'
@@ -199,6 +200,7 @@ export interface ToolCatalogEntry {
     | 'load_deployment'
     | 'load_integration_tool'
     | 'load_skill'
+    | 'load_slide_layout'
     | 'manage_credential'
     | 'manage_custom_tool'
     | 'manage_knowledge_base'
@@ -3137,6 +3139,24 @@ export const LoadSkill: ToolCatalogEntry = {
         type: 'string',
         description:
           "Skill name exactly as it appears in the Loadable Skills index (e.g. 'pptx-writing').",
+      },
+    },
+    required: ['name'],
+  },
+}
+
+export const LoadSlideLayout: ToolCatalogEntry = {
+  id: 'load_slide_layout',
+  name: 'load_slide_layout',
+  route: 'go',
+  mode: 'sync',
+  parameters: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description:
+          "Layout name exactly as it appears in the Layout Library index (e.g. 'metric-cards').",
       },
     },
     required: ['name'],
@@ -7041,6 +7061,7 @@ export const TOOL_CATALOG: Record<string, ToolCatalogEntry> = {
   [LoadDeployment.id]: LoadDeployment,
   [LoadIntegrationTool.id]: LoadIntegrationTool,
   [LoadSkill.id]: LoadSkill,
+  [LoadSlideLayout.id]: LoadSlideLayout,
   [ManageCredential.id]: ManageCredential,
   [ManageCustomTool.id]: ManageCustomTool,
   [ManageKnowledgeBase.id]: ManageKnowledgeBase,

--- a/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
@@ -3028,6 +3028,20 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
     },
     resultSchema: undefined,
   },
+  load_slide_layout: {
+    parameters: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description:
+            "Layout name exactly as it appears in the Layout Library index (e.g. 'metric-cards').",
+        },
+      },
+      required: ['name'],
+    },
+    resultSchema: undefined,
+  },
   manage_credential: {
     parameters: {
       type: 'object',

--- a/apps/sim/lib/copilot/tools/client/hidden-tools.ts
+++ b/apps/sim/lib/copilot/tools/client/hidden-tools.ts
@@ -5,13 +5,16 @@
 // search_integration_tools is gateway plumbing: the discovery step is not a
 // user-meaningful action, only the resolved call_integration_tool row is.
 // load_skill is the same shape — the agent pulling in a reference guide before
-// doing the work is a step toward the action, not the action.
+// doing the work is a step toward the action, not the action. load_slide_layout
+// is that shape again: the file agent reading a layout from the slide library
+// ahead of writing the deck.
 const HIDDEN_TOOL_NAMES = new Set([
   'load_agent_skill',
   'load_custom_tool',
   'load_mcp_tool',
   'load_integration_tool',
   'load_skill',
+  'load_slide_layout',
   'search_integration_tools',
 ])
 

--- a/apps/sim/lib/copilot/tools/tool-display.ts
+++ b/apps/sim/lib/copilot/tools/tool-display.ts
@@ -535,6 +535,7 @@ const TOOL_TITLES: Record<string, string> = {
   search_integration_tools: 'Finding the right integration',
   load_integration_tool: 'Loading integration tools',
   load_skill: 'Loading skill',
+  load_slide_layout: 'Loading slide layout',
   read: 'Reading file',
   search_library_docs: 'Searching library docs',
   user_table: 'Managing table',


### PR DESCRIPTION
## Summary
- Syncs `load_slide_layout` into the generated tool catalog — the file agent's slide-layout loader from mothership #445. It runs in Go and is never executed by Sim; the catalog had simply never been regenerated since it was added
- Hides its transcript row like `load_skill` (a reference load ahead of the action, not the action) and keeps a fallback title for history

## Type of Change
- [x] Chore

## Testing
- `bunx vitest run lib/copilot/tools/tool-display.test.ts lib/copilot/tools/client/hidden-tools.test.ts`, `bun run type-check`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
