### PR TITLE
fix(attio): stop swallowing JSON parse failures and guard path segments

### DIFF
--- a/apps/sim/tools/attio/assert_record.ts
+++ b/apps/sim/tools/attio/assert_record.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioAssertRecordParams, AttioAssertRecordResponse } from './types'
 import { RECORD_OUTPUT_PROPERTIES } from './types'
 
@@ -48,8 +49,12 @@ export const attioAssertRecordTool: ToolConfig<AttioAssertRecordParams, AttioAss
     },
 
     request: {
-      url: (params) =>
-        `https://api.attio.com/v2/objects/${params.objectType.trim()}/records?matching_attribute=${params.matchingAttribute.trim()}`,
+      url: (params) => {
+        const searchParams = new URLSearchParams({
+          matching_attribute: String(params.matchingAttribute ?? '').trim(),
+        })
+        return `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.objectType, 'objectType')}/records?${searchParams.toString()}`
+      },
       method: 'PUT',
       headers: (params) => ({
         Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/assert_record.ts
+++ b/apps/sim/tools/attio/assert_record.ts
@@ -50,9 +50,11 @@ export const attioAssertRecordTool: ToolConfig<AttioAssertRecordParams, AttioAss
 
     request: {
       url: (params) => {
-        const searchParams = new URLSearchParams({
-          matching_attribute: String(params.matchingAttribute ?? '').trim(),
-        })
+        const matchingAttribute = String(params.matchingAttribute ?? '').trim()
+        if (!matchingAttribute) {
+          throw new Error('matchingAttribute is required')
+        }
+        const searchParams = new URLSearchParams({ matching_attribute: matchingAttribute })
         return `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.objectType, 'objectType')}/records?${searchParams.toString()}`
       },
       method: 'PUT',

--- a/apps/sim/tools/attio/assert_record.ts
+++ b/apps/sim/tools/attio/assert_record.ts
@@ -50,7 +50,15 @@ export const attioAssertRecordTool: ToolConfig<AttioAssertRecordParams, AttioAss
 
     request: {
       url: (params) => {
-        const matchingAttribute = String(params.matchingAttribute ?? '').trim()
+        if (params.matchingAttribute === null || params.matchingAttribute === undefined) {
+          throw new Error('matchingAttribute is required')
+        }
+        if (typeof params.matchingAttribute !== 'string') {
+          throw new Error(
+            `matchingAttribute must be a string (received ${typeof params.matchingAttribute})`
+          )
+        }
+        const matchingAttribute = params.matchingAttribute.trim()
         if (!matchingAttribute) {
           throw new Error('matchingAttribute is required')
         }

--- a/apps/sim/tools/attio/create_attribute.ts
+++ b/apps/sim/tools/attio/create_attribute.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioCreateAttributeParams, AttioCreateAttributeResponse } from './types'
 import { ATTRIBUTE_OUTPUT_PROPERTIES } from './types'
 
@@ -92,7 +93,7 @@ export const attioCreateAttributeTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.attio.com/v2/${params.target.trim()}/${params.identifier.trim()}/attributes`,
+      `https://api.attio.com/v2/${safeUrlPathSegment(params.target, 'target')}/${safeUrlPathSegment(params.identifier, 'identifier')}/attributes`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/create_list.ts
+++ b/apps/sim/tools/attio/create_list.ts
@@ -85,7 +85,7 @@ export const attioCreateListTool: ToolConfig<AttioCreateListParams, AttioCreateL
               ? JSON.parse(params.workspaceMemberAccess)
               : params.workspaceMemberAccess
         } catch {
-          data.workspace_member_access = params.workspaceMemberAccess
+          throw new Error('Invalid JSON provided for workspace member access')
         }
       }
       return { data }

--- a/apps/sim/tools/attio/create_list_entry.ts
+++ b/apps/sim/tools/attio/create_list_entry.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioCreateListEntryParams, AttioCreateListEntryResponse } from './types'
 import { LIST_ENTRY_OUTPUT_PROPERTIES } from './types'
 
@@ -53,7 +54,8 @@ export const attioCreateListEntryTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/lists/${params.list.trim()}/entries`,
+    url: (params) =>
+      `https://api.attio.com/v2/lists/${safeUrlPathSegment(params.list, 'list')}/entries`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,
@@ -68,7 +70,7 @@ export const attioCreateListEntryTool: ToolConfig<
               ? JSON.parse(params.entryValues)
               : params.entryValues
         } catch {
-          entryValues = {}
+          throw new Error('Invalid JSON provided for entry values')
         }
       }
       const data: Record<string, unknown> = {

--- a/apps/sim/tools/attio/create_record.ts
+++ b/apps/sim/tools/attio/create_record.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioCreateRecordParams, AttioCreateRecordResponse } from './types'
 import { RECORD_OBJECT_OUTPUT } from './types'
 
