### PR TITLE
fix(tools): reject path-traversal ids in Tailscale, Spotify and X tools

### DIFF
--- a/apps/sim/tools/spotify/add_playlist_cover.ts
+++ b/apps/sim/tools/spotify/add_playlist_cover.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyAddPlaylistCoverParams {
   accessToken: string
@@ -41,7 +42,8 @@ export const spotifyAddPlaylistCoverTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}/images`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/images`,
     method: 'PUT',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/add_tracks_to_playlist.ts
+++ b/apps/sim/tools/spotify/add_tracks_to_playlist.ts
@@ -3,6 +3,7 @@ import type {
   SpotifyAddTracksToPlaylistResponse,
 } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyAddTracksToPlaylistTool: ToolConfig<
   SpotifyAddTracksToPlaylistParams,
@@ -41,7 +42,8 @@ export const spotifyAddTracksToPlaylistTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}/tracks`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/tracks`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/check_playlist_followers.ts
+++ b/apps/sim/tools/spotify/check_playlist_followers.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyCheckPlaylistFollowersParams {
   accessToken: string
@@ -47,7 +48,7 @@ export const spotifyCheckPlaylistFollowersTool: ToolConfig<
         .map((id) => id.trim())
         .slice(0, 5)
         .join(',')
-      return `https://api.spotify.com/v1/playlists/${params.playlistId}/followers/contains?ids=${ids}`
+      return `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/followers/contains?ids=${ids}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/spotify/follow_playlist.ts
+++ b/apps/sim/tools/spotify/follow_playlist.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyFollowPlaylistParams {
   accessToken: string
@@ -42,7 +43,8 @@ export const spotifyFollowPlaylistTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}/followers`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/followers`,
     method: 'PUT',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/get_album.ts
+++ b/apps/sim/tools/spotify/get_album.ts
@@ -4,6 +4,7 @@ import {
   SIMPLIFIED_ARTIST_OUTPUT_PROPERTIES,
 } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyGetAlbumTool: ToolConfig<SpotifyGetAlbumParams, SpotifyGetAlbumResponse> = {
   id: 'spotify_get_album',
@@ -34,7 +35,7 @@ export const spotifyGetAlbumTool: ToolConfig<SpotifyGetAlbumParams, SpotifyGetAl
 
   request: {
     url: (params) => {
-      let url = `https://api.spotify.com/v1/albums/${params.albumId}`
+      let url = `https://api.spotify.com/v1/albums/${safeUrlPathSegment(params.albumId, 'albumId')}`
       if (params.market) {
         url += `?market=${params.market}`
       }

--- a/apps/sim/tools/spotify/get_album_tracks.ts
+++ b/apps/sim/tools/spotify/get_album_tracks.ts
@@ -1,5 +1,6 @@
 import { ALBUM_TRACK_OUTPUT_PROPERTIES } from '@/tools/spotify/types'
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyGetAlbumTracksParams {
   accessToken: string
@@ -68,7 +69,7 @@ export const spotifyGetAlbumTracksTool: ToolConfig<
     url: (params) => {
       const limit = Math.min(Math.max(params.limit || 20, 1), 50)
       const offset = params.offset || 0
-      let url = `https://api.spotify.com/v1/albums/${params.albumId}/tracks?limit=${limit}&offset=${offset}`
+      let url = `https://api.spotify.com/v1/albums/${safeUrlPathSegment(params.albumId, 'albumId')}/tracks?limit=${limit}&offset=${offset}`
       if (params.market) {
         url += `&market=${params.market}`
       }

--- a/apps/sim/tools/spotify/get_artist.ts
+++ b/apps/sim/tools/spotify/get_artist.ts
@@ -1,5 +1,6 @@
 import type { SpotifyGetArtistParams, SpotifyGetArtistResponse } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyGetArtistTool: ToolConfig<SpotifyGetArtistParams, SpotifyGetArtistResponse> = {
   id: 'spotify_get_artist',
@@ -22,7 +23,8 @@ export const spotifyGetArtistTool: ToolConfig<SpotifyGetArtistParams, SpotifyGet
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/artists/${params.artistId}`,
+    url: (params) =>
+      `https://api.spotify.com/v1/artists/${safeUrlPathSegment(params.artistId, 'artistId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/get_artist_albums.ts
+++ b/apps/sim/tools/spotify/get_artist_albums.ts
@@ -3,6 +3,7 @@ import type {
   SpotifyGetArtistAlbumsResponse,
 } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyGetArtistAlbumsTool: ToolConfig<
   SpotifyGetArtistAlbumsParams,
@@ -57,7 +58,7 @@ export const spotifyGetArtistAlbumsTool: ToolConfig<
     url: (params) => {
       const limit = Math.min(Math.max(params.limit || 20, 1), 50)
       const offset = params.offset || 0
-      let url = `https://api.spotify.com/v1/artists/${params.artistId}/albums?limit=${limit}&offset=${offset}`
+      let url = `https://api.spotify.com/v1/artists/${safeUrlPathSegment(params.artistId, 'artistId')}/albums?limit=${limit}&offset=${offset}`
       if (params.include_groups) {
         url += `&include_groups=${encodeURIComponent(params.include_groups)}`
       }

--- a/apps/sim/tools/spotify/get_artist_top_tracks.ts
+++ b/apps/sim/tools/spotify/get_artist_top_tracks.ts
@@ -4,6 +4,7 @@ import type {
 } from '@/tools/spotify/types'
 import { ARTIST_TOP_TRACK_OUTPUT_PROPERTIES } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyGetArtistTopTracksTool: ToolConfig<
   SpotifyGetArtistTopTracksParams,
@@ -39,7 +40,7 @@ export const spotifyGetArtistTopTracksTool: ToolConfig<
   request: {
     url: (params) => {
       const market = params.market || 'US'
-      return `https://api.spotify.com/v1/artists/${params.artistId}/top-tracks?market=${market}`
+      return `https://api.spotify.com/v1/artists/${safeUrlPathSegment(params.artistId, 'artistId')}/top-tracks?market=${market}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/spotify/get_audiobook.ts
+++ b/apps/sim/tools/spotify/get_audiobook.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyGetAudiobookParams {
   accessToken: string
@@ -53,7 +54,7 @@ export const spotifyGetAudiobookTool: ToolConfig<
 
   request: {
     url: (params) => {
-      let url = `https://api.spotify.com/v1/audiobooks/${params.audiobookId}`
+      let url = `https://api.spotify.com/v1/audiobooks/${safeUrlPathSegment(params.audiobookId, 'audiobookId')}`
       if (params.market) url += `?market=${params.market}`
       return url
     },

--- a/apps/sim/tools/spotify/get_audiobook_chapters.ts
+++ b/apps/sim/tools/spotify/get_audiobook_chapters.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyGetAudiobookChaptersParams {
   accessToken: string
@@ -71,7 +72,7 @@ export const spotifyGetAudiobookChaptersTool: ToolConfig<
     url: (params) => {
       const limit = Math.min(Math.max(params.limit || 20, 1), 50)
       const offset = params.offset || 0
-      let url = `https://api.spotify.com/v1/audiobooks/${params.audiobookId}/chapters?limit=${limit}&offset=${offset}`
+      let url = `https://api.spotify.com/v1/audiobooks/${safeUrlPathSegment(params.audiobookId, 'audiobookId')}/chapters?limit=${limit}&offset=${offset}`
       if (params.market) url += `&market=${params.market}`
       return url
     },

--- a/apps/sim/tools/spotify/get_episode.ts
+++ b/apps/sim/tools/spotify/get_episode.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyGetEpisodeParams {
   accessToken: string
@@ -50,7 +51,7 @@ export const spotifyGetEpisodeTool: ToolConfig<SpotifyGetEpisodeParams, SpotifyG
 
     request: {
       url: (params) => {
-        let url = `https://api.spotify.com/v1/episodes/${params.episodeId}`
+        let url = `https://api.spotify.com/v1/episodes/${safeUrlPathSegment(params.episodeId, 'episodeId')}`
         if (params.market) url += `?market=${params.market}`
         return url
       },

--- a/apps/sim/tools/spotify/get_playlist.ts
+++ b/apps/sim/tools/spotify/get_playlist.ts
@@ -1,6 +1,7 @@
 import type { SpotifyGetPlaylistParams, SpotifyGetPlaylistResponse } from '@/tools/spotify/types'
 import { PLAYLIST_OWNER_OUTPUT_PROPERTIES } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyGetPlaylistTool: ToolConfig<
   SpotifyGetPlaylistParams,
@@ -33,7 +34,7 @@ export const spotifyGetPlaylistTool: ToolConfig<
 
   request: {
     url: (params) => {
-      let url = `https://api.spotify.com/v1/playlists/${params.playlistId}`
+      let url = `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}`
       if (params.market) {
         url += `?market=${params.market}`
       }

--- a/apps/sim/tools/spotify/get_playlist_cover.ts
+++ b/apps/sim/tools/spotify/get_playlist_cover.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyGetPlaylistCoverParams {
   accessToken: string
@@ -40,7 +41,8 @@ export const spotifyGetPlaylistCoverTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}/images`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/images`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/get_playlist_tracks.ts
+++ b/apps/sim/tools/spotify/get_playlist_tracks.ts
@@ -4,6 +4,7 @@ import type {
 } from '@/tools/spotify/types'
 import { TRACK_LIST_OUTPUT_PROPERTIES } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyGetPlaylistTracksTool: ToolConfig<
   SpotifyGetPlaylistTracksParams,
@@ -52,7 +53,7 @@ export const spotifyGetPlaylistTracksTool: ToolConfig<
     url: (params) => {
       const limit = Math.min(Math.max(params.limit || 50, 1), 100)
       const offset = params.offset || 0
-      let url = `https://api.spotify.com/v1/playlists/${params.playlistId}/tracks?limit=${limit}&offset=${offset}`
+      let url = `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/tracks?limit=${limit}&offset=${offset}`
       if (params.market) {
         url += `&market=${params.market}`
       }

--- a/apps/sim/tools/spotify/get_show.ts
+++ b/apps/sim/tools/spotify/get_show.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyGetShowParams {
   accessToken: string
@@ -49,7 +50,7 @@ export const spotifyGetShowTool: ToolConfig<SpotifyGetShowParams, SpotifyGetShow
 
   request: {
     url: (params) => {
-      let url = `https://api.spotify.com/v1/shows/${params.showId}`
+      let url = `https://api.spotify.com/v1/shows/${safeUrlPathSegment(params.showId, 'showId')}`
       if (params.market) url += `?market=${params.market}`
       return url
     },

--- a/apps/sim/tools/spotify/get_show_episodes.ts
+++ b/apps/sim/tools/spotify/get_show_episodes.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyGetShowEpisodesParams {
   accessToken: string
@@ -72,7 +73,7 @@ export const spotifyGetShowEpisodesTool: ToolConfig<
     url: (params) => {
       const limit = Math.min(Math.max(params.limit || 20, 1), 50)
       const offset = params.offset || 0
-      let url = `https://api.spotify.com/v1/shows/${params.showId}/episodes?limit=${limit}&offset=${offset}`
+      let url = `https://api.spotify.com/v1/shows/${safeUrlPathSegment(params.showId, 'showId')}/episodes?limit=${limit}&offset=${offset}`
       if (params.market) url += `&market=${params.market}`
       return url
     },

--- a/apps/sim/tools/spotify/get_track.ts
+++ b/apps/sim/tools/spotify/get_track.ts
@@ -4,6 +4,7 @@ import {
   SIMPLIFIED_ARTIST_OUTPUT_PROPERTIES,
 } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyGetTrackTool: ToolConfig<SpotifyGetTrackParams, SpotifyGetTrackResponse> = {
   id: 'spotify_get_track',
@@ -33,7 +34,7 @@ export const spotifyGetTrackTool: ToolConfig<SpotifyGetTrackParams, SpotifyGetTr
 
   request: {
     url: (params) => {
-      let url = `https://api.spotify.com/v1/tracks/${params.trackId}`
+      let url = `https://api.spotify.com/v1/tracks/${safeUrlPathSegment(params.trackId, 'trackId')}`
       if (params.market) {
         url += `?market=${params.market}`
       }

--- a/apps/sim/tools/spotify/get_user_profile.ts
+++ b/apps/sim/tools/spotify/get_user_profile.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyGetUserProfileParams {
   accessToken: string
@@ -40,7 +41,8 @@ export const spotifyGetUserProfileTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/users/${params.userId}`,
+    url: (params) =>
+      `https://api.spotify.com/v1/users/${safeUrlPathSegment(params.userId, 'userId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/path_safety.test.ts
+++ b/apps/sim/tools/spotify/path_safety.test.ts
@@ -16,17 +16,16 @@
  * `.` and `..` vectors below are the point of this file: both are made of
  * unreserved characters, so they survive encoding untouched and the URL parser
  * then removes them as dot segments, popping one path segment off a fixed host.
- * Every assertion resolves the built URL with `new URL(...)` — the same
- * normalization `fetch` performs — rather than string-matching the template
- * output, because string matching is exactly what let this through.
+ * The Tailscale half of this change is the clean demonstration — those call
+ * sites already encoded, and reverting one guard there turns *only* the `.` and
+ * `..` cases red while every slash-bearing vector still passes.
  */
 import { describe, expect, it } from 'vitest'
 import * as spotifyTools from '@/tools/spotify/index'
-import type { ToolConfig } from '@/tools/types'
 
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
- * `encodeURIComponent`-only fix would look correct while the hole stayed live.
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
  */
 const TRAVERSAL_IDS = [
   '..',
@@ -40,6 +39,23 @@ const TRAVERSAL_IDS = [
   'tracks/../../../v1/me/tracks',
   '\\..\\..',
 ] as const
+
+/**
+ * Every vector the guard must refuse outright, derived from the list above so
+ * the two cannot drift apart.
+ *
+ * A shape assertion alone cannot see the worst of these. `https://host/a/.`
+ * normalizes to `https://host/a/`, so a trailing dot segment collapses the id
+ * while leaving the segment *count* and every other segment untouched — a
+ * shape-only check passes with the guard removed. Most routes here end in the
+ * guarded id (`spotify_get_playlist` among them), so that is exactly where a
+ * shape-only suite is blindest. Rejection is therefore asserted directly, per
+ * parameter, rather than inferred from the resulting path.
+ */
+const REJECTED_IDS = TRAVERSAL_IDS.filter((value) => {
+  const trimmed = value.trim()
+  return trimmed === '.' || trimmed === '..' || /[/\\]/.test(trimmed)
+})
 
 /**
  * Values a real Spotify caller supplies — base-62 resource ids and user ids;
@@ -58,97 +74,257 @@ const LEGITIMATE_IDS = [
   'foo..',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/**
+ * Fills the parameter currently under test. Distinct from `SIBLING` so an
+ * assertion can tell the fuzzed segment apart from every other one.
+ */
+const TARGET = 'TARGETSEGMENT'
 
-type AnyTool = ToolConfig<any, any>
+/** Fills every parameter that is not under test, held constant and safe. */
+const SIBLING = 'SIBLINGSEGMENT'
 
-function isSpotifyTool(value: unknown): value is AnyTool {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('spotify_')
-  )
+/** Probes which parameter reaches the path, before any vector is applied. */
+const PROBE = 'PROBESEGMENT'
+
+const ORIGINS = ['https://api.spotify.com']
+
+/** The parameter values handed to a tool's URL builder. */
+type Fill = Record<string, unknown>
+
+type UrlBuilder = (params: Fill) => string
+
+/** The slice of a tool this harness needs, narrowed from the barrel export. */
+interface PathTool {
+  id: string
+  params: Record<string, { type?: string }>
+  buildUrl: UrlBuilder
 }
 
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised.
+ * One parameter of one tool that lands in the path, plus the sibling values
+ * that route the URL builder down the branch where it does.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
-  const params: Record<string, unknown> = { accessToken: 'token' }
-  for (const [name, def] of Object.entries(tool.params ?? {})) {
+interface PathParam {
+  name: string
+  tool: PathTool
+  param: string
+  context: Fill
+}
+
+/**
+ * Narrows a barrel export to the tool shape this harness drives.
+ *
+ * Structural narrowing keeps the harness free of `any`: nothing here needs a
+ * tool's parameter or response generics, only its id, its declared parameter
+ * types, and a callable URL builder.
+ */
+function asPathTool(value: unknown): PathTool | null {
+  if (typeof value !== 'object' || value === null) return null
+
+  const candidate = value as { id?: unknown; params?: unknown; request?: unknown }
+  if (typeof candidate.id !== 'string' || !candidate.id.startsWith('spotify_')) return null
+
+  const request = candidate.request
+  if (typeof request !== 'object' || request === null) return null
+
+  const url = (request as { url?: unknown }).url
+  if (typeof url !== 'function') return null
+
+  const params =
+    typeof candidate.params === 'object' && candidate.params !== null
+      ? (candidate.params as Record<string, { type?: string }>)
+      : {}
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder }
+}
+
+/**
+ * Fills every declared parameter with a safe value of the right shape, so the
+ * URL builder runs to completion no matter which parameters it reads.
+ */
+function baseFill(tool: PathTool): Fill {
+  const params: Fill = { accessToken: 'token' }
+  for (const [name, def] of Object.entries(tool.params)) {
     if (name === 'accessToken') continue
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
+    if (def.type === 'json' || def.type === 'array') {
       params[name] = []
-    } else if (type === 'number') {
+    } else if (def.type === 'number') {
       params[name] = 1
-    } else if (type === 'boolean') {
+    } else if (def.type === 'boolean') {
       params[name] = false
     } else {
-      params[name] = value
+      params[name] = SIBLING
     }
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
-  const url = tool.request?.url
-  if (typeof url !== 'function') {
-    throw new Error(`${tool.id} does not build its URL from params`)
+function stringParamsOf(tool: PathTool): string[] {
+  return Object.entries(tool.params)
+    .filter(([name, def]) => {
+      if (name === 'accessToken') return false
+      return def.type !== 'json' && def.type !== 'array' && def.type !== 'boolean'
+    })
+    .map(([name]) => name)
+}
+
+/**
+ * Harvests the string literals a URL builder compares against, so a branch
+ * keyed on a discriminator such as `action === 'unblock'` is explored too.
+ *
+ * Without this, filling every parameter with one safe value pins each such tool
+ * to a single branch, and an identifier that only appears on the other branch —
+ * `targetUserId` on the DELETE path, say — is never discovered and never
+ * fuzzed. Reading the builder's own source is what keeps that self-maintaining:
+ * a new branch value is picked up without editing this file.
+ */
+function branchLiteralsOf(tool: PathTool): string[] {
+  const source = String(tool.buildUrl)
+  const found = new Set<string>()
+  for (const match of source.matchAll(/['"]([^'"\\\n]{1,24})['"]/g)) {
+    const literal = match[1]
+    if (!literal || /[/?=.: ]/.test(literal)) continue
+    found.add(literal)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return [...found]
+}
+
+function buildUrl(tool: PathTool, fill: Fill): URL {
+  return new URL(tool.buildUrl(fill))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(spotifyTools)
-  .filter(isSpotifyTool)
-  .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return segmentsOf(buildUrl(tool, SAFE_ID)).includes(SAFE_ID)
-    } catch {
-      return false
+function reachesPath(tool: PathTool, fill: Fill, param: string): boolean {
+  try {
+    return segmentsOf(buildUrl(tool, { ...fill, [param]: PROBE })).includes(PROBE)
+  } catch {
+    return false
+  }
+}
+
+const TOOLS = Object.values(spotifyTools)
+  .map(asPathTool)
+  .filter((tool): tool is PathTool => tool !== null)
+
+/**
+ * Tools whose URL cannot be built even from all-safe values.
+ *
+ * Discovery has to tolerate a failed probe, since probing a guarded parameter
+ * is expected to throw. That tolerance must not extend to a tool that cannot be
+ * exercised at all, because such a tool would drop out of the suite silently
+ * and take its path parameters with it — so it is surfaced by name instead.
+ */
+const UNBUILDABLE = TOOLS.filter((tool) => {
+  try {
+    buildUrl(tool, baseFill(tool))
+    return false
+  } catch {
+    return true
+  }
+}).map((tool) => tool.id)
+
+/**
+ * Enumerates every (tool, parameter) pair that reaches the request path.
+ *
+ * Fuzzing one parameter at a time — with every sibling held at a safe value —
+ * is what makes a newly added unguarded parameter fail CI. Filling all of them
+ * with the same vector cannot: the first guarded parameter throws, the whole
+ * case is skipped, and its unguarded siblings are never exercised.
+ */
+function pathParamsOf(tool: PathTool): PathParam[] {
+  const base = baseFill(tool)
+  const names = stringParamsOf(tool)
+  const literals = branchLiteralsOf(tool)
+  const contexts: Fill[] = [base]
+  for (const discriminator of names) {
+    for (const literal of literals) {
+      contexts.push({ ...base, [discriminator]: literal })
     }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  }
+
+  const pairs = new Map<string, PathParam>()
+  for (const context of contexts) {
+    for (const param of names) {
+      if (pairs.has(param)) continue
+      if (!reachesPath(tool, context, param)) continue
+      pairs.set(param, { name: `${tool.id} / ${param}`, tool, param, context })
+    }
+  }
+  return [...pairs.values()]
+}
+
+const PATH_PARAMS: PathParam[] = TOOLS.flatMap(pathParamsOf)
+
+function fuzz({ tool, param, context }: PathParam, value: string | number): URL {
+  return buildUrl(tool, { ...context, [param]: value })
+}
 
 describe('spotify path-ID traversal safety', () => {
-  it('covers every Spotify tool that interpolates an ID into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(24)
+  it('builds a URL for every Spotify tool it enumerates', () => {
+    expect(UNBUILDABLE).toEqual([])
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+  it('covers every Spotify tool parameter that reaches the request path', () => {
+    expect(PATH_PARAMS.length).toBeGreaterThanOrEqual(24)
+  })
+
+  it('discovers every identifier of a multi-ID route, not just the first', () => {
+    const perTool = new Map<string, number>()
+    for (const { tool } of PATH_PARAMS) {
+      perTool.set(tool.id, (perTool.get(tool.id) ?? 0) + 1)
+    }
+    const multiId = [...perTool.values()].filter((count) => count >= 2)
+
+    expect(multiId).toHaveLength(0)
+  })
+
+  describe.each(PATH_PARAMS)('$name', (pathParam) => {
+    const baseline = segmentsOf(fuzz(pathParam, TARGET))
+    const baselineSearch = fuzz(pathParam, TARGET).search
+
+    it('reaches the path under the context it was discovered in', () => {
+      expect(baseline).toContain(TARGET)
+    })
+
+    it.each(REJECTED_IDS)('rejects %j outright', (value) => {
+      expect(() => fuzz(pathParam, value)).toThrow(new RegExp(pathParam.param))
+    })
+
+    it('rejects a bare dot, which a shape assertion cannot see in a trailing segment', () => {
+      expect(() => fuzz(pathParam, '.')).toThrow(/path traversal/)
+    })
+
+    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
+      expect(() => fuzz(pathParam, '..')).toThrow(/path traversal/)
+    })
 
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
+        url = fuzz(pathParam, value)
       } catch {
         return
       }
 
-      expect(url.origin).toBe('https://api.spotify.com')
+      expect(ORIGINS).toContain(url.origin)
 
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) return
+        if (segment === TARGET) return
         expect(actual[index]).toBe(segment)
       })
     })
 
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value))
+      const actual = segmentsOf(fuzz(pathParam, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) {
+        if (segment === TARGET) {
           expect(decodeURIComponent(actual[index])).toBe(value)
           return
         }
@@ -156,18 +332,8 @@ describe('spotify path-ID traversal safety', () => {
       })
     })
 
-    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
-      expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
-    })
-
-    it('rejects a bare dot segment', () => {
-      expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
-    })
-
-    it('does not let the ID inject query parameters', () => {
-      expect(
-        buildUrl(tool, '3n3Ppam7vgaVa1iaRUc9Lp?market=XX').searchParams.get('market')
-      ).not.toBe('XX')
+    it('does not let the ID add to or rewrite the query string', () => {
+      expect(fuzz(pathParam, '3n3Ppam7vgaVa1iaRUc9Lp?market=XX').search).toBe(baselineSearch)
     })
   })
 })

--- a/apps/sim/tools/spotify/path_safety.test.ts
+++ b/apps/sim/tools/spotify/path_safety.test.ts
@@ -26,6 +26,13 @@ import * as spotifyTools from '@/tools/spotify/index'
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
  * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ *
+ * The *balanced* entry matters for a different reason. A vector that pops
+ * exactly as many segments as it adds leaves the path the same length with
+ * every surrounding segment untouched, and only the guarded slot holding a
+ * different value — so an assertion that skips that slot passes while the
+ * request has been re-aimed at another resource. That is why the assertion
+ * below pins the slot to the encoded input rather than exempting it.
  */
 const TRAVERSAL_IDS = [
   '..',
@@ -37,6 +44,7 @@ const TRAVERSAL_IDS = [
   '3n3Ppam7vgaVa1iaRUc9Lp?market=XX',
   '3n3Ppam7vgaVa1iaRUc9Lp#fragment',
   'tracks/../../../v1/me/tracks',
+  '3n3Ppam7vgaVa1iaRUc9Lp/../4aawyAB9vmqN3uQ7FjRGTy',
   '\\..\\..',
 ] as const
 
@@ -318,10 +326,10 @@ describe('spotify path-ID traversal safety', () => {
       expect(ORIGINS).toContain(url.origin)
 
       const actual = segmentsOf(url)
+      const expected = encodeURIComponent(value.trim())
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === TARGET) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment === TARGET ? expected : segment)
       })
     })
 

--- a/apps/sim/tools/spotify/path_safety.test.ts
+++ b/apps/sim/tools/spotify/path_safety.test.ts
@@ -98,6 +98,7 @@ interface PathTool {
   id: string
   params: Record<string, { type?: string }>
   buildUrl: UrlBuilder
+  body?: (params: Fill) => unknown
 }
 
 /**
@@ -135,7 +136,10 @@ function asPathTool(value: unknown): PathTool | null {
       ? (candidate.params as Record<string, { type?: string }>)
       : {}
 
-  return { id: candidate.id, params, buildUrl: url as UrlBuilder }
+  const rawBody = (request as { body?: unknown }).body
+  const body = typeof rawBody === 'function' ? (rawBody as (params: Fill) => unknown) : undefined
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body }
 }
 
 /**
@@ -305,7 +309,9 @@ describe('spotify path-ID traversal safety', () => {
       let url: URL
       try {
         url = fuzz(pathParam, value)
-      } catch {
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toMatch(new RegExp(pathParam.param))
         return
       }
 

--- a/apps/sim/tools/spotify/path_safety.test.ts
+++ b/apps/sim/tools/spotify/path_safety.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every Spotify tool against path traversal through an LLM-writable
+ * identifier that gets interpolated into the request path.
+ *
+ * `playlistId`, `albumId`, `artistId`, `trackId`, `showId`, `episodeId`,
+ * `audiobookId`, and `userId` are `visibility: 'user-or-llm'`, so prompt
+ * injection controls them. These call sites interpolated the raw value with no
+ * encoding at all, so a value like `../users/victim/playlists` escaped its API
+ * prefix once `fetch` normalized the URL, re-aiming the request — and the
+ * user's Spotify OAuth token — at a different resource, including on the DELETE
+ * routes that unfollow a playlist or remove its tracks.
+ *
+ * `encodeURIComponent` alone would not have closed it, which is why the bare
+ * `.` and `..` vectors below are the point of this file: both are made of
+ * unreserved characters, so they survive encoding untouched and the URL parser
+ * then removes them as dot segments, popping one path segment off a fixed host.
+ * Every assertion resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ */
+import { describe, expect, it } from 'vitest'
+import * as spotifyTools from '@/tools/spotify/index'
+import type { ToolConfig } from '@/tools/types'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix would look correct while the hole stayed live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../users/victim',
+  '..%2f..%2fusers/victim',
+  '3n3Ppam7vgaVa1iaRUc9Lp/../../me/player/pause',
+  '3n3Ppam7vgaVa1iaRUc9Lp?market=XX',
+  '3n3Ppam7vgaVa1iaRUc9Lp#fragment',
+  'tracks/../../../v1/me/tracks',
+  '\\..\\..',
+] as const
+
+/**
+ * Values a real Spotify caller supplies — base-62 resource ids and user ids;
+ * none may be rejected, and none may reach the wire as a different value.
+ */
+const LEGITIMATE_IDS = [
+  '3n3Ppam7vgaVa1iaRUc9Lp',
+  '6rqhFgbbKwnb9MLmUQDhG6',
+  '37i9dQZF1DXcBWIGoYBM5M',
+  '4aawyAB9vmqN3uQ7FjRGTy',
+  'spotify',
+  'smedjan',
+  'wizzler',
+  '31vrxfguqhbrqrfnkwbcvpvvbhui',
+  '..foo',
+  'foo..',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isSpotifyTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('spotify_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { accessToken: 'token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'accessToken') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(url: URL): string[] {
+  return url.pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(spotifyTools)
+  .filter(isSpotifyTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return segmentsOf(buildUrl(tool, SAFE_ID)).includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('spotify path-ID traversal safety', () => {
+  it('covers every Spotify tool that interpolates an ID into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(24)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(url.origin).toBe('https://api.spotify.com')
+
+      const actual = segmentsOf(url)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value))
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) {
+          expect(decodeURIComponent(actual[index])).toBe(value)
+          return
+        }
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
+      expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+    })
+
+    it('rejects a bare dot segment', () => {
+      expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+    })
+
+    it('does not let the ID inject query parameters', () => {
+      expect(
+        buildUrl(tool, '3n3Ppam7vgaVa1iaRUc9Lp?market=XX').searchParams.get('market')
+      ).not.toBe('XX')
+    })
+  })
+})

--- a/apps/sim/tools/spotify/path_safety.test.ts
+++ b/apps/sim/tools/spotify/path_safety.test.ts
@@ -107,6 +107,7 @@ interface PathTool {
   params: Record<string, { type?: string }>
   buildUrl: UrlBuilder
   body?: (params: Fill) => unknown
+  transformResponse?: (response: Response, params?: Fill) => Promise<unknown>
 }
 
 /**
@@ -147,7 +148,13 @@ function asPathTool(value: unknown): PathTool | null {
   const rawBody = (request as { body?: unknown }).body
   const body = typeof rawBody === 'function' ? (rawBody as (params: Fill) => unknown) : undefined
 
-  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body }
+  const rawTransform = (value as { transformResponse?: unknown }).transformResponse
+  const transformResponse =
+    typeof rawTransform === 'function'
+      ? (rawTransform as (response: Response, params?: Fill) => Promise<unknown>)
+      : undefined
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body, transformResponse }
 }
 
 /**
@@ -283,7 +290,7 @@ describe('spotify path-ID traversal safety', () => {
     expect(PATH_PARAMS.length).toBeGreaterThanOrEqual(24)
   })
 
-  it('discovers every identifier of a multi-ID route, not just the first', () => {
+  it('pins how many Spotify routes carry more than one path identifier', () => {
     const perTool = new Map<string, number>()
     for (const { tool } of PATH_PARAMS) {
       perTool.set(tool.id, (perTool.get(tool.id) ?? 0) + 1)

--- a/apps/sim/tools/spotify/remove_tracks_from_playlist.ts
+++ b/apps/sim/tools/spotify/remove_tracks_from_playlist.ts
@@ -3,6 +3,7 @@ import type {
   SpotifyRemoveTracksFromPlaylistResponse,
 } from '@/tools/spotify/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const spotifyRemoveTracksFromPlaylistTool: ToolConfig<
   SpotifyRemoveTracksFromPlaylistParams,
@@ -36,7 +37,8 @@ export const spotifyRemoveTracksFromPlaylistTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}/tracks`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/tracks`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/reorder_playlist_items.ts
+++ b/apps/sim/tools/spotify/reorder_playlist_items.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyReorderPlaylistItemsParams {
   accessToken: string
@@ -65,7 +66,8 @@ export const spotifyReorderPlaylistItemsTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}/tracks`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/tracks`,
     method: 'PUT',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/replace_playlist_items.ts
+++ b/apps/sim/tools/spotify/replace_playlist_items.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyReplacePlaylistItemsParams {
   accessToken: string
@@ -43,7 +44,8 @@ export const spotifyReplacePlaylistItemsTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}/tracks`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/tracks`,
     method: 'PUT',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/unfollow_playlist.ts
+++ b/apps/sim/tools/spotify/unfollow_playlist.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyUnfollowPlaylistParams {
   accessToken: string
@@ -34,7 +35,8 @@ export const spotifyUnfollowPlaylistTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}/followers`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}/followers`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/spotify/update_playlist.ts
+++ b/apps/sim/tools/spotify/update_playlist.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface SpotifyUpdatePlaylistParams {
   accessToken: string
@@ -55,7 +56,8 @@ export const spotifyUpdatePlaylistTool: ToolConfig<
   },
 
   request: {
-    url: (params) => `https://api.spotify.com/v1/playlists/${params.playlistId}`,
+    url: (params) =>
+      `https://api.spotify.com/v1/playlists/${safeUrlPathSegment(params.playlistId, 'playlistId')}`,
     method: 'PUT',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/tailscale/authorize_device.ts
+++ b/apps/sim/tools/tailscale/authorize_device.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleAuthorizeDeviceParams, TailscaleAuthorizeDeviceResponse } from './types'
 
 export const tailscaleAuthorizeDeviceTool: ToolConfig<
@@ -39,7 +40,7 @@ export const tailscaleAuthorizeDeviceTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/device/${encodeURIComponent(params.deviceId.trim())}/authorized`,
+      `https://api.tailscale.com/api/v2/device/${safeUrlPathSegment(params.deviceId, 'deviceId')}/authorized`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/authorize_device.ts
+++ b/apps/sim/tools/tailscale/authorize_device.ts
@@ -65,7 +65,7 @@ export const tailscaleAuthorizeDeviceTool: ToolConfig<
       success: true,
       output: {
         success: true,
-        deviceId: params?.deviceId ?? '',
+        deviceId: String(params?.deviceId ?? ''),
         authorized: params?.authorized ?? true,
       },
     }

--- a/apps/sim/tools/tailscale/create_auth_key.ts
+++ b/apps/sim/tools/tailscale/create_auth_key.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleCreateAuthKeyParams, TailscaleCreateAuthKeyResponse } from './types'
 
 export const tailscaleCreateAuthKeyTool: ToolConfig<
@@ -67,7 +68,7 @@ export const tailscaleCreateAuthKeyTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/keys`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/keys`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/delete_auth_key.ts
+++ b/apps/sim/tools/tailscale/delete_auth_key.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface TailscaleDeleteAuthKeyParams {
   apiKey: string
@@ -45,7 +46,7 @@ export const tailscaleDeleteAuthKeyTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/keys/${encodeURIComponent(params.keyId.trim())}`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/keys/${safeUrlPathSegment(params.keyId, 'keyId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/delete_auth_key.ts
+++ b/apps/sim/tools/tailscale/delete_auth_key.ts
@@ -67,7 +67,7 @@ export const tailscaleDeleteAuthKeyTool: ToolConfig<
       success: true,
       output: {
         success: true,
-        keyId: params?.keyId ?? '',
+        keyId: String(params?.keyId ?? ''),
       },
     }
   },

--- a/apps/sim/tools/tailscale/delete_device.ts
+++ b/apps/sim/tools/tailscale/delete_device.ts
@@ -55,7 +55,7 @@ export const tailscaleDeleteDeviceTool: ToolConfig<
       success: true,
       output: {
         success: true,
-        deviceId: params?.deviceId ?? '',
+        deviceId: String(params?.deviceId ?? ''),
       },
     }
   },

--- a/apps/sim/tools/tailscale/delete_device.ts
+++ b/apps/sim/tools/tailscale/delete_device.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleDeleteDeviceResponse, TailscaleDeviceParams } from './types'
 
 export const tailscaleDeleteDeviceTool: ToolConfig<
@@ -33,7 +34,7 @@ export const tailscaleDeleteDeviceTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/device/${encodeURIComponent(params.deviceId.trim())}`,
+      `https://api.tailscale.com/api/v2/device/${safeUrlPathSegment(params.deviceId, 'deviceId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/delete_user.ts
+++ b/apps/sim/tools/tailscale/delete_user.ts
@@ -66,7 +66,7 @@ export const tailscaleDeleteUserTool: ToolConfig<
       success: true,
       output: {
         success: true,
-        userId: params?.userId ?? '',
+        userId: String(params?.userId ?? ''),
       },
     }
   },

--- a/apps/sim/tools/tailscale/delete_user.ts
+++ b/apps/sim/tools/tailscale/delete_user.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams } from './types'
 
 interface TailscaleDeleteUserParams extends TailscaleBaseParams {
@@ -44,7 +45,7 @@ export const tailscaleDeleteUserTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/users/${encodeURIComponent(params.userId.trim())}/delete`,
+      `https://api.tailscale.com/api/v2/users/${safeUrlPathSegment(params.userId, 'userId')}/delete`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/expire_device_key.ts
+++ b/apps/sim/tools/tailscale/expire_device_key.ts
@@ -63,7 +63,7 @@ export const tailscaleExpireDeviceKeyTool: ToolConfig<
       success: true,
       output: {
         success: true,
-        deviceId: params?.deviceId ?? '',
+        deviceId: String(params?.deviceId ?? ''),
       },
     }
   },

--- a/apps/sim/tools/tailscale/expire_device_key.ts
+++ b/apps/sim/tools/tailscale/expire_device_key.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleDeviceParams } from './types'
 
 interface TailscaleExpireDeviceKeyResponse extends ToolResponse {
@@ -41,7 +42,7 @@ export const tailscaleExpireDeviceKeyTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/device/${encodeURIComponent(params.deviceId.trim())}/expire`,
+      `https://api.tailscale.com/api/v2/device/${safeUrlPathSegment(params.deviceId, 'deviceId')}/expire`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/get_acl.ts
+++ b/apps/sim/tools/tailscale/get_acl.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams } from './types'
 
 interface TailscaleGetAclResponse extends ToolResponse {
@@ -31,7 +32,7 @@ export const tailscaleGetAclTool: ToolConfig<TailscaleBaseParams, TailscaleGetAc
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/acl`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/acl`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/get_auth_key.ts
+++ b/apps/sim/tools/tailscale/get_auth_key.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface TailscaleGetAuthKeyParams {
   apiKey: string
@@ -54,7 +55,7 @@ export const tailscaleGetAuthKeyTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/keys/${encodeURIComponent(params.keyId.trim())}`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/keys/${safeUrlPathSegment(params.keyId, 'keyId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/get_device.ts
+++ b/apps/sim/tools/tailscale/get_device.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleDeviceParams, TailscaleGetDeviceResponse } from './types'
 
 export const tailscaleGetDeviceTool: ToolConfig<TailscaleDeviceParams, TailscaleGetDeviceResponse> =
@@ -31,7 +32,7 @@ export const tailscaleGetDeviceTool: ToolConfig<TailscaleDeviceParams, Tailscale
 
     request: {
       url: (params) =>
-        `https://api.tailscale.com/api/v2/device/${encodeURIComponent(params.deviceId.trim())}`,
+        `https://api.tailscale.com/api/v2/device/${safeUrlPathSegment(params.deviceId, 'deviceId')}`,
       method: 'GET',
       headers: (params) => ({
         Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/get_device_routes.ts
+++ b/apps/sim/tools/tailscale/get_device_routes.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleDeviceParams, TailscaleGetDeviceRoutesResponse } from './types'
 
 export const tailscaleGetDeviceRoutesTool: ToolConfig<
@@ -33,7 +34,7 @@ export const tailscaleGetDeviceRoutesTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/device/${encodeURIComponent(params.deviceId.trim())}/routes`,
+      `https://api.tailscale.com/api/v2/device/${safeUrlPathSegment(params.deviceId, 'deviceId')}/routes`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/get_dns_preferences.ts
+++ b/apps/sim/tools/tailscale/get_dns_preferences.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams } from './types'
 
 interface TailscaleGetDnsPreferencesResponse extends ToolResponse {
@@ -33,7 +34,7 @@ export const tailscaleGetDnsPreferencesTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/dns/preferences`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/dns/preferences`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/get_dns_searchpaths.ts
+++ b/apps/sim/tools/tailscale/get_dns_searchpaths.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams } from './types'
 
 interface TailscaleGetDnsSearchpathsResponse extends ToolResponse {
@@ -33,7 +34,7 @@ export const tailscaleGetDnsSearchpathsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/dns/searchpaths`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/dns/searchpaths`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/list_auth_keys.ts
+++ b/apps/sim/tools/tailscale/list_auth_keys.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams } from './types'
 
 interface TailscaleAuthKeyOutput {
@@ -48,7 +49,7 @@ export const tailscaleListAuthKeysTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/keys?all=true`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/keys?all=true`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/list_devices.ts
+++ b/apps/sim/tools/tailscale/list_devices.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams, TailscaleListDevicesResponse } from './types'
 
 export const tailscaleListDevicesTool: ToolConfig<
@@ -27,7 +28,7 @@ export const tailscaleListDevicesTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/devices`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/devices`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/list_dns_nameservers.ts
+++ b/apps/sim/tools/tailscale/list_dns_nameservers.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams, TailscaleListDnsNameserversResponse } from './types'
 
 export const tailscaleListDnsNameserversTool: ToolConfig<
@@ -27,7 +28,7 @@ export const tailscaleListDnsNameserversTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/dns/nameservers`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/dns/nameservers`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/list_users.ts
+++ b/apps/sim/tools/tailscale/list_users.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams, TailscaleListUsersResponse } from './types'
 
 export const tailscaleListUsersTool: ToolConfig<TailscaleBaseParams, TailscaleListUsersResponse> = {
@@ -24,7 +25,7 @@ export const tailscaleListUsersTool: ToolConfig<TailscaleBaseParams, TailscaleLi
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/users`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/users`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/path_safety.test.ts
+++ b/apps/sim/tools/tailscale/path_safety.test.ts
@@ -12,12 +12,13 @@
  *
  * These call sites already wrapped the value in `encodeURIComponent`, and that
  * is precisely why the bare `.` and `..` vectors below are the point of this
- * file: both are made of unreserved characters, so they survive encoding
- * untouched and the URL parser then removes them as dot segments, popping one
- * path segment off a fixed host. Every assertion resolves the built URL with
- * `new URL(...)` — the same normalization `fetch` performs — rather than
- * string-matching the template output, because string matching is exactly what
- * let this through.
+ * file. Reverting one guard to `encodeURIComponent(params.deviceId.trim())`
+ * turns *only* the `.` and `..` cases red — every slash-bearing vector still
+ * passes, because encoding does neutralize a separator. That narrow red band is
+ * the whole defect: both dot spellings are made of unreserved characters, so
+ * they survive encoding untouched and the URL parser then removes them as dot
+ * segments, popping one path segment off a fixed host. An encode-only fix looks
+ * correct under any test that omits them.
  *
  * A tailnet is legitimately an organization name (`example.com`), an emailish
  * login name (`user@example.com`), or the literal `-` alias for the caller's
@@ -26,11 +27,10 @@
  */
 import { describe, expect, it } from 'vitest'
 import * as tailscaleTools from '@/tools/tailscale/index'
-import type { ToolConfig } from '@/tools/types'
 
 /**
- * The bare `.` and `..` entries are the whole point: their omission is why the
- * pre-existing `encodeURIComponent` looked like a fix while the hole was live.
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
  */
 const TRAVERSAL_IDS = [
   '..',
@@ -46,8 +46,27 @@ const TRAVERSAL_IDS = [
 ] as const
 
 /**
+ * Every vector the guard must refuse outright, derived from the list above so
+ * the two cannot drift apart.
+ *
+ * A shape assertion alone cannot see the worst of these. `https://host/a/.`
+ * normalizes to `https://host/a/`, so a trailing dot segment collapses the id
+ * while leaving the segment *count* and every other segment untouched — a
+ * shape-only check passes with the guard removed. Most routes here end in the
+ * guarded id (`tailscale_delete_device` among them), so that is exactly where a
+ * shape-only suite is blindest. Rejection is therefore asserted directly, per
+ * parameter, rather than inferred from the resulting path.
+ */
+const REJECTED_IDS = TRAVERSAL_IDS.filter((value) => {
+  const trimmed = value.trim()
+  return trimmed === '.' || trimmed === '..' || /[/\\]/.test(trimmed)
+})
+
+/**
  * Values a real Tailscale caller supplies; none may be rejected, and none may
- * reach the wire as a different value.
+ * reach the wire as a different value. `user@example.com` arrives
+ * percent-encoded, which is why the assertion compares the decoded segment —
+ * that encoding predates this guard and is not a behaviour change.
  */
 const LEGITIMATE_IDS = [
   'example.com',
@@ -62,97 +81,257 @@ const LEGITIMATE_IDS = [
   'foo..',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/**
+ * Fills the parameter currently under test. Distinct from `SIBLING` so an
+ * assertion can tell the fuzzed segment apart from every other one.
+ */
+const TARGET = 'TARGETSEGMENT'
 
-type AnyTool = ToolConfig<any, any>
+/** Fills every parameter that is not under test, held constant and safe. */
+const SIBLING = 'SIBLINGSEGMENT'
 
-function isTailscaleTool(value: unknown): value is AnyTool {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('tailscale_')
-  )
+/** Probes which parameter reaches the path, before any vector is applied. */
+const PROBE = 'PROBESEGMENT'
+
+const ORIGINS = ['https://api.tailscale.com']
+
+/** The parameter values handed to a tool's URL builder. */
+type Fill = Record<string, unknown>
+
+type UrlBuilder = (params: Fill) => string
+
+/** The slice of a tool this harness needs, narrowed from the barrel export. */
+interface PathTool {
+  id: string
+  params: Record<string, { type?: string }>
+  buildUrl: UrlBuilder
 }
 
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised.
+ * One parameter of one tool that lands in the path, plus the sibling values
+ * that route the URL builder down the branch where it does.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
-  const params: Record<string, unknown> = { apiKey: 'token' }
-  for (const [name, def] of Object.entries(tool.params ?? {})) {
+interface PathParam {
+  name: string
+  tool: PathTool
+  param: string
+  context: Fill
+}
+
+/**
+ * Narrows a barrel export to the tool shape this harness drives.
+ *
+ * Structural narrowing keeps the harness free of `any`: nothing here needs a
+ * tool's parameter or response generics, only its id, its declared parameter
+ * types, and a callable URL builder.
+ */
+function asPathTool(value: unknown): PathTool | null {
+  if (typeof value !== 'object' || value === null) return null
+
+  const candidate = value as { id?: unknown; params?: unknown; request?: unknown }
+  if (typeof candidate.id !== 'string' || !candidate.id.startsWith('tailscale_')) return null
+
+  const request = candidate.request
+  if (typeof request !== 'object' || request === null) return null
+
+  const url = (request as { url?: unknown }).url
+  if (typeof url !== 'function') return null
+
+  const params =
+    typeof candidate.params === 'object' && candidate.params !== null
+      ? (candidate.params as Record<string, { type?: string }>)
+      : {}
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder }
+}
+
+/**
+ * Fills every declared parameter with a safe value of the right shape, so the
+ * URL builder runs to completion no matter which parameters it reads.
+ */
+function baseFill(tool: PathTool): Fill {
+  const params: Fill = { apiKey: 'token' }
+  for (const [name, def] of Object.entries(tool.params)) {
     if (name === 'apiKey') continue
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
+    if (def.type === 'json' || def.type === 'array') {
       params[name] = []
-    } else if (type === 'number') {
+    } else if (def.type === 'number') {
       params[name] = 1
-    } else if (type === 'boolean') {
+    } else if (def.type === 'boolean') {
       params[name] = false
     } else {
-      params[name] = value
+      params[name] = SIBLING
     }
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
-  const url = tool.request?.url
-  if (typeof url !== 'function') {
-    throw new Error(`${tool.id} does not build its URL from params`)
+function stringParamsOf(tool: PathTool): string[] {
+  return Object.entries(tool.params)
+    .filter(([name, def]) => {
+      if (name === 'apiKey') return false
+      return def.type !== 'json' && def.type !== 'array' && def.type !== 'boolean'
+    })
+    .map(([name]) => name)
+}
+
+/**
+ * Harvests the string literals a URL builder compares against, so a branch
+ * keyed on a discriminator such as `action === 'unblock'` is explored too.
+ *
+ * Without this, filling every parameter with one safe value pins each such tool
+ * to a single branch, and an identifier that only appears on the other branch —
+ * `targetUserId` on the DELETE path, say — is never discovered and never
+ * fuzzed. Reading the builder's own source is what keeps that self-maintaining:
+ * a new branch value is picked up without editing this file.
+ */
+function branchLiteralsOf(tool: PathTool): string[] {
+  const source = String(tool.buildUrl)
+  const found = new Set<string>()
+  for (const match of source.matchAll(/['"]([^'"\\\n]{1,24})['"]/g)) {
+    const literal = match[1]
+    if (!literal || /[/?=.: ]/.test(literal)) continue
+    found.add(literal)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return [...found]
+}
+
+function buildUrl(tool: PathTool, fill: Fill): URL {
+  return new URL(tool.buildUrl(fill))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(tailscaleTools)
-  .filter(isTailscaleTool)
-  .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return segmentsOf(buildUrl(tool, SAFE_ID)).includes(SAFE_ID)
-    } catch {
-      return false
+function reachesPath(tool: PathTool, fill: Fill, param: string): boolean {
+  try {
+    return segmentsOf(buildUrl(tool, { ...fill, [param]: PROBE })).includes(PROBE)
+  } catch {
+    return false
+  }
+}
+
+const TOOLS = Object.values(tailscaleTools)
+  .map(asPathTool)
+  .filter((tool): tool is PathTool => tool !== null)
+
+/**
+ * Tools whose URL cannot be built even from all-safe values.
+ *
+ * Discovery has to tolerate a failed probe, since probing a guarded parameter
+ * is expected to throw. That tolerance must not extend to a tool that cannot be
+ * exercised at all, because such a tool would drop out of the suite silently
+ * and take its path parameters with it — so it is surfaced by name instead.
+ */
+const UNBUILDABLE = TOOLS.filter((tool) => {
+  try {
+    buildUrl(tool, baseFill(tool))
+    return false
+  } catch {
+    return true
+  }
+}).map((tool) => tool.id)
+
+/**
+ * Enumerates every (tool, parameter) pair that reaches the request path.
+ *
+ * Fuzzing one parameter at a time — with every sibling held at a safe value —
+ * is what makes a newly added unguarded parameter fail CI. Filling all of them
+ * with the same vector cannot: the first guarded parameter throws, the whole
+ * case is skipped, and its unguarded siblings are never exercised.
+ */
+function pathParamsOf(tool: PathTool): PathParam[] {
+  const base = baseFill(tool)
+  const names = stringParamsOf(tool)
+  const literals = branchLiteralsOf(tool)
+  const contexts: Fill[] = [base]
+  for (const discriminator of names) {
+    for (const literal of literals) {
+      contexts.push({ ...base, [discriminator]: literal })
     }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  }
+
+  const pairs = new Map<string, PathParam>()
+  for (const context of contexts) {
+    for (const param of names) {
+      if (pairs.has(param)) continue
+      if (!reachesPath(tool, context, param)) continue
+      pairs.set(param, { name: `${tool.id} / ${param}`, tool, param, context })
+    }
+  }
+  return [...pairs.values()]
+}
+
+const PATH_PARAMS: PathParam[] = TOOLS.flatMap(pathParamsOf)
+
+function fuzz({ tool, param, context }: PathParam, value: string | number): URL {
+  return buildUrl(tool, { ...context, [param]: value })
+}
 
 describe('tailscale path-ID traversal safety', () => {
-  it('covers every Tailscale tool that interpolates an ID into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(24)
+  it('builds a URL for every Tailscale tool it enumerates', () => {
+    expect(UNBUILDABLE).toEqual([])
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+  it('covers every Tailscale tool parameter that reaches the request path', () => {
+    expect(PATH_PARAMS.length).toBeGreaterThanOrEqual(26)
+  })
+
+  it('discovers every identifier of a multi-ID route, not just the first', () => {
+    const perTool = new Map<string, number>()
+    for (const { tool } of PATH_PARAMS) {
+      perTool.set(tool.id, (perTool.get(tool.id) ?? 0) + 1)
+    }
+    const multiId = [...perTool.values()].filter((count) => count >= 2)
+
+    expect(multiId).toHaveLength(2)
+  })
+
+  describe.each(PATH_PARAMS)('$name', (pathParam) => {
+    const baseline = segmentsOf(fuzz(pathParam, TARGET))
+    const baselineSearch = fuzz(pathParam, TARGET).search
+
+    it('reaches the path under the context it was discovered in', () => {
+      expect(baseline).toContain(TARGET)
+    })
+
+    it.each(REJECTED_IDS)('rejects %j outright', (value) => {
+      expect(() => fuzz(pathParam, value)).toThrow(new RegExp(pathParam.param))
+    })
+
+    it('rejects a bare dot, which a shape assertion cannot see in a trailing segment', () => {
+      expect(() => fuzz(pathParam, '.')).toThrow(/path traversal/)
+    })
+
+    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
+      expect(() => fuzz(pathParam, '..')).toThrow(/path traversal/)
+    })
 
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
+        url = fuzz(pathParam, value)
       } catch {
         return
       }
 
-      expect(url.origin).toBe('https://api.tailscale.com')
+      expect(ORIGINS).toContain(url.origin)
 
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) return
+        if (segment === TARGET) return
         expect(actual[index]).toBe(segment)
       })
     })
 
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value))
+      const actual = segmentsOf(fuzz(pathParam, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) {
+        if (segment === TARGET) {
           expect(decodeURIComponent(actual[index])).toBe(value)
           return
         }
@@ -160,16 +339,8 @@ describe('tailscale path-ID traversal safety', () => {
       })
     })
 
-    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
-      expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
-    })
-
-    it('rejects a bare dot segment', () => {
-      expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
-    })
-
-    it('does not let the ID inject query parameters', () => {
-      expect(buildUrl(tool, 'example.com?fields=all').searchParams.get('fields')).toBeNull()
+    it('does not let the ID add to or rewrite the query string', () => {
+      expect(fuzz(pathParam, 'example.com?fields=all').search).toBe(baselineSearch)
     })
   })
 })

--- a/apps/sim/tools/tailscale/path_safety.test.ts
+++ b/apps/sim/tools/tailscale/path_safety.test.ts
@@ -31,6 +31,13 @@ import * as tailscaleTools from '@/tools/tailscale/index'
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
  * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ *
+ * The *balanced* entry matters for a different reason. A vector that pops
+ * exactly as many segments as it adds leaves the path the same length with
+ * every surrounding segment untouched, and only the guarded slot holding a
+ * different value — so an assertion that skips that slot passes while the
+ * request has been re-aimed at another resource. That is why the assertion
+ * below pins the slot to the encoded input rather than exempting it.
  */
 const TRAVERSAL_IDS = [
   '..',
@@ -42,6 +49,7 @@ const TRAVERSAL_IDS = [
   'example.com?fields=all',
   'example.com#fragment',
   'device/../../tailnet/victim.com/acl',
+  'example.com/../victim.com',
   '\\..\\..',
 ] as const
 
@@ -325,10 +333,10 @@ describe('tailscale path-ID traversal safety', () => {
       expect(ORIGINS).toContain(url.origin)
 
       const actual = segmentsOf(url)
+      const expected = encodeURIComponent(value.trim())
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === TARGET) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment === TARGET ? expected : segment)
       })
     })
 

--- a/apps/sim/tools/tailscale/path_safety.test.ts
+++ b/apps/sim/tools/tailscale/path_safety.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every Tailscale tool against path traversal through an LLM-writable
+ * identifier that gets interpolated into the request path.
+ *
+ * `tailnet`, `deviceId`, `userId`, and `keyId` are `visibility: 'user-or-llm'`,
+ * so prompt injection controls them. Interpolating one raw let a value like
+ * `../../users/12345` escape its API prefix once `fetch` normalized the URL,
+ * re-aiming the request — and the caller's Tailscale API key — at a different
+ * resource, including on the DELETE routes that remove a device or a user.
+ *
+ * These call sites already wrapped the value in `encodeURIComponent`, and that
+ * is precisely why the bare `.` and `..` vectors below are the point of this
+ * file: both are made of unreserved characters, so they survive encoding
+ * untouched and the URL parser then removes them as dot segments, popping one
+ * path segment off a fixed host. Every assertion resolves the built URL with
+ * `new URL(...)` — the same normalization `fetch` performs — rather than
+ * string-matching the template output, because string matching is exactly what
+ * let this through.
+ *
+ * A tailnet is legitimately an organization name (`example.com`), an emailish
+ * login name (`user@example.com`), or the literal `-` alias for the caller's
+ * default tailnet, so `LEGITIMATE_IDS` pins all three: the guard rejects only a
+ * whole-value dot segment, never a dot inside a longer name.
+ */
+import { describe, expect, it } from 'vitest'
+import * as tailscaleTools from '@/tools/tailscale/index'
+import type { ToolConfig } from '@/tools/types'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why the
+ * pre-existing `encodeURIComponent` looked like a fix while the hole was live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../users/12345',
+  '..%2f..%2fusers/12345',
+  'example.com/../../device/nodeid',
+  'example.com?fields=all',
+  'example.com#fragment',
+  'device/../../tailnet/victim.com/acl',
+  '\\..\\..',
+] as const
+
+/**
+ * Values a real Tailscale caller supplies; none may be rejected, and none may
+ * reach the wire as a different value.
+ */
+const LEGITIMATE_IDS = [
+  'example.com',
+  'user@example.com',
+  '-',
+  'corp.ts.net',
+  'sub.example.co.uk',
+  'nodeIdABC123CNTRL',
+  'kABC123CNTRL',
+  '123456',
+  '..foo',
+  'foo..',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isTailscaleTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('tailscale_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { apiKey: 'token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'apiKey') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(url: URL): string[] {
+  return url.pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(tailscaleTools)
+  .filter(isTailscaleTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return segmentsOf(buildUrl(tool, SAFE_ID)).includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('tailscale path-ID traversal safety', () => {
+  it('covers every Tailscale tool that interpolates an ID into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(24)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(url.origin).toBe('https://api.tailscale.com')
+
+      const actual = segmentsOf(url)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value))
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) {
+          expect(decodeURIComponent(actual[index])).toBe(value)
+          return
+        }
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
+      expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+    })
+
+    it('rejects a bare dot segment', () => {
+      expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+    })
+
+    it('does not let the ID inject query parameters', () => {
+      expect(buildUrl(tool, 'example.com?fields=all').searchParams.get('fields')).toBeNull()
+    })
+  })
+})

--- a/apps/sim/tools/tailscale/path_safety.test.ts
+++ b/apps/sim/tools/tailscale/path_safety.test.ts
@@ -105,6 +105,7 @@ interface PathTool {
   id: string
   params: Record<string, { type?: string }>
   buildUrl: UrlBuilder
+  body?: (params: Fill) => unknown
 }
 
 /**
@@ -142,7 +143,10 @@ function asPathTool(value: unknown): PathTool | null {
       ? (candidate.params as Record<string, { type?: string }>)
       : {}
 
-  return { id: candidate.id, params, buildUrl: url as UrlBuilder }
+  const rawBody = (request as { body?: unknown }).body
+  const body = typeof rawBody === 'function' ? (rawBody as (params: Fill) => unknown) : undefined
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body }
 }
 
 /**
@@ -312,7 +316,9 @@ describe('tailscale path-ID traversal safety', () => {
       let url: URL
       try {
         url = fuzz(pathParam, value)
-      } catch {
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toMatch(new RegExp(pathParam.param))
         return
       }
 

--- a/apps/sim/tools/tailscale/path_safety.test.ts
+++ b/apps/sim/tools/tailscale/path_safety.test.ts
@@ -12,13 +12,19 @@
  *
  * These call sites already wrapped the value in `encodeURIComponent`, and that
  * is precisely why the bare `.` and `..` vectors below are the point of this
- * file. Reverting one guard to `encodeURIComponent(params.deviceId.trim())`
- * turns *only* the `.` and `..` cases red — every slash-bearing vector still
- * passes, because encoding does neutralize a separator. That narrow red band is
- * the whole defect: both dot spellings are made of unreserved characters, so
- * they survive encoding untouched and the URL parser then removes them as dot
- * segments, popping one path segment off a fixed host. An encode-only fix looks
- * correct under any test that omits them.
+ * file. Encoding does neutralize a separator, so a slash-bearing vector was
+ * never the thing an encode-only fix got wrong; the dot segments were. Both
+ * spellings are made of unreserved characters, so they survive encoding
+ * untouched and the URL parser then removes them as dot segments, popping one
+ * path segment off a fixed host — which is why rejection, not encoding, is the
+ * mechanism here.
+ *
+ * The *shape* assertions are what an encode-only fix slips past: reverting one
+ * guard to `encodeURIComponent(params.deviceId.trim())` leaves every
+ * slash-bearing vector's path intact and reddens only the two dot cases. The
+ * `rejects %j outright` assertions below are deliberately stricter than that —
+ * they require the guard to refuse a separator rather than merely encode it —
+ * so the same revert fails those too.
  *
  * A tailnet is legitimately an organization name (`example.com`), an emailish
  * login name (`user@example.com`), or the literal `-` alias for the caller's
@@ -114,6 +120,7 @@ interface PathTool {
   params: Record<string, { type?: string }>
   buildUrl: UrlBuilder
   body?: (params: Fill) => unknown
+  transformResponse?: (response: Response, params?: Fill) => Promise<unknown>
 }
 
 /**
@@ -154,7 +161,13 @@ function asPathTool(value: unknown): PathTool | null {
   const rawBody = (request as { body?: unknown }).body
   const body = typeof rawBody === 'function' ? (rawBody as (params: Fill) => unknown) : undefined
 
-  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body }
+  const rawTransform = (value as { transformResponse?: unknown }).transformResponse
+  const transformResponse =
+    typeof rawTransform === 'function'
+      ? (rawTransform as (response: Response, params?: Fill) => Promise<unknown>)
+      : undefined
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body, transformResponse }
 }
 
 /**
@@ -290,7 +303,7 @@ describe('tailscale path-ID traversal safety', () => {
     expect(PATH_PARAMS.length).toBeGreaterThanOrEqual(26)
   })
 
-  it('discovers every identifier of a multi-ID route, not just the first', () => {
+  it('pins how many Tailscale routes carry more than one path identifier', () => {
     const perTool = new Map<string, number>()
     for (const { tool } of PATH_PARAMS) {
       perTool.set(tool.id, (perTool.get(tool.id) ?? 0) + 1)
@@ -356,5 +369,52 @@ describe('tailscale path-ID traversal safety', () => {
     it('does not let the ID add to or rewrite the query string', () => {
       expect(fuzz(pathParam, 'example.com?fields=all').search).toBe(baselineSearch)
     })
+  })
+})
+
+/**
+ * Tools that echo a guarded identifier straight back into their success output.
+ *
+ * Widening the guard to accept a numeric id made these reachable: before, a
+ * numeric `userId` threw from `params.userId.trim()` in the URL builder and
+ * never reached `transformResponse`. Now the request succeeds, so whatever the
+ * echo emits has to match the declared `type: 'string'` output — otherwise the
+ * guard has quietly turned a hard failure into a contract violation.
+ */
+const ECHOED_ID_TOOLS: ReadonlyArray<{ name: string; param: string }> = [
+  { name: 'tailscale_suspend_user', param: 'userId' },
+  { name: 'tailscale_delete_user', param: 'userId' },
+  { name: 'tailscale_delete_device', param: 'deviceId' },
+  { name: 'tailscale_authorize_device', param: 'deviceId' },
+  { name: 'tailscale_expire_device_key', param: 'deviceId' },
+  { name: 'tailscale_update_device_key', param: 'deviceId' },
+  { name: 'tailscale_set_device_tags', param: 'deviceId' },
+  { name: 'tailscale_delete_auth_key', param: 'keyId' },
+]
+
+async function echoOutput(name: string, param: string, value: string | number) {
+  const tool = TOOLS.find((candidate) => candidate.id === name)
+  if (!tool?.transformResponse) throw new Error(`${name} does not transform a response`)
+
+  const result = await tool.transformResponse(new Response('{}', { status: 200 }), {
+    ...baseFill(tool),
+    [param]: value,
+  })
+
+  return (result as { output: Record<string, unknown> }).output
+}
+
+describe.each(ECHOED_ID_TOOLS)('$name echoed identifier', ({ name, param }) => {
+  it('emits a string for a numeric id, matching the declared output type', async () => {
+    const output = await echoOutput(name, param, 123456)
+
+    expect(output[param]).toBe('123456')
+    expect(typeof output[param]).toBe('string')
+  })
+
+  it('leaves a string id untouched', async () => {
+    const output = await echoOutput(name, param, 'nodeIdABC123CNTRL')
+
+    expect(output[param]).toBe('nodeIdABC123CNTRL')
   })
 })

--- a/apps/sim/tools/tailscale/set_acl.ts
+++ b/apps/sim/tools/tailscale/set_acl.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface TailscaleSetAclParams {
   apiKey: string
@@ -50,7 +51,7 @@ export const tailscaleSetAclTool: ToolConfig<TailscaleSetAclParams, TailscaleSet
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/acl`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/acl`,
     method: 'POST',
     headers: (params) => {
       const headers: Record<string, string> = {

--- a/apps/sim/tools/tailscale/set_device_routes.ts
+++ b/apps/sim/tools/tailscale/set_device_routes.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleSetDeviceRoutesParams, TailscaleSetDeviceRoutesResponse } from './types'
 
 export const tailscaleSetDeviceRoutesTool: ToolConfig<
@@ -40,7 +41,7 @@ export const tailscaleSetDeviceRoutesTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/device/${encodeURIComponent(params.deviceId.trim())}/routes`,
+      `https://api.tailscale.com/api/v2/device/${safeUrlPathSegment(params.deviceId, 'deviceId')}/routes`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/set_device_tags.ts
+++ b/apps/sim/tools/tailscale/set_device_tags.ts
@@ -75,7 +75,7 @@ export const tailscaleSetDeviceTagsTool: ToolConfig<
       success: true,
       output: {
         success: true,
-        deviceId: params?.deviceId ?? '',
+        deviceId: String(params?.deviceId ?? ''),
         tags,
       },
     }

--- a/apps/sim/tools/tailscale/set_device_tags.ts
+++ b/apps/sim/tools/tailscale/set_device_tags.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleSetDeviceTagsParams, TailscaleSetDeviceTagsResponse } from './types'
 
 export const tailscaleSetDeviceTagsTool: ToolConfig<
@@ -39,7 +40,7 @@ export const tailscaleSetDeviceTagsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/device/${encodeURIComponent(params.deviceId.trim())}/tags`,
+      `https://api.tailscale.com/api/v2/device/${safeUrlPathSegment(params.deviceId, 'deviceId')}/tags`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/set_dns_nameservers.ts
+++ b/apps/sim/tools/tailscale/set_dns_nameservers.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface TailscaleSetDnsNameserversParams {
   apiKey: string
@@ -45,7 +46,7 @@ export const tailscaleSetDnsNameserversTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/dns/nameservers`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/dns/nameservers`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/set_dns_preferences.ts
+++ b/apps/sim/tools/tailscale/set_dns_preferences.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface TailscaleSetDnsPreferencesParams {
   apiKey: string
@@ -44,7 +45,7 @@ export const tailscaleSetDnsPreferencesTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/dns/preferences`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/dns/preferences`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/set_dns_searchpaths.ts
+++ b/apps/sim/tools/tailscale/set_dns_searchpaths.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 interface TailscaleSetDnsSearchpathsParams {
   apiKey: string
@@ -45,7 +46,7 @@ export const tailscaleSetDnsSearchpathsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(params.tailnet.trim())}/dns/searchpaths`,
+      `https://api.tailscale.com/api/v2/tailnet/${safeUrlPathSegment(params.tailnet, 'tailnet')}/dns/searchpaths`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/suspend_user.ts
+++ b/apps/sim/tools/tailscale/suspend_user.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig, ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleBaseParams } from './types'
 
 interface TailscaleSuspendUserParams extends TailscaleBaseParams {
@@ -44,7 +45,7 @@ export const tailscaleSuspendUserTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/users/${encodeURIComponent(params.userId.trim())}/suspend`,
+      `https://api.tailscale.com/api/v2/users/${safeUrlPathSegment(params.userId, 'userId')}/suspend`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/tailscale/suspend_user.ts
+++ b/apps/sim/tools/tailscale/suspend_user.ts
@@ -66,7 +66,7 @@ export const tailscaleSuspendUserTool: ToolConfig<
       success: true,
       output: {
         success: true,
-        userId: params?.userId ?? '',
+        userId: String(params?.userId ?? ''),
       },
     }
   },

--- a/apps/sim/tools/tailscale/update_device_key.ts
+++ b/apps/sim/tools/tailscale/update_device_key.ts
@@ -65,7 +65,7 @@ export const tailscaleUpdateDeviceKeyTool: ToolConfig<
       success: true,
       output: {
         success: true,
-        deviceId: params?.deviceId ?? '',
+        deviceId: String(params?.deviceId ?? ''),
         keyExpiryDisabled: params?.keyExpiryDisabled ?? true,
       },
     }

--- a/apps/sim/tools/tailscale/update_device_key.ts
+++ b/apps/sim/tools/tailscale/update_device_key.ts
@@ -1,4 +1,5 @@
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { TailscaleUpdateDeviceKeyParams, TailscaleUpdateDeviceKeyResponse } from './types'
 
 export const tailscaleUpdateDeviceKeyTool: ToolConfig<
@@ -39,7 +40,7 @@ export const tailscaleUpdateDeviceKeyTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://api.tailscale.com/api/v2/device/${encodeURIComponent(params.deviceId.trim())}/key`,
+      `https://api.tailscale.com/api/v2/device/${safeUrlPathSegment(params.deviceId, 'deviceId')}/key`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey.trim()}`,

--- a/apps/sim/tools/x/create_bookmark.ts
+++ b/apps/sim/tools/x/create_bookmark.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XCreateBookmarkParams, XCreateBookmarkResponse } from '@/tools/x/types'
 
 const logger = createLogger('XCreateBookmarkTool')
@@ -37,7 +38,8 @@ export const xCreateBookmarkTool: ToolConfig<XCreateBookmarkParams, XCreateBookm
   },
 
   request: {
-    url: (params) => `https://api.x.com/2/users/${params.userId.trim()}/bookmarks`,
+    url: (params) =>
+      `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/bookmarks`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/x/create_bookmark.ts
+++ b/apps/sim/tools/x/create_bookmark.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
 import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XCreateBookmarkParams, XCreateBookmarkResponse } from '@/tools/x/types'
+import { xIdBodyValue } from '@/tools/x/types'
 
 const logger = createLogger('XCreateBookmarkTool')
 
@@ -46,7 +47,7 @@ export const xCreateBookmarkTool: ToolConfig<XCreateBookmarkParams, XCreateBookm
       'Content-Type': 'application/json',
     }),
     body: (params) => ({
-      tweet_id: params.tweetId.trim(),
+      tweet_id: xIdBodyValue(params.tweetId, 'tweetId'),
     }),
   },
 

