### PR TITLE
fix(ci): actually prune the BuildKit layer cache

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -21,10 +21,13 @@ inputs:
     required: true
   max-cache-size-mb:
     description: >-
-      Layer cache to retain after the post-job prune, in MB. Must stay above one
+      Layer cache to retain after this action prunes, in MB. Must stay above one
       build's working set (base + dependency layers + RUN --mount=type=cache
       dirs) or every build evicts what the next one needs. Falls back to the
-      small-image default below when empty.
+      small-image default in the prune step when empty — the fallback lives there
+      rather than here because callers pass this from a matrix field, and an unset
+      matrix key arrives as the empty string, which counts as "provided" and would
+      bypass an input `default:` entirely.
     required: false
 
 # Registry logins must precede this action. provenance/sbom stay off: attestation
@@ -49,24 +52,16 @@ runs:
         PLATFORMS: ${{ inputs.platforms }}
       run: echo "value=${GITHUB_REPOSITORY##*/}/${FILE#./}/${PLATFORMS//\//-}" >> "$GITHUB_OUTPUT"
 
-    # max-cache-size-mb is what bounds the disk: BuildKit's default GC is
-    # time-based only (layers unused for 8 days), and setup-docker-builder skips
-    # pruning altogether when the value is empty. On a repo that builds this
-    # often nothing ever ages out, so the disks grew without limit —
-    # app.Dockerfile/linux-amd64 reached 351 GB inside a day, and realtime, whose
-    # image is under 300 MB, sat at 249 GB. Sticky disks bill at ~$0.51/GB-month,
-    # so that was real money for layers no build would ever read again.
-    #
-    # The fallback is here rather than an input `default:` because callers pass
-    # this from a matrix field, and an unset matrix key arrives as the empty
-    # string — which counts as "provided", so a `default:` would never apply and
-    # a row that forgot the field would silently go back to unbounded growth.
+    # This action does NOT bound the disk — see the prune step below. BuildKit's
+    # own GC is time-based only (layers unused for 8 days), and these disks are
+    # mounted many times a day, so nothing ever ages out: app.Dockerfile/linux-amd64
+    # reached 351 GB inside a day of being created, and realtime, whose image is
+    # under 300 MB, sat at 249 GB. Sticky disks bill at ~$0.51/GB-month.
     - name: Set up Blacksmith builder
       if: inputs.provider == '' || inputs.provider == 'blacksmith'
       uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2
       with:
         cache-key: ${{ steps.cache-key.outputs.value }}
-        max-cache-size-mb: ${{ inputs.max-cache-size-mb || '25600' }}
 
     - name: Build and push (Blacksmith)
       if: inputs.provider == '' || inputs.provider == 'blacksmith'
@@ -79,6 +74,78 @@ runs:
         tags: ${{ inputs.tags }}
         provenance: false
         sbom: false
