### PR TITLE
docs(library): update what-is-an-agentic-workflow

### DIFF
--- a/apps/sim/content/library/what-is-an-agentic-workflow/index.mdx
+++ b/apps/sim/content/library/what-is-an-agentic-workflow/index.mdx
@@ -3,28 +3,32 @@ slug: what-is-an-agentic-workflow
 title: 'What Is an Agentic Workflow? (And How It''s Different From Automation)'
 description: 'Learn what an agentic workflow is, how it differs from traditional automation, and when to combine AI agent reasoning with deterministic workflow controls.'
 date: 2026-08-10
-updated: 2026-08-10
+updated: 2026-08-28
 authors:
   - andrew
-readingTime: 7
+readingTime: 9
 tags: [AI Agents, Workflow Automation, Agentic Workflows, Sim]
 ogImage: /library/what-is-an-agentic-workflow/cover.jpg
 canonical: https://www.sim.ai/library/what-is-an-agentic-workflow
 draft: false
 faq:
   - q: "Is agentic AI the same as automation?"
-    a: "No. Agentic AI chooses actions at runtime, while traditional automation follows human-authored rules. Sim supports both modes in one workflow graph, so you can use reasoning for ambiguous work and fixed logic for predictable steps."
+    a: "No. Agentic AI chooses actions while a workflow runs, whereas traditional automation follows rules defined in advance. Sim supports both modes in one graph for ambiguous and predictable steps."
   - q: "Can Zapier or Make build agentic workflows?"
-    a: "Zapier and Make can include AI or agent steps within their trigger-action workflows. Sim instead treats Agent blocks as first-class parts of the execution graph alongside deterministic blocks. Your choice depends on whether reasoning serves as one isolated step or directs several parts of the workflow."
+    a: "Yes. Zapier and Make offer agent features alongside trigger-action workflows, but the degree of agency depends on how much control the agent receives. Sim places Agent and fixed-control blocks in the same execution graph."
   - q: "What is the difference between an AI agent and an agentic workflow?"
-    a: "An AI agent reasons and uses tools, while an agentic workflow coordinates that reasoning with triggers, data, control flow, and other steps. The workflow gives an agent defined inputs, boundaries, and operational context."
+    a: "An AI agent reasons and uses tools. An agentic workflow coordinates that reasoning with triggers, data, control flow, boundaries, and other steps."
   - q: "Do agentic workflows replace deterministic automation?"
-    a: "No. Agentic workflows still need deterministic automation for validation, routing, approvals, and compliance rules. Sim lets builders combine those fixed steps with model reasoning in one graph, reserving autonomy for decisions that require judgment while keeping sensitive actions predictable."
+    a: "No. Fixed automation remains important for exact validation, routing, approvals, and compliance rules. Agentic reasoning is best reserved for decisions that require judgment."
+  - q: "What are the main operational tradeoffs of agentic workflows?"
+    a: "Agentic steps can handle ambiguity, but they usually add model cost, inference latency, variable outputs, and more complex debugging. Fixed steps are generally easier to reproduce, audit, and govern."
+  - q: "When should a workflow use human approval?"
+    a: "Require human approval when an agent proposes a consequential, financial, legal, or hard-to-reverse action. The agent can prepare the recommendation while a controlled gate decides whether execution continues."
 ---
 
 ## TL;DR
 
-- An agentic workflow is a system where an AI model evaluates context and chooses its next action or tool call at runtime.
+- An agentic workflow is a system where an AI model evaluates context and chooses its next action or tool call while the workflow runs.
 - Traditional automation follows triggers, branches, and actions that a human defines in advance. The workflow cannot choose an unplanned next step.
 - Agentic reasoning and deterministic automation serve complementary roles. Production systems often use reasoning for judgment and fixed logic for validation, routing, and approvals.
 - Sim provides one example of this hybrid architecture. Its workflow graph combines Agent blocks with functions, conditions, routers, loops, parallel branches, and human approval.
