### PR TITLE
fix(runtime): bump Bun to 1.4.0 to fix Stagehand/Browserbase WebSocket upgrades

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.14-alpine
+FROM oven/bun:1.4.0-alpine
 
 # Install necessary packages for development
 RUN apk add --no-cache \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -657,7 +657,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       # Docker Compose and Kubernetes must run the same background jobs on the
       # same schedules; this fails the build if the two drift apart. The script

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/publish-sim-cli.yml
+++ b/.github/workflows/publish-sim-cli.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/publish-sim-setup.yml
+++ b/.github/workflows/publish-sim-setup.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -231,7 +231,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "main": "dist/main.cjs",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "scripts": {

--- a/apps/realtime/package.json
+++ b/apps/realtime/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "scripts": {

--- a/apps/sim/lib/core/utils/fetch-deadline.ts
+++ b/apps/sim/lib/core/utils/fetch-deadline.ts
@@ -42,6 +42,10 @@ import { Agent, type Dispatcher } from 'undici'
  *   timeout: false -> RESOLVED 310031ms               <- disarmed
  *   timeout: 1000  -> RESOLVED 3008ms on a 3s request <- numeric ignored
  *
+ * Re-checked on Bun 1.4.0: `timeout: 1000` against a 3s-delayed response still
+ * resolves at ~3s rather than throwing at 1s — the numeric form is still
+ * ignored, so nothing below changed with that bump.
+ *
  * So a positive numeric `timeout` silently changes nothing on this version; the
  * numeric idle-deadline form and `BUN_CONFIG_HTTP_IDLE_TIMEOUT` both exist only
  * on Bun's `main`. Do not "improve" this into a numeric pass-through until the

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=22.19.0"
   },
   "scripts": {

--- a/apps/sim/scripts/pi-sandbox-packages.ts
+++ b/apps/sim/scripts/pi-sandbox-packages.ts
@@ -14,7 +14,7 @@
  */
 
 /** Bun version mirrored from the root packageManager field. */
-export const PI_BUN_VERSION = '1.3.14'
+export const PI_BUN_VERSION = '1.4.0'
 
 /** Exact global package versions mirrored from package.json and bun.lock. */
 export const PI_GLOBAL_NPM_PACKAGES = [

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: runtime-only dependencies (inherited by the final image)
 # ========================================
-FROM oven/bun:1.3.14-slim AS base
+FROM oven/bun:1.4.0-slim AS base
 
 # Install Node.js 24 (Active LTS) and the runtime dependencies once in base.
 # Node runs only the isolated-vm sandbox worker (the app itself runs under Bun);

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.0-alpine AS base
 
 # ========================================
 # Dependencies Stage: Install Dependencies

--- a/docker/realtime.Dockerfile
+++ b/docker/realtime.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.0-alpine AS base
 
 RUN apk add --no-cache libc6-compat curl
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simstudio",
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
@@ -58,6 +58,8 @@
     "check:icon-path-precision": "bun run scripts/check-icon-path-precision.ts",
     "check:migrations": "bun run scripts/check-migrations-safety.ts",
     "check:native-typecheck": "bun run scripts/check-native-typecheck.ts",
+    "check:bun-websocket-upgrade": "bun run scripts/check-bun-websocket-upgrade.ts",
+    "check:bun-version-pins": "bun run scripts/check-bun-version-pins.ts",
     "check:source-text": "bun run scripts/check-source-text.ts",
     "check:spec-example-ids": "bun run scripts/check-spec-example-ids.ts",
     "check:script-tests": "bun run scripts/check-script-test-coverage.ts",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/browser-protocol/package.json
+++ b/packages/browser-protocol/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/desktop-bridge/package.json
+++ b/packages/desktop-bridge/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/emcn/package.json
+++ b/packages/emcn/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/platform-authz/package.json
+++ b/packages/platform-authz/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/realtime-protocol/package.json
+++ b/packages/realtime-protocol/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/runtime-secrets/package.json
+++ b/packages/runtime-secrets/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/terminal-protocol/package.json
+++ b/packages/terminal-protocol/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/workflow-persistence/package.json
+++ b/packages/workflow-persistence/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/workflow-renderer/package.json
+++ b/packages/workflow-renderer/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/workflow-types/package.json
+++ b/packages/workflow-types/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.0",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/scripts/check-bun-version-pins.ts
+++ b/scripts/check-bun-version-pins.ts
@@ -13,7 +13,9 @@
  * Run: `bun run scripts/check-bun-version-pins.ts`
  */
 import path from 'node:path'
+import { createLogger } from '@sim/logger'
 
+const logger = createLogger('BunVersionPinsCheck')
 const ROOT = path.resolve(import.meta.dir, '..')
 
 interface Mismatch {
@@ -25,7 +27,7 @@ const rootManifest = await Bun.file(path.join(ROOT, 'package.json')).json()
 const packageManager = rootManifest.packageManager as string | undefined
 const versionMatch = /^bun@(\d+\.\d+\.\d+)$/.exec(packageManager ?? '')
 if (!versionMatch) {
-  console.error(
+  logger.error(
     `Bun version pin audit failed: root package.json "packageManager" is "${packageManager}", ` +
       'expected "bun@<major>.<minor>.<patch>".'
   )
@@ -96,14 +98,15 @@ await Promise.all([
 ])
 
 if (mismatches.length > 0) {
-  console.error(
+  const details = mismatches
+    .sort((a, b) => a.file.localeCompare(b.file))
+    .map(({ file, found }) => `  ${file}: found ${found}`)
+    .join('\n')
+  logger.error(
     `Bun version pin audit failed: expected every pin to match root packageManager ` +
-      `"bun@${expectedVersion}".\n`
+      `"bun@${expectedVersion}".\n\n${details}`
   )
-  for (const { file, found } of mismatches.sort((a, b) => a.file.localeCompare(b.file))) {
-    console.error(`  ${file}: found ${found}`)
-  }
   process.exit(1)
 }
 
-console.log(`Bun version pin audit passed (every pin matches bun@${expectedVersion}).`)
+logger.info(`Bun version pin audit passed (every pin matches bun@${expectedVersion}).`)

--- a/scripts/check-bun-version-pins.ts
+++ b/scripts/check-bun-version-pins.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+/**
+ * Asserts every place the repo pins a Bun version agrees with the root `packageManager` field.
+ *
+ * The pin is duplicated by necessity — `engines.bun` in each workspace package.json, the `FROM
+ * oven/bun:...` base image in every Dockerfile, `bun-version:` in every CI workflow, and the
+ * `PI_BUN_VERSION` mirror in `apps/sim/scripts/pi-sandbox-packages.ts` — and nothing enforced that
+ * duplication. A version bump that misses one of these leaves that surface running (or asserting)
+ * a stale Bun, silently: the Pi sandbox miss on the 1.3.13 -> 1.3.14 bump shipped and needed a
+ * follow-up commit. This script makes the root `packageManager` field the single source of truth
+ * and fails on any file that disagrees with it.
+ *
+ * Run: `bun run scripts/check-bun-version-pins.ts`
+ */
+import path from 'node:path'
+
+const ROOT = path.resolve(import.meta.dir, '..')
+
+interface Mismatch {
+  file: string
+  found: string
+}
+
+const rootManifest = await Bun.file(path.join(ROOT, 'package.json')).json()
+const packageManager = rootManifest.packageManager as string | undefined
+const versionMatch = /^bun@(\d+\.\d+\.\d+)$/.exec(packageManager ?? '')
+if (!versionMatch) {
+  console.error(
+    `Bun version pin audit failed: root package.json "packageManager" is "${packageManager}", ` +
+      'expected "bun@<major>.<minor>.<patch>".'
+  )
+  process.exit(1)
+}
+const expectedVersion = versionMatch[1]
+
+const mismatches: Mismatch[] = []
+
+/** Packages that opt into the `engines.bun` floor; others are skipped, not flagged. */
+async function checkEnginesBun(relativePath: string): Promise<void> {
+  const manifest = await Bun.file(path.join(ROOT, relativePath)).json()
+  const engines = manifest.engines as Record<string, string> | undefined
+  const found = engines?.bun
+  if (found !== undefined && found !== `>=${expectedVersion}`) {
+    mismatches.push({ file: relativePath, found })
+  }
+}
+
+async function checkDockerfileBunTag(relativePath: string): Promise<void> {
+  const text = await Bun.file(path.join(ROOT, relativePath)).text()
+  for (const match of text.matchAll(/FROM oven\/bun:(\d+\.\d+\.\d+)-\S+/g)) {
+    if (match[1] !== expectedVersion) {
+      mismatches.push({ file: relativePath, found: match[1] })
+    }
+  }
+}
+
+async function checkWorkflowBunVersion(relativePath: string): Promise<void> {
+  const text = await Bun.file(path.join(ROOT, relativePath)).text()
+  for (const match of text.matchAll(/bun-version:\s*(\d+\.\d+\.\d+)/g)) {
+    if (match[1] !== expectedVersion) {
+      mismatches.push({ file: relativePath, found: match[1] })
+    }
+  }
+}
+
+async function checkPiSandboxBunVersion(): Promise<void> {
+  const relativePath = 'apps/sim/scripts/pi-sandbox-packages.ts'
+  const text = await Bun.file(path.join(ROOT, relativePath)).text()
+  const match = /export const PI_BUN_VERSION = '(\d+\.\d+\.\d+)'/.exec(text)
+  if (!match) {
+    mismatches.push({ file: relativePath, found: '(PI_BUN_VERSION not found)' })
+    return
+  }
+  if (match[1] !== expectedVersion) {
+    mismatches.push({ file: relativePath, found: match[1] })
+  }
+}
+
+const enginesFiles = [
+  ...(await Array.fromAsync(new Bun.Glob('apps/*/package.json').scan({ cwd: ROOT }))),
+  ...(await Array.fromAsync(new Bun.Glob('packages/*/package.json').scan({ cwd: ROOT }))),
+]
+const dockerfiles = [
+  ...(await Array.fromAsync(new Bun.Glob('docker/*.Dockerfile').scan({ cwd: ROOT }))),
+  '.devcontainer/Dockerfile',
+]
+const workflowFiles = await Array.fromAsync(
+  new Bun.Glob('.github/workflows/*.yml').scan({ cwd: ROOT })
+)
+
+await Promise.all([
+  ...enginesFiles.map(checkEnginesBun),
+  ...dockerfiles.map(checkDockerfileBunTag),
+  ...workflowFiles.map(checkWorkflowBunVersion),
+  checkPiSandboxBunVersion(),
+])
+
+if (mismatches.length > 0) {
+  console.error(
+    `Bun version pin audit failed: expected every pin to match root packageManager ` +
+      `"bun@${expectedVersion}".\n`
+  )
+  for (const { file, found } of mismatches.sort((a, b) => a.file.localeCompare(b.file))) {
+    console.error(`  ${file}: found ${found}`)
+  }
+  process.exit(1)
+}
+
+console.log(`Bun version pin audit passed (every pin matches bun@${expectedVersion}).`)

--- a/scripts/check-bun-websocket-upgrade.ts
+++ b/scripts/check-bun-websocket-upgrade.ts
@@ -24,7 +24,10 @@
 import { createHash } from 'node:crypto'
 import http from 'node:http'
 import net from 'node:net'
+import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
+
+const logger = createLogger('BunWebsocketUpgradeCheck')
 
 const WEBSOCKET_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
 const CLIENT_KEY = 'dGhlIHNhbXBsZSBub25jZQ=='
@@ -123,7 +126,7 @@ const BUG_REMEDIATION =
   '`bun run check:bun-version-pins` to check whether a Bun version pin has drifted back below it.'
 
 function reportFailure(reason: string): never {
-  console.error(`Bun WebSocket upgrade audit failed: ${reason}`)
+  logger.error(`Bun WebSocket upgrade audit failed: ${reason}`)
   process.exit(1)
 }
 
@@ -144,4 +147,4 @@ if (result.event !== 'upgrade' || result.statusCode !== 101) {
   )
 }
 
-console.log("Bun WebSocket upgrade audit passed (a 101 response correctly fires 'upgrade').")
+logger.info("Bun WebSocket upgrade audit passed (a 101 response correctly fires 'upgrade').")

--- a/scripts/check-bun-websocket-upgrade.ts
+++ b/scripts/check-bun-websocket-upgrade.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env bun
+/**
+ * Asserts the current Bun binary delivers a real `'upgrade'` event for a successful (101)
+ * WebSocket handshake, instead of routing it through `'response'`.
+ *
+ * apps/sim runs entirely on Bun in production (`docker/app.Dockerfile` boots
+ * `apps/sim/bootstrap.js` with `bun`, not `node`). Tool routes that open an outbound WebSocket —
+ * Stagehand's Browserbase/CDP session for the Run Agent operation is the known case — go through
+ * Node's `http.request` + the `'upgrade'` event, which is exactly what a bundled CDP transport
+ * (Playwright inlines its own WebSocket client rather than resolving the top-level `ws` package,
+ * so Bun's package-level `ws` shim never intercepts it) relies on. Bun 1.3.x never delivered that
+ * event for a genuine 101 response — the request's `'response'` handler fired instead, and the
+ * client library then threw `Unexpected server response: 101` for what was actually a successful
+ * upgrade. Fixed upstream in Bun 1.4.0 (oven-sh/bun#31792, oven-sh/bun#28114).
+ *
+ * The responder below is a raw `net` socket, not `http.createServer`: Bun 1.3.x's server-side
+ * upgrade handling is also broken, so an `http`-based responder masks the client-side bug behind
+ * a timeout instead of the actual `'response'`-instead-of-`'upgrade'` misclassification. A raw
+ * socket keeps this probe honest about which side (the client, which is all Sim's outbound
+ * connections ever exercise) is under test.
+ *
+ * @see https://github.com/oven-sh/bun/issues/31792
+ */
+import { createHash } from 'node:crypto'
+import http from 'node:http'
+import net from 'node:net'
+import { getErrorMessage } from '@sim/utils/errors'
+
+const WEBSOCKET_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+const CLIENT_KEY = 'dGhlIHNhbXBsZSBub25jZQ=='
+const PROBE_TIMEOUT_MS = 10_000
+
+function acceptKeyFor(key: string): string {
+  return createHash('sha1')
+    .update(key + WEBSOCKET_MAGIC)
+    .digest('base64')
+}
+
+/** A raw TCP responder that answers exactly one WebSocket handshake with a 101, then closes. */
+function startRawUpgradeResponder(): Promise<{ port: number; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer((socket) => {
+      socket.once('data', (chunk) => {
+        const match = /Sec-WebSocket-Key:\s*(\S+)/i.exec(chunk.toString('utf8'))
+        if (!match) {
+          socket.destroy()
+          return
+        }
+        socket.end(
+          [
+            'HTTP/1.1 101 Switching Protocols',
+            'Upgrade: websocket',
+            'Connection: Upgrade',
+            `Sec-WebSocket-Accept: ${acceptKeyFor(match[1])}`,
+            '',
+            '',
+          ].join('\r\n')
+        )
+      })
+      socket.on('error', () => socket.destroy())
+    })
+
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to bind the raw upgrade responder'))
+        return
+      }
+      resolve({ port: address.port, close: () => server.close() })
+    })
+  })
+}
+
+interface ProbeResult {
+  event: 'upgrade' | 'response'
+  statusCode: number | undefined
+}
+
+/** Issues an upgrade request through `node:http` and reports which event fires, and with what status. */
+function probeUpgrade(port: number): Promise<ProbeResult> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1',
+      port,
+      headers: {
+        Connection: 'Upgrade',
+        Upgrade: 'websocket',
+        'Sec-WebSocket-Version': '13',
+        'Sec-WebSocket-Key': CLIENT_KEY,
+      },
+    })
+
+    const timeout = setTimeout(() => {
+      req.destroy()
+      reject(
+        new Error(`Timed out after ${PROBE_TIMEOUT_MS}ms waiting for the handshake to resolve`)
+      )
+    }, PROBE_TIMEOUT_MS)
+
+    req.on('upgrade', (res, socket) => {
+      clearTimeout(timeout)
+      socket.destroy()
+      resolve({ event: 'upgrade', statusCode: res.statusCode })
+    })
+    req.on('response', (res) => {
+      clearTimeout(timeout)
+      res.resume()
+      resolve({ event: 'response', statusCode: res.statusCode })
+    })
+    req.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    req.end()
+  })
+}
+
+const BUG_REMEDIATION =
+  "This is oven-sh/bun#31792 — outbound WebSocket clients (Stagehand/Playwright's Browserbase " +
+  'CDP session, chrome-devtools-mcp, puppeteer) fail with "Unexpected server response: 101" ' +
+  'even though the handshake succeeded. Fixed in Bun 1.4.0 — run ' +
+  '`bun run check:bun-version-pins` to check whether a Bun version pin has drifted back below it.'
+
+function reportFailure(reason: string): never {
+  console.error(`Bun WebSocket upgrade audit failed: ${reason}`)
+  process.exit(1)
+}
+
+const { port, close } = await startRawUpgradeResponder()
+let result: ProbeResult
+try {
+  result = await probeUpgrade(port)
+} catch (error) {
+  close()
+  reportFailure(`could not complete the probe (${getErrorMessage(error)}).`)
+}
+close()
+
+if (result.event !== 'upgrade' || result.statusCode !== 101) {
+  reportFailure(
+    `a successful 101 handshake fired '${result.event}' (status ${result.statusCode ?? 'unknown'}) ` +
+      `instead of 'upgrade' with 101.\n\n  ${BUG_REMEDIATION}`
+  )
+}
+
+console.log("Bun WebSocket upgrade audit passed (a 101 response correctly fires 'upgrade').")


