### PR TITLE
fix(execution): release the lease when abort races an undetermined acquisition

### DIFF
--- a/apps/sim/lib/execution/isolated-vm.test.ts
+++ b/apps/sim/lib/execution/isolated-vm.test.ts
@@ -704,6 +704,7 @@ describe('isolated-vm scheduler', () => {
   })
 
   it('reports cancellation when abort races a rejected distributed lease', async () => {
+    const scripts: string[] = []
     let resolveLease!: (value: number) => void
     let markLeaseRequested!: () => void
     const leaseResult = new Promise<number>((resolve) => {
@@ -719,6 +720,7 @@ describe('isolated-vm scheduler', () => {
       spawns: [() => createReadyProc('unused')],
       redisEvalImpl: (...args: unknown[]) => {
         const script = String(args[0] ?? '')
+        scripts.push(script)
         if (script.includes('ZREMRANGEBYSCORE')) {
           markLeaseRequested()
           return leaseResult
@@ -748,6 +750,8 @@ describe('isolated-vm scheduler', () => {
       termination: 'cancelled',
       error: { name: 'AbortError' },
     })
+    // Redis answered before its ZADD, so there is nothing to remove.
+    expect(scripts.some((script) => script.includes("'ZREM'"))).toBe(false)
     expect(spawnMock).not.toHaveBeenCalled()
   })
 

--- a/apps/sim/lib/execution/isolated-vm.test.ts
+++ b/apps/sim/lib/execution/isolated-vm.test.ts
@@ -654,6 +654,55 @@ describe('isolated-vm scheduler', () => {
     expect(result.error?.message).toContain('Too many concurrent')
   })
 
+  it('releases the lease when abort races an undetermined acquisition', async () => {
+    const scripts: string[] = []
+    let markLeaseRequested!: () => void
+    const leaseRequested = new Promise<void>((resolve) => {
+      markLeaseRequested = resolve
+    })
+    const { executeInIsolatedVM, spawnMock } = await loadExecutionModule({
+      envOverrides: {
+        REDIS_URL: 'redis://localhost:6379',
+        IVM_LEASE_REDIS_DEADLINE_MS: '5',
+      },
+      spawns: [() => createReadyProc('unused')],
+      redisEvalImpl: (...args: unknown[]) => {
+        const script = String(args[0] ?? '')
+        scripts.push(script)
+        // Never settles, so the deadline decides and Redis may still register
+        // the lease id afterwards.
+        if (script.includes('ZREMRANGEBYSCORE')) {
+          markLeaseRequested()
+          return new Promise<number>(() => {})
+        }
+        return 1
+      },
+    })
+    const controller = new AbortController()
+
+    const execution = executeInIsolatedVM(
+      {
+        code: 'return "unused"',
+        params: {},
+        envVars: {},
+        contextVariables: {},
+        timeoutMs: 100,
+        requestId: 'req-abort-undetermined',
+        ownerKey: 'user:cancelled-undetermined',
+      },
+      { signal: controller.signal }
+    )
+    await leaseRequested
+    controller.abort(new DOMException('user', 'AbortError'))
+
+    await expect(execution).resolves.toMatchObject({
+      termination: 'cancelled',
+      error: { name: 'AbortError' },
+    })
+    expect(scripts.some((script) => script.includes("'ZREM'"))).toBe(true)
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
   it('reports cancellation when abort races a rejected distributed lease', async () => {
     let resolveLease!: (value: number) => void
     let markLeaseRequested!: () => void

--- a/apps/sim/lib/execution/isolated-vm.ts
+++ b/apps/sim/lib/execution/isolated-vm.ts
@@ -1415,7 +1415,28 @@ export async function executeInIsolatedVM(
     distributedLeaseId,
     req.timeoutMs
   )
+  let settled = false
+  /**
+   * Released even when the acquisition was undetermined. The deadline abandons
+   * the local wait but cannot cancel the script, so a late completion still
+   * registers this lease id — and unreleased it would count against the owner
+   * for the whole TTL, denying later executions that do have capacity. The
+   * lease id is unique to this execution, so removing one that was never
+   * registered is a no-op.
+   *
+   * Declared before the early returns below so every exit path that can leave a
+   * registration behind reaches it, not just the ones that run the execution.
+   */
+  const releaseLease = () => {
+    if (settled) return
+    settled = true
+    releaseDistributedLease(ownerKey, distributedLeaseId).catch((error) => {
+      logger.error('Failed to release distributed lease', { ownerKey, error })
+    })
+  }
+
   if (leaseAcquireResult !== 'acquired' && signal?.aborted) {
+    releaseLease()
     maybeCleanupOwner(ownerKey)
     return {
       result: null,
@@ -1430,6 +1451,7 @@ export async function executeInIsolatedVM(
       ownerKey,
       max: DISTRIBUTED_MAX_INFLIGHT_PER_OWNER,
     })
+    // No release: the script returns this before its ZADD, so nothing was registered.
     maybeCleanupOwner(ownerKey)
     return {
       result: null,
@@ -1443,23 +1465,6 @@ export async function executeInIsolatedVM(
   }
   // An undetermined lease cannot reject the execution: the per-process pool and
   // the per-owner active/queued limits above still bound this work.
-
-  let settled = false
-  /**
-   * Released even when the acquisition was undetermined. The deadline abandons
-   * the local wait but cannot cancel the script, so a late completion still
-   * registers this lease id — and unreleased it would count against the owner
-   * for the whole TTL, denying later executions that do have capacity. The
-   * lease id is unique to this execution, so removing one that was never
-   * registered is a no-op.
-   */
-  const releaseLease = () => {
-    if (settled) return
-    settled = true
-    releaseDistributedLease(ownerKey, distributedLeaseId).catch((error) => {
-      logger.error('Failed to release distributed lease', { ownerKey, error })
-    })
-  }
 
   const state: ExecutionState = { cancelled: false }
 

--- a/apps/sim/lib/execution/isolated-vm.ts
+++ b/apps/sim/lib/execution/isolated-vm.ts
@@ -1436,7 +1436,8 @@ export async function executeInIsolatedVM(
   }
 
   if (leaseAcquireResult !== 'acquired' && signal?.aborted) {
-    releaseLease()
+    // Only an undetermined result can have registered; see the over-limit branch below.
+    if (leaseAcquireResult === 'undetermined') releaseLease()
     maybeCleanupOwner(ownerKey)
     return {
       result: null,


### PR DESCRIPTION
## Summary
- The cancellation return for an aborted execution ran before `releaseLease` was declared, so it exited without releasing the distributed owner lease.
- An undetermined acquisition can still be registered by Redis after the deadline abandons the local wait. Aborting in that window left the member counted against the owner for the whole TTL, denying later executions that had capacity — the same failure the fallback change set out to remove, on the one exit path that missed it.
- Declared the release before the early returns so every exit path that can leave a registration behind reaches it, and call it on the cancellation path.
- The over-limit return still skips the release deliberately: the script answers that before its `ZADD`, so nothing was ever registered. Noted inline so it is not "corrected" later.

## Type of Change
- [x] Bug fix

## Testing
`vitest run lib/execution/isolated-vm.test.ts` — 16 passing, including a new case asserting that an abort racing an undetermined acquisition still issues the release. Verified it fails against the previous behavior while the existing over-limit abort case keeps passing. `bun run type-check`, `bun run lint`, and `bun run check:audits` (39 audits) pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