@@ -33,43 +37,56 @@ faq:
 
 An agentic workflow is a system in which a model reasons over available context and chooses its next action or tool call while the workflow runs. Traditional automation follows triggers, branches, and actions that a person defined before execution. This runtime use of reasoning and tools is also central to [what an AI agent is](https://www.sim.ai/library/what-is-an-ai-agent-definition-how-it-works-and-examples).
 
-A support-triage run provides a concrete example. The model reads an email that reports both a billing discrepancy and possible account compromise, checks the customer’s account history, and then chooses between opening a billing ticket and escalating a security case. The email and retrieved account data determine the choice during execution. No human-authored branch covers that exact combination of claims and account history.
+A support-triage run provides a concrete example. The model reads an email that reports both a billing discrepancy and possible account compromise, checks the customer’s account history, and then chooses between opening a billing ticket and escalating a security case. The email and retrieved account data determine the choice during execution. No predefined branch covers that exact combination of claims and account history.
 
-Runtime discretion still operates within boundaries. You define the workflow’s goal, available tools, instructions, and permissions in advance. The model decides which permitted action best fits the current context instead of matching the input against a complete set of prewritten conditions.
+This discretion still operates within boundaries. You define the workflow’s goal, available tools, instructions, and permissions in advance. The model decides which permitted action best fits the current context instead of matching the input against a complete set of prewritten conditions.
 
-## What traditional automation is, and where Zapier and Make sit today
+## What traditional automation is, and where automation platforms sit today
 
-Traditional trigger-action automation executes a path that a human defines before the run begins. You choose an event that starts the workflow, then specify which actions follow under each condition. Every trigger and branch is authored in advance. At runtime, the software evaluates those rules, but it cannot choose a new type of action outside them. This distinction resembles the boundary between agents and rule-driven systems explored in [AI agents vs. RPA](https://www.sim.ai/library/ai-agents-vs-rpa).
+Traditional trigger-action automation executes a path that a human defines before the run begins. You choose an event that starts the workflow, then specify which actions follow under each condition. Every trigger and branch is configured in advance. During a run, the software evaluates those rules, but it cannot choose a new type of action outside them. This distinction resembles the boundary between agents and rule-driven systems explored in [AI agents vs. RPA](https://www.sim.ai/library/ai-agents-vs-rpa).
 
-Zapier and Make grew around this architecture. [Zapier’s conventional workflow builder connects triggers and actions](https://help.zapier.com/hc/en-us/articles/8496183585293-Create-Zaps), while [Make scenarios arrange modules and routes in a visual editor](https://help.make.com/scenario-editor), so builders define the available paths and the conditions that select them. Both platforms now offer agent features through [Zapier Agents](https://zapier.com/agents) and [Make AI Agents](https://www.make.com/en/ai-agents). In a standard automation, however, an AI step usually performs a bounded task inside a predetermined path, such as classifying an email or drafting a reply. Human-authored logic still determines when the model runs and where its output goes.
+Zapier and Make grew around this architecture. [Zapier’s conventional workflow builder connects triggers and actions](https://help.zapier.com/hc/en-us/articles/8496183585293-Create-Zaps), while [Make scenarios arrange modules and routes in a visual editor](https://help.make.com/scenario-editor), so builders define the available paths and the conditions that select them. Both platforms now offer agent features through [Zapier Agents](https://zapier.com/agents) and [Make AI Agents](https://www.make.com/en/ai-agents). In a standard automation, however, an AI step usually performs a bounded task inside a predetermined path, such as classifying an email or drafting a reply. Preconfigured logic still determines when the model runs and where its output goes.
+
+Other platforms cover a similar spectrum without being interchangeable. [n8n workflows connect nodes and route data between them](https://docs.n8n.io/workflows/components/nodes/), and n8n also provides an [AI Agent node that uses tools and APIs](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/). Microsoft documents [Power Automate cloud flows as trigger-and-action workflows](https://learn.microsoft.com/en-us/power-automate/overview-cloud), while [AI Builder actions can bring models into those flows](https://learn.microsoft.com/en-us/ai-builder/use-in-flow-overview). These products can all combine model work with automation; the practical question is how much choice the model has and which controls surround that choice.
 
 Trigger-action automation cannot create a path for input its author did not anticipate. A malformed payload may cause the run to fail. An unmatched condition may follow a fallback route or end the run, depending on the authored rules. The software does not inspect the situation and select an unplanned tool. Reasoning remains a capability within a step rather than the mechanism that directs execution.
 
 ## Agentic workflows vs. automation, side by side
 
-The main tradeoff is runtime discretion versus human control. Zapier- and Make-style automation follows authored paths, while an agentic workflow lets a model choose among available actions during execution.
+The main tradeoff is in-run discretion versus human control. Traditional automation follows predefined paths, while an agentic workflow lets a model choose among available actions during execution.
 
 | Comparison | Traditional automation | Agentic workflow |
 | --- | --- | --- |
 | Decision-maker | A human defines each trigger, condition, branch, and action before execution. | A model evaluates the current context and selects the next action or tool during execution. |
-| Unexpected input | The workflow follows a fallback path, skips a step, or fails when no authored rule covers the input. | The model can interpret unfamiliar input and choose an available action, although its choice may be wrong. |
-| Flexibility and predictability | Fixed paths produce consistent behavior for known inputs but require edits when requirements change. | Runtime reasoning handles wider input variation but can produce different decisions for similar inputs. |
+| Unexpected input | The workflow follows a fallback path, skips a step, or fails when no predefined rule covers the input. | The model can interpret unfamiliar input and choose an available action, although its choice may be wrong. |
+| Flexibility and predictability | Fixed paths produce consistent behavior for known inputs but require edits when requirements change. | Model reasoning handles wider input variation but can produce different decisions for similar inputs. |
 | Typical failure mode | Schema drift, missing fields, or unhandled conditions can break the workflow or send execution down the wrong branch. | The model can loop, invent an unsupported tool call, pass invalid arguments, or act on flawed reasoning. |
-| Auditability and debugging | Each action maps directly to an authored node and condition, which makes execution paths easier to reproduce. | Debugging requires inspection of prompts, context, model outputs, and tool calls. Model variability can make exact reproduction harder. |
+| Auditability and debugging | Each action maps directly to a configured node and condition, which makes execution paths easier to reproduce. | Debugging requires inspection of prompts, context, model outputs, and tool calls. Model variability can make exact reproduction harder. |
 
 Neither column represents a universal improvement. Each mode accepts a different set of constraints and failure risks. For a deeper look at tracing model decisions and tool calls, see [AI agent observability](https://www.sim.ai/library/ai-agent-observability).
 
+## Operational tradeoffs: cost, latency, observability, and governance
+
+The choice affects operations as much as workflow design. Evaluate these costs step by step rather than labeling an entire system agentic or fixed.
+
+- **Cost:** A rule, transformation, or direct integration call has a relatively fixed execution profile. An agent adds model usage, and repeated reasoning or tool-selection turns can multiply that spend. Reserve model calls for decisions that need interpretation; do not ask a model to perform a validation that a simple function can express exactly.
+- **Latency:** Direct actions and condition checks proceed without waiting for model inference. An agent may need several model responses and tool round trips before it reaches a decision. For a user-facing support flow, that delay may be acceptable for interpreting a difficult case but wasteful for checking whether an account ID exists.
+- **Observability:** In a fixed path, an operator can map an action back to a node and its condition. For an agent, useful diagnosis also needs the model input, output, and tool-call record. Capture both the recommendation and the data that reached the model; otherwise a failed tool call can look like a reasoning error, and vice versa.
+- **Governance:** Permission scope should match the smallest set of tools an agent needs. Put schema checks before external writes, use approval gates for consequential actions, and retain execution records. Fixed rules improve reproducibility, while approval separates a model’s recommendation from the authority to act.
+
+These concerns often argue for a mixed design: let a model classify or recommend, then hand the result to explicit validation, routing, and approval steps.
+
 ## Why agentic and deterministic are complementary, not competing
 
-Agentic and deterministic modes solve different kinds of steps, so forcing one mode across an entire workflow usually creates avoidable failure. A fully deterministic workflow cannot handle cases its author did not anticipate. A fully agentic workflow gives a model discretion over steps that may require exact, repeatable behavior.
+Agentic and deterministic modes solve different kinds of steps, so forcing one mode across an entire workflow usually creates avoidable failure. A fully rule-driven workflow cannot handle cases its designer did not anticipate. A fully agentic workflow gives a model discretion over steps that may require exact, repeatable behavior.
 
-Deterministic logic belongs wherever the same input should produce the same action. A validator can reject records that lack required fields, while routing rules can send approved records to fixed destinations. Human approval gates can pause refunds or account changes until an authorized person reviews them. These controls give auditors a clear record of which rule produced each action.
+Deterministic logic belongs wherever the same input should produce the same action. A validator can reject records that lack required fields, while routing rules can send approved records to fixed destinations. Human approval gates can pause refunds or account changes until an authorized person reviews them. These controls make it easier for auditors to trace which rule produced each action.
 
 Agentic reasoning fits steps that require judgment under ambiguity. A model can interpret an unstructured request and weigh incomplete evidence. The model can then choose between searching a knowledge base, querying a CRM, or asking the user for more information. Because model reasoning can produce an incorrect tool call or enter a loop, the surrounding workflow should enforce tool permissions, retry limits, and output checks.
 
 A support workflow shows how the modes can divide responsibility. Deterministic validation can verify the ticket fields before an agent interprets the customer’s message. The agent can recommend a response and select a relevant tool, while fixed rules route high-value refunds to human approval. Each mode handles the failure it can control most effectively. Practical [support ticket triage patterns](https://www.sim.ai/library/best-ai-agents-support-ticket-triage) apply the same division of responsibility.
 
-Architecture determines how closely those modes can cooperate. Automation-first platforms such as Zapier and Make generally place AI steps inside a trigger-action graph whose surrounding paths remain human-authored, as reflected in the official guides to [adding AI steps in Zapier](https://help.zapier.com/hc/en-us/articles/16276574838925-Use-AI-by-Zapier-in-your-Zap) and [building scenarios in Make](https://help.make.com/scenario-editor). The model can reason within its assigned step, but predefined edges usually control where execution goes afterward. Builders must add branches around the AI output if they want the wider workflow to react differently.
+Architecture determines how closely those modes can cooperate. The official guides to [adding AI steps in Zapier](https://help.zapier.com/hc/en-us/articles/16276574838925-Use-AI-by-Zapier-in-your-Zap), [building scenarios in Make](https://help.make.com/scenario-editor), [using n8n’s AI Agent node](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/), and [using AI Builder in Power Automate](https://learn.microsoft.com/en-us/ai-builder/use-in-flow-overview) show different ways to place AI within visual automation. In a conventional flow, the model can reason within its assigned step, but predefined connections control where execution goes afterward. Builders add branches around the AI output when the wider workflow must react differently.
 
 A reasoning-native graph treats the model as a node that can choose tools and return structured decisions to deterministic controls. Fixed blocks can validate the model’s output, restrict available actions, and require approval before execution continues. You can then give the model discretion only where the task needs it, while preserving predictable behavior around sensitive operations.
 
@@ -79,11 +96,11 @@ A reasoning-native graph treats the model as a node that can choose tools and re
 
 Agent blocks reason over available context and choose tools during a run. Builders can constrain that discretion by selecting the tools an Agent block may call and defining the structured output that later blocks receive.
 
-Deterministic blocks control the parts that need fixed behavior. Functions validate or transform data, while conditions and routers direct execution through human-authored paths. Loops repeat known operations, and parallel branches run independent work concurrently. Human approval can pause the workflow before a consequential action proceeds.
+Deterministic blocks control the parts that need fixed behavior. Functions validate or transform data, while conditions and routers direct execution through configured paths. Loops repeat known operations, and parallel branches run independent work concurrently. Human approval can pause the workflow before a consequential action proceeds.
 
-A support workflow shows how these blocks can work together. An Agent block can interpret an unstructured request and propose a category. A function can validate the required fields, and a router can send refund requests for human approval while passing routine account updates to an integration action.
+A procurement workflow shows how these blocks can work together. An Agent block can interpret an unstructured purchase request and propose a category. A function can validate the required fields, and a router can send high-value purchases for human approval while passing routine requests to an integration action.
 
-Sim makes the boundary between discretion and control visible in the graph. The Agent block handles ambiguity within its permitted tools, while surrounding blocks enforce validation, routing, and approval rules. You can inspect each block’s inputs and outputs after a run, which helps isolate whether a failure came from model reasoning or deterministic logic.
+Sim makes the boundary between discretion and control visible in the graph. The Agent block handles ambiguity within its permitted tools, while surrounding blocks enforce validation, routing, and approval rules. Execution traces expose block inputs and outputs after a run, which helps isolate whether a failure came from model reasoning, fixed logic, or the data passed between them.
 
 ## Deciding whether a given step should be deterministic or agentic
 
@@ -92,7 +109,7 @@ Evaluate each workflow step separately. A single workflow can use deterministic 
 - Would the same input always require the same action? Use a deterministic step when you can express the decision as a stable rule.
 - Must an auditor reconstruct why the step ran? Use deterministic logic when you need an explicit decision path, fixed approval rules, or repeatable results.
 - Does the step interpret unstructured input? Use an agent when the answer depends on context, judgment, or meaning that fixed conditions cannot cover reliably.
-- Must the step choose among tools based on the situation? An agent can inspect the request and select an appropriate tool at runtime.
+- Must the step choose among tools based on the situation? An agent can inspect the request and select an appropriate tool while the workflow runs.
 - Could a wrong decision create a legal or financial consequence? Keep the final action deterministic or require human approval, even if an agent prepares the recommendation.
 
 You can also split one task across both modes. An agent might interpret a customer request and propose a route, while deterministic rules validate required fields and approve the destination. Good workflow design puts the boundary where judgment ends and enforceable rules begin.


### PR DESCRIPTION
Content update to `apps/sim/content/library/what-is-an-agentic-workflow`: Surgical improvement pass on the existing post. Do NOT rewrite it from scratch and do NOT restructure it.

PRESERVE (do not remove or reorder):
- The overall structure: TL;DR -> definition -> automation section -> comparison table -> complementary framing -> Sim example -> decision framework -> FAQ.
- The agentic-vs-automation comparison table. It is the post's strongest asset. You may tighten or add a row, but do not delete it or replace it with prose.
- The support-triage and procurement examples. Keep them concrete.
- The existing Sim positioning and its fair treatment of competitors.
- ALL existing frontmatter FAQ entries (there should be 6). Do not drop any, do not merge any, do not reduce the count.
- The existing frontmatter title. It is unchanged in this run.

APPLY THESE CHANGES:

1. Verify factual claims and link primary sources. Every claim about Zapier, Make, OpenAI, or any other third party — architecture, feature availability, agent/AI capabilities, pricing, limits — must be checked against that vendor's own current docs/product pages and carry an inline outbound markdown link to that primary source. Correct anything the primary source does not support. If a claim cannot be sourced to a vendor primary page, soften it to a qualitative statement rather than asserting a specific. Do not cite listicles or aggregators.

2. Verify Sim claims against the repo. Any specific, checkable claim about Sim behavior (block types, limits, supported formats, execution semantics) must be verified in the codebase before it stays in. Soften or correct anything the code does not support. Do not invent new specifics.

3. Add depth on operational tradeoffs. The post is thin here. Add substantive coverage — ideally a new section placed after the comparison table and before or within the complementary-modes framing — on how agentic and deterministic steps differ on: cost (token/LLM spend vs fixed execution), latency (model inference and multi-turn tool calls vs direct action execution), observability (inspecting model inputs/outputs/tool-call records vs mapping each action to an authored node), and governance (permission scoping, approval gates, auditability, reproducibility). Keep it concrete and tied to real design decisions, not abstract. Verify any Sim-specific observability/approval claims against the repo.

4. Broaden competitive coverage. Right now only Zapier and Make are covered. Add at least two more relevant automation/agent platforms to the discussion (for example n8n, Workato, Power Automate, or a comparable player), each with a primary-source outbound link, treated as fairly as the existing Zapier/Make coverage. Where a comparison table row makes sense, extend the table rather than bolting on a list.

5. Vary repetitive phrasing. The words "authored", "deterministic", and "runtime" are overused and give the prose a generated texture. Reduce their frequency with natural synonyms and varied sentence construction. Do not change the meaning of any technical statement while doing this, and keep "deterministic" where it is genuinely the precise term.

6. Tighten FAQ answers for snippet extraction. Existing answers run long. Shorten each answer so it leads with a direct one- or two-sentence answer to the question, then any needed qualification. Keep all 6 entries, keep the questions intact, keep the substance — this is compression for AI/answer-engine extraction, not deletion.

7. Internal links: verify every www.sim.ai link in the body against the repo content folders and make sure the post ends with 3-5 valid internal library links.

REFERENCE ARTICLE (use as a source of improved framing, sharper wording, better-sourced claims, and the tradeoff framing — do NOT paste it in wholesale and do NOT let it shrink the FAQ from 6 entries to 4):

Title: What Is an Agentic Workflow? (And How It's Different From Automation)

## TL;DR

- Agentic reasoning and deterministic automation serve complementary roles: use reasoning for judgment and fixed logic for validation, routing, and approvals.
- An agentic workflow lets an AI model evaluate context and choose its next action or tool call at runtime.
- Traditional automation follows a path defined in advance and cannot choose an unplanned next step.
- Sim combines Agent blocks, deterministic controls, and human approval in one workflow graph.

## What an agentic workflow actually is

An agentic workflow is a system in which a model reasons over available context and chooses its next action or tool call while the workflow runs. Traditional automation follows a path that a person defined before execution.

In support triage, the model reads an email reporting a billing discrepancy and possible account compromise. After checking the customer's account history, the model chooses whether to open a billing ticket or escalate a security case. No human-authored branch covers that exact combination of claims and account history.

Runtime discretion still operates within boundaries. You set the workflow's goal and operating rules in advance. The operating rules specify which tools the model may use. The model decides which permitted action best fits the current context instead of matching the input against a complete set of prewritten conditions.

## What traditional automation is, and where Zapier and Make sit today

Traditional trigger-action automation follows a path that you define before the run begins. You choose the starting event and specify the action for each condition. At runtime, the software evaluates those rules, but it cannot choose a new type of action outside them.

[Zapier](https://zapier.com/) and [Make](https://www.make.com/en) grew around this architecture. Their conventional builders connect triggers to actions through filters and branches, so you define the available paths and the conditions that select them. Both platforms now include AI steps and agent features, via [Zapier Agents](https://zapier.com/agents) and [Make AI Agents](https://www.make.com/en/ai-agents). In a standard automation, however, an AI step usually performs a bounded task inside a predetermined path, such as classifying an email or drafting a reply. Human-authored logic still determines when the model runs and where its output goes.

This limitation becomes visible when an input matches no authored condition: the run follows a fallback route or stops. Supporting that case requires a person to add another branch, whereas an agentic step can interpret the input and select from its permitted tools at runtime.

## Agentic workflows vs. automation, side by side

The main tradeoff is runtime discretion versus human control. Zapier- and Make-style automation follows authored paths, while an agentic workflow lets a model choose among available actions during execution.

| Comparison | Traditional automation | Agentic workflow |
| --- | --- | --- |
| Decision-maker | A human defines the execution path before the workflow runs. | A model evaluates the current context and selects the next action or tool during execution. |
| Unexpected input | The workflow uses an authored fallback or stops when no rule covers the input. | The model can interpret unfamiliar input and choose an available action, although its choice may be wrong. |
| Flexibility and predictability | Fixed paths produce consistent behavior for known inputs but require edits when requirements change. | Runtime reasoning handles wider input variation but can produce different decisions for similar inputs. |
| Typical failure mode | A schema or condition mismatch can stop the workflow or select the wrong branch. | The model can loop or issue an invalid tool call. |
| Auditability and debugging | Each action maps directly to an authored node and condition, which makes execution paths easier to reproduce. | Debugging requires inspection of model inputs, outputs, and tool-call records. Model variability can make exact reproduction harder. |

Neither column represents a universal improvement. Each mode accepts a different set of constraints and failure risks.

## Why agentic and deterministic are complementary, not competing

Use agentic and deterministic modes for different types of steps. Deterministic workflows handle anticipated cases through fixed rules. Agentic workflows can handle ambiguous cases, but models should not control steps that require exact, repeatable behavior.

Use deterministic logic wherever the same input should produce the same action. Validators can reject records without required fields, and routing rules can send approved records to fixed destinations. Approval gates can pause consequential actions for authorized review and record which rule produced each action.

Use agentic reasoning for steps that require judgment under ambiguity. A model can weigh incomplete evidence in an unstructured request. The model can then choose an available tool or ask the user for more information. The surrounding workflow should limit available tools and validate model output, while retry limits stop loops.

In a support workflow, deterministic validation can verify the ticket fields before an agent interprets the customer's message. The agent can recommend a response and select a relevant tool, while fixed rules route high-value refunds to human approval.

Architecture determines how closely these modes can cooperate. In conventional Zapier Zaps and Make scenarios, users connect triggers and actions through authored filters, routers, and branches. An AI step can reason within its assigned node, but the surrounding connections determine where its output goes; making the wider workflow respond differently requires additional authored branches.

A unified graph can instead pass structured agent decisions directly into validation, routing, and approval blocks, keeping judgment and enforceable controls in the same execution path.

## How Sim structures agentic and deterministic blocks in one graph

At [Sim](https://sim.ai), we've built a visual workflow graph that places Agent blocks alongside deterministic blocks, so model reasoning participates directly in execution rather than sitting inside a fixed automation step.

Agent blocks reason over available context and choose tools during a run. You can constrain that discretion by selecting the tools an Agent block may call and defining the structured output that later blocks receive.

Deterministic blocks provide fixed behavior by using functions to validate or transform data. Conditions and routers direct execution along human-authored paths, while loops repeat known operations. Parallel branches execute independent tasks concurrently, and human approval can pause consequential actions.

In a procurement workflow, an Agent block can interpret an unstructured purchase request and propose a category. A function can validate required fields, while a router sends high-value purchases for human approval and routine requests to an integration action.

After a run, you can inspect each block's inputs and outputs to determine whether a failure came from model reasoning, deterministic logic, or the data passed between them.

## Deciding whether a given step should be deterministic or agentic

Evaluate each workflow step separately. A single workflow can use deterministic rules for one decision and agentic reasoning for the next.

- Would the same input always require the same action? Use a deterministic step when you can express the decision as a stable rule.
- Must an auditor reconstruct why the step ran? Use deterministic logic when you need a repeatable decision path or fixed approval rules.
- Does the step interpret unstructured input? Use an agent when the answer requires contextual judgment that fixed conditions cannot represent reliably.
- Must the step choose among tools based on the situation? An agent can inspect the request and select an appropriate tool at runtime.
- Does the step carry legal or financial authority? Keep the final action deterministic or require human approval, even if an agent prepares the recommendation.

You can also split one task across both modes. An agent might interpret a customer request and propose a route, while deterministic rules validate required fields and approve the destination. Set the boundary where judgment ends and enforceable rules begin.

## FAQs (reference wording only — the live post keeps all 6 of its existing entries)

- Is agentic AI the same as automation? No, agentic AI chooses actions at runtime, while traditional automation follows human-authored rules. At Sim, we support both modes in one workflow graph.
- Can Zapier or Make build agentic workflows? Zapier and Make can add AI or agent steps to authored trigger-action routes, but the workflow's degree of agency depends on how much runtime control those steps receive.
- What is the difference between an AI agent and an agentic workflow? An AI agent reasons and uses tools, while an agentic workflow coordinates that reasoning with inputs, control flow, and other steps.
- Do agentic workflows replace deterministic automation? No. They use fixed logic for steps that require exact validation, routing, or approval.

## Put the boundary into practice

Map each workflow step according to whether it requires contextual judgment or a repeatable rule, then place validation and approval controls around any consequential agent action.

[Build a workflow in Sim](https://sim.ai) to combine Agent blocks, deterministic logic, and human approval in one graph.

- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)