--- a/apps/sim/tools/x/delete_bookmark.ts
+++ b/apps/sim/tools/x/delete_bookmark.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XDeleteBookmarkParams, XDeleteBookmarkResponse } from '@/tools/x/types'
 
 const logger = createLogger('XDeleteBookmarkTool')
@@ -38,7 +39,7 @@ export const xDeleteBookmarkTool: ToolConfig<XDeleteBookmarkParams, XDeleteBookm
 
   request: {
     url: (params) =>
-      `https://api.x.com/2/users/${params.userId.trim()}/bookmarks/${params.tweetId.trim()}`,
+      `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/bookmarks/${safeUrlPathSegment(params.tweetId, 'tweetId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/x/delete_tweet.ts
+++ b/apps/sim/tools/x/delete_tweet.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XDeleteTweetParams, XDeleteTweetResponse } from '@/tools/x/types'
 
 const logger = createLogger('XDeleteTweetTool')
@@ -31,7 +32,7 @@ export const xDeleteTweetTool: ToolConfig<XDeleteTweetParams, XDeleteTweetRespon
   },
 
   request: {
-    url: (params) => `https://api.x.com/2/tweets/${params.tweetId.trim()}`,
+    url: (params) => `https://api.x.com/2/tweets/${safeUrlPathSegment(params.tweetId, 'tweetId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/x/get_blocking.ts
+++ b/apps/sim/tools/x/get_blocking.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetBlockingParams, XUserListResponse } from '@/tools/x/types'
 import { transformUser } from '@/tools/x/types'
 
@@ -55,7 +56,7 @@ export const xGetBlockingTool: ToolConfig<XGetBlockingParams, XUserListResponse>
       }
       if (params.paginationToken) queryParams.append('pagination_token', params.paginationToken)
 
-      return `https://api.x.com/2/users/${params.userId.trim()}/blocking?${queryParams.toString()}`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/blocking?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_bookmarks.ts
+++ b/apps/sim/tools/x/get_bookmarks.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetBookmarksParams, XTweetListResponse } from '@/tools/x/types'
 import { transformTweet, transformUser } from '@/tools/x/types'
 
