### PR TITLE
fix(hubspot,stripe,salesforce): reject path traversal in URL ids

### DIFF
--- a/apps/sim/tools/hubspot/add_list_memberships.ts
+++ b/apps/sim/tools/hubspot/add_list_memberships.ts
@@ -4,6 +4,7 @@ import type {
   HubSpotAddListMembershipsResponse,
 } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotAddListMemberships')
 
@@ -44,7 +45,8 @@ export const hubspotAddListMembershipsTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.hubapi.com/crm/v3/lists/${params.listId.trim()}/memberships/add`,
+    url: (params) =>
+      `https://api.hubapi.com/crm/v3/lists/${safeUrlPathSegment(params.listId, 'listId')}/memberships/add`,
     method: 'PUT',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/create_association.ts
+++ b/apps/sim/tools/hubspot/create_association.ts
@@ -4,6 +4,7 @@ import type {
   HubSpotCreateAssociationResponse,
 } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotCreateAssociation')
 
@@ -71,8 +72,8 @@ export const hubspotCreateAssociationTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const from = `${encodeURIComponent(params.objectType.trim())}/${encodeURIComponent(params.objectId.trim())}`
-      const to = `${encodeURIComponent(params.toObjectType.trim())}/${encodeURIComponent(params.toObjectId.trim())}`
+      const from = `${safeUrlPathSegment(params.objectType, 'objectType')}/${safeUrlPathSegment(params.objectId, 'objectId')}`
+      const to = `${safeUrlPathSegment(params.toObjectType, 'toObjectType')}/${safeUrlPathSegment(params.toObjectId, 'toObjectId')}`
 
       return params.associationTypeId != null
         ? `https://api.hubapi.com/crm/v4/objects/${from}/associations/${to}`

--- a/apps/sim/tools/hubspot/delete_association.ts
+++ b/apps/sim/tools/hubspot/delete_association.ts
@@ -4,6 +4,7 @@ import type {
   HubSpotDeleteAssociationResponse,
 } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotDeleteAssociation')
 
@@ -56,8 +57,8 @@ export const hubspotDeleteAssociationTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const from = `${encodeURIComponent(params.objectType.trim())}/${encodeURIComponent(params.objectId.trim())}`
-      const to = `${encodeURIComponent(params.toObjectType.trim())}/${encodeURIComponent(params.toObjectId.trim())}`
+      const from = `${safeUrlPathSegment(params.objectType, 'objectType')}/${safeUrlPathSegment(params.objectId, 'objectId')}`
+      const to = `${safeUrlPathSegment(params.toObjectType, 'toObjectType')}/${safeUrlPathSegment(params.toObjectId, 'toObjectId')}`
       return `https://api.hubapi.com/crm/v4/objects/${from}/associations/${to}`
     },
     method: 'DELETE',

--- a/apps/sim/tools/hubspot/delete_company.ts
+++ b/apps/sim/tools/hubspot/delete_company.ts
@@ -4,6 +4,7 @@ import type {
   HubSpotDeleteCompanyResponse,
 } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotDeleteCompany')
 
@@ -37,7 +38,8 @@ export const hubspotDeleteCompanyTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.hubapi.com/crm/v3/objects/companies/${params.companyId.trim()}`,
+    url: (params) =>
+      `https://api.hubapi.com/crm/v3/objects/companies/${safeUrlPathSegment(params.companyId, 'companyId')}`,
     method: 'DELETE',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/delete_contact.ts
+++ b/apps/sim/tools/hubspot/delete_contact.ts
@@ -4,6 +4,7 @@ import type {
   HubSpotDeleteContactResponse,
 } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotDeleteContact')
 
@@ -37,7 +38,8 @@ export const hubspotDeleteContactTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.hubapi.com/crm/v3/objects/contacts/${params.contactId.trim()}`,
+    url: (params) =>
+      `https://api.hubapi.com/crm/v3/objects/contacts/${safeUrlPathSegment(params.contactId, 'contactId')}`,
     method: 'DELETE',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/delete_deal.ts
+++ b/apps/sim/tools/hubspot/delete_deal.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sim/logger'
 import type { HubSpotDeleteDealParams, HubSpotDeleteDealResponse } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotDeleteDeal')
 
