### PR TITLE
fix(provenance): derive final-output provenance instead of declaring it unvouchable

### DIFF
--- a/apps/sim/executor/execution/engine.test.ts
+++ b/apps/sim/executor/execution/engine.test.ts
@@ -233,6 +233,81 @@ describe('ExecutionEngine', () => {
       expect(result.executionState?.finalOutputResolvedSecretTraceProvenance?.entries).toEqual([])
     })
 
+    /**
+     * A subflow sentinel stores its aggregate without provenance, and a loop that ran no
+     * iterations has none to merge. Treating that absence as a verdict marked the run
+     * unvouchable, which withheld the user's own final output from their execution log on every
+     * later view.
+     */
+    it('derives final output provenance when the last block state carries none', async () => {
+      const node = createMockNode('loop-1', 'loop')
+      const registry = new ResolvedSecretTraceRegistry([
+        { name: 'TOKEN', plaintext: 'secret-value-1234', encryptedValue: 'ciphertext' },
+      ])
+      registry.recordResolved('TOKEN', 'secret-value-1234')
+      const context = createMockContext({
+        decisions: { router: new Map(), condition: new Map() },
+        resolvedSecretTraceRegistry: registry,
+      })
+      const nodeOrchestrator = createMockNodeOrchestrator()
+      vi.mocked(nodeOrchestrator.executeNode).mockResolvedValue({
+        nodeId: node.id,
+        output: { results: ['secret-value-1234'] },
+        isFinalOutput: true,
+      })
+      vi.mocked(nodeOrchestrator.handleNodeCompletion).mockImplementation(
+        (_ctx, nodeId, output) => {
+          context.blockStates.set(nodeId, { output, executed: true, executionTime: 1 })
+        }
+      )
+
+      const engine = new ExecutionEngine(
+        context,
+        createMockDAG([node]),
+        createMockEdgeManager(),
+        nodeOrchestrator
+      )
+      const result = await engine.run(node.id)
+
+      const provenance = result.executionState?.finalOutputResolvedSecretTraceProvenance
+      expect(provenance?.complete).toBe(true)
+      expect(provenance?.entries).toEqual([{ name: 'TOKEN', encryptedValue: 'ciphertext' }])
+    })
+
+    /** Deriving must not weaken the guarantee: a latched registry still exports incomplete. */
+    it('keeps the final output envelope incomplete when the registry latched', async () => {
+      const node = createMockNode('loop-1', 'loop')
+      const registry = new ResolvedSecretTraceRegistry([
+        { name: 'TOKEN', plaintext: 'secret-value-1234', encryptedValue: 'ciphertext' },
+      ])
+      registry.markIncomplete('unspecified')
+      const context = createMockContext({
+        decisions: { router: new Map(), condition: new Map() },
+        resolvedSecretTraceRegistry: registry,
+      })
+      const nodeOrchestrator = createMockNodeOrchestrator()
+      vi.mocked(nodeOrchestrator.executeNode).mockResolvedValue({
+        nodeId: node.id,
+        output: { results: ['secret-value-1234'] },
+        isFinalOutput: true,
+      })
+      vi.mocked(nodeOrchestrator.handleNodeCompletion).mockImplementation(
+        (_ctx, nodeId, output) => {
+          context.blockStates.set(nodeId, { output, executed: true, executionTime: 1 })
+        }
+      )
+
+      const engine = new ExecutionEngine(
+        context,
+        createMockDAG([node]),
+        createMockEdgeManager(),
+        nodeOrchestrator
+      )
+      const result = await engine.run(node.id)
+
+      expect(result.executionState?.finalOutputResolvedSecretTraceProvenance?.complete).toBe(false)
+    })
+
     it('should not fall back to starter blocks for terminal resume snapshots', async () => {
       const startNode = createMockNode('start', 'starter')
       const dag = createMockDAG([startNode])

--- a/apps/sim/executor/execution/engine.ts
+++ b/apps/sim/executor/execution/engine.ts
@@ -505,25 +505,31 @@ export class ExecutionEngine {
       this.context.finalOutputResolvedSecretTraceProvenance = state.resolvedSecretTraceProvenance
       return
     }
+    /**
+     * A block state without provenance is an absence of a shortcut, not a verdict. Several state
+     * writers legitimately store an output without one — a subflow sentinel aggregating iteration
+     * results is the common case, and a loop that ran no iterations has nothing to merge — so
+     * stamping an incomplete envelope here declared the run unvouchable whenever the last block
+     * was one of them. Every other consumer of a provenance-less block state falls back to the run
+     * registry; deriving does the same, against the value actually being described.
+     */
+    this.deriveFinalOutputProvenance()
+  }
 
-    if (this.context.resolvedSecretTraceRegistry) {
-      this.context.finalOutputResolvedSecretTraceProvenance = {
-        version: 1,
-        complete: false,
-        entries: [],
-      }
-    }
+  /**
+   * Derives the final-output envelope from the run registry. Fails closed on its own terms: a
+   * latched registry exports an incomplete envelope, which is the genuinely unvouchable case.
+   */
+  private deriveFinalOutputProvenance(): void {
+    const registry = this.context.resolvedSecretTraceRegistry
+    if (!registry) return
+    this.context.finalOutputResolvedSecretTraceProvenance =
+      registry.exportCommittedProvenanceForValue(this.finalOutput)
   }
 
   private ensureFinalOutputProvenance(): void {
-    if (
-      Object.hasOwn(this.context, 'finalOutputResolvedSecretTraceProvenance') ||
-      !this.context.resolvedSecretTraceRegistry
-    ) {
-      return
-    }
-    this.context.finalOutputResolvedSecretTraceProvenance =
-      this.context.resolvedSecretTraceRegistry.exportCommittedProvenanceForValue(this.finalOutput)
+    if (Object.hasOwn(this.context, 'finalOutputResolvedSecretTraceProvenance')) return
+    this.deriveFinalOutputProvenance()
   }
 
   private buildPausedResult(startTime: number): ExecutionResult {


### PR DESCRIPTION
## Summary
- Fixes the live producer behind the `TraceStore — displayProjection` stream that is now ~95% of provenance log output (105 of 110 lines post-deploy). Every one of those lines is `parts: ["finalOutput"]`, and the stock is real and growing — 30 distinct executions in under 4 hours — so this was never just a fixed backlog of bug-era rows.
- **Root cause:** `ExecutionEngine.setFinalOutput` stamped `{ complete: false }` whenever the final block's state carried no provenance. But an absent block-state envelope is not a verdict — several state writers legitimately omit one, and a subflow sentinel aggregating iteration results is the common case (a loop that ran no iterations has nothing to merge, so `setBlockOutput` is called without provenance). The affected production workflows end in a **loop** block, which is exactly this shape.
- **The cost was user-facing, not just log noise.** An incomplete final-output envelope makes the display projection withhold `finalOutput`, so the workflow's author could not see their own run's output in the execution log — on every view, permanently. Each view then re-derived the same verdict, which is the read-path re-fire dominating the stream.
- **The fix:** derive from the run registry against the value being described — precisely what the end-of-run path (`ensureFinalOutputProvenance`) already did, and what every other consumer of a provenance-less block state does (the trace-store block-output reader falls back to the run registry). The two paths now share one `deriveFinalOutputProvenance` rather than disagreeing: take the block state's exact envelope as a shortcut when present, derive otherwise.
- **Still fails closed:** `exportCommittedProvenanceForValue` returns an incomplete envelope when the registry itself latched, which is the genuinely unvouchable case. That guard has its own regression test.

## Type of Change
- [x] Bug fix

## Testing
Two new engine tests: one pins the derivation (a final block whose state carries no provenance yields a **complete** envelope naming the secret actually present in the output), one pins fail-closed (a latched registry still exports incomplete). Verified the derivation test **fails without the fix** and passes with it. 5,071 tests green across `executor/`, `lib/logs/`, and `lib/workflows/`; `bun run type-check` clean; all 36 audits pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)