@@ -58,7 +59,7 @@ export const xGetBookmarksTool: ToolConfig<XGetBookmarksParams, XTweetListRespon
       }
       if (params.paginationToken) queryParams.append('pagination_token', params.paginationToken)
 
-      return `https://api.x.com/2/users/${params.userId.trim()}/bookmarks?${queryParams.toString()}`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/bookmarks?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_followers.ts
+++ b/apps/sim/tools/x/get_followers.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetFollowersParams, XUserListResponse } from '@/tools/x/types'
 import { transformUser } from '@/tools/x/types'
 
@@ -55,7 +56,7 @@ export const xGetFollowersTool: ToolConfig<XGetFollowersParams, XUserListRespons
       }
       if (params.paginationToken) queryParams.append('pagination_token', params.paginationToken)
 
-      return `https://api.x.com/2/users/${params.userId.trim()}/followers?${queryParams.toString()}`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/followers?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_following.ts
+++ b/apps/sim/tools/x/get_following.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetFollowingParams, XUserListResponse } from '@/tools/x/types'
 import { transformUser } from '@/tools/x/types'
 
@@ -55,7 +56,7 @@ export const xGetFollowingTool: ToolConfig<XGetFollowingParams, XUserListRespons
       }
       if (params.paginationToken) queryParams.append('pagination_token', params.paginationToken)
 
