### PR TITLE
improvement(ci): scan CodeQL PRs at the promotion boundary, refresh main daily

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -31,3 +31,11 @@ paths-ignore:
   - '**/dist/**'
   - '**/.next/**'
   - 'apps/docs/content/**'
+
+# Do NOT add `queries:`, `packs:`, `query-filters:`, or `disable-default-queries`
+# here to try to speed the scan up. Under the code-scanning feature flag the
+# action's checkOverlayAnalysisFeatureEnabled treats any of those as
+# OverlayDisabledReason.NonDefaultQueries and permanently turns off overlay
+# (incremental) analysis. Extraction is ~53% of a run and is exactly what overlay
+# skips, so scoping the queries trades a documented up-to-10x win for a few
+# percent off the 27% query phase.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,8 +20,16 @@ on:
   # created, prevents developers from introducing new vulnerabilities."
   push:
     branches: [main]
+  # main only, not staging. Feature PRs land on staging and are ~90% of PR scan
+  # volume, and every one of them is scanned again — against the exact tree being
+  # promoted — when the staging->main PR opens. Scanning at the promotion
+  # boundary defers the signal rather than dropping it.
+  #
+  # Deliberately a branch cut and not an activity-type cut: dropping
+  # `synchronize` would have scanned each PR's first commit and never its final
+  # state, which is backwards, since review fixups land in later pushes.
   pull_request:
-    branches: [main, staging]
+    branches: [main]
     # `ready_for_review` is not a default activity type, so it has to be listed
     # alongside the defaults it replaces. Without it, a PR opened as a draft and
     # then marked ready is skipped by the job-level draft guard and never
@@ -41,7 +49,15 @@ on:
     # Safety net behind the push trigger, and the thing that keeps the
     # default-branch alert view fresh when main is quiet. Only fires once this
     # file is on the default branch — schedule events ignore other branches.
-    - cron: '17 8 * * 1'
+    #
+    # Daily rather than weekly. Pushes to main are rare, and with PR scans now
+    # limited to main the alert view leans on this more than it used to; a week
+    # is too long to leave it stale. It also reseeds the overlay-base database
+    # that PR runs restore from — that cache key embeds the CodeQL bundle
+    # version, so a bundle bump invalidates it, and an unused Actions cache is
+    # evicted after 7 days. One 8 vCPU default-branch scan a day is a few
+    # dollars a month against a PR scan that halves when the base is warm.
+    - cron: '17 8 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

CodeQL runs ~3,090 times a month and costs ~$382/mo across both languages. **90 of the last 100 PRs target `staging`**, and every one of those is scanned again — against the exact tree being promoted — when the `staging`→`main` PR opens.

- **PR scans restricted to `main`.** This defers the signal to the promotion boundary rather than dropping it. Verified safe: no ruleset or branch protection requires a CodeQL status check (all four rulesets carry only `pull_request`/`deletion`/`non_fast_forward`), and the code-scanning alert view is fed by the push-to-`main` and scheduled analyses — PR analyses upload against `refs/pull/N/merge` and only ever surface as PR annotations.
- **Deliberately a branch cut, not an activity-type cut.** Dropping `synchronize` would have cut a similar share, but it scans a PR's *first* commit and never its final state — backwards, since review fixups land in later pushes.
- **Scheduled scan weekly → daily.** Pushes to `main` are rare, so with PR scans limited to `main` the alert view leans on the cron more than before. It also reseeds the overlay-base database (see below). Costs a few dollars a month.
- **Documented a trap** in `codeql-config.yml`: adding `queries:`/`packs:`/`query-filters:` trips `OverlayDisabledReason.NonDefaultQueries` and *permanently disables* overlay analysis — trading a documented up-to-10x win for a few percent.

## Follow-up, not fixed here

The scan is slow for a reason unrelated to scope: the **overlay-base database uploads on every push to `main` and never restores on a PR run**. Observed 4/4 misses against a byte-identical cache key:

```
Looking in Actions cache for overlay-base database with restore key
  codeql-overlay-base-database-1-<hash>-javascript-<version>-
No overlay-base database found in Actions cache
```

...49 minutes after a run logged `Successfully uploaded overlay-base database` with a key matching that prefix exactly. Phase timings show extraction is **118s of a 221s run (53%)** — precisely what overlay skips. GitHub's cache API holds zero overlay entries, so the multi-GB base is going into the runner provider's transparent cache rather than GitHub's. Fixing that restore is worth roughly **half of every PR scan** and is tracked separately.

## Type of Change
- [x] Improvement

## Testing
`actionlint` clean. Verified the parsed triggers (`pull_request.branches: [main]`, unchanged `types`, `push: [main]`, daily cron) and that both matrix languages still expand. `bun run lint` and all 38 `check:audits` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)