+
+    # Bound the layer cache ourselves. setup-docker-builder v1 took a
+    # max-cache-size-mb input and pruned in its own post step, but the v2 rewrite
+    # dropped it — and GitHub only WARNS on an unknown composite input, so passing
+    # it to v2 silently did nothing for a day while the app disk sat at 200+ GB.
+    #
+    # This is v1's command verbatim (its dist/index.js pruneBuildkitCache), against
+    # the fixed address v2 itself uses for `buildctl du` and `debug workers`:
+    #   sudo buildctl --addr tcp://127.0.0.1:1234 prune --all --keep-storage <MB>
+    #
+    # Note buildctl's --all is NOT `docker buildx prune --all`. Here it means
+    # "include internal/frontend references" (cache/manager.go: without it, records
+    # typed internal or frontend, and any ref shared with an external source, are
+    # skipped). It does not wipe the cache, and --keep-storage still caps what is
+    # retained -- it maps straight onto the modern MaxUsedSpace field, so it is the
+    # buildctl spelling of --max-used-space rather than a deprecated alias.
+    # `RUN --mount=type=cache` dirs are typed exec.cachemount and are reclaimed
+    # either way; --all is here because it is what v1 used and it prunes strictly
+    # more. Runs before the builder's post step, which is what commits the disk.
+    #
+    # Warn rather than fail: a cache that is too large is not worth failing a
+    # deploy over. The du either side is what makes a silent no-op visible — the
+    # failure mode that hid the v2 input regression in the first place.
+    - name: Prune the layer cache
+      if: (inputs.provider == '' || inputs.provider == 'blacksmith') && !cancelled()
+      shell: bash
+      env:
+        KEEP_MB: ${{ inputs.max-cache-size-mb || '25600' }}
+      run: |
+        addr='tcp://127.0.0.1:1234'
+
+        # A zero or non-numeric value is NOT a no-op. buildctl parses
+        # --keep-storage as a float, and BuildKit's cache manager treats
+        # keepBytes==0 as "no cap" (`gcMode := opt.keepBytes != 0`), pruning
+        # everything eligible rather than trimming to a limit. A typo such as
+        # '40GB' — valid in turbo.json, but this flag is a bare MB number — would
+        # silently empty the cache and make every later build cold, costing far
+        # more than the storage it saves. Refuse instead.
+        if ! [[ "$KEEP_MB" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::warning::max-cache-size-mb must be a positive whole number of MB, got '${KEEP_MB}' — skipping prune rather than risk wiping the cache"
+          exit 0
+        fi
+
+        # Print the whole Total line rather than picking a column: buildctl's du
+        # table is whitespace-aligned and its layout is not a stable contract.
+        total() { sudo buildctl --addr "$addr" du 2>/dev/null | grep -iE '^total:' | tr -s ' \t' ' '; }
+        echo "before prune -> $(total)"
+
+        if sudo buildctl --addr "$addr" prune --all --keep-storage "$KEEP_MB"; then
+          # buildctl prune returns BEFORE buildkitd has finished deleting
+          # (moby/buildkit#1198). The builder's post step then SIGTERMs buildkitd
+          # and SIGKILLs it after 30s (shutdownBuildkitd: `const a=3e4`); on
+          # SIGKILL it sets sigkillUsed and SKIPS the sticky disk commit, throwing
+          # away this run's cache and risking a corrupt bbolt metadata DB. So wait
+          # for du to stop moving before handing back. Bounded — this is hygiene,
+          # not correctness, and the steady-state trim settles almost at once.
+          prev=''; stable=0
+          for _ in $(seq 1 60); do
+            cur="$(total)"
+            if [ "$cur" = "$prev" ]; then
+              stable=$((stable + 1))
+              [ "$stable" -ge 2 ] && break
+            else
+              stable=0
+            fi
+            prev="$cur"
+            sleep 2
+          done
+          echo "after prune  -> $(total)  (keep-storage ${KEEP_MB} MB)"
+        else
+          echo "::warning::Layer cache prune failed; this sticky disk is unbounded for this run"
+        fi
 
     - name: Set up Docker Buildx
       if: inputs.provider != '' && inputs.provider != 'blacksmith'


### PR DESCRIPTION
## Summary

The `max-cache-size-mb` input I added in `8fa7f0cc4e` **never did anything**. Every Docker build since has logged:

```
##[warning]Unexpected input(s) 'max-cache-size-mb', valid inputs are ['cache-key',
'buildx-version', 'platforms', 'nofallback', 'github-token', 'buildkit-version',
'skip-integrity-check', 'driver-opts', 'max-parallelism']
```

`setup-docker-builder` **v1** accepted that input and pruned in its own post step. The **v2 rewrite dropped it**, and we pin v2.1.0. GitHub only *warns* on an unknown composite input, so it failed silently — the app disk sat above 200 GB for a full day while the config looked correct.

Scanned every tag rather than infer:

| Tag | has `max-cache-size-mb` |
|---|---|
| v2.1.0 (pinned), v2.0.1, v2.0.0 | **no** |
| v1.12.0, v1.11.0, v1.10.0, v1.9.0, v1.8.0 | yes |

## The fix

Rather than downgrade a builder rewrite to reach a config knob, run the prune ourselves — **v1's command verbatim** (from its `dist/index.js` `pruneBuildkitCache`), against the fixed address **v2 itself uses** for `buildctl du` and `debug workers`:

```
sudo buildctl --addr tcp://127.0.0.1:1234 prune --all --keep-storage <MB>
```

### Both flags verified against BuildKit master, not assumed

- **`buildctl`'s `--all` is not `docker buildx prune --all`.** It means *"Include internal/frontend references"*. `cache/manager.go` shows the only records skipped without it:
  ```go
  if !opt.all {
      if recordType == UsageRecordTypeInternal || recordType == UsageRecordTypeFrontend || shared {
          continue
      }
  }
  ```
  It does **not** wipe the cache. (I initially justified `--all` as being required to reclaim `RUN --mount=type=cache` dirs — that was wrong. Those are typed `exec.cachemount` and are reclaimed either way. `--all` is kept because it's what v1 used and it prunes strictly more.)
- **`--keep-storage` is not deprecated.** In `cmd/buildctl/prune.go` it maps straight onto the modern `MaxUsedSpace` field — it is buildctl's spelling of `--max-used-space`, and the only size flag buildctl exposes.

### Why a foreground command

Turborepo's equivalent eviction runs on a **detached thread that is never joined**, and on a 206 GB cache it makes no measurable progress inside a 150s job (measured: the disk moved 206.2 → 206.7 GB across 17h of builds). A blocking `buildctl prune` either completes or reports why not.

**Warns rather than fails** — an oversized cache isn't worth failing a deploy over — but prints `buildctl du` **either side**, because a silent no-op is precisely the failure mode that hid this for a day.

## Verification

- Extracted v1's and v2's bundled `dist/index.js`; confirmed v1's exact command and that v2 hardcodes `tcp://127.0.0.1:1234` and already shells out to `buildctl`, so binary and address are both present at that point in the job.
- Flag semantics read from BuildKit master source (`cmd/buildctl/prune.go`, `client/prune.go`, `cache/manager.go`, `client/diskusage.go`).
- `actionlint` output **identical to the staging baseline**; `shellcheck` clean on the new run block.
- `bun run lint` and all 39 `check:audits` pass.

Effect is not yet measurable — it applies from the first build after merge. I'll report the real `du` deltas from build logs rather than assume.

## Type of Change
- [x] Bug fix

## Testing
As above. The real verification is the `before prune -> / after prune ->` lines this adds to every Docker build log.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)