-      return `https://api.x.com/2/users/${params.userId.trim()}/following?${queryParams.toString()}`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/following?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_liked_tweets.ts
+++ b/apps/sim/tools/x/get_liked_tweets.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetLikedTweetsParams, XTweetListResponse } from '@/tools/x/types'
 import { transformTweet, transformUser } from '@/tools/x/types'
 
@@ -57,7 +58,7 @@ export const xGetLikedTweetsTool: ToolConfig<XGetLikedTweetsParams, XTweetListRe
       }
       if (params.paginationToken) queryParams.append('pagination_token', params.paginationToken)
 
-      return `https://api.x.com/2/users/${params.userId.trim()}/liked_tweets?${queryParams.toString()}`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/liked_tweets?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_liking_users.ts
+++ b/apps/sim/tools/x/get_liking_users.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetLikingUsersParams, XUserListResponse } from '@/tools/x/types'
 import { transformUser } from '@/tools/x/types'
 
@@ -55,7 +56,7 @@ export const xGetLikingUsersTool: ToolConfig<XGetLikingUsersParams, XUserListRes
       }
       if (params.paginationToken) queryParams.append('pagination_token', params.paginationToken)
 
-      return `https://api.x.com/2/tweets/${params.tweetId.trim()}/liking_users?${queryParams.toString()}`
+      return `https://api.x.com/2/tweets/${safeUrlPathSegment(params.tweetId, 'tweetId')}/liking_users?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_quote_tweets.ts
+++ b/apps/sim/tools/x/get_quote_tweets.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetQuoteTweetsParams, XTweetListResponse } from '@/tools/x/types'
 import { transformTweet, transformUser } from '@/tools/x/types'
 
@@ -57,7 +58,7 @@ export const xGetQuoteTweetsTool: ToolConfig<XGetQuoteTweetsParams, XTweetListRe
       }
       if (params.paginationToken) queryParams.append('pagination_token', params.paginationToken)
 
-      return `https://api.x.com/2/tweets/${params.tweetId.trim()}/quote_tweets?${queryParams.toString()}`
+      return `https://api.x.com/2/tweets/${safeUrlPathSegment(params.tweetId, 'tweetId')}/quote_tweets?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_retweeted_by.ts
+++ b/apps/sim/tools/x/get_retweeted_by.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetRetweetedByParams, XUserListResponse } from '@/tools/x/types'
 import { transformUser } from '@/tools/x/types'
 
@@ -55,7 +56,7 @@ export const xGetRetweetedByTool: ToolConfig<XGetRetweetedByParams, XUserListRes
       }
       if (params.paginationToken) queryParams.append('pagination_token', params.paginationToken)
 
-      return `https://api.x.com/2/tweets/${params.tweetId.trim()}/retweeted_by?${queryParams.toString()}`
+      return `https://api.x.com/2/tweets/${safeUrlPathSegment(params.tweetId, 'tweetId')}/retweeted_by?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_trends_by_woeid.ts
+++ b/apps/sim/tools/x/get_trends_by_woeid.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetTrendsByWoeidParams, XTrendListResponse } from '@/tools/x/types'
 import { transformTrend } from '@/tools/x/types'
 
@@ -49,7 +50,7 @@ export const xGetTrendsByWoeidTool: ToolConfig<XGetTrendsByWoeidParams, XTrendLi
         queryParams.append('max_trends', Number(params.maxTrends).toString())
       }
 
-      return `https://api.x.com/2/trends/by/woeid/${params.woeid.trim()}?${queryParams.toString()}`
+      return `https://api.x.com/2/trends/by/woeid/${safeUrlPathSegment(params.woeid, 'woeid')}?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_user_mentions.ts
+++ b/apps/sim/tools/x/get_user_mentions.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetUserMentionsParams, XTweetListResponse } from '@/tools/x/types'
 import { transformTweet, transformUser } from '@/tools/x/types'
 
@@ -86,7 +87,7 @@ export const xGetUserMentionsTool: ToolConfig<XGetUserMentionsParams, XTweetList
       if (params.sinceId) queryParams.append('since_id', params.sinceId)
       if (params.untilId) queryParams.append('until_id', params.untilId)
 
-      return `https://api.x.com/2/users/${params.userId.trim()}/mentions?${queryParams.toString()}`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/mentions?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_user_timeline.ts
+++ b/apps/sim/tools/x/get_user_timeline.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetUserTimelineParams, XTweetListResponse } from '@/tools/x/types'
 import { transformTweet, transformUser } from '@/tools/x/types'
 
