### PR TITLE
test(utils): cover generateId's insecure-context fallback

### DIFF
--- a/packages/utils/src/id.test.ts
+++ b/packages/utils/src/id.test.ts
@@ -1,18 +1,41 @@
 /**
  * @vitest-environment node
  */
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { generateId, generateShortId, isValidUuid } from './id.js'
 
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 describe('generateId', () => {
+  const originalRandomUUID = crypto.randomUUID
+
+  afterEach(() => {
+    crypto.randomUUID = originalRandomUUID
+  })
+
   it('returns a valid UUID v4', () => {
     const id = generateId()
     expect(id).toMatch(UUID_V4_RE)
   })
 
   it('returns unique values across 100 calls', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateId()))
+    expect(ids.size).toBe(100)
+  })
+
+  it('falls back to crypto.getRandomValues when randomUUID is unavailable', () => {
+    // Simulates a browser insecure context (plain-HTTP self-hosted deployment,
+    // e.g. issue #3393): `crypto.randomUUID` is undefined there, and the
+    // pre-fix code threw `TypeError: crypto.randomUUID is not a function`.
+    // @ts-expect-error simulating a runtime without crypto.randomUUID
+    crypto.randomUUID = undefined
+    const id = generateId()
+    expect(id).toMatch(UUID_V4_RE)
+  })
+
+  it('returns unique fallback values across 100 calls', () => {
+    // @ts-expect-error simulating a runtime without crypto.randomUUID
+    crypto.randomUUID = undefined
     const ids = new Set(Array.from({ length: 100 }, () => generateId()))
     expect(ids.size).toBe(100)
   })


### PR DESCRIPTION
## Summary

- Issue #3393 reports a white-screen crash on self-hosted deployments accessed over plain HTTP (a LAN IP, not localhost/HTTPS): `TypeError: crypto.randomUUID is not a function`. Browsers only expose `crypto.randomUUID()` in secure contexts.
- **This is already fixed on current staging** — `generateId()` (`packages/utils/src/id.ts`) has feature-detected `crypto.randomUUID` and fallen back to a `crypto.getRandomValues()`-based UUID v4 since `b5674d9ed4` (#4228). A repo-wide grep confirms no client-side code in `apps/sim` calls `crypto.randomUUID` directly anymore, and `scripts/check-utils-enforcement.ts` bans direct usage outside that one definition file. This PR does **not** fix a bug — nothing here changes production behavior.
- What it does close: the existing test suite for `generateId()` only ever exercised the "happy path" — Node/Bun's `crypto.randomUUID` is always present in the test environment, so the fallback branch that actually fixes #3393 had zero coverage. A future refactor could silently reintroduce the exact crash with nothing catching it.
- Adds two tests to `packages/utils/src/id.test.ts` that stub `crypto.randomUUID` to `undefined` (restored in `afterEach`, verified not to leak across tests or files) and assert `generateId()` still returns a valid, unique UUID v4. Verified these tests genuinely fail with the original `TypeError` when `generateId()` is temporarily reverted to a naive `crypto.randomUUID()` call, and pass again once restored.

Refs #3393 (using `Refs`, not `Fixes` — the underlying bug isn't something this PR resolves; it already isn't reproducible on staging).

## Type of Change

- [x] Other: test-only regression coverage for an already-fixed bug

## Testing

- `cd packages/utils && bunx vitest run src/id.test.ts` — **PASS**, 12/12.
- Reverted `generateId()` to the pre-fix `return crypto.randomUUID()` (no guard) and re-ran the same file — the two new tests **failed** with `TypeError: crypto.randomUUID is not a function`, the exact error from #3393; all other tests still passed. Restored the file and confirmed `git diff` clean before committing.
- `cd packages/utils && bunx vitest run` (full workspace, all 14 files) — **PASS**, 194/194, both before and after the regression check above — the `afterEach` restore doesn't leak across tests or files.
- `bunx tsc --noEmit` / `bunx turbo run type-check --filter=@sim/utils` — **PASS**. Confirms the two `@ts-expect-error` directives suppress a real type error rather than being stale (an unused directive is itself a type error).
- `bunx biome check packages/utils/src/id.test.ts` — **PASS**.
- `bun run check:utils` — pre-existing baseline failures only (13 hits, all in files already on the allowlist — `id.ts`'s own definition, `helpers.ts`, `random.ts`, etc.); none are in `id.test.ts`, which is already allowlisted at `scripts/check-utils-enforcement.ts:37` for referencing the banned pattern directly (needed to test it).
- Full grep of `apps/sim` for `crypto.randomUUID` / `randomUUID` — 6 hits, all `vi.fn()` test mocks; zero production callsites.

An independent adversarial review (Claude subagent, no session context, in place of Codex which isn't installed on this machine) reproduced all of the above itself — including a stress test running the full suite with `--no-isolate --no-file-parallelism` to rule out cross-file leakage from the `crypto.randomUUID` stub — and confirmed the diff is correct as-is. It also independently traced the fix to `b5674d9ed4` and flagged that the PR should be framed as coverage rather than a fix (reflected above), which is the only change it asked for.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

N/A — test-only change, no UI.