@@ -39,7 +40,8 @@ export const attioCreateRecordTool: ToolConfig<AttioCreateRecordParams, AttioCre
     },
 
     request: {
-      url: (params) => `https://api.attio.com/v2/objects/${params.objectType.trim()}/records`,
+      url: (params) =>
+        `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.objectType, 'objectType')}/records`,
       method: 'POST',
       headers: (params) => ({
         Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/create_task.ts
+++ b/apps/sim/tools/attio/create_task.ts
@@ -75,7 +75,7 @@ export const attioCreateTaskTool: ToolConfig<AttioCreateTaskParams, AttioCreateT
               : params.linkedRecords
         }
       } catch {
-        linkedRecords = []
+        throw new Error('Invalid JSON provided for linked records')
       }
       try {
         if (params.assignees) {
@@ -83,7 +83,7 @@ export const attioCreateTaskTool: ToolConfig<AttioCreateTaskParams, AttioCreateT
             typeof params.assignees === 'string' ? JSON.parse(params.assignees) : params.assignees
         }
       } catch {
-        assignees = []
+        throw new Error('Invalid JSON provided for assignees')
       }
       return {
         data: {

--- a/apps/sim/tools/attio/create_webhook.ts
+++ b/apps/sim/tools/attio/create_webhook.ts
@@ -56,7 +56,7 @@ export const attioCreateWebhookTool: ToolConfig<
             ? JSON.parse(params.subscriptions)
             : params.subscriptions
       } catch {
-        subscriptions = []
+        throw new Error('Invalid JSON provided for subscriptions')
       }
       return {
         data: {

--- a/apps/sim/tools/attio/delete_comment.ts
+++ b/apps/sim/tools/attio/delete_comment.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioDeleteCommentParams, AttioDeleteCommentResponse } from './types'
 
 const logger = createLogger('AttioDeleteComment')
@@ -34,7 +35,8 @@ export const attioDeleteCommentTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/comments/${params.commentId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/comments/${safeUrlPathSegment(params.commentId, 'commentId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/delete_list_entry.ts
+++ b/apps/sim/tools/attio/delete_list_entry.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioDeleteListEntryParams, AttioDeleteListEntryResponse } from './types'
 
 const logger = createLogger('AttioDeleteListEntry')
@@ -41,7 +42,7 @@ export const attioDeleteListEntryTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.attio.com/v2/lists/${params.list.trim()}/entries/${params.entryId.trim()}`,
+      `https://api.attio.com/v2/lists/${safeUrlPathSegment(params.list, 'list')}/entries/${safeUrlPathSegment(params.entryId, 'entryId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/delete_note.ts
+++ b/apps/sim/tools/attio/delete_note.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioDeleteNoteParams, AttioDeleteNoteResponse } from './types'
 
 const logger = createLogger('AttioDeleteNote')
@@ -31,7 +32,8 @@ export const attioDeleteNoteTool: ToolConfig<AttioDeleteNoteParams, AttioDeleteN
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/notes/${params.noteId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/notes/${safeUrlPathSegment(params.noteId, 'noteId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/delete_record.ts
+++ b/apps/sim/tools/attio/delete_record.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioDeleteRecordParams, AttioDeleteRecordResponse } from './types'
 
 const logger = createLogger('AttioDeleteRecord')
@@ -39,7 +40,7 @@ export const attioDeleteRecordTool: ToolConfig<AttioDeleteRecordParams, AttioDel
 
     request: {
       url: (params) =>
-        `https://api.attio.com/v2/objects/${params.objectType.trim()}/records/${params.recordId.trim()}`,
+        `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.objectType, 'objectType')}/records/${safeUrlPathSegment(params.recordId, 'recordId')}`,
       method: 'DELETE',
       headers: (params) => ({
         Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/delete_task.ts
+++ b/apps/sim/tools/attio/delete_task.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioDeleteTaskParams, AttioDeleteTaskResponse } from './types'
 
 const logger = createLogger('AttioDeleteTask')
@@ -31,7 +32,8 @@ export const attioDeleteTaskTool: ToolConfig<AttioDeleteTaskParams, AttioDeleteT
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/tasks/${params.taskId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/tasks/${safeUrlPathSegment(params.taskId, 'taskId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/delete_webhook.ts
+++ b/apps/sim/tools/attio/delete_webhook.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioDeleteWebhookParams, AttioDeleteWebhookResponse } from './types'
 
 const logger = createLogger('AttioDeleteWebhook')
@@ -34,7 +35,8 @@ export const attioDeleteWebhookTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/webhooks/${params.webhookId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/webhooks/${safeUrlPathSegment(params.webhookId, 'webhookId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_attribute.ts
+++ b/apps/sim/tools/attio/get_attribute.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetAttributeParams, AttioGetAttributeResponse } from './types'
 import { ATTRIBUTE_OUTPUT_PROPERTIES } from './types'
 
@@ -46,7 +47,7 @@ export const attioGetAttributeTool: ToolConfig<AttioGetAttributeParams, AttioGet
 
     request: {
       url: (params) =>
-        `https://api.attio.com/v2/${params.target.trim()}/${params.identifier.trim()}/attributes/${params.attribute.trim()}`,
+        `https://api.attio.com/v2/${safeUrlPathSegment(params.target, 'target')}/${safeUrlPathSegment(params.identifier, 'identifier')}/attributes/${safeUrlPathSegment(params.attribute, 'attribute')}`,
       method: 'GET',
       headers: (params) => ({
         Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_comment.ts
+++ b/apps/sim/tools/attio/get_comment.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetCommentParams, AttioGetCommentResponse } from './types'
 import { COMMENT_OUTPUT_PROPERTIES } from './types'
 
@@ -32,7 +33,8 @@ export const attioGetCommentTool: ToolConfig<AttioGetCommentParams, AttioGetComm
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/comments/${params.commentId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/comments/${safeUrlPathSegment(params.commentId, 'commentId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_list.ts
+++ b/apps/sim/tools/attio/get_list.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetListParams, AttioGetListResponse } from './types'
 import { LIST_OUTPUT_PROPERTIES } from './types'
 
@@ -32,7 +33,7 @@ export const attioGetListTool: ToolConfig<AttioGetListParams, AttioGetListRespon
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/lists/${params.list.trim()}`,
+    url: (params) => `https://api.attio.com/v2/lists/${safeUrlPathSegment(params.list, 'list')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_list_entry.ts
+++ b/apps/sim/tools/attio/get_list_entry.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetListEntryParams, AttioGetListEntryResponse } from './types'
 import { LIST_ENTRY_OUTPUT_PROPERTIES } from './types'
 
@@ -40,7 +41,7 @@ export const attioGetListEntryTool: ToolConfig<AttioGetListEntryParams, AttioGet
 
     request: {
       url: (params) =>
-        `https://api.attio.com/v2/lists/${params.list.trim()}/entries/${params.entryId.trim()}`,
+        `https://api.attio.com/v2/lists/${safeUrlPathSegment(params.list, 'list')}/entries/${safeUrlPathSegment(params.entryId, 'entryId')}`,
       method: 'GET',
       headers: (params) => ({
         Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_member.ts
+++ b/apps/sim/tools/attio/get_member.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetMemberParams, AttioGetMemberResponse } from './types'
 import { MEMBER_OUTPUT_PROPERTIES } from './types'
 
@@ -32,7 +33,8 @@ export const attioGetMemberTool: ToolConfig<AttioGetMemberParams, AttioGetMember
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/workspace_members/${params.memberId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/workspace_members/${safeUrlPathSegment(params.memberId, 'memberId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_note.ts
+++ b/apps/sim/tools/attio/get_note.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetNoteParams, AttioGetNoteResponse } from './types'
 import { mapNoteTags, NOTE_OUTPUT_PROPERTIES } from './types'
 
@@ -32,7 +33,8 @@ export const attioGetNoteTool: ToolConfig<AttioGetNoteParams, AttioGetNoteRespon
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/notes/${params.noteId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/notes/${safeUrlPathSegment(params.noteId, 'noteId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_object.ts
+++ b/apps/sim/tools/attio/get_object.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetObjectParams, AttioGetObjectResponse } from './types'
 import { OBJECT_OUTPUT_PROPERTIES } from './types'
 
@@ -32,7 +33,8 @@ export const attioGetObjectTool: ToolConfig<AttioGetObjectParams, AttioGetObject
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/objects/${params.object.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.object, 'object')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_record.ts
+++ b/apps/sim/tools/attio/get_record.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetRecordParams, AttioGetRecordResponse } from './types'
 import { RECORD_OBJECT_OUTPUT } from './types'
 
@@ -39,7 +40,7 @@ export const attioGetRecordTool: ToolConfig<AttioGetRecordParams, AttioGetRecord
 
   request: {
     url: (params) =>
-      `https://api.attio.com/v2/objects/${params.objectType.trim()}/records/${params.recordId.trim()}`,
+      `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.objectType, 'objectType')}/records/${safeUrlPathSegment(params.recordId, 'recordId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_task.ts
+++ b/apps/sim/tools/attio/get_task.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetTaskParams, AttioGetTaskResponse } from './types'
 import { TASK_OUTPUT_PROPERTIES } from './types'
 
@@ -32,7 +33,8 @@ export const attioGetTaskTool: ToolConfig<AttioGetTaskParams, AttioGetTaskRespon
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/tasks/${params.taskId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/tasks/${safeUrlPathSegment(params.taskId, 'taskId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_thread.ts
+++ b/apps/sim/tools/attio/get_thread.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetThreadParams, AttioGetThreadResponse } from './types'
 import { THREAD_OUTPUT_PROPERTIES } from './types'
 
@@ -32,7 +33,8 @@ export const attioGetThreadTool: ToolConfig<AttioGetThreadParams, AttioGetThread
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/threads/${params.threadId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/threads/${safeUrlPathSegment(params.threadId, 'threadId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/get_webhook.ts
+++ b/apps/sim/tools/attio/get_webhook.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioGetWebhookParams, AttioGetWebhookResponse } from './types'
 import { WEBHOOK_OUTPUT_PROPERTIES } from './types'
 
@@ -32,7 +33,8 @@ export const attioGetWebhookTool: ToolConfig<AttioGetWebhookParams, AttioGetWebh
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/webhooks/${params.webhookId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/webhooks/${safeUrlPathSegment(params.webhookId, 'webhookId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/json_integrity.test.ts
+++ b/apps/sim/tools/attio/json_integrity.test.ts
@@ -19,9 +19,9 @@
  */
 import { describe, expect, it } from 'vitest'
 import * as attioTools from '@/tools/attio/index'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
-type AnyTool = ToolConfig<any, any>
+type BodyTool = ToolConfig<Record<string, unknown>, ToolResponse>
 
 const SENTINEL = '__ATTIO_SENTINEL__'
 const VALID_JSON_WITH_SENTINEL = `["${SENTINEL}"]`
@@ -30,20 +30,28 @@ const MALFORMED_JSON_WITH_SENTINEL = `["${SENTINEL}"`
 /** A valid JSON object that is also a harmless plain-string value. */
 const NEUTRAL_FILLER = '{}'
 
-function isAttioTool(value: unknown): value is AnyTool {
+function isAttioTool(value: unknown): value is BodyTool {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('attio_')
+    typeof (value as BodyTool).id === 'string' &&
+    (value as BodyTool).id.startsWith('attio_')
   )
 }
 
-const BODY_TOOLS = Object.values(attioTools)
-  .filter(isAttioTool)
-  .filter((tool) => typeof tool.request?.body === 'function')
+/**
+ * Seeded as `unknown[]` so `isAttioTool` is the single narrowing point. The
+ * barrel's element type is a union of `ToolConfig<AttioXParams, …>`, and
+ * `ToolConfig` places its param type in the contravariant position of
+ * `request.body`, so no specific member is assignable to `BodyTool` directly.
+ */
+const ALL_ATTIO_TOOLS: readonly unknown[] = Object.values(attioTools)
 
-function stringParamNames(tool: AnyTool): string[] {
+const BODY_TOOLS = ALL_ATTIO_TOOLS.filter(isAttioTool).filter(
+  (tool) => typeof tool.request?.body === 'function'
+)
+
+function stringParamNames(tool: BodyTool): string[] {
   return Object.entries(tool.params ?? {})
     .filter(([name]) => name !== 'accessToken')
     .filter(([, def]) => {
@@ -53,7 +61,7 @@ function stringParamNames(tool: AnyTool): string[] {
     .map(([name]) => name)
 }
 
-function buildParams(tool: AnyTool, overrideName: string, overrideValue: string) {
+function buildParams(tool: BodyTool, overrideName: string, overrideValue: string) {
   const params: Record<string, unknown> = { accessToken: 'token' }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name === 'accessToken') continue
@@ -70,10 +78,10 @@ function buildParams(tool: AnyTool, overrideName: string, overrideValue: string)
   return params
 }
 
-function serializeBody(tool: AnyTool, overrideName: string, overrideValue: string): string {
+function serializeBody(tool: BodyTool, overrideName: string, overrideValue: string): string {
   const body = tool.request?.body
   if (typeof body !== 'function') throw new Error(`${tool.id} has no body builder`)
-  return JSON.stringify(body(buildParams(tool, overrideName, overrideValue) as any))
+  return JSON.stringify(body(buildParams(tool, overrideName, overrideValue)))
 }
 
 /**
@@ -132,7 +140,7 @@ const SWALLOWED_SITES: ReadonlyArray<{ id: string; param: string }> = [
   { id: 'attio_query_list_entries', param: 'sorts' },
 ]
 
-function toolById(id: string): AnyTool {
+function toolById(id: string): BodyTool {
   const tool = BODY_TOOLS.find((candidate) => candidate.id === id)
   if (!tool) throw new Error(`${id} is not an Attio tool with a body builder`)
   return tool

--- a/apps/sim/tools/attio/json_integrity.test.ts
+++ b/apps/sim/tools/attio/json_integrity.test.ts
@@ -85,38 +85,100 @@ function serializeBody(tool: BodyTool, overrideName: string, overrideValue: stri
 }
 
 /**
- * Params that actually reach the request body, discovered by feeding a valid
- * JSON value carrying a sentinel and checking whether the sentinel survives.
- * Params that only feed the URL are skipped rather than hard-coded.
+ * Where a param's value ended up in the serialized body.
+ *
+ * - `parsed`   — the sentinel appears as its own string inside an array or
+ *   object, so the tool ran `JSON.parse` on the value.
+ * - `raw`      — the sentinel appears only inside a longer string, so the tool
+ *   forwarded the value verbatim. Correct for a plain-text param.
+ * - `absent`   — the value never reaches the body (it feeds the URL instead).
+ *
+ * `parsed` wins if both are seen, so a tool that both parses and echoes a value
+ * is still held to the parsing contract.
  */
+type SentinelPlacement = 'parsed' | 'raw' | 'absent'
+
+function classify(body: unknown): SentinelPlacement {
+  let found: SentinelPlacement = 'absent'
+
+  const walk = (value: unknown): void => {
+    if (typeof value === 'string') {
+      if (value === SENTINEL) {
+        found = 'parsed'
+      } else if (value.includes(SENTINEL) && found === 'absent') {
+        found = 'raw'
+      }
+      return
+    }
+    if (Array.isArray(value)) {
+      value.forEach(walk)
+      return
+    }
+    if (value !== null && typeof value === 'object') {
+      Object.values(value).forEach(walk)
+    }
+  }
+
+  walk(body)
+  return found
+}
+
+function placementOf(tool: BodyTool, param: string): SentinelPlacement {
+  try {
+    return classify(JSON.parse(serializeBody(tool, param, VALID_JSON_WITH_SENTINEL)))
+  } catch {
+    return 'absent'
+  }
+}
+
 const BODY_PARAM_CASES = BODY_TOOLS.flatMap((tool) =>
   stringParamNames(tool)
-    .filter((name) => {
-      try {
-        return serializeBody(tool, name, VALID_JSON_WITH_SENTINEL).includes(SENTINEL)
-      } catch {
-        return false
-      }
-    })
-    .map((param) => ({ name: `${tool.id} / ${param}`, tool, param }))
+    .map((param) => ({
+      name: `${tool.id} / ${param}`,
+      tool,
+      param,
+      placement: placementOf(tool, param),
+    }))
+    .filter(({ placement }) => placement !== 'absent')
 )
+
+/**
+ * Params the tool actually runs `JSON.parse` on. A malformed value here must
+ * raise the folder's named error — substituting an empty value (the original
+ * defect) and forwarding the raw string (which reaches Attio as a 400 with no
+ * hint of the real cause) are both failures.
+ */
+const PARSED_PARAM_CASES = BODY_PARAM_CASES.filter(({ placement }) => placement === 'parsed')
+
+/** Plain-text params, which must forward whatever they are given untouched. */
+const PASSTHROUGH_PARAM_CASES = BODY_PARAM_CASES.filter(({ placement }) => placement === 'raw')
 
 describe('attio JSON parse integrity', () => {
   it('discovers the body-bound params it is meant to cover', () => {
     expect(BODY_PARAM_CASES.length).toBeGreaterThanOrEqual(20)
   })
 
-  it.each(BODY_PARAM_CASES)(
-    '$name never silently drops a value that fails to parse',
-    ({ tool, param }) => {
-      let serialized: string
-      try {
-        serialized = serializeBody(tool, param, MALFORMED_JSON_WITH_SENTINEL)
-      } catch {
-        return
-      }
+  it('discovers every JSON-parsed param', () => {
+    expect(PARSED_PARAM_CASES.length).toBeGreaterThanOrEqual(18)
+  })
 
-      expect(serialized).toContain(SENTINEL)
+  it.each(PARSED_PARAM_CASES)(
+    '$name raises the folder-standard error rather than dropping or forwarding a malformed value',
+    ({ tool, param }) => {
+      expect(() => serializeBody(tool, param, MALFORMED_JSON_WITH_SENTINEL)).toThrow(
+        /Invalid JSON provided/
+      )
+    }
+  )
+
+  it.each(PARSED_PARAM_CASES)('$name still accepts a well-formed value', ({ tool, param }) => {
+    expect(() => serializeBody(tool, param, VALID_JSON_WITH_SENTINEL)).not.toThrow()
+  })
+
+  it.each(PASSTHROUGH_PARAM_CASES)(
+    '$name forwards a plain-text value untouched',
+    ({ tool, param }) => {
+      expect(serializeBody(tool, param, MALFORMED_JSON_WITH_SENTINEL)).toContain(SENTINEL)
     }
   )
 })

--- a/apps/sim/tools/attio/json_integrity.test.ts
+++ b/apps/sim/tools/attio/json_integrity.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every Attio tool against silent data substitution when a JSON-encoded
+ * parameter fails to parse.
+ *
+ * Several tools caught the `JSON.parse` failure and substituted an empty value
+ * (`{}` / `[]`) before reporting success. The worst case was
+ * `attio_query_list_entries`: a filter the caller set was silently dropped, the
+ * **unfiltered** query ran against the whole list, and the tool reported
+ * success — so the caller received rows they never asked for and had no signal
+ * that their filter was discarded.
+ *
+ * The established pattern in this folder (`create_record`, `assert_record`,
+ * `update_record`, `create_attribute`, `update_attribute`, `list_records`) is
+ * to throw a named `Invalid JSON provided for …` error. This file pins that
+ * pattern for every tool, and the sweep below is written so that a NEW tool
+ * that swallows a parse failure fails CI without anyone remembering to add it.
+ */
+import { describe, expect, it } from 'vitest'
+import * as attioTools from '@/tools/attio/index'
+import type { ToolConfig } from '@/tools/types'
+
+type AnyTool = ToolConfig<any, any>
+
+const SENTINEL = '__ATTIO_SENTINEL__'
+const VALID_JSON_WITH_SENTINEL = `["${SENTINEL}"]`
+const MALFORMED_JSON_WITH_SENTINEL = `["${SENTINEL}"`
+
+/** A valid JSON object that is also a harmless plain-string value. */
+const NEUTRAL_FILLER = '{}'
+
+function isAttioTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('attio_')
+  )
+}
+
+const BODY_TOOLS = Object.values(attioTools)
+  .filter(isAttioTool)
+  .filter((tool) => typeof tool.request?.body === 'function')
+
+function stringParamNames(tool: AnyTool): string[] {
+  return Object.entries(tool.params ?? {})
+    .filter(([name]) => name !== 'accessToken')
+    .filter(([, def]) => {
+      const type = (def as { type?: string }).type
+      return type === undefined || type === 'string' || type === 'json'
+    })
+    .map(([name]) => name)
+}
+
+function buildParams(tool: AnyTool, overrideName: string, overrideValue: string) {
+  const params: Record<string, unknown> = { accessToken: 'token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'accessToken') continue
+    const type = (def as { type?: string }).type
+    if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = NEUTRAL_FILLER
+    }
+  }
+  params[overrideName] = overrideValue
+  return params
+}
+
+function serializeBody(tool: AnyTool, overrideName: string, overrideValue: string): string {
+  const body = tool.request?.body
+  if (typeof body !== 'function') throw new Error(`${tool.id} has no body builder`)
+  return JSON.stringify(body(buildParams(tool, overrideName, overrideValue) as any))
+}
+
+/**
+ * Params that actually reach the request body, discovered by feeding a valid
+ * JSON value carrying a sentinel and checking whether the sentinel survives.
+ * Params that only feed the URL are skipped rather than hard-coded.
+ */
+const BODY_PARAM_CASES = BODY_TOOLS.flatMap((tool) =>
+  stringParamNames(tool)
+    .filter((name) => {
+      try {
+        return serializeBody(tool, name, VALID_JSON_WITH_SENTINEL).includes(SENTINEL)
+      } catch {
+        return false
+      }
+    })
+    .map((param) => ({ name: `${tool.id} / ${param}`, tool, param }))
+)
+
+describe('attio JSON parse integrity', () => {
+  it('discovers the body-bound params it is meant to cover', () => {
+    expect(BODY_PARAM_CASES.length).toBeGreaterThanOrEqual(20)
+  })
+
+  it.each(BODY_PARAM_CASES)(
+    '$name never silently drops a value that fails to parse',
+    ({ tool, param }) => {
+      let serialized: string
+      try {
+        serialized = serializeBody(tool, param, MALFORMED_JSON_WITH_SENTINEL)
+      } catch {
+        return
+      }
+
+      expect(serialized).toContain(SENTINEL)
+    }
+  )
+})
+
+/**
+ * The parse sites confirmed on staging as swallowing the failure. Each must now
+ * throw the folder's named error rather than substituting an empty value.
+ */
+const SWALLOWED_SITES: ReadonlyArray<{ id: string; param: string }> = [
+  { id: 'attio_create_list_entry', param: 'entryValues' },
+  { id: 'attio_update_list_entry', param: 'entryValues' },
+  { id: 'attio_create_task', param: 'linkedRecords' },
+  { id: 'attio_create_task', param: 'assignees' },
+  { id: 'attio_update_task', param: 'linkedRecords' },
+  { id: 'attio_update_task', param: 'assignees' },
+  { id: 'attio_create_webhook', param: 'subscriptions' },
+  { id: 'attio_update_webhook', param: 'subscriptions' },
+  { id: 'attio_create_list', param: 'workspaceMemberAccess' },
+  { id: 'attio_update_list', param: 'workspaceMemberAccess' },
+  { id: 'attio_query_list_entries', param: 'filter' },
+  { id: 'attio_query_list_entries', param: 'sorts' },
+]
+
+function toolById(id: string): AnyTool {
+  const tool = BODY_TOOLS.find((candidate) => candidate.id === id)
+  if (!tool) throw new Error(`${id} is not an Attio tool with a body builder`)
+  return tool
+}
+
+describe.each(SWALLOWED_SITES)('$id / $param', ({ id, param }) => {
+  it('throws a named Invalid JSON error instead of substituting an empty value', () => {
+    expect(() => serializeBody(toolById(id), param, '{"broken":')).toThrow(/Invalid JSON provided/)
+  })
+
+  it('still accepts a well-formed value', () => {
+    expect(() => serializeBody(toolById(id), param, VALID_JSON_WITH_SENTINEL)).not.toThrow()
+  })
+})
+
+/**
+ * `attio_query_list_entries` is called out on its own because its failure mode
+ * is the most damaging: dropping the filter widens the query rather than
+ * narrowing it, so the caller gets MORE data than they asked for.
+ */
+describe('attio_query_list_entries filter integrity', () => {
+  const tool = toolById('attio_query_list_entries')
+
+  it('never runs an unfiltered query when the filter fails to parse', () => {
+    expect(() => serializeBody(tool, 'filter', '{"name":{"$eq":"acme"')).toThrow(
+      /Invalid JSON provided for filter/
+    )
+  })
+
+  it('forwards a well-formed filter verbatim', () => {
+    const serialized = serializeBody(tool, 'filter', '{"name":{"$eq":"acme"}}')
+
+    expect(JSON.parse(serialized).filter).toEqual({ name: { $eq: 'acme' } })
+  })
+})

--- a/apps/sim/tools/attio/list_attributes.ts
+++ b/apps/sim/tools/attio/list_attributes.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioListAttributesParams, AttioListAttributesResponse } from './types'
 import { ATTRIBUTE_OUTPUT_PROPERTIES } from './types'
 
@@ -66,7 +67,7 @@ export const attioListAttributesTool: ToolConfig<
       if (params.showArchived != null)
         searchParams.set('show_archived', String(params.showArchived))
       const qs = searchParams.toString()
-      return `https://api.attio.com/v2/${params.target.trim()}/${params.identifier.trim()}/attributes${qs ? `?${qs}` : ''}`
+      return `https://api.attio.com/v2/${safeUrlPathSegment(params.target, 'target')}/${safeUrlPathSegment(params.identifier, 'identifier')}/attributes${qs ? `?${qs}` : ''}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/attio/list_records.ts
+++ b/apps/sim/tools/attio/list_records.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioListRecordsParams, AttioListRecordsResponse } from './types'
 import { RECORDS_ARRAY_OUTPUT } from './types'
 
@@ -56,7 +57,8 @@ export const attioListRecordsTool: ToolConfig<AttioListRecordsParams, AttioListR
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/objects/${params.objectType.trim()}/records/query`,
+    url: (params) =>
+      `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.objectType, 'objectType')}/records/query`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/path_safety.test.ts
+++ b/apps/sim/tools/attio/path_safety.test.ts
@@ -252,3 +252,46 @@ describe('attio path-ID traversal safety', () => {
     })
   })
 })
+
+/**
+ * `assert_record` is the only Attio tool that puts a caller-supplied value in
+ * the query string rather than the path. `matching_attribute` selects which
+ * attribute the upsert matches on, so an empty selector is not a narrower
+ * request — it is an incomplete one, and the same reject-don't-substitute rule
+ * that governs the path segments applies to it.
+ */
+describe('attio_assert_record matching_attribute', () => {
+  const tool = ALL_ATTIO_TOOLS.filter(isAttioTool).find(
+    (candidate) => candidate.id === 'attio_assert_record'
+  )
+
+  function build(matchingAttribute: unknown): URL {
+    const url = tool?.request?.url
+    if (typeof url !== 'function') throw new Error('assert_record builds no URL')
+    return new URL(
+      url({ accessToken: 'token', objectType: 'people', matchingAttribute, values: {} })
+    )
+  }
+
+  it('encodes a legitimate selector unchanged', () => {
+    expect(build('email_addresses').searchParams.get('matching_attribute')).toBe('email_addresses')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(build('  domains  ').searchParams.get('matching_attribute')).toBe('domains')
+  })
+
+  it('cannot inject an extra query parameter', () => {
+    const url = build('email_addresses&limit=500')
+
+    expect(url.searchParams.get('limit')).toBeNull()
+    expect(url.searchParams.get('matching_attribute')).toBe('email_addresses&limit=500')
+  })
+
+  it.each([undefined, null, '', '   '])(
+    'rejects %j rather than sending an empty selector',
+    (value) => {
+      expect(() => build(value)).toThrow(/matchingAttribute is required/)
+    }
+  )
+})

--- a/apps/sim/tools/attio/path_safety.test.ts
+++ b/apps/sim/tools/attio/path_safety.test.ts
@@ -31,7 +31,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import * as attioTools from '@/tools/attio/index'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
@@ -72,14 +72,14 @@ const SIBLING_ID = 'SIBLING'
 /** Distinct from `SIBLING_ID` so the param under test is locatable in the path. */
 const PROBE_ID = 'PROBEVALUE'
 
-type AnyTool = ToolConfig<any, any>
+type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
 
-function isAttioTool(value: unknown): value is AnyTool {
+function isAttioTool(value: unknown): value is PathTool {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('attio_')
+    typeof (value as PathTool).id === 'string' &&
+    (value as PathTool).id.startsWith('attio_')
   )
 }
 
@@ -88,7 +88,7 @@ function isAttioTool(value: unknown): value is AnyTool {
  * `value` on `target` alone. Holding the siblings safe is what keeps a throw
  * from `target` attributable to `target`.
  */
-function buildParams(tool: AnyTool, target: string, value: string): Record<string, unknown> {
+function buildParams(tool: PathTool, target: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { accessToken: 'token' }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name === 'accessToken') continue
@@ -107,15 +107,15 @@ function buildParams(tool: AnyTool, target: string, value: string): Record<strin
   return params
 }
 
-function buildUrl(tool: AnyTool, target: string, value: string): URL {
+function buildUrl(tool: PathTool, target: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, target, value) as any))
+  return new URL(url(buildParams(tool, target, value)))
 }
 
-function buildPath(tool: AnyTool, target: string, value: string): string {
+function buildPath(tool: PathTool, target: string, value: string): string {
   return buildUrl(tool, target, value).pathname
 }
 
@@ -123,7 +123,7 @@ function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-function stringParamNames(tool: AnyTool): string[] {
+function stringParamNames(tool: PathTool): string[] {
   return Object.entries(tool.params ?? {})
     .filter(([name]) => name !== 'accessToken')
     .filter(([, def]) => {
@@ -138,8 +138,15 @@ function stringParamNames(tool: AnyTool): string[] {
  * by probing one param at a time rather than declared in a hand-kept list — a
  * new path param is picked up here without anyone editing this file.
  */
-const PATH_PARAM_CASES = Object.values(attioTools)
-  .filter(isAttioTool)
+/**
+ * Seeded as `unknown[]` so `isAttioTool` is the single narrowing point. The
+ * barrel's element type is a union of `ToolConfig<AttioXParams, …>`, and
+ * `ToolConfig` places its param type in the contravariant position of
+ * `request.url`, so no specific member is assignable to `PathTool` directly.
+ */
+const ALL_ATTIO_TOOLS: readonly unknown[] = Object.values(attioTools)
+
+const PATH_PARAM_CASES = ALL_ATTIO_TOOLS.filter(isAttioTool)
   .filter((tool) => typeof tool.request?.url === 'function')
   .flatMap((tool) =>
     stringParamNames(tool)

--- a/apps/sim/tools/attio/path_safety.test.ts
+++ b/apps/sim/tools/attio/path_safety.test.ts
@@ -19,6 +19,15 @@
  * Every assertion here resolves the built URL with `new URL(...)` — the same
  * normalization `fetch` performs — rather than string-matching the template
  * output, because string matching is exactly what let this through.
+ *
+ * **One param is fuzzed at a time**, with every sibling held at a safe value.
+ * Fuzzing all params at once and skipping the vector when the builder throws
+ * looks equivalent but is not: as soon as a tool has one guarded param, that
+ * param throws first and its unguarded siblings stop being exercised at all.
+ * A tool like `attio_get_attribute` carries three path params, so the coarse
+ * form would report full coverage while testing exactly one of them. Case
+ * discovery below is therefore per **(tool, param)** pair, and each pair gets
+ * its own baseline so an unguarded sibling cannot hide behind a guarded one.
  */
 import { describe, expect, it } from 'vitest'
 import * as attioTools from '@/tools/attio/index'
@@ -58,7 +67,10 @@ const LEGITIMATE_IDS = [
   'v1.2.3',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/** Held by every param except the one under test. */
+const SIBLING_ID = 'SIBLING'
+/** Distinct from `SIBLING_ID` so the param under test is locatable in the path. */
+const PROBE_ID = 'PROBEVALUE'
 
 type AnyTool = ToolConfig<any, any>
 
@@ -72,10 +84,11 @@ function isAttioTool(value: unknown): value is AnyTool {
 }
 
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised.
+ * Builds a param object with every declared param at a safe value, then puts
+ * `value` on `target` alone. Holding the siblings safe is what keeps a throw
+ * from `target` attributable to `target`.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+function buildParams(tool: AnyTool, target: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { accessToken: 'token' }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name === 'accessToken') continue
@@ -87,52 +100,77 @@ function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
     } else if (type === 'boolean') {
       params[name] = false
     } else {
-      params[name] = value
+      params[name] = SIBLING_ID
     }
   }
+  params[target] = value
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
+function buildUrl(tool: AnyTool, target: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return new URL(url(buildParams(tool, target, value) as any))
 }
 
-function buildPath(tool: AnyTool, value: string): string {
-  return buildUrl(tool, value).pathname
+function buildPath(tool: AnyTool, target: string, value: string): string {
+  return buildUrl(tool, target, value).pathname
 }
 
 function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(attioTools)
+function stringParamNames(tool: AnyTool): string[] {
+  return Object.entries(tool.params ?? {})
+    .filter(([name]) => name !== 'accessToken')
+    .filter(([, def]) => {
+      const type = (def as { type?: string }).type
+      return type === undefined || type === 'string' || type === 'json'
+    })
+    .map(([name]) => name)
+}
+
+/**
+ * Every (tool, param) pair whose value reaches the request **path**, discovered
+ * by probing one param at a time rather than declared in a hand-kept list — a
+ * new path param is picked up here without anyone editing this file.
+ */
+const PATH_PARAM_CASES = Object.values(attioTools)
   .filter(isAttioTool)
   .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return buildPath(tool, SAFE_ID).includes(SAFE_ID)
-    } catch {
-      return false
-    }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  .flatMap((tool) =>
+    stringParamNames(tool)
+      .filter((param) => {
+        try {
+          return buildPath(tool, param, PROBE_ID).includes(PROBE_ID)
+        } catch {
+          return false
+        }
+      })
+      .map((param) => ({ name: `${tool.id} / ${param}`, tool, param }))
+  )
 
 describe('attio path-ID traversal safety', () => {
-  it('covers every Attio tool that interpolates an ID into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(30)
+  it('covers every (tool, param) pair that reaches a request path', () => {
+    expect(PATH_PARAM_CASES.length).toBeGreaterThanOrEqual(43)
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildPath(tool, SAFE_ID))
+  it('exercises every tool that builds a dynamic path', () => {
+    const tools = new Set(PATH_PARAM_CASES.map(({ tool }) => tool.id))
+
+    expect(tools.size).toBeGreaterThanOrEqual(31)
+  })
+
+  describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {
+    const baseline = segmentsOf(buildPath(tool, param, PROBE_ID))
 
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let path: string
       try {
-        path = buildPath(tool, value)
+        path = buildPath(tool, param, value)
       } catch {
         return
       }
@@ -140,7 +178,7 @@ describe('attio path-ID traversal safety', () => {
       const actual = segmentsOf(path)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) return
+        if (segment === PROBE_ID) return
         expect(actual[index]).toBe(segment)
       })
     })
@@ -148,7 +186,7 @@ describe('attio path-ID traversal safety', () => {
     it.each(TRAVERSAL_IDS)('stays on the Attio v2 API with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
+        url = buildUrl(tool, param, value)
       } catch {
         return
       }
@@ -158,30 +196,40 @@ describe('attio path-ID traversal safety', () => {
     })
 
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildPath(tool, value))
+      const actual = segmentsOf(buildPath(tool, param, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment === SAFE_ID ? value : segment)
+        expect(actual[index]).toBe(segment === PROBE_ID ? value : segment)
       })
     })
 
     it('rejects a bare dot-dot segment by name instead of silently popping a segment', () => {
-      expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+      expect(() => buildUrl(tool, param, '..')).toThrow(
+        new RegExp(`${param}\\b.*path traversal is not allowed`)
+      )
     })
 
-    it('rejects a bare dot segment', () => {
-      expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+    it('rejects a bare dot segment by name', () => {
+      expect(() => buildUrl(tool, param, '.')).toThrow(
+        new RegExp(`${param}\\b.*path traversal is not allowed`)
+      )
     })
 
-    it('does not let an id inject query parameters', () => {
-      const url = buildUrl(tool, 'list_abc?limit=500')
+    it('rejects a path separator by name', () => {
+      expect(() => buildUrl(tool, param, 'list_abc/entries')).toThrow(
+        new RegExp(`${param}\\b.*cannot contain a path separator`)
+      )
+    })
+
+    it('does not let the id inject query parameters', () => {
+      const url = buildUrl(tool, param, 'list_abc?limit=500')
 
       expect(url.searchParams.get('limit')).not.toBe('500')
     })
 
     it('trims surrounding whitespace rather than encoding it', () => {
-      expect(buildPath(tool, '  people  ')).toBe(buildPath(tool, 'people'))
+      expect(buildPath(tool, param, '  people  ')).toBe(buildPath(tool, param, 'people'))
     })
   })
 })

--- a/apps/sim/tools/attio/path_safety.test.ts
+++ b/apps/sim/tools/attio/path_safety.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every Attio tool against path traversal through an LLM-writable ID
+ * that gets interpolated into the request path.
+ *
+ * These IDs are `visibility: 'user-or-llm'`, so prompt injection controls them.
+ * Interpolating one raw let a value like `../../objects/people` escape its
+ * intended resource once `fetch` normalized the URL, re-aiming the request (and
+ * the user's Attio bearer token) at an arbitrary Attio resource — including on
+ * DELETE. `assertRequestUrlMatchesTrust` in `tools/request-transport.ts` only
+ * applies its canonicalization guard to internal `/api/` routes, so nothing
+ * downstream catches this.
+ *
+ * Wrapping the ID in `encodeURIComponent` is NOT enough, which is why the
+ * vector list below includes the bare `.` and `..` segments: both are made of
+ * unreserved characters, so they survive encoding untouched and the URL parser
+ * then removes them as dot segments, popping one path segment off a fixed host.
+ * Every assertion here resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ */
+import { describe, expect, it } from 'vitest'
+import * as attioTools from '@/tools/attio/index'
+import type { ToolConfig } from '@/tools/types'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../objects/people',
+  '..%2f..%2fobjects/people',
+  'list_abc/../../../objects/people',
+  'list_abc?limit=500',
+  'list_abc#fragment',
+  'list_abc/entries/../../../webhooks',
+  '\\..\\..',
+] as const
+
+/** Values a real user legitimately supplies; none may be rejected or altered. */
+const LEGITIMATE_IDS = [
+  'people',
+  'companies',
+  'deals',
+  'objects',
+  'lists',
+  'sales-pipeline',
+  '2e6d8c1a-6a1a-4b2e-9a6f-1c2d3e4f5a6b',
+  'user_email_address',
+  'example.com',
+  'sub.example.co.uk',
+  '..foo',
+  'foo..',
+  'v1.2.3',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isAttioTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('attio_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { accessToken: 'token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'accessToken') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array' || type === 'object') {
+      params[name] = []
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function buildPath(tool: AnyTool, value: string): string {
+  return buildUrl(tool, value).pathname
+}
+
+function segmentsOf(pathname: string): string[] {
+  return pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(attioTools)
+  .filter(isAttioTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return buildPath(tool, SAFE_ID).includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('attio path-ID traversal safety', () => {
+  it('covers every Attio tool that interpolates an ID into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(30)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildPath(tool, SAFE_ID))
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let path: string
+      try {
+        path = buildPath(tool, value)
+      } catch {
+        return
+      }
+
+      const actual = segmentsOf(path)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(TRAVERSAL_IDS)('stays on the Attio v2 API with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(url.origin).toBe('https://api.attio.com')
+      expect(url.pathname.startsWith('/v2/')).toBe(true)
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildPath(tool, value))
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        expect(actual[index]).toBe(segment === SAFE_ID ? value : segment)
+      })
+    })
+
+    it('rejects a bare dot-dot segment by name instead of silently popping a segment', () => {
+      expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+    })
+
+    it('rejects a bare dot segment', () => {
+      expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+    })
+
+    it('does not let an id inject query parameters', () => {
+      const url = buildUrl(tool, 'list_abc?limit=500')
+
+      expect(url.searchParams.get('limit')).not.toBe('500')
+    })
+
+    it('trims surrounding whitespace rather than encoding it', () => {
+      expect(buildPath(tool, '  people  ')).toBe(buildPath(tool, 'people'))
+    })
+  })
+})

--- a/apps/sim/tools/attio/path_safety.test.ts
+++ b/apps/sim/tools/attio/path_safety.test.ts
@@ -20,6 +20,14 @@
  * normalization `fetch` performs — rather than string-matching the template
  * output, because string matching is exactly what let this through.
  *
+ * The probe slot is asserted, never skipped. Checking only the segment count
+ * and the surrounding segments misses a **balanced** traversal, where the
+ * removed dot segments are matched by added ones: `list_abc/../../lists/victim`
+ * resolves `/v2/lists/PROBEVALUE` to `/v2/lists/victim` — same length, same
+ * neighbours, and only the slot the loop used to skip is different. The slot
+ * must equal `encodeURIComponent` of the trimmed input, which is what a guarded
+ * param emits for any vector it does not reject outright.
+ *
  * **One param is fuzzed at a time**, with every sibling held at a safe value.
  * Fuzzing all params at once and skipping the vector when the builder throws
  * looks equivalent but is not: as soon as a tool has one guarded param, that
@@ -48,6 +56,9 @@ const TRAVERSAL_IDS = [
   'list_abc#fragment',
   'list_abc/entries/../../../webhooks',
   '\\..\\..',
+  'list_abc/../../lists/victim',
+  'people/../../objects/victim',
+  'a/../b',
 ] as const
 
 /** Values a real user legitimately supplies; none may be rejected or altered. */
@@ -185,8 +196,9 @@ describe('attio path-ID traversal safety', () => {
       const actual = segmentsOf(path)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === PROBE_ID) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(
+          segment === PROBE_ID ? encodeURIComponent(value.trim()) : segment
+        )
       })
     })
 

--- a/apps/sim/tools/attio/path_safety.test.ts
+++ b/apps/sim/tools/attio/path_safety.test.ts
@@ -294,4 +294,18 @@ describe('attio_assert_record matching_attribute', () => {
       expect(() => build(value)).toThrow(/matchingAttribute is required/)
     }
   )
+
+  /**
+   * `String()` turns a single-element array into its element, so
+   * `['email_addresses']` would coerce into a selector that looks entirely
+   * valid. `tools/url-path.ts` rejects non-string kinds for this exact reason:
+   * a bare `String()` produces a plausible but wrong value instead of a named
+   * error. The same rule has to hold for the one query-string selector.
+   */
+  it.each([[['email_addresses']], [{}], [true], [123], [['email_addresses', 'domains']]])(
+    'rejects %j rather than coercing it into a selector',
+    (value) => {
+      expect(() => build(value)).toThrow(/matchingAttribute must be a string/)
+    }
+  )
 })

--- a/apps/sim/tools/attio/query_list_entries.ts
+++ b/apps/sim/tools/attio/query_list_entries.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioQueryListEntriesParams, AttioQueryListEntriesResponse } from './types'
 import { LIST_ENTRY_OUTPUT_PROPERTIES } from './types'
 
@@ -60,7 +61,8 @@ export const attioQueryListEntriesTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/lists/${params.list.trim()}/entries/query`,
+    url: (params) =>
+      `https://api.attio.com/v2/lists/${safeUrlPathSegment(params.list, 'list')}/entries/query`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,
@@ -73,14 +75,14 @@ export const attioQueryListEntriesTool: ToolConfig<
           body.filter =
             typeof params.filter === 'string' ? JSON.parse(params.filter) : params.filter
         } catch {
-          body.filter = {}
+          throw new Error('Invalid JSON provided for filter')
         }
       }
       if (params.sorts) {
         try {
           body.sorts = typeof params.sorts === 'string' ? JSON.parse(params.sorts) : params.sorts
         } catch {
-          body.sorts = []
+          throw new Error('Invalid JSON provided for sorts')
         }
       }
       if (params.limit != null) body.limit = params.limit

--- a/apps/sim/tools/attio/update_attribute.ts
+++ b/apps/sim/tools/attio/update_attribute.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioUpdateAttributeParams, AttioUpdateAttributeResponse } from './types'
 import { ATTRIBUTE_OUTPUT_PROPERTIES } from './types'
 
@@ -90,7 +91,7 @@ export const attioUpdateAttributeTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.attio.com/v2/${params.target.trim()}/${params.identifier.trim()}/attributes/${params.attribute.trim()}`,
+      `https://api.attio.com/v2/${safeUrlPathSegment(params.target, 'target')}/${safeUrlPathSegment(params.identifier, 'identifier')}/attributes/${safeUrlPathSegment(params.attribute, 'attribute')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/update_list.ts
+++ b/apps/sim/tools/attio/update_list.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioUpdateListParams, AttioUpdateListResponse } from './types'
 import { LIST_OUTPUT_PROPERTIES } from './types'
 
@@ -58,7 +59,7 @@ export const attioUpdateListTool: ToolConfig<AttioUpdateListParams, AttioUpdateL
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/lists/${params.list.trim()}`,
+    url: (params) => `https://api.attio.com/v2/lists/${safeUrlPathSegment(params.list, 'list')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,
@@ -76,7 +77,7 @@ export const attioUpdateListTool: ToolConfig<AttioUpdateListParams, AttioUpdateL
               ? JSON.parse(params.workspaceMemberAccess)
               : params.workspaceMemberAccess
         } catch {
-          data.workspace_member_access = params.workspaceMemberAccess
+          throw new Error('Invalid JSON provided for workspace member access')
         }
       }
       return { data }

--- a/apps/sim/tools/attio/update_list_entry.ts
+++ b/apps/sim/tools/attio/update_list_entry.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioUpdateListEntryParams, AttioUpdateListEntryResponse } from './types'
 import { LIST_ENTRY_OUTPUT_PROPERTIES } from './types'
 
@@ -48,7 +49,7 @@ export const attioUpdateListEntryTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.attio.com/v2/lists/${params.list.trim()}/entries/${params.entryId.trim()}`,
+      `https://api.attio.com/v2/lists/${safeUrlPathSegment(params.list, 'list')}/entries/${safeUrlPathSegment(params.entryId, 'entryId')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,
@@ -62,7 +63,7 @@ export const attioUpdateListEntryTool: ToolConfig<
             ? JSON.parse(params.entryValues)
             : params.entryValues
       } catch {
-        entryValues = {}
+        throw new Error('Invalid JSON provided for entry values')
       }
       return { data: { entry_values: entryValues } }
     },

--- a/apps/sim/tools/attio/update_object.ts
+++ b/apps/sim/tools/attio/update_object.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioUpdateObjectParams, AttioUpdateObjectResponse } from './types'
 import { OBJECT_OUTPUT_PROPERTIES } from './types'
 
@@ -51,7 +52,8 @@ export const attioUpdateObjectTool: ToolConfig<AttioUpdateObjectParams, AttioUpd
     },
 
     request: {
-      url: (params) => `https://api.attio.com/v2/objects/${params.object.trim()}`,
+      url: (params) =>
+        `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.object, 'object')}`,
       method: 'PATCH',
       headers: (params) => ({
         Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/update_record.ts
+++ b/apps/sim/tools/attio/update_record.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioUpdateRecordParams, AttioUpdateRecordResponse } from './types'
 import { RECORD_OBJECT_OUTPUT } from './types'
 
@@ -46,7 +47,7 @@ export const attioUpdateRecordTool: ToolConfig<AttioUpdateRecordParams, AttioUpd
 
     request: {
       url: (params) =>
-        `https://api.attio.com/v2/objects/${params.objectType.trim()}/records/${params.recordId.trim()}`,
+        `https://api.attio.com/v2/objects/${safeUrlPathSegment(params.objectType, 'objectType')}/records/${safeUrlPathSegment(params.recordId, 'recordId')}`,
       method: 'PATCH',
       headers: (params) => ({
         Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/attio/update_task.ts
+++ b/apps/sim/tools/attio/update_task.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioUpdateTaskParams, AttioUpdateTaskResponse } from './types'
 import { TASK_OUTPUT_PROPERTIES } from './types'
 
@@ -56,7 +57,8 @@ export const attioUpdateTaskTool: ToolConfig<AttioUpdateTaskParams, AttioUpdateT
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/tasks/${params.taskId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/tasks/${safeUrlPathSegment(params.taskId, 'taskId')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,
@@ -73,7 +75,7 @@ export const attioUpdateTaskTool: ToolConfig<AttioUpdateTaskParams, AttioUpdateT
               ? JSON.parse(params.linkedRecords)
               : params.linkedRecords
         } catch {
-          data.linked_records = []
+          throw new Error('Invalid JSON provided for linked records')
         }
       }
       if (params.assignees) {
@@ -81,7 +83,7 @@ export const attioUpdateTaskTool: ToolConfig<AttioUpdateTaskParams, AttioUpdateT
           data.assignees =
             typeof params.assignees === 'string' ? JSON.parse(params.assignees) : params.assignees
         } catch {
-          data.assignees = []
+          throw new Error('Invalid JSON provided for assignees')
         }
       }
       return { data }

--- a/apps/sim/tools/attio/update_webhook.ts
+++ b/apps/sim/tools/attio/update_webhook.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { AttioUpdateWebhookParams, AttioUpdateWebhookResponse } from './types'
 import { WEBHOOK_OUTPUT_PROPERTIES } from './types'
 
@@ -47,7 +48,8 @@ export const attioUpdateWebhookTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.attio.com/v2/webhooks/${params.webhookId.trim()}`,
+    url: (params) =>
+      `https://api.attio.com/v2/webhooks/${safeUrlPathSegment(params.webhookId, 'webhookId')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,
@@ -63,7 +65,7 @@ export const attioUpdateWebhookTool: ToolConfig<
               ? JSON.parse(params.subscriptions)
               : params.subscriptions
         } catch {
-          data.subscriptions = []
+          throw new Error('Invalid JSON provided for subscriptions')
         }
       }
       return { data }


### PR DESCRIPTION
Two integrity defects in the Attio tools, plus the test harnesses that pin them.

## Defect 1 — silent data substitution on JSON parse failure

**13 parse sites across 9 tools** caught a `JSON.parse` failure and substituted an empty value (`{}` / `[]`), or forwarded the raw unparsed string, then reported success.

All now throw the folder's established named error, matching what `create_record`, `assert_record`, `update_record`, `create_attribute`, `update_attribute` and `list_records` already did.

| Tool | Param | Was | Consequence before |
|---|---|---|---|
| `query_list_entries` | `filter` | `{}` | **Unfiltered** query over the whole list, reported as success — the caller gets *more* rows than they asked for |
| `query_list_entries` | `sorts` | `[]` | Unsorted results, reported as success |
| `create_list_entry` / `update_list_entry` | `entryValues` | `{}` | Entry written with no values |
| `create_task` / `update_task` | `linkedRecords` | `[]` | Task created/updated with no links |
| `create_task` / `update_task` | `assignees` | `[]` | Task created/updated unassigned |
| `create_webhook` | `subscriptions` | `[]` | Webhook created subscribed to **nothing** — it silently never fires |
| `update_webhook` | `subscriptions` | `[]` | **Destructive**: replaces a live webhook's subscriptions with `[]`, silently disabling it |
| `create_list` / `update_list` | `workspaceMemberAccess` | raw string | Attio 400 with an opaque provider error |

Verified against Attio's official docs: `filter` is an object and `sorts` an array in the `POST /v2/lists/{list}/entries/query` body; `data.subscriptions` is a **required** array on `POST /v2/webhooks`. So `[]` was not a harmless default — it was a valid-looking body with the caller's intent removed.

## Defect 2 — path traversal

**43 path segments across 31 tools** interpolated an LLM-writable id straight into the request path. These params are `visibility: 'user-or-llm'`, so prompt injection controls them.

`encodeURIComponent` is not sufficient: `.` and `..` are unreserved, so they survive encoding untouched and the URL parser then removes them as dot segments — popping a path segment on a fixed host with the caller's Attio bearer token still attached, including on DELETE. Every segment now goes through the shared `safeUrlPathSegment`, which rejects rather than encodes.

`assert_record` additionally built its `matching_attribute` **query** value by raw interpolation; it now uses `URLSearchParams`. Docs confirm `matching_attribute` is a required query parameter on `PUT /v2/objects/{object}/records`.

Two follow-up hardenings on that same selector, both found in review and both the same class of bug this PR exists to fix:

- An absent selector was being substituted with `matching_attribute=` and the upsert sent anyway — the exact silent substitution the rest of the PR removes, and a local *weakening*, since the previous `.trim()` at least threw on `null`/`undefined`. It now throws `matchingAttribute is required`.
- A bare `String()` coerced non-strings into plausible-but-wrong selectors: `String(['email_addresses'])` is `'email_addresses'`, so a single-element array passed as a completely valid-looking selector, and `{}` became `'[object Object]'`. This is the trap `tools/url-path.ts` documents for path segments; the runtime type is now checked before any stringification.

## Behaviour changes and backwards compatibility

Every behaviour change, and why it cannot break a working workflow.

**1. Malformed JSON now throws instead of substituting.** This is the one change an existing user can notice. A workflow that was unknowingly passing malformed JSON — and therefore unknowingly running an unfiltered `query_list_entries`, or writing an unassigned task — previously reported **success**. It now fails loudly. The data was already wrong; only the reporting changes. Stated plainly because it *is* a change for an existing user.

Unaffected, verified by test: valid JSON; an omitted param; a **blank** optional param (`''`); and an already-parsed object/array piped from another block. The truthy guard is deliberately preserved — `apps/sim/tools/params.ts:858-863` treats `''` as the platform's canonical "not provided" value, so a blank optional field must not throw.

**2. Values that previously reached the wire and now throw** — the complete list:
- exactly `.` or `..` after trimming
- any value containing `/` or `\`

Neither is a legitimate Attio identifier. Attio ids are UUIDs and slugs; a dot *inside* a longer segment (`example.com`, `v1.2.3`, `..foo`, `foo..`) is preserved untouched and is covered by `LEGITIMATE_IDS`.

**3. Values that previously threw, and now throw a better error** (no compatibility surface):
- `null` / `undefined` — was `TypeError: params.X.trim is not a function`, now `X is required`
- object / boolean / array — was the same `TypeError`, now `X must be a string or a number (received object)`
- unpaired UTF-16 surrogate — was a bare `URIError` naming nothing, now named

**4. Values that previously threw and now succeed** (strictly more permissive): a numeric id arriving as a JSON number, which `.trim()` used to crash on.

**5. Percent-encoding is now applied.** For Attio slugs and UUIDs encoding is the identity, so no legitimate value changes; `path_safety.test.ts` proves this with `LEGITIMATE_IDS`. A literal `%` would now become `%25`, but no Attio identifier contains one, and a raw `%` previously formed an invalid escape anyway.

**6. `matching_attribute` encoding and validation.** For documented values (`email_addresses`, `domains`) encoding is the identity. A value containing `&` or `=` previously injected query parameters. Newly rejected: an absent selector (was silently sent as empty) and a non-string selector (was coerced). Both were previously reachable only from surfaces that do not run the platform's required-param check, since `matchingAttribute` is `required: true` and `params.ts:858-863` rejects `''` on the normal executor path — the guard should not depend on a caller's validation.

**Not changed:** no subBlock id, no `visibility`, no `required`, no param/output/description line. `blocks/blocks/attio.ts` is untouched. Every changed line in the 34 tool files is one of exactly three kinds — the import, a URL builder, or a `catch` body. No new non-test file, and no new helper: `safeUrlPathSegment` is imported from the pre-existing shared `@/tools/url-path`.

## Tests

Both harnesses enumerate the tools from the barrel and discover their own cases, so a new unguarded path param or a new swallowed parse site fails CI without anyone extending a list. Every URL assertion resolves with `new URL(...)` — the normalization `fetch` performs — rather than string-matching the template.

Three holes were found and closed during review, each verified by a scoped revert:

1. **Fuzzing all params at once.** The original harness filled every string param with the same value and did `catch { return }`, so the first guarded param threw and its siblings were never exercised. Discovery is now per **(tool, param)** pair — 43 pairs across 31 tools, matching the 43 guarded call sites one for one.
2. **Skipping the probe slot.** `if (segment === PROBE_ID) return` proved the segment count and the neighbours but never what landed in the slot. A *balanced* traversal defeats that. The slot is now asserted to equal `encodeURIComponent` of the trimmed input.
3. **A sweep that only caught empty-value substitution.** Raw-string forwarding and non-named errors both slipped through. The sweep now classifies each body param by where a sentinel lands and holds parsed params to `/Invalid JSON provided/`.

Scoped revert of `get_attribute / identifier`, showing each hole in turn:

| Harness | Failures |
|---|---|
| 10 vectors, slot skipped (original) | 15 |
| 13 vectors, slot skipped | 17 — `a/../b` still passing |
| 13 vectors, slot asserted (current) | **18** |

`a/../b` is the minimal witness: it pops one segment and adds one, so length and neighbours are identical and only the slot differs.

Red-first for the sweep, by reverting `create_list` to each violation shape: raw-string forwarding fails 2 tests, `throw new Error('bad input')` fails 2 tests. Both passed before.

**2014 tests pass.**

## Validation against Attio's official API docs

Ran the `validate-integration` checklist. Verified from the official docs (Context7 `/websites/attio_mintlify_app`):

- `POST /v2/objects/{object}/records/query` and `POST /v2/lists/{list}/entries/query` — `filter` object, `sorts` array, `limit`/`offset` in the **body**. Matches.
- `PUT /v2/objects/{object}/records` with `matching_attribute` as a **required query param**. Matches.
- `POST /v2/webhooks` — `data.target_url` + required `data.subscriptions` array of `{event_type, filter?}`. Matches.
- Task write bodies — `linked_records` and `assignees` arrays. Matches.
- Response envelope — all 45 tools read `data.data`, consistent with the documented `{ data: ... }` shape.

Conventions: 45/45 tools registered in `tools/registry.ts` and exported from the barrel with no orphans and no phantom entries; all 45 `accessToken` params are `visibility: 'hidden'`; every param has explicit `required`, `visibility` and `description`; no duplicate subBlock ids.

**Unverifiable, reported rather than guessed:** per-endpoint response field lists for the individual `get_*`/`list_*` tools are not enumerated in the public docs beyond the `{ data: ... }` envelope. Those `transformResponse` field extractions are pre-existing and untouched by this PR, so they are flagged for a follow-up with sample payloads rather than adjusted on inference.

## Gates

`bun run lint`, `bun run check:audits` (**39/39**), `check-block-registry` — all clean. Test files type-check clean under an explicit tsconfig (note `apps/sim/tsconfig.json` excludes `**/*.test.ts`, so CI does not cover them). `tool-metadata:check` passes with no regeneration: no param or output changed.