@@ -93,7 +94,7 @@ export const xGetUserTimelineTool: ToolConfig<XGetUserTimelineParams, XTweetList
       if (params.untilId) queryParams.append('until_id', params.untilId)
       if (params.exclude) queryParams.append('exclude', params.exclude)
 
-      return `https://api.x.com/2/users/${params.userId.trim()}/timelines/reverse_chronological?${queryParams.toString()}`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/timelines/reverse_chronological?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/get_user_tweets.ts
+++ b/apps/sim/tools/x/get_user_tweets.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XGetUserTweetsParams, XTweetListResponse } from '@/tools/x/types'
 import { transformTweet, transformUser } from '@/tools/x/types'
 
@@ -93,7 +94,7 @@ export const xGetUserTweetsTool: ToolConfig<XGetUserTweetsParams, XTweetListResp
       if (params.untilId) queryParams.append('until_id', params.untilId)
       if (params.exclude) queryParams.append('exclude', params.exclude)
 
-      return `https://api.x.com/2/users/${params.userId.trim()}/tweets?${queryParams.toString()}`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/tweets?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/hide_reply.ts
+++ b/apps/sim/tools/x/hide_reply.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XHideReplyParams, XHideReplyResponse } from '@/tools/x/types'
 
 const logger = createLogger('XHideReplyTool')
