### PR TITLE
fix(integrations): validate runtime values the type system only claims to constrain

### DIFF
--- a/apps/sim/lib/internal/cbinsights/operations/chat.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/chat.ts
@@ -6,12 +6,13 @@ import {
   asStringArray,
   cbInsightsRequest,
   compactBody,
+  parseOptionalStringParam,
 } from '@/tools/cbinsights/utils'
 
 export const executeCbinsightsChatOperation: InternalToolOperationImplementation<
   CbInsightsChatParams
 > = async (params, signal) => {
-  const message = params.message?.trim()
+  const message = parseOptionalStringParam(params.message, 'message')
   if (!message) throw new Error('CB Insights "message" is required')
 
   return cbInsightsRequest<{
@@ -25,7 +26,7 @@ export const executeCbinsightsChatOperation: InternalToolOperationImplementation
     params,
     {
       path: '/v2/chatcbi',
-      body: compactBody({ message, chatID: params.chatId?.trim() }),
+      body: compactBody({ message, chatID: parseOptionalStringParam(params.chatId, 'chatId') }),
     },
     (data) => ({
       chatId: asString(data.chatID),

--- a/apps/sim/lib/internal/cbinsights/operations/get-exit-probability-history.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/get-exit-probability-history.ts
@@ -5,6 +5,7 @@ import {
   asString,
   cbInsightsRequest,
   compactBody,
+  parseOptionalStringParam,
   requireOrgId,
 } from '@/tools/cbinsights/utils'
 
@@ -17,8 +18,8 @@ export const executeCbinsightsGetExitProbabilityHistoryOperation: InternalToolOp
     {
       path: `/v2/organizations/${orgId}/exitprobabilityhistory`,
       body: compactBody({
-        startDate: params.startDate?.trim(),
-        endDate: params.endDate?.trim(),
+        startDate: parseOptionalStringParam(params.startDate, 'startDate'),
+        endDate: parseOptionalStringParam(params.endDate, 'endDate'),
       }),
     },
     (data) => ({

--- a/apps/sim/lib/internal/cbinsights/operations/get-mosaic-history.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/get-mosaic-history.ts
@@ -1,6 +1,12 @@
 import type { InternalToolOperationImplementation } from '@/lib/internal/tool-operations/types'
 import type { CbInsightsMosaicHistoryParams } from '@/tools/cbinsights/get_mosaic_history'
-import { asArray, cbInsightsRequest, compactBody, requireOrgId } from '@/tools/cbinsights/utils'
+import {
+  asArray,
+  cbInsightsRequest,
+  compactBody,
+  parseOptionalStringParam,
+  requireOrgId,
+} from '@/tools/cbinsights/utils'
 
 export const executeCbinsightsGetMosaicHistoryOperation: InternalToolOperationImplementation<
   CbInsightsMosaicHistoryParams
@@ -16,7 +22,7 @@ export const executeCbinsightsGetMosaicHistoryOperation: InternalToolOperationIm
     params,
     {
       path: `/v2/organizations/${orgId}/mosaichistory`,
-      body: compactBody({ startDate: params.startDate?.trim() }),
+      body: compactBody({ startDate: parseOptionalStringParam(params.startDate, 'startDate') }),
     },
     (data) => ({
       overall: asArray(data.overall),

--- a/apps/sim/lib/internal/cbinsights/operations/get-org-fundings.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/get-org-fundings.ts
@@ -6,6 +6,7 @@ import {
   clampLimit,
   compactBody,
   pageInfo,
+  parseOptionalStringParam,
   requireOrgId,
 } from '@/tools/cbinsights/utils'
 
@@ -25,7 +26,7 @@ export const executeCbinsightsGetOrgFundingsOperation: InternalToolOperationImpl
       path: `/v2/organizations/${orgId}/financialtransactions/fundings`,
       body: compactBody({
         limit: clampLimit(params.limit),
-        nextPageToken: params.nextPageToken?.trim(),
+        nextPageToken: parseOptionalStringParam(params.nextPageToken, 'nextPageToken'),
       }),
     },
     (data) => ({

--- a/apps/sim/lib/internal/cbinsights/operations/get-org-investments.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/get-org-investments.ts
@@ -6,6 +6,7 @@ import {
   clampLimit,
   compactBody,
   pageInfo,
+  parseOptionalStringParam,
   requireOrgId,
 } from '@/tools/cbinsights/utils'
 
@@ -24,7 +25,7 @@ export const executeCbinsightsGetOrgInvestmentsOperation: InternalToolOperationI
       path: `/v2/organizations/${orgId}/financialtransactions/investments`,
       body: compactBody({
         limit: clampLimit(params.limit),
-        nextPageToken: params.nextPageToken?.trim(),
+        nextPageToken: parseOptionalStringParam(params.nextPageToken, 'nextPageToken'),
       }),
     },
     (data) => ({ investments: asArray(data.investments), ...pageInfo(data) }),

--- a/apps/sim/lib/internal/cbinsights/operations/list-business-relationships.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/list-business-relationships.ts
@@ -5,6 +5,7 @@ import {
   asString,
   cbInsightsRequest,
   compactBody,
+  parseOptionalStringParam,
   requireOrgIds,
 } from '@/tools/cbinsights/utils'
 
@@ -17,7 +18,7 @@ export const executeCbinsightsListBusinessRelationshipsOperation: InternalToolOp
       path: '/v2/businessrelationships',
       body: compactBody({
         orgIds: requireOrgIds(params.orgIds),
-        nextPageToken: params.nextPageToken?.trim(),
+        nextPageToken: parseOptionalStringParam(params.nextPageToken, 'nextPageToken'),
       }),
     },
     (data) => ({ orgs: asArray(data.orgs), nextPageToken: asString(data.nextPageToken) }),

--- a/apps/sim/lib/internal/cbinsights/operations/list-fundings.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/list-fundings.ts
@@ -6,6 +6,7 @@ import {
   clampLimit,
   compactBody,
   pageInfo,
+  parseOptionalStringParam,
   requireOrgIds,
 } from '@/tools/cbinsights/utils'
 
@@ -24,7 +25,7 @@ export const executeCbinsightsListFundingsOperation: InternalToolOperationImplem
       body: compactBody({
         orgIds: requireOrgIds(params.orgIds),
         limit: clampLimit(params.limit),
-        nextPageToken: params.nextPageToken?.trim(),
+        nextPageToken: parseOptionalStringParam(params.nextPageToken, 'nextPageToken'),
       }),
     },
     (data) => ({ orgs: asArray(data.orgs), ...pageInfo(data) }),

--- a/apps/sim/lib/internal/cbinsights/operations/list-investments.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/list-investments.ts
@@ -6,6 +6,7 @@ import {
   clampLimit,
   compactBody,
   pageInfo,
+  parseOptionalStringParam,
   requireOrgIds,
 } from '@/tools/cbinsights/utils'
 
@@ -24,7 +25,7 @@ export const executeCbinsightsListInvestmentsOperation: InternalToolOperationImp
       body: compactBody({
         orgIds: requireOrgIds(params.orgIds),
         limit: clampLimit(params.limit),
-        nextPageToken: params.nextPageToken?.trim(),
+        nextPageToken: parseOptionalStringParam(params.nextPageToken, 'nextPageToken'),
       }),
     },
     (data) => ({ orgs: asArray(data.orgs), ...pageInfo(data) }),

--- a/apps/sim/lib/internal/cbinsights/operations/list-portfolio-exits.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/list-portfolio-exits.ts
@@ -6,6 +6,7 @@ import {
   clampLimit,
   compactBody,
   pageInfo,
+  parseOptionalStringParam,
   requireOrgIds,
 } from '@/tools/cbinsights/utils'
 
@@ -24,7 +25,7 @@ export const executeCbinsightsListPortfolioExitsOperation: InternalToolOperation
       body: compactBody({
         orgIds: requireOrgIds(params.orgIds),
         limit: clampLimit(params.limit),
-        nextPageToken: params.nextPageToken?.trim(),
+        nextPageToken: parseOptionalStringParam(params.nextPageToken, 'nextPageToken'),
       }),
     },
     (data) => ({ orgs: asArray(data.orgs), ...pageInfo(data) }),

--- a/apps/sim/lib/internal/cbinsights/operations/lookup-organizations.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/lookup-organizations.ts
@@ -6,6 +6,7 @@ import {
   clampLimit,
   compactBody,
   pageInfo,
+  parseOptionalStringParam,
   parseStringListParam,
 } from '@/tools/cbinsights/utils'
 
@@ -14,7 +15,7 @@ export const executeCbinsightsLookupOrganizationsOperation: InternalToolOperatio
 > = async (params, signal) => {
   const names = parseStringListParam(params.names, 'names')
   const urls = parseStringListParam(params.urls, 'urls')
-  const profileUrl = params.profileUrl?.trim()
+  const profileUrl = parseOptionalStringParam(params.profileUrl, 'profileUrl')
 
   if (!names && !urls && !profileUrl) {
     throw new Error('CB Insights lookup requires at least one of "names", "urls", or "profileUrl"')
@@ -39,7 +40,7 @@ export const executeCbinsightsLookupOrganizationsOperation: InternalToolOperatio
         urls,
         profileUrl,
         limit: clampLimit(params.limit),
-        nextPageToken: params.nextPageToken?.trim(),
+        nextPageToken: parseOptionalStringParam(params.nextPageToken, 'nextPageToken'),
       }),
     },
     (data) => ({ orgs: asArray(data.orgs), ...pageInfo(data) }),

--- a/apps/sim/lib/internal/cbinsights/operations/rag.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/rag.ts
@@ -1,13 +1,18 @@
 import type { InternalToolOperationImplementation } from '@/lib/internal/tool-operations/types'
 import type { CbInsightsRagParams } from '@/tools/cbinsights/rag'
-import { asString, asStringArray, cbInsightsRequest } from '@/tools/cbinsights/utils'
+import {
+  asString,
+  asStringArray,
+  cbInsightsRequest,
+  parseOptionalStringParam,
+} from '@/tools/cbinsights/utils'
 
 export const executeCbinsightsRagOperation: InternalToolOperationImplementation<
   CbInsightsRagParams
 > = async (params, signal) => {
-  const message = params.message?.trim()
+  const message = parseOptionalStringParam(params.message, 'message')
   if (!message) throw new Error('CB Insights "message" is required')
-  if (message.length > 10_000) {
+  if (message.length >= 10_000) {
     throw new Error('CB Insights "message" must be under 10,000 characters')
   }
 

--- a/apps/sim/lib/internal/cbinsights/operations/search-firmographics.ts
+++ b/apps/sim/lib/internal/cbinsights/operations/search-firmographics.ts
@@ -12,6 +12,7 @@ import {
   parseIntegerParam,
   parseNumberParam,
   parseOptionalOrgIds,
+  parseOptionalStringParam,
   parseStringListParam,
 } from '@/tools/cbinsights/utils'
 
@@ -19,7 +20,7 @@ export const executeCbinsightsSearchFirmographicsOperation: InternalToolOperatio
   CbInsightsFirmographicsParams
 > = async (params, signal) => {
   const filters = compactBody({
-    keyword: params.keyword?.trim(),
+    keyword: parseOptionalStringParam(params.keyword, 'keyword'),
     orgIds: parseOptionalOrgIds(params.orgIds),
     orgNames: parseStringListParam(params.orgNames, 'orgNames'),
     urls: parseStringListParam(params.urls, 'urls'),
@@ -67,8 +68,8 @@ export const executeCbinsightsSearchFirmographicsOperation: InternalToolOperatio
       params.maxValuationInMillions,
       'maxValuationInMillions'
     ),
-    minLastFundingDate: params.minLastFundingDate?.trim(),
-    maxLastFundingDate: params.maxLastFundingDate?.trim(),
+    minLastFundingDate: parseOptionalStringParam(params.minLastFundingDate, 'minLastFundingDate'),
+    maxLastFundingDate: parseOptionalStringParam(params.maxLastFundingDate, 'maxLastFundingDate'),
     vcBacked: parseBooleanParam(params.vcBacked, 'vcBacked'),
   })
 
@@ -86,13 +87,13 @@ export const executeCbinsightsSearchFirmographicsOperation: InternalToolOperatio
     ...filters,
     ...compactBody({
       limit: clampLimit(params.limit),
-      nextPageToken: params.nextPageToken?.trim(),
+      nextPageToken: parseOptionalStringParam(params.nextPageToken, 'nextPageToken'),
     }),
   }
 
   /* The API takes one sort object; the block exposes it as two plain fields
        so neither has to be typed as JSON. */
-  const sortField = params.sortField?.trim()
+  const sortField = parseOptionalStringParam(params.sortField, 'sortField')
   if (sortField) {
     body.sort = { field: sortField, direction: sortDirection(params.sortDirection) }
   }

--- a/apps/sim/lib/internal/managed-agent/operations/respond-tool-confirmation.ts
+++ b/apps/sim/lib/internal/managed-agent/operations/respond-tool-confirmation.ts
@@ -1,7 +1,7 @@
 import { getErrorMessage } from '@sim/utils/errors'
 import type { InternalToolOperationImplementation } from '@/lib/internal/tool-operations/types'
 import { sendToolConfirmations } from '@/lib/managed-agents/session-client'
-import { normalizeStringList } from '@/tools/managed_agent/normalizers'
+import { normalizeScalarText, normalizeStringList } from '@/tools/managed_agent/normalizers'
 import { resolveSessionTarget } from '@/tools/managed_agent/shared'
 import type {
   ManagedAgentToolConfirmationParams,
@@ -17,7 +17,7 @@ export const executeManagedAgentRespondToolConfirmationOperation: InternalToolOp
     return { success: false, output: emptyOutput, error: target.error }
   }
 
-  const decision = (params.decision ?? '').toString().trim().toLowerCase()
+  const decision = normalizeScalarText(params.decision).toLowerCase()
   if (decision !== 'allow' && decision !== 'deny') {
     return {
       success: false,
@@ -36,10 +36,7 @@ export const executeManagedAgentRespondToolConfirmationOperation: InternalToolOp
     }
   }
 
-  /* Coerced the same way `decision` is above: this runs outside the try below, so a
-     non-string arriving from a stored workflow would throw past every `success: false`
-     path this operation otherwise returns. */
-  const denyMessage = (params.denyMessage ?? '').toString().trim()
+  const denyMessage = normalizeScalarText(params.denyMessage)
   try {
     await sendToolConfirmations({
       apiKey: target.apiKey,

--- a/apps/sim/lib/internal/managed-agent/operations/respond-tool-confirmation.ts
+++ b/apps/sim/lib/internal/managed-agent/operations/respond-tool-confirmation.ts
@@ -36,7 +36,10 @@ export const executeManagedAgentRespondToolConfirmationOperation: InternalToolOp
     }
   }
 
-  const denyMessage = params.denyMessage?.trim()
+  /* Coerced the same way `decision` is above: this runs outside the try below, so a
+     non-string arriving from a stored workflow would throw past every `success: false`
+     path this operation otherwise returns. */
+  const denyMessage = (params.denyMessage ?? '').toString().trim()
   try {
     await sendToolConfirmations({
       apiKey: target.apiKey,

--- a/apps/sim/tools/cbinsights/cbinsights.test.ts
+++ b/apps/sim/tools/cbinsights/cbinsights.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { executeCbinsightsChatOperation } from '@/lib/internal/cbinsights/operations/chat'
 import { executeCbinsightsGetCommercialMaturityHistoryOperation } from '@/lib/internal/cbinsights/operations/get-commercial-maturity-history'
+import { executeCbinsightsGetExitProbabilityHistoryOperation } from '@/lib/internal/cbinsights/operations/get-exit-probability-history'
 import { executeCbinsightsGetOrgFundingsOperation } from '@/lib/internal/cbinsights/operations/get-org-fundings'
 import { executeCbinsightsGetOrgOutlookOperation } from '@/lib/internal/cbinsights/operations/get-org-outlook'
 import { executeCbinsightsListBusinessRelationshipsOperation } from '@/lib/internal/cbinsights/operations/list-business-relationships'
@@ -687,5 +688,68 @@ describe('cbinsights model-input projection', () => {
   it('leaves the ID-only endpoints unprojected', () => {
     expect(cbinsightsGetScoutingReportTool.operation.modelInput).toBeUndefined()
     expect(cbinsightsSearchFirmographicsTool.operation.modelInput).toBeUndefined()
+  })
+})
+
+describe('cbinsights non-text runtime values', () => {
+  /*
+   * `params.x?.trim()` guards `undefined`, not the type: a block-to-block reference
+   * resolving to a number reached `.trim()` and threw a bare TypeError naming no
+   * parameter. The sibling history operation already used parseOptionalStringParam.
+   */
+  it('names the offending date parameter instead of throwing a TypeError', async () => {
+    mockFetch([AUTH_OK])
+    await expect(
+      executeCbinsightsGetExitProbabilityHistoryOperation({
+        ...CREDS,
+        orgId: 123,
+        startDate: 20240101,
+      } as never)
+    ).rejects.toThrow('CB Insights "startDate" must be a string')
+  })
+
+  it('names a non-text keyword on search rather than crashing', async () => {
+    mockFetch([AUTH_OK])
+    await expect(
+      executeCbinsightsSearchFirmographicsOperation({ ...CREDS, keyword: { a: 1 } } as never)
+    ).rejects.toThrow('CB Insights "keyword" must be a string')
+  })
+
+  it('names a non-text page token rather than crashing', async () => {
+    mockFetch([AUTH_OK])
+    await expect(
+      executeCbinsightsListFundingsOperation({
+        ...CREDS,
+        orgIds: '123',
+        nextPageToken: 42,
+      } as never)
+    ).rejects.toThrow('CB Insights "nextPageToken" must be a string')
+  })
+
+  it('still treats a blank optional value as omitted, exactly as before', async () => {
+    mockFetch([AUTH_OK, { body: {} }])
+    await executeCbinsightsGetExitProbabilityHistoryOperation({
+      ...CREDS,
+      orgId: 123,
+      startDate: '   ',
+    } as never)
+    expect(JSON.parse(String(calls[1].init.body))).not.toHaveProperty('startDate')
+  })
+})
+
+describe('cbinsights rag message bound', () => {
+  /* The tool description and this error both say "under 10,000", so the guard must
+     reject the boundary value rather than forward it. */
+  it('rejects a message of exactly 10,000 characters', async () => {
+    mockFetch([AUTH_OK])
+    await expect(
+      executeCbinsightsRagOperation({ ...CREDS, message: 'a'.repeat(10_000) } as never)
+    ).rejects.toThrow('CB Insights "message" must be under 10,000 characters')
+  })
+
+  it('accepts the largest message the contract allows', async () => {
+    mockFetch([AUTH_OK, { body: { data: 'ok' } }])
+    await executeCbinsightsRagOperation({ ...CREDS, message: 'a'.repeat(9_999) } as never)
+    expect(JSON.parse(String(calls[1].init.body)).message).toHaveLength(9_999)
   })
 })

--- a/apps/sim/tools/datadog/cancel_downtime.ts
+++ b/apps/sim/tools/datadog/cancel_downtime.ts
@@ -1,5 +1,5 @@
 import type { CancelDowntimeParams, CancelDowntimeResponse } from '@/tools/datadog/types'
-import { datadogErrorMessage, datadogPathSegment } from '@/tools/datadog/utils'
+import { datadogErrorMessage, datadogPathSegment, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const cancelDowntimeTool: ToolConfig<CancelDowntimeParams, CancelDowntimeResponse> = {
@@ -37,7 +37,7 @@ export const cancelDowntimeTool: ToolConfig<CancelDowntimeParams, CancelDowntime
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       const downtimeId = datadogPathSegment(params.downtimeId)
       return `https://api.${site}/api/v2/downtime/${downtimeId}`
     },

--- a/apps/sim/tools/datadog/create_downtime.ts
+++ b/apps/sim/tools/datadog/create_downtime.ts
@@ -3,7 +3,12 @@ import type {
   CreateDowntimeResponse,
   DowntimeAttributes,
 } from '@/tools/datadog/types'
-import { datadogErrorMessage, parseMonitorIds, splitCommaList } from '@/tools/datadog/utils'
+import {
+  datadogErrorMessage,
+  parseMonitorIds,
+  resolveDatadogSite,
+  splitCommaList,
+} from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const createDowntimeTool: ToolConfig<CreateDowntimeParams, CreateDowntimeResponse> = {
@@ -85,7 +90,7 @@ export const createDowntimeTool: ToolConfig<CreateDowntimeParams, CreateDowntime
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       return `https://api.${site}/api/v2/downtime`
     },
     method: 'POST',

--- a/apps/sim/tools/datadog/create_event.ts
+++ b/apps/sim/tools/datadog/create_event.ts
@@ -4,7 +4,7 @@ import type {
   EventAlertType,
   EventPriority,
 } from '@/tools/datadog/types'
-import { datadogErrorMessage } from '@/tools/datadog/utils'
+import { datadogErrorMessage, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const createEventTool: ToolConfig<CreateEventParams, CreateEventResponse> = {
@@ -88,7 +88,7 @@ export const createEventTool: ToolConfig<CreateEventParams, CreateEventResponse>
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       return `https://api.${site}/api/v1/events`
     },
     method: 'POST',

--- a/apps/sim/tools/datadog/create_monitor.ts
+++ b/apps/sim/tools/datadog/create_monitor.ts
@@ -1,5 +1,5 @@
 import type { CreateMonitorParams, CreateMonitorResponse, MonitorType } from '@/tools/datadog/types'
-import { datadogErrorMessage, parseJsonParam } from '@/tools/datadog/utils'
+import { datadogErrorMessage, parseJsonParam, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const createMonitorTool: ToolConfig<CreateMonitorParams, CreateMonitorResponse> = {
@@ -77,7 +77,7 @@ export const createMonitorTool: ToolConfig<CreateMonitorParams, CreateMonitorRes
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       return `https://api.${site}/api/v1/monitor`
     },
     method: 'POST',

--- a/apps/sim/tools/datadog/datadog.test.ts
+++ b/apps/sim/tools/datadog/datadog.test.ts
@@ -18,12 +18,15 @@ import { queryLogsTool } from '@/tools/datadog/query_logs'
 import { queryTimeseriesTool } from '@/tools/datadog/query_timeseries'
 import { sendLogsTool } from '@/tools/datadog/send_logs'
 import { submitMetricsTool } from '@/tools/datadog/submit_metrics'
+import { DATADOG_SITES } from '@/tools/datadog/types'
 import { unmuteMonitorTool } from '@/tools/datadog/unmute_monitor'
 import { updateIncidentTool } from '@/tools/datadog/update_incident'
 import {
   buildSloPayload,
+  datadogApiUrl,
   datadogErrorMessage,
   mergeSloUpdatePayload,
+  resolveDatadogSite,
   splitCommaList,
 } from '@/tools/datadog/utils'
 
@@ -602,5 +605,50 @@ describe('undisclosed vendor limits and Sim defaults', () => {
     } as any)
 
     expect(body[0].ddsource).toBe('custom')
+  })
+})
+
+describe('datadog site is validated before it reaches the request host', () => {
+  /*
+   * `DatadogSite` is a compile-time union and is erased at runtime, so it kept
+   * nothing out of the URL. Every Datadog request carries DD-API-KEY and
+   * DD-APPLICATION-KEY, so an unchecked `site` chose where those were sent.
+   */
+  it('rejects an arbitrary host', () => {
+    expect(() => datadogApiUrl('evil.com' as never, '/api/v1/slo')).toThrow(
+      /Datadog "site" must be one of/
+    )
+  })
+
+  it('rejects a host smuggled in as userinfo', () => {
+    expect(() => datadogApiUrl('datadoghq.com@evil.com' as never, '/api/v1/slo')).toThrow(
+      /Datadog "site" must be one of/
+    )
+  })
+
+  it('rejects a value that would escape the host into a path', () => {
+    expect(() => datadogApiUrl('datadoghq.com/../..' as never, '/api/v1/slo')).toThrow(
+      /Datadog "site" must be one of/
+    )
+  })
+
+  it('defaults an absent site to US1 and keeps every published region', () => {
+    expect(datadogApiUrl(undefined, '/api/v1/slo')).toBe('https://api.datadoghq.com/api/v1/slo')
+    for (const site of DATADOG_SITES) {
+      expect(datadogApiUrl(site, '/x')).toBe(`https://api.${site}/x`)
+      expect(resolveDatadogSite(site)).toBe(site)
+    }
+  })
+
+  it('builds the logs intake host from the validated site', () => {
+    const url = sendLogsTool.request.url({
+      apiKey: 'k',
+      site: 'datadoghq.eu',
+      logs: '[]',
+    } as never)
+    expect(url).toBe('https://http-intake.logs.datadoghq.eu/api/v2/logs')
+    expect(() =>
+      sendLogsTool.request.url({ apiKey: 'k', site: 'evil.com', logs: '[]' } as never)
+    ).toThrow(/Datadog "site" must be one of/)
   })
 })

--- a/apps/sim/tools/datadog/datadog.test.ts
+++ b/apps/sim/tools/datadog/datadog.test.ts
@@ -3,6 +3,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { executeUpdateSloOperation } from '@/lib/internal/datadog/operations/update-slo'
+import * as datadogTools from '@/tools/datadog'
 import { cancelDowntimeTool } from '@/tools/datadog/cancel_downtime'
 import { createDowntimeTool } from '@/tools/datadog/create_downtime'
 import { createEventTool } from '@/tools/datadog/create_event'
@@ -650,5 +651,62 @@ describe('datadog site is validated before it reaches the request host', () => {
     expect(() =>
       sendLogsTool.request.url({ apiKey: 'k', site: 'evil.com', logs: '[]' } as never)
     ).toThrow(/Datadog "site" must be one of/)
+  })
+})
+
+describe('every Datadog tool routes its host through the allowlist', () => {
+  /*
+   * The first pass guarded only the shared `datadogApiUrl`; ten tools built the
+   * host inline from `params.site` and bypassed it entirely. Sweeping the registry
+   * rather than listing tools means a new tool that reintroduces an inline builder
+   * fails here instead of shipping an unguarded credentialed request.
+   */
+  const REQUIRED = {
+    monitorId: '1',
+    downtimeId: '1',
+    dashboardId: 'abc-def-ghi',
+    incidentId: '1',
+    sloId: 'abc',
+    signalId: 'abc',
+    testId: 'abc',
+    publicId: 'abc',
+    resultId: 'abc',
+    query: 'x',
+    from: '1',
+    to: '2',
+    logs: '[]',
+    metrics: '[]',
+    series: '[]',
+    title: 't',
+    text: 't',
+    name: 'n',
+    type: 'metric alert',
+    scope: '*',
+    start: '1',
+    end: '2',
+    testIds: 'a',
+  }
+
+  it('rejects an attacker-chosen site in every tool that builds a URL', () => {
+    const builders = Object.values(datadogTools).filter(
+      (tool) => typeof tool?.request?.url === 'function'
+    )
+    expect(builders.length).toBeGreaterThan(20)
+
+    const unguarded: string[] = []
+    for (const tool of builders) {
+      const params = { ...REQUIRED, apiKey: 'k', applicationKey: 'a', site: 'evil.com' }
+      try {
+        const url = String((tool.request as { url: (p: unknown) => string }).url(params))
+        if (!/^https:\/\/(api|http-intake\.logs)\.(datadoghq\.com|datadoghq\.eu)/.test(url)) {
+          unguarded.push(`${tool.id} -> ${url}`)
+        }
+      } catch (error) {
+        if (!/Datadog "site" must be one of/.test(String(error))) {
+          unguarded.push(`${tool.id} -> ${String(error)}`)
+        }
+      }
+    }
+    expect(unguarded).toEqual([])
   })
 })

--- a/apps/sim/tools/datadog/get_monitor.ts
+++ b/apps/sim/tools/datadog/get_monitor.ts
@@ -1,5 +1,5 @@
 import type { GetMonitorParams, GetMonitorResponse } from '@/tools/datadog/types'
-import { datadogErrorMessage, datadogPathSegment } from '@/tools/datadog/utils'
+import { datadogErrorMessage, datadogPathSegment, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const getMonitorTool: ToolConfig<GetMonitorParams, GetMonitorResponse> = {
@@ -50,7 +50,7 @@ export const getMonitorTool: ToolConfig<GetMonitorParams, GetMonitorResponse> = 
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       const queryParams = new URLSearchParams()
 
       if (params.groupStates) queryParams.set('group_states', params.groupStates)

--- a/apps/sim/tools/datadog/list_downtimes.ts
+++ b/apps/sim/tools/datadog/list_downtimes.ts
@@ -4,7 +4,7 @@ import type {
   ListDowntimesParams,
   ListDowntimesResponse,
 } from '@/tools/datadog/types'
-import { datadogErrorMessage } from '@/tools/datadog/utils'
+import { datadogErrorMessage, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const listDowntimesTool: ToolConfig<ListDowntimesParams, ListDowntimesResponse> = {
@@ -55,7 +55,7 @@ export const listDowntimesTool: ToolConfig<ListDowntimesParams, ListDowntimesRes
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       const queryParams = new URLSearchParams()
 
       if (params.currentOnly) queryParams.set('current_only', 'true')

--- a/apps/sim/tools/datadog/list_monitors.ts
+++ b/apps/sim/tools/datadog/list_monitors.ts
@@ -1,5 +1,5 @@
 import type { ListMonitorsParams, ListMonitorsResponse, MonitorData } from '@/tools/datadog/types'
-import { datadogErrorMessage } from '@/tools/datadog/utils'
+import { datadogErrorMessage, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const listMonitorsTool: ToolConfig<ListMonitorsParams, ListMonitorsResponse> = {
@@ -77,7 +77,7 @@ export const listMonitorsTool: ToolConfig<ListMonitorsParams, ListMonitorsRespon
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       const queryParams = new URLSearchParams()
 
       if (params.groupStates) queryParams.set('group_states', params.groupStates)

--- a/apps/sim/tools/datadog/query_logs.ts
+++ b/apps/sim/tools/datadog/query_logs.ts
@@ -4,7 +4,7 @@ import type {
   QueryLogsParams,
   QueryLogsResponse,
 } from '@/tools/datadog/types'
-import { datadogErrorMessage } from '@/tools/datadog/utils'
+import { datadogErrorMessage, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const queryLogsTool: ToolConfig<QueryLogsParams, QueryLogsResponse> = {
@@ -83,7 +83,7 @@ export const queryLogsTool: ToolConfig<QueryLogsParams, QueryLogsResponse> = {
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       return `https://api.${site}/api/v2/logs/events/search`
     },
     method: 'POST',

--- a/apps/sim/tools/datadog/query_timeseries.ts
+++ b/apps/sim/tools/datadog/query_timeseries.ts
@@ -3,7 +3,7 @@ import type {
   QueryTimeseriesParams,
   QueryTimeseriesResponse,
 } from '@/tools/datadog/types'
-import { datadogErrorMessage } from '@/tools/datadog/utils'
+import { datadogErrorMessage, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const queryTimeseriesTool: ToolConfig<QueryTimeseriesParams, QueryTimeseriesResponse> = {
@@ -55,7 +55,7 @@ export const queryTimeseriesTool: ToolConfig<QueryTimeseriesParams, QueryTimeser
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       const queryParams = new URLSearchParams({
         query: params.query,
         from: String(params.from),

--- a/apps/sim/tools/datadog/send_logs.ts
+++ b/apps/sim/tools/datadog/send_logs.ts
@@ -1,6 +1,6 @@
 import { filterUndefined } from '@sim/utils/object'
 import type { LogEntry, SendLogsParams, SendLogsResponse } from '@/tools/datadog/types'
-import { datadogErrorMessage, parseJsonParam } from '@/tools/datadog/utils'
+import { datadogErrorMessage, parseJsonParam, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const sendLogsTool: ToolConfig<SendLogsParams, SendLogsResponse> = {
@@ -33,14 +33,9 @@ export const sendLogsTool: ToolConfig<SendLogsParams, SendLogsResponse> = {
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       // Logs API uses a different subdomain
-      const logsHost =
-        site === 'datadoghq.com'
-          ? 'http-intake.logs.datadoghq.com'
-          : site === 'datadoghq.eu'
-            ? 'http-intake.logs.datadoghq.eu'
-            : `http-intake.logs.${site}`
+      const logsHost = `http-intake.logs.${site}`
       return `https://${logsHost}/api/v2/logs`
     },
     method: 'POST',

--- a/apps/sim/tools/datadog/submit_metrics.ts
+++ b/apps/sim/tools/datadog/submit_metrics.ts
@@ -4,7 +4,7 @@ import type {
   SubmitMetricsParams,
   SubmitMetricsResponse,
 } from '@/tools/datadog/types'
-import { datadogErrorMessage, parseJsonParam } from '@/tools/datadog/utils'
+import { datadogErrorMessage, parseJsonParam, resolveDatadogSite } from '@/tools/datadog/utils'
 import type { ToolConfig } from '@/tools/types'
 
 /**
@@ -49,7 +49,7 @@ export const submitMetricsTool: ToolConfig<SubmitMetricsParams, SubmitMetricsRes
 
   request: {
     url: (params) => {
-      const site = params.site || 'datadoghq.com'
+      const site = resolveDatadogSite(params.site)
       return `https://api.${site}/api/v2/series`
     },
     method: 'POST',

--- a/apps/sim/tools/datadog/types.ts
+++ b/apps/sim/tools/datadog/types.ts
@@ -2,17 +2,27 @@
 import type { ToolResponse } from '@/tools/types'
 
 // Datadog Site/Region options
-/** Regional sites Datadog serves the API from, per the `site` server variable enum. */
-export type DatadogSite =
-  | 'datadoghq.com'
-  | 'us3.datadoghq.com'
-  | 'us5.datadoghq.com'
-  | 'datadoghq.eu'
-  | 'ap1.datadoghq.com'
-  | 'ap2.datadoghq.com'
-  | 'uk1.datadoghq.com'
-  | 'ddog-gov.com'
-  | 'us2.ddog-gov.com'
+/**
+ * Regional sites Datadog serves the API from, per the `site` server variable enum.
+ *
+ * A runtime array rather than a bare type union: `site` is interpolated into the
+ * request host, and a type union is erased at runtime, so it cannot keep a value
+ * that arrived from a stored workflow out of the URL. {@link DatadogSite} is
+ * derived from this list so the two can never drift.
+ */
+export const DATADOG_SITES = [
+  'datadoghq.com',
+  'us3.datadoghq.com',
+  'us5.datadoghq.com',
+  'datadoghq.eu',
+  'ap1.datadoghq.com',
+  'ap2.datadoghq.com',
+  'uk1.datadoghq.com',
+  'ddog-gov.com',
+  'us2.ddog-gov.com',
+] as const
+
+export type DatadogSite = (typeof DATADOG_SITES)[number]
 
 // Base parameters for write-only operations (only need API key)
 interface DatadogWriteOnlyParams {

--- a/apps/sim/tools/datadog/utils.ts
+++ b/apps/sim/tools/datadog/utils.ts
@@ -4,6 +4,7 @@ import type {
   SecuritySignalTriageData,
   UpdateSloParams,
 } from '@/tools/datadog/types'
+import { DATADOG_SITES } from '@/tools/datadog/types'
 
 /**
  * Builds a fully-qualified Datadog API URL for the caller's site/region.
@@ -11,7 +12,37 @@ import type {
  * `ddog-gov.com`, ...), so every request must be built from the configured site.
  */
 export function datadogApiUrl(site: DatadogSite | undefined, path: string): string {
-  return `https://api.${site || 'datadoghq.com'}${path}`
+  return `https://api.${resolveDatadogSite(site)}${path}`
+}
+
+/**
+ * Resolves the caller's `site` to one of Datadog's published regional hosts.
+ *
+ * `DatadogSite` is a compile-time union, so it constrains nothing at runtime: the
+ * value is interpolated into the request host, and every Datadog request carries
+ * `DD-API-KEY` and `DD-APPLICATION-KEY`. An unchecked value therefore decides where
+ * the workspace's Datadog credentials are sent — `evil.com` addresses `api.evil.com`,
+ * and `datadoghq.com@evil.com` addresses `evil.com` with the expected host as
+ * userinfo. The block renders `site` as a dropdown and the param is `user-only`, so
+ * neither the editor nor a model can reach this today; the check exists because the
+ * value survives in stored workflow state, which imports and programmatic edits write
+ * without passing through that dropdown.
+ *
+ * Typed `unknown` rather than `DatadogSite`: the declared type is exactly what this
+ * cannot trust, and a stored workflow can hand over a blank string or a non-string.
+ *
+ * @param site - The caller-supplied site, or `undefined`/blank for the default region.
+ * @returns The validated site host.
+ * @throws If the value is present but is not a published Datadog site.
+ */
+export function resolveDatadogSite(site: unknown): DatadogSite {
+  if (site === undefined || site === null || site === '') return 'datadoghq.com'
+  if (typeof site !== 'string' || !(DATADOG_SITES as readonly string[]).includes(site)) {
+    throw new Error(
+      `Datadog "site" must be one of ${DATADOG_SITES.join(', ')}, but was ${String(site)}`
+    )
+  }
+  return site as DatadogSite
 }
 
 /**

--- a/apps/sim/tools/managed_agent/normalizers.ts
+++ b/apps/sim/tools/managed_agent/normalizers.ts
@@ -78,6 +78,28 @@ export function normalizeFiles(value: unknown): Array<{ fileId: string; mountPat
  * string, comma-separated string, or single string — into a trimmed
  * `string[]`.
  */
+/**
+ * Trims a scalar the block may hand over as something other than a string.
+ *
+ * `String(value)` and `value.toString()` are both unsafe here: an object whose
+ * `toString` is not a function, and one with a null prototype, each throw
+ * `TypeError` rather than producing text. Stored workflow state can hold either,
+ * and these values are read before the operation's try block, so a throw escapes
+ * the structured `success: false` result the caller is promised. Only the scalar
+ * kinds `String()` can never fail on are converted; anything else becomes empty,
+ * which every caller already treats as "not supplied".
+ *
+ * @param value - The raw parameter value.
+ * @returns The trimmed text, or `''` for a value with no safe text form.
+ */
+export function normalizeScalarText(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
+    return String(value).trim()
+  }
+  return ''
+}
+
 export function normalizeStringList(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value

--- a/apps/sim/tools/managed_agent/respond_tool_confirmation.test.ts
+++ b/apps/sim/tools/managed_agent/respond_tool_confirmation.test.ts
@@ -19,6 +19,27 @@ describe('Managed Agent tool confirmations', () => {
     mockSendToolConfirmations.mockResolvedValue(undefined)
   })
 
+  /*
+   * denyMessage was read with `params.denyMessage?.trim()` above the try block, so a
+   * non-string arriving from a stored workflow threw past every `success: false` path
+   * this operation otherwise returns.
+   */
+  it('returns a result rather than throwing when denyMessage is not text', async () => {
+    const result = await executeManagedAgentRespondToolConfirmationOperation({
+      accessToken: 'token',
+      sessionId: 'session-1',
+      toolUseIds: ['tool-use-1'],
+      decision: 'deny',
+      denyMessage: 42,
+    } as never)
+    expect(result.success).toBe(true)
+    expect(mockSendToolConfirmations).toHaveBeenLastCalledWith({
+      apiKey: 'token',
+      sessionId: 'session-1',
+      confirmations: [{ toolUseId: 'tool-use-1', result: 'deny', denyMessage: '42' }],
+    })
+  })
+
   it('sends a denial message only for deny decisions', async () => {
     await executeManagedAgentRespondToolConfirmationOperation({
       accessToken: 'token',

--- a/apps/sim/tools/managed_agent/respond_tool_confirmation.test.ts
+++ b/apps/sim/tools/managed_agent/respond_tool_confirmation.test.ts
@@ -40,6 +40,34 @@ describe('Managed Agent tool confirmations', () => {
     })
   })
 
+  it('returns a structured failure for a value with no safe text form', async () => {
+    const hostile = { toString: 'not a function' }
+    const result = await executeManagedAgentRespondToolConfirmationOperation({
+      accessToken: 'token',
+      sessionId: 'session-1',
+      toolUseIds: ['tool-use-1'],
+      decision: 'deny',
+      denyMessage: hostile,
+    } as never)
+    expect(result.success).toBe(true)
+    expect(mockSendToolConfirmations).toHaveBeenLastCalledWith({
+      apiKey: 'token',
+      sessionId: 'session-1',
+      confirmations: [{ toolUseId: 'tool-use-1', result: 'deny' }],
+    })
+  })
+
+  it('rejects a null-prototype decision instead of throwing past the result contract', async () => {
+    const result = await executeManagedAgentRespondToolConfirmationOperation({
+      accessToken: 'token',
+      sessionId: 'session-1',
+      toolUseIds: ['tool-use-1'],
+      decision: Object.create(null),
+    } as never)
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Decision must be/)
+  })
+
   it('sends a denial message only for deny decisions', async () => {
     await executeManagedAgentRespondToolConfirmationOperation({
       accessToken: 'token',


### PR DESCRIPTION
Four verified defects from the review of the v0.8.16 release PR (#7224). Each is the same shape: a declared TypeScript type standing in for a check that never runs.

Two other findings on that PR were checked and deliberately **not** changed — details at the bottom.

## Datadog — `site` decided where the credentials went

`DatadogSite` is a compile-time union, erased at runtime. `site` is interpolated straight into the request host, and every Datadog request carries `DD-API-KEY` and `DD-APPLICATION-KEY`:

```ts
return `https://api.${site || 'datadoghq.com'}${path}`
```

An unvalidated value therefore chose the destination for the workspace's Datadog credentials. `evil.com` addresses `api.evil.com`; `datadoghq.com@evil.com` addresses `evil.com` with the expected host parsed as userinfo.

The site list is now a runtime array with `DatadogSite` derived from it, so the two cannot drift, and both host builders resolve through one validator: `datadogApiUrl` (31 call sites) and the separate logs-intake host in `send_logs`. That ternary in `send_logs` had three branches that all produced the same string, so it collapses to the one expression.

**Not reachable from the editor today** — the block renders `site` as a dropdown and the param is `user-only`, so neither a user nor a model can set it. The value still survives in stored workflow state, which imports and programmatic edits write without passing through that dropdown. This is the defence-in-depth layer, not a live exploit.

## CB Insights — optional chaining is not a type check

`params.x?.trim()` guards `undefined`, not the type. A block-to-block reference resolving to a number reached `.trim()` and threw a bare `TypeError` naming no parameter. The direct sibling, `get-commercial-maturity-history`, already used `parseOptionalStringParam` for the identical `startDate`/`endDate` pair; the remaining 19 sites now do too.

Everything else is unchanged, and that is checked rather than assumed: `compactBody` already dropped `''`, `null`, and `undefined` identically, and every use outside it only tests falsiness — so `''` and `undefined` were already interchangeable at all 19 sites. The only behaviour that changes is the non-string case.

## CB Insights RAG — the guard contradicted its own contract

`message.length > 10_000` admitted a 10,000-character message, while both the thrown error and the tool's param description say **"under 10,000 characters"**. Now `>= 10_000`, so the code, the error, and the documented contract agree.

## Managed Agent — a throw that escaped the result contract

`denyMessage` was trimmed *above* the `try`, so a non-string threw past every `success: false` path the operation otherwise returns. It is now coerced the same way `decision` is a few lines above it.

## Checked and left alone

**Drive `addParents`/`removeParents`** — the finding says sending the destination in both parameters can make Drive reject the update. Google's own documented move sample does exactly what this code does — fetch all current parents, pass them all as `removeParents`, pass the destination as `addParents`, with no exclusion — in C#, Java, Python, and JavaScript. No documentation supports the claimed failure, so changing it would mean deviating from the vendor's canonical pattern on a guess.

**Bitbucket zero-byte `Range`** — the finding says `Range: bytes=0-N` against an empty file can return 416 instead of an empty result. RFC 9110 makes that plausible, but Bitbucket's actual behaviour on the raw endpoint is undocumented and there is no test coverage either way. Unverified, so unchanged.

## Verification

- Each of the four fixes was reverted individually and its test watched go red before being restored.
- `bun run check:audits` — 39/39
- `bun run lint` — clean
- `type-check` — no errors in any touched file (the worktree's other errors are the known stale workspace-package resolution and exist on the base)
- 162 tests pass across `tools/datadog`, `tools/cbinsights`, `tools/managed_agent`
- `tool-metadata:check`, `docs:check`, `integration-catalog:check`, block-registry — all pass