### PR TITLE
fix(ui): prevent competing sidebar tooltips

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-footer/sidebar-footer.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-footer/sidebar-footer.test.tsx
@@ -51,7 +51,10 @@ import { SidebarFooter } from '@/app/workspace/[workspaceId]/w/components/sideba
 let container: HTMLDivElement
 let root: Root
 
-async function renderFooter(initialState: Record<string, unknown>) {
+async function renderFooter(
+  initialState: Record<string, unknown>,
+  overrides: Partial<Parameters<typeof SidebarFooter>[0]> = {}
+) {
   desktopMocks.getState.mockResolvedValue(initialState)
   await act(async () => {
     root.render(
@@ -64,6 +67,7 @@ async function renderFooter(initialState: Record<string, unknown>) {
         onOpenDocs={() => {}}
         onJoinSlack={() => {}}
         onContactSupport={() => {}}
+        {...overrides}
       />
     )
   })
@@ -123,7 +127,23 @@ afterEach(() => {
   container.remove()
 })
 
-describe('SidebarFooter desktop update affordance', () => {
+describe('SidebarFooter', () => {
+  it('keeps the overflow tooltip disabled while the collapsed tooltip still owns the trigger', async () => {
+    await renderFooter({ status: 'idle' }, { isCollapsed: false, showCollapsedTooltips: true })
+    const label = profileTrigger().querySelector<HTMLElement>('[data-overflow-text]')
+    if (!label) throw new Error('Profile label was not rendered')
+    Object.defineProperties(label, {
+      clientWidth: { configurable: true, value: 40 },
+      scrollWidth: { configurable: true, value: 80 },
+    })
+
+    act(() => {
+      label.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+    })
+
+    expect(document.querySelector('[data-native-surface-overlay]')).toBeNull()
+  })
+
   it('renders profile settings destinations with native link semantics', async () => {
     await renderFooter({ status: 'idle' })
 

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-footer/sidebar-footer.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-footer/sidebar-footer.tsx
@@ -255,7 +255,7 @@ export function SidebarFooter({
               <OverflowText
                 label={name}
                 className={cn('sidebar-collapse-hide flex-1', chipContentLabelClass)}
-                tooltipEnabled={!isCollapsed}
+                tooltipEnabled={!isCollapsed && !showCollapsedTooltips}
                 focusTarget='nearest-interactive'
               />
             ) : (

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.test.tsx
@@ -167,6 +167,7 @@ describe('WorkspaceHeader workspace switcher highlight', () => {
 
     const switcher = container.querySelector('button[aria-label="Switch workspace"]')
     expect(switcher).toBeDisabled()
+    expect(switcher).not.toHaveAttribute('title')
     expect(switcher).toHaveTextContent('Brightwave')
     expect(switcher).toHaveTextContent('B')
     expect(switcher?.querySelector('.animate-pulse')).toBeNull()
@@ -174,6 +175,10 @@ describe('WorkspaceHeader workspace switcher highlight', () => {
 
   it('leaves Enter unarmed until a cursor is on screen', () => {
     render()
+
+    expect(container.querySelector('button[aria-label="Switch workspace"]')).not.toHaveAttribute(
+      'title'
+    )
 
     const search = document.querySelector('input[placeholder="Search workspaces..."]')
     act(() => {

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.tsx
@@ -519,7 +519,6 @@ function WorkspaceHeaderImpl({
               type='button'
               aria-label='Switch workspace'
               className={cn(chipVariants(), 'min-w-0 max-w-full')}
-              title={activeWorkspace?.name}
               onContextMenu={(e) => {
                 if (activeWorkspaceFull) {
                   handleContextMenu(e, activeWorkspaceFull)
@@ -871,7 +870,6 @@ function WorkspaceHeaderImpl({
              shifts when the workspace resolves. Chips carry no margin, so neither
              does this. */
           className={cn(chipGeometryClass, isCollapsed ? 'flex' : 'inline-flex min-w-0 max-w-full')}
-          title={activeWorkspace?.name}
           disabled
         >
           {activeWorkspaceFull?.logoUrl ? (


### PR DESCRIPTION
## Summary

- keep the collapsed sidebar tooltip as the sole tooltip owner during expansion transitions
- remove redundant native workspace-name tooltips when OverflowText owns the full-value tooltip
- cover both live and loading workspace triggers plus the transition overlap regression

## Verification

- bun run --cwd apps/sim test -- app/workspace/[workspaceId]/w/components/sidebar/components/sidebar-footer/sidebar-footer.test.tsx app/workspace/[workspaceId]/w/components/sidebar/components/workspace-header/workspace-header.test.tsx
- bun run lint:check
- bun run lint
- bun run apps/sim/scripts/check-block-registry.ts origin/staging
- bun run check:audits