### PR DESCRIPTION
## Summary

- `apps/sim` runs entirely under Bun in production (`docker/app.Dockerfile` boots `apps/sim/bootstrap.js` with `bun`, not `node`). Bun 1.3.x never fired the `'upgrade'` event for a genuine 101 WebSocket handshake response — it misrouted through `'response'` instead, so any outbound WebSocket client threw `Unexpected server response: 101` for a handshake that had actually succeeded.
- This is the root cause of the Stagehand "Run Agent" block failing to open a Browserbase session: Playwright's CDP transport (which Stagehand uses) inlines its own WebSocket client rather than resolving the top-level `ws` package, so it hits Bun's `node:http`-compat layer directly and trips this exact bug. Confirmed against the upstream report: [oven-sh/bun#31792](https://github.com/oven-sh/bun/issues/31792) (duplicate of #5951, fixed via #28114/#31800), fixed in Bun 1.4.0 (released 2026-08-20).
- Bumps the pinned Bun version 1.3.14 → 1.4.0 everywhere it's referenced: root `packageManager`, every workspace `engines.bun` floor, all four Dockerfiles, every CI workflow's `bun-version`, and the Pi sandbox image's mirrored `PI_BUN_VERSION` pin.
- Adds two audits (auto-picked-up by `bun run check:audits`):
  - `scripts/check-bun-websocket-upgrade.ts` — a runtime probe (raw TCP responder + `node:http` client, no `ws` dependency) that fails when the current Bun binary misclassifies a successful 101 upgrade, passes once fixed. Verified: fails on 1.3.14, passes on 1.4.0.
  - `scripts/check-bun-version-pins.ts` — asserts every Bun version pin in the repo agrees with the root `packageManager` field, so a future bump can't silently miss one of them (a previous 1.3.13 → 1.3.14 bump did exactly that to the Pi sandbox mirror, and needed a follow-up commit).

Fixes #5629

## Type of Change

- [x] Bug fix

## Testing

Exact commands run locally, on Windows, under both Bun versions:

- `bunx vitest run app/api/tools/file/manage/route.test.ts` — not applicable to this change; full `apps/sim` suite run instead:
- `cd apps/sim && bunx vitest run` — **2354 files / 34888 tests**: 34819 passed, 46 skipped, 23 failed. Verified the same 23 failures across the same 6 files occur identically on Bun 1.3.14 (pre-bump baseline) — all pre-existing Windows-environment issues (`spawnSync('/bin/bash')` unavailable, a Windows drive-letter path bug in a test helper, a `:` in a generated filename) unrelated to this change.
- `bun run check:bun-websocket-upgrade` — **PASS** on 1.4.0, **FAIL** on 1.3.14 (verified both ways — this is the regression guard).
- `bun run check:bun-version-pins` — **PASS**. Verified it actually catches drift by temporarily reverting the Pi sandbox pin and a Dockerfile tag; both were caught, then restored.
- `bun run check:native-typecheck` — **PASS**.
- `bunx turbo run type-check --filter=@sim/app` (`tsc --noEmit`) — **PASS**.
- `bunx biome check` on all changed/new files — **PASS**.
- `bun run check:audits` (full suite) — 33 passed, 5 failed. Confirmed all 5 failures (`check:skills`, `check:tool-registry-boundary`, `check:desktop-bridge`, `check:api-validation:strict`, `check:utils`) are pre-existing on a clean, unmodified `upstream/staging` checkout (verified via `git stash` + re-run) — none touch files this PR changes.
- `bun install --frozen-lockfile` under 1.4.0 — **PASS**, `bun.lock` unchanged (a plain `bun install` under the new binary drifted unrelated dependency versions on first attempt; reverted and re-verified frozen-lockfile installs cleanly instead, so no dependency versions changed, only the engine pin).
- Full `apps/sim` production build (`bun run build`) — **UNVERIFIED** on this machine: blocked by an unrelated, pre-existing Windows-only bug in `lib/execution/sandbox/bundles/build.ts` (a Windows backslash path gets corrupted when interpolated into a generated import string, independent of Bun version — confirmed identical failure on 1.3.14). This step is exercised by CI's Linux runners on every PR, so it isn't blocked there.

An independent adversarial review (in place of Codex, which isn't installed on this machine) verified the root cause and fix directly by reproducing the Bun 1.3.14/1.4.0 client/server behavior matrix itself, and caught one real miss now fixed in this PR: `apps/sim/scripts/pi-sandbox-packages.ts`'s `PI_BUN_VERSION` constant (originally missed because it's a `.ts` file, outside the `.json`/`.toml`/`Dockerfile`/`.yml` grep scope used for the initial sweep — which is exactly the class of gap `check:bun-version-pins` now closes).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

N/A — runtime/infrastructure fix, no UI change.