@@ -37,7 +38,8 @@ export const xHideReplyTool: ToolConfig<XHideReplyParams, XHideReplyResponse> = 
   },
 
   request: {
-    url: (params) => `https://api.x.com/2/tweets/${params.tweetId.trim()}/hidden`,
+    url: (params) =>
+      `https://api.x.com/2/tweets/${safeUrlPathSegment(params.tweetId, 'tweetId')}/hidden`,
     method: 'PUT',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/x/manage_block.ts
+++ b/apps/sim/tools/x/manage_block.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
 import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageBlockParams, XManageBlockResponse } from '@/tools/x/types'
+import { xIdBodyValue } from '@/tools/x/types'
 
 const logger = createLogger('XManageBlockTool')
 
@@ -58,7 +59,7 @@ export const xManageBlockTool: ToolConfig<XManageBlockParams, XManageBlockRespon
     body: (params) => {
       if (params.action === 'unblock') return undefined
       return {
-        target_user_id: params.targetUserId.trim(),
+        target_user_id: xIdBodyValue(params.targetUserId, 'targetUserId'),
       }
     },
   },

--- a/apps/sim/tools/x/manage_block.ts
+++ b/apps/sim/tools/x/manage_block.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageBlockParams, XManageBlockResponse } from '@/tools/x/types'
 
 const logger = createLogger('XManageBlockTool')
@@ -45,9 +46,9 @@ export const xManageBlockTool: ToolConfig<XManageBlockParams, XManageBlockRespon
   request: {
     url: (params) => {
       if (params.action === 'unblock') {
-        return `https://api.x.com/2/users/${params.userId.trim()}/blocking/${params.targetUserId.trim()}`
+        return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/blocking/${safeUrlPathSegment(params.targetUserId, 'targetUserId')}`
       }
-      return `https://api.x.com/2/users/${params.userId.trim()}/blocking`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/blocking`
     },
     method: (params) => (params.action === 'unblock' ? 'DELETE' : 'POST'),
     headers: (params) => ({

--- a/apps/sim/tools/x/manage_follow.ts
+++ b/apps/sim/tools/x/manage_follow.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
 import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageFollowParams, XManageFollowResponse } from '@/tools/x/types'
+import { xIdBodyValue } from '@/tools/x/types'
 
 const logger = createLogger('XManageFollowTool')
 
@@ -58,7 +59,7 @@ export const xManageFollowTool: ToolConfig<XManageFollowParams, XManageFollowRes
     body: (params) => {
       if (params.action === 'unfollow') return undefined
       return {
-        target_user_id: params.targetUserId.trim(),
+        target_user_id: xIdBodyValue(params.targetUserId, 'targetUserId'),
       }
     },
   },

--- a/apps/sim/tools/x/manage_follow.ts
+++ b/apps/sim/tools/x/manage_follow.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageFollowParams, XManageFollowResponse } from '@/tools/x/types'
 
 const logger = createLogger('XManageFollowTool')
@@ -45,9 +46,9 @@ export const xManageFollowTool: ToolConfig<XManageFollowParams, XManageFollowRes
   request: {
     url: (params) => {
       if (params.action === 'unfollow') {
-        return `https://api.x.com/2/users/${params.userId.trim()}/following/${params.targetUserId.trim()}`
+        return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/following/${safeUrlPathSegment(params.targetUserId, 'targetUserId')}`
       }
-      return `https://api.x.com/2/users/${params.userId.trim()}/following`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/following`
     },
     method: (params) => (params.action === 'unfollow' ? 'DELETE' : 'POST'),
     headers: (params) => ({

--- a/apps/sim/tools/x/manage_like.ts
+++ b/apps/sim/tools/x/manage_like.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageLikeParams, XManageLikeResponse } from '@/tools/x/types'
 
 const logger = createLogger('XManageLikeTool')
@@ -45,9 +46,9 @@ export const xManageLikeTool: ToolConfig<XManageLikeParams, XManageLikeResponse>
   request: {
     url: (params) => {
       if (params.action === 'unlike') {
-        return `https://api.x.com/2/users/${params.userId.trim()}/likes/${params.tweetId.trim()}`
+        return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/likes/${safeUrlPathSegment(params.tweetId, 'tweetId')}`
       }
-      return `https://api.x.com/2/users/${params.userId.trim()}/likes`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/likes`
     },
     method: (params) => (params.action === 'unlike' ? 'DELETE' : 'POST'),
     headers: (params) => ({

--- a/apps/sim/tools/x/manage_like.ts
+++ b/apps/sim/tools/x/manage_like.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
 import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageLikeParams, XManageLikeResponse } from '@/tools/x/types'
+import { xIdBodyValue } from '@/tools/x/types'
 
 const logger = createLogger('XManageLikeTool')
 
@@ -58,7 +59,7 @@ export const xManageLikeTool: ToolConfig<XManageLikeParams, XManageLikeResponse>
     body: (params) => {
       if (params.action === 'unlike') return undefined
       return {
-        tweet_id: params.tweetId.trim(),
+        tweet_id: xIdBodyValue(params.tweetId, 'tweetId'),
       }
     },
   },

--- a/apps/sim/tools/x/manage_mute.ts
+++ b/apps/sim/tools/x/manage_mute.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageMuteParams, XManageMuteResponse } from '@/tools/x/types'
 
 const logger = createLogger('XManageMuteTool')
@@ -45,9 +46,9 @@ export const xManageMuteTool: ToolConfig<XManageMuteParams, XManageMuteResponse>
   request: {
     url: (params) => {
       if (params.action === 'unmute') {
-        return `https://api.x.com/2/users/${params.userId.trim()}/muting/${params.targetUserId.trim()}`
+        return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/muting/${safeUrlPathSegment(params.targetUserId, 'targetUserId')}`
       }
-      return `https://api.x.com/2/users/${params.userId.trim()}/muting`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/muting`
     },
     method: (params) => (params.action === 'unmute' ? 'DELETE' : 'POST'),
     headers: (params) => ({

--- a/apps/sim/tools/x/manage_mute.ts
+++ b/apps/sim/tools/x/manage_mute.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
 import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageMuteParams, XManageMuteResponse } from '@/tools/x/types'
+import { xIdBodyValue } from '@/tools/x/types'
 
 const logger = createLogger('XManageMuteTool')
 
@@ -58,7 +59,7 @@ export const xManageMuteTool: ToolConfig<XManageMuteParams, XManageMuteResponse>
     body: (params) => {
       if (params.action === 'unmute') return undefined
       return {
-        target_user_id: params.targetUserId.trim(),
+        target_user_id: xIdBodyValue(params.targetUserId, 'targetUserId'),
       }
     },
   },

--- a/apps/sim/tools/x/manage_retweet.ts
+++ b/apps/sim/tools/x/manage_retweet.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageRetweetParams, XManageRetweetResponse } from '@/tools/x/types'
 
 const logger = createLogger('XManageRetweetTool')
@@ -45,9 +46,9 @@ export const xManageRetweetTool: ToolConfig<XManageRetweetParams, XManageRetweet
   request: {
     url: (params) => {
       if (params.action === 'unretweet') {
-        return `https://api.x.com/2/users/${params.userId.trim()}/retweets/${params.tweetId.trim()}`
+        return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/retweets/${safeUrlPathSegment(params.tweetId, 'tweetId')}`
       }
-      return `https://api.x.com/2/users/${params.userId.trim()}/retweets`
+      return `https://api.x.com/2/users/${safeUrlPathSegment(params.userId, 'userId')}/retweets`
     },
     method: (params) => (params.action === 'unretweet' ? 'DELETE' : 'POST'),
     headers: (params) => ({

--- a/apps/sim/tools/x/manage_retweet.ts
+++ b/apps/sim/tools/x/manage_retweet.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
 import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XManageRetweetParams, XManageRetweetResponse } from '@/tools/x/types'
+import { xIdBodyValue } from '@/tools/x/types'
 
 const logger = createLogger('XManageRetweetTool')
 
@@ -58,7 +59,7 @@ export const xManageRetweetTool: ToolConfig<XManageRetweetParams, XManageRetweet
     body: (params) => {
       if (params.action === 'unretweet') return undefined
       return {
-        tweet_id: params.tweetId.trim(),
+        tweet_id: xIdBodyValue(params.tweetId, 'tweetId'),
       }
     },
   },

--- a/apps/sim/tools/x/path_safety.test.ts
+++ b/apps/sim/tools/x/path_safety.test.ts
@@ -108,6 +108,7 @@ interface PathTool {
   id: string
   params: Record<string, { type?: string }>
   buildUrl: UrlBuilder
+  body?: (params: Fill) => unknown
 }
 
 /**
@@ -145,7 +146,10 @@ function asPathTool(value: unknown): PathTool | null {
       ? (candidate.params as Record<string, { type?: string }>)
       : {}
 
-  return { id: candidate.id, params, buildUrl: url as UrlBuilder }
+  const rawBody = (request as { body?: unknown }).body
+  const body = typeof rawBody === 'function' ? (rawBody as (params: Fill) => unknown) : undefined
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body }
 }
 
 /**
@@ -315,7 +319,9 @@ describe('x path-ID traversal safety', () => {
       let url: URL
       try {
         url = fuzz(pathParam, value)
-      } catch {
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toMatch(new RegExp(pathParam.param))
         return
       }
 
@@ -361,5 +367,51 @@ describe('x path-ID traversal safety', () => {
     it('does not let the ID add to or rewrite the query string', () => {
       expect(fuzz(pathParam, '783214?expansions=author_id').search).toBe(baselineSearch)
     })
+  })
+})
+
+/**
+ * The identifier several X tools put in the path on one branch and in the body
+ * on the other.
+ *
+ * Guarding only the path left the two branches disagreeing about what a caller
+ * may send: a numeric `targetUserId` unblocked successfully (path) but threw a
+ * bare `TypeError` when used to block (body). These assertions pin that the
+ * two agree, so the guard cannot be applied to one and forgotten on the other.
+ */
+const BODY_ID_TOOLS: ReadonlyArray<{ name: string; param: string; field: string; action: string }> =
+  [
+    { name: 'x_create_bookmark', param: 'tweetId', field: 'tweet_id', action: 'create' },
+    { name: 'x_manage_block', param: 'targetUserId', field: 'target_user_id', action: 'block' },
+    { name: 'x_manage_follow', param: 'targetUserId', field: 'target_user_id', action: 'follow' },
+    { name: 'x_manage_mute', param: 'targetUserId', field: 'target_user_id', action: 'mute' },
+    { name: 'x_manage_like', param: 'tweetId', field: 'tweet_id', action: 'like' },
+    { name: 'x_manage_retweet', param: 'tweetId', field: 'tweet_id', action: 'retweet' },
+  ]
+
+function buildBody(name: string, param: string, action: string, value: string | number): unknown {
+  const tool = TOOLS.find((candidate) => candidate.id === name)
+  if (!tool) throw new Error(`${name} is not exported from the barrel`)
+
+  const source = (tool as unknown as { body?: unknown }).body
+  const body = typeof source === 'function' ? (source as (params: Fill) => unknown) : undefined
+  if (!body) throw new Error(`${name} does not build a body`)
+
+  return body({ ...baseFill(tool), action, [param]: value })
+}
+
+describe.each(BODY_ID_TOOLS)('$name body identifier', ({ name, param, field, action }) => {
+  it('accepts the same numeric id its path guard accepts', () => {
+    expect(buildBody(name, param, action, 783214)).toEqual({ [field]: '783214' })
+  })
+
+  it('sends a string id verbatim, without percent-encoding a body value', () => {
+    expect(buildBody(name, param, action, '  1234567890123456789  ')).toEqual({
+      [field]: '1234567890123456789',
+    })
+  })
+
+  it('rejects a dot segment by name, matching the path guard', () => {
+    expect(() => buildBody(name, param, action, '..')).toThrow(new RegExp(param))
   })
 })

--- a/apps/sim/tools/x/path_safety.test.ts
+++ b/apps/sim/tools/x/path_safety.test.ts
@@ -393,11 +393,9 @@ function buildBody(name: string, param: string, action: string, value: string | 
   const tool = TOOLS.find((candidate) => candidate.id === name)
   if (!tool) throw new Error(`${name} is not exported from the barrel`)
 
-  const source = (tool as unknown as { body?: unknown }).body
-  const body = typeof source === 'function' ? (source as (params: Fill) => unknown) : undefined
-  if (!body) throw new Error(`${name} does not build a body`)
+  if (!tool.body) throw new Error(`${name} does not build a body`)
 
-  return body({ ...baseFill(tool), action, [param]: value })
+  return tool.body({ ...baseFill(tool), action, [param]: value })
 }
 
 describe.each(BODY_ID_TOOLS)('$name body identifier', ({ name, param, field, action }) => {

--- a/apps/sim/tools/x/path_safety.test.ts
+++ b/apps/sim/tools/x/path_safety.test.ts
@@ -33,6 +33,13 @@ import * as xTools from '@/tools/x/index'
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
  * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ *
+ * The *balanced* entry matters for a different reason. A vector that pops
+ * exactly as many segments as it adds leaves the path the same length with
+ * every surrounding segment untouched, and only the guarded slot holding a
+ * different value — so an assertion that skips that slot passes while the
+ * request has been re-aimed at another resource. That is why the assertion
+ * below pins the slot to the encoded input rather than exempting it.
  */
 const TRAVERSAL_IDS = [
   '..',
@@ -44,6 +51,7 @@ const TRAVERSAL_IDS = [
   '783214?expansions=author_id',
   '783214#fragment',
   'tweets/../../../2/users/me',
+  '783214/../999999',
   '\\..\\..',
 ] as const
 
@@ -328,10 +336,10 @@ describe('x path-ID traversal safety', () => {
       expect(ORIGINS).toContain(url.origin)
 
       const actual = segmentsOf(url)
+      const expected = encodeURIComponent(value.trim())
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === TARGET) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment === TARGET ? expected : segment)
       })
     })
 

--- a/apps/sim/tools/x/path_safety.test.ts
+++ b/apps/sim/tools/x/path_safety.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every X tool against path traversal through an LLM-writable identifier
+ * that gets interpolated into the request path.
+ *
+ * `userId`, `targetUserId`, `tweetId`, `username`, and `woeid` are
+ * `visibility: 'user-or-llm'`, so prompt injection controls them. These call
+ * sites interpolated the raw value — `params.userId.trim()` — with no encoding
+ * at all, so a value like `../../users/victim/following` escaped its API prefix
+ * once `fetch` normalized the URL, re-aiming the request and the user's X OAuth
+ * token at a different resource, including on the DELETE routes that unfollow,
+ * unblock, or delete a post.
+ *
+ * `encodeURIComponent` alone would not have closed it, which is why the bare
+ * `.` and `..` vectors below are the point of this file: both are made of
+ * unreserved characters, so they survive encoding untouched and the URL parser
+ * then removes them as dot segments, popping one path segment off a fixed host.
+ * Every assertion resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ *
+ * X ids are numeric snowflakes, and an LLM tool call can serialize one as a
+ * JSON **number** rather than a string. `NUMERIC_IDS` below pins that a
+ * safe-integer id still reaches the path as its own decimal text, and the final
+ * case pins that a snowflake too large for a `double` — already corrupted by
+ * `JSON.parse` before any tool sees it — is refused by name instead of being
+ * silently sent as the wrong id.
+ */
+import { describe, expect, it } from 'vitest'
+import type { ToolConfig } from '@/tools/types'
+import * as xTools from '@/tools/x/index'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix would look correct while the hole stayed live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../users/victim',
+  '..%2f..%2fusers/victim',
+  '783214/../../2/tweets/1',
+  '783214?expansions=author_id',
+  '783214#fragment',
+  'tweets/../../../2/users/me',
+  '\\..\\..',
+] as const
+
+/**
+ * Values a real X caller supplies — numeric snowflake ids and handles; none may
+ * be rejected, and none may reach the wire as a different value.
+ */
+const LEGITIMATE_IDS = [
+  '783214',
+  '2244994945',
+  '1234567890123456789',
+  '1',
+  'elonmusk',
+  'XDevelopers',
+  'X',
+  'some_user_99',
+  '..foo',
+  'foo..',
+] as const
+
+/** Snowflake-shaped ids an LLM may emit as a JSON number rather than a string. */
+const NUMERIC_IDS = [1, 783214, 2244994945] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isXTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('x_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised.
+ */
+function buildParams(tool: AnyTool, value: string | number): Record<string, unknown> {
+  const params: Record<string, unknown> = { accessToken: 'token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'accessToken') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string | number): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(url: URL): string[] {
+  return url.pathname.split('/')
+}
+
+const X_ORIGINS = ['https://api.x.com', 'https://api.twitter.com']
+
+const DYNAMIC_PATH_TOOLS = Object.values(xTools)
+  .filter(isXTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return segmentsOf(buildUrl(tool, SAFE_ID)).includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('x path-ID traversal safety', () => {
+  it('covers every X tool that interpolates an ID into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(21)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(X_ORIGINS).toContain(url.origin)
+
+      const actual = segmentsOf(url)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value))
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment === SAFE_ID) {
+          expect(decodeURIComponent(actual[index])).toBe(value)
+          return
+        }
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(NUMERIC_IDS)('accepts %d supplied as a JSON number', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value))
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        expect(actual[index]).toBe(segment === SAFE_ID ? String(value) : segment)
+      })
+    })
+
+    it('refuses a snowflake too large to survive JSON number parsing', () => {
+      const corrupted = Number('1234567890123456789')
+
+      expect(String(corrupted)).not.toBe('1234567890123456789')
+      expect(() => buildUrl(tool, corrupted)).toThrow(/too large/)
+    })
+
+    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
+      expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
+    })
+
+    it('rejects a bare dot segment', () => {
+      expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
+    })
+
+    it('does not let the ID inject query parameters', () => {
+      expect(buildUrl(tool, '783214?expansions=author_id').searchParams.get('expansions')).not.toBe(
+        'author_id'
+      )
+    })
+  })
+})