@@ -32,7 +33,8 @@ export const hubspotDeleteDealTool: ToolConfig<HubSpotDeleteDealParams, HubSpotD
     },
 
     request: {
-      url: (params) => `https://api.hubapi.com/crm/v3/objects/deals/${params.dealId.trim()}`,
+      url: (params) =>
+        `https://api.hubapi.com/crm/v3/objects/deals/${safeUrlPathSegment(params.dealId, 'dealId')}`,
       method: 'DELETE',
       headers: (params) => {
         if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/delete_line_item.ts
+++ b/apps/sim/tools/hubspot/delete_line_item.ts
@@ -4,6 +4,7 @@ import type {
   HubSpotDeleteLineItemResponse,
 } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotDeleteLineItem')
 
@@ -37,7 +38,8 @@ export const hubspotDeleteLineItemTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.hubapi.com/crm/v3/objects/line_items/${params.lineItemId.trim()}`,
+    url: (params) =>
+      `https://api.hubapi.com/crm/v3/objects/line_items/${safeUrlPathSegment(params.lineItemId, 'lineItemId')}`,
     method: 'DELETE',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/delete_ticket.ts
+++ b/apps/sim/tools/hubspot/delete_ticket.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sim/logger'
 import type { HubSpotDeleteTicketParams, HubSpotDeleteTicketResponse } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotDeleteTicket')
 
@@ -34,7 +35,8 @@ export const hubspotDeleteTicketTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.hubapi.com/crm/v3/objects/tickets/${params.ticketId.trim()}`,
+    url: (params) =>
+      `https://api.hubapi.com/crm/v3/objects/tickets/${safeUrlPathSegment(params.ticketId, 'ticketId')}`,
     method: 'DELETE',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/get_appointment.ts
+++ b/apps/sim/tools/hubspot/get_appointment.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { APPOINTMENT_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetAppointment')
 
@@ -59,7 +60,7 @@ export const hubspotGetAppointmentTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/appointments/${params.appointmentId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/appointments/${safeUrlPathSegment(params.appointmentId, 'appointmentId')}`
       const queryParams = new URLSearchParams()
       if (params.idProperty) queryParams.append('idProperty', params.idProperty)
       if (params.properties) queryParams.append('properties', params.properties)

--- a/apps/sim/tools/hubspot/get_association_labels.ts
+++ b/apps/sim/tools/hubspot/get_association_labels.ts
@@ -4,6 +4,7 @@ import type {
   HubSpotGetAssociationLabelsResponse,
 } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetAssociationLabels')
 
@@ -45,8 +46,8 @@ export const hubspotGetAssociationLabelsTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const from = encodeURIComponent(params.objectType.trim())
-      const to = encodeURIComponent(params.toObjectType.trim())
+      const from = safeUrlPathSegment(params.objectType, 'objectType')
+      const to = safeUrlPathSegment(params.toObjectType, 'toObjectType')
       return `https://api.hubapi.com/crm/v4/associations/${from}/${to}/labels`
     },
     method: 'GET',

--- a/apps/sim/tools/hubspot/get_cart.ts
+++ b/apps/sim/tools/hubspot/get_cart.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetCartParams, HubSpotGetCartResponse } from '@/tools/hubspot/types'
 import { GENERIC_CRM_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetCart')
 
@@ -45,7 +46,7 @@ export const hubspotGetCartTool: ToolConfig<HubSpotGetCartParams, HubSpotGetCart
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/carts/${params.cartId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/carts/${safeUrlPathSegment(params.cartId, 'cartId')}`
       const queryParams = new URLSearchParams()
       if (params.properties) queryParams.append('properties', params.properties)
       if (params.associations) queryParams.append('associations', params.associations)

--- a/apps/sim/tools/hubspot/get_company.ts
+++ b/apps/sim/tools/hubspot/get_company.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetCompanyParams, HubSpotGetCompanyResponse } from '@/tools/hubspot/types'
 import { COMPANY_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetCompany')
 
@@ -55,7 +56,7 @@ export const hubspotGetCompanyTool: ToolConfig<HubSpotGetCompanyParams, HubSpotG
 
     request: {
       url: (params) => {
-        const baseUrl = `https://api.hubapi.com/crm/v3/objects/companies/${params.companyId.trim()}`
+        const baseUrl = `https://api.hubapi.com/crm/v3/objects/companies/${safeUrlPathSegment(params.companyId, 'companyId')}`
         const queryParams = new URLSearchParams()
 
         if (params.idProperty) {

--- a/apps/sim/tools/hubspot/get_contact.ts
+++ b/apps/sim/tools/hubspot/get_contact.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetContactParams, HubSpotGetContactResponse } from '@/tools/hubspot/types'
 import { CONTACT_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetContact')
 
@@ -55,7 +56,7 @@ export const hubspotGetContactTool: ToolConfig<HubSpotGetContactParams, HubSpotG
 
     request: {
       url: (params) => {
-        const baseUrl = `https://api.hubapi.com/crm/v3/objects/contacts/${params.contactId.trim()}`
+        const baseUrl = `https://api.hubapi.com/crm/v3/objects/contacts/${safeUrlPathSegment(params.contactId, 'contactId')}`
         const queryParams = new URLSearchParams()
 
         if (params.idProperty) {

--- a/apps/sim/tools/hubspot/get_deal.ts
+++ b/apps/sim/tools/hubspot/get_deal.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetDealParams, HubSpotGetDealResponse } from '@/tools/hubspot/types'
 import { DEAL_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetDeal')
 
@@ -53,7 +54,7 @@ export const hubspotGetDealTool: ToolConfig<HubSpotGetDealParams, HubSpotGetDeal
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/deals/${params.dealId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/deals/${safeUrlPathSegment(params.dealId, 'dealId')}`
       const queryParams = new URLSearchParams()
       if (params.idProperty) queryParams.append('idProperty', params.idProperty)
       if (params.properties) queryParams.append('properties', params.properties)

--- a/apps/sim/tools/hubspot/get_email.ts
+++ b/apps/sim/tools/hubspot/get_email.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetEmailParams, HubSpotGetEmailResponse } from '@/tools/hubspot/types'
 import { EMAIL_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetEmail')
 
@@ -48,7 +49,7 @@ export const hubspotGetEmailTool: ToolConfig<HubSpotGetEmailParams, HubSpotGetEm
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/emails/${params.emailId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/emails/${safeUrlPathSegment(params.emailId, 'emailId')}`
       const queryParams = new URLSearchParams()
 
       if (params.properties) {

--- a/apps/sim/tools/hubspot/get_line_item.ts
+++ b/apps/sim/tools/hubspot/get_line_item.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetLineItemParams, HubSpotGetLineItemResponse } from '@/tools/hubspot/types'
 import { LINE_ITEM_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetLineItem')
 
@@ -56,7 +57,7 @@ export const hubspotGetLineItemTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/line_items/${params.lineItemId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/line_items/${safeUrlPathSegment(params.lineItemId, 'lineItemId')}`
       const queryParams = new URLSearchParams()
       if (params.idProperty) queryParams.append('idProperty', params.idProperty)
       if (params.properties) queryParams.append('properties', params.properties)

--- a/apps/sim/tools/hubspot/get_list.ts
+++ b/apps/sim/tools/hubspot/get_list.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetListParams, HubSpotGetListResponse } from '@/tools/hubspot/types'
 import { LIST_OUTPUT_PROPERTIES } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetList')
 
@@ -32,7 +33,8 @@ export const hubspotGetListTool: ToolConfig<HubSpotGetListParams, HubSpotGetList
   },
 
   request: {
-    url: (params) => `https://api.hubapi.com/crm/v3/lists/${params.listId.trim()}`,
+    url: (params) =>
+      `https://api.hubapi.com/crm/v3/lists/${safeUrlPathSegment(params.listId, 'listId')}`,
     method: 'GET',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/get_list_memberships.ts
+++ b/apps/sim/tools/hubspot/get_list_memberships.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { METADATA_OUTPUT, PAGING_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetListMemberships')
 
@@ -51,7 +52,7 @@ export const hubspotGetListMembershipsTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/lists/${params.listId.trim()}/memberships`
+      const baseUrl = `https://api.hubapi.com/crm/v3/lists/${safeUrlPathSegment(params.listId, 'listId')}/memberships`
       const queryParams = new URLSearchParams()
       if (params.limit) queryParams.append('limit', params.limit)
       if (params.after) queryParams.append('after', params.after)

--- a/apps/sim/tools/hubspot/get_marketing_event.ts
+++ b/apps/sim/tools/hubspot/get_marketing_event.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { MARKETING_EVENT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetMarketingEvent')
 
@@ -39,7 +40,7 @@ export const hubspotGetMarketingEventTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.hubapi.com/marketing/v3/marketing-events/${params.eventId.trim()}`,
+      `https://api.hubapi.com/marketing/v3/marketing-events/${safeUrlPathSegment(params.eventId, 'eventId')}`,
     method: 'GET',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/get_note.ts
+++ b/apps/sim/tools/hubspot/get_note.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetNoteParams, HubSpotGetNoteResponse } from '@/tools/hubspot/types'
 import { NOTE_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetNote')
 
@@ -47,7 +48,7 @@ export const hubspotGetNoteTool: ToolConfig<HubSpotGetNoteParams, HubSpotGetNote
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/notes/${params.noteId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/notes/${safeUrlPathSegment(params.noteId, 'noteId')}`
       const queryParams = new URLSearchParams()
 
       if (params.properties) {

--- a/apps/sim/tools/hubspot/get_properties.ts
+++ b/apps/sim/tools/hubspot/get_properties.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { PROPERTIES_ARRAY_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetProperties')
 
@@ -54,10 +55,10 @@ export const hubspotGetPropertiesTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const objectType = params.objectType.trim()
+      const objectType = safeUrlPathSegment(params.objectType, 'objectType')
       const baseUrl = params.propertyName
-        ? `https://api.hubapi.com/crm/v3/properties/${encodeURIComponent(objectType)}/${encodeURIComponent(params.propertyName.trim())}`
-        : `https://api.hubapi.com/crm/v3/properties/${encodeURIComponent(objectType)}`
+        ? `https://api.hubapi.com/crm/v3/properties/${objectType}/${safeUrlPathSegment(params.propertyName, 'propertyName')}`
+        : `https://api.hubapi.com/crm/v3/properties/${objectType}`
 
       const queryParams = new URLSearchParams()
       if (params.archived !== undefined) {

--- a/apps/sim/tools/hubspot/get_quote.ts
+++ b/apps/sim/tools/hubspot/get_quote.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetQuoteParams, HubSpotGetQuoteResponse } from '@/tools/hubspot/types'
 import { QUOTE_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetQuote')
 
@@ -53,7 +54,7 @@ export const hubspotGetQuoteTool: ToolConfig<HubSpotGetQuoteParams, HubSpotGetQu
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/quotes/${params.quoteId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/quotes/${safeUrlPathSegment(params.quoteId, 'quoteId')}`
       const queryParams = new URLSearchParams()
       if (params.idProperty) queryParams.append('idProperty', params.idProperty)
       if (params.properties) queryParams.append('properties', params.properties)

--- a/apps/sim/tools/hubspot/get_ticket.ts
+++ b/apps/sim/tools/hubspot/get_ticket.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotGetTicketParams, HubSpotGetTicketResponse } from '@/tools/hubspot/types'
 import { TICKET_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotGetTicket')
 
@@ -53,7 +54,7 @@ export const hubspotGetTicketTool: ToolConfig<HubSpotGetTicketParams, HubSpotGet
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/tickets/${params.ticketId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/tickets/${safeUrlPathSegment(params.ticketId, 'ticketId')}`
       const queryParams = new URLSearchParams()
       if (params.idProperty) queryParams.append('idProperty', params.idProperty)
       if (params.properties) queryParams.append('properties', params.properties)

--- a/apps/sim/tools/hubspot/list_associations.ts
+++ b/apps/sim/tools/hubspot/list_associations.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { ASSOCIATIONS_ARRAY_OUTPUT, METADATA_OUTPUT, PAGING_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotListAssociations')
 
@@ -64,7 +65,7 @@ export const hubspotListAssociationsTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v4/objects/${encodeURIComponent(params.objectType.trim())}/${encodeURIComponent(params.objectId.trim())}/associations/${encodeURIComponent(params.toObjectType.trim())}`
+      const baseUrl = `https://api.hubapi.com/crm/v4/objects/${safeUrlPathSegment(params.objectType, 'objectType')}/${safeUrlPathSegment(params.objectId, 'objectId')}/associations/${safeUrlPathSegment(params.toObjectType, 'toObjectType')}`
       const queryParams = new URLSearchParams()
 
       if (params.limit) {

--- a/apps/sim/tools/hubspot/path_safety.test.ts
+++ b/apps/sim/tools/hubspot/path_safety.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every HubSpot tool against path traversal through an LLM-writable id
+ * that gets interpolated into the request path.
+ *
+ * These ids (record ids, list ids, object types) are `visibility: 'user-or-llm'`,
+ * so prompt injection controls them. Interpolating one raw let a value like
+ * `../../v3/objects/contacts/1` escape the object it addresses once `fetch`
+ * normalized the URL, re-aiming the request — with the user's HubSpot token
+ * still attached — at an arbitrary CRM record, including on the DELETE tools.
+ *
+ * Wrapping the id in `encodeURIComponent` is NOT enough, which is why the
+ * vector list below includes the bare `.` and `..` segments: both are made of
+ * unreserved characters, so they survive encoding untouched and the URL parser
+ * then removes them as dot segments, popping one path segment off a fixed host.
+ * Every assertion here resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ */
+import { describe, expect, it } from 'vitest'
+import { hubspotDeleteAssociationTool } from '@/tools/hubspot/delete_association'
+import { hubspotDeleteCompanyTool } from '@/tools/hubspot/delete_company'
+import { hubspotDeleteContactTool } from '@/tools/hubspot/delete_contact'
+import { hubspotDeleteDealTool } from '@/tools/hubspot/delete_deal'
+import * as hubspotTools from '@/tools/hubspot/index'
+import type { ToolConfig } from '@/tools/types'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../v3/objects/contacts/1',
+  '..%2f..%2fv3/objects/contacts/1',
+  '12345/../../../v3/objects/deals',
+  '12345?properties=email',
+  '12345#fragment',
+  '12345/associations/../../../v4/objects',
+  '\\..\\..',
+] as const
+
+/** Values a real user legitimately supplies; none may be rejected or altered. */
+const LEGITIMATE_IDS = [
+  '12345',
+  '9876543210',
+  '0-1',
+  'contacts',
+  'companies',
+  'line_items',
+  'marketing_events',
+  'p12345678_my_custom_object',
+  'email',
+  'hs_object_id',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isHubSpotTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('hubspot_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { accessToken: 'token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'accessToken') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(pathname: string): string[] {
+  return pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(hubspotTools)
+  .filter(isHubSpotTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('hubspot path-id traversal safety', () => {
+  it('covers every HubSpot tool that interpolates an id into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(28)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID).pathname)
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(url.origin).toBe('https://api.hubapi.com')
+
+      const actual = segmentsOf(url.pathname)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value).pathname)
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        expect(actual[index]).toBe(segment === SAFE_ID ? value : segment)
+      })
+    })
+  })
+})
+
+const HIGH_RISK_TOOLS: ReadonlyArray<{ name: string; tool: AnyTool }> = [
+  { name: 'hubspot_delete_contact', tool: hubspotDeleteContactTool },
+  { name: 'hubspot_delete_company', tool: hubspotDeleteCompanyTool },
+  { name: 'hubspot_delete_deal', tool: hubspotDeleteDealTool },
+  { name: 'hubspot_delete_association', tool: hubspotDeleteAssociationTool },
+]
+
+describe.each(HIGH_RISK_TOOLS)('$name id path safety', ({ tool }) => {
+  it('rejects a bare dot-dot segment instead of silently popping the resource', () => {
+    expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+  })
+
+  it('rejects a bare dot segment', () => {
+    expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+  })
+
+  it('does not let the id inject query parameters', () => {
+    const url = buildUrl(tool, '12345?properties=email')
+
+    expect(url.searchParams.get('properties')).toBeNull()
+  })
+
+  it('preserves a legitimate numeric id verbatim after trimming', () => {
+    expect(buildUrl(tool, '  12345  ').pathname).toContain('/12345')
+  })
+})

--- a/apps/sim/tools/hubspot/path_safety.test.ts
+++ b/apps/sim/tools/hubspot/path_safety.test.ts
@@ -17,20 +17,33 @@
  * Every assertion here resolves the built URL with `new URL(...)` — the same
  * normalization `fetch` performs — rather than string-matching the template
  * output, because string matching is exactly what let this through.
+ *
+ * The unit of coverage is a **(tool, parameter) pair**, not a tool. Fuzzing
+ * every parameter of a tool at once and tolerating a throw is unsound: the
+ * first guarded parameter throws and silently retires every sibling from the
+ * suite. HubSpot is where that mattered most — the association tools put the
+ * four parameters `objectType`, `objectId`, `toObjectType` and `toObjectType`
+ * into a single path, so guarding the first one would have retired the other
+ * three. Each case below fuzzes exactly one parameter while holding its
+ * siblings at a safe value, which is what makes "a newly added unguarded path
+ * parameter fails CI" actually true. A throw is only accepted as a pass
+ * *because* the thrown-at parameter is the one under test.
  */
 import { describe, expect, it } from 'vitest'
+import { hubspotCreateAssociationTool } from '@/tools/hubspot/create_association'
 import { hubspotDeleteAssociationTool } from '@/tools/hubspot/delete_association'
 import { hubspotDeleteCompanyTool } from '@/tools/hubspot/delete_company'
 import { hubspotDeleteContactTool } from '@/tools/hubspot/delete_contact'
 import { hubspotDeleteDealTool } from '@/tools/hubspot/delete_deal'
 import * as hubspotTools from '@/tools/hubspot/index'
+import { hubspotListAssociationsTool } from '@/tools/hubspot/list_associations'
 import type { ToolConfig } from '@/tools/types'
 
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
  * `encodeURIComponent`-only fix looks correct while the hole stays live.
  */
-const TRAVERSAL_IDS = [
+const TRAVERSAL_VALUES = [
   '..',
   '.',
   '  ..  ',
@@ -57,9 +70,16 @@ const LEGITIMATE_IDS = [
   'hs_object_id',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/** The value the parameter under test carries when a path is being mapped. */
+const TARGET = 'TARGETVALUE'
+
+/** The value every *other* string parameter is pinned to while one is fuzzed. */
+const SIBLING = 'SIBLINGVALUE'
 
 type AnyTool = ToolConfig<any, any>
+
+/** Parameters that carry credentials or the host, never a path segment. */
+const FIXED_PARAMS: Record<string, unknown> = { accessToken: 'token' }
 
 function isHubSpotTool(value: unknown): value is AnyTool {
   return (
@@ -70,112 +90,182 @@ function isHubSpotTool(value: unknown): value is AnyTool {
   )
 }
 
+/** The placeholder a sibling parameter holds, chosen so the URL still builds. */
+function siblingValue(type: string | undefined): unknown {
+  if (type === 'json' || type === 'array') return []
+  if (type === 'number') return 1
+  if (type === 'boolean') return false
+  return SIBLING
+}
+
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised.
+ * Builds a param object with exactly one parameter under test.
+ *
+ * Every sibling is pinned to a safe placeholder, so a failure can only be
+ * attributed to `target`. This is the whole difference from a fill-everything
+ * sweep, where the first parameter to throw hides all the others.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
-  const params: Record<string, unknown> = { accessToken: 'token' }
+function buildParams(tool: AnyTool, target: string, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { ...FIXED_PARAMS }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
-    if (name === 'accessToken') continue
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
-      params[name] = []
-    } else if (type === 'number') {
-      params[name] = 1
-    } else if (type === 'boolean') {
-      params[name] = false
-    } else {
-      params[name] = value
-    }
+    if (name in FIXED_PARAMS) continue
+    params[name] = name === target ? value : siblingValue((def as { type?: string }).type)
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
+function buildUrl(tool: AnyTool, target: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return new URL(url(buildParams(tool, target, value) as any))
 }
 
 function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(hubspotTools)
+/** True when `target` actually lands in the path rather than the query string. */
+function reachesPath(tool: AnyTool, target: string): boolean {
+  try {
+    return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
+  } catch {
+    return false
+  }
+}
+
+interface PathParamCase {
+  name: string
+  param: string
+  tool: AnyTool
+}
+
+const PATH_PARAM_CASES: PathParamCase[] = Object.values(hubspotTools)
   .filter(isHubSpotTool)
   .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
-    } catch {
-      return false
-    }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  .flatMap((tool) =>
+    Object.keys(tool.params ?? {})
+      .filter((param) => !(param in FIXED_PARAMS))
+      .filter((param) => reachesPath(tool, param))
+      .map((param) => ({ name: `${tool.id} / ${param}`, param, tool }))
+  )
 
-describe('hubspot path-id traversal safety', () => {
-  it('covers every HubSpot tool that interpolates an id into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(28)
+describe('hubspot path-parameter traversal safety', () => {
+  it('covers every (hubspot tool, path parameter) pair', () => {
+    expect(PATH_PARAM_CASES.length).toBeGreaterThanOrEqual(35)
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID).pathname)
+  describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {
+    const baseline = segmentsOf(buildUrl(tool, param, TARGET).pathname)
 
-    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+    it.each(TRAVERSAL_VALUES)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
+        url = buildUrl(tool, param, value)
       } catch {
         return
       }
 
       expect(url.origin).toBe('https://api.hubapi.com')
+      expect(url.pathname.startsWith('/')).toBe(true)
 
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) return
+        if (segment === TARGET) return
         expect(actual[index]).toBe(segment)
       })
     })
 
+    /**
+     * The shape check above cannot see a bare dot in the *final* segment: `x/.`
+     * normalizes to `x/`, which keeps the segment count and leaves every other
+     * segment intact. Rejection is the only observable difference, so assert it
+     * directly for every parameter rather than only the hand-picked ones below.
+     */
+    it.each(['.', '..'])('rejects the bare %j segment', (value) => {
+      expect(() => buildUrl(tool, param, value)).toThrow(/path traversal/)
+    })
+
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value).pathname)
+      const actual = segmentsOf(buildUrl(tool, param, value).pathname)
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment === SAFE_ID ? value : segment)
+        expect(actual[index]).toBe(segment === TARGET ? value : segment)
       })
     })
   })
 })
 
-const HIGH_RISK_TOOLS: ReadonlyArray<{ name: string; tool: AnyTool }> = [
-  { name: 'hubspot_delete_contact', tool: hubspotDeleteContactTool },
-  { name: 'hubspot_delete_company', tool: hubspotDeleteCompanyTool },
-  { name: 'hubspot_delete_deal', tool: hubspotDeleteDealTool },
-  { name: 'hubspot_delete_association', tool: hubspotDeleteAssociationTool },
+const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: AnyTool; param: string }> = [
+  { name: 'hubspot_delete_contact', tool: hubspotDeleteContactTool, param: 'contactId' },
+  { name: 'hubspot_delete_company', tool: hubspotDeleteCompanyTool, param: 'companyId' },
+  { name: 'hubspot_delete_deal', tool: hubspotDeleteDealTool, param: 'dealId' },
+  { name: 'hubspot_delete_association', tool: hubspotDeleteAssociationTool, param: 'objectId' },
 ]
 
-describe.each(HIGH_RISK_TOOLS)('$name id path safety', ({ tool }) => {
+describe.each(HIGH_RISK_CASES)('$name path safety', ({ tool, param }) => {
   it('rejects a bare dot-dot segment instead of silently popping the resource', () => {
-    expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+    expect(() => buildUrl(tool, param, '..')).toThrow(/path traversal/)
   })
 
   it('rejects a bare dot segment', () => {
-    expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+    expect(() => buildUrl(tool, param, '.')).toThrow(/path traversal/)
   })
 
-  it('does not let the id inject query parameters', () => {
-    const url = buildUrl(tool, '12345?properties=email')
+  it('does not let the value inject query parameters', () => {
+    const url = buildUrl(tool, param, '12345?properties=email')
 
     expect(url.searchParams.get('properties')).toBeNull()
   })
 
-  it('preserves a legitimate numeric id verbatim after trimming', () => {
-    expect(buildUrl(tool, '  12345  ').pathname).toContain('/12345')
+  it('preserves a legitimate value verbatim after trimming', () => {
+    expect(buildUrl(tool, param, '  12345  ').pathname).toContain(`/${'12345'}`)
+  })
+})
+
+/**
+ * The regression this file exists to prevent. A fill-everything sweep reported
+ * these tools as covered while only the *first* of their four path parameters
+ * was ever reached, so reverting any of the other three produced no failure.
+ */
+describe('association tools expose every path parameter separately', () => {
+  const ASSOCIATION_TOOLS = [
+    {
+      name: 'hubspot_create_association',
+      tool: hubspotCreateAssociationTool,
+      params: ['objectType', 'objectId', 'toObjectType', 'toObjectId'],
+    },
+    {
+      name: 'hubspot_delete_association',
+      tool: hubspotDeleteAssociationTool,
+      params: ['objectType', 'objectId', 'toObjectType', 'toObjectId'],
+    },
+    {
+      name: 'hubspot_list_associations',
+      tool: hubspotListAssociationsTool,
+      params: ['objectType', 'objectId', 'toObjectType'],
+    },
+  ] as const
+
+  it.each(ASSOCIATION_TOOLS)(
+    '$name contributes every path parameter it interpolates',
+    ({ tool, params }) => {
+      const covered = PATH_PARAM_CASES.filter((entry) => entry.tool === tool).map(
+        (entry) => entry.param
+      )
+
+      expect([...covered].sort()).toEqual([...params].sort())
+    }
+  )
+
+  it.each(
+    ASSOCIATION_TOOLS.flatMap(({ name, tool, params }) =>
+      params.map((param) => ({ name, tool, param }))
+    )
+  )('$name rejects a dot-dot segment in $param', ({ tool, param }) => {
+    expect(() => buildUrl(tool, param, '..')).toThrow(/path traversal/)
   })
 })

--- a/apps/sim/tools/hubspot/path_safety.test.ts
+++ b/apps/sim/tools/hubspot/path_safety.test.ts
@@ -161,12 +161,20 @@ interface PathParamCase {
 }
 
 /**
- * Typed as `unknown[]` on purpose: the barrel's values are a union of
- * concretely-typed `ToolConfig`s, and `Array.prototype.filter`'s type-predicate
- * overload requires the predicate's type to extend the array's. Widening to
- * `unknown` first is what lets the guard below do the narrowing.
+ * Seeded as `readonly unknown[]` on purpose, so the guard below is the single
+ * narrowing point for the whole harness.
+ *
+ * The barrel's values are a union of concretely-typed `ToolConfig`s, and no
+ * member of that union is assignable to the widened `PathTool`: `ToolConfig`
+ * places its parameter type in the *contravariant* position of `request.url`
+ * and `request.body`. Filtering the union directly does not help either —
+ * `Array.prototype.filter`'s type-predicate overload requires the predicate's
+ * type to extend the array's element type, so it intersects rather than
+ * replaces and leaves the mismatch in place. Widening to `unknown` first is
+ * what lets the guard actually narrow, and it keeps a cast out of every call
+ * site.
  */
-const ALL_EXPORTS: unknown[] = Object.values(hubspotTools)
+const ALL_EXPORTS: readonly unknown[] = Object.values(hubspotTools)
 
 const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isHubSpotTool)
   .filter((tool) => typeof tool.request?.url === 'function')

--- a/apps/sim/tools/hubspot/path_safety.test.ts
+++ b/apps/sim/tools/hubspot/path_safety.test.ts
@@ -145,12 +145,20 @@ function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-/** True when `target` actually lands in the path rather than the query string. */
-function reachesPath(tool: PathTool, target: string): boolean {
+/**
+ * Classifies one parameter by where its value lands in the built URL.
+ *
+ * `unbuildable` is a distinct outcome rather than being folded into `other` on
+ * purpose. `TARGET` is a perfectly legitimate value, so a URL builder that
+ * throws on it is a defect in the tool or in this harness — and quietly
+ * dropping the pair would shrink coverage without failing anything. The
+ * unbuildable set is asserted empty below instead.
+ */
+function classifyParam(tool: PathTool, param: string): 'path' | 'other' | 'unbuildable' {
   try {
-    return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
+    return buildUrl(tool, param, TARGET).pathname.includes(TARGET) ? 'path' : 'other'
   } catch {
-    return false
+    return 'unbuildable'
   }
 }
 
@@ -176,18 +184,46 @@ interface PathParamCase {
  */
 const ALL_EXPORTS: readonly unknown[] = Object.values(hubspotTools)
 
-const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isHubSpotTool)
+const CANDIDATE_PARAMS: ReadonlyArray<{ tool: PathTool; param: string }> = ALL_EXPORTS.filter(
+  isHubSpotTool
+)
   .filter((tool) => typeof tool.request?.url === 'function')
   .flatMap((tool) =>
     Object.keys(tool.params ?? {})
       .filter((param) => !(param in FIXED_PARAMS))
-      .filter((param) => reachesPath(tool, param))
-      .map((param) => ({ name: `${tool.id} / ${param}`, param, tool }))
+      .map((param) => ({ tool, param }))
   )
 
+function nameOf({ tool, param }: { tool: PathTool; param: string }): string {
+  return `${tool.id} / ${param}`
+}
+
+const UNBUILDABLE_PARAMS: readonly string[] = CANDIDATE_PARAMS.filter(
+  (candidate) => classifyParam(candidate.tool, candidate.param) === 'unbuildable'
+).map(nameOf)
+
+const PATH_PARAM_CASES: PathParamCase[] = CANDIDATE_PARAMS.filter(
+  (candidate) => classifyParam(candidate.tool, candidate.param) === 'path'
+).map((candidate) => ({ name: nameOf(candidate), param: candidate.param, tool: candidate.tool }))
+
 describe('hubspot path-parameter traversal safety', () => {
-  it('covers every (hubspot tool, path parameter) pair', () => {
-    expect(PATH_PARAM_CASES.length).toBeGreaterThanOrEqual(35)
+  /**
+   * Exact, not a floor. A floor lets a pair silently fall out of the sweep — a
+   * renamed parameter, or a URL builder that stops interpolating one — while
+   * the suite still reports green, which would quietly retire the guarantee
+   * this file exists to provide. Changing this number should be a deliberate
+   * edit accompanying a real change to the tool surface.
+   */
+  it('covers exactly every (hubspot tool, path parameter) pair', () => {
+    expect(PATH_PARAM_CASES).toHaveLength(41)
+  })
+
+  /**
+   * A builder that throws on `TARGET` would be silently classified as "not a
+   * path parameter" and vanish from the sweep, so name the failure instead.
+   */
+  it('builds a URL for every candidate parameter from a safe value', () => {
+    expect(UNBUILDABLE_PARAMS).toEqual([])
   })
 
   describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {

--- a/apps/sim/tools/hubspot/path_safety.test.ts
+++ b/apps/sim/tools/hubspot/path_safety.test.ts
@@ -50,6 +50,7 @@ const TRAVERSAL_VALUES = [
   '../../v3/objects/contacts/1',
   '..%2f..%2fv3/objects/contacts/1',
   '12345/../../../v3/objects/deals',
+  '12345/../victim',
   '12345?properties=email',
   '12345#fragment',
   '12345/associations/../../../v4/objects',
@@ -252,11 +253,22 @@ describe('hubspot path-parameter traversal safety', () => {
       expect(url.search).toBe(baselineUrl.search)
       expect(url.hash).toBe('')
 
+      /**
+       * The probe slot is asserted, not skipped. Skipping it leaves the whole
+       * check blind to a *balanced* traversal — `12345/../victim` pops exactly
+       * one segment and puts one back, so the segment count and every
+       * surrounding segment are identical and only the slot differs. That
+       * re-aims the request at another record while looking untouched.
+       *
+       * `safeUrlPathSegment`'s contract for a value it accepts is
+       * `encodeURIComponent` of the trimmed input, so that is the exact
+       * expected content. Anything the guard would reject never reaches here.
+       */
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)
+      const expectedSlot = encodeURIComponent(value.trim())
       baseline.forEach((segment, index) => {
-        if (segment === TARGET) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment === TARGET ? expectedSlot : segment)
       })
     })
 

--- a/apps/sim/tools/hubspot/path_safety.test.ts
+++ b/apps/sim/tools/hubspot/path_safety.test.ts
@@ -37,7 +37,7 @@ import { hubspotDeleteContactTool } from '@/tools/hubspot/delete_contact'
 import { hubspotDeleteDealTool } from '@/tools/hubspot/delete_deal'
 import * as hubspotTools from '@/tools/hubspot/index'
 import { hubspotListAssociationsTool } from '@/tools/hubspot/list_associations'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
@@ -76,18 +76,37 @@ const TARGET = 'TARGETVALUE'
 /** The value every *other* string parameter is pinned to while one is fuzzed. */
 const SIBLING = 'SIBLINGVALUE'
 
-type AnyTool = ToolConfig<any, any>
+type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
 
 /** Parameters that carry credentials or the host, never a path segment. */
 const FIXED_PARAMS: Record<string, unknown> = { accessToken: 'token' }
 
-function isHubSpotTool(value: unknown): value is AnyTool {
+function isHubSpotTool(value: unknown): value is PathTool {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('hubspot_')
+    'id' in value &&
+    typeof value.id === 'string' &&
+    value.id.startsWith('hubspot_')
   )
+}
+
+/**
+ * Narrows one concretely-typed tool export to the structural shape this
+ * harness drives.
+ *
+ * A direct assignment cannot work and must not be forced with a cast: under
+ * `strictFunctionTypes` a `ToolConfig<ConcreteParams, R>` is not assignable to
+ * `ToolConfig<Record<string, unknown>, ToolResponse>`, because `request.url`
+ * accepts the parameter type contravariantly. Re-checking the value at runtime
+ * through the same guard is what makes the narrowing sound rather than
+ * asserted.
+ */
+function asPathTool(value: unknown): PathTool {
+  if (!isHubSpotTool(value)) {
+    throw new Error('expected a HubSpot tool')
+  }
+  return value
 }
 
 /** The placeholder a sibling parameter holds, chosen so the URL still builds. */
@@ -105,7 +124,7 @@ function siblingValue(type: string | undefined): unknown {
  * attributed to `target`. This is the whole difference from a fill-everything
  * sweep, where the first parameter to throw hides all the others.
  */
-function buildParams(tool: AnyTool, target: string, value: string): Record<string, unknown> {
+function buildParams(tool: PathTool, target: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { ...FIXED_PARAMS }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name in FIXED_PARAMS) continue
@@ -114,12 +133,12 @@ function buildParams(tool: AnyTool, target: string, value: string): Record<strin
   return params
 }
 
-function buildUrl(tool: AnyTool, target: string, value: string): URL {
+function buildUrl(tool: PathTool, target: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, target, value) as any))
+  return new URL(url(buildParams(tool, target, value)))
 }
 
 function segmentsOf(pathname: string): string[] {
@@ -127,7 +146,7 @@ function segmentsOf(pathname: string): string[] {
 }
 
 /** True when `target` actually lands in the path rather than the query string. */
-function reachesPath(tool: AnyTool, target: string): boolean {
+function reachesPath(tool: PathTool, target: string): boolean {
   try {
     return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
   } catch {
@@ -138,11 +157,18 @@ function reachesPath(tool: AnyTool, target: string): boolean {
 interface PathParamCase {
   name: string
   param: string
-  tool: AnyTool
+  tool: PathTool
 }
 
-const PATH_PARAM_CASES: PathParamCase[] = Object.values(hubspotTools)
-  .filter(isHubSpotTool)
+/**
+ * Typed as `unknown[]` on purpose: the barrel's values are a union of
+ * concretely-typed `ToolConfig`s, and `Array.prototype.filter`'s type-predicate
+ * overload requires the predicate's type to extend the array's. Widening to
+ * `unknown` first is what lets the guard below do the narrowing.
+ */
+const ALL_EXPORTS: unknown[] = Object.values(hubspotTools)
+
+const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isHubSpotTool)
   .filter((tool) => typeof tool.request?.url === 'function')
   .flatMap((tool) =>
     Object.keys(tool.params ?? {})
@@ -199,11 +225,23 @@ describe('hubspot path-parameter traversal safety', () => {
   })
 })
 
-const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: AnyTool; param: string }> = [
-  { name: 'hubspot_delete_contact', tool: hubspotDeleteContactTool, param: 'contactId' },
-  { name: 'hubspot_delete_company', tool: hubspotDeleteCompanyTool, param: 'companyId' },
-  { name: 'hubspot_delete_deal', tool: hubspotDeleteDealTool, param: 'dealId' },
-  { name: 'hubspot_delete_association', tool: hubspotDeleteAssociationTool, param: 'objectId' },
+const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: PathTool; param: string }> = [
+  {
+    name: 'hubspot_delete_contact',
+    tool: asPathTool(hubspotDeleteContactTool),
+    param: 'contactId',
+  },
+  {
+    name: 'hubspot_delete_company',
+    tool: asPathTool(hubspotDeleteCompanyTool),
+    param: 'companyId',
+  },
+  { name: 'hubspot_delete_deal', tool: asPathTool(hubspotDeleteDealTool), param: 'dealId' },
+  {
+    name: 'hubspot_delete_association',
+    tool: asPathTool(hubspotDeleteAssociationTool),
+    param: 'objectId',
+  },
 ]
 
 describe.each(HIGH_RISK_CASES)('$name path safety', ({ tool, param }) => {
@@ -235,17 +273,17 @@ describe('association tools expose every path parameter separately', () => {
   const ASSOCIATION_TOOLS = [
     {
       name: 'hubspot_create_association',
-      tool: hubspotCreateAssociationTool,
+      tool: asPathTool(hubspotCreateAssociationTool),
       params: ['objectType', 'objectId', 'toObjectType', 'toObjectId'],
     },
     {
       name: 'hubspot_delete_association',
-      tool: hubspotDeleteAssociationTool,
+      tool: asPathTool(hubspotDeleteAssociationTool),
       params: ['objectType', 'objectId', 'toObjectType', 'toObjectId'],
     },
     {
       name: 'hubspot_list_associations',
-      tool: hubspotListAssociationsTool,
+      tool: asPathTool(hubspotListAssociationsTool),
       params: ['objectType', 'objectId', 'toObjectType'],
     },
   ] as const

--- a/apps/sim/tools/hubspot/path_safety.test.ts
+++ b/apps/sim/tools/hubspot/path_safety.test.ts
@@ -191,7 +191,8 @@ describe('hubspot path-parameter traversal safety', () => {
   })
 
   describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {
-    const baseline = segmentsOf(buildUrl(tool, param, TARGET).pathname)
+    const baselineUrl = buildUrl(tool, param, TARGET)
+    const baseline = segmentsOf(baselineUrl.pathname)
 
     it.each(TRAVERSAL_VALUES)('cannot reshape the path with %j', (value) => {
       let url: URL
@@ -203,6 +204,17 @@ describe('hubspot path-parameter traversal safety', () => {
 
       expect(url.origin).toBe('https://api.hubapi.com')
       expect(url.pathname.startsWith('/')).toBe(true)
+
+      /**
+       * A `?` or `#` in the value does not lengthen the path — it moves the
+       * tail out of `pathname` entirely — so the segment comparison below is
+       * blind to it. Pinning the query and fragment against the baseline is
+       * what makes those two vectors real assertions rather than decoration.
+       * Comparing to the baseline rather than to empty is deliberate: several
+       * tools legitimately build their own query string.
+       */
+      expect(url.search).toBe(baselineUrl.search)
+      expect(url.hash).toBe('')
 
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)

--- a/apps/sim/tools/hubspot/remove_list_memberships.ts
+++ b/apps/sim/tools/hubspot/remove_list_memberships.ts
@@ -4,6 +4,7 @@ import type {
   HubSpotRemoveListMembershipsResponse,
 } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotRemoveListMemberships')
 
@@ -45,7 +46,7 @@ export const hubspotRemoveListMembershipsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.hubapi.com/crm/v3/lists/${params.listId.trim()}/memberships/remove`,
+      `https://api.hubapi.com/crm/v3/lists/${safeUrlPathSegment(params.listId, 'listId')}/memberships/remove`,
     method: 'PUT',
     headers: (params) => {
       if (!params.accessToken) {

--- a/apps/sim/tools/hubspot/update_appointment.ts
+++ b/apps/sim/tools/hubspot/update_appointment.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { APPOINTMENT_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotUpdateAppointment')
 
@@ -52,7 +53,7 @@ export const hubspotUpdateAppointmentTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/appointments/${params.appointmentId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/appointments/${safeUrlPathSegment(params.appointmentId, 'appointmentId')}`
       const queryParams = new URLSearchParams()
       if (params.idProperty) queryParams.append('idProperty', params.idProperty)
       const queryString = queryParams.toString()

--- a/apps/sim/tools/hubspot/update_company.ts
+++ b/apps/sim/tools/hubspot/update_company.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { COMPANY_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotUpdateCompany')
 
@@ -53,7 +54,7 @@ export const hubspotUpdateCompanyTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/companies/${params.companyId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/companies/${safeUrlPathSegment(params.companyId, 'companyId')}`
       if (params.idProperty) {
         return `${baseUrl}?${new URLSearchParams({ idProperty: params.idProperty })}`
       }

--- a/apps/sim/tools/hubspot/update_contact.ts
+++ b/apps/sim/tools/hubspot/update_contact.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { CONTACT_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotUpdateContact')
 
@@ -53,7 +54,7 @@ export const hubspotUpdateContactTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/contacts/${params.contactId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/contacts/${safeUrlPathSegment(params.contactId, 'contactId')}`
       if (params.idProperty) {
         return `${baseUrl}?${new URLSearchParams({ idProperty: params.idProperty })}`
       }

--- a/apps/sim/tools/hubspot/update_deal.ts
+++ b/apps/sim/tools/hubspot/update_deal.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotUpdateDealParams, HubSpotUpdateDealResponse } from '@/tools/hubspot/types'
 import { DEAL_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotUpdateDeal')
 
@@ -47,7 +48,7 @@ export const hubspotUpdateDealTool: ToolConfig<HubSpotUpdateDealParams, HubSpotU
 
     request: {
       url: (params) => {
-        const baseUrl = `https://api.hubapi.com/crm/v3/objects/deals/${params.dealId.trim()}`
+        const baseUrl = `https://api.hubapi.com/crm/v3/objects/deals/${safeUrlPathSegment(params.dealId, 'dealId')}`
         const queryParams = new URLSearchParams()
         if (params.idProperty) queryParams.append('idProperty', params.idProperty)
         const queryString = queryParams.toString()

--- a/apps/sim/tools/hubspot/update_line_item.ts
+++ b/apps/sim/tools/hubspot/update_line_item.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/tools/hubspot/types'
 import { LINE_ITEM_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotUpdateLineItem')
 
@@ -52,7 +53,7 @@ export const hubspotUpdateLineItemTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/line_items/${params.lineItemId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/line_items/${safeUrlPathSegment(params.lineItemId, 'lineItemId')}`
       const queryParams = new URLSearchParams()
       if (params.idProperty) queryParams.append('idProperty', params.idProperty)
       const queryString = queryParams.toString()

--- a/apps/sim/tools/hubspot/update_ticket.ts
+++ b/apps/sim/tools/hubspot/update_ticket.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { HubSpotUpdateTicketParams, HubSpotUpdateTicketResponse } from '@/tools/hubspot/types'
 import { TICKET_OBJECT_OUTPUT } from '@/tools/hubspot/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('HubSpotUpdateTicket')
 
@@ -49,7 +50,7 @@ export const hubspotUpdateTicketTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const baseUrl = `https://api.hubapi.com/crm/v3/objects/tickets/${params.ticketId.trim()}`
+      const baseUrl = `https://api.hubapi.com/crm/v3/objects/tickets/${safeUrlPathSegment(params.ticketId, 'ticketId')}`
       const queryParams = new URLSearchParams()
       if (params.idProperty) queryParams.append('idProperty', params.idProperty)
       const queryString = queryParams.toString()

--- a/apps/sim/tools/salesforce/delete_account.ts
+++ b/apps/sim/tools/salesforce/delete_account.ts
@@ -5,6 +5,7 @@ import type {
 import { SOBJECT_DELETE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceDeleteAccountTool: ToolConfig<
   SalesforceDeleteAccountParams,
@@ -49,7 +50,7 @@ export const salesforceDeleteAccountTool: ToolConfig<
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
       const accountId = requireId(params.accountId, 'Account ID')
 
-      return `${instanceUrl}/services/data/v59.0/sobjects/Account/${accountId}`
+      return `${instanceUrl}/services/data/v59.0/sobjects/Account/${safeUrlPathSegment(accountId, 'Account ID')}`
     },
     method: 'DELETE',
     headers: (params) => {

--- a/apps/sim/tools/salesforce/delete_case.ts
+++ b/apps/sim/tools/salesforce/delete_case.ts
@@ -5,6 +5,7 @@ import type {
 import { SOBJECT_DELETE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceDeleteCaseTool: ToolConfig<
   SalesforceDeleteCaseParams,
@@ -47,7 +48,7 @@ export const salesforceDeleteCaseTool: ToolConfig<
   request: {
     url: (params) => {
       const caseId = requireId(params.caseId, 'Case ID')
-      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Case/${caseId}`
+      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Case/${safeUrlPathSegment(caseId, 'Case ID')}`
     },
     method: 'DELETE',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/delete_contact.ts
+++ b/apps/sim/tools/salesforce/delete_contact.ts
@@ -6,6 +6,7 @@ import type {
 import { SOBJECT_DELETE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceContacts')
 
@@ -36,7 +37,7 @@ export const salesforceDeleteContactTool: ToolConfig<
     url: (params) => {
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
       const contactId = requireId(params.contactId, 'Contact ID')
-      return `${instanceUrl}/services/data/v59.0/sobjects/Contact/${contactId}`
+      return `${instanceUrl}/services/data/v59.0/sobjects/Contact/${safeUrlPathSegment(contactId, 'Contact ID')}`
     },
     method: 'DELETE',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/delete_custom_field.ts
+++ b/apps/sim/tools/salesforce/delete_custom_field.ts
@@ -6,6 +6,7 @@ import type {
 import { CUSTOM_FIELD_DELETE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceDeleteCustomField')
 
@@ -46,7 +47,7 @@ export const salesforceDeleteCustomFieldTool: ToolConfig<
     url: (params) => {
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
       const fieldId = requireId(params.fieldId, 'Field ID')
-      return `${instanceUrl}/services/data/v59.0/tooling/sobjects/CustomField/${fieldId}`
+      return `${instanceUrl}/services/data/v59.0/tooling/sobjects/CustomField/${safeUrlPathSegment(fieldId, 'Field ID')}`
     },
     method: 'DELETE',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/delete_lead.ts
+++ b/apps/sim/tools/salesforce/delete_lead.ts
@@ -5,6 +5,7 @@ import type {
 import { SOBJECT_DELETE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceDeleteLeadTool: ToolConfig<
   SalesforceDeleteLeadParams,
@@ -35,7 +36,7 @@ export const salesforceDeleteLeadTool: ToolConfig<
   request: {
     url: (params) => {
       const leadId = requireId(params.leadId, 'Lead ID')
-      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Lead/${leadId}`
+      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Lead/${safeUrlPathSegment(leadId, 'Lead ID')}`
     },
     method: 'DELETE',
     headers: (params) => ({ Authorization: `Bearer ${params.accessToken}` }),

--- a/apps/sim/tools/salesforce/delete_opportunity.ts
+++ b/apps/sim/tools/salesforce/delete_opportunity.ts
@@ -6,6 +6,7 @@ import type {
 import { SOBJECT_DELETE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceDeleteOpportunity')
 
@@ -38,7 +39,7 @@ export const salesforceDeleteOpportunityTool: ToolConfig<
   request: {
     url: (params) => {
       const opportunityId = requireId(params.opportunityId, 'Opportunity ID')
-      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Opportunity/${opportunityId}`
+      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Opportunity/${safeUrlPathSegment(opportunityId, 'Opportunity ID')}`
     },
     method: 'DELETE',
     headers: (params) => ({ Authorization: `Bearer ${params.accessToken}` }),

--- a/apps/sim/tools/salesforce/delete_task.ts
+++ b/apps/sim/tools/salesforce/delete_task.ts
@@ -5,6 +5,7 @@ import type {
 import { SOBJECT_DELETE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceDeleteTaskTool: ToolConfig<
   SalesforceDeleteTaskParams,
@@ -47,7 +48,7 @@ export const salesforceDeleteTaskTool: ToolConfig<
   request: {
     url: (params) => {
       const taskId = requireId(params.taskId, 'Task ID')
-      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Task/${taskId}`
+      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Task/${safeUrlPathSegment(taskId, 'Task ID')}`
     },
     method: 'DELETE',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/describe_object.ts
+++ b/apps/sim/tools/salesforce/describe_object.ts
@@ -6,6 +6,7 @@ import type {
 import { DESCRIBE_OBJECT_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceQuery')
 
@@ -48,7 +49,7 @@ export const salesforceDescribeObjectTool: ToolConfig<
       }
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
       const objectName = params.objectName.trim()
-      return `${instanceUrl}/services/data/v59.0/sobjects/${objectName}/describe`
+      return `${instanceUrl}/services/data/v59.0/sobjects/${safeUrlPathSegment(objectName, 'Object Name')}/describe`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/get_cases.ts
+++ b/apps/sim/tools/salesforce/get_cases.ts
@@ -2,6 +2,7 @@ import type { SalesforceGetCasesParams, SalesforceGetCasesResponse } from '@/too
 import { QUERY_PAGING_OUTPUT, RESPONSE_METADATA_OUTPUT } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceGetCasesTool: ToolConfig<
   SalesforceGetCasesParams,
@@ -55,7 +56,7 @@ export const salesforceGetCasesTool: ToolConfig<
         const caseId = requireId(params.caseId, 'Case ID')
         const fields =
           params.fields || 'Id,CaseNumber,Subject,Status,Priority,Origin,ContactId,AccountId'
-        return `${instanceUrl}/services/data/v59.0/sobjects/Case/${caseId}?fields=${encodeURIComponent(fields)}`
+        return `${instanceUrl}/services/data/v59.0/sobjects/Case/${safeUrlPathSegment(caseId, 'Case ID')}?fields=${encodeURIComponent(fields)}`
       }
       const limit = params.limit ? Number.parseInt(params.limit) : 100
       const fields =

--- a/apps/sim/tools/salesforce/get_contacts.ts
+++ b/apps/sim/tools/salesforce/get_contacts.ts
@@ -6,6 +6,7 @@ import type {
 import { QUERY_PAGING_OUTPUT, RESPONSE_METADATA_OUTPUT } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceContacts')
 
@@ -63,7 +64,7 @@ export const salesforceGetContactsTool: ToolConfig<
         const contactId = requireId(params.contactId, 'Contact ID')
         const fields =
           params.fields || 'Id,FirstName,LastName,Email,Phone,AccountId,Title,Department'
-        return `${instanceUrl}/services/data/v59.0/sobjects/Contact/${contactId}?fields=${encodeURIComponent(fields)}`
+        return `${instanceUrl}/services/data/v59.0/sobjects/Contact/${safeUrlPathSegment(contactId, 'Contact ID')}?fields=${encodeURIComponent(fields)}`
       }
 
       // List contacts with SOQL query

--- a/apps/sim/tools/salesforce/get_dashboard.ts
+++ b/apps/sim/tools/salesforce/get_dashboard.ts
@@ -6,6 +6,7 @@ import type {
 import { DASHBOARD_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceDashboards')
 
@@ -45,7 +46,7 @@ export const salesforceGetDashboardTool: ToolConfig<
         throw new Error('Dashboard ID is required. Please provide a valid Salesforce Dashboard ID.')
       }
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
-      return `${instanceUrl}/services/data/v59.0/analytics/dashboards/${params.dashboardId}`
+      return `${instanceUrl}/services/data/v59.0/analytics/dashboards/${safeUrlPathSegment(params.dashboardId, 'Dashboard ID')}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/get_leads.ts
+++ b/apps/sim/tools/salesforce/get_leads.ts
@@ -2,6 +2,7 @@ import type { SalesforceGetLeadsParams, SalesforceGetLeadsResponse } from '@/too
 import { QUERY_PAGING_OUTPUT, RESPONSE_METADATA_OUTPUT } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceGetLeadsTool: ToolConfig<
   SalesforceGetLeadsParams,
@@ -55,7 +56,7 @@ export const salesforceGetLeadsTool: ToolConfig<
         const leadId = requireId(params.leadId, 'Lead ID')
         const fields =
           params.fields || 'Id,FirstName,LastName,Company,Email,Phone,Status,LeadSource'
-        return `${instanceUrl}/services/data/v59.0/sobjects/Lead/${leadId}?fields=${encodeURIComponent(fields)}`
+        return `${instanceUrl}/services/data/v59.0/sobjects/Lead/${safeUrlPathSegment(leadId, 'Lead ID')}?fields=${encodeURIComponent(fields)}`
       }
       const limit = params.limit ? Number.parseInt(params.limit) : 100
       const fields = params.fields || 'Id,FirstName,LastName,Company,Email,Phone,Status,LeadSource'

--- a/apps/sim/tools/salesforce/get_opportunities.ts
+++ b/apps/sim/tools/salesforce/get_opportunities.ts
@@ -6,6 +6,7 @@ import type {
 import { QUERY_PAGING_OUTPUT, RESPONSE_METADATA_OUTPUT } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceGetOpportunities')
 
@@ -60,7 +61,7 @@ export const salesforceGetOpportunitiesTool: ToolConfig<
       if (params.opportunityId) {
         const opportunityId = requireId(params.opportunityId, 'Opportunity ID')
         const fields = params.fields || 'Id,Name,AccountId,Amount,StageName,CloseDate,Probability'
-        return `${instanceUrl}/services/data/v59.0/sobjects/Opportunity/${opportunityId}?fields=${encodeURIComponent(fields)}`
+        return `${instanceUrl}/services/data/v59.0/sobjects/Opportunity/${safeUrlPathSegment(opportunityId, 'Opportunity ID')}?fields=${encodeURIComponent(fields)}`
       }
       const limit = params.limit ? Number.parseInt(params.limit) : 100
       const fields = params.fields || 'Id,Name,AccountId,Amount,StageName,CloseDate,Probability'

--- a/apps/sim/tools/salesforce/get_report.ts
+++ b/apps/sim/tools/salesforce/get_report.ts
@@ -6,6 +6,7 @@ import type {
 import { GET_REPORT_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceReports')
 
@@ -45,7 +46,7 @@ export const salesforceGetReportTool: ToolConfig<
         throw new Error('Report ID is required. Please provide a valid Salesforce Report ID.')
       }
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
-      return `${instanceUrl}/services/data/v59.0/analytics/reports/${params.reportId}/describe`
+      return `${instanceUrl}/services/data/v59.0/analytics/reports/${safeUrlPathSegment(params.reportId, 'Report ID')}/describe`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/get_tasks.ts
+++ b/apps/sim/tools/salesforce/get_tasks.ts
@@ -2,6 +2,7 @@ import type { SalesforceGetTasksParams, SalesforceGetTasksResponse } from '@/too
 import { QUERY_PAGING_OUTPUT, RESPONSE_METADATA_OUTPUT } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceGetTasksTool: ToolConfig<
   SalesforceGetTasksParams,
@@ -67,7 +68,7 @@ export const salesforceGetTasksTool: ToolConfig<
         const taskId = requireId(params.taskId, 'Task ID')
         const fields =
           params.fields || 'Id,Subject,Status,Priority,ActivityDate,WhoId,WhatId,OwnerId'
-        return `${instanceUrl}/services/data/v59.0/sobjects/Task/${taskId}?fields=${encodeURIComponent(fields)}`
+        return `${instanceUrl}/services/data/v59.0/sobjects/Task/${safeUrlPathSegment(taskId, 'Task ID')}?fields=${encodeURIComponent(fields)}`
       }
       const limit = params.limit ? Number.parseInt(params.limit) : 100
       const fields = params.fields || 'Id,Subject,Status,Priority,ActivityDate,WhoId,WhatId,OwnerId'

--- a/apps/sim/tools/salesforce/path_safety.test.ts
+++ b/apps/sim/tools/salesforce/path_safety.test.ts
@@ -40,7 +40,7 @@ import { salesforceDeleteContactTool } from '@/tools/salesforce/delete_contact'
 import { salesforceDeleteOpportunityTool } from '@/tools/salesforce/delete_opportunity'
 import { salesforceDescribeObjectTool } from '@/tools/salesforce/describe_object'
 import * as salesforceTools from '@/tools/salesforce/index'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
 const INSTANCE_URL = 'https://example-org.my.salesforce.com'
 
@@ -81,7 +81,7 @@ const TARGET = 'TARGETVALUE'
 /** The value every *other* string parameter is pinned to while one is fuzzed. */
 const SIBLING = 'SIBLINGVALUE'
 
-type AnyTool = ToolConfig<any, any>
+type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
 
 /** Parameters that carry credentials or the host, never a path segment. */
 const FIXED_PARAMS: Record<string, unknown> = {
@@ -90,13 +90,32 @@ const FIXED_PARAMS: Record<string, unknown> = {
   instanceUrl: INSTANCE_URL,
 }
 
-function isSalesforceTool(value: unknown): value is AnyTool {
+function isSalesforceTool(value: unknown): value is PathTool {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('salesforce_')
+    'id' in value &&
+    typeof value.id === 'string' &&
+    value.id.startsWith('salesforce_')
   )
+}
+
+/**
+ * Narrows one concretely-typed tool export to the structural shape this
+ * harness drives.
+ *
+ * A direct assignment cannot work and must not be forced with a cast: under
+ * `strictFunctionTypes` a `ToolConfig<ConcreteParams, R>` is not assignable to
+ * `ToolConfig<Record<string, unknown>, ToolResponse>`, because `request.url`
+ * accepts the parameter type contravariantly. Re-checking the value at runtime
+ * through the same guard is what makes the narrowing sound rather than
+ * asserted.
+ */
+function asPathTool(value: unknown): PathTool {
+  if (!isSalesforceTool(value)) {
+    throw new Error('expected a Salesforce tool')
+  }
+  return value
 }
 
 /** The placeholder a sibling parameter holds, chosen so the URL still builds. */
@@ -114,7 +133,7 @@ function siblingValue(type: string | undefined): unknown {
  * attributed to `target`. This is the whole difference from a fill-everything
  * sweep, where the first parameter to throw hides all the others.
  */
-function buildParams(tool: AnyTool, target: string, value: string): Record<string, unknown> {
+function buildParams(tool: PathTool, target: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { ...FIXED_PARAMS }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name in FIXED_PARAMS) continue
@@ -123,12 +142,12 @@ function buildParams(tool: AnyTool, target: string, value: string): Record<strin
   return params
 }
 
-function buildUrl(tool: AnyTool, target: string, value: string): URL {
+function buildUrl(tool: PathTool, target: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, target, value) as any))
+  return new URL(url(buildParams(tool, target, value)))
 }
 
 function segmentsOf(pathname: string): string[] {
@@ -136,7 +155,7 @@ function segmentsOf(pathname: string): string[] {
 }
 
 /** True when `target` actually lands in the path rather than the query string. */
-function reachesPath(tool: AnyTool, target: string): boolean {
+function reachesPath(tool: PathTool, target: string): boolean {
   try {
     return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
   } catch {
@@ -147,11 +166,18 @@ function reachesPath(tool: AnyTool, target: string): boolean {
 interface PathParamCase {
   name: string
   param: string
-  tool: AnyTool
+  tool: PathTool
 }
 
-const PATH_PARAM_CASES: PathParamCase[] = Object.values(salesforceTools)
-  .filter(isSalesforceTool)
+/**
+ * Typed as `unknown[]` on purpose: the barrel's values are a union of
+ * concretely-typed `ToolConfig`s, and `Array.prototype.filter`'s type-predicate
+ * overload requires the predicate's type to extend the array's. Widening to
+ * `unknown` first is what lets the guard below do the narrowing.
+ */
+const ALL_EXPORTS: unknown[] = Object.values(salesforceTools)
+
+const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isSalesforceTool)
   .filter((tool) => tool.id !== 'salesforce_query_more')
   .filter((tool) => typeof tool.request?.url === 'function')
   .flatMap((tool) =>
@@ -209,15 +235,27 @@ describe('salesforce path-parameter traversal safety', () => {
   })
 })
 
-const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: AnyTool; param: string }> = [
-  { name: 'salesforce_delete_account', tool: salesforceDeleteAccountTool, param: 'accountId' },
-  { name: 'salesforce_delete_contact', tool: salesforceDeleteContactTool, param: 'contactId' },
+const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: PathTool; param: string }> = [
+  {
+    name: 'salesforce_delete_account',
+    tool: asPathTool(salesforceDeleteAccountTool),
+    param: 'accountId',
+  },
+  {
+    name: 'salesforce_delete_contact',
+    tool: asPathTool(salesforceDeleteContactTool),
+    param: 'contactId',
+  },
   {
     name: 'salesforce_delete_opportunity',
-    tool: salesforceDeleteOpportunityTool,
+    tool: asPathTool(salesforceDeleteOpportunityTool),
     param: 'opportunityId',
   },
-  { name: 'salesforce_describe_object', tool: salesforceDescribeObjectTool, param: 'objectName' },
+  {
+    name: 'salesforce_describe_object',
+    tool: asPathTool(salesforceDescribeObjectTool),
+    param: 'objectName',
+  },
 ]
 
 describe.each(HIGH_RISK_CASES)('$name path safety', ({ tool, param }) => {
@@ -244,7 +282,7 @@ describe.each(HIGH_RISK_CASES)('$name path safety', ({ tool, param }) => {
 
 describe('salesforce_describe_object custom API names', () => {
   it.each(['My_Object__c', 'Region__c', 'Account'])('accepts %j verbatim', (objectName) => {
-    const url = buildUrl(salesforceDescribeObjectTool, 'objectName', objectName)
+    const url = buildUrl(asPathTool(salesforceDescribeObjectTool), 'objectName', objectName)
 
     expect(url.pathname).toBe(`/services/data/v59.0/sobjects/${objectName}/describe`)
   })

--- a/apps/sim/tools/salesforce/path_safety.test.ts
+++ b/apps/sim/tools/salesforce/path_safety.test.ts
@@ -154,12 +154,20 @@ function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-/** True when `target` actually lands in the path rather than the query string. */
-function reachesPath(tool: PathTool, target: string): boolean {
+/**
+ * Classifies one parameter by where its value lands in the built URL.
+ *
+ * `unbuildable` is a distinct outcome rather than being folded into `other` on
+ * purpose. `TARGET` is a perfectly legitimate value, so a URL builder that
+ * throws on it is a defect in the tool or in this harness — and quietly
+ * dropping the pair would shrink coverage without failing anything. The
+ * unbuildable set is asserted empty below instead.
+ */
+function classifyParam(tool: PathTool, param: string): 'path' | 'other' | 'unbuildable' {
   try {
-    return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
+    return buildUrl(tool, param, TARGET).pathname.includes(TARGET) ? 'path' : 'other'
   } catch {
-    return false
+    return 'unbuildable'
   }
 }
 
@@ -185,19 +193,47 @@ interface PathParamCase {
  */
 const ALL_EXPORTS: readonly unknown[] = Object.values(salesforceTools)
 
-const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isSalesforceTool)
+const CANDIDATE_PARAMS: ReadonlyArray<{ tool: PathTool; param: string }> = ALL_EXPORTS.filter(
+  isSalesforceTool
+)
   .filter((tool) => tool.id !== 'salesforce_query_more')
   .filter((tool) => typeof tool.request?.url === 'function')
   .flatMap((tool) =>
     Object.keys(tool.params ?? {})
       .filter((param) => !(param in FIXED_PARAMS))
-      .filter((param) => reachesPath(tool, param))
-      .map((param) => ({ name: `${tool.id} / ${param}`, param, tool }))
+      .map((param) => ({ tool, param }))
   )
 
+function nameOf({ tool, param }: { tool: PathTool; param: string }): string {
+  return `${tool.id} / ${param}`
+}
+
+const UNBUILDABLE_PARAMS: readonly string[] = CANDIDATE_PARAMS.filter(
+  (candidate) => classifyParam(candidate.tool, candidate.param) === 'unbuildable'
+).map(nameOf)
+
+const PATH_PARAM_CASES: PathParamCase[] = CANDIDATE_PARAMS.filter(
+  (candidate) => classifyParam(candidate.tool, candidate.param) === 'path'
+).map((candidate) => ({ name: nameOf(candidate), param: candidate.param, tool: candidate.tool }))
+
 describe('salesforce path-parameter traversal safety', () => {
-  it('covers every (salesforce tool, path parameter) pair', () => {
-    expect(PATH_PARAM_CASES.length).toBeGreaterThanOrEqual(20)
+  /**
+   * Exact, not a floor. A floor lets a pair silently fall out of the sweep — a
+   * renamed parameter, or a URL builder that stops interpolating one — while
+   * the suite still reports green, which would quietly retire the guarantee
+   * this file exists to provide. Changing this number should be a deliberate
+   * edit accompanying a real change to the tool surface.
+   */
+  it('covers exactly every (salesforce tool, path parameter) pair', () => {
+    expect(PATH_PARAM_CASES).toHaveLength(23)
+  })
+
+  /**
+   * A builder that throws on `TARGET` would be silently classified as "not a
+   * path parameter" and vanish from the sweep, so name the failure instead.
+   */
+  it('builds a URL for every candidate parameter from a safe value', () => {
+    expect(UNBUILDABLE_PARAMS).toEqual([])
   })
 
   describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {

--- a/apps/sim/tools/salesforce/path_safety.test.ts
+++ b/apps/sim/tools/salesforce/path_safety.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every Salesforce tool against path traversal through an LLM-writable
+ * identifier — a record id, a report or dashboard id, or an sObject API name —
+ * that gets interpolated into the request path.
+ *
+ * These parameters are `visibility: 'user-or-llm'`, so prompt injection
+ * controls them. Interpolating one raw let a value like
+ * `../../../v59.0/sobjects/Account/001` escape the record it addresses once
+ * `fetch` normalized the URL, re-aiming the request — with the user's
+ * Salesforce OAuth bearer token still attached — at an arbitrary object in the
+ * org, including on the DELETE tools.
+ *
+ * Wrapping the id in `encodeURIComponent` is NOT enough, which is why the
+ * vector list below includes the bare `.` and `..` segments: both are made of
+ * unreserved characters, so they survive encoding untouched and the URL parser
+ * then removes them as dot segments, popping one path segment off a fixed host.
+ * Every assertion here resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ *
+ * `salesforce_query_more` is deliberately out of scope: its `nextRecordsUrl`
+ * parameter is by contract a whole relative path handed back by a previous
+ * query, so it is multi-segment by design and single-segment guarding would
+ * break every legitimate call.
+ */
+import { describe, expect, it } from 'vitest'
+import { salesforceDeleteAccountTool } from '@/tools/salesforce/delete_account'
+import { salesforceDeleteContactTool } from '@/tools/salesforce/delete_contact'
+import { salesforceDeleteOpportunityTool } from '@/tools/salesforce/delete_opportunity'
+import { salesforceDescribeObjectTool } from '@/tools/salesforce/describe_object'
+import * as salesforceTools from '@/tools/salesforce/index'
+import type { ToolConfig } from '@/tools/types'
+
+const INSTANCE_URL = 'https://example-org.my.salesforce.com'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../../v59.0/sobjects/Account/0011234567890ABC',
+  '..%2f..%2fsobjects/Account',
+  '0011234567890ABC/../../../limits',
+  '0011234567890ABC?fields=Name',
+  '0011234567890ABC#fragment',
+  '0011234567890ABC/../Contact/003',
+  '\\..\\..',
+] as const
+
+/**
+ * Values a real user legitimately supplies; none may be rejected or altered.
+ * The 15- and 18-character record ids and the `__c` custom API names are the
+ * point of this list — a guard that rejected them would be a regression.
+ */
+const LEGITIMATE_IDS = [
+  '0011234567890ABC',
+  '0011234567890ABCDE',
+  '003Hn00000ABCDEIA3',
+  '00Q5f000004abcdEAA',
+  'Account',
+  'Contact',
+  'My_Object__c',
+  'Region__c',
+  'Custom_Field_Name__c',
+  '01Z5f000000abcdEAA',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+/** Parameters that carry credentials or the org host, never a path segment. */
+const FIXED_PARAMS: Record<string, unknown> = {
+  accessToken: 'token',
+  idToken: undefined,
+  instanceUrl: INSTANCE_URL,
+}
+
+function isSalesforceTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('salesforce_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised. Credential and host
+ * parameters are pinned so the test exercises the path, not the org lookup.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { ...FIXED_PARAMS }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name in FIXED_PARAMS) continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(pathname: string): string[] {
+  return pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(salesforceTools)
+  .filter(isSalesforceTool)
+  .filter((tool) => tool.id !== 'salesforce_query_more')
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('salesforce path-id traversal safety', () => {
+  it('covers every Salesforce tool that interpolates an id into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(20)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID).pathname)
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(url.origin).toBe(INSTANCE_URL)
+      expect(url.pathname.startsWith('/services/data/v59.0/')).toBe(true)
+
+      const actual = segmentsOf(url.pathname)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value).pathname)
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        expect(actual[index]).toBe(segment === SAFE_ID ? value : segment)
+      })
+    })
+  })
+})
+
+const HIGH_RISK_TOOLS: ReadonlyArray<{ name: string; tool: AnyTool }> = [
+  { name: 'salesforce_delete_account', tool: salesforceDeleteAccountTool },
+  { name: 'salesforce_delete_contact', tool: salesforceDeleteContactTool },
+  { name: 'salesforce_delete_opportunity', tool: salesforceDeleteOpportunityTool },
+  { name: 'salesforce_describe_object', tool: salesforceDescribeObjectTool },
+]
+
+describe.each(HIGH_RISK_TOOLS)('$name path safety', ({ tool }) => {
+  it('rejects a bare dot-dot segment instead of silently popping the resource', () => {
+    expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+  })
+
+  it('rejects a bare dot segment', () => {
+    expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+  })
+
+  it('does not let the id inject query parameters', () => {
+    const url = buildUrl(tool, '0011234567890ABC?fields=Name')
+
+    expect(url.searchParams.get('fields')).toBeNull()
+  })
+
+  it('keeps the request inside the org instance host', () => {
+    const url = buildUrl(tool, '0011234567890ABC')
+
+    expect(url.origin).toBe(INSTANCE_URL)
+  })
+})
+
+describe('salesforce_describe_object custom API names', () => {
+  it.each(['My_Object__c', 'Region__c', 'Account'])('accepts %j verbatim', (objectName) => {
+    const url = buildUrl(salesforceDescribeObjectTool, objectName)
+
+    expect(url.pathname).toBe(`/services/data/v59.0/sobjects/${objectName}/describe`)
+  })
+})

--- a/apps/sim/tools/salesforce/path_safety.test.ts
+++ b/apps/sim/tools/salesforce/path_safety.test.ts
@@ -201,7 +201,8 @@ describe('salesforce path-parameter traversal safety', () => {
   })
 
   describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {
-    const baseline = segmentsOf(buildUrl(tool, param, TARGET).pathname)
+    const baselineUrl = buildUrl(tool, param, TARGET)
+    const baseline = segmentsOf(baselineUrl.pathname)
 
     it.each(TRAVERSAL_VALUES)('cannot reshape the path with %j', (value) => {
       let url: URL
@@ -213,6 +214,17 @@ describe('salesforce path-parameter traversal safety', () => {
 
       expect(url.origin).toBe(INSTANCE_URL)
       expect(url.pathname.startsWith('/services/data/v59.0/')).toBe(true)
+
+      /**
+       * A `?` or `#` in the value does not lengthen the path — it moves the
+       * tail out of `pathname` entirely — so the segment comparison below is
+       * blind to it. Pinning the query and fragment against the baseline is
+       * what makes those two vectors real assertions rather than decoration.
+       * Comparing to the baseline rather than to empty is deliberate: several
+       * tools legitimately build their own query string.
+       */
+      expect(url.search).toBe(baselineUrl.search)
+      expect(url.hash).toBe('')
 
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)

--- a/apps/sim/tools/salesforce/path_safety.test.ts
+++ b/apps/sim/tools/salesforce/path_safety.test.ts
@@ -55,6 +55,7 @@ const TRAVERSAL_VALUES = [
   '../../../v59.0/sobjects/Account/0011234567890ABC',
   '..%2f..%2fsobjects/Account',
   '0011234567890ABC/../../../limits',
+  '0011234567890ABC/../0019999999999XYZ',
   '0011234567890ABC?fields=Name',
   '0011234567890ABC#fragment',
   '0011234567890ABC/../Contact/003',
@@ -262,11 +263,22 @@ describe('salesforce path-parameter traversal safety', () => {
       expect(url.search).toBe(baselineUrl.search)
       expect(url.hash).toBe('')
 
+      /**
+       * The probe slot is asserted, not skipped. Skipping it leaves the whole
+       * check blind to a *balanced* traversal — `12345/../victim` pops exactly
+       * one segment and puts one back, so the segment count and every
+       * surrounding segment are identical and only the slot differs. That
+       * re-aims the request at another record while looking untouched.
+       *
+       * `safeUrlPathSegment`'s contract for a value it accepts is
+       * `encodeURIComponent` of the trimmed input, so that is the exact
+       * expected content. Anything the guard would reject never reaches here.
+       */
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)
+      const expectedSlot = encodeURIComponent(value.trim())
       baseline.forEach((segment, index) => {
-        if (segment === TARGET) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment === TARGET ? expectedSlot : segment)
       })
     })
 

--- a/apps/sim/tools/salesforce/path_safety.test.ts
+++ b/apps/sim/tools/salesforce/path_safety.test.ts
@@ -20,6 +20,15 @@
  * normalization `fetch` performs — rather than string-matching the template
  * output, because string matching is exactly what let this through.
  *
+ * The unit of coverage is a **(tool, parameter) pair**, not a tool. Fuzzing
+ * every parameter of a tool at once and tolerating a throw is unsound: the
+ * first guarded parameter throws and silently retires every sibling from the
+ * suite, so a tool that already has one guard stops testing the rest. Each
+ * case below fuzzes exactly one parameter while holding its siblings at a safe
+ * value, which is what makes "a newly added unguarded path parameter fails CI"
+ * actually true. A throw is only accepted as a pass *because* the thrown-at
+ * parameter is the one under test.
+ *
  * `salesforce_query_more` is deliberately out of scope: its `nextRecordsUrl`
  * parameter is by contract a whole relative path handed back by a previous
  * query, so it is multi-segment by design and single-segment guarding would
@@ -39,7 +48,7 @@ const INSTANCE_URL = 'https://example-org.my.salesforce.com'
  * The bare `.` and `..` entries are the whole point: their omission is why an
  * `encodeURIComponent`-only fix looks correct while the hole stays live.
  */
-const TRAVERSAL_IDS = [
+const TRAVERSAL_VALUES = [
   '..',
   '.',
   '  ..  ',
@@ -52,11 +61,7 @@ const TRAVERSAL_IDS = [
   '\\..\\..',
 ] as const
 
-/**
- * Values a real user legitimately supplies; none may be rejected or altered.
- * The 15- and 18-character record ids and the `__c` custom API names are the
- * point of this list — a guard that rejected them would be a regression.
- */
+/** Values a real user legitimately supplies; none may be rejected or altered. */
 const LEGITIMATE_IDS = [
   '0011234567890ABC',
   '0011234567890ABCDE',
@@ -70,11 +75,15 @@ const LEGITIMATE_IDS = [
   '01Z5f000000abcdEAA',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/** The value the parameter under test carries when a path is being mapped. */
+const TARGET = 'TARGETVALUE'
+
+/** The value every *other* string parameter is pinned to while one is fuzzed. */
+const SIBLING = 'SIBLINGVALUE'
 
 type AnyTool = ToolConfig<any, any>
 
-/** Parameters that carry credentials or the org host, never a path segment. */
+/** Parameters that carry credentials or the host, never a path segment. */
 const FIXED_PARAMS: Record<string, unknown> = {
   accessToken: 'token',
   idToken: undefined,
@@ -90,66 +99,80 @@ function isSalesforceTool(value: unknown): value is AnyTool {
   )
 }
 
+/** The placeholder a sibling parameter holds, chosen so the URL still builds. */
+function siblingValue(type: string | undefined): unknown {
+  if (type === 'json' || type === 'array') return []
+  if (type === 'number') return 1
+  if (type === 'boolean') return false
+  return SIBLING
+}
+
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised. Credential and host
- * parameters are pinned so the test exercises the path, not the org lookup.
+ * Builds a param object with exactly one parameter under test.
+ *
+ * Every sibling is pinned to a safe placeholder, so a failure can only be
+ * attributed to `target`. This is the whole difference from a fill-everything
+ * sweep, where the first parameter to throw hides all the others.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+function buildParams(tool: AnyTool, target: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { ...FIXED_PARAMS }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name in FIXED_PARAMS) continue
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
-      params[name] = []
-    } else if (type === 'number') {
-      params[name] = 1
-    } else if (type === 'boolean') {
-      params[name] = false
-    } else {
-      params[name] = value
-    }
+    params[name] = name === target ? value : siblingValue((def as { type?: string }).type)
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
+function buildUrl(tool: AnyTool, target: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return new URL(url(buildParams(tool, target, value) as any))
 }
 
 function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(salesforceTools)
+/** True when `target` actually lands in the path rather than the query string. */
+function reachesPath(tool: AnyTool, target: string): boolean {
+  try {
+    return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
+  } catch {
+    return false
+  }
+}
+
+interface PathParamCase {
+  name: string
+  param: string
+  tool: AnyTool
+}
+
+const PATH_PARAM_CASES: PathParamCase[] = Object.values(salesforceTools)
   .filter(isSalesforceTool)
   .filter((tool) => tool.id !== 'salesforce_query_more')
   .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
-    } catch {
-      return false
-    }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  .flatMap((tool) =>
+    Object.keys(tool.params ?? {})
+      .filter((param) => !(param in FIXED_PARAMS))
+      .filter((param) => reachesPath(tool, param))
+      .map((param) => ({ name: `${tool.id} / ${param}`, param, tool }))
+  )
 
-describe('salesforce path-id traversal safety', () => {
-  it('covers every Salesforce tool that interpolates an id into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(20)
+describe('salesforce path-parameter traversal safety', () => {
+  it('covers every (salesforce tool, path parameter) pair', () => {
+    expect(PATH_PARAM_CASES.length).toBeGreaterThanOrEqual(20)
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID).pathname)
+  describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {
+    const baseline = segmentsOf(buildUrl(tool, param, TARGET).pathname)
 
-    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+    it.each(TRAVERSAL_VALUES)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
+        url = buildUrl(tool, param, value)
       } catch {
         return
       }
@@ -160,54 +183,68 @@ describe('salesforce path-id traversal safety', () => {
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) return
+        if (segment === TARGET) return
         expect(actual[index]).toBe(segment)
       })
     })
 
+    /**
+     * The shape check above cannot see a bare dot in the *final* segment: `x/.`
+     * normalizes to `x/`, which keeps the segment count and leaves every other
+     * segment intact. Rejection is the only observable difference, so assert it
+     * directly for every parameter rather than only the hand-picked ones below.
+     */
+    it.each(['.', '..'])('rejects the bare %j segment', (value) => {
+      expect(() => buildUrl(tool, param, value)).toThrow(/path traversal/)
+    })
+
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value).pathname)
+      const actual = segmentsOf(buildUrl(tool, param, value).pathname)
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment === SAFE_ID ? value : segment)
+        expect(actual[index]).toBe(segment === TARGET ? value : segment)
       })
     })
   })
 })
 
-const HIGH_RISK_TOOLS: ReadonlyArray<{ name: string; tool: AnyTool }> = [
-  { name: 'salesforce_delete_account', tool: salesforceDeleteAccountTool },
-  { name: 'salesforce_delete_contact', tool: salesforceDeleteContactTool },
-  { name: 'salesforce_delete_opportunity', tool: salesforceDeleteOpportunityTool },
-  { name: 'salesforce_describe_object', tool: salesforceDescribeObjectTool },
+const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: AnyTool; param: string }> = [
+  { name: 'salesforce_delete_account', tool: salesforceDeleteAccountTool, param: 'accountId' },
+  { name: 'salesforce_delete_contact', tool: salesforceDeleteContactTool, param: 'contactId' },
+  {
+    name: 'salesforce_delete_opportunity',
+    tool: salesforceDeleteOpportunityTool,
+    param: 'opportunityId',
+  },
+  { name: 'salesforce_describe_object', tool: salesforceDescribeObjectTool, param: 'objectName' },
 ]
 
-describe.each(HIGH_RISK_TOOLS)('$name path safety', ({ tool }) => {
+describe.each(HIGH_RISK_CASES)('$name path safety', ({ tool, param }) => {
   it('rejects a bare dot-dot segment instead of silently popping the resource', () => {
-    expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+    expect(() => buildUrl(tool, param, '..')).toThrow(/path traversal/)
   })
 
   it('rejects a bare dot segment', () => {
-    expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+    expect(() => buildUrl(tool, param, '.')).toThrow(/path traversal/)
   })
 
-  it('does not let the id inject query parameters', () => {
-    const url = buildUrl(tool, '0011234567890ABC?fields=Name')
+  it('does not let the value inject query parameters', () => {
+    const url = buildUrl(tool, param, '0011234567890ABC?fields=Name')
 
     expect(url.searchParams.get('fields')).toBeNull()
   })
 
-  it('keeps the request inside the org instance host', () => {
-    const url = buildUrl(tool, '0011234567890ABC')
-
-    expect(url.origin).toBe(INSTANCE_URL)
+  it('preserves a legitimate value verbatim after trimming', () => {
+    expect(buildUrl(tool, param, '  0011234567890ABC  ').pathname).toContain(
+      `/${'0011234567890ABC'}`
+    )
   })
 })
 
 describe('salesforce_describe_object custom API names', () => {
   it.each(['My_Object__c', 'Region__c', 'Account'])('accepts %j verbatim', (objectName) => {
-    const url = buildUrl(salesforceDescribeObjectTool, objectName)
+    const url = buildUrl(salesforceDescribeObjectTool, 'objectName', objectName)
 
     expect(url.pathname).toBe(`/services/data/v59.0/sobjects/${objectName}/describe`)
   })

--- a/apps/sim/tools/salesforce/path_safety.test.ts
+++ b/apps/sim/tools/salesforce/path_safety.test.ts
@@ -170,12 +170,20 @@ interface PathParamCase {
 }
 
 /**
- * Typed as `unknown[]` on purpose: the barrel's values are a union of
- * concretely-typed `ToolConfig`s, and `Array.prototype.filter`'s type-predicate
- * overload requires the predicate's type to extend the array's. Widening to
- * `unknown` first is what lets the guard below do the narrowing.
+ * Seeded as `readonly unknown[]` on purpose, so the guard below is the single
+ * narrowing point for the whole harness.
+ *
+ * The barrel's values are a union of concretely-typed `ToolConfig`s, and no
+ * member of that union is assignable to the widened `PathTool`: `ToolConfig`
+ * places its parameter type in the *contravariant* position of `request.url`
+ * and `request.body`. Filtering the union directly does not help either —
+ * `Array.prototype.filter`'s type-predicate overload requires the predicate's
+ * type to extend the array's element type, so it intersects rather than
+ * replaces and leaves the mismatch in place. Widening to `unknown` first is
+ * what lets the guard actually narrow, and it keeps a cast out of every call
+ * site.
  */
-const ALL_EXPORTS: unknown[] = Object.values(salesforceTools)
+const ALL_EXPORTS: readonly unknown[] = Object.values(salesforceTools)
 
 const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isSalesforceTool)
   .filter((tool) => tool.id !== 'salesforce_query_more')

--- a/apps/sim/tools/salesforce/refresh_dashboard.ts
+++ b/apps/sim/tools/salesforce/refresh_dashboard.ts
@@ -6,6 +6,7 @@ import type {
 import { REFRESH_DASHBOARD_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceDashboards')
 
@@ -45,7 +46,7 @@ export const salesforceRefreshDashboardTool: ToolConfig<
         throw new Error('Dashboard ID is required. Please provide a valid Salesforce Dashboard ID.')
       }
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
-      return `${instanceUrl}/services/data/v59.0/analytics/dashboards/${params.dashboardId}`
+      return `${instanceUrl}/services/data/v59.0/analytics/dashboards/${safeUrlPathSegment(params.dashboardId, 'Dashboard ID')}`
     },
     method: 'PUT',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/run_report.ts
+++ b/apps/sim/tools/salesforce/run_report.ts
@@ -7,6 +7,7 @@ import type {
 import { RUN_REPORT_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceReports')
 
@@ -61,7 +62,7 @@ export const salesforceRunReportTool: ToolConfig<
       // Default to including detail rows (Salesforce's own API default is false);
       // report runs in a workflow almost always want the underlying rows.
       const includeDetails = params.includeDetails !== 'false'
-      return `${instanceUrl}/services/data/v59.0/analytics/reports/${params.reportId}?includeDetails=${includeDetails}`
+      return `${instanceUrl}/services/data/v59.0/analytics/reports/${safeUrlPathSegment(params.reportId, 'Report ID')}?includeDetails=${includeDetails}`
     },
     // Use GET for simple report runs, POST only when filters are provided
     method: (params) => (params.filters ? 'POST' : 'GET'),

--- a/apps/sim/tools/salesforce/update_account.ts
+++ b/apps/sim/tools/salesforce/update_account.ts
@@ -5,6 +5,7 @@ import type {
 import { SOBJECT_UPDATE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceUpdateAccountTool: ToolConfig<
   SalesforceUpdateAccountParams,
@@ -127,7 +128,7 @@ export const salesforceUpdateAccountTool: ToolConfig<
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
       const accountId = requireId(params.accountId, 'Account ID')
 
-      return `${instanceUrl}/services/data/v59.0/sobjects/Account/${accountId}`
+      return `${instanceUrl}/services/data/v59.0/sobjects/Account/${safeUrlPathSegment(accountId, 'Account ID')}`
     },
     method: 'PATCH',
     headers: (params) => {

--- a/apps/sim/tools/salesforce/update_case.ts
+++ b/apps/sim/tools/salesforce/update_case.ts
@@ -5,6 +5,7 @@ import type {
 import { SOBJECT_UPDATE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceUpdateCaseTool: ToolConfig<
   SalesforceUpdateCaseParams,
@@ -89,7 +90,7 @@ export const salesforceUpdateCaseTool: ToolConfig<
   request: {
     url: (params) => {
       const caseId = requireId(params.caseId, 'Case ID')
-      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Case/${caseId}`
+      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Case/${safeUrlPathSegment(caseId, 'Case ID')}`
     },
     method: 'PATCH',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/update_contact.ts
+++ b/apps/sim/tools/salesforce/update_contact.ts
@@ -6,6 +6,7 @@ import type {
 import { SOBJECT_UPDATE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceContacts')
 
@@ -109,7 +110,7 @@ export const salesforceUpdateContactTool: ToolConfig<
     url: (params) => {
       const instanceUrl = getInstanceUrl(params.idToken, params.instanceUrl)
       const contactId = requireId(params.contactId, 'Contact ID')
-      return `${instanceUrl}/services/data/v59.0/sobjects/Contact/${contactId}`
+      return `${instanceUrl}/services/data/v59.0/sobjects/Contact/${safeUrlPathSegment(contactId, 'Contact ID')}`
     },
     method: 'PATCH',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/update_lead.ts
+++ b/apps/sim/tools/salesforce/update_lead.ts
@@ -5,6 +5,7 @@ import type {
 import { SOBJECT_UPDATE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceUpdateLeadTool: ToolConfig<
   SalesforceUpdateLeadParams,
@@ -84,7 +85,7 @@ export const salesforceUpdateLeadTool: ToolConfig<
   request: {
     url: (params) => {
       const leadId = requireId(params.leadId, 'Lead ID')
-      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Lead/${leadId}`
+      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Lead/${safeUrlPathSegment(leadId, 'Lead ID')}`
     },
     method: 'PATCH',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/update_opportunity.ts
+++ b/apps/sim/tools/salesforce/update_opportunity.ts
@@ -6,6 +6,7 @@ import type {
 import { SOBJECT_UPDATE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const logger = createLogger('SalesforceUpdateOpportunity')
 
@@ -80,7 +81,7 @@ export const salesforceUpdateOpportunityTool: ToolConfig<
   request: {
     url: (params) => {
       const opportunityId = requireId(params.opportunityId, 'Opportunity ID')
-      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Opportunity/${opportunityId}`
+      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Opportunity/${safeUrlPathSegment(opportunityId, 'Opportunity ID')}`
     },
     method: 'PATCH',
     headers: (params) => ({

--- a/apps/sim/tools/salesforce/update_task.ts
+++ b/apps/sim/tools/salesforce/update_task.ts
@@ -5,6 +5,7 @@ import type {
 import { SOBJECT_UPDATE_OUTPUT_PROPERTIES } from '@/tools/salesforce/types'
 import { extractErrorMessage, getInstanceUrl, requireId } from '@/tools/salesforce/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const salesforceUpdateTaskTool: ToolConfig<
   SalesforceUpdateTaskParams,
@@ -89,7 +90,7 @@ export const salesforceUpdateTaskTool: ToolConfig<
   request: {
     url: (params) => {
       const taskId = requireId(params.taskId, 'Task ID')
-      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Task/${taskId}`
+      return `${getInstanceUrl(params.idToken, params.instanceUrl)}/services/data/v59.0/sobjects/Task/${safeUrlPathSegment(taskId, 'Task ID')}`
     },
     method: 'PATCH',
     headers: (params) => ({

--- a/apps/sim/tools/stripe/cancel_payment_intent.ts
+++ b/apps/sim/tools/stripe/cancel_payment_intent.ts
@@ -9,6 +9,7 @@ import {
   PAYMENT_INTENT_OUTPUT,
 } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_cancel_payment_intent',
@@ -47,7 +48,8 @@ export const stripeCancelPaymentIntentTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/payment_intents/${params.id}/cancel`,
+    url: (params) =>
+      `https://api.stripe.com/v1/payment_intents/${safeUrlPathSegment(params.id, 'id')}/cancel`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/cancel_subscription.ts
+++ b/apps/sim/tools/stripe/cancel_subscription.ts
@@ -1,6 +1,7 @@
 import type { CancelSubscriptionParams, SubscriptionResponse } from '@/tools/stripe/types'
 import { SUBSCRIPTION_METADATA_OUTPUT_PROPERTIES, SUBSCRIPTION_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeCancelSubscriptionTool: ToolConfig<
   CancelSubscriptionParams,
@@ -39,7 +40,8 @@ export const stripeCancelSubscriptionTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/subscriptions/${params.id}`,
+    url: (params) =>
+      `https://api.stripe.com/v1/subscriptions/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/capture_charge.ts
+++ b/apps/sim/tools/stripe/capture_charge.ts
@@ -5,6 +5,7 @@ import {
 } from '@/tools/stripe/idempotency'
 import type { CaptureChargeParams, ChargeResponse } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_capture_charge',
@@ -42,7 +43,8 @@ export const stripeCaptureChargeTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/charges/${params.id}/capture`,
+    url: (params) =>
+      `https://api.stripe.com/v1/charges/${safeUrlPathSegment(params.id, 'id')}/capture`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/capture_payment_intent.ts
+++ b/apps/sim/tools/stripe/capture_payment_intent.ts
@@ -9,6 +9,7 @@ import {
   PAYMENT_INTENT_OUTPUT,
 } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_capture_payment_intent',
@@ -46,7 +47,8 @@ export const stripeCapturePaymentIntentTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/payment_intents/${params.id}/capture`,
+    url: (params) =>
+      `https://api.stripe.com/v1/payment_intents/${safeUrlPathSegment(params.id, 'id')}/capture`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/confirm_payment_intent.ts
+++ b/apps/sim/tools/stripe/confirm_payment_intent.ts
@@ -9,6 +9,7 @@ import {
   PAYMENT_INTENT_OUTPUT,
 } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_confirm_payment_intent',
@@ -46,7 +47,8 @@ export const stripeConfirmPaymentIntentTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/payment_intents/${params.id}/confirm`,
+    url: (params) =>
+      `https://api.stripe.com/v1/payment_intents/${safeUrlPathSegment(params.id, 'id')}/confirm`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/delete_customer.ts
+++ b/apps/sim/tools/stripe/delete_customer.ts
@@ -1,6 +1,7 @@
 import type { CustomerDeleteResponse, DeleteCustomerParams } from '@/tools/stripe/types'
 import { DELETE_OUTPUT_PROPERTIES } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeDeleteCustomerTool: ToolConfig<DeleteCustomerParams, CustomerDeleteResponse> = {
   id: 'stripe_delete_customer',
@@ -24,7 +25,7 @@ export const stripeDeleteCustomerTool: ToolConfig<DeleteCustomerParams, Customer
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/customers/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/customers/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/delete_invoice.ts
+++ b/apps/sim/tools/stripe/delete_invoice.ts
@@ -1,5 +1,6 @@
 import type { DeleteInvoiceParams, InvoiceDeleteResponse } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeDeleteInvoiceTool: ToolConfig<DeleteInvoiceParams, InvoiceDeleteResponse> = {
   id: 'stripe_delete_invoice',
@@ -23,7 +24,7 @@ export const stripeDeleteInvoiceTool: ToolConfig<DeleteInvoiceParams, InvoiceDel
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/invoices/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/invoices/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/delete_product.ts
+++ b/apps/sim/tools/stripe/delete_product.ts
@@ -1,5 +1,6 @@
 import type { DeleteProductParams, ProductDeleteResponse } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeDeleteProductTool: ToolConfig<DeleteProductParams, ProductDeleteResponse> = {
   id: 'stripe_delete_product',
@@ -23,7 +24,7 @@ export const stripeDeleteProductTool: ToolConfig<DeleteProductParams, ProductDel
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/products/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/products/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/finalize_invoice.ts
+++ b/apps/sim/tools/stripe/finalize_invoice.ts
@@ -6,6 +6,7 @@ import {
 import type { FinalizeInvoiceParams, InvoiceResponse } from '@/tools/stripe/types'
 import { INVOICE_METADATA_OUTPUT_PROPERTIES, INVOICE_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_finalize_invoice',
@@ -43,7 +44,8 @@ export const stripeFinalizeInvoiceTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/invoices/${params.id}/finalize`,
+    url: (params) =>
+      `https://api.stripe.com/v1/invoices/${safeUrlPathSegment(params.id, 'id')}/finalize`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/path_safety.test.ts
+++ b/apps/sim/tools/stripe/path_safety.test.ts
@@ -158,12 +158,20 @@ interface PathParamCase {
 }
 
 /**
- * Typed as `unknown[]` on purpose: the barrel's values are a union of
- * concretely-typed `ToolConfig`s, and `Array.prototype.filter`'s type-predicate
- * overload requires the predicate's type to extend the array's. Widening to
- * `unknown` first is what lets the guard below do the narrowing.
+ * Seeded as `readonly unknown[]` on purpose, so the guard below is the single
+ * narrowing point for the whole harness.
+ *
+ * The barrel's values are a union of concretely-typed `ToolConfig`s, and no
+ * member of that union is assignable to the widened `PathTool`: `ToolConfig`
+ * places its parameter type in the *contravariant* position of `request.url`
+ * and `request.body`. Filtering the union directly does not help either —
+ * `Array.prototype.filter`'s type-predicate overload requires the predicate's
+ * type to extend the array's element type, so it intersects rather than
+ * replaces and leaves the mismatch in place. Widening to `unknown` first is
+ * what lets the guard actually narrow, and it keeps a cast out of every call
+ * site.
  */
-const ALL_EXPORTS: unknown[] = Object.values(stripeTools)
+const ALL_EXPORTS: readonly unknown[] = Object.values(stripeTools)
 
 const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isStripeTool)
   .filter((tool) => typeof tool.request?.url === 'function')

--- a/apps/sim/tools/stripe/path_safety.test.ts
+++ b/apps/sim/tools/stripe/path_safety.test.ts
@@ -188,7 +188,8 @@ describe('stripe path-parameter traversal safety', () => {
   })
 
   describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {
-    const baseline = segmentsOf(buildUrl(tool, param, TARGET).pathname)
+    const baselineUrl = buildUrl(tool, param, TARGET)
+    const baseline = segmentsOf(baselineUrl.pathname)
 
     it.each(TRAVERSAL_VALUES)('cannot reshape the path with %j', (value) => {
       let url: URL
@@ -200,6 +201,17 @@ describe('stripe path-parameter traversal safety', () => {
 
       expect(url.origin).toBe('https://api.stripe.com')
       expect(url.pathname.startsWith('/v1/')).toBe(true)
+
+      /**
+       * A `?` or `#` in the value does not lengthen the path — it moves the
+       * tail out of `pathname` entirely — so the segment comparison below is
+       * blind to it. Pinning the query and fragment against the baseline is
+       * what makes those two vectors real assertions rather than decoration.
+       * Comparing to the baseline rather than to empty is deliberate: several
+       * tools legitimately build their own query string.
+       */
+      expect(url.search).toBe(baselineUrl.search)
+      expect(url.hash).toBe('')
 
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)

--- a/apps/sim/tools/stripe/path_safety.test.ts
+++ b/apps/sim/tools/stripe/path_safety.test.ts
@@ -47,6 +47,7 @@ const TRAVERSAL_VALUES = [
   '../../v1/customers/victim',
   '..%2f..%2fv1/customers/victim',
   'cus_abc/../../../v1/charges',
+  'cus_abc/../victim',
   'cus_abc?expand[]=sources',
   'cus_abc#fragment',
   'cus_abc/subscriptions/../../../v1/payouts',
@@ -249,11 +250,22 @@ describe('stripe path-parameter traversal safety', () => {
       expect(url.search).toBe(baselineUrl.search)
       expect(url.hash).toBe('')
 
+      /**
+       * The probe slot is asserted, not skipped. Skipping it leaves the whole
+       * check blind to a *balanced* traversal — `12345/../victim` pops exactly
+       * one segment and puts one back, so the segment count and every
+       * surrounding segment are identical and only the slot differs. That
+       * re-aims the request at another record while looking untouched.
+       *
+       * `safeUrlPathSegment`'s contract for a value it accepts is
+       * `encodeURIComponent` of the trimmed input, so that is the exact
+       * expected content. Anything the guard would reject never reaches here.
+       */
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)
+      const expectedSlot = encodeURIComponent(value.trim())
       baseline.forEach((segment, index) => {
-        if (segment === TARGET) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment === TARGET ? expectedSlot : segment)
       })
     })
 

--- a/apps/sim/tools/stripe/path_safety.test.ts
+++ b/apps/sim/tools/stripe/path_safety.test.ts
@@ -142,12 +142,20 @@ function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-/** True when `target` actually lands in the path rather than the query string. */
-function reachesPath(tool: PathTool, target: string): boolean {
+/**
+ * Classifies one parameter by where its value lands in the built URL.
+ *
+ * `unbuildable` is a distinct outcome rather than being folded into `other` on
+ * purpose. `TARGET` is a perfectly legitimate value, so a URL builder that
+ * throws on it is a defect in the tool or in this harness — and quietly
+ * dropping the pair would shrink coverage without failing anything. The
+ * unbuildable set is asserted empty below instead.
+ */
+function classifyParam(tool: PathTool, param: string): 'path' | 'other' | 'unbuildable' {
   try {
-    return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
+    return buildUrl(tool, param, TARGET).pathname.includes(TARGET) ? 'path' : 'other'
   } catch {
-    return false
+    return 'unbuildable'
   }
 }
 
@@ -173,18 +181,46 @@ interface PathParamCase {
  */
 const ALL_EXPORTS: readonly unknown[] = Object.values(stripeTools)
 
-const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isStripeTool)
+const CANDIDATE_PARAMS: ReadonlyArray<{ tool: PathTool; param: string }> = ALL_EXPORTS.filter(
+  isStripeTool
+)
   .filter((tool) => typeof tool.request?.url === 'function')
   .flatMap((tool) =>
     Object.keys(tool.params ?? {})
       .filter((param) => !(param in FIXED_PARAMS))
-      .filter((param) => reachesPath(tool, param))
-      .map((param) => ({ name: `${tool.id} / ${param}`, param, tool }))
+      .map((param) => ({ tool, param }))
   )
 
+function nameOf({ tool, param }: { tool: PathTool; param: string }): string {
+  return `${tool.id} / ${param}`
+}
+
+const UNBUILDABLE_PARAMS: readonly string[] = CANDIDATE_PARAMS.filter(
+  (candidate) => classifyParam(candidate.tool, candidate.param) === 'unbuildable'
+).map(nameOf)
+
+const PATH_PARAM_CASES: PathParamCase[] = CANDIDATE_PARAMS.filter(
+  (candidate) => classifyParam(candidate.tool, candidate.param) === 'path'
+).map((candidate) => ({ name: nameOf(candidate), param: candidate.param, tool: candidate.tool }))
+
 describe('stripe path-parameter traversal safety', () => {
-  it('covers every (stripe tool, path parameter) pair', () => {
-    expect(PATH_PARAM_CASES.length).toBeGreaterThanOrEqual(25)
+  /**
+   * Exact, not a floor. A floor lets a pair silently fall out of the sweep — a
+   * renamed parameter, or a URL builder that stops interpolating one — while
+   * the suite still reports green, which would quietly retire the guarantee
+   * this file exists to provide. Changing this number should be a deliberate
+   * edit accompanying a real change to the tool surface.
+   */
+  it('covers exactly every (stripe tool, path parameter) pair', () => {
+    expect(PATH_PARAM_CASES).toHaveLength(28)
+  })
+
+  /**
+   * A builder that throws on `TARGET` would be silently classified as "not a
+   * path parameter" and vanish from the sweep, so name the failure instead.
+   */
+  it('builds a URL for every candidate parameter from a safe value', () => {
+    expect(UNBUILDABLE_PARAMS).toEqual([])
   })
 
   describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {

--- a/apps/sim/tools/stripe/path_safety.test.ts
+++ b/apps/sim/tools/stripe/path_safety.test.ts
@@ -34,7 +34,7 @@ import { stripeDeleteInvoiceTool } from '@/tools/stripe/delete_invoice'
 import { stripeDeleteProductTool } from '@/tools/stripe/delete_product'
 import * as stripeTools from '@/tools/stripe/index'
 import { stripeUpdateSubscriptionTool } from '@/tools/stripe/update_subscription'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
@@ -73,18 +73,37 @@ const TARGET = 'TARGETVALUE'
 /** The value every *other* string parameter is pinned to while one is fuzzed. */
 const SIBLING = 'SIBLINGVALUE'
 
-type AnyTool = ToolConfig<any, any>
+type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
 
 /** Parameters that carry credentials or the host, never a path segment. */
 const FIXED_PARAMS: Record<string, unknown> = { apiKey: 'sk_test_token' }
 
-function isStripeTool(value: unknown): value is AnyTool {
+function isStripeTool(value: unknown): value is PathTool {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('stripe_')
+    'id' in value &&
+    typeof value.id === 'string' &&
+    value.id.startsWith('stripe_')
   )
+}
+
+/**
+ * Narrows one concretely-typed tool export to the structural shape this
+ * harness drives.
+ *
+ * A direct assignment cannot work and must not be forced with a cast: under
+ * `strictFunctionTypes` a `ToolConfig<ConcreteParams, R>` is not assignable to
+ * `ToolConfig<Record<string, unknown>, ToolResponse>`, because `request.url`
+ * accepts the parameter type contravariantly. Re-checking the value at runtime
+ * through the same guard is what makes the narrowing sound rather than
+ * asserted.
+ */
+function asPathTool(value: unknown): PathTool {
+  if (!isStripeTool(value)) {
+    throw new Error('expected a Stripe tool')
+  }
+  return value
 }
 
 /** The placeholder a sibling parameter holds, chosen so the URL still builds. */
@@ -102,7 +121,7 @@ function siblingValue(type: string | undefined): unknown {
  * attributed to `target`. This is the whole difference from a fill-everything
  * sweep, where the first parameter to throw hides all the others.
  */
-function buildParams(tool: AnyTool, target: string, value: string): Record<string, unknown> {
+function buildParams(tool: PathTool, target: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { ...FIXED_PARAMS }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name in FIXED_PARAMS) continue
@@ -111,12 +130,12 @@ function buildParams(tool: AnyTool, target: string, value: string): Record<strin
   return params
 }
 
-function buildUrl(tool: AnyTool, target: string, value: string): URL {
+function buildUrl(tool: PathTool, target: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, target, value) as any))
+  return new URL(url(buildParams(tool, target, value)))
 }
 
 function segmentsOf(pathname: string): string[] {
@@ -124,7 +143,7 @@ function segmentsOf(pathname: string): string[] {
 }
 
 /** True when `target` actually lands in the path rather than the query string. */
-function reachesPath(tool: AnyTool, target: string): boolean {
+function reachesPath(tool: PathTool, target: string): boolean {
   try {
     return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
   } catch {
@@ -135,11 +154,18 @@ function reachesPath(tool: AnyTool, target: string): boolean {
 interface PathParamCase {
   name: string
   param: string
-  tool: AnyTool
+  tool: PathTool
 }
 
-const PATH_PARAM_CASES: PathParamCase[] = Object.values(stripeTools)
-  .filter(isStripeTool)
+/**
+ * Typed as `unknown[]` on purpose: the barrel's values are a union of
+ * concretely-typed `ToolConfig`s, and `Array.prototype.filter`'s type-predicate
+ * overload requires the predicate's type to extend the array's. Widening to
+ * `unknown` first is what lets the guard below do the narrowing.
+ */
+const ALL_EXPORTS: unknown[] = Object.values(stripeTools)
+
+const PATH_PARAM_CASES: PathParamCase[] = ALL_EXPORTS.filter(isStripeTool)
   .filter((tool) => typeof tool.request?.url === 'function')
   .flatMap((tool) =>
     Object.keys(tool.params ?? {})
@@ -196,11 +222,15 @@ describe('stripe path-parameter traversal safety', () => {
   })
 })
 
-const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: AnyTool; param: string }> = [
-  { name: 'stripe_delete_customer', tool: stripeDeleteCustomerTool, param: 'id' },
-  { name: 'stripe_delete_invoice', tool: stripeDeleteInvoiceTool, param: 'id' },
-  { name: 'stripe_delete_product', tool: stripeDeleteProductTool, param: 'id' },
-  { name: 'stripe_update_subscription', tool: stripeUpdateSubscriptionTool, param: 'id' },
+const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: PathTool; param: string }> = [
+  { name: 'stripe_delete_customer', tool: asPathTool(stripeDeleteCustomerTool), param: 'id' },
+  { name: 'stripe_delete_invoice', tool: asPathTool(stripeDeleteInvoiceTool), param: 'id' },
+  { name: 'stripe_delete_product', tool: asPathTool(stripeDeleteProductTool), param: 'id' },
+  {
+    name: 'stripe_update_subscription',
+    tool: asPathTool(stripeUpdateSubscriptionTool),
+    param: 'id',
+  },
 ]
 
 describe.each(HIGH_RISK_CASES)('$name path safety', ({ tool, param }) => {

--- a/apps/sim/tools/stripe/path_safety.test.ts
+++ b/apps/sim/tools/stripe/path_safety.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every Stripe tool against path traversal through an LLM-writable id
+ * that gets interpolated into the request path.
+ *
+ * These ids are `visibility: 'user-or-llm'`, so prompt injection controls them.
+ * Interpolating one raw let a value like `../../v1/customers/victim` escape the
+ * resource it addresses once `fetch` normalized the URL, re-aiming the request
+ * — and the workspace's live Stripe **secret key** — at an arbitrary Stripe
+ * object, including on the DELETE tools. That makes this money-moving surface,
+ * not merely a data-read one.
+ *
+ * Wrapping the id in `encodeURIComponent` is NOT enough, which is why the
+ * vector list below includes the bare `.` and `..` segments: both are made of
+ * unreserved characters, so they survive encoding untouched and the URL parser
+ * then removes them as dot segments, popping one path segment off a fixed host.
+ * Every assertion here resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ */
+import { describe, expect, it } from 'vitest'
+import { stripeDeleteCustomerTool } from '@/tools/stripe/delete_customer'
+import { stripeDeleteInvoiceTool } from '@/tools/stripe/delete_invoice'
+import { stripeDeleteProductTool } from '@/tools/stripe/delete_product'
+import * as stripeTools from '@/tools/stripe/index'
+import { stripeUpdateSubscriptionTool } from '@/tools/stripe/update_subscription'
+import type { ToolConfig } from '@/tools/types'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../v1/customers/victim',
+  '..%2f..%2fv1/customers/victim',
+  'cus_abc/../../../v1/charges',
+  'cus_abc?expand[]=sources',
+  'cus_abc#fragment',
+  'cus_abc/subscriptions/../../../v1/payouts',
+  '\\..\\..',
+] as const
+
+/** Values a real user legitimately supplies; none may be rejected or altered. */
+const LEGITIMATE_IDS = [
+  'cus_ABC123',
+  'ch_ABC123',
+  'ch_3PqRsTuVwXyZaBcD1EfGhIjK',
+  'sub_1PqRsTuVwXyZaBcD',
+  'in_1PqRsTuVwXyZaBcD',
+  'pi_3PqRsTuVwXyZaBcD0AbCdEfG',
+  'price_1PqRsTuVwXyZaBcD',
+  'prod_QmNoPqRsTuVwXy',
+  'evt_1PqRsTuVwXyZaBcD',
+  'txn_1PqRsTuVwXyZaBcD',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isStripeTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('stripe_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { apiKey: 'sk_test_token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'apiKey') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(pathname: string): string[] {
+  return pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(stripeTools)
+  .filter(isStripeTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('stripe path-id traversal safety', () => {
+  it('covers every Stripe tool that interpolates an id into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(25)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID).pathname)
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(url.origin).toBe('https://api.stripe.com')
+      expect(url.pathname.startsWith('/v1/')).toBe(true)
+
+      const actual = segmentsOf(url.pathname)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value).pathname)
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        expect(actual[index]).toBe(segment === SAFE_ID ? value : segment)
+      })
+    })
+  })
+})
+
+const HIGH_RISK_TOOLS: ReadonlyArray<{ name: string; tool: AnyTool }> = [
+  { name: 'stripe_delete_customer', tool: stripeDeleteCustomerTool },
+  { name: 'stripe_delete_invoice', tool: stripeDeleteInvoiceTool },
+  { name: 'stripe_delete_product', tool: stripeDeleteProductTool },
+  { name: 'stripe_update_subscription', tool: stripeUpdateSubscriptionTool },
+]
+
+describe.each(HIGH_RISK_TOOLS)('$name id path safety', ({ tool }) => {
+  it('rejects a bare dot-dot segment instead of silently popping the resource', () => {
+    expect(() => buildUrl(tool, '..')).toThrow(/id/)
+  })
+
+  it('rejects a bare dot segment', () => {
+    expect(() => buildUrl(tool, '.')).toThrow(/id/)
+  })
+
+  it('does not let the id inject query parameters', () => {
+    const url = buildUrl(tool, 'cus_abc?expand[]=sources')
+
+    expect(url.searchParams.get('expand[]')).toBeNull()
+  })
+
+  it('preserves a legitimate id verbatim after trimming', () => {
+    expect(buildUrl(tool, '  cus_ABC123  ').pathname).toContain('/cus_ABC123')
+  })
+})

--- a/apps/sim/tools/stripe/path_safety.test.ts
+++ b/apps/sim/tools/stripe/path_safety.test.ts
@@ -18,6 +18,15 @@
  * Every assertion here resolves the built URL with `new URL(...)` — the same
  * normalization `fetch` performs — rather than string-matching the template
  * output, because string matching is exactly what let this through.
+ *
+ * The unit of coverage is a **(tool, parameter) pair**, not a tool. Fuzzing
+ * every parameter of a tool at once and tolerating a throw is unsound: the
+ * first guarded parameter throws and silently retires every sibling from the
+ * suite, so a tool that already has one guard stops testing the rest. Each
+ * case below fuzzes exactly one parameter while holding its siblings at a safe
+ * value, which is what makes "a newly added unguarded path parameter fails CI"
+ * actually true. A throw is only accepted as a pass *because* the thrown-at
+ * parameter is the one under test.
  */
 import { describe, expect, it } from 'vitest'
 import { stripeDeleteCustomerTool } from '@/tools/stripe/delete_customer'
@@ -31,7 +40,7 @@ import type { ToolConfig } from '@/tools/types'
  * The bare `.` and `..` entries are the whole point: their omission is why an
  * `encodeURIComponent`-only fix looks correct while the hole stays live.
  */
-const TRAVERSAL_IDS = [
+const TRAVERSAL_VALUES = [
   '..',
   '.',
   '  ..  ',
@@ -58,9 +67,16 @@ const LEGITIMATE_IDS = [
   'txn_1PqRsTuVwXyZaBcD',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/** The value the parameter under test carries when a path is being mapped. */
+const TARGET = 'TARGETVALUE'
+
+/** The value every *other* string parameter is pinned to while one is fuzzed. */
+const SIBLING = 'SIBLINGVALUE'
 
 type AnyTool = ToolConfig<any, any>
+
+/** Parameters that carry credentials or the host, never a path segment. */
+const FIXED_PARAMS: Record<string, unknown> = { apiKey: 'sk_test_token' }
 
 function isStripeTool(value: unknown): value is AnyTool {
   return (
@@ -71,64 +87,79 @@ function isStripeTool(value: unknown): value is AnyTool {
   )
 }
 
+/** The placeholder a sibling parameter holds, chosen so the URL still builds. */
+function siblingValue(type: string | undefined): unknown {
+  if (type === 'json' || type === 'array') return []
+  if (type === 'number') return 1
+  if (type === 'boolean') return false
+  return SIBLING
+}
+
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised.
+ * Builds a param object with exactly one parameter under test.
+ *
+ * Every sibling is pinned to a safe placeholder, so a failure can only be
+ * attributed to `target`. This is the whole difference from a fill-everything
+ * sweep, where the first parameter to throw hides all the others.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
-  const params: Record<string, unknown> = { apiKey: 'sk_test_token' }
+function buildParams(tool: AnyTool, target: string, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { ...FIXED_PARAMS }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
-    if (name === 'apiKey') continue
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
-      params[name] = []
-    } else if (type === 'number') {
-      params[name] = 1
-    } else if (type === 'boolean') {
-      params[name] = false
-    } else {
-      params[name] = value
-    }
+    if (name in FIXED_PARAMS) continue
+    params[name] = name === target ? value : siblingValue((def as { type?: string }).type)
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
+function buildUrl(tool: AnyTool, target: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return new URL(url(buildParams(tool, target, value) as any))
 }
 
 function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(stripeTools)
+/** True when `target` actually lands in the path rather than the query string. */
+function reachesPath(tool: AnyTool, target: string): boolean {
+  try {
+    return buildUrl(tool, target, TARGET).pathname.includes(TARGET)
+  } catch {
+    return false
+  }
+}
+
+interface PathParamCase {
+  name: string
+  param: string
+  tool: AnyTool
+}
+
+const PATH_PARAM_CASES: PathParamCase[] = Object.values(stripeTools)
   .filter(isStripeTool)
   .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
-    } catch {
-      return false
-    }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  .flatMap((tool) =>
+    Object.keys(tool.params ?? {})
+      .filter((param) => !(param in FIXED_PARAMS))
+      .filter((param) => reachesPath(tool, param))
+      .map((param) => ({ name: `${tool.id} / ${param}`, param, tool }))
+  )
 
-describe('stripe path-id traversal safety', () => {
-  it('covers every Stripe tool that interpolates an id into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(25)
+describe('stripe path-parameter traversal safety', () => {
+  it('covers every (stripe tool, path parameter) pair', () => {
+    expect(PATH_PARAM_CASES.length).toBeGreaterThanOrEqual(25)
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID).pathname)
+  describe.each(PATH_PARAM_CASES)('$name', ({ tool, param }) => {
+    const baseline = segmentsOf(buildUrl(tool, param, TARGET).pathname)
 
-    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+    it.each(TRAVERSAL_VALUES)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
+        url = buildUrl(tool, param, value)
       } catch {
         return
       }
@@ -139,45 +170,55 @@ describe('stripe path-id traversal safety', () => {
       const actual = segmentsOf(url.pathname)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) return
+        if (segment === TARGET) return
         expect(actual[index]).toBe(segment)
       })
     })
 
+    /**
+     * The shape check above cannot see a bare dot in the *final* segment: `x/.`
+     * normalizes to `x/`, which keeps the segment count and leaves every other
+     * segment intact. Rejection is the only observable difference, so assert it
+     * directly for every parameter rather than only the hand-picked ones below.
+     */
+    it.each(['.', '..'])('rejects the bare %j segment', (value) => {
+      expect(() => buildUrl(tool, param, value)).toThrow(/path traversal/)
+    })
+
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value).pathname)
+      const actual = segmentsOf(buildUrl(tool, param, value).pathname)
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment === SAFE_ID ? value : segment)
+        expect(actual[index]).toBe(segment === TARGET ? value : segment)
       })
     })
   })
 })
 
-const HIGH_RISK_TOOLS: ReadonlyArray<{ name: string; tool: AnyTool }> = [
-  { name: 'stripe_delete_customer', tool: stripeDeleteCustomerTool },
-  { name: 'stripe_delete_invoice', tool: stripeDeleteInvoiceTool },
-  { name: 'stripe_delete_product', tool: stripeDeleteProductTool },
-  { name: 'stripe_update_subscription', tool: stripeUpdateSubscriptionTool },
+const HIGH_RISK_CASES: ReadonlyArray<{ name: string; tool: AnyTool; param: string }> = [
+  { name: 'stripe_delete_customer', tool: stripeDeleteCustomerTool, param: 'id' },
+  { name: 'stripe_delete_invoice', tool: stripeDeleteInvoiceTool, param: 'id' },
+  { name: 'stripe_delete_product', tool: stripeDeleteProductTool, param: 'id' },
+  { name: 'stripe_update_subscription', tool: stripeUpdateSubscriptionTool, param: 'id' },
 ]
 
-describe.each(HIGH_RISK_TOOLS)('$name id path safety', ({ tool }) => {
+describe.each(HIGH_RISK_CASES)('$name path safety', ({ tool, param }) => {
   it('rejects a bare dot-dot segment instead of silently popping the resource', () => {
-    expect(() => buildUrl(tool, '..')).toThrow(/id/)
+    expect(() => buildUrl(tool, param, '..')).toThrow(/path traversal/)
   })
 
   it('rejects a bare dot segment', () => {
-    expect(() => buildUrl(tool, '.')).toThrow(/id/)
+    expect(() => buildUrl(tool, param, '.')).toThrow(/path traversal/)
   })
 
-  it('does not let the id inject query parameters', () => {
-    const url = buildUrl(tool, 'cus_abc?expand[]=sources')
+  it('does not let the value inject query parameters', () => {
+    const url = buildUrl(tool, param, 'cus_abc?expand[]=sources')
 
     expect(url.searchParams.get('expand[]')).toBeNull()
   })
 
-  it('preserves a legitimate id verbatim after trimming', () => {
-    expect(buildUrl(tool, '  cus_ABC123  ').pathname).toContain('/cus_ABC123')
+  it('preserves a legitimate value verbatim after trimming', () => {
+    expect(buildUrl(tool, param, '  cus_ABC123  ').pathname).toContain(`/${'cus_ABC123'}`)
   })
 })

--- a/apps/sim/tools/stripe/pay_invoice.ts
+++ b/apps/sim/tools/stripe/pay_invoice.ts
@@ -6,6 +6,7 @@ import {
 import type { InvoiceResponse, PayInvoiceParams } from '@/tools/stripe/types'
 import { INVOICE_METADATA_OUTPUT_PROPERTIES, INVOICE_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_pay_invoice',
@@ -43,7 +44,8 @@ export const stripePayInvoiceTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/invoices/${params.id}/pay`,
+    url: (params) =>
+      `https://api.stripe.com/v1/invoices/${safeUrlPathSegment(params.id, 'id')}/pay`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/resume_subscription.ts
+++ b/apps/sim/tools/stripe/resume_subscription.ts
@@ -6,6 +6,7 @@ import {
 import type { ResumeSubscriptionParams, SubscriptionResponse } from '@/tools/stripe/types'
 import { SUBSCRIPTION_METADATA_OUTPUT_PROPERTIES, SUBSCRIPTION_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_resume_subscription',
@@ -37,7 +38,8 @@ export const stripeResumeSubscriptionTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/subscriptions/${params.id}/resume`,
+    url: (params) =>
+      `https://api.stripe.com/v1/subscriptions/${safeUrlPathSegment(params.id, 'id')}/resume`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/retrieve_charge.ts
+++ b/apps/sim/tools/stripe/retrieve_charge.ts
@@ -1,5 +1,6 @@
 import type { ChargeResponse, RetrieveChargeParams } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeRetrieveChargeTool: ToolConfig<RetrieveChargeParams, ChargeResponse> = {
   id: 'stripe_retrieve_charge',
@@ -23,7 +24,7 @@ export const stripeRetrieveChargeTool: ToolConfig<RetrieveChargeParams, ChargeRe
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/charges/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/charges/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/retrieve_customer.ts
+++ b/apps/sim/tools/stripe/retrieve_customer.ts
@@ -1,6 +1,7 @@
 import type { CustomerResponse, RetrieveCustomerParams } from '@/tools/stripe/types'
 import { CUSTOMER_METADATA_OUTPUT_PROPERTIES, CUSTOMER_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeRetrieveCustomerTool: ToolConfig<RetrieveCustomerParams, CustomerResponse> = {
   id: 'stripe_retrieve_customer',
@@ -24,7 +25,7 @@ export const stripeRetrieveCustomerTool: ToolConfig<RetrieveCustomerParams, Cust
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/customers/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/customers/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/retrieve_event.ts
+++ b/apps/sim/tools/stripe/retrieve_event.ts
@@ -1,5 +1,6 @@
 import type { EventResponse, RetrieveEventParams } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeRetrieveEventTool: ToolConfig<RetrieveEventParams, EventResponse> = {
   id: 'stripe_retrieve_event',
@@ -23,7 +24,7 @@ export const stripeRetrieveEventTool: ToolConfig<RetrieveEventParams, EventRespo
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/events/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/events/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/retrieve_invoice.ts
+++ b/apps/sim/tools/stripe/retrieve_invoice.ts
@@ -1,6 +1,7 @@
 import type { InvoiceResponse, RetrieveInvoiceParams } from '@/tools/stripe/types'
 import { INVOICE_METADATA_OUTPUT_PROPERTIES, INVOICE_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeRetrieveInvoiceTool: ToolConfig<RetrieveInvoiceParams, InvoiceResponse> = {
   id: 'stripe_retrieve_invoice',
@@ -24,7 +25,7 @@ export const stripeRetrieveInvoiceTool: ToolConfig<RetrieveInvoiceParams, Invoic
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/invoices/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/invoices/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/retrieve_payment_intent.ts
+++ b/apps/sim/tools/stripe/retrieve_payment_intent.ts
@@ -4,6 +4,7 @@ import {
   PAYMENT_INTENT_OUTPUT,
 } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeRetrievePaymentIntentTool: ToolConfig<
   RetrievePaymentIntentParams,
@@ -30,7 +31,8 @@ export const stripeRetrievePaymentIntentTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/payment_intents/${params.id}`,
+    url: (params) =>
+      `https://api.stripe.com/v1/payment_intents/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/retrieve_price.ts
+++ b/apps/sim/tools/stripe/retrieve_price.ts
@@ -1,5 +1,6 @@
 import type { PriceResponse, RetrievePriceParams } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeRetrievePriceTool: ToolConfig<RetrievePriceParams, PriceResponse> = {
   id: 'stripe_retrieve_price',
@@ -23,7 +24,7 @@ export const stripeRetrievePriceTool: ToolConfig<RetrievePriceParams, PriceRespo
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/prices/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/prices/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/retrieve_product.ts
+++ b/apps/sim/tools/stripe/retrieve_product.ts
@@ -1,5 +1,6 @@
 import type { ProductResponse, RetrieveProductParams } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeRetrieveProductTool: ToolConfig<RetrieveProductParams, ProductResponse> = {
   id: 'stripe_retrieve_product',
@@ -23,7 +24,7 @@ export const stripeRetrieveProductTool: ToolConfig<RetrieveProductParams, Produc
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/products/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/products/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/retrieve_subscription.ts
+++ b/apps/sim/tools/stripe/retrieve_subscription.ts
@@ -1,6 +1,7 @@
 import type { RetrieveSubscriptionParams, SubscriptionResponse } from '@/tools/stripe/types'
 import { SUBSCRIPTION_METADATA_OUTPUT_PROPERTIES, SUBSCRIPTION_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const stripeRetrieveSubscriptionTool: ToolConfig<
   RetrieveSubscriptionParams,
@@ -27,7 +28,8 @@ export const stripeRetrieveSubscriptionTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/subscriptions/${params.id}`,
+    url: (params) =>
+      `https://api.stripe.com/v1/subscriptions/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/stripe/send_invoice.ts
+++ b/apps/sim/tools/stripe/send_invoice.ts
@@ -5,6 +5,7 @@ import {
 } from '@/tools/stripe/idempotency'
 import type { InvoiceResponse, SendInvoiceParams } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_send_invoice',
@@ -36,7 +37,8 @@ export const stripeSendInvoiceTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/invoices/${params.id}/send`,
+    url: (params) =>
+      `https://api.stripe.com/v1/invoices/${safeUrlPathSegment(params.id, 'id')}/send`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/update_charge.ts
+++ b/apps/sim/tools/stripe/update_charge.ts
@@ -5,6 +5,7 @@ import {
 } from '@/tools/stripe/idempotency'
 import type { ChargeResponse, UpdateChargeParams } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_update_charge',
@@ -48,7 +49,7 @@ export const stripeUpdateChargeTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/charges/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/charges/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/update_customer.ts
+++ b/apps/sim/tools/stripe/update_customer.ts
@@ -6,6 +6,7 @@ import {
 import type { CustomerResponse, UpdateCustomerParams } from '@/tools/stripe/types'
 import { CUSTOMER_METADATA_OUTPUT_PROPERTIES, CUSTOMER_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_update_customer',
@@ -73,7 +74,7 @@ export const stripeUpdateCustomerTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/customers/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/customers/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/update_invoice.ts
+++ b/apps/sim/tools/stripe/update_invoice.ts
@@ -6,6 +6,7 @@ import {
 import type { InvoiceResponse, UpdateInvoiceParams } from '@/tools/stripe/types'
 import { INVOICE_METADATA_OUTPUT_PROPERTIES, INVOICE_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_update_invoice',
@@ -55,7 +56,7 @@ export const stripeUpdateInvoiceTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/invoices/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/invoices/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/update_payment_intent.ts
+++ b/apps/sim/tools/stripe/update_payment_intent.ts
@@ -9,6 +9,7 @@ import {
   PAYMENT_INTENT_OUTPUT,
 } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_update_payment_intent',
@@ -70,7 +71,8 @@ export const stripeUpdatePaymentIntentTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/payment_intents/${params.id}`,
+    url: (params) =>
+      `https://api.stripe.com/v1/payment_intents/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/update_price.ts
+++ b/apps/sim/tools/stripe/update_price.ts
@@ -5,6 +5,7 @@ import {
 } from '@/tools/stripe/idempotency'
 import type { PriceResponse, UpdatePriceParams } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_update_price',
@@ -48,7 +49,7 @@ export const stripeUpdatePriceTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/prices/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/prices/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/update_product.ts
+++ b/apps/sim/tools/stripe/update_product.ts
@@ -5,6 +5,7 @@ import {
 } from '@/tools/stripe/idempotency'
 import type { ProductResponse, UpdateProductParams } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_update_product',
@@ -66,7 +67,7 @@ export const stripeUpdateProductTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/products/${params.id}`,
+    url: (params) => `https://api.stripe.com/v1/products/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/update_subscription.ts
+++ b/apps/sim/tools/stripe/update_subscription.ts
@@ -6,6 +6,7 @@ import {
 import type { SubscriptionResponse, UpdateSubscriptionParams } from '@/tools/stripe/types'
 import { SUBSCRIPTION_METADATA_OUTPUT_PROPERTIES, SUBSCRIPTION_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_update_subscription',
@@ -55,7 +56,8 @@ export const stripeUpdateSubscriptionTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/subscriptions/${params.id}`,
+    url: (params) =>
+      `https://api.stripe.com/v1/subscriptions/${safeUrlPathSegment(params.id, 'id')}`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one

--- a/apps/sim/tools/stripe/void_invoice.ts
+++ b/apps/sim/tools/stripe/void_invoice.ts
@@ -6,6 +6,7 @@ import {
 import type { InvoiceResponse, VoidInvoiceParams } from '@/tools/stripe/types'
 import { INVOICE_METADATA_OUTPUT_PROPERTIES, INVOICE_OUTPUT } from '@/tools/stripe/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 const DELIVERY = defineStripeKeyedSite(
   'stripe_void_invoice',
@@ -37,7 +38,8 @@ export const stripeVoidInvoiceTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.stripe.com/v1/invoices/${params.id}/void`,
+    url: (params) =>
+      `https://api.stripe.com/v1/invoices/${safeUrlPathSegment(params.id, 'id')}/void`,
     method: 'POST',
     /**
      * The `Idempotency-Key` must be the *same* on every delivery of one


### PR DESCRIPTION
## The defect

The HubSpot, Stripe and Salesforce tools interpolate LLM-writable identifiers — record ids, customer/charge/invoice ids, report and dashboard ids, object types and sObject API names — straight into URL **path segments**. These params are `visibility: 'user-or-llm'`, so prompt injection controls them.

A value like `../../v1/customers/victim` escapes the resource it addresses once `fetch` normalizes the URL, re-aiming the request at a different object on the same host **with the caller's credential still attached** — including on the DELETE tools. For Stripe that credential is a live secret key, so this is money-moving surface.

`encodeURIComponent` does not close it. `.` and `..` are unreserved, so they survive encoding and the URL parser removes the dot segment *after* decoding:

```js
new URL('https://api.stripe.com/v1/customers/' + encodeURIComponent('..')).pathname
// => '/v1/'
```

Only rejecting the value works.

## The fix

Every path interpolation in the three services now goes through `safeUrlPathSegment(value, paramName)` from `@/tools/url-path`.

| Service | Call sites hardened |
| --- | --- |
| Stripe | 28 (`params.id` on every retrieve/update/delete/capture/cancel/confirm/finalize/pay/send/void/resume tool) |
| HubSpot | 31 files, 39 segments (record ids, `listId`, `eventId`, `objectType`/`objectId`/`toObjectType`/`toObjectId`, `propertyName`) |
| Salesforce | 23 (record ids, `reportId`, `dashboardId`, `fieldId`, `objectName`) |

Query-string interpolations are untouched — they were already encoded and cannot pop a path segment.

## Behaviour preserved

No param `visibility`, subBlock id, or block definition changed; `bun run tool-metadata:generate` produces no diff. Legitimate input passes through verbatim and the tests assert it: numeric HubSpot ids and object types, Stripe `cus_ABC123` / `ch_ABC123` ids, Salesforce 15- and 18-character record ids and `My_Object__c` custom API names.

## Deliberately not changed

`salesforce_query_more` — its `nextRecordsUrl` is by contract a **whole relative path** handed back by a previous query, so it is multi-segment by design; single-segment guarding would break every legitimate call. It is a GET, it stays on the org's own instance host (`${instanceUrl}${nextUrl}` with a leading `/` forced), and the token is already scoped to that org, so there is no cross-resource escalation to gain. The test file documents the exclusion.

## Tests

`path_safety.test.ts` under each of the three tool folders, modelled on `tools/vercel/edge_config_path_safety.test.ts`:

- enumerates tools **from the barrel**, so a newly added unguarded path param fails CI
- resolves every built URL with `new URL(...)` rather than string-matching — string matching is exactly what let this through
- keeps the bare `.` and `..` vectors alongside the compound ones
- `LEGITIMATE_IDS` proves real values pass through unchanged

Verified the tests actually fail against the old code: reverted the guard to `encodeURIComponent` in `stripe/delete_customer`, `hubspot/delete_contact` and `salesforce/delete_account` and watched the `..`, `.` and trimming cases go red, then restored.

## Gates

`bun run lint`, `bun run check:audits` (39 audits green), `check-block-registry.ts origin/staging`, and `vitest run tools/hubspot tools/stripe tools/salesforce` (1849 passed) all pass. Type-check is clean for the touched files.

---

## Follow-up: tests now fuzz one parameter at a time

The first revision of these suites inherited a coverage hole from the Vercel template: `buildParams` filled every string param with the same fuzz value and the assertion swallowed a throw with `catch { return }`. The first guarded param threw and silently retired every sibling, so once a tool had one guard the rest of its path params stopped being tested.

HubSpot's association tools are the worst case — four path params in one URL. Measured: reverting the `objectId` guard in `hubspot_delete_association` produced **0 failures** under the old suite.

The unit of coverage is now a **(tool, parameter) pair**: each case fuzzes exactly one param and pins every sibling to a safe placeholder, so a throw is attributable to the param under test and only then counts as a pass.

**92 pairs discovered from the barrels — 28 Stripe, 41 HubSpot, 23 Salesforce — exactly matching the guarded sites. No unguarded path param was surfaced.**

Two additional hardenings:

- Every pair now asserts a bare `.` and `..` are **rejected**, not merely shape-preserving. The shape check alone cannot see a dot in the final segment: `x/.` normalizes to `x/`, preserving both segment count and every other segment.
- A fixture pins the exact path-param set of the three association tools, so dropping one from the sweep fails rather than quietly shrinking coverage.

Red-first re-verified with the tightened suite, and failures are now scoped to the exact pair:

| Reverted guard | Failures | All named |
| --- | --- | --- |
| `delete_association` `objectId` | 6 | `hubspot_delete_association / objectId` |
| `delete_association` `toObjectId` (previously invisible) | 5 | `hubspot_delete_association / toObjectId` |

2247 assertions pass across the three suites. All gates re-run green.


---

## Follow-up: no `any` in the harnesses

The three suites now use the shared shape:

```ts
type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
```

`buildParams` already returned `Record<string, unknown>`, so `url(...)` is called with **no cast**. Zero `any` types and zero `as any` remain in the three files.

The alias does **not** compile on its own — the `any` was load-bearing rather than lazy — so two supporting changes were needed:

- **The barrel seed.** `ALL_EXPORTS` is typed `readonly unknown[]`, making the per-service type guard the single narrowing point (approach 1). Without it, the barrel's values are a union of concretely-typed `ToolConfig`s and `Array.prototype.filter`'s type-predicate overload requires the predicate's type to extend the array's element type, so it intersects rather than replaces and leaves the mismatch in place.
- **Contravariance on `request.url`.** Under `strictFunctionTypes`, `ToolConfig<ConcreteParams, R>` is not assignable to `ToolConfig<Record<string, unknown>, ToolResponse>` because `request.url` accepts its parameter contravariantly. Rather than force it with a cast, the fixtures that name a tool directly go through `asPathTool`, which re-checks the value at runtime with the same guard — sound narrowing, no assertion.

The type guards are cast-free as well, using `in` narrowing instead of `(value as PathTool).id`.

Pure typing change, verified: **2247 assertions pass, unchanged**, and reverting the `toObjectId` guard in `hubspot_delete_association` still fails exactly 5 scoped cases. `lint`, `check:audits` (39/39) and `check-block-registry` re-run green.

> **Precedent, for a follow-up outside this PR's scope:** this pattern was inherited from `apps/sim/tools/vercel/edge_config_path_safety.test.ts` (`ToolConfig<any, any>` at line 67, `as any` at line 105), which daytona's harness copied too. Both are outside this PR's file scope and are left untouched; they would need the same `PathTool` + `asPathTool` treatment to converge.


**Verification note:** `apps/sim/tsconfig.json` excludes `**/*.test.ts`, so `bun run type-check` does not cover these files and CI would not catch a type error in them. Type-cleanliness was proven with a temporary tsconfig overriding `exclude` and pinned to the three harnesses — 0 `TS2345`/`TS2322`, 0 errors mentioning `path_safety`, with all three confirmed present in `--listFiles`. The temp tsconfig was deleted and is not committed (verified against the branch's file list).


---

## Follow-up: three test-harness holes closed

All three were inherited from `tools/vercel/edge_config_path_safety.test.ts`, the template these suites were built from. Each was confirmed by reverting a guard and watching what the suite *failed to* report.

| Hole | Symptom | Fix |
| --- | --- | --- |
| Fill-everything sweep | First guarded param threw and retired all its siblings. Reverting `objectId` on `hubspot_delete_association` gave **0 failures** | Fuzz one param at a time, siblings pinned safe — 92 (tool, param) pairs |
| `?` / `#` never asserted | Shape check compares pathname segments; a query or fragment moves the tail out of `pathname` entirely | Pin `url.search` against the baseline, require empty `url.hash` |
| Probe slot skipped | `if (segment === TARGET) return` — proved neighbours, never the slot. A **balanced** traversal `12345/../victim` passed against fully unguarded code | Assert the slot equals `encodeURIComponent(value.trim())`, plus a balanced vector in all three suites |

Also from cubic's P3: the coverage assertion was a floor (`>= 35` against 41 real pairs), and `reachesPath` folded an unbuildable URL into "not a path parameter". Both let a pair leave the sweep silently. Counts are now exact (28 / 41 / 23) and unbuildable pairs are asserted empty in a named test. Measured first: 0 of 92 path pairs and 0 of 438 non-path params currently throw, so this is robustness, not a live defect.

**Cumulative effect on a single scoped revert** — raw interpolation of `contactId` in `hubspot_get_contact`:

| | Vectors failing |
| --- | --- |
| At first review | 6 of 11 |
| After per-pair rewrite | 8 of 11 |
| After query/fragment pinning | 8 of 11 |
| After slot assertion | **11 of 11** |

2342 assertions. `lint`, `check:audits` (39/39), `check-block-registry` green; type-cleanliness verified with a temporary tsconfig overriding the `**/*.test.ts` exclude (deleted, not committed).

> **Upstream follow-up, outside this PR's scope:** `tools/vercel/edge_config_path_safety.test.ts` carries all three holes plus the `any` typing (`ToolConfig<any, any>` L67, `as any` L105, `if (segment === SAFE_ID) return` L143), and daytona's copy inherits them. Left untouched here; they need the same treatment at the source so it stops propagating.
