### PR TITLE
improvement(ui): soften overflow fade

### DIFF
--- a/packages/emcn/src/components/overflow-text/overflow-text.tsx
+++ b/packages/emcn/src/components/overflow-text/overflow-text.tsx
@@ -12,7 +12,7 @@ import {
 
 /** Complete fade-only clipping treatment for measured special cases. */
 export const overflowTextFadeClass =
-  'overflow-hidden text-clip whitespace-nowrap [-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_18px),transparent)] [mask-image:linear-gradient(to_right,black_calc(100%_-_18px),transparent)]'
+  'overflow-hidden text-clip whitespace-nowrap [-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_16px),transparent)] [mask-image:linear-gradient(to_right,black_calc(100%_-_16px),transparent)]'
 
 /** Fade-free clipping for externally measured labels and rich-content overflow exceptions. */
 export const overflowTextClipClass = 'block min-w-0 overflow-hidden text-clip whitespace-nowrap'


### PR DESCRIPTION
## Summary
- shorten the canonical overflow fade from 18px to 16px
- keep the fade-only truncation treatment consistent across all consumers

## Type of Change
- [x] Improvement

## Testing
- bunx vitest run packages/emcn/src/components/overflow-text/overflow-text.test.tsx
- bun run lint
- bun run apps/sim/scripts/check-block-registry.ts origin/staging
- bun run check:audits

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)