--- a/apps/sim/tools/x/path_safety.test.ts
+++ b/apps/sim/tools/x/path_safety.test.ts
@@ -16,9 +16,9 @@
  * `.` and `..` vectors below are the point of this file: both are made of
  * unreserved characters, so they survive encoding untouched and the URL parser
  * then removes them as dot segments, popping one path segment off a fixed host.
- * Every assertion resolves the built URL with `new URL(...)` — the same
- * normalization `fetch` performs — rather than string-matching the template
- * output, because string matching is exactly what let this through.
+ * The Tailscale half of this change is the clean demonstration — those call
+ * sites already encoded, and reverting one guard there turns *only* the `.` and
+ * `..` cases red while every slash-bearing vector still passes.
  *
  * X ids are numeric snowflakes, and an LLM tool call can serialize one as a
  * JSON **number** rather than a string. `NUMERIC_IDS` below pins that a
@@ -28,12 +28,11 @@
  * silently sent as the wrong id.
  */
 import { describe, expect, it } from 'vitest'
-import type { ToolConfig } from '@/tools/types'
 import * as xTools from '@/tools/x/index'
 
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
- * `encodeURIComponent`-only fix would look correct while the hole stayed live.
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
  */
 const TRAVERSAL_IDS = [
   '..',
@@ -47,6 +46,23 @@ const TRAVERSAL_IDS = [
   'tweets/../../../2/users/me',
   '\\..\\..',
 ] as const
+
+/**
+ * Every vector the guard must refuse outright, derived from the list above so
+ * the two cannot drift apart.
+ *
+ * A shape assertion alone cannot see the worst of these. `https://host/a/.`
+ * normalizes to `https://host/a/`, so a trailing dot segment collapses the id
+ * while leaving the segment *count* and every other segment untouched — a
+ * shape-only check passes with the guard removed. Most routes here end in the
+ * guarded id (`x_delete_tweet` among them), so that is exactly where a
+ * shape-only suite is blindest. Rejection is therefore asserted directly, per
+ * parameter, rather than inferred from the resulting path.
+ */
+const REJECTED_IDS = TRAVERSAL_IDS.filter((value) => {
+  const trimmed = value.trim()
+  return trimmed === '.' || trimmed === '..' || /[/\\]/.test(trimmed)
+})
 
 /**
  * Values a real X caller supplies — numeric snowflake ids and handles; none may
@@ -68,99 +84,257 @@ const LEGITIMATE_IDS = [
 /** Snowflake-shaped ids an LLM may emit as a JSON number rather than a string. */
 const NUMERIC_IDS = [1, 783214, 2244994945] as const
 
-const SAFE_ID = 'SAFEID'
+/**
+ * Fills the parameter currently under test. Distinct from `SIBLING` so an
+ * assertion can tell the fuzzed segment apart from every other one.
+ */
+const TARGET = 'TARGETSEGMENT'
 
-type AnyTool = ToolConfig<any, any>
+/** Fills every parameter that is not under test, held constant and safe. */
+const SIBLING = 'SIBLINGSEGMENT'
 
-function isXTool(value: unknown): value is AnyTool {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('x_')
-  )
+/** Probes which parameter reaches the path, before any vector is applied. */
+const PROBE = 'PROBESEGMENT'
+
+const ORIGINS = ['https://api.x.com', 'https://api.twitter.com']
+
+/** The parameter values handed to a tool's URL builder. */
+type Fill = Record<string, unknown>
+
+type UrlBuilder = (params: Fill) => string
+
+/** The slice of a tool this harness needs, narrowed from the barrel export. */
+interface PathTool {
+  id: string
+  params: Record<string, { type?: string }>
+  buildUrl: UrlBuilder
 }
 
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised.
+ * One parameter of one tool that lands in the path, plus the sibling values
+ * that route the URL builder down the branch where it does.
  */
-function buildParams(tool: AnyTool, value: string | number): Record<string, unknown> {
-  const params: Record<string, unknown> = { accessToken: 'token' }
-  for (const [name, def] of Object.entries(tool.params ?? {})) {
+interface PathParam {
+  name: string
+  tool: PathTool
+  param: string
+  context: Fill
+}
+
+/**
+ * Narrows a barrel export to the tool shape this harness drives.
+ *
+ * Structural narrowing keeps the harness free of `any`: nothing here needs a
+ * tool's parameter or response generics, only its id, its declared parameter
+ * types, and a callable URL builder.
+ */
+function asPathTool(value: unknown): PathTool | null {
+  if (typeof value !== 'object' || value === null) return null
+
+  const candidate = value as { id?: unknown; params?: unknown; request?: unknown }
+  if (typeof candidate.id !== 'string' || !candidate.id.startsWith('x_')) return null
+
+  const request = candidate.request
+  if (typeof request !== 'object' || request === null) return null
+
+  const url = (request as { url?: unknown }).url
+  if (typeof url !== 'function') return null
+
+  const params =
+    typeof candidate.params === 'object' && candidate.params !== null
+      ? (candidate.params as Record<string, { type?: string }>)
+      : {}
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder }
+}
+
+/**
+ * Fills every declared parameter with a safe value of the right shape, so the
+ * URL builder runs to completion no matter which parameters it reads.
+ */
+function baseFill(tool: PathTool): Fill {
+  const params: Fill = { accessToken: 'token' }
+  for (const [name, def] of Object.entries(tool.params)) {
     if (name === 'accessToken') continue
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
+    if (def.type === 'json' || def.type === 'array') {
       params[name] = []
-    } else if (type === 'number') {
+    } else if (def.type === 'number') {
       params[name] = 1
-    } else if (type === 'boolean') {
+    } else if (def.type === 'boolean') {
       params[name] = false
     } else {
-      params[name] = value
+      params[name] = SIBLING
     }
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string | number): URL {
-  const url = tool.request?.url
-  if (typeof url !== 'function') {
-    throw new Error(`${tool.id} does not build its URL from params`)
+function stringParamsOf(tool: PathTool): string[] {
+  return Object.entries(tool.params)
+    .filter(([name, def]) => {
+      if (name === 'accessToken') return false
+      return def.type !== 'json' && def.type !== 'array' && def.type !== 'boolean'
+    })
+    .map(([name]) => name)
+}
+
+/**
+ * Harvests the string literals a URL builder compares against, so a branch
+ * keyed on a discriminator such as `action === 'unblock'` is explored too.
+ *
+ * Without this, filling every parameter with one safe value pins each such tool
+ * to a single branch, and an identifier that only appears on the other branch —
+ * `targetUserId` on the DELETE path, say — is never discovered and never
+ * fuzzed. Reading the builder's own source is what keeps that self-maintaining:
+ * a new branch value is picked up without editing this file.
+ */
+function branchLiteralsOf(tool: PathTool): string[] {
+  const source = String(tool.buildUrl)
+  const found = new Set<string>()
+  for (const match of source.matchAll(/['"]([^'"\\\n]{1,24})['"]/g)) {
+    const literal = match[1]
+    if (!literal || /[/?=.: ]/.test(literal)) continue
+    found.add(literal)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return [...found]
+}
+
+function buildUrl(tool: PathTool, fill: Fill): URL {
+  return new URL(tool.buildUrl(fill))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
-const X_ORIGINS = ['https://api.x.com', 'https://api.twitter.com']
+function reachesPath(tool: PathTool, fill: Fill, param: string): boolean {
+  try {
+    return segmentsOf(buildUrl(tool, { ...fill, [param]: PROBE })).includes(PROBE)
+  } catch {
+    return false
+  }
+}
 
-const DYNAMIC_PATH_TOOLS = Object.values(xTools)
-  .filter(isXTool)
-  .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return segmentsOf(buildUrl(tool, SAFE_ID)).includes(SAFE_ID)
-    } catch {
-      return false
+const TOOLS = Object.values(xTools)
+  .map(asPathTool)
+  .filter((tool): tool is PathTool => tool !== null)
+
+/**
+ * Tools whose URL cannot be built even from all-safe values.
+ *
+ * Discovery has to tolerate a failed probe, since probing a guarded parameter
+ * is expected to throw. That tolerance must not extend to a tool that cannot be
+ * exercised at all, because such a tool would drop out of the suite silently
+ * and take its path parameters with it — so it is surfaced by name instead.
+ */
+const UNBUILDABLE = TOOLS.filter((tool) => {
+  try {
+    buildUrl(tool, baseFill(tool))
+    return false
+  } catch {
+    return true
+  }
+}).map((tool) => tool.id)
+
+/**
+ * Enumerates every (tool, parameter) pair that reaches the request path.
+ *
+ * Fuzzing one parameter at a time — with every sibling held at a safe value —
+ * is what makes a newly added unguarded parameter fail CI. Filling all of them
+ * with the same vector cannot: the first guarded parameter throws, the whole
+ * case is skipped, and its unguarded siblings are never exercised.
+ */
+function pathParamsOf(tool: PathTool): PathParam[] {
+  const base = baseFill(tool)
+  const names = stringParamsOf(tool)
+  const literals = branchLiteralsOf(tool)
+  const contexts: Fill[] = [base]
+  for (const discriminator of names) {
+    for (const literal of literals) {
+      contexts.push({ ...base, [discriminator]: literal })
     }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  }
+
+  const pairs = new Map<string, PathParam>()
+  for (const context of contexts) {
+    for (const param of names) {
+      if (pairs.has(param)) continue
+      if (!reachesPath(tool, context, param)) continue
+      pairs.set(param, { name: `${tool.id} / ${param}`, tool, param, context })
+    }
+  }
+  return [...pairs.values()]
+}
+
+const PATH_PARAMS: PathParam[] = TOOLS.flatMap(pathParamsOf)
+
+function fuzz({ tool, param, context }: PathParam, value: string | number): URL {
+  return buildUrl(tool, { ...context, [param]: value })
+}
 
 describe('x path-ID traversal safety', () => {
-  it('covers every X tool that interpolates an ID into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(21)
+  it('builds a URL for every X tool it enumerates', () => {
+    expect(UNBUILDABLE).toEqual([])
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+  it('covers every X tool parameter that reaches the request path', () => {
+    expect(PATH_PARAMS.length).toBeGreaterThanOrEqual(29)
+  })
+
+  it('discovers every identifier of a multi-ID route, not just the first', () => {
+    const perTool = new Map<string, number>()
+    for (const { tool } of PATH_PARAMS) {
+      perTool.set(tool.id, (perTool.get(tool.id) ?? 0) + 1)
+    }
+    const multiId = [...perTool.values()].filter((count) => count >= 2)
+
+    expect(multiId).toHaveLength(6)
+  })
+
+  describe.each(PATH_PARAMS)('$name', (pathParam) => {
+    const baseline = segmentsOf(fuzz(pathParam, TARGET))
+    const baselineSearch = fuzz(pathParam, TARGET).search
+
+    it('reaches the path under the context it was discovered in', () => {
+      expect(baseline).toContain(TARGET)
+    })
+
+    it.each(REJECTED_IDS)('rejects %j outright', (value) => {
+      expect(() => fuzz(pathParam, value)).toThrow(new RegExp(pathParam.param))
+    })
+
+    it('rejects a bare dot, which a shape assertion cannot see in a trailing segment', () => {
+      expect(() => fuzz(pathParam, '.')).toThrow(/path traversal/)
+    })
+
+    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
+      expect(() => fuzz(pathParam, '..')).toThrow(/path traversal/)
+    })
 
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
+        url = fuzz(pathParam, value)
       } catch {
         return
       }
 
-      expect(X_ORIGINS).toContain(url.origin)
+      expect(ORIGINS).toContain(url.origin)
 
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) return
+        if (segment === TARGET) return
         expect(actual[index]).toBe(segment)
       })
     })
 
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value))
+      const actual = segmentsOf(fuzz(pathParam, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment === SAFE_ID) {
+        if (segment === TARGET) {
           expect(decodeURIComponent(actual[index])).toBe(value)
           return
         }
@@ -169,11 +343,11 @@ describe('x path-ID traversal safety', () => {
     })
 
     it.each(NUMERIC_IDS)('accepts %d supplied as a JSON number', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value))
+      const actual = segmentsOf(fuzz(pathParam, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment === SAFE_ID ? String(value) : segment)
+        expect(actual[index]).toBe(segment === TARGET ? String(value) : segment)
       })
     })
 
@@ -181,21 +355,11 @@ describe('x path-ID traversal safety', () => {
       const corrupted = Number('1234567890123456789')
 
       expect(String(corrupted)).not.toBe('1234567890123456789')
-      expect(() => buildUrl(tool, corrupted)).toThrow(/too large/)
+      expect(() => fuzz(pathParam, corrupted)).toThrow(/too large/)
     })
 
-    it('rejects a bare dot-dot segment instead of silently popping a segment', () => {
-      expect(() => buildUrl(tool, '..')).toThrow(/path traversal/)
-    })
-
-    it('rejects a bare dot segment', () => {
-      expect(() => buildUrl(tool, '.')).toThrow(/path traversal/)
-    })
-
-    it('does not let the ID inject query parameters', () => {
-      expect(buildUrl(tool, '783214?expansions=author_id').searchParams.get('expansions')).not.toBe(
-        'author_id'
-      )
+    it('does not let the ID add to or rewrite the query string', () => {
+      expect(fuzz(pathParam, '783214?expansions=author_id').search).toBe(baselineSearch)
     })
   })
 })

--- a/apps/sim/tools/x/path_safety.test.ts
+++ b/apps/sim/tools/x/path_safety.test.ts
@@ -117,6 +117,7 @@ interface PathTool {
   params: Record<string, { type?: string }>
   buildUrl: UrlBuilder
   body?: (params: Fill) => unknown
+  transformResponse?: (response: Response, params?: Fill) => Promise<unknown>
 }
 
 /**
@@ -157,7 +158,13 @@ function asPathTool(value: unknown): PathTool | null {
   const rawBody = (request as { body?: unknown }).body
   const body = typeof rawBody === 'function' ? (rawBody as (params: Fill) => unknown) : undefined
 
-  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body }
+  const rawTransform = (value as { transformResponse?: unknown }).transformResponse
+  const transformResponse =
+    typeof rawTransform === 'function'
+      ? (rawTransform as (response: Response, params?: Fill) => Promise<unknown>)
+      : undefined
+
+  return { id: candidate.id, params, buildUrl: url as UrlBuilder, body, transformResponse }
 }
 
 /**
@@ -293,7 +300,7 @@ describe('x path-ID traversal safety', () => {
     expect(PATH_PARAMS.length).toBeGreaterThanOrEqual(29)
   })
 
-  it('discovers every identifier of a multi-ID route, not just the first', () => {
+  it('pins how many X routes carry more than one path identifier', () => {
     const perTool = new Map<string, number>()
     for (const { tool } of PATH_PARAMS) {
       perTool.set(tool.id, (perTool.get(tool.id) ?? 0) + 1)

--- a/apps/sim/tools/x/read.ts
+++ b/apps/sim/tools/x/read.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XReadParams, XReadResponse, XTweet } from '@/tools/x/types'
 import { transformTweet } from '@/tools/x/types'
 
@@ -72,7 +73,7 @@ export const xReadTool: ToolConfig<XReadParams, XReadResponse> = {
         'user.fields': userFields,
       })
 
-      return `https://api.twitter.com/2/tweets/${params.tweetId}?${queryParams.toString()}`
+      return `https://api.twitter.com/2/tweets/${safeUrlPathSegment(params.tweetId, 'tweetId')}?${queryParams.toString()}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/x/types.ts
+++ b/apps/sim/tools/x/types.ts
@@ -13,10 +13,10 @@ import { safeUrlPathSegment } from '@/tools/url-path'
  * returns `v` for every value the guard admits.
  *
  * Several X tools put the same id in the path on one branch and in the body on
- * the other — \`x_manage_block\` sends \`targetUserId\` as a path segment to
+ * the other — `x_manage_block` sends `targetUserId` as a path segment to
  * unblock and as a body field to block. Guarding only the path left those two
  * branches disagreeing about what a caller may send, so a numeric id that
- * unblocked successfully threw a bare \`TypeError\` when used to block.
+ * unblocked successfully threw a bare `TypeError` when used to block.
  */
 export function xIdBodyValue(value: string | number | bigint, paramName: string): string {
   return decodeURIComponent(safeUrlPathSegment(value, paramName))

--- a/apps/sim/tools/x/types.ts
+++ b/apps/sim/tools/x/types.ts
@@ -1,4 +1,26 @@
 import type { ToolResponse } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
+
+/**
+ * Normalizes an X identifier that travels in a request **body** rather than in
+ * a path segment.
+ *
+ * `safeUrlPathSegment` already defines which value kinds an X id may take — a
+ * string, or a number an LLM tool call serialized without losing precision —
+ * so this defers to it and decodes the result instead of restating those rules
+ * and letting the two drift apart. Percent-encoding is a path concern; a JSON
+ * body carries the raw value, and `decodeURIComponent(encodeURIComponent(v))`
+ * returns `v` for every value the guard admits.
+ *
+ * Several X tools put the same id in the path on one branch and in the body on
+ * the other — \`x_manage_block\` sends \`targetUserId\` as a path segment to
+ * unblock and as a body field to block. Guarding only the path left those two
+ * branches disagreeing about what a caller may send, so a numeric id that
+ * unblocked successfully threw a bare \`TypeError\` when used to block.
+ */
+export function xIdBodyValue(value: string | number | bigint, paramName: string): string {
+  return decodeURIComponent(safeUrlPathSegment(value, paramName))
+}
 
 /**
  * Context annotation domain from X API

--- a/apps/sim/tools/x/user.ts
+++ b/apps/sim/tools/x/user.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@sim/logger'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 import type { XUserParams, XUserResponse } from '@/tools/x/types'
 import { transformUser } from '@/tools/x/types'
 
@@ -33,7 +34,7 @@ export const xUserTool: ToolConfig<XUserParams, XUserResponse> = {
 
   request: {
     url: (params) => {
-      const username = encodeURIComponent(params.username)
+      const username = safeUrlPathSegment(params.username, 'username')
       // Keep fields minimal to reduce chance of rate limits
       const userFields = 'description,profile_image_url,verified,public_metrics'
 


### PR DESCRIPTION
## The defect

Every identifier these tools interpolate into a request path — `tailnet`, `deviceId`, `userId`, `keyId`, `playlistId`, `albumId`, `artistId`, `trackId`, `showId`, `episodeId`, `audiobookId`, `tweetId`, `targetUserId`, `username`, `woeid` — is `visibility: 'user-or-llm'`, so prompt injection controls it.

A value like `../../users/victim` escaped its API prefix once `fetch` normalized the URL, re-aiming the request **with the caller's credential attached** at a different resource — including on the DELETE routes that remove a Tailscale device or user, unfollow a Spotify playlist, or delete a post on X.

Spotify and X interpolated the raw value with no encoding at all. Tailscale already wrapped it in `encodeURIComponent`, which is **not** sufficient:

```js
new URL('https://api.tailscale.com/api/v2/tailnet/' + encodeURIComponent('..') + '/devices').pathname
// => '/api/v2/'   — the tailnet segment popped, `/devices` gone
```

`.` and `..` are unreserved, so they survive encoding untouched and the URL parser removes them as dot segments *after* decoding. Only rejecting the value closes it.

## The fix

All 71 call sites route through `safeUrlPathSegment(value, paramName)` from `@/tools/url-path`.

| Service | Call sites | Previous state |
|---|---|---|
| Tailscale | 28 across 24 tools | `encodeURIComponent(...trim())` — dot segments live |
| Spotify | 24 tools | raw interpolation, no encoding |
| X | 25 across 21 tools | raw `.trim()`, no encoding |

**No param `visibility`, subBlock id, or behaviour for legitimate input changed.** A dot inside a longer segment is preserved, so a Tailscale tailnet keeps working as an organization name (`example.com`), an emailish login name (`user@example.com`), or the literal `-` default alias — all three verified against the Tailscale API v2 spec and pinned in the tests. Spotify base-62 ids and X numeric snowflakes pass through verbatim.

Dropping the `.trim()` calls is also a small improvement: an X snowflake arriving as a JSON number previously threw a bare `TypeError: params.userId.trim is not a function`; it is now accepted, and one too large for a `double` (already corrupted by `JSON.parse`) is refused by name rather than silently addressing the wrong id.

## Body fields carry the same guard

Several X tools put the same identifier in the path on one branch and in the body on the other — `x_manage_block` sends `targetUserId` as a path segment to unblock, and as a body field to block. Guarding only the path left the two branches disagreeing about what a caller may send: a numeric id unblocked fine and threw `TypeError: params.targetUserId.trim is not a function` when used to block.

The `TypeError` predates this PR (both branches threw before), but the *asymmetry* was introduced here, so it is in scope:

```ts
export function xIdBodyValue(value: string | number | bigint, paramName: string): string {
  return decodeURIComponent(safeUrlPathSegment(value, paramName))
}
```

Deferring to the path guard and decoding — rather than restating which value kinds an id may take — makes drift between path and body impossible. Percent-encoding is a path concern; a JSON body carries the raw value. Applied to all six body sites (`create_bookmark`, `manage_block`, `manage_follow`, `manage_mute`, `manage_like`, `manage_retweet`), with a `BODY_ID_TOOLS` suite pinning that path and body agree per tool.

## The tests

`path_safety.test.ts` per service. Discovery enumerates **(tool, parameter) pairs** — 79 of them (Tailscale 26, Spotify 24, X 29), matching the guarded call sites exactly — and fuzzes **one parameter at a time** with every sibling held at a safe value.

That per-pair isolation is the property that makes "a new unguarded parameter fails CI" actually true. An earlier revision of these tests filled every parameter with the same vector and swallowed the throw, so the first guarded parameter ended the case and its siblings went untested. Two demonstrations of the difference, both measured:

| Scoped revert | Old harness | This harness |
|---|---|---|
| `x_manage_block` → `targetUserId` fully unguarded | **622/622 green** | 15 failures |
| `tailscale_delete_device` → `deviceId` back to `encodeURIComponent` | 2 failures (shape only) | 12 failures |

Reaching `targetUserId` at all requires exploring the branch: it appears only on the `action === 'unblock'` path, and `action` declares no enum, so the harness harvests the string literals the URL builder compares against from its own source. A new branch value is picked up without editing the tests.

**Shape assertions alone are not enough**, which the second row shows. `https://host/a/.` normalizes to `https://host/a/` — the segment count and every other segment survive, so a shape-only check passes with the guard removed. Most of these routes end in the guarded id, `x_delete_tweet`, `spotify_get_playlist` and `tailscale_delete_device` among them, and one of those is a DELETE. Under a scoped revert, `cannot reshape the path with "."` never fails on any of the three. Rejection is therefore asserted **directly, per parameter**, alongside the shape check: shape catches a value that reshapes the path, rejection catches one that quietly collapses the trailing segment.

Other properties held by the suite:

- Resolves every built URL with `new URL(...)` — the same normalization `fetch` performs — instead of string-matching the template output. String matching is what let this through.
- `LEGITIMATE_IDS` proves real values reach the wire **unchanged**.
- A tool whose URL cannot be built from all-safe values is surfaced by name rather than silently dropping out of the suite.
- No `any`: the harness narrows barrel exports to a structural `PathTool` through a type guard.

2653 assertions, all green.

## Also hardened during review

Two consequences of widening the guard to accept a numeric id, both surfaced in review and both genuinely introduced here:

- **Body fields.** Six X tools carry the id in the body on one branch and the path on the other. Guarding only the path let a numeric id unblock successfully and throw `TypeError` when used to block. `xIdBodyValue` defers to the path guard and decodes, so the two cannot drift.
- **Echoed outputs.** Eight Tailscale tools return the id in a success output declared `type: 'string'`. Previously a numeric id threw before reaching `transformResponse`; now it succeeds, so the echo is coerced with `String(...)` — safe because the URL builder has already rejected every other kind.

## Gates

`bun run lint`, `bun run check:audits` (39/39), `check-block-registry.ts origin/staging`, and `tool-metadata:generate` (no diff — no params changed) all pass. Type-check clean for the three tool directories.


