### PR TITLE
fix(sixtyfour,enrow): stop nulling model-supplied struct, retry transient poll failures

### DIFF
--- a/apps/sim/blocks/blocks/sixtyfour.test.ts
+++ b/apps/sim/blocks/blocks/sixtyfour.test.ts
@@ -72,6 +72,55 @@ describe('SixtyfourBlock agent path', () => {
     expect(sent.targetCompany).toBe('{"name":"Acme Inc"}')
   })
 
+  it.each([
+    ['null', null],
+    ['an empty string', ''],
+  ])('keeps the model-supplied struct when the subBlock resolves to %s', async (_label, empty) => {
+    const transform = await agentParamsTransform('enrich_lead', { apiKey: 'key' })
+
+    const sent = transform({
+      operation: 'enrich_lead',
+      apiKey: 'key',
+      leadInfo: '{"name":"John Doe"}',
+      leadStruct: empty,
+      struct: '{"email":"Work email address"}',
+    })
+
+    expect(sent.struct).toBe('{"email":"Work email address"}')
+  })
+
+  it('keeps the model-supplied company struct when the subBlock resolves to null', async () => {
+    const transform = await agentParamsTransform('enrich_company', { apiKey: 'key' })
+
+    const sent = transform({
+      operation: 'enrich_company',
+      apiKey: 'key',
+      companyStruct: null,
+      targetCompany: '{"name":"Acme Inc"}',
+      struct: '{"website":"Company website URL"}',
+    })
+
+    expect(sent.struct).toBe('{"website":"Company website URL"}')
+    expect(sent.targetCompany).toBe('{"name":"Acme Inc"}')
+  })
+
+  it('forwards an explicit false switch without coercing an untouched one', () => {
+    const mapped = buildParams({
+      operation: 'enrich_company',
+      apiKey: 'key',
+      targetCompany: '{"name":"Acme Inc"}',
+      companyStruct: '{"website":"Company website URL"}',
+      findPeople: false,
+      fullOrgChart: null,
+    })
+
+    // A switch the user actually turned off must still reach the tool as `false`.
+    expect(mapped.findPeople).toBe(false)
+    // An untouched one must not be written at all, so `Boolean(null)` cannot
+    // force `false` over a `true` the model sent.
+    expect('fullOrgChart' in mapped).toBe(false)
+  })
+
   it('lets a configured block value win over the model for enrich_lead', async () => {
     const transform = await agentParamsTransform('enrich_lead', {
       apiKey: 'key',

--- a/apps/sim/blocks/blocks/sixtyfour.test.ts
+++ b/apps/sim/blocks/blocks/sixtyfour.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { SixtyfourBlock } from '@/blocks/blocks/sixtyfour'
+import { transformBlockTool } from '@/providers/utils'
+import { sixtyfourEnrichCompanyTool } from '@/tools/sixtyfour/enrich_company'
+import { sixtyfourEnrichLeadTool } from '@/tools/sixtyfour/enrich_lead'
+import { sixtyfourFindEmailTool } from '@/tools/sixtyfour/find_email'
+import { sixtyfourFindPhoneTool } from '@/tools/sixtyfour/find_phone'
+import type { ExecutableToolConfig } from '@/tools/types'
+
+const SIXTYFOUR_TOOLS: Record<string, ExecutableToolConfig> = {
+  sixtyfour_find_phone: sixtyfourFindPhoneTool as ExecutableToolConfig,
+  sixtyfour_find_email: sixtyfourFindEmailTool as ExecutableToolConfig,
+  sixtyfour_enrich_lead: sixtyfourEnrichLeadTool as ExecutableToolConfig,
+  sixtyfour_enrich_company: sixtyfourEnrichCompanyTool as ExecutableToolConfig,
+}
+
+const buildParams = SixtyfourBlock.tools.config!.params!
+
+/** The shape the generic (canvas) handler forwards: raw inputs overlaid by the mapper. */
+const resolve = (inputs: Record<string, unknown>) => ({ ...inputs, ...buildParams(inputs) })
+
+/**
+ * Builds the agent-path `paramsTransform` the way `transformBlockTool` does, so
+ * assertions run against the exact function that rewrites a model's tool-call
+ * arguments before `executeTool` sees them.
+ */
+async function agentParamsTransform(
+  operation: string,
+  blockParams: Record<string, unknown>
+): Promise<(args: Record<string, unknown>) => Record<string, unknown>> {
+  const tool = await transformBlockTool(
+    { type: 'sixtyfour', operation, params: { operation, ...blockParams } },
+    {
+      selectedOperation: operation,
+      getAllBlocks: () => [SixtyfourBlock],
+      getTool: (id: string) => SIXTYFOUR_TOOLS[id],
+    }
+  )
+  if (!tool?.paramsTransform) throw new Error(`No paramsTransform for ${operation}`)
+  return tool.paramsTransform as (args: Record<string, unknown>) => Record<string, unknown>
+}
+
+describe('SixtyfourBlock agent path', () => {
+  it('keeps the model-supplied struct for enrich_lead', async () => {
+    const transform = await agentParamsTransform('enrich_lead', { apiKey: 'key' })
+
+    const sent = transform({
+      operation: 'enrich_lead',
+      apiKey: 'key',
+      leadInfo: '{"name":"John Doe"}',
+      struct: '{"email":"Work email address"}',
+    })
+
+    expect(sent.struct).toBe('{"email":"Work email address"}')
+    expect(sent.leadInfo).toBe('{"name":"John Doe"}')
+  })
+
+  it('keeps the model-supplied struct for enrich_company', async () => {
+    const transform = await agentParamsTransform('enrich_company', { apiKey: 'key' })
+
+    const sent = transform({
+      operation: 'enrich_company',
+      apiKey: 'key',
+      targetCompany: '{"name":"Acme Inc"}',
+      struct: '{"website":"Company website URL"}',
+    })
+
+    expect(sent.struct).toBe('{"website":"Company website URL"}')
+    expect(sent.targetCompany).toBe('{"name":"Acme Inc"}')
+  })
+
+  it('lets a configured block value win over the model for enrich_lead', async () => {
+    const transform = await agentParamsTransform('enrich_lead', {
+      apiKey: 'key',
+      leadStruct: '{"phone":"Phone number"}',
+    })
+
+    const sent = transform({
+      operation: 'enrich_lead',
+      apiKey: 'key',
+      leadStruct: '{"phone":"Phone number"}',
+      leadInfo: '{"name":"John Doe"}',
+    })
+
+    expect(sent.struct).toBe('{"phone":"Phone number"}')
+  })
+})
+
+describe('SixtyfourBlock canvas path', () => {
+  it('maps the lead subBlocks onto the tool params', () => {
+    const params = resolve({
+      operation: 'enrich_lead',
+      apiKey: 'key',
+      leadInfo: '{"name":"John Doe"}',
+      leadStruct: '{"email":"Work email address"}',
+      leadResearchPlan: 'Check LinkedIn first',
+    })
+
+    expect(params.leadInfo).toBe('{"name":"John Doe"}')
+    expect(params.struct).toBe('{"email":"Work email address"}')
+    expect(params.researchPlan).toBe('Check LinkedIn first')
+  })
+
+  it('maps the company subBlocks onto the tool params', () => {
+    const params = resolve({
+      operation: 'enrich_company',
+      apiKey: 'key',
+      targetCompany: '{"name":"Acme Inc"}',
+      companyStruct: '{"website":"Company website URL"}',
+      companyLeadStruct: '{"name":"Full name"}',
+      companyResearchPlan: 'Start from the careers page',
+    })
+
+    expect(params.targetCompany).toBe('{"name":"Acme Inc"}')
+    expect(params.struct).toBe('{"website":"Company website URL"}')
+    expect(params.leadStruct).toBe('{"name":"Full name"}')
+    expect(params.researchPlan).toBe('Start from the careers page')
+  })
+
+  it('renames the lookup inputs for the find operations', () => {
+    expect(resolve({ operation: 'find_phone', emailInput: 'a@b.com' }).email).toBe('a@b.com')
+    expect(resolve({ operation: 'find_email', phoneInput: '+15551234' }).phone).toBe('+15551234')
+  })
+})

--- a/apps/sim/blocks/blocks/sixtyfour.ts
+++ b/apps/sim/blocks/blocks/sixtyfour.ts
@@ -223,7 +223,8 @@ export const SixtyfourBlock: BlockConfig = {
       /**
        * Renames the operation-scoped subBlock ids onto the tool's param names.
        *
-       * Every assignment is guarded on the source being present. The agent path
+       * Every assignment is guarded on the source being present — see `present` below
+       * for why `undefined` alone is not a sufficient test. The agent path
        * overlays this return on top of the model's own tool-call arguments, and
        * the model supplies the *tool* names (`struct`, `targetCompany`), not the
        * subBlock names (`leadStruct`, `companyStruct`) — so an unguarded write
@@ -233,19 +234,31 @@ export const SixtyfourBlock: BlockConfig = {
       params: (params) => {
         const result: Record<string, unknown> = {}
 
+        /**
+         * Whether a source value is present enough to overwrite what the model sent.
+         *
+         * `undefined` alone is not sufficient: the serializer stores every untouched
+         * subBlock as `params[id] ?? null`, so an unfilled field arrives as `null`,
+         * and a cleared one as `''`. Both would otherwise be written over a valid
+         * model argument — `null` reaching the tool as an invalid required param,
+         * `''` failing its `JSON.parse` with "struct must be valid JSON". This is
+         * the same guard `trigger_dev`'s `scoped()` and the `enrow` mapper use.
+         */
+        const present = (value: unknown) => value !== undefined && value !== null && value !== ''
+
         if (params.operation === 'find_phone') {
           if (params.emailInput) result.email = params.emailInput
         } else if (params.operation === 'find_email') {
           if (params.phoneInput) result.phone = params.phoneInput
         } else if (params.operation === 'enrich_lead') {
-          if (params.leadInfo !== undefined) result.leadInfo = params.leadInfo
-          if (params.leadStruct !== undefined) result.struct = params.leadStruct
+          if (present(params.leadInfo)) result.leadInfo = params.leadInfo
+          if (present(params.leadStruct)) result.struct = params.leadStruct
           if (params.leadResearchPlan) result.researchPlan = params.leadResearchPlan
         } else if (params.operation === 'enrich_company') {
-          if (params.targetCompany !== undefined) result.targetCompany = params.targetCompany
-          if (params.companyStruct !== undefined) result.struct = params.companyStruct
-          if (params.findPeople !== undefined) result.findPeople = Boolean(params.findPeople)
-          if (params.fullOrgChart !== undefined) result.fullOrgChart = Boolean(params.fullOrgChart)
+          if (present(params.targetCompany)) result.targetCompany = params.targetCompany
+          if (present(params.companyStruct)) result.struct = params.companyStruct
+          if (present(params.findPeople)) result.findPeople = Boolean(params.findPeople)
+          if (present(params.fullOrgChart)) result.fullOrgChart = Boolean(params.fullOrgChart)
           if (params.peopleFocusPrompt) result.peopleFocusPrompt = params.peopleFocusPrompt
           if (params.companyLeadStruct) result.leadStruct = params.companyLeadStruct
           if (params.companyResearchPlan) result.researchPlan = params.companyResearchPlan

--- a/apps/sim/blocks/blocks/sixtyfour.ts
+++ b/apps/sim/blocks/blocks/sixtyfour.ts
@@ -220,6 +220,16 @@ export const SixtyfourBlock: BlockConfig = {
     ],
     config: {
       tool: (params) => `sixtyfour_${params.operation}`,
+      /**
+       * Renames the operation-scoped subBlock ids onto the tool's param names.
+       *
+       * Every assignment is guarded on the source being present. The agent path
+       * overlays this return on top of the model's own tool-call arguments, and
+       * the model supplies the *tool* names (`struct`, `targetCompany`), not the
+       * subBlock names (`leadStruct`, `companyStruct`) — so an unguarded write
+       * would set the required `struct` to `undefined` and drop what the model
+       * sent. A configured block value still wins, because it is present.
+       */
       params: (params) => {
         const result: Record<string, unknown> = {}
 
@@ -228,12 +238,12 @@ export const SixtyfourBlock: BlockConfig = {
         } else if (params.operation === 'find_email') {
           if (params.phoneInput) result.phone = params.phoneInput
         } else if (params.operation === 'enrich_lead') {
-          result.leadInfo = params.leadInfo
-          result.struct = params.leadStruct
+          if (params.leadInfo !== undefined) result.leadInfo = params.leadInfo
+          if (params.leadStruct !== undefined) result.struct = params.leadStruct
           if (params.leadResearchPlan) result.researchPlan = params.leadResearchPlan
         } else if (params.operation === 'enrich_company') {
-          result.targetCompany = params.targetCompany
-          result.struct = params.companyStruct
+          if (params.targetCompany !== undefined) result.targetCompany = params.targetCompany
+          if (params.companyStruct !== undefined) result.struct = params.companyStruct
           if (params.findPeople !== undefined) result.findPeople = Boolean(params.findPeople)
           if (params.fullOrgChart !== undefined) result.fullOrgChart = Boolean(params.fullOrgChart)
           if (params.peopleFocusPrompt) result.peopleFocusPrompt = params.peopleFocusPrompt

--- a/apps/sim/tools/enrow/find_email.test.ts
+++ b/apps/sim/tools/enrow/find_email.test.ts
@@ -42,10 +42,11 @@ const DOCUMENTED_FIND_BODY = {
   custom: {},
 }
 
-function jsonResponse(status: number, body: unknown): Response {
+function jsonResponse(status: number, body: unknown, headers?: Record<string, string>): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(headers),
     json: async () => body,
     text: async () => JSON.stringify(body),
   } as Response
@@ -71,8 +72,11 @@ const submittedFindResult: EnrowFindEmailResponse = {
   },
 }
 
-/** `MAX_POLL_TIME_MS / POLL_INTERVAL_MS` in `find_email.ts` — 120_000 / 3_000. */
+/** `MAX_POLL_TIME_MS / POLL_INTERVAL_MS` in `poll.ts` — 120_000 / 3_000. */
 const MAX_POLLS = 40
+
+/** `MAX_TRANSIENT_RETRIES` in `poll.ts`. */
+const MAX_TRANSIENT_RETRIES = 3
 
 describe('enrow_find_email', () => {
   beforeEach(() => {
@@ -139,6 +143,63 @@ describe('enrow_find_email', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it('retries a transient 5xx and still resolves the result', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(202, { qualification: 'ongoing' }))
+      .mockResolvedValueOnce(jsonResponse(503, { message: 'upstream unavailable' }))
+      .mockResolvedValueOnce(jsonResponse(200, DOCUMENTED_FIND_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(result.output.email).toBe('john.doe@stripe.com')
+  })
+
+  it('retries a 429 and honours Retry-After', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(429, { message: 'slow down' }, { 'retry-after': '2' }))
+      .mockResolvedValueOnce(jsonResponse(200, DOCUMENTED_FIND_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.output.qualification).toBe('valid')
+  })
+
+  it('gives up after a bounded number of transient failures', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(500, { message: 'boom' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow(/poll error: 500 - .*boom/)
+
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_TRANSIENT_RETRIES + 1)
+  })
+
+  it('never retries a non-transient 4xx', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(403, { message: 'forbidden' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow(/poll error: 403 - .*forbidden/)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('gives up after the polling window when every poll stays 202', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(202, { qualification: 'ongoing' }))
     vi.stubGlobal('fetch', fetchMock)
@@ -158,6 +219,27 @@ describe('enrow_verify_email', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('retries a transient 5xx on the verify poll too', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(502, { message: 'bad gateway' }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { email: 'john.doe@stripe.com', qualification: 'valid' })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const submitted: EnrowVerifyEmailResponse = {
+      success: true,
+      output: { id: JOB_ID, email: null, qualification: null },
+    }
+    const params: EnrowVerifyEmailParams = { apiKey: 'test-key', email: 'john.doe@stripe.com' }
+
+    const result = await enrowVerifyEmailTool.postProcess!(submitted, params, executeTool)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.output.qualification).toBe('valid')
   })
 
   it('reads the FLAT documented verify body — there is no `info` level here', async () => {

--- a/apps/sim/tools/enrow/find_email.test.ts
+++ b/apps/sim/tools/enrow/find_email.test.ts
@@ -100,7 +100,9 @@ const MAX_TRANSIENT_RETRIES = 3
 describe('enrow_find_email', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.restoreAllMocks()
     cancelledBodies = []
+    vi.mocked(sleep).mockImplementation(async () => undefined)
   })
 
   afterEach(() => {
@@ -264,6 +266,36 @@ describe('enrow_find_email', () => {
     ).rejects.toThrow('fetch failed')
   })
 
+  it('never sleeps past the wall-clock deadline when the polls themselves are slow', async () => {
+    // `elapsed` charges nothing for time spent inside `fetch`, so with slow polls
+    // the real clock runs ahead of it. A backoff sized against `elapsed` alone
+    // lands well past the deadline; it has to be clamped to the real remainder.
+    let now = Date.now()
+    const deadline = now + MAX_POLL_TIME_MS
+    const sleepStarts: number[] = []
+
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    vi.mocked(sleep).mockImplementation(async (ms: number) => {
+      sleepStarts.push(now)
+      now += ms
+    })
+
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      now += 55_000
+      return jsonResponse(500, { message: 'boom' }, { 'retry-after': '15' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+
+    // Second poll ends past the deadline, so its 15s backoff must be dropped to
+    // zero rather than clamped against the 99s that `elapsed` still thinks it has.
+    expect(sleepDelays()).toEqual([POLL_INTERVAL_MS, 15_000, POLL_INTERVAL_MS])
+    expect(sleepStarts.every((startedAt) => startedAt < deadline)).toBe(true)
+  })
+
   it('waits out the whole window when a late backoff would overrun it', async () => {
     const fetchMock = vi.fn().mockImplementation(async () => {
       // 38 in-progress polls, then a transient failure asking for far more time
@@ -323,7 +355,9 @@ describe('enrow_find_email', () => {
 describe('enrow_verify_email', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.restoreAllMocks()
     cancelledBodies = []
+    vi.mocked(sleep).mockImplementation(async () => undefined)
   })
 
   afterEach(() => {

--- a/apps/sim/tools/enrow/find_email.test.ts
+++ b/apps/sim/tools/enrow/find_email.test.ts
@@ -340,6 +340,17 @@ describe('enrow_find_email', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('never retries a 6xx from a misbehaving intermediary', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(600, { message: 'nonsense' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow(/poll error: 600 - .*nonsense/)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('gives up after the polling window when every poll stays 202', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(202, { qualification: 'ongoing' }))
     vi.stubGlobal('fetch', fetchMock)

--- a/apps/sim/tools/enrow/find_email.test.ts
+++ b/apps/sim/tools/enrow/find_email.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
  */
 vi.mock('@sim/utils/helpers', () => ({ sleep: vi.fn().mockResolvedValue(undefined) }))
 
+import { sleep } from '@sim/utils/helpers'
 import { enrowFindEmailTool } from '@/tools/enrow/find_email'
 import type {
   EnrowFindEmailParams,
@@ -42,14 +43,26 @@ const DOCUMENTED_FIND_BODY = {
   custom: {},
 }
 
+/** Records `body.cancel()` so the tests can prove an abandoned stream is released. */
 function jsonResponse(status: number, body: unknown, headers?: Record<string, string>): Response {
+  const cancel = vi.fn().mockResolvedValue(undefined)
+  cancelledBodies.push(cancel)
   return {
     ok: status >= 200 && status < 300,
     status,
     headers: new Headers(headers),
+    body: { cancel } as unknown as ReadableStream<Uint8Array>,
     json: async () => body,
     text: async () => JSON.stringify(body),
   } as Response
+}
+
+/** Every `body.cancel` spy handed out by `jsonResponse`, in creation order. */
+let cancelledBodies: Array<ReturnType<typeof vi.fn>> = []
+
+/** The delays the tool actually asked `sleep` for, in order. */
+function sleepDelays(): number[] {
+  return vi.mocked(sleep).mock.calls.map((call) => call[0] as number)
 }
 
 const findParams: EnrowFindEmailParams = {
@@ -72,8 +85,14 @@ const submittedFindResult: EnrowFindEmailResponse = {
   },
 }
 
-/** `MAX_POLL_TIME_MS / POLL_INTERVAL_MS` in `poll.ts` — 120_000 / 3_000. */
-const MAX_POLLS = 40
+/** `POLL_INTERVAL_MS` in `poll.ts`. */
+const POLL_INTERVAL_MS = 3000
+
+/** `MAX_POLL_TIME_MS` in `poll.ts`. */
+const MAX_POLL_TIME_MS = 120_000
+
+/** `MAX_POLL_TIME_MS / POLL_INTERVAL_MS`. */
+const MAX_POLLS = MAX_POLL_TIME_MS / POLL_INTERVAL_MS
 
 /** `MAX_TRANSIENT_RETRIES` in `poll.ts`. */
 const MAX_TRANSIENT_RETRIES = 3
@@ -81,6 +100,7 @@ const MAX_TRANSIENT_RETRIES = 3
 describe('enrow_find_email', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    cancelledBodies = []
   })
 
   afterEach(() => {
@@ -143,7 +163,7 @@ describe('enrow_find_email', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
-  it('retries a transient 5xx and still resolves the result', async () => {
+  it('backs off exponentially after a transient 5xx, then resolves', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse(202, { qualification: 'ongoing' }))
@@ -159,9 +179,21 @@ describe('enrow_find_email', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(result.output.email).toBe('john.doe@stripe.com')
+
+    // Three poll intervals plus one backoff, which is attempt 1 off the 1000ms
+    // base with +/-20% jitter — and notably not another 3000ms poll interval.
+    const delays = sleepDelays()
+    expect(delays).toHaveLength(4)
+    expect([delays[0], delays[1], delays[3]]).toEqual([
+      POLL_INTERVAL_MS,
+      POLL_INTERVAL_MS,
+      POLL_INTERVAL_MS,
+    ])
+    expect(delays[2]).toBeGreaterThanOrEqual(800)
+    expect(delays[2]).toBeLessThanOrEqual(1200)
   })
 
-  it('retries a 429 and honours Retry-After', async () => {
+  it('waits exactly the Retry-After delay on a 429 instead of its own backoff', async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse(429, { message: 'slow down' }, { 'retry-after': '2' }))
@@ -176,6 +208,82 @@ describe('enrow_find_email', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(result.output.qualification).toBe('valid')
+
+    // `Retry-After: 2` is honoured verbatim (2000ms, no jitter), not replaced by
+    // the 1000ms exponential base the 5xx path would have produced.
+    expect(sleepDelays()).toEqual([POLL_INTERVAL_MS, 2000, POLL_INTERVAL_MS])
+  })
+
+  it('releases the body of every response it abandons', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(202, { qualification: 'ongoing' }))
+      .mockResolvedValueOnce(jsonResponse(503, { message: 'upstream unavailable' }))
+      .mockResolvedValueOnce(jsonResponse(200, DOCUMENTED_FIND_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+
+    const [inProgress, transient, completed] = cancelledBodies
+    expect(inProgress).toHaveBeenCalledTimes(1)
+    expect(transient).toHaveBeenCalledTimes(1)
+    expect(completed).not.toHaveBeenCalled()
+  })
+
+  it('bounds every poll request with an abort signal', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, DOCUMENTED_FIND_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.enrow.io/email/find/single?id=job-123',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+  })
+
+  it('reports the polling window when a request is aborted at the deadline', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows a genuine transport failure rather than calling it a timeout', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow('fetch failed')
+  })
+
+  it('waits out the whole window when a late backoff would overrun it', async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      // 38 in-progress polls, then a transient failure asking for far more time
+      // than the window has left. The wait must be clipped to the remainder, not
+      // skipped — skipping it abandons a live job before the window is spent.
+      const call = fetchMock.mock.calls.length
+      return call <= 38
+        ? jsonResponse(202, { qualification: 'ongoing' })
+        : jsonResponse(500, { message: 'boom' }, { 'retry-after': '60' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+
+    expect(fetchMock).toHaveBeenCalledTimes(39)
+    const total = sleepDelays().reduce((sum, delay) => sum + delay, 0)
+    expect(total).toBe(MAX_POLL_TIME_MS)
+    expect(sleepDelays().at(-1)).toBe(MAX_POLL_TIME_MS - 39 * POLL_INTERVAL_MS)
   })
 
   it('gives up after a bounded number of transient failures', async () => {
@@ -215,6 +323,7 @@ describe('enrow_find_email', () => {
 describe('enrow_verify_email', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    cancelledBodies = []
   })
 
   afterEach(() => {

--- a/apps/sim/tools/enrow/find_email.test.ts
+++ b/apps/sim/tools/enrow/find_email.test.ts
@@ -351,6 +351,33 @@ describe('enrow_find_email', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('reports the polling window when a 200 body aborts mid-read', async () => {
+    const abort = new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    const stalled = jsonResponse(200, {})
+    stalled.json = async () => {
+      throw abort
+    }
+    const fetchMock = vi.fn().mockResolvedValue(stalled)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+  })
+
+  it('keeps the status when an error body cannot be read', async () => {
+    const unreadable = jsonResponse(403, {})
+    unreadable.text = async () => {
+      throw new Error('socket hang up')
+    }
+    const fetchMock = vi.fn().mockResolvedValue(unreadable)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
+    ).rejects.toThrow('Enrow find-email poll error: 403 - <unreadable body>')
+  })
+
   it('gives up after the polling window when every poll stays 202', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(202, { qualification: 'ongoing' }))
     vi.stubGlobal('fetch', fetchMock)

--- a/apps/sim/tools/enrow/find_email.test.ts
+++ b/apps/sim/tools/enrow/find_email.test.ts
@@ -158,9 +158,14 @@ describe('enrow_find_email', () => {
       .mockResolvedValueOnce(jsonResponse(401, { message: 'invalid api key' }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow(/poll error: 401 - .*invalid api key/)
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toMatch(/poll error: 401 - .*invalid api key/)
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
@@ -250,9 +255,14 @@ describe('enrow_find_email', () => {
       .mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError'))
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toContain('Enrow find-email did not complete within the polling window')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
@@ -261,9 +271,14 @@ describe('enrow_find_email', () => {
     const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed'))
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow('fetch failed')
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toContain('fetch failed')
   })
 
   it('never sleeps past the wall-clock deadline when the polls themselves are slow', async () => {
@@ -286,9 +301,14 @@ describe('enrow_find_email', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toContain('Enrow find-email did not complete within the polling window')
 
     // Second poll ends past the deadline, so its 15s backoff must be dropped to
     // zero rather than clamped against the 99s that `elapsed` still thinks it has.
@@ -308,9 +328,14 @@ describe('enrow_find_email', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toContain('Enrow find-email did not complete within the polling window')
 
     expect(fetchMock).toHaveBeenCalledTimes(39)
     const total = sleepDelays().reduce((sum, delay) => sum + delay, 0)
@@ -322,9 +347,14 @@ describe('enrow_find_email', () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(500, { message: 'boom' }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow(/poll error: 500 - .*boom/)
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toMatch(/poll error: 500 - .*boom/)
 
     expect(fetchMock).toHaveBeenCalledTimes(MAX_TRANSIENT_RETRIES + 1)
   })
@@ -333,9 +363,14 @@ describe('enrow_find_email', () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(403, { message: 'forbidden' }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow(/poll error: 403 - .*forbidden/)
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toMatch(/poll error: 403 - .*forbidden/)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
@@ -344,9 +379,14 @@ describe('enrow_find_email', () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(600, { message: 'nonsense' }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow(/poll error: 600 - .*nonsense/)
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toMatch(/poll error: 600 - .*nonsense/)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
@@ -360,9 +400,14 @@ describe('enrow_find_email', () => {
     const fetchMock = vi.fn().mockResolvedValue(stalled)
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toContain('Enrow find-email did not complete within the polling window')
   })
 
   it('keeps the status when an error body cannot be read', async () => {
@@ -373,18 +418,51 @@ describe('enrow_find_email', () => {
     const fetchMock = vi.fn().mockResolvedValue(unreadable)
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow('Enrow find-email poll error: 403 - <unreadable body>')
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toContain('Enrow find-email poll error: 403 - <unreadable body>')
+  })
+
+  it('reports a failed poll as a failed tool response, not a null-field success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(403, { message: 'forbidden' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    /*
+     * `executeTool` swallows a throw from `postProcess` and restores the submit
+     * response — `success: true` with every field null — so the failure has to
+     * be returned rather than thrown or the user sees a successful lookup that
+     * merely found nothing.
+     */
+    expect(failed.success).toBe(false)
+    expect(failed.error).toMatch(/poll error: 403/)
+    expect(failed.output.id).toBe(submittedFindResult.output.id)
+    expect(failed.output.email).toBeNull()
+    expect(failed.output.qualification).toBeNull()
   })
 
   it('gives up after the polling window when every poll stays 202', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(202, { qualification: 'ongoing' }))
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(
-      enrowFindEmailTool.postProcess!(submittedFindResult, findParams, executeTool)
-    ).rejects.toThrow('Enrow find-email did not complete within the polling window')
+    const failed = await enrowFindEmailTool.postProcess!(
+      submittedFindResult,
+      findParams,
+      executeTool
+    )
+
+    expect(failed.success).toBe(false)
+    expect(failed.error).toContain('Enrow find-email did not complete within the polling window')
 
     expect(fetchMock).toHaveBeenCalledTimes(MAX_POLLS)
   })

--- a/apps/sim/tools/enrow/find_email.ts
+++ b/apps/sim/tools/enrow/find_email.ts
@@ -1,5 +1,5 @@
-import { sleep } from '@sim/utils/helpers'
 import { enrowHosting } from '@/tools/enrow/hosting'
+import { pollEnrowJob } from '@/tools/enrow/poll'
 import type {
   EnrowFindEmailParams,
   EnrowFindEmailResponse,
@@ -11,9 +11,6 @@ import {
   ENROW_QUALIFICATION_OUTPUT,
 } from '@/tools/enrow/types'
 import type { ToolConfig } from '@/tools/types'
-
-const POLL_INTERVAL_MS = 3000
-const MAX_POLL_TIME_MS = 120_000
 
 /**
  * Map a raw Enrow find-email result payload to the typed output shape.
@@ -137,40 +134,17 @@ export const enrowFindEmailTool: ToolConfig<EnrowFindEmailParams, EnrowFindEmail
       throw new Error('Enrow find-email did not return a job id to poll')
     }
 
-    let elapsed = 0
-    while (elapsed < MAX_POLL_TIME_MS) {
-      await sleep(POLL_INTERVAL_MS)
-      elapsed += POLL_INTERVAL_MS
+    const data = await pollEnrowJob({
+      resultUrl: 'https://api.enrow.io/email/find/single',
+      jobId,
+      apiKey: params.apiKey,
+      label: 'Enrow find-email',
+    })
 
-      const pollResponse = await fetch(
-        `https://api.enrow.io/email/find/single?id=${encodeURIComponent(jobId)}`,
-        {
-          headers: {
-            'x-api-key': params.apiKey,
-          },
-        }
-      )
-
-      if (pollResponse.status === 202) {
-        // Still in progress — keep polling
-        continue
-      }
-
-      if (!pollResponse.ok) {
-        const errorText = await pollResponse.text()
-        throw new Error(`Enrow find-email poll error: ${pollResponse.status} - ${errorText}`)
-      }
-
-      // HTTP 200 → complete
-      const json = await pollResponse.json()
-      const data = (json as Record<string, unknown>) ?? {}
-      return {
-        success: true,
-        output: mapFindResult(data, jobId),
-      }
+    return {
+      success: true,
+      output: mapFindResult(data, jobId),
     }
-
-    throw new Error('Enrow find-email did not complete within the polling window')
   },
 
   outputs: {

--- a/apps/sim/tools/enrow/find_email.ts
+++ b/apps/sim/tools/enrow/find_email.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@sim/utils/errors'
 import { enrowHosting } from '@/tools/enrow/hosting'
 import { pollEnrowJob } from '@/tools/enrow/poll'
 import type {
@@ -134,12 +135,41 @@ export const enrowFindEmailTool: ToolConfig<EnrowFindEmailParams, EnrowFindEmail
       throw new Error('Enrow find-email did not return a job id to poll')
     }
 
-    const data = await pollEnrowJob({
-      resultUrl: 'https://api.enrow.io/email/find/single',
-      jobId,
-      apiKey: params.apiKey,
-      label: 'Enrow find-email',
-    })
+    /*
+     * A failed poll must surface as a failed tool response, not as a throw.
+     *
+     * `executeTool` wraps every `postProcess` call in a catch that logs and
+     * then restores the pre-`postProcess` result. That result is the *submit*
+     * response — `success: true` with every result field null — so an escaping
+     * error would be reported to the user as a successful lookup that simply
+     * found nothing. Returning the failure explicitly keeps the reason
+     * attached, and `success: false` also stops the hosted-key cost hook from
+     * billing an execution that produced no result.
+     */
+    let data: Record<string, unknown>
+    try {
+      data = await pollEnrowJob({
+        resultUrl: 'https://api.enrow.io/email/find/single',
+        jobId,
+        apiKey: params.apiKey,
+        label: 'Enrow find-email',
+      })
+    } catch (error) {
+      return {
+        success: false,
+        error: getErrorMessage(error, 'Enrow find-email polling failed'),
+        output: {
+          id: jobId,
+          email: null,
+          qualification: null,
+          fullname: null,
+          firstname: null,
+          lastname: null,
+          company_name: null,
+          company_domain: null,
+        },
+      }
+    }
 
     return {
       success: true,

--- a/apps/sim/tools/enrow/hosting.ts
+++ b/apps/sim/tools/enrow/hosting.ts
@@ -7,12 +7,19 @@ import type { ToolHostingConfig } from '@/tools/types'
 export const ENROW_API_KEY_PREFIX = 'ENROW_API_KEY'
 
 /**
- * Dollar cost of a single Enrow credit.
+ * Dollar cost of a single Enrow credit, as billed to a hosted-key workspace.
  *
- * Enrow's Starter plan is $24/month for 2,000 finder credits/month — $0.012
- * per credit. The email verifier costs 0.25 credits per verification and the
- * email finder costs 1 credit per valid result.
- * Source: https://enrow.io/pricing
+ * The email finder costs 1 credit per valid result and the email verifier
+ * 0.25 credits per check (https://docs.enrow.io/api-reference/email-finder/find-single).
+ *
+ * Enrow's published monthly tiers are Start $17 / 1,000 credits ($0.017),
+ * Pro $87 / 10,000 ($0.0087) and Scale $397 / 50,000 ($0.00794), with a 40%
+ * annual discount and a custom tier above that (https://enrow.io/pricing).
+ * This rate sits between the Start and Pro per-credit prices and therefore
+ * does not correspond to any single published tier; it can only be pinned by
+ * the plan the hosted `ENROW_API_KEY_*` keys are actually enrolled on. Do not
+ * adjust it from the public price list alone — a wrong value over- or
+ * under-bills every hosted Enrow call.
  */
 export const ENROW_CREDIT_USD = 0.012
 

--- a/apps/sim/tools/enrow/hosting.ts
+++ b/apps/sim/tools/enrow/hosting.ts
@@ -51,12 +51,14 @@ export function enrowHosting<P>(
        * call, so the poll loop's own GETs are not counted against it; nothing
        * here throttles a single call's polling.
        *
-       * That is the right shape for what Enrow actually publishes. Its
+       * It is still the right order of magnitude for what Enrow publishes. Its
        * documented limit is 10 req/s per API key on every *POST* endpoint —
-       * 600/min (https://docs.enrow.io/rate-limits). Each execution issues
-       * exactly one POST, so 60/min sits an order of magnitude under the
-       * documented ceiling. The polling GETs are not covered by that limit at
-       * all, and each one is separated by a 3s interval within a 120s budget.
+       * 600/min (https://docs.enrow.io/rate-limits). An admitted execution
+       * issues at least one POST and, when `executeTool` retries an upstream
+       * 429/503 and re-acquires a key, up to a small handful; even at that
+       * ceiling 60 admissions/min stays an order of magnitude under 600. The
+       * polling GETs are not covered by the documented POST limit at all, and
+       * within one call they are serialized 3s apart under a 120s budget.
        */
       requestsPerMinute: 60,
     },

--- a/apps/sim/tools/enrow/hosting.ts
+++ b/apps/sim/tools/enrow/hosting.ts
@@ -45,9 +45,19 @@ export function enrowHosting<P>(
     },
     rateLimit: {
       mode: 'per_request',
-      // Enrow allows 10 req/s per API key on every POST endpoint — 600/min
-      // (https://docs.enrow.io/rate-limits). Cap at 60 req/min to stay well
-      // clear of it and avoid bursting into the limit during polling.
+      /*
+       * A per-workspace cap on hosted-key tool *executions* — not on outbound
+       * provider requests. The limiter is consulted once per `executeTool`
+       * call, so the poll loop's own GETs are not counted against it; nothing
+       * here throttles a single call's polling.
+       *
+       * That is the right shape for what Enrow actually publishes. Its
+       * documented limit is 10 req/s per API key on every *POST* endpoint —
+       * 600/min (https://docs.enrow.io/rate-limits). Each execution issues
+       * exactly one POST, so 60/min sits an order of magnitude under the
+       * documented ceiling. The polling GETs are not covered by that limit at
+       * all, and each one is separated by a 3s interval within a 120s budget.
+       */
       requestsPerMinute: 60,
     },
   }

--- a/apps/sim/tools/enrow/hosting.ts
+++ b/apps/sim/tools/enrow/hosting.ts
@@ -9,8 +9,10 @@ export const ENROW_API_KEY_PREFIX = 'ENROW_API_KEY'
 /**
  * Dollar cost of a single Enrow credit, as billed to a hosted-key workspace.
  *
- * The email finder costs 1 credit per valid result and the email verifier
- * 0.25 credits per check (https://docs.enrow.io/api-reference/email-finder/find-single).
+ * The email finder costs 1 credit per valid result
+ * (https://docs.enrow.io/api-reference/email-finder/find-single) and the email
+ * verifier 0.25 credits per check, which that endpoint reports back on the
+ * response (https://docs.enrow.io/api-reference/email-verifier/verify-single).
  *
  * Enrow's published monthly tiers are Start $17 / 1,000 credits ($0.017),
  * Pro $87 / 10,000 ($0.0087) and Scale $397 / 50,000 ($0.00794), with a 40%

--- a/apps/sim/tools/enrow/hosting.ts
+++ b/apps/sim/tools/enrow/hosting.ts
@@ -45,8 +45,9 @@ export function enrowHosting<P>(
     },
     rateLimit: {
       mode: 'per_request',
-      // Enrow rate limit is ~50 req/s; cap at 60 req/min to stay conservative
-      // and avoid bursting into the limit during polling.
+      // Enrow allows 10 req/s per API key on every POST endpoint — 600/min
+      // (https://docs.enrow.io/rate-limits). Cap at 60 req/min to stay well
+      // clear of it and avoid bursting into the limit during polling.
       requestsPerMinute: 60,
     },
   }

--- a/apps/sim/tools/enrow/poll.ts
+++ b/apps/sim/tools/enrow/poll.ts
@@ -68,14 +68,15 @@ export interface EnrowPollOptions {
  * up to `MAX_TRANSIENT_RETRIES` for the whole poll. Any other non-2xx, or one
  * transient failure past the cap, throws with the status and body.
  *
- * Two things bound the call, and both are needed. `elapsed` accumulates the
- * delays the loop intends to wait, which is what decides when to stop polling
- * and keeps the poll count deterministic. A wall-clock `deadline` additionally
- * caps each individual request, because `await fetch` on a hung socket advances
- * no accumulator at all — without it a single stalled connection outlives the
+ * Two budgets bound the call and every wait is clamped to whichever is smaller.
+ * `elapsed` accumulates the delays the loop intends to wait; it drives the poll
+ * count and keeps that count deterministic under a stubbed `sleep`. The
+ * wall-clock `deadline` is the one that actually holds, because `elapsed`
+ * charges nothing for time spent inside `await fetch` — with slow or hung polls
+ * the real clock runs ahead of it, so a wait sized against `elapsed` alone can
+ * land past the deadline, and a request awaited without a deadline outlives the
  * window entirely. Backoff is charged against the budget rather than added to
- * it, and is clamped to whatever remains so the loop waits out the full window
- * instead of stopping short of it.
+ * it, so the loop waits out the full window without ever overrunning it.
  */
 export async function pollEnrowJob({
   resultUrl,
@@ -88,18 +89,24 @@ export async function pollEnrowJob({
   let elapsed = 0
   let transientFailures = 0
 
-  while (elapsed < MAX_POLL_TIME_MS) {
-    await sleep(POLL_INTERVAL_MS)
-    elapsed += POLL_INTERVAL_MS
+  /** Whichever of the two budgets has less left, floored at zero. */
+  const remainingBudgetMs = () =>
+    Math.max(0, Math.min(MAX_POLL_TIME_MS - elapsed, deadline - Date.now()))
 
-    const remainingMs = deadline - Date.now()
-    if (remainingMs <= 0) break
+  while (true) {
+    const pollDelayMs = Math.min(POLL_INTERVAL_MS, remainingBudgetMs())
+    if (pollDelayMs <= 0) break
+    await sleep(pollDelayMs)
+    elapsed += pollDelayMs
+
+    const requestBudgetMs = deadline - Date.now()
+    if (requestBudgetMs <= 0) break
 
     let response: Response
     try {
       response = await fetch(url, {
         headers: { 'x-api-key': apiKey },
-        signal: AbortSignal.timeout(remainingMs),
+        signal: AbortSignal.timeout(requestBudgetMs),
       })
     } catch (error) {
       if (isAbortError(error)) break
@@ -119,9 +126,11 @@ export async function pollEnrowJob({
           maxMs: TRANSIENT_BACKOFF_MAX_MS,
         })
         await discardBody(response)
-        const delayMs = Math.min(backoffMs, MAX_POLL_TIME_MS - elapsed)
-        elapsed += delayMs
-        if (delayMs > 0) await sleep(delayMs)
+        const delayMs = Math.min(backoffMs, remainingBudgetMs())
+        if (delayMs > 0) {
+          await sleep(delayMs)
+          elapsed += delayMs
+        }
         continue
       }
       const errorText = await response.text()

--- a/apps/sim/tools/enrow/poll.ts
+++ b/apps/sim/tools/enrow/poll.ts
@@ -75,7 +75,11 @@ export interface EnrowPollOptions {
  *
  * HTTP 202 means still running. A 429 or 5xx is retried with jittered backoff,
  * up to `MAX_TRANSIENT_RETRIES` for the whole poll. Any other non-2xx, or one
- * transient failure past the cap, throws with the status and body.
+ * transient failure past the cap, throws with the status and body — and the
+ * status survives even when that body cannot be read.
+ *
+ * The deadline covers reading the 200 body, not just receiving its headers, so
+ * a stalled body ends the poll with this function's own window error.
  *
  * Two budgets bound the call and every wait is clamped to whichever is smaller.
  * `elapsed` accumulates the delays the loop intends to wait; it drives the poll
@@ -142,11 +146,25 @@ export async function pollEnrowJob({
         }
         continue
       }
-      const errorText = await response.text()
+      const errorText = await response.text().catch(() => '<unreadable body>')
       throw new Error(`${label} poll error: ${response.status} - ${errorText}`)
     }
 
-    return ((await response.json()) as Record<string, unknown> | null) ?? {}
+    /*
+     * The body is read under the same deadline as the headers.
+     *
+     * `AbortSignal.timeout` fires against the whole exchange, so a 200 whose
+     * headers arrive just inside the window can still have its body aborted
+     * mid-read. That rejection surfaces here rather than at the `fetch` above,
+     * so it needs the same abort handling: without it the raw `TimeoutError`
+     * escapes, naming neither Enrow nor the window it exhausted.
+     */
+    try {
+      return ((await response.json()) as Record<string, unknown> | null) ?? {}
+    } catch (error) {
+      if (isAbortError(error)) break
+      throw error
+    }
   }
 
   throw new Error(`${label} did not complete within the polling window`)

--- a/apps/sim/tools/enrow/poll.ts
+++ b/apps/sim/tools/enrow/poll.ts
@@ -20,9 +20,18 @@ const MAX_TRANSIENT_RETRIES = 3
 const TRANSIENT_BACKOFF_BASE_MS = 1000
 const TRANSIENT_BACKOFF_MAX_MS = 15_000
 
-/** 429 and 5xx are the statuses a later poll can plausibly recover from. */
+/**
+ * 429 and 5xx are the statuses a later poll can plausibly recover from.
+ *
+ * Bounded at the top of the 5xx range rather than left open: a status is a
+ * three-digit field, and while the `Response` constructor refuses anything
+ * outside 200-599, a status parsed off the wire is not built that way, so a
+ * misbehaving intermediary can surface a 6xx. That is not a server error a
+ * later poll recovers from, so it fails fast with the status attached instead
+ * of burning retries on it.
+ */
 function isTransientStatus(status: number): boolean {
-  return status === 429 || status >= 500
+  return status === 429 || (status >= 500 && status <= 599)
 }
 
 function readRetryAfterMs(response: Response): number | null {

--- a/apps/sim/tools/enrow/poll.ts
+++ b/apps/sim/tools/enrow/poll.ts
@@ -4,7 +4,7 @@ import { backoffWithJitter, parseRetryAfter } from '@sim/utils/retry'
 /** Delay between two ordinary (202 in-progress) polls. */
 const POLL_INTERVAL_MS = 3000
 
-/** Total wall-clock budget for a poll, retries included. */
+/** Total budget for a poll, retries included. */
 const MAX_POLL_TIME_MS = 120_000
 
 /**
@@ -29,6 +29,29 @@ function readRetryAfterMs(response: Response): number | null {
   return parseRetryAfter(response.headers?.get('retry-after') ?? null, TRANSIENT_BACKOFF_MAX_MS)
 }
 
+/**
+ * Releases a response whose body this poll will never read.
+ *
+ * A 202 or a to-be-retried 5xx is discarded mid-stream; without cancelling it
+ * the socket stays checked out of the connection pool for the rest of the poll.
+ * A cancel on an already-broken stream throws and is ignored — the connection
+ * is gone either way, which is the outcome the cancel was asking for.
+ */
+async function discardBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel()
+  } catch {
+    return
+  }
+}
+
+/** Distinguishes an abort/timeout rejection from a genuine transport failure. */
+function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof DOMException && (error.name === 'AbortError' || error.name === 'TimeoutError')
+  )
+}
+
 export interface EnrowPollOptions {
   /** Result URL, minus the job id. */
   resultUrl: string
@@ -42,10 +65,17 @@ export interface EnrowPollOptions {
  * Polls an Enrow async job until it completes, and returns the decoded 200 body.
  *
  * HTTP 202 means still running. A 429 or 5xx is retried with jittered backoff,
- * up to `MAX_TRANSIENT_RETRIES` for the whole poll and always inside the same
- * `MAX_POLL_TIME_MS` budget — the backoff is charged against that budget rather
- * than added to it. Any other non-2xx, or one transient failure past the cap,
- * throws with the status and body.
+ * up to `MAX_TRANSIENT_RETRIES` for the whole poll. Any other non-2xx, or one
+ * transient failure past the cap, throws with the status and body.
+ *
+ * Two things bound the call, and both are needed. `elapsed` accumulates the
+ * delays the loop intends to wait, which is what decides when to stop polling
+ * and keeps the poll count deterministic. A wall-clock `deadline` additionally
+ * caps each individual request, because `await fetch` on a hung socket advances
+ * no accumulator at all — without it a single stalled connection outlives the
+ * window entirely. Backoff is charged against the budget rather than added to
+ * it, and is clamped to whatever remains so the loop waits out the full window
+ * instead of stopping short of it.
  */
 export async function pollEnrowJob({
   resultUrl,
@@ -53,6 +83,8 @@ export async function pollEnrowJob({
   apiKey,
   label,
 }: EnrowPollOptions): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + MAX_POLL_TIME_MS
+  const url = `${resultUrl}?id=${encodeURIComponent(jobId)}`
   let elapsed = 0
   let transientFailures = 0
 
@@ -60,22 +92,36 @@ export async function pollEnrowJob({
     await sleep(POLL_INTERVAL_MS)
     elapsed += POLL_INTERVAL_MS
 
-    const response = await fetch(`${resultUrl}?id=${encodeURIComponent(jobId)}`, {
-      headers: { 'x-api-key': apiKey },
-    })
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) break
 
-    if (response.status === 202) continue
+    let response: Response
+    try {
+      response = await fetch(url, {
+        headers: { 'x-api-key': apiKey },
+        signal: AbortSignal.timeout(remainingMs),
+      })
+    } catch (error) {
+      if (isAbortError(error)) break
+      throw error
+    }
+
+    if (response.status === 202) {
+      await discardBody(response)
+      continue
+    }
 
     if (!response.ok) {
       if (isTransientStatus(response.status) && transientFailures < MAX_TRANSIENT_RETRIES) {
         transientFailures += 1
-        const delayMs = backoffWithJitter(transientFailures, readRetryAfterMs(response), {
+        const backoffMs = backoffWithJitter(transientFailures, readRetryAfterMs(response), {
           baseMs: TRANSIENT_BACKOFF_BASE_MS,
           maxMs: TRANSIENT_BACKOFF_MAX_MS,
         })
+        await discardBody(response)
+        const delayMs = Math.min(backoffMs, MAX_POLL_TIME_MS - elapsed)
         elapsed += delayMs
-        if (elapsed >= MAX_POLL_TIME_MS) break
-        await sleep(delayMs)
+        if (delayMs > 0) await sleep(delayMs)
         continue
       }
       const errorText = await response.text()

--- a/apps/sim/tools/enrow/poll.ts
+++ b/apps/sim/tools/enrow/poll.ts
@@ -1,0 +1,89 @@
+import { sleep } from '@sim/utils/helpers'
+import { backoffWithJitter, parseRetryAfter } from '@sim/utils/retry'
+
+/** Delay between two ordinary (202 in-progress) polls. */
+const POLL_INTERVAL_MS = 3000
+
+/** Total wall-clock budget for a poll, retries included. */
+const MAX_POLL_TIME_MS = 120_000
+
+/**
+ * Transient upstream failures tolerated across the whole poll.
+ *
+ * `GET /email/{find,verify}/single` documents a 500 "could not retrieve single
+ * search results", and retrieving a result consumes no credits, so a retry is
+ * free and safe. The cap is a total, not per-attempt, so the loop stays bounded
+ * even if every poll fails a different way.
+ */
+const MAX_TRANSIENT_RETRIES = 3
+
+const TRANSIENT_BACKOFF_BASE_MS = 1000
+const TRANSIENT_BACKOFF_MAX_MS = 15_000
+
+/** 429 and 5xx are the statuses a later poll can plausibly recover from. */
+function isTransientStatus(status: number): boolean {
+  return status === 429 || status >= 500
+}
+
+function readRetryAfterMs(response: Response): number | null {
+  return parseRetryAfter(response.headers?.get('retry-after') ?? null, TRANSIENT_BACKOFF_MAX_MS)
+}
+
+export interface EnrowPollOptions {
+  /** Result URL, minus the job id. */
+  resultUrl: string
+  jobId: string
+  apiKey: string
+  /** Message prefix identifying the operation, e.g. `'Enrow find-email'`. */
+  label: string
+}
+
+/**
+ * Polls an Enrow async job until it completes, and returns the decoded 200 body.
+ *
+ * HTTP 202 means still running. A 429 or 5xx is retried with jittered backoff,
+ * up to `MAX_TRANSIENT_RETRIES` for the whole poll and always inside the same
+ * `MAX_POLL_TIME_MS` budget — the backoff is charged against that budget rather
+ * than added to it. Any other non-2xx, or one transient failure past the cap,
+ * throws with the status and body.
+ */
+export async function pollEnrowJob({
+  resultUrl,
+  jobId,
+  apiKey,
+  label,
+}: EnrowPollOptions): Promise<Record<string, unknown>> {
+  let elapsed = 0
+  let transientFailures = 0
+
+  while (elapsed < MAX_POLL_TIME_MS) {
+    await sleep(POLL_INTERVAL_MS)
+    elapsed += POLL_INTERVAL_MS
+
+    const response = await fetch(`${resultUrl}?id=${encodeURIComponent(jobId)}`, {
+      headers: { 'x-api-key': apiKey },
+    })
+
+    if (response.status === 202) continue
+
+    if (!response.ok) {
+      if (isTransientStatus(response.status) && transientFailures < MAX_TRANSIENT_RETRIES) {
+        transientFailures += 1
+        const delayMs = backoffWithJitter(transientFailures, readRetryAfterMs(response), {
+          baseMs: TRANSIENT_BACKOFF_BASE_MS,
+          maxMs: TRANSIENT_BACKOFF_MAX_MS,
+        })
+        elapsed += delayMs
+        if (elapsed >= MAX_POLL_TIME_MS) break
+        await sleep(delayMs)
+        continue
+      }
+      const errorText = await response.text()
+      throw new Error(`${label} poll error: ${response.status} - ${errorText}`)
+    }
+
+    return ((await response.json()) as Record<string, unknown> | null) ?? {}
+  }
+
+  throw new Error(`${label} did not complete within the polling window`)
+}

--- a/apps/sim/tools/enrow/verify_email.ts
+++ b/apps/sim/tools/enrow/verify_email.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@sim/utils/errors'
 import { enrowHosting } from '@/tools/enrow/hosting'
 import { pollEnrowJob } from '@/tools/enrow/poll'
 import type {
@@ -104,12 +105,36 @@ export const enrowVerifyEmailTool: ToolConfig<EnrowVerifyEmailParams, EnrowVerif
       throw new Error('Enrow verify-email did not return a job id to poll')
     }
 
-    const data = await pollEnrowJob({
-      resultUrl: 'https://api.enrow.io/email/verify/single',
-      jobId,
-      apiKey: params.apiKey,
-      label: 'Enrow verify-email',
-    })
+    /*
+     * A failed poll must surface as a failed tool response, not as a throw.
+     *
+     * `executeTool` wraps every `postProcess` call in a catch that logs and
+     * then restores the pre-`postProcess` result. That result is the *submit*
+     * response — `success: true` with every result field null — so an escaping
+     * error would be reported to the user as a successful lookup that simply
+     * found nothing. Returning the failure explicitly keeps the reason
+     * attached, and `success: false` also stops the hosted-key cost hook from
+     * billing an execution that produced no result.
+     */
+    let data: Record<string, unknown>
+    try {
+      data = await pollEnrowJob({
+        resultUrl: 'https://api.enrow.io/email/verify/single',
+        jobId,
+        apiKey: params.apiKey,
+        label: 'Enrow verify-email',
+      })
+    } catch (error) {
+      return {
+        success: false,
+        error: getErrorMessage(error, 'Enrow verify-email polling failed'),
+        output: {
+          id: jobId,
+          email: null,
+          qualification: null,
+        },
+      }
+    }
 
     return {
       success: true,

--- a/apps/sim/tools/enrow/verify_email.ts
+++ b/apps/sim/tools/enrow/verify_email.ts
@@ -1,5 +1,5 @@
-import { sleep } from '@sim/utils/helpers'
 import { enrowHosting } from '@/tools/enrow/hosting'
+import { pollEnrowJob } from '@/tools/enrow/poll'
 import type {
   EnrowVerifyEmailParams,
   EnrowVerifyEmailResponse,
@@ -11,9 +11,6 @@ import {
   ENROW_QUALIFICATION_OUTPUT,
 } from '@/tools/enrow/types'
 import type { ToolConfig } from '@/tools/types'
-
-const POLL_INTERVAL_MS = 3000
-const MAX_POLL_TIME_MS = 120_000
 
 /** Map a raw Enrow verify-email result payload to the typed output shape. */
 function mapVerifyResult(data: Record<string, unknown>, jobId: string): EnrowVerifyEmailResult {
@@ -107,40 +104,17 @@ export const enrowVerifyEmailTool: ToolConfig<EnrowVerifyEmailParams, EnrowVerif
       throw new Error('Enrow verify-email did not return a job id to poll')
     }
 
-    let elapsed = 0
-    while (elapsed < MAX_POLL_TIME_MS) {
-      await sleep(POLL_INTERVAL_MS)
-      elapsed += POLL_INTERVAL_MS
+    const data = await pollEnrowJob({
+      resultUrl: 'https://api.enrow.io/email/verify/single',
+      jobId,
+      apiKey: params.apiKey,
+      label: 'Enrow verify-email',
+    })
 
-      const pollResponse = await fetch(
-        `https://api.enrow.io/email/verify/single?id=${encodeURIComponent(jobId)}`,
-        {
-          headers: {
-            'x-api-key': params.apiKey,
-          },
-        }
-      )
-
-      if (pollResponse.status === 202) {
-        // Still in progress — keep polling
-        continue
-      }
-
-      if (!pollResponse.ok) {
-        const errorText = await pollResponse.text()
-        throw new Error(`Enrow verify-email poll error: ${pollResponse.status} - ${errorText}`)
-      }
-
-      // HTTP 200 → complete
-      const json = await pollResponse.json()
-      const data = (json as Record<string, unknown>) ?? {}
-      return {
-        success: true,
-        output: mapVerifyResult(data, jobId),
-      }
+    return {
+      success: true,
+      output: mapVerifyResult(data, jobId),
     }
-
-    throw new Error('Enrow verify-email did not complete within the polling window')
   },
 
   outputs: {


### PR DESCRIPTION
Three reported defects across the SixtyFour and Enrow integrations. Two were real and are fixed here; the third is real but the corrected value is not derivable from public sources, so the number is left alone and only its (false) citation is corrected.

## 1. SixtyFour nulled a model-supplied required field — VERIFIED, FIXED

`SixtyfourBlock.tools.config.params` wrote two renames unconditionally:

```ts
result.struct = params.leadStruct      // enrich_lead
result.struct = params.companyStruct   // enrich_company
```

On the canvas path that is fine — `leadStruct` is a real subBlock. On the agent path it is not. `transformBlockTool` (`apps/sim/providers/utils.ts`) builds a `paramsTransform` that runs `result = { ...result, ...blockParamsFn(result) }` over the model's tool-call arguments, and the LLM schema is derived from `toolConfig.params`, which names the field `struct`, not `leadStruct`. So the model sends `struct`, the mapper reads a `leadStruct` that was never there, and writes `struct: undefined` straight over the model's value. `struct` is `required: true` on both tools, so the request went out to `api.sixtyfour.ai` with the required field missing.

Fix: guard every rename on its source being present. A configured block value still wins, because it is present.

Proof is `apps/sim/blocks/blocks/sixtyfour.test.ts`, which drives the real `transformBlockTool` with the real block and tool configs — not a hand-rolled imitation of the agent path.

## 2. Enrow aborted a polling job on any transient 5xx — VERIFIED, FIXED

Both `enrow_find_email` and `enrow_verify_email` polled with `if (!pollResponse.ok) throw`. A single 500 ended a job that was still running server-side — and Enrow documents 500 as a *retrieval* failure on the result endpoint ("could not retrieve single search results"), and documents that retrieving a result consumes no credits, so retrying is both free and correct.

Both polls now share `apps/sim/tools/enrow/poll.ts`, which:

- retries only 429 and 5xx; every other non-2xx still fails on the first response
- caps transient retries at 3 **for the whole poll** (a total, not per-attempt) — bounded, no unbounded loop
- paces with `backoffWithJitter(attempt, parseRetryAfter(header))` from `@sim/utils/retry`, honouring `Retry-After`
- charges the backoff **against** the existing 120s `MAX_POLL_TIME_MS` budget rather than extending it, so worst-case wall clock is unchanged

## 3. Enrow hosted-credit rate cites a plan that does not exist — VERIFIED, NUMBER NOT CHANGED

`ENROW_CREDIT_USD = 0.012` was documented as "Enrow's Starter plan is \$24/month for 2,000 finder credits/month". No such plan exists. Enrow's published monthly tiers (https://enrow.io/pricing) are:

| Plan | Price | Credits | Per credit |
|---|---|---|---|
| Start | \$17/mo | 1,000 | \$0.017 |
| Pro | \$87/mo | 10,000 | \$0.0087 |
| Scale | \$397/mo | 50,000 | \$0.00794 |
| Custom | \$1,000+/mo | unlimited | n/a |

plus a 40% annual discount. `0.012` matches none of them, monthly or annual.

**The number is unchanged and this PR does not alter anyone's bill.** Which rate is correct depends entirely on the plan the hosted `ENROW_API_KEY_*` keys are actually enrolled on, which is not a public fact. Only the docblock is corrected, to state the real price list and to say plainly that the rate corresponds to no published tier.

**Billing exposure if someone later "corrects" it from the price list alone:**

- if the hosted keys sit on **Start** (\$0.017/credit), the current \$0.012 **under-bills by ~29%** — Sim absorbs the difference
- if they sit on **Pro** (\$0.0087) the current rate **over-bills by ~38%**; on **Scale** (\$0.00794) it **over-bills by ~51%** — customers are charged above cost

To pin this correctly I need one of: the Enrow plan on the hosted account (billing portal or invoice), or the contracted per-credit rate if it is a Custom tier. Until then, changing the number is a coin flip in both directions and is deliberately not done here.

## Testing

`bun run lint`, `bun run check:audits` (39/39), `check-block-registry`, and `type-check` are all clean. `tool-metadata:check` passes — no params/outputs changed, so no artifact regeneration was needed.

Every fix has a test that was watched fail against the pre-fix code and pass after:

- reverting `sixtyfour.ts` puts both agent-path assertions red (`expected undefined to be '{"website":"Company website URL"}'`) while the four canvas-path tests stay green — i.e. the tests pin the agent path specifically, not the mapper's shape
- reverting the Enrow poll rewiring puts all four new retry tests red (`Enrow find-email poll error: 503`, `expected 4 calls, got 1`, and the same on the verify poll), while the existing 202/401/window tests stay green — the 4xx no-retry test passes both before and after, which is the point

---

## Follow-up: second false citation in the same file (de50aca)

A validation audit against Enrow's published API docs found the rate-limit comment in the same `hosting.ts` was wrong in the same way `ENROW_CREDIT_USD`'s was — it claimed "Enrow rate limit is ~50 req/s". Enrow documents **10 req/s per API key on every POST endpoint** ([rate-limits](https://docs.enrow.io/rate-limits)) — 600/min, not 3,000.

`requestsPerMinute: 60` is unchanged and stays correct: it is conservative against either figure, and the reason for it (not bursting into the limit while a job polls) is untouched. Only the number a future reader would size the cap against was wrong.

### Two audit findings worth recording

**The retry design matches Enrow's own guidance exactly.** The rate-limit page recommends "exponential backoff… default maximum of 3 retries" and shows 1s / 2s / 4s. This PR implements precisely that — `MAX_TRANSIENT_RETRIES = 3` with `backoffWithJitter` at `baseMs: 1000`. The retryable set is confirmed too: 429 is documented there, 500 "Could not retrieve single search results" is documented on the result endpoints, and 400 ("id missing in the URL query string") is correctly *not* retried. Critically, both result endpoints state verbatim that **"Retrieving a result does not consume credits — only the verification itself does"**, so a retry is provably free.

**SixtyFour's `struct`: the prose docs and the OpenAPI schema disagree.** The company-intelligence prose lists `struct` as optional, but the OpenAPI schema lists it under `required`. The tool's `required: true` is correct and the prose is wrong — which matters, because `struct` being required is exactly what made the unguarded `result.struct = undefined` overwrite a data-loss bug rather than a cosmetic one.

Audit also confirmed **no other subBlock-id-vs-tool-param mismatch** in that mapper: all 20 block inputs map 1:1 to tool param names except six deliberate remaps (`emailInput`→`email`, `phoneInput`→`phone`, `leadStruct`/`companyStruct`→`struct`, `companyLeadStruct`→`leadStruct`, `*ResearchPlan`→`researchPlan`), and every one is now guarded.
