### PR TITLE
improvement(usage): drop the segmented allowance meter from the usage summary

### DIFF
--- a/apps/sim/ee/organization-usage/components/usage-summary.tsx
+++ b/apps/sim/ee/organization-usage/components/usage-summary.tsx
@@ -5,18 +5,10 @@ import { Badge } from '@sim/emcn'
 import { BarChart } from '@/components/charts'
 import type { OrganizationUsageSummary } from '@/lib/api/contracts/organization-usage'
 import { formatCreditsLabel } from '@/lib/billing/credits/conversion'
-import { SegmentedMeter } from '@/app/workspace/[workspaceId]/settings/components/segmented-meter'
 import { SettingsEmptyState } from '@/app/workspace/[workspaceId]/settings/components/settings-empty-state'
 
 /** Consumption, matching the seat meter's indicator rather than an outcome colour. */
 const USAGE_SERIES_COLOR = 'var(--indicator-seat-filled)'
-
-/**
- * A credit allowance runs to the millions, so the meter cannot be countable the way
- * the seat meter is — a fixed count reads as a percentage instead. Matches the seat
- * overview's own fallback.
- */
-const ALLOWANCE_SEGMENTS = 24
 
 interface UsageSummaryProps {
   summary?: OrganizationUsageSummary
@@ -94,15 +86,6 @@ export function UsageSummary({ summary, limitCredits, isLoading, isError }: Usag
           </Badge>
         )}
       </div>
-
-      {/*
-        The shared allowance meter, not a second bar drawn from the same token.
-        `SegmentedMeter` already owns the overage tone, and it is the affordance the
-        seat overview uses for exactly this question.
-      */}
-      {hasLimit && (
-        <SegmentedMeter used={used} total={limitCredits} segments={ALLOWANCE_SEGMENTS} />
-      )}
 
       <BarChart data={series} label='' color={USAGE_SERIES_COLOR} unit='credits' height={160} />
     </div>


### PR DESCRIPTION
## Summary
- Removed the 24-segment allowance meter from the organization usage summary. The line above it — "511,877 credits of 2,000,000" — already states the proportion exactly; the pills restate it approximately, and sitting directly above a chart of the same data in the same colour they read as a third series rather than a summary.
- The seat meter keeps `SegmentedMeter`, which is where it belongs: seats are countable, so a pill per seat is legible in a way a pill per ~83,000 credits is not.
- No signal lost — the "Over limit" badge beside the figure already states the overage, in words.
- Refreshed the usage-tracking docs screenshot, which predated the source-mix radar and still showed the pills.
- Corrected two facts that went stale with the last release: the tab table listed **BYOK**, which is withheld until the ledger carries rows for it, and **Open logs** now opens the organization audit feed scoped to that workspace rather than the workspace's execution logs.

## Type of Change
- [x] Improvement

## Testing
Tested manually. `bun run lint:check`, `bun run check:audits` 37/37, `bun run docs:check`, `bun run docs-manifest:check`, and type-check all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)