### PR TITLE
fix(ci): stop the layer-cache prune from being able to fail a build

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -119,7 +119,16 @@ runs:
 
         # Print the whole Total line rather than picking a column: buildctl's du
         # table is whitespace-aligned and its layout is not a stable contract.
-        total() { sudo buildctl --addr "$addr" du 2>/dev/null | grep -iE '^total:' | tr -s ' \t' ' '; }
+        #
+        # The trailing `|| true` is load-bearing. Composite steps run under
+        # `bash -e -o pipefail`, where `cur="$(total)"` takes the substitution's
+        # exit status, so a failing du would abort the step and fail the build --
+        # `echo "$(total)"` survives but the assignment in the settle loop does
+        # not. buildctl exiting non-zero here is entirely plausible: deleting a
+        # sticky disk out from under a running job makes buildkitd panic inside
+        # DiskUsage, and grep also exits 1 whenever the table has no Total line.
+        # Cache hygiene must never be able to fail a deploy.
+        total() { sudo buildctl --addr "$addr" du 2>/dev/null | grep -iE '^total:' | tr -s ' \t' ' ' || true; }
         echo "before prune -> $(total)"
 
         if sudo buildctl --addr "$addr" prune --all --keep-storage "$KEEP_MB"; then


### PR DESCRIPTION
## Summary

The settle loop added in `4f651038f3` reads `cur="$(total)"`. Composite steps run under `bash -e -o pipefail`, where **an assignment takes its command substitution's exit status** — so any failing `buildctl du` aborts the step and fails the build.

Reproduced directly:

```bash
set -e -o pipefail
total() { false | grep -iE '^total:' | tr -s ' ' ' '; }
echo "echo form: $(total)"   # survives
cur="$(total)"               # ABORTS, exit 1
```

That asymmetry is why it was invisible: the `echo "$(total)"` calls run first and survive, and only the assignment inside the settle loop trips it.

**Not hypothetical.** Deleting a sticky disk out from under a running job makes buildkitd panic inside `cache.(*cacheManager).DiskUsage`, and it took a `Build AMD64` job down exactly this way:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/moby/buildkit/cache.(*cacheManager).DiskUsage(...)
```

`grep` also exits 1 whenever `du` prints no `Total:` line, so a genuinely empty cache would have done it too.

## Fix

`total()` now always returns 0. Cache hygiene must never be able to fail a deploy.

The prune's own failure was already handled correctly — it sits in an `if` condition, and a failing condition does not trip `-e`.

## Verification

- Reproduced the abort and confirmed the fix under the exact shell flags GitHub uses (`bash -e -o pipefail`): the settle loop now completes with a totally failing `du`.
- `shellcheck` clean; `actionlint` identical to the staging baseline; `bun run lint` passes.

## Type of Change
- [x] Bug fix

## Testing
Shell-level reproduction of both the failure and the fix, as above.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)