### PR TITLE
chore(skills): name directExecution as retired in the add-integration checklist

### DIFF
--- a/.agents/skills/add-integration/SKILL.md
+++ b/.agents/skills/add-integration/SKILL.md
@@ -606,8 +606,8 @@ If creating V2 versions (API-aligned outputs):
 - [ ] Created tool file for each operation
 - [ ] Chose exactly one boundary per tool: registered `InternalToolConfig.operation` or absolute
       external HTTP(S) `ToolConfig.request`
-- [ ] No tool points to `/api/...`, constructs a URL back to Sim, declares `request.internal`, or
-      `directExecution`, or has an HTTP fallback for an in-process operation
+- [ ] No tool points to `/api/...`, constructs a URL back to Sim, declares `request.internal` or the
+      retired `directExecution` property, or has an HTTP fallback for an in-process operation
 - [ ] All params have correct visibility
 - [ ] All nullable fields use `?? null`
 - [ ] All optional outputs have `optional: true`


### PR DESCRIPTION
Follow-up to the `directExecution` retirement, from a review finding on the v0.8.16 release PR (#7224).

The add-integration transport checklist listed the property inside a bare enumeration:

> No tool points to `/api/...`, constructs a URL back to Sim, declares `request.internal`, or `directExecution`, or has an HTTP fallback for an in-process operation

That stacks two disjunctions and drops the "retired" framing every other statement of the same rule carries — including line 71 of this very file, and the `add-tools`, `add-trigger`, and `add-block` skills. A reader scanning the checklist could reasonably take `directExecution` for a property that still exists and is merely discouraged, which is the opposite of the intent.

Now reads:

> No tool points to `/api/...`, constructs a URL back to Sim, declares `request.internal` or the retired `directExecution` property, or has an HTTP fallback for an in-process operation

Wording only. The rule itself is unchanged, and it is enforced mechanically by `check:tool-request-boundary`, which fails with `directExecution is retired; use InternalToolConfig.operation and a registered server handler`.

## Checks

- `bun run lint` — clean
- `bun run check:audits` — 39/39 pass (includes `check:skills` and `check:tool-request-boundary`)
- `check-block-registry.ts origin/staging` — pass
- `skills:sync` + `agent-stream-docs:generate` — no artifact drift