### PR TITLE
docs(library): update best-ai-agent-builder-2026

### DIFF
--- a/apps/sim/content/library/best-ai-agent-builder-2026/index.mdx
+++ b/apps/sim/content/library/best-ai-agent-builder-2026/index.mdx
@@ -3,10 +3,10 @@ slug: best-ai-agent-builder-2026
 title: 'Best AI Agent Builder in 2026: Sim Leads for Open-Source, Self-Hostable Teams'
 description: 'Compare the best AI agent builders in 2026 across open-source licensing, self-hosting, build modes, integrations, deployment options, and pricing.'
 date: 2026-08-01
-updated: 2026-08-01
+updated: 2026-08-28
 authors:
   - andrew
-readingTime: 9
+readingTime: 8
 tags: [AI Agents, Agent Builders, Open Source, Self-Hosting, Comparison, Sim]
 ogImage: /library/best-ai-agent-builder-2026/cover.jpg
 canonical: https://www.sim.ai/library/best-ai-agent-builder-2026
@@ -24,28 +24,28 @@ faq:
     a: "Sim is the better fit when permissive licensing, agent-native context, and infrastructure control are priorities. n8n may fit engineering-led deterministic automation, while Zapier may fit teams that prioritize guided SaaS automation."
   - q: "Which AI agent platform fits enterprise security reviews?"
     a: "The right platform depends on your organization's controls. Sim offers enterprise deployment and governance options, while its open-source core gives technical teams source visibility and infrastructure choice."
+  - q: "What is the best AI agent builder if you write code?"
+    a: "A code-friendly AI agent builder combines programmable interfaces with tools for designing and deploying agent workflows. Sim provides APIs alongside Mothership and a visual block canvas, and it can deploy workflows via hosted chat, API endpoints, or MCP tools. Developers can move from visual prototypes to production services without changing workspaces."
 ---
 
 *Last updated: August 2026*
 
 ## TL;DR
 
-- [Sim](https://www.sim.ai/) is the best AI agent builder for technical teams that want an [Apache 2.0](https://github.com/simstudioai/sim), self-hostable workspace. Its public repository shows its current GitHub community, while Sim reports a community of more than 100,000 builders.
-- [n8n suits engineers who want self-hosted workflow automation](https://docs.n8n.io/hosting/) under its [fair-code Sustainable Use License](https://docs.n8n.io/sustainable-use-license/).
-- [Zapier suits users who prioritize guided setup and a large app catalog](https://zapier.com/apps), and whose workloads fit its [task-based plans](https://zapier.com/pricing).
-- [Make suits operations users building visual automation scenarios](https://www.make.com/en), while [Make AI Agents](https://www.make.com/en/ai-agents) remains a separate, evolving product surface.
-- [Gumloop offers a managed, no-code AI automation builder](https://www.gumloop.com/) for users who do not need to operate the platform's infrastructure.
-- The deciding factor is architecture. Sim began as an agent workspace, while the other four grew from workflow automation products or managed automation builders.
+- Among the tools compared here, [Sim](https://www.sim.ai/) is the top AI agent builder for technical users who want a self-hostable workspace licensed under [Apache 2.0](https://github.com/simstudioai/sim).
+- This ranking favors self-hostability and agent-building features over the broader deterministic automation offered by traditional workflow platforms.
+- [n8n](https://n8n.io/) suits engineers who want self-hosted, deterministic workflow automation under its [Sustainable Use License](https://docs.n8n.io/sustainable-use-license/).
+- [Zapier](https://zapier.com/apps) suits nontechnical users who prioritize easy setup and a large app catalog.
+- [Make](https://www.make.com/en/pricing) suits operations users building complex visual automation scenarios.
+- [Gumloop](https://gumloop.com/pricing) suits users who want a managed, no-code AI automation builder.
 
 For a wider market survey, see this comparison of the [best AI agent platforms in 2026](https://www.sim.ai/library/best-ai-agent-platforms-2026).
 
-## The best AI agent builder for technical, self-hosting teams
+## Sim ranks first for technical users who self-host
 
-Sim is the best AI agent builder for technical builders and teams that prioritize open-source licensing and self-hosting control. Sim's [core repository](https://github.com/simstudioai/sim) uses the permissive Apache 2.0 license, displays the project's current star count, and includes self-hosting resources. [Sim reports](https://www.sim.ai/) that more than 100,000 builders use the platform.
+Sim ranks first among these tools for technical builders who prioritize open-source licensing and control over self-hosting. Our [core repository](https://github.com/simstudioai/sim) uses the permissive Apache 2.0 license and supports self-hosting. [Mothership](https://docs.sim.ai/mothership) lets users build and operate workspace resources through natural language. The [Sim workspace](https://sim.ai) provides native data features through Tables and Files, context through Knowledge Bases, and access to [1,000+ integrations](https://www.sim.ai/integrations) and [100+ models](https://www.sim.ai/models). You can deploy the same workflow through an [API or hosted chat](https://docs.sim.ai/workflows/deployment), while other software can call it as an [MCP tool](https://docs.sim.ai/workflows/deployment/mcp).
 
-[Mothership](https://docs.sim.ai/mothership) lets users create and operate workspace resources through natural language. The [Sim workspace](https://sim.ai) includes native Tables, Files, and Knowledge Bases, along with [1,000+ integrations](https://www.sim.ai/integrations) and support for [major model providers](https://www.sim.ai/models). As documented in the [Sim product documentation](https://docs.sim.ai/), users can publish workflows for API access, hosted chat, and use by MCP clients.
-
-Sim fits technical builders at startups and enterprise teams that want to limit vendor lock-in through source access and infrastructure choice. If you mainly need simple SaaS automation and do not plan to self-host, a managed automation platform with guided onboarding may suit you better.
+Sim fits you if you want source access and control over where you run the software. If you mainly need simple SaaS automation and do not plan to self-host, choose a managed automation platform with guided onboarding.
 
 ## Why AI-native architecture beats retrofitted automation
 
@@ -89,30 +89,32 @@ Exact controls and deployment responsibilities should be confirmed with Sim for 
 
 The ranking weighs ownership, building flexibility, production use, and cost because those factors determine whether a platform fits your technical requirements and operating model.
 
-- **License and self-hosting** determine whether you can inspect, modify, and run the software on your own infrastructure.
-- **Build modes** show whether you can create agents through natural language, a visual editor, code, or a combination.
-- **Integrations and models** measure how readily agents can use your existing tools, data, and preferred model providers.
-- **Deployment surfaces** define how you can publish a finished agent, such as through an API, chat interface, or callable tool.
-- **Pricing model** reveals whether costs depend on seats, tasks, executions, operations, platform credits, model usage, or infrastructure you operate.
+- **License and self-hosting** determine whether you can inspect and modify the source, then run the software on your own infrastructure.
+- **Build modes** show whether you can create agents with a visual editor or code, including natural-language controls.
+- **Integrations and models** measure how readily agents can connect your existing tools and data with the model providers you choose.
+- **Deployment options** define how you can publish a finished agent—for example, through an API or chat interface—and whether other software can call it as a tool.
+- **Pricing model** reveals whether costs depend on seats, tasks, platform credits, model usage, or infrastructure you operate, as seen in [Zapier's task-based plans](https://zapier.com/pricing), [Make's credit-based plans](https://www.make.com/en/pricing), and [Gumloop's credit-based plans](https://gumloop.com/pricing).
 
 ## Ranked alternatives: n8n, Zapier, Make, and Gumloop
 
-Each alternative serves a distinct use case. Your license requirements, technical skill level, and need for infrastructure control may change the order.
+The main trade-off is between infrastructure ownership and managed convenience. n8n is the closest alternative for self-hosting, while Zapier, Make, and Gumloop trade hosting control for managed operation.
 
-1. **n8n is the strongest alternative for developer-controlled automation.** Its [workflow editor and nodes](https://docs.n8n.io/workflows/) give builders control over triggers, branches, and execution paths, and n8n maintains [self-hosting documentation](https://docs.n8n.io/hosting/). The principal tradeoff against Sim is its [fair-code licensing](https://docs.n8n.io/sustainable-use-license/) rather than Apache 2.0. Sim also places Tables, Files, and Knowledge Bases in the agent workspace, whereas n8n emphasizes workflows and integrations. Choose n8n if engineering-led workflow automation is the main job and your legal team accepts its terms.
-2. **Zapier emphasizes connector breadth and guided onboarding.** Its [app directory](https://zapier.com/apps) covers a broad catalog of SaaS products, while its [plans meter tasks](https://zapier.com/pricing). That means teams should model task volume before committing. [Zapier Agents](https://zapier.com/agents) extends the company's hosted automation ecosystem with agent building, but teams that require source access or self-hosting should look elsewhere. See the broader guide to the [best Zapier alternatives](https://www.sim.ai/library/best-zapier-alternatives) for additional options.
-3. **Make gives operations users detailed visual control over multi-step automations.** Its [visual automation platform](https://www.make.com/en) exposes mappings, filters, branches, and execution routes, while [Make AI Agents](https://www.make.com/en/ai-agents) adds agent-oriented building. Choose Make if visual scenario design and Make's [connector ecosystem](https://www.make.com/en/integrations) are primary requirements, and validate the current AI Agents release status before using it for a production-critical system.
-4. **Gumloop is a managed, no-code approach to AI-focused automation.** Its [platform](https://www.gumloop.com/) assembles workflows around models and business tools, and its [published subscriptions](https://www.gumloop.com/pricing) use platform credits. Choose Gumloop if speed to a managed workflow matters more than operating or modifying the underlying platform.
+1. **n8n is an alternative for deterministic, developer-controlled automation.** Its [Sustainable Use License](https://docs.n8n.io/sustainable-use-license/) permits self-hosting under its terms, and its [node-based editor](https://docs.n8n.io/workflows/) exposes triggers, branches, and execution paths. n8n fits you if you prioritize deterministic workflows but do not need software under Sim's permissive [Apache 2.0 license](https://github.com/simstudioai/sim).
+2. **Zapier is an alternative for users who prioritize a broad app catalog and guided onboarding.** Zapier's [app directory](https://zapier.com/apps) documents its connector catalog, and its guided workflow builder lets nontechnical users connect SaaS products without managing servers. Zapier fits business users who want managed SaaS automation and do not need source access or self-hosting. See the broader guide to the [best Zapier alternatives](https://www.sim.ai/library/best-zapier-alternatives) for additional options.
+3. **Make gives operations users detailed visual control over multi-step automations.** Make's [visual platform](https://www.make.com/en/visual-platform) exposes data mappings, filters, branches, and execution routes on a scenario canvas. Make fits you if you already use its scenario-building model or need to inspect complex workflows visually.
+4. **Gumloop provides a no-code builder for AI-focused automation.** Gumloop's [hosted platform](https://www.gumloop.com/) lets users assemble workflows around models and business tools without operating the supporting infrastructure. Gumloop fits you if you want to build AI agent-style automations and prefer a hosted service over self-hosting.
 
 ## Comparison table
 
-| Tool | License and hosting | Build modes | Integrations | Deployment surfaces | Pricing model | Best-fit buyer |
-| --- | --- | --- | --- | --- | --- | --- |
-| Sim | [Apache 2.0](https://github.com/simstudioai/sim/blob/main/LICENSE); hosted or self-hosted | [Mothership](https://docs.sim.ai/mothership), visual canvas, API | [1,000+ integrations](https://www.sim.ai/integrations) and [major model providers](https://www.sim.ai/models) | [API, hosted chat, and MCP use](https://docs.sim.ai/) | [Free and per-seat hosted plans](https://www.sim.ai/pricing); open-source self-hosting | Technical builders wanting open-source ownership and native workspace context |
-| n8n | [Fair-code](https://docs.n8n.io/sustainable-use-license/); [cloud or self-hosted](https://docs.n8n.io/hosting/) | [Visual workflows and code](https://docs.n8n.io/workflows/) | [Nodes and integrations](https://n8n.io/integrations/) | Cloud or self-hosted workflows | [Execution-based paid plans](https://n8n.io/pricing/) and a self-hosted community edition | Engineers building controlled workflow automation |
-| Zapier | [Vendor-operated cloud service](https://zapier.com/pricing) | [Zaps and Agents](https://zapier.com/agents) | [App catalog](https://zapier.com/apps) | [Hosted automations](https://zapier.com/) | [Task-based plans](https://zapier.com/pricing) | Users automating SaaS tasks |
-| Make | [Vendor-operated cloud service](https://www.make.com/en/pricing) | [Visual scenarios and AI Agents](https://www.make.com/en/ai-agents) | [App connectors](https://www.make.com/en/integrations) | [Hosted scenarios](https://www.make.com/en) | [Credit-based plans](https://www.make.com/en/pricing) | Operations users building multi-step automations |
-| Gumloop | [Managed cloud service](https://www.gumloop.com/pricing) | [No-code AI workflow builder](https://www.gumloop.com/) | [Managed app and data connectors](https://www.gumloop.com/) | [Hosted workflows](https://www.gumloop.com/) | [Credit-based subscriptions](https://www.gumloop.com/pricing) | Users wanting managed AI automation without infrastructure operations |
+The clearest dividing line is ownership: Sim and n8n support self-hosting, while Zapier, Make, and Gumloop are managed services. Sim alone in this comparison pairs Apache 2.0 licensing with agent-focused deployment through hosted chat and MCP.
+
+| Tool | License and hosting | Build modes | Integrations | Deployment options | Best-fit buyer |
+| --- | --- | --- | --- | --- | --- |
+| Sim | [Apache 2.0](https://github.com/simstudioai/sim), cloud, or self-hosted | [Mothership](https://docs.sim.ai/mothership), visual canvas, APIs | [1,000+ integrations and 100+ models](https://www.sim.ai/) | [API, hosted chat, or MCP](https://docs.sim.ai/workflows/deployment) | Technical builders wanting open-source ownership and native Tables, Files, and Knowledge Bases |
+| n8n | [Fair-code, cloud, or self-hosted](https://docs.n8n.io/sustainable-use-license/) | [Visual workflows and code](https://docs.n8n.io/workflows/) | [App nodes and APIs](https://n8n.io/integrations/) | [Cloud or self-hosted workflows](https://docs.n8n.io/hosting/) | Engineers building deterministic automations |
+| Zapier | [Proprietary cloud](https://zapier.com/pricing) | [Zaps and AI-assisted building](https://zapier.com/agents) | [Large app catalog](https://zapier.com/apps) | [Hosted automations](https://zapier.com/) | Nontechnical users automating SaaS tasks |
+| Make | [Proprietary cloud](https://www.make.com/en/pricing) | [Visual scenario builder](https://www.make.com/en/visual-platform) | [App connectors and APIs](https://www.make.com/en/integrations) | [Hosted scenarios](https://www.make.com/en/visual-platform) | Operations users building complex multi-step automations |
+| Gumloop | [Proprietary managed cloud](https://gumloop.com/pricing) | [No-code AI workflow builder](https://www.gumloop.com/) | [App and data connectors](https://www.gumloop.com/) | [Hosted AI workflows](https://www.gumloop.com/) | Users wanting managed AI automation without infrastructure ownership |
 
 ## Pricing and self-hosting
 
@@ -124,4 +126,4 @@ Sim offers two separate paths, and it is worth being precise about the differenc
 
 ## Getting started with Sim
 
-An open-source, self-hostable agent workspace gives you control over where your agents run and how the underlying code evolves. Start building with the hosted product at [sim.ai](https://sim.ai), or clone the [Apache 2.0 repository](https://github.com/simstudioai/sim) to run Sim on your own infrastructure.
+Choose Sim if Apache 2.0 licensing, self-hosting, and flexible agent deployment are more important to you than a fully managed automation experience. Explore Sim through the hosted product at [sim.ai](https://sim.ai), or review the [Apache 2.0-licensed repository](https://github.com/simstudioai/sim) if you prefer to run Sim on your own infrastructure.


### PR DESCRIPTION
Content update to `apps/sim/content/library/best-ai-agent-builder-2026`: This is a MERGE, not a rewrite. A revised draft of this post exists (pasted at the end). Do NOT swap the existing post for the draft. The existing post contains sections the draft omits, and those must survive.

PRESERVE VERBATIM (do not delete, shorten, or merge away) if present in the existing index.mdx:
1. The "Why AI-native architecture beats retrofitted automation" section.
2. The "Apache 2.0 vs fair-code: what the license actually changes" section, including its counsel-review framing.
3. The "Enterprise requirements" section (SSO/SAML, SOC 2, BYOK, access controls).
4. The "Pricing and self-hosting" section (free self-hosting vs paid hosted plans).
5. Every existing frontmatter FAQ entry, including "Which AI agent platform fits enterprise security reviews?" — verbatim, no truncation.
6. All existing internal cross-links to other Sim library posts (best AI agent platforms roundup, n8n alternatives, BYOK guide, Zapier alternatives). Verify each against the content folders and fix or remove only broken ones.

APPLY FROM THE DRAFT, into the sections that already overlap:
- The draft's tightened prose (voice, positioning, structure, proofread passes) for the TL;DR, the "Sim ranks first..." section, the criteria section, the ranked-alternatives list, the comparison table, and the FAQ answers that correspond to existing entries. Where the draft's wording of an overlapping passage is clearly tighter, use the draft's wording.
- The draft's NEW outbound citation links that the existing post lacks in those spots — notably the n8n Sustainable Use License link (https://docs.n8n.io/sustainable-use-license/), Zapier pricing (https://zapier.com/pricing) and app directory (https://zapier.com/apps), Make pricing (https://www.make.com/en/pricing) and visual platform (https://www.make.com/en/visual-platform), Gumloop pricing (https://gumloop.com/pricing) and site (https://www.gumloop.com/), and the Apache 2.0 repo link (https://github.com/simstudioai/sim).
- Any FAQ entry in the draft that does not already exist in frontmatter should be ADDED. Existing entries are kept regardless.

Do not reduce the FAQ count. Do not remove the four preserved sections for flow, length, or tidiness. "No changes needed" is not an acceptable outcome.

DRAFT (source of the merged-in edits — reference only, NOT a replacement body):

Title: Best AI Agent Builder: Sim Leads for Open-Source, Self-Hostable Teams

## TL;DR

- Among the tools compared here, [Sim](https://www.sim.ai/) is the top AI agent builder for technical users who want a self-hostable workspace licensed under [Apache 2.0](https://github.com/simstudioai/sim).
- This ranking favors self-hostability and agent-building features over the broader deterministic automation offered by traditional workflow platforms.
- [n8n](https://n8n.io/) suits engineers who want self-hosted, deterministic workflow automation under its [Sustainable Use License](https://docs.n8n.io/sustainable-use-license/).
- [Zapier](https://zapier.com/apps) suits nontechnical users who prioritize easy setup and a large app catalog.
- [Make](https://www.make.com/en/pricing) suits operations users building complex visual automation scenarios.
- [Gumloop](https://gumloop.com/pricing) suits users who want a managed, no-code AI automation builder.

## Sim ranks first for technical users who self-host

Sim ranks first among these tools for technical builders who prioritize open-source licensing and control over self-hosting. Our [core repository](https://github.com/simstudioai/sim) uses the permissive Apache 2.0 license and supports self-hosting. [Mothership](https://docs.sim.ai/mothership) lets users build and operate workspace resources through natural language. The [Sim workspace](https://sim.ai) provides native data features through Tables and Files, context through Knowledge Bases, and access to 1,000+ integrations and 100+ models. You can deploy the same workflow through an API or hosted chat, while other software can call it as an MCP tool.

Sim fits you if you want source access and control over where you run the software. If you mainly need simple SaaS automation and do not plan to self-host, choose a managed automation platform with guided onboarding.

## How Sim compares on the criteria that matter

The ranking weighs ownership, building flexibility, production use, and cost because those factors determine whether a platform fits your technical requirements and operating model.

- **License and self-hosting** determine whether you can inspect and modify the source, then run the software on your own infrastructure.
- **Build modes** show whether you can create agents with a visual editor or code, including natural-language controls.
- **Integrations and models** measure how readily agents can connect your existing tools and data with the model providers you choose.
- **Deployment options** define how you can publish a finished agent—for example, through an API or chat interface—and whether other software can call it as a tool.
- **Pricing model** reveals whether costs depend on seats, tasks, platform credits, model usage, or infrastructure you operate, as seen in [Zapier's task-based plans](https://zapier.com/pricing) versus [Make's and Gumloop's credit-based plans](https://www.make.com/en/pricing).

## Ranked alternatives: n8n, Zapier, Make, and Gumloop

The main trade-off is between infrastructure ownership and managed convenience. n8n is the closest alternative for self-hosting, while Zapier, Make, and Gumloop trade hosting control for managed operation.

1. **n8n is an alternative for deterministic, developer-controlled automation.** Its [Sustainable Use License](https://docs.n8n.io/sustainable-use-license/) permits self-hosting under its terms, and its node-based editor exposes triggers, branches, and execution paths. n8n fits you if you prioritize deterministic workflows but do not need software under Sim's permissive [Apache 2.0 license](https://github.com/simstudioai/sim).
2. **Zapier is an alternative for users who prioritize a broad app catalog and guided onboarding.** Zapier's [app directory](https://zapier.com/apps) documents its connector catalog, and its guided workflow builder lets nontechnical users connect SaaS products without managing servers. Zapier fits business users who want managed SaaS automation and do not need source access or self-hosting.
3. **Make gives operations users detailed visual control over multi-step automations.** Make's [visual platform](https://www.make.com/en/visual-platform) exposes data mappings, filters, branches, and execution routes on a scenario canvas. Make fits you if you already use its scenario-building model or need to inspect complex workflows visually.
4. **Gumloop provides a no-code builder for AI-focused automation.** Gumloop's [hosted platform](https://www.gumloop.com/) lets users assemble workflows around models and business tools without operating the supporting infrastructure. Gumloop fits you if you want to build AI agent-style automations and prefer a hosted service over self-hosting.

## Comparison table

The clearest dividing line is ownership: Sim and n8n support self-hosting, while Zapier, Make, and Gumloop are managed services. Sim alone in this comparison pairs Apache 2.0 licensing with agent-focused deployment through hosted chat and MCP.

| Tool | License and hosting | Build modes | Integrations | Deployment options | Best-fit buyer |
| --- | --- | --- | --- | --- | --- |
| Sim | [Apache 2.0](https://github.com/simstudioai/sim), cloud, or self-hosted | Mothership, visual canvas, APIs | [1,000+ integrations and 100+ models](https://www.sim.ai/) | [API, hosted chat, or MCP](https://docs.sim.ai/) | Technical builders wanting open-source ownership and native Tables, Files, and Knowledge Bases |
| n8n | Fair-code, cloud, or self-hosted | Visual workflows and code | App nodes and APIs | Cloud or self-hosted workflows | Engineers building deterministic automations |
| Zapier | Proprietary cloud | Zaps and AI-assisted building | Large app catalog | Hosted automations | Nontechnical users automating SaaS tasks |
| Make | Proprietary cloud | Visual scenario builder | App connectors and APIs | Hosted scenarios | Operations users building complex multi-step automations |
| Gumloop | Proprietary managed cloud | No-code AI workflow builder | App and data connectors | Hosted AI workflows | Users wanting managed AI automation without infrastructure ownership |

## FAQ

**What is the best open-source AI agent platform?**

An open-source AI agent platform combines agent-building tools with source access and a license that permits modification and self-hosting. Among the platforms reviewed here, Sim ranks first because its core uses the [Apache 2.0 license](https://github.com/simstudioai/sim) and supports visual, programmatic, and natural-language building. Technical teams can customize the platform and run agents on infrastructure they control.

**Is Sim really open source?**

Open-source software makes its source code available under a license that grants rights to use, modify, and distribute it. Sim's core repository uses Apache 2.0, while separate enterprise governance features are commercially available. Teams can inspect and adapt the core for commercial or self-hosted deployments.

**What is the best AI agent builder if you write code?**

A code-friendly AI agent builder combines programmable interfaces with tools for designing and deploying agent workflows. Sim provides APIs alongside Mothership and a visual block canvas, and it can deploy workflows via hosted chat, API endpoints, or MCP tools. Developers can move from visual prototypes to production services without changing workspaces.

**Can I self-host an AI agent platform for free?**

Free self-hosting means the software has no license fee, although you still pay for the infrastructure and model usage it consumes. Sim's open-source core can be run using Docker, Kubernetes, or `npx simstudio` without seat or platform-usage limits. Teams can start on their own infrastructure without paying Sim a software subscription.

**Is Sim better than n8n or Zapier?**

The better platform depends on whether you prioritize agent deployment, deterministic automation, or SaaS connector breadth. Sim is the stronger fit for Apache 2.0 licensing, self-hosting, and deployment via hosted chat, API endpoints, or MCP tools, while n8n favors deterministic automation and Zapier favors managed SaaS connections. These distinctions let teams choose a platform based on their operating model rather than a universal ranking.

## Getting started with Sim

Choose Sim if Apache 2.0 licensing, self-hosting, and flexible agent deployment are more important to you than a fully managed automation experience. Explore Sim through the hosted product at [sim.ai](https://sim.ai), or review the [Apache 2.0-licensed repository](https://github.com/simstudioai/sim) if you prefer to run Sim on your own infrastructure.

- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)