### PR TITLE
fix(security): reject path-traversal IDs in Google Vault, AgentMail and Algolia tools

### DIFF
--- a/apps/sim/tools/agentmail/create_draft.ts
+++ b/apps/sim/tools/agentmail/create_draft.ts
@@ -1,5 +1,6 @@
 import type { CreateDraftParams, CreateDraftResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailCreateDraftTool: ToolConfig<CreateDraftParams, CreateDraftResult> = {
   id: 'agentmail_create_draft',
@@ -71,7 +72,8 @@ export const agentmailCreateDraftTool: ToolConfig<CreateDraftParams, CreateDraft
   },
 
   request: {
-    url: (params) => `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/drafts`,
+    url: (params) =>
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/drafts`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/delete_draft.ts
+++ b/apps/sim/tools/agentmail/delete_draft.ts
@@ -1,5 +1,6 @@
 import type { DeleteDraftParams, DeleteDraftResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailDeleteDraftTool: ToolConfig<DeleteDraftParams, DeleteDraftResult> = {
   id: 'agentmail_delete_draft',
@@ -30,7 +31,7 @@ export const agentmailDeleteDraftTool: ToolConfig<DeleteDraftParams, DeleteDraft
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/drafts/${params.draftId.trim()}`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/drafts/${safeUrlPathSegment(params.draftId, 'draftId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/delete_inbox.ts
+++ b/apps/sim/tools/agentmail/delete_inbox.ts
@@ -1,5 +1,6 @@
 import type { DeleteInboxParams, DeleteInboxResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailDeleteInboxTool: ToolConfig<DeleteInboxParams, DeleteInboxResult> = {
   id: 'agentmail_delete_inbox',
@@ -23,7 +24,8 @@ export const agentmailDeleteInboxTool: ToolConfig<DeleteInboxParams, DeleteInbox
   },
 
   request: {
-    url: (params) => `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}`,
+    url: (params) =>
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/delete_thread.ts
+++ b/apps/sim/tools/agentmail/delete_thread.ts
@@ -1,5 +1,6 @@
 import type { DeleteThreadParams, DeleteThreadResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailDeleteThreadTool: ToolConfig<DeleteThreadParams, DeleteThreadResult> = {
   id: 'agentmail_delete_thread',
@@ -40,7 +41,7 @@ export const agentmailDeleteThreadTool: ToolConfig<DeleteThreadParams, DeleteThr
       const query = new URLSearchParams()
       if (params.permanent) query.set('permanent', 'true')
       const qs = query.toString()
-      return `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/threads/${params.threadId.trim()}${qs ? `?${qs}` : ''}`
+      return `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/threads/${safeUrlPathSegment(params.threadId, 'threadId')}${qs ? `?${qs}` : ''}`
     },
     method: 'DELETE',
     headers: (params) => ({

--- a/apps/sim/tools/agentmail/forward_message.ts
+++ b/apps/sim/tools/agentmail/forward_message.ts
@@ -1,5 +1,6 @@
 import type { ForwardMessageParams, ForwardMessageResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailForwardMessageTool: ToolConfig<ForwardMessageParams, ForwardMessageResult> = {
   id: 'agentmail_forward_message',
@@ -66,7 +67,7 @@ export const agentmailForwardMessageTool: ToolConfig<ForwardMessageParams, Forwa
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/messages/${params.messageId.trim()}/forward`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/messages/${safeUrlPathSegment(params.messageId, 'messageId')}/forward`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/get_draft.ts
+++ b/apps/sim/tools/agentmail/get_draft.ts
@@ -1,5 +1,6 @@
 import type { GetDraftParams, GetDraftResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailGetDraftTool: ToolConfig<GetDraftParams, GetDraftResult> = {
   id: 'agentmail_get_draft',
@@ -30,7 +31,7 @@ export const agentmailGetDraftTool: ToolConfig<GetDraftParams, GetDraftResult> =
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/drafts/${params.draftId.trim()}`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/drafts/${safeUrlPathSegment(params.draftId, 'draftId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/get_inbox.ts
+++ b/apps/sim/tools/agentmail/get_inbox.ts
@@ -1,5 +1,6 @@
 import type { GetInboxParams, GetInboxResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailGetInboxTool: ToolConfig<GetInboxParams, GetInboxResult> = {
   id: 'agentmail_get_inbox',
@@ -23,7 +24,8 @@ export const agentmailGetInboxTool: ToolConfig<GetInboxParams, GetInboxResult> =
   },
 
   request: {
-    url: (params) => `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}`,
+    url: (params) =>
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/get_message.ts
+++ b/apps/sim/tools/agentmail/get_message.ts
@@ -1,5 +1,6 @@
 import type { GetMessageParams, GetMessageResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailGetMessageTool: ToolConfig<GetMessageParams, GetMessageResult> = {
   id: 'agentmail_get_message',
@@ -30,7 +31,7 @@ export const agentmailGetMessageTool: ToolConfig<GetMessageParams, GetMessageRes
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/messages/${params.messageId.trim()}`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/messages/${safeUrlPathSegment(params.messageId, 'messageId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/get_thread.ts
+++ b/apps/sim/tools/agentmail/get_thread.ts
@@ -1,5 +1,6 @@
 import type { GetThreadParams, GetThreadResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailGetThreadTool: ToolConfig<GetThreadParams, GetThreadResult> = {
   id: 'agentmail_get_thread',
@@ -30,7 +31,7 @@ export const agentmailGetThreadTool: ToolConfig<GetThreadParams, GetThreadResult
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/threads/${params.threadId.trim()}`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/threads/${safeUrlPathSegment(params.threadId, 'threadId')}`,
     method: 'GET',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/list_drafts.ts
+++ b/apps/sim/tools/agentmail/list_drafts.ts
@@ -1,5 +1,6 @@
 import type { ListDraftsParams, ListDraftsResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailListDraftsTool: ToolConfig<ListDraftsParams, ListDraftsResult> = {
   id: 'agentmail_list_drafts',
@@ -40,7 +41,7 @@ export const agentmailListDraftsTool: ToolConfig<ListDraftsParams, ListDraftsRes
       if (params.limit) query.set('limit', String(params.limit))
       if (params.pageToken) query.set('page_token', params.pageToken)
       const qs = query.toString()
-      return `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/drafts${qs ? `?${qs}` : ''}`
+      return `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/drafts${qs ? `?${qs}` : ''}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/agentmail/list_messages.ts
+++ b/apps/sim/tools/agentmail/list_messages.ts
@@ -1,5 +1,6 @@
 import type { ListMessagesParams, ListMessagesResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailListMessagesTool: ToolConfig<ListMessagesParams, ListMessagesResult> = {
   id: 'agentmail_list_messages',
@@ -40,7 +41,7 @@ export const agentmailListMessagesTool: ToolConfig<ListMessagesParams, ListMessa
       if (params.limit) query.set('limit', String(params.limit))
       if (params.pageToken) query.set('page_token', params.pageToken)
       const qs = query.toString()
-      return `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/messages${qs ? `?${qs}` : ''}`
+      return `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/messages${qs ? `?${qs}` : ''}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/agentmail/list_threads.ts
+++ b/apps/sim/tools/agentmail/list_threads.ts
@@ -1,5 +1,6 @@
 import type { ListThreadsParams, ListThreadsResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailListThreadsTool: ToolConfig<ListThreadsParams, ListThreadsResult> = {
   id: 'agentmail_list_threads',
@@ -65,7 +66,7 @@ export const agentmailListThreadsTool: ToolConfig<ListThreadsParams, ListThreads
       if (params.before) query.set('before', params.before)
       if (params.after) query.set('after', params.after)
       const qs = query.toString()
-      return `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/threads${qs ? `?${qs}` : ''}`
+      return `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/threads${qs ? `?${qs}` : ''}`
     },
     method: 'GET',
     headers: (params) => ({

--- a/apps/sim/tools/agentmail/path_safety.test.ts
+++ b/apps/sim/tools/agentmail/path_safety.test.ts
@@ -12,6 +12,14 @@
  * AgentMail API key, at somebody else's inbox. `delete_inbox`, `delete_thread`
  * and `delete_draft` are DELETEs, so the reachable damage is destructive.
  *
+ * An AgentMail inbox ID legitimately *is* an email address, so the guard now
+ * percent-encodes the `@`. The legitimate-value assertions below therefore
+ * check the segment round-trips through `decodeURIComponent` back to the exact
+ * value supplied, which is the property AgentMail's own Node SDK relies on: it
+ * wraps every path parameter in `encodeURIComponent`
+ * (`core/url/encodePathParam`), while the Python SDK sends the address raw —
+ * both ship, so the server decodes percent-encoding normally.
+ *
  * Wrapping the ID in `encodeURIComponent` is NOT enough, which is why the
  * vector list below includes the bare `.` and `..` segments: both are made of
  * unreserved characters, so they survive encoding untouched and the URL parser
@@ -27,22 +35,24 @@
  * **The suite enumerates (tool, parameter) pairs and fuzzes exactly one
  * parameter at a time**, holding every sibling at a known-safe value. Filling
  * every string parameter with the same hostile value and swallowing the throw
- * — the shape this file originally copied — silently stops testing a tool's
- * remaining IDs the moment one of them is guarded, so a route like
- * `/inboxes/{inboxId}/threads/{threadId}` would have been reported as covered
- * while `threadId` was never exercised at all.
+ * silently stops testing a tool's remaining IDs the moment one of them is
+ * guarded, so a route like
+ * `/inboxes/{inboxId}/threads/{threadId}`
+ * would be reported as covered while the second ID was never exercised.
  *
- * An AgentMail inbox ID legitimately *is* an email address, so the guard now
- * percent-encodes the `@`. The legitimate-value assertions below therefore
- * check the segment round-trips through `decodeURIComponent` back to the exact
- * value supplied, which is the property AgentMail's own Node SDK relies on: it
- * wraps every path parameter in `encodeURIComponent`
- * (`core/url/encodePathParam`), while the Python SDK sends the address raw —
- * both ship, so the server decodes percent-encoding normally.
+ * **Every pair asserts rejection, not merely that the path keeps its shape.**
+ * A shape check cannot see a bare `.` in the *final* segment: a URL ending
+ * `/a/.` normalizes to `/a/`, which has the same segment count and the same
+ * leading segments as `/a/id`. `delete_inbox`, `get_inbox` and `update_inbox`
+ * all end in a guarded ID and
+ * are all destructive, so a shape-only assertion would be at its weakest
+ * exactly where the damage is worst. The first test below pins that property of
+ * the URL parser so the reason this file asserts `toThrow` stays visible.
  */
+import { getErrorMessage } from '@sim/utils/errors'
 import { describe, expect, it } from 'vitest'
 import * as agentmailTools from '@/tools/agentmail/index'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
@@ -58,8 +68,11 @@ const TRAVERSAL_IDS = [
   'me@agentmail.to?injectedParam=attacker',
   'me@agentmail.to#fragment',
   'me@agentmail.to/threads/../../../v0/inboxes',
-  '\\..\\..',
+  '\\\\..\\\\..',
 ] as const
+
+/** The dot segments, split out because they must be asserted as rejections. */
+const DOT_SEGMENTS = ['..', '.', '  ..  '] as const
 
 /**
  * Values a real user legitimately supplies; none may be rejected, and each must
@@ -84,38 +97,57 @@ const SIBLING = 'SIBLINGID'
 
 const ORIGIN = 'https://api.agentmail.to'
 
-type AnyTool = ToolConfig<any, any>
+/** Credentials, not path identifiers; pinned so only one variable moves. */
+const CREDENTIAL_PARAMS: readonly string[] = ['apiKey']
 
-function isAgentmailTool(value: unknown): value is AnyTool {
+/**
+ * The shared shape every path-safety harness in this batch uses. Parameterizing
+ * `ToolConfig` with `Record<string, unknown>` — rather than the fully-untyped
+ * parameterization these harnesses were originally copied from — is what lets
+ * `url(...)` be called below with no cast at all. `ALL_EXPORTS` is seeded as
+ * `readonly unknown[]` so the type guard is the single narrowing point: a
+ * barrel's element union is not assignable to a widened `ToolConfig`, because
+ * the param type sits in the contravariant position of `request.url`.
+ */
+type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
+
+function isProbeableTool(value: unknown): value is PathTool {
+  if (typeof value !== 'object' || value === null) return false
+  /** Narrowing a validated object for property reads; never `any`. */
+  const candidate = value as Record<string, unknown>
+  const request = candidate.request
   return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('agentmail_')
+    typeof candidate.id === 'string' &&
+    candidate.id.startsWith('agentmail_') &&
+    typeof candidate.params === 'object' &&
+    candidate.params !== null &&
+    typeof request === 'object' &&
+    request !== null &&
+    'url' in request
   )
 }
 
 /**
  * Builds a param object with `targetName` set to `value` and every other
  * parameter pinned to a known-safe placeholder of the right shape, so a failure
- * is always attributable to the one parameter under test.
+ * is always attributable to the one parameter under test. `apiKey` is a credential,
+ * not a path identifier, and stays fixed.
  */
-function buildParams(tool: AnyTool, targetName: string, value: string): Record<string, unknown> {
+function buildParams(tool: PathTool, targetName: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { apiKey: 'token' }
-  for (const [name, def] of Object.entries(tool.params ?? {})) {
-    if (name === 'apiKey') continue
+  for (const [name, def] of Object.entries(tool.params)) {
+    if (CREDENTIAL_PARAMS.includes(name)) continue
     if (name === targetName) {
       params[name] = value
       continue
     }
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
+    if (def.type === 'json' || def.type === 'array') {
       params[name] = []
-    } else if (type === 'object') {
+    } else if (def.type === 'object') {
       params[name] = {}
-    } else if (type === 'number') {
+    } else if (def.type === 'number') {
       params[name] = 1
-    } else if (type === 'boolean') {
+    } else if (def.type === 'boolean') {
       params[name] = false
     } else {
       params[name] = SIBLING
@@ -124,44 +156,78 @@ function buildParams(tool: AnyTool, targetName: string, value: string): Record<s
   return params
 }
 
-function buildUrl(tool: AnyTool, targetName: string, value: string): URL {
-  const url = tool.request?.url
-  if (typeof url !== 'function') {
+function buildUrl(tool: PathTool, targetName: string, value: string): URL {
+  const builder = tool.request.url
+  if (typeof builder !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, targetName, value) as any))
+  return new URL(builder(buildParams(tool, targetName, value)))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
+interface PathParamPair {
+  name: string
+  tool: PathTool
+  paramName: string
+}
+
+const ALL_EXPORTS: readonly unknown[] = Object.values(agentmailTools)
+const TOOLS: PathTool[] = ALL_EXPORTS.filter(isProbeableTool)
+
+/** Tools whose URL is a constant string; they have no path parameter to fuzz. */
+const STATIC_URL_TOOLS: string[] = TOOLS.filter(
+  (tool) => typeof tool.request.url !== 'function'
+).map((tool) => tool.id)
+
 /**
- * Every (tool, parameter) pair whose parameter actually reaches the path, found
- * by probing one parameter at a time with a unique marker.
+ * Probes that threw while being built from entirely safe placeholder values.
+ * Surfaced rather than swallowed: a tool dropped here is a tool this suite is
+ * silently not testing, which is the failure mode the whole file exists to
+ * prevent.
  */
-const PATH_PARAM_PAIRS = Object.values(agentmailTools)
-  .filter(isAgentmailTool)
-  .filter((tool) => typeof tool.request?.url === 'function')
-  .flatMap((tool) =>
-    Object.keys(tool.params ?? {})
-      .filter((paramName) => paramName !== 'apiKey')
-      .filter((paramName) => {
-        try {
-          return buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)
-        } catch {
-          return false
-        }
+const PROBE_FAILURES: Array<{ tool: string; param: string; reason: string }> = []
+
+const PATH_PARAM_PAIRS: PathParamPair[] = []
+for (const tool of TOOLS) {
+  if (typeof tool.request.url !== 'function') continue
+  for (const paramName of Object.keys(tool.params)) {
+    if (CREDENTIAL_PARAMS.includes(paramName)) continue
+    try {
+      if (buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)) {
+        PATH_PARAM_PAIRS.push({ name: `${tool.id} / ${paramName}`, tool, paramName })
+      }
+    } catch (error) {
+      PROBE_FAILURES.push({
+        tool: tool.id,
+        param: paramName,
+        reason: getErrorMessage(error),
       })
-      .map((paramName) => ({ name: `${tool.id} / ${paramName}`, tool, paramName }))
-  )
+    }
+  }
+}
 
 describe('agentmail path-ID traversal safety', () => {
-  it('covers every AgentMail path parameter, not just the first per tool', () => {
+  it('a trailing dot segment is invisible to a shape check, so rejection is asserted', () => {
+    const withId = new URL(`https://api.agentmail.to/a/b/id`)
+    const withDot = new URL(`https://api.agentmail.to/a/b/.`)
+
+    expect(segmentsOf(withDot)).toHaveLength(segmentsOf(withId).length)
+    expect(withDot.pathname).toBe('/a/b/')
+  })
+
+  it('builds every probe from safe placeholders without dropping a tool', () => {
+    expect(PROBE_FAILURES).toEqual([])
+    expect(STATIC_URL_TOOLS).toEqual(['agentmail_create_inbox'])
+  })
+
+  it('covers every path parameter, not just the first per tool', () => {
     expect(PATH_PARAM_PAIRS.length).toBeGreaterThanOrEqual(30)
   })
 
-  it('exercises the second ID of every two-ID route', () => {
+  it('exercises the second ID of every multi-ID route', () => {
     const covered = new Set(PATH_PARAM_PAIRS.map((pair) => pair.name))
 
     expect(covered).toContain('agentmail_delete_thread / threadId')
@@ -180,12 +246,16 @@ describe('agentmail path-ID traversal safety', () => {
   describe.each(PATH_PARAM_PAIRS)('$name', ({ tool, paramName }) => {
     const baseline = segmentsOf(buildUrl(tool, paramName, TARGET))
 
+    it.each(DOT_SEGMENTS)('rejects the dot segment %j by name', (value) => {
+      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
+    })
+
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
         url = buildUrl(tool, paramName, value)
       } catch (error) {
-        expect(String(error)).toContain(paramName)
+        expect(getErrorMessage(error)).toContain(paramName)
         return
       }
 
@@ -200,11 +270,7 @@ describe('agentmail path-ID traversal safety', () => {
       })
     })
 
-    it.each(['..', '.', '  ..  '])('rejects the bare dot segment %j by name', (value) => {
-      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
-    })
-
-    it.each(LEGITIMATE_IDS)('round-trips %j through the path unchanged', (value) => {
+    it.each(LEGITIMATE_IDS)('round-trips %j through the path unchanged %j', (value) => {
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)

--- a/apps/sim/tools/agentmail/path_safety.test.ts
+++ b/apps/sim/tools/agentmail/path_safety.test.ts
@@ -43,8 +43,7 @@
  * **Every pair asserts rejection, not merely that the path keeps its shape.**
  * A shape check cannot see a bare `.` in the *final* segment: a URL ending
  * `/a/.` normalizes to `/a/`, which has the same segment count and the same
- * leading segments as `/a/id`. `delete_inbox`, `get_inbox` and `update_inbox`
- * all end in a guarded ID and
+ * leading segments as `/a/id`. `delete_inbox`, `get_inbox` and `update_inbox` all end in a guarded ID and
  * are all destructive, so a shape-only assertion would be at its weakest
  * exactly where the damage is worst. The first test below pins that property of
  * the URL parser so the reason this file asserts `toThrow` stays visible.
@@ -168,6 +167,22 @@ function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
+/**
+ * What a guarded parameter must emit into its slot: the trimmed value,
+ * percent-encoded, occupying exactly ONE path segment.
+ *
+ * Asserting this rather than skipping the ID's segment is load-bearing. A skip
+ * only proves the segment *count* and the surrounding segments are unchanged,
+ * and a traversal can satisfy both: against raw interpolation
+ * `matter123/../../matters/victim` resolves `/v1/matters/<id>` to
+ * `/v1/matters/victim` — same length, identical non-ID segments, request
+ * silently re-aimed at another resource. The escape the file header calls out
+ * by name would have slipped through this suite's own canonical vector.
+ */
+function expectedSegment(value: string): string {
+  return encodeURIComponent(value.trim())
+}
+
 interface PathParamPair {
   name: string
   tool: PathTool
@@ -262,19 +277,21 @@ describe('agentmail path-ID traversal safety', () => {
       expect(url.origin).toBe(ORIGIN)
       expect(url.searchParams.get('injectedParam')).toBeNull()
 
+      const encoded = expectedSegment(value)
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment.includes(TARGET)) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment.replaceAll(TARGET, encoded))
       })
     })
 
     it.each(LEGITIMATE_IDS)('round-trips %j through the path unchanged %j', (value) => {
+      const encoded = expectedSegment(value)
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
+        expect(actual[index]).toBe(segment.replaceAll(TARGET, encoded))
         expect(decodeURIComponent(actual[index])).toBe(segment.replaceAll(TARGET, value))
       })
     })

--- a/apps/sim/tools/agentmail/path_safety.test.ts
+++ b/apps/sim/tools/agentmail/path_safety.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every AgentMail tool against path traversal through an LLM-writable
+ * ID that gets interpolated into the request path.
+ *
+ * `inboxId`, `threadId`, `messageId`, and `draftId` are all
+ * `visibility: 'user-or-llm'`, so prompt injection controls them. Each one was
+ * interpolated raw (`${params.inboxId.trim()}`), which let a value like
+ * `../../inboxes/victim@agentmail.to` escape its `/v0/inboxes/<id>` prefix once
+ * `fetch` normalized the URL — re-aiming the request, and the workspace's
+ * AgentMail API key, at somebody else's inbox. `delete_inbox`, `delete_thread`
+ * and `delete_draft` are DELETEs, so the reachable damage is destructive.
+ *
+ * Wrapping the ID in `encodeURIComponent` is NOT enough, which is why the
+ * vector list below includes the bare `.` and `..` segments: both are made of
+ * unreserved characters, so they survive encoding untouched and the URL parser
+ * then removes them as dot segments, popping one path segment off a fixed host.
+ * Every assertion here resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ *
+ * An AgentMail inbox ID legitimately *is* an email address, so the guard now
+ * percent-encodes the `@`. The legitimate-value assertions below therefore
+ * check the segment round-trips through `decodeURIComponent` back to the exact
+ * value supplied, which is the property AgentMail's own Node SDK relies on: it
+ * wraps every path parameter in `encodeURIComponent` (`core/url/encodePathParam`),
+ * while the Python SDK sends the address raw — both ship, so the server decodes
+ * percent-encoding normally.
+ */
+import { describe, expect, it } from 'vitest'
+import * as agentmailTools from '@/tools/agentmail/index'
+import type { ToolConfig } from '@/tools/types'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../inboxes/victim@agentmail.to',
+  '..%2f..%2finboxes/victim@agentmail.to',
+  'me@agentmail.to/../../inboxes/victim@agentmail.to',
+  'me@agentmail.to?limit=100',
+  'me@agentmail.to#fragment',
+  'me@agentmail.to/threads/../../../v0/inboxes',
+  '\\..\\..',
+] as const
+
+/**
+ * Values a real user legitimately supplies; none may be rejected, and each must
+ * survive the round trip byte for byte.
+ */
+const LEGITIMATE_IDS = [
+  'example@agentmail.to',
+  'sales-team@agentmail.to',
+  'support.desk@agentmail.to',
+  'msg_01HQ8ZK3TVN4XR',
+  'thread_2W7QpN8xkE4hVvRt6bLd',
+  'draft-abc-123',
+  '..foo',
+  'foo..',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isAgentmailTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('agentmail_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { apiKey: 'token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'apiKey') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'object') {
+      params[name] = {}
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(url: URL): string[] {
+  return url.pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(agentmailTools)
+  .filter(isAgentmailTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('agentmail path-ID traversal safety', () => {
+  it('covers every AgentMail tool that interpolates an ID into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(17)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(url.origin).toBe('https://api.agentmail.to')
+
+      const actual = segmentsOf(url)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment.includes(SAFE_ID)) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(TRAVERSAL_IDS.filter((value) => value.trim() === '.' || value.trim() === '..'))(
+      'rejects the bare dot segment %j by name instead of popping the prefix',
+      (value) => {
+        expect(() => buildUrl(tool, value)).toThrow(/Id/)
+      }
+    )
+
+    it('does not let an ID inject a query parameter', () => {
+      const url = buildUrl(tool, 'me@agentmail.to?injectedParam=attacker')
+
+      expect(url.searchParams.get('injectedParam')).toBeNull()
+    })
+
+    it.each(LEGITIMATE_IDS)('round-trips %j through the path unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value))
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        const expected = segment.replaceAll(SAFE_ID, value)
+        expect(decodeURIComponent(actual[index])).toBe(expected)
+      })
+    })
+
+    it('percent-encodes an email-address inbox ID rather than rejecting it', () => {
+      const url = buildUrl(tool, 'example@agentmail.to')
+
+      expect(url.pathname).toContain('example%40agentmail.to')
+      expect(decodeURIComponent(url.pathname)).toContain('example@agentmail.to')
+    })
+
+    it('trims surrounding whitespace rather than encoding it into the path', () => {
+      const actual = segmentsOf(buildUrl(tool, `  ${SAFE_ID}  `))
+
+      expect(actual).toEqual(baseline)
+    })
+  })
+})

--- a/apps/sim/tools/agentmail/path_safety.test.ts
+++ b/apps/sim/tools/agentmail/path_safety.test.ts
@@ -16,17 +16,29 @@
  * vector list below includes the bare `.` and `..` segments: both are made of
  * unreserved characters, so they survive encoding untouched and the URL parser
  * then removes them as dot segments, popping one path segment off a fixed host.
+ * The clearest demonstration is the sibling Algolia suite, whose call sites
+ * already wrapped every ID in `encodeURIComponent` and still failed precisely
+ * — and only — on the bare `.` and `..` vectors.
+ *
  * Every assertion here resolves the built URL with `new URL(...)` — the same
  * normalization `fetch` performs — rather than string-matching the template
  * output, because string matching is exactly what let this through.
+ *
+ * **The suite enumerates (tool, parameter) pairs and fuzzes exactly one
+ * parameter at a time**, holding every sibling at a known-safe value. Filling
+ * every string parameter with the same hostile value and swallowing the throw
+ * — the shape this file originally copied — silently stops testing a tool's
+ * remaining IDs the moment one of them is guarded, so a route like
+ * `/inboxes/{inboxId}/threads/{threadId}` would have been reported as covered
+ * while `threadId` was never exercised at all.
  *
  * An AgentMail inbox ID legitimately *is* an email address, so the guard now
  * percent-encodes the `@`. The legitimate-value assertions below therefore
  * check the segment round-trips through `decodeURIComponent` back to the exact
  * value supplied, which is the property AgentMail's own Node SDK relies on: it
- * wraps every path parameter in `encodeURIComponent` (`core/url/encodePathParam`),
- * while the Python SDK sends the address raw — both ship, so the server decodes
- * percent-encoding normally.
+ * wraps every path parameter in `encodeURIComponent`
+ * (`core/url/encodePathParam`), while the Python SDK sends the address raw —
+ * both ship, so the server decodes percent-encoding normally.
  */
 import { describe, expect, it } from 'vitest'
 import * as agentmailTools from '@/tools/agentmail/index'
@@ -43,7 +55,7 @@ const TRAVERSAL_IDS = [
   '../../inboxes/victim@agentmail.to',
   '..%2f..%2finboxes/victim@agentmail.to',
   'me@agentmail.to/../../inboxes/victim@agentmail.to',
-  'me@agentmail.to?limit=100',
+  'me@agentmail.to?injectedParam=attacker',
   'me@agentmail.to#fragment',
   'me@agentmail.to/threads/../../../v0/inboxes',
   '\\..\\..',
@@ -64,7 +76,13 @@ const LEGITIMATE_IDS = [
   'foo..',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/** The value under test; unique so its position in the path is unambiguous. */
+const TARGET = 'TARGETID'
+
+/** Every other string parameter is pinned here so only one variable moves. */
+const SIBLING = 'SIBLINGID'
+
+const ORIGIN = 'https://api.agentmail.to'
 
 type AnyTool = ToolConfig<any, any>
 
@@ -78,13 +96,18 @@ function isAgentmailTool(value: unknown): value is AnyTool {
 }
 
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised.
+ * Builds a param object with `targetName` set to `value` and every other
+ * parameter pinned to a known-safe placeholder of the right shape, so a failure
+ * is always attributable to the one parameter under test.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+function buildParams(tool: AnyTool, targetName: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { apiKey: 'token' }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name === 'apiKey') continue
+    if (name === targetName) {
+      params[name] = value
+      continue
+    }
     const type = (def as { type?: string }).type
     if (type === 'json' || type === 'array') {
       params[name] = []
@@ -95,96 +118,110 @@ function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
     } else if (type === 'boolean') {
       params[name] = false
     } else {
-      params[name] = value
+      params[name] = SIBLING
     }
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
+function buildUrl(tool: AnyTool, targetName: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return new URL(url(buildParams(tool, targetName, value) as any))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(agentmailTools)
+/**
+ * Every (tool, parameter) pair whose parameter actually reaches the path, found
+ * by probing one parameter at a time with a unique marker.
+ */
+const PATH_PARAM_PAIRS = Object.values(agentmailTools)
   .filter(isAgentmailTool)
   .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
-    } catch {
-      return false
-    }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  .flatMap((tool) =>
+    Object.keys(tool.params ?? {})
+      .filter((paramName) => paramName !== 'apiKey')
+      .filter((paramName) => {
+        try {
+          return buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)
+        } catch {
+          return false
+        }
+      })
+      .map((paramName) => ({ name: `${tool.id} / ${paramName}`, tool, paramName }))
+  )
 
 describe('agentmail path-ID traversal safety', () => {
-  it('covers every AgentMail tool that interpolates an ID into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(17)
+  it('covers every AgentMail path parameter, not just the first per tool', () => {
+    expect(PATH_PARAM_PAIRS.length).toBeGreaterThanOrEqual(30)
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+  it('exercises the second ID of every two-ID route', () => {
+    const covered = new Set(PATH_PARAM_PAIRS.map((pair) => pair.name))
+
+    expect(covered).toContain('agentmail_delete_thread / threadId')
+    expect(covered).toContain('agentmail_get_thread / threadId')
+    expect(covered).toContain('agentmail_update_thread / threadId')
+    expect(covered).toContain('agentmail_get_message / messageId')
+    expect(covered).toContain('agentmail_update_message / messageId')
+    expect(covered).toContain('agentmail_forward_message / messageId')
+    expect(covered).toContain('agentmail_reply_message / messageId')
+    expect(covered).toContain('agentmail_delete_draft / draftId')
+    expect(covered).toContain('agentmail_get_draft / draftId')
+    expect(covered).toContain('agentmail_send_draft / draftId')
+    expect(covered).toContain('agentmail_update_draft / draftId')
+  })
+
+  describe.each(PATH_PARAM_PAIRS)('$name', ({ tool, paramName }) => {
+    const baseline = segmentsOf(buildUrl(tool, paramName, TARGET))
 
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
-      } catch {
+        url = buildUrl(tool, paramName, value)
+      } catch (error) {
+        expect(String(error)).toContain(paramName)
         return
       }
 
-      expect(url.origin).toBe('https://api.agentmail.to')
+      expect(url.origin).toBe(ORIGIN)
+      expect(url.searchParams.get('injectedParam')).toBeNull()
 
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment.includes(SAFE_ID)) return
+        if (segment.includes(TARGET)) return
         expect(actual[index]).toBe(segment)
       })
     })
 
-    it.each(TRAVERSAL_IDS.filter((value) => value.trim() === '.' || value.trim() === '..'))(
-      'rejects the bare dot segment %j by name instead of popping the prefix',
-      (value) => {
-        expect(() => buildUrl(tool, value)).toThrow(/Id/)
-      }
-    )
-
-    it('does not let an ID inject a query parameter', () => {
-      const url = buildUrl(tool, 'me@agentmail.to?injectedParam=attacker')
-
-      expect(url.searchParams.get('injectedParam')).toBeNull()
+    it.each(['..', '.', '  ..  '])('rejects the bare dot segment %j by name', (value) => {
+      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
     })
 
     it.each(LEGITIMATE_IDS)('round-trips %j through the path unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value))
+      const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        const expected = segment.replaceAll(SAFE_ID, value)
-        expect(decodeURIComponent(actual[index])).toBe(expected)
+        expect(decodeURIComponent(actual[index])).toBe(segment.replaceAll(TARGET, value))
       })
     })
 
-    it('percent-encodes an email-address inbox ID rather than rejecting it', () => {
-      const url = buildUrl(tool, 'example@agentmail.to')
+    it('percent-encodes an email-address ID rather than rejecting it', () => {
+      const url = buildUrl(tool, paramName, 'example@agentmail.to')
 
       expect(url.pathname).toContain('example%40agentmail.to')
       expect(decodeURIComponent(url.pathname)).toContain('example@agentmail.to')
     })
 
     it('trims surrounding whitespace rather than encoding it into the path', () => {
-      const actual = segmentsOf(buildUrl(tool, `  ${SAFE_ID}  `))
-
-      expect(actual).toEqual(baseline)
+      expect(segmentsOf(buildUrl(tool, paramName, `  ${TARGET}  `))).toEqual(baseline)
     })
   })
 })

--- a/apps/sim/tools/agentmail/path_safety.test.ts
+++ b/apps/sim/tools/agentmail/path_safety.test.ts
@@ -285,7 +285,7 @@ describe('agentmail path-ID traversal safety', () => {
       })
     })
 
-    it.each(LEGITIMATE_IDS)('round-trips %j through the path unchanged %j', (value) => {
+    it.each(LEGITIMATE_IDS)('round-trips %j through the path unchanged', (value) => {
       const encoded = expectedSegment(value)
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 

--- a/apps/sim/tools/agentmail/reply_message.ts
+++ b/apps/sim/tools/agentmail/reply_message.ts
@@ -1,5 +1,6 @@
 import type { ReplyMessageParams, ReplyMessageResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailReplyMessageTool: ToolConfig<ReplyMessageParams, ReplyMessageResult> = {
   id: 'agentmail_reply_message',
@@ -67,7 +68,7 @@ export const agentmailReplyMessageTool: ToolConfig<ReplyMessageParams, ReplyMess
   request: {
     url: (params) => {
       const endpoint = params.replyAll ? 'reply-all' : 'reply'
-      return `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/messages/${params.messageId.trim()}/${endpoint}`
+      return `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/messages/${safeUrlPathSegment(params.messageId, 'messageId')}/${endpoint}`
     },
     method: 'POST',
     headers: (params) => ({

--- a/apps/sim/tools/agentmail/send_draft.ts
+++ b/apps/sim/tools/agentmail/send_draft.ts
@@ -1,5 +1,6 @@
 import type { SendDraftParams, SendDraftResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailSendDraftTool: ToolConfig<SendDraftParams, SendDraftResult> = {
   id: 'agentmail_send_draft',
@@ -30,7 +31,7 @@ export const agentmailSendDraftTool: ToolConfig<SendDraftParams, SendDraftResult
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/drafts/${params.draftId.trim()}/send`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/drafts/${safeUrlPathSegment(params.draftId, 'draftId')}/send`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/send_message.ts
+++ b/apps/sim/tools/agentmail/send_message.ts
@@ -1,5 +1,6 @@
 import type { SendMessageParams, SendMessageResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailSendMessageTool: ToolConfig<SendMessageParams, SendMessageResult> = {
   id: 'agentmail_send_message',
@@ -59,7 +60,8 @@ export const agentmailSendMessageTool: ToolConfig<SendMessageParams, SendMessage
   },
 
   request: {
-    url: (params) => `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/messages/send`,
+    url: (params) =>
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/messages/send`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/update_draft.ts
+++ b/apps/sim/tools/agentmail/update_draft.ts
@@ -1,5 +1,6 @@
 import type { UpdateDraftParams, UpdateDraftResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailUpdateDraftTool: ToolConfig<UpdateDraftParams, UpdateDraftResult> = {
   id: 'agentmail_update_draft',
@@ -72,7 +73,7 @@ export const agentmailUpdateDraftTool: ToolConfig<UpdateDraftParams, UpdateDraft
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/drafts/${params.draftId.trim()}`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/drafts/${safeUrlPathSegment(params.draftId, 'draftId')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/update_inbox.ts
+++ b/apps/sim/tools/agentmail/update_inbox.ts
@@ -1,5 +1,6 @@
 import type { UpdateInboxParams, UpdateInboxResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailUpdateInboxTool: ToolConfig<UpdateInboxParams, UpdateInboxResult> = {
   id: 'agentmail_update_inbox',
@@ -29,7 +30,8 @@ export const agentmailUpdateInboxTool: ToolConfig<UpdateInboxParams, UpdateInbox
   },
 
   request: {
-    url: (params) => `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}`,
+    url: (params) =>
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/update_message.ts
+++ b/apps/sim/tools/agentmail/update_message.ts
@@ -1,5 +1,6 @@
 import type { UpdateMessageParams, UpdateMessageResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailUpdateMessageTool: ToolConfig<UpdateMessageParams, UpdateMessageResult> = {
   id: 'agentmail_update_message',
@@ -42,7 +43,7 @@ export const agentmailUpdateMessageTool: ToolConfig<UpdateMessageParams, UpdateM
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/messages/${params.messageId.trim()}`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/messages/${safeUrlPathSegment(params.messageId, 'messageId')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/agentmail/update_thread.ts
+++ b/apps/sim/tools/agentmail/update_thread.ts
@@ -1,5 +1,6 @@
 import type { UpdateThreadParams, UpdateThreadResult } from '@/tools/agentmail/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const agentmailUpdateThreadTool: ToolConfig<UpdateThreadParams, UpdateThreadResult> = {
   id: 'agentmail_update_thread',
@@ -42,7 +43,7 @@ export const agentmailUpdateThreadTool: ToolConfig<UpdateThreadParams, UpdateThr
 
   request: {
     url: (params) =>
-      `https://api.agentmail.to/v0/inboxes/${params.inboxId.trim()}/threads/${params.threadId.trim()}`,
+      `https://api.agentmail.to/v0/inboxes/${safeUrlPathSegment(params.inboxId, 'inboxId')}/threads/${safeUrlPathSegment(params.threadId, 'threadId')}`,
     method: 'PATCH',
     headers: (params) => ({
       Authorization: `Bearer ${params.apiKey}`,

--- a/apps/sim/tools/algolia/add_record.ts
+++ b/apps/sim/tools/algolia/add_record.ts
@@ -1,5 +1,7 @@
 import type { AlgoliaAddRecordParams, AlgoliaAddRecordResponse } from '@/tools/algolia/types'
+import { safeAlgoliaObjectId } from '@/tools/algolia/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const addRecordTool: ToolConfig<AlgoliaAddRecordParams, AlgoliaAddRecordResponse> = {
   id: 'algolia_add_record',
@@ -42,9 +44,9 @@ export const addRecordTool: ToolConfig<AlgoliaAddRecordParams, AlgoliaAddRecordR
 
   request: {
     url: (params) => {
-      const base = `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}`
+      const base = `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}`
       if (params.objectID) {
-        return `${base}/${encodeURIComponent(params.objectID.trim())}`
+        return `${base}/${safeAlgoliaObjectId(params.objectID, 'objectID')}`
       }
       return base
     },

--- a/apps/sim/tools/algolia/batch_operations.ts
+++ b/apps/sim/tools/algolia/batch_operations.ts
@@ -3,6 +3,7 @@ import type {
   AlgoliaBatchOperationsResponse,
 } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const batchOperationsTool: ToolConfig<
   AlgoliaBatchOperationsParams,
@@ -44,7 +45,7 @@ export const batchOperationsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/batch`,
+      `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/batch`,
     method: 'POST',
     headers: (params) => ({
       'x-algolia-application-id': params.applicationId,

--- a/apps/sim/tools/algolia/browse_records.ts
+++ b/apps/sim/tools/algolia/browse_records.ts
@@ -3,6 +3,7 @@ import type {
   AlgoliaBrowseRecordsResponse,
 } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const browseRecordsTool: ToolConfig<
   AlgoliaBrowseRecordsParams,
@@ -91,7 +92,7 @@ export const browseRecordsTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.applicationId}-dsn.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/browse`,
+      `https://${params.applicationId}-dsn.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/browse`,
     method: 'POST',
     headers: (params) => ({
       'x-algolia-application-id': params.applicationId,

--- a/apps/sim/tools/algolia/clear_records.ts
+++ b/apps/sim/tools/algolia/clear_records.ts
@@ -1,5 +1,6 @@
 import type { AlgoliaClearRecordsParams, AlgoliaClearRecordsResponse } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const clearRecordsTool: ToolConfig<AlgoliaClearRecordsParams, AlgoliaClearRecordsResponse> =
   {
@@ -32,7 +33,7 @@ export const clearRecordsTool: ToolConfig<AlgoliaClearRecordsParams, AlgoliaClea
 
     request: {
       url: (params) =>
-        `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/clear`,
+        `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/clear`,
       method: 'POST',
       headers: (params) => ({
         'x-algolia-application-id': params.applicationId,

--- a/apps/sim/tools/algolia/copy_move_index.ts
+++ b/apps/sim/tools/algolia/copy_move_index.ts
@@ -3,6 +3,7 @@ import type {
   AlgoliaCopyMoveIndexResponse,
 } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const copyMoveIndexTool: ToolConfig<
   AlgoliaCopyMoveIndexParams,
@@ -55,7 +56,7 @@ export const copyMoveIndexTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/operation`,
+      `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/operation`,
     method: 'POST',
     headers: (params) => ({
       'x-algolia-application-id': params.applicationId,

--- a/apps/sim/tools/algolia/delete_by_filter.ts
+++ b/apps/sim/tools/algolia/delete_by_filter.ts
@@ -3,6 +3,7 @@ import type {
   AlgoliaDeleteByFilterResponse,
 } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const deleteByFilterTool: ToolConfig<
   AlgoliaDeleteByFilterParams,
@@ -85,7 +86,7 @@ export const deleteByFilterTool: ToolConfig<
 
   request: {
     url: (params) =>
-      `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/deleteByQuery`,
+      `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/deleteByQuery`,
     method: 'POST',
     headers: (params) => ({
       'x-algolia-application-id': params.applicationId,

--- a/apps/sim/tools/algolia/delete_index.ts
+++ b/apps/sim/tools/algolia/delete_index.ts
@@ -1,5 +1,6 @@
 import type { AlgoliaDeleteIndexParams, AlgoliaDeleteIndexResponse } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const deleteIndexTool: ToolConfig<AlgoliaDeleteIndexParams, AlgoliaDeleteIndexResponse> = {
   id: 'algolia_delete_index',
@@ -31,7 +32,7 @@ export const deleteIndexTool: ToolConfig<AlgoliaDeleteIndexParams, AlgoliaDelete
   request: {
     method: 'DELETE',
     url: (params) =>
-      `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}`,
+      `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}`,
     headers: (params) => ({
       'x-algolia-application-id': params.applicationId,
       'x-algolia-api-key': params.apiKey,

--- a/apps/sim/tools/algolia/delete_record.ts
+++ b/apps/sim/tools/algolia/delete_record.ts
@@ -1,5 +1,7 @@
 import type { AlgoliaDeleteRecordParams, AlgoliaDeleteRecordResponse } from '@/tools/algolia/types'
+import { safeAlgoliaObjectId } from '@/tools/algolia/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const deleteRecordTool: ToolConfig<AlgoliaDeleteRecordParams, AlgoliaDeleteRecordResponse> =
   {
@@ -38,7 +40,7 @@ export const deleteRecordTool: ToolConfig<AlgoliaDeleteRecordParams, AlgoliaDele
     request: {
       method: 'DELETE',
       url: (params) =>
-        `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/${encodeURIComponent(params.objectID.trim())}`,
+        `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/${safeAlgoliaObjectId(params.objectID, 'objectID')}`,
       headers: (params) => ({
         'x-algolia-application-id': params.applicationId,
         'x-algolia-api-key': params.apiKey,

--- a/apps/sim/tools/algolia/get_record.ts
+++ b/apps/sim/tools/algolia/get_record.ts
@@ -1,5 +1,7 @@
 import type { AlgoliaGetRecordParams, AlgoliaGetRecordResponse } from '@/tools/algolia/types'
+import { safeAlgoliaObjectId } from '@/tools/algolia/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const getRecordTool: ToolConfig<AlgoliaGetRecordParams, AlgoliaGetRecordResponse> = {
   id: 'algolia_get_record',
@@ -43,7 +45,7 @@ export const getRecordTool: ToolConfig<AlgoliaGetRecordParams, AlgoliaGetRecordR
   request: {
     method: 'GET',
     url: (params) => {
-      const base = `https://${params.applicationId}-dsn.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/${encodeURIComponent(params.objectID.trim())}`
+      const base = `https://${params.applicationId}-dsn.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/${safeAlgoliaObjectId(params.objectID, 'objectID')}`
       if (params.attributesToRetrieve) {
         return `${base}?attributesToRetrieve=${encodeURIComponent(params.attributesToRetrieve)}`
       }

--- a/apps/sim/tools/algolia/get_settings.ts
+++ b/apps/sim/tools/algolia/get_settings.ts
@@ -1,5 +1,6 @@
 import type { AlgoliaGetSettingsParams, AlgoliaGetSettingsResponse } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const getSettingsTool: ToolConfig<AlgoliaGetSettingsParams, AlgoliaGetSettingsResponse> = {
   id: 'algolia_get_settings',
@@ -31,7 +32,7 @@ export const getSettingsTool: ToolConfig<AlgoliaGetSettingsParams, AlgoliaGetSet
   request: {
     method: 'GET',
     url: (params) =>
-      `https://${params.applicationId}-dsn.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/settings`,
+      `https://${params.applicationId}-dsn.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/settings`,
     headers: (params) => ({
       'x-algolia-application-id': params.applicationId,
       'x-algolia-api-key': params.apiKey,

--- a/apps/sim/tools/algolia/get_task_status.ts
+++ b/apps/sim/tools/algolia/get_task_status.ts
@@ -3,6 +3,7 @@ import type {
   AlgoliaGetTaskStatusResponse,
 } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const getTaskStatusTool: ToolConfig<
   AlgoliaGetTaskStatusParams,
@@ -43,7 +44,7 @@ export const getTaskStatusTool: ToolConfig<
   request: {
     method: 'GET',
     url: (params) =>
-      `https://${params.applicationId}-dsn.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/task/${encodeURIComponent(String(params.taskID).trim())}`,
+      `https://${params.applicationId}-dsn.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/task/${safeUrlPathSegment(params.taskID, 'taskID')}`,
     headers: (params) => ({
       'x-algolia-application-id': params.applicationId,
       'x-algolia-api-key': params.apiKey,

--- a/apps/sim/tools/algolia/partial_update_record.ts
+++ b/apps/sim/tools/algolia/partial_update_record.ts
@@ -2,7 +2,9 @@ import type {
   AlgoliaPartialUpdateRecordParams,
   AlgoliaPartialUpdateRecordResponse,
 } from '@/tools/algolia/types'
+import { safeAlgoliaObjectId } from '@/tools/algolia/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const partialUpdateRecordTool: ToolConfig<
   AlgoliaPartialUpdateRecordParams,
@@ -55,7 +57,7 @@ export const partialUpdateRecordTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const base = `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/${encodeURIComponent(params.objectID.trim())}/partial`
+      const base = `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/${safeAlgoliaObjectId(params.objectID, 'objectID')}/partial`
       if (params.createIfNotExists === false) {
         return `${base}?createIfNotExists=false`
       }

--- a/apps/sim/tools/algolia/path_safety.test.ts
+++ b/apps/sim/tools/algolia/path_safety.test.ts
@@ -13,14 +13,29 @@
  * workspace's Algolia admin key attached — and `delete_index`, `delete_record`
  * and `clear_records` are destructive.
  *
+ * These call sites are the clearest demonstration in the whole change that
+ * encoding is not a fix: with the pre-existing `encodeURIComponent` restored,
+ * `algolia_delete_index` and `algolia_delete_record` fail precisely — and only
+ * — on the bare `.` and `..` vectors, passing every multi-segment escape,
+ * encoded separator and backslash vector, because encoding genuinely does
+ * neutralize those.
+ *
  * Every assertion here resolves the built URL with `new URL(...)` — the same
  * normalization `fetch` performs — rather than string-matching the template
  * output, because string matching is exactly what let this through.
  *
- * `applicationId` is deliberately not in scope: it is `visibility: 'user-only'`
+ * **The suite enumerates (tool, parameter) pairs and fuzzes exactly one
+ * parameter at a time**, holding every sibling at a known-safe value. Filling
+ * every string parameter with the same hostile value and swallowing the throw
+ * — the shape this file originally copied — silently stops testing a tool's
+ * remaining IDs the moment one of them is guarded, so a route like
+ * `/1/indexes/{indexName}/{objectID}` would have been reported as covered while
+ * `objectID` was never exercised at all.
+ *
+ * `applicationId` is deliberately out of scope: it is `visibility: 'user-only'`
  * and lands in the *host*, not the path, so it is neither LLM-writable nor a
- * dot-segment vector. It is pinned to a fixed value below so the origin
- * assertions stay meaningful.
+ * dot-segment vector. It is pinned below so the host assertions stay
+ * meaningful.
  */
 import { describe, expect, it } from 'vitest'
 import * as algoliaTools from '@/tools/algolia/index'
@@ -43,7 +58,7 @@ const TRAVERSAL_IDS = [
   '../../1/keys',
   '..%2f..%2f1/keys',
   'products/../../../1/keys',
-  'products?attributesToRetrieve=*',
+  'products?injectedParam=attacker',
   'products#fragment',
   'products/settings/../../../1/keys',
   '\\..\\..',
@@ -64,7 +79,11 @@ const LEGITIMATE_IDS = [
   'foo..',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/** The value under test; unique so its position in the path is unambiguous. */
+const TARGET = 'TARGETID'
+
+/** Every other string parameter is pinned here so only one variable moves. */
+const SIBLING = 'SIBLINGID'
 
 type AnyTool = ToolConfig<any, any>
 
@@ -78,14 +97,19 @@ function isAlgoliaTool(value: unknown): value is AnyTool {
 }
 
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised. `applicationId` and
- * `apiKey` are pinned: they are credentials, not path identifiers.
+ * Builds a param object with `targetName` set to `value` and every other
+ * parameter pinned to a known-safe placeholder of the right shape, so a failure
+ * is always attributable to the one parameter under test. `applicationId` and
+ * `apiKey` are credentials, not path identifiers, and stay fixed.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+function buildParams(tool: AnyTool, targetName: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { applicationId: APPLICATION_ID, apiKey: 'key' }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name === 'applicationId' || name === 'apiKey') continue
+    if (name === targetName) {
+      params[name] = value
+      continue
+    }
     const type = (def as { type?: string }).type
     if (type === 'json' || type === 'array') {
       params[name] = []
@@ -96,143 +120,126 @@ function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
     } else if (type === 'boolean') {
       params[name] = false
     } else {
-      params[name] = value
+      params[name] = SIBLING
     }
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
+function buildUrl(tool: AnyTool, targetName: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return new URL(url(buildParams(tool, targetName, value) as any))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(algoliaTools)
+/**
+ * Every (tool, parameter) pair whose parameter actually reaches the path, found
+ * by probing one parameter at a time with a unique marker.
+ */
+const PATH_PARAM_PAIRS = Object.values(algoliaTools)
   .filter(isAlgoliaTool)
   .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
-    } catch {
-      return false
-    }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  .flatMap((tool) =>
+    Object.keys(tool.params ?? {})
+      .filter((paramName) => paramName !== 'applicationId' && paramName !== 'apiKey')
+      .filter((paramName) => {
+        try {
+          return buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)
+        } catch {
+          return false
+        }
+      })
+      .map((paramName) => ({ name: `${tool.id} / ${paramName}`, tool, paramName }))
+  )
 
 describe('algolia path-ID traversal safety', () => {
-  it('covers every Algolia tool that interpolates an ID into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(12)
+  it('covers every Algolia path parameter, not just the first per tool', () => {
+    expect(PATH_PARAM_PAIRS.length).toBeGreaterThanOrEqual(18)
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+  it('exercises the second ID of every two-ID route', () => {
+    const covered = new Set(PATH_PARAM_PAIRS.map((pair) => pair.name))
+
+    expect(covered).toContain('algolia_add_record / objectID')
+    expect(covered).toContain('algolia_get_record / objectID')
+    expect(covered).toContain('algolia_delete_record / objectID')
+    expect(covered).toContain('algolia_partial_update_record / objectID')
+    expect(covered).toContain('algolia_get_task_status / taskID')
+  })
+
+  describe.each(PATH_PARAM_PAIRS)('$name', ({ tool, paramName }) => {
+    const baseline = segmentsOf(buildUrl(tool, paramName, TARGET))
 
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
-      } catch {
+        url = buildUrl(tool, paramName, value)
+      } catch (error) {
+        expect(String(error)).toContain(paramName)
         return
       }
 
       expect(ALGOLIA_HOSTS).toContain(url.hostname)
       expect(url.pathname.startsWith('/1/indexes')).toBe(true)
+      expect(url.searchParams.get('injectedParam')).toBeNull()
 
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment.includes(SAFE_ID)) return
+        if (segment.includes(TARGET)) return
         expect(actual[index]).toBe(segment)
       })
     })
 
-    it.each(TRAVERSAL_IDS.filter((value) => value.trim() === '.' || value.trim() === '..'))(
-      'rejects the bare dot segment %j by name instead of popping the prefix',
-      (value) => {
-        expect(() => buildUrl(tool, value)).toThrow(/indexName|objectID|taskID/)
-      }
-    )
-
-    it('does not let an ID inject a query parameter', () => {
-      const url = buildUrl(tool, 'products?injectedParam=attacker')
-
-      expect(url.searchParams.get('injectedParam')).toBeNull()
+    it.each(['..', '.', '  ..  '])('rejects the bare dot segment %j by name', (value) => {
+      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
     })
 
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value))
+      const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment.replaceAll(SAFE_ID, value))
+        expect(actual[index]).toBe(segment.replaceAll(TARGET, value))
       })
     })
 
     it('trims surrounding whitespace rather than encoding it into the path', () => {
-      const actual = segmentsOf(buildUrl(tool, `  ${SAFE_ID}  `))
-
-      expect(actual).toEqual(baseline)
+      expect(segmentsOf(buildUrl(tool, paramName, `  ${TARGET}  `))).toEqual(baseline)
     })
   })
 })
 
 /**
  * An Algolia `objectID` is an arbitrary caller-chosen string, and Algolia's own
- * clients percent-encode it, so a record keyed `products/123` is legitimate and
- * has always worked. `safeAlgoliaObjectId` therefore guards each `/`-delimited
- * piece rather than refusing the separator outright, which would have been a
- * behaviour change for valid input.
+ * clients percent-encode it, so a record keyed `catalog/sku-123` is legitimate
+ * and has always worked. `safeAlgoliaObjectId` therefore guards each
+ * `/`-delimited piece rather than refusing the separator outright, which would
+ * have been a behaviour change for valid input.
  */
-const OBJECT_ID_TOOLS = Object.values(algoliaTools)
-  .filter(isAlgoliaTool)
-  .filter((tool) => Object.hasOwn(tool.params ?? {}, 'objectID'))
-  .map((tool) => ({ name: tool.id, tool }))
+const OBJECT_ID_TOOLS = PATH_PARAM_PAIRS.filter((pair) => pair.paramName === 'objectID')
 
-function buildObjectIdUrl(tool: AnyTool, objectID: string): URL {
-  const url = tool.request?.url
-  if (typeof url !== 'function') {
-    throw new Error(`${tool.id} does not build its URL from params`)
-  }
-  return new URL(
-    url({
-      applicationId: APPLICATION_ID,
-      apiKey: 'key',
-      indexName: 'products',
-      objectID,
-      record: {},
-      attributes: {},
-    } as any)
-  )
-}
-
-describe.each(OBJECT_ID_TOOLS)('$name objectID path safety', ({ tool }) => {
+describe.each(OBJECT_ID_TOOLS)('$name slash-bearing object ids', ({ tool, paramName }) => {
   it('keeps a slash-bearing object id working as one encoded segment', () => {
-    const url = buildObjectIdUrl(tool, 'catalog/sku-123')
+    const url = buildUrl(tool, paramName, 'catalog/sku-123')
 
     expect(url.pathname).toContain('catalog%2Fsku-123')
-    expect(url.pathname.split('/')).toHaveLength(
-      buildObjectIdUrl(tool, 'catalogsku123').pathname.split('/').length
+    expect(segmentsOf(url)).toHaveLength(
+      segmentsOf(buildUrl(tool, paramName, 'catalogsku123')).length
     )
   })
 
   it('rejects a dot segment hidden inside a slash-bearing object id', () => {
-    expect(() => buildObjectIdUrl(tool, 'catalog/../../1/keys')).toThrow(/objectID/)
-  })
-
-  it('rejects a bare dot-dot object id', () => {
-    expect(() => buildObjectIdUrl(tool, '..')).toThrow(/objectID/)
+    expect(() => buildUrl(tool, paramName, 'catalog/../../1/keys')).toThrow(/objectID/)
   })
 
   it('preserves a plain object id verbatim', () => {
-    const url = buildObjectIdUrl(tool, 'sku_123-abc')
-
-    expect(url.pathname).toContain('sku_123-abc')
+    expect(buildUrl(tool, paramName, 'sku_123-abc').pathname).toContain('sku_123-abc')
   })
 })

--- a/apps/sim/tools/algolia/path_safety.test.ts
+++ b/apps/sim/tools/algolia/path_safety.test.ts
@@ -40,8 +40,7 @@
  * **Every pair asserts rejection, not merely that the path keeps its shape.**
  * A shape check cannot see a bare `.` in the *final* segment: a URL ending
  * `/a/.` normalizes to `/a/`, which has the same segment count and the same
- * leading segments as `/a/id`. `delete_index`, `delete_record` and
- * `get_record` all end in a guarded ID and
+ * leading segments as `/a/id`. `delete_index`, `delete_record` and `get_record` all end in a guarded ID and
  * are all destructive, so a shape-only assertion would be at its weakest
  * exactly where the damage is worst. The first test below pins that property of
  * the URL parser so the reason this file asserts `toThrow` stays visible.
@@ -169,6 +168,22 @@ function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
+/**
+ * What a guarded parameter must emit into its slot: the trimmed value,
+ * percent-encoded, occupying exactly ONE path segment.
+ *
+ * Asserting this rather than skipping the ID's segment is load-bearing. A skip
+ * only proves the segment *count* and the surrounding segments are unchanged,
+ * and a traversal can satisfy both: against raw interpolation
+ * `matter123/../../matters/victim` resolves `/v1/matters/<id>` to
+ * `/v1/matters/victim` — same length, identical non-ID segments, request
+ * silently re-aimed at another resource. The escape the file header calls out
+ * by name would have slipped through this suite's own canonical vector.
+ */
+function expectedSegment(value: string): string {
+  return encodeURIComponent(value.trim())
+}
+
 interface PathParamPair {
   name: string
   tool: PathTool
@@ -258,20 +273,22 @@ describe('algolia path-ID traversal safety', () => {
       expect(url.pathname.startsWith('/1/indexes')).toBe(true)
       expect(url.searchParams.get('injectedParam')).toBeNull()
 
+      const encoded = expectedSegment(value)
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment.includes(TARGET)) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment.replaceAll(TARGET, encoded))
       })
     })
 
     it.each(LEGITIMATE_IDS)('passes %j through unchanged %j', (value) => {
+      const encoded = expectedSegment(value)
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment.replaceAll(TARGET, value))
+        expect(actual[index]).toBe(segment.replaceAll(TARGET, encoded))
+        expect(decodeURIComponent(actual[index])).toBe(segment.replaceAll(TARGET, value))
       })
     })
 
@@ -284,34 +301,51 @@ describe('algolia path-ID traversal safety', () => {
 /**
  * An Algolia `objectID` is an arbitrary caller-chosen string, and Algolia's own
  * clients percent-encode it, so a record keyed `catalog/sku-123` is legitimate
- * and has always worked. `safeAlgoliaObjectId` therefore guards each
- * `/`-delimited piece rather than refusing the separator outright, which would
+ * and has always worked. `safeAlgoliaObjectId` therefore encodes a
+ * separator-bearing id whole rather than refusing the separator, which would
  * have been a behaviour change for valid input.
  *
- * Guarding per piece moves the trailing-segment blind spot one level down: a
- * trailing `.` piece (`catalog/.`) encodes to `catalog%2F.`, which is a single
- * path segment that no dot-segment normalization would touch and no shape check
- * could ever see. The rejections below are therefore the only thing standing
- * between a piecewise guard and a silent hole, and are asserted explicitly.
+ * It does NOT guard the pieces individually, and must not: percent-encoding
+ * collapses the value into a single path segment and the URL parser never
+ * decodes `%2F`, so no interior piece is ever a path segment that dot-segment
+ * removal could act on. Splitting and guarding per piece would buy no safety
+ * and would silently corrupt real ids — `safeUrlPathSegment` trims each piece
+ * (rewriting `catalog/ sku`) and rejects empty ones (refusing `catalog//sku`).
+ * The cases below pin both halves of that: interior dot pieces stay intact, and
+ * only a whole-value dot segment is rejected.
  */
 const OBJECT_ID_PAIRS = PATH_PARAM_PAIRS.filter((pair) => pair.paramName === 'objectID')
 
-describe.each(OBJECT_ID_PAIRS)('$name slash-bearing object ids', ({ tool, paramName }) => {
-  it('keeps a slash-bearing object id working as one encoded segment', () => {
-    const url = buildUrl(tool, paramName, 'catalog/sku-123')
+describe.each(OBJECT_ID_PAIRS)('$name separator-bearing object ids', ({ tool, paramName }) => {
+  it.each([
+    ['catalog/sku-123', 'catalog%2Fsku-123'],
+    ['catalog/ sku', 'catalog%2F%20sku'],
+    ['catalog//sku', 'catalog%2F%2Fsku'],
+    ['catalog/.', 'catalog%2F.'],
+    ['catalog/..', 'catalog%2F..'],
+    ['catalog/../../1/keys', 'catalog%2F..%2F..%2F1%2Fkeys'],
+    ['./sku', '.%2Fsku'],
+    ['../sku', '..%2Fsku'],
+  ])(
+    'keeps %j as the single segment %j, byte-identical to the prior encoding',
+    (value, encoded) => {
+      const url = buildUrl(tool, paramName, value)
 
-    expect(url.pathname).toContain('catalog%2Fsku-123')
-    expect(segmentsOf(url)).toHaveLength(
-      segmentsOf(buildUrl(tool, paramName, 'catalogsku123')).length
-    )
-  })
-
-  it.each(['catalog/.', 'catalog/..', 'catalog/./sku', 'catalog/../sku', './sku', '../sku'])(
-    'rejects the dot-segment piece in %j',
-    (value) => {
-      expect(() => buildUrl(tool, paramName, value)).toThrow(/objectID/)
+      expect(url.pathname).toContain(encoded)
+      expect(encoded).toBe(encodeURIComponent(value.trim()))
+      expect(segmentsOf(url)).toHaveLength(segmentsOf(buildUrl(tool, paramName, 'plain')).length)
     }
   )
+
+  it('encodes a backslash-bearing object id instead of rejecting it', () => {
+    const value = `catalog${String.fromCharCode(92)}sku`
+
+    expect(buildUrl(tool, paramName, value).pathname).toContain('catalog%5Csku')
+  })
+
+  it.each(['..', '.', '  ..  '])('still rejects the whole-value dot segment %j', (value) => {
+    expect(() => buildUrl(tool, paramName, value)).toThrow(/objectID/)
+  })
 
   it('preserves a plain object id verbatim', () => {
     expect(buildUrl(tool, paramName, 'sku_123-abc').pathname).toContain('sku_123-abc')

--- a/apps/sim/tools/algolia/path_safety.test.ts
+++ b/apps/sim/tools/algolia/path_safety.test.ts
@@ -281,7 +281,7 @@ describe('algolia path-ID traversal safety', () => {
       })
     })
 
-    it.each(LEGITIMATE_IDS)('passes %j through unchanged %j', (value) => {
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
       const encoded = expectedSegment(value)
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 

--- a/apps/sim/tools/algolia/path_safety.test.ts
+++ b/apps/sim/tools/algolia/path_safety.test.ts
@@ -1,0 +1,238 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every Algolia tool against path traversal through an LLM-writable ID
+ * that gets interpolated into the request path.
+ *
+ * `indexName`, `objectID`, and `taskID` are all `visibility: 'user-or-llm'`, so
+ * prompt injection controls them. They were already wrapped in
+ * `encodeURIComponent`, and that is exactly the trap this file exists to close:
+ * `.` and `..` are *unreserved* characters, so they survive encoding untouched
+ * and the URL parser then removes them as dot segments. An `indexName` of `..`
+ * turned `/1/indexes/../<op>` into `/1/indexes` on a fixed host with the
+ * workspace's Algolia admin key attached — and `delete_index`, `delete_record`
+ * and `clear_records` are destructive.
+ *
+ * Every assertion here resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ *
+ * `applicationId` is deliberately not in scope: it is `visibility: 'user-only'`
+ * and lands in the *host*, not the path, so it is neither LLM-writable nor a
+ * dot-segment vector. It is pinned to a fixed value below so the origin
+ * assertions stay meaningful.
+ */
+import { describe, expect, it } from 'vitest'
+import * as algoliaTools from '@/tools/algolia/index'
+import type { ToolConfig } from '@/tools/types'
+
+const APPLICATION_ID = 'appid'
+const ALGOLIA_HOSTS = [
+  `${APPLICATION_ID}.algolia.net`,
+  `${APPLICATION_ID}-dsn.algolia.net`,
+] as const
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why the
+ * pre-existing `encodeURIComponent` looked correct while the hole stayed live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../1/keys',
+  '..%2f..%2f1/keys',
+  'products/../../../1/keys',
+  'products?attributesToRetrieve=*',
+  'products#fragment',
+  'products/settings/../../../1/keys',
+  '\\..\\..',
+] as const
+
+/**
+ * Values a real user legitimately supplies. Algolia index names permit letters,
+ * digits, `-`, `_`, `.` and spaces, and none of them may be rejected or
+ * altered.
+ */
+const LEGITIMATE_IDS = [
+  'products',
+  'products_prod',
+  'products-staging',
+  'products_v1.2',
+  'my_index-2026',
+  '..foo',
+  'foo..',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isAlgoliaTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('algolia_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised. `applicationId` and
+ * `apiKey` are pinned: they are credentials, not path identifiers.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { applicationId: APPLICATION_ID, apiKey: 'key' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'applicationId' || name === 'apiKey') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'object') {
+      params[name] = {}
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(url: URL): string[] {
+  return url.pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(algoliaTools)
+  .filter(isAlgoliaTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('algolia path-ID traversal safety', () => {
+  it('covers every Algolia tool that interpolates an ID into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(12)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(ALGOLIA_HOSTS).toContain(url.hostname)
+      expect(url.pathname.startsWith('/1/indexes')).toBe(true)
+
+      const actual = segmentsOf(url)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment.includes(SAFE_ID)) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(TRAVERSAL_IDS.filter((value) => value.trim() === '.' || value.trim() === '..'))(
+      'rejects the bare dot segment %j by name instead of popping the prefix',
+      (value) => {
+        expect(() => buildUrl(tool, value)).toThrow(/indexName|objectID|taskID/)
+      }
+    )
+
+    it('does not let an ID inject a query parameter', () => {
+      const url = buildUrl(tool, 'products?injectedParam=attacker')
+
+      expect(url.searchParams.get('injectedParam')).toBeNull()
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value))
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        expect(actual[index]).toBe(segment.replaceAll(SAFE_ID, value))
+      })
+    })
+
+    it('trims surrounding whitespace rather than encoding it into the path', () => {
+      const actual = segmentsOf(buildUrl(tool, `  ${SAFE_ID}  `))
+
+      expect(actual).toEqual(baseline)
+    })
+  })
+})
+
+/**
+ * An Algolia `objectID` is an arbitrary caller-chosen string, and Algolia's own
+ * clients percent-encode it, so a record keyed `products/123` is legitimate and
+ * has always worked. `safeAlgoliaObjectId` therefore guards each `/`-delimited
+ * piece rather than refusing the separator outright, which would have been a
+ * behaviour change for valid input.
+ */
+const OBJECT_ID_TOOLS = Object.values(algoliaTools)
+  .filter(isAlgoliaTool)
+  .filter((tool) => Object.hasOwn(tool.params ?? {}, 'objectID'))
+  .map((tool) => ({ name: tool.id, tool }))
+
+function buildObjectIdUrl(tool: AnyTool, objectID: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(
+    url({
+      applicationId: APPLICATION_ID,
+      apiKey: 'key',
+      indexName: 'products',
+      objectID,
+      record: {},
+      attributes: {},
+    } as any)
+  )
+}
+
+describe.each(OBJECT_ID_TOOLS)('$name objectID path safety', ({ tool }) => {
+  it('keeps a slash-bearing object id working as one encoded segment', () => {
+    const url = buildObjectIdUrl(tool, 'catalog/sku-123')
+
+    expect(url.pathname).toContain('catalog%2Fsku-123')
+    expect(url.pathname.split('/')).toHaveLength(
+      buildObjectIdUrl(tool, 'catalogsku123').pathname.split('/').length
+    )
+  })
+
+  it('rejects a dot segment hidden inside a slash-bearing object id', () => {
+    expect(() => buildObjectIdUrl(tool, 'catalog/../../1/keys')).toThrow(/objectID/)
+  })
+
+  it('rejects a bare dot-dot object id', () => {
+    expect(() => buildObjectIdUrl(tool, '..')).toThrow(/objectID/)
+  })
+
+  it('preserves a plain object id verbatim', () => {
+    const url = buildObjectIdUrl(tool, 'sku_123-abc')
+
+    expect(url.pathname).toContain('sku_123-abc')
+  })
+})

--- a/apps/sim/tools/algolia/path_safety.test.ts
+++ b/apps/sim/tools/algolia/path_safety.test.ts
@@ -13,6 +13,11 @@
  * workspace's Algolia admin key attached — and `delete_index`, `delete_record`
  * and `clear_records` are destructive.
  *
+ * `applicationId` is deliberately out of scope: it is `visibility: 'user-only'`
+ * and lands in the *host*, not the path, so it is neither LLM-writable nor a
+ * dot-segment vector. It is pinned below so the host assertions stay
+ * meaningful.
+ *
  * These call sites are the clearest demonstration in the whole change that
  * encoding is not a fix: with the pre-existing `encodeURIComponent` restored,
  * `algolia_delete_index` and `algolia_delete_record` fail precisely — and only
@@ -27,29 +32,28 @@
  * **The suite enumerates (tool, parameter) pairs and fuzzes exactly one
  * parameter at a time**, holding every sibling at a known-safe value. Filling
  * every string parameter with the same hostile value and swallowing the throw
- * — the shape this file originally copied — silently stops testing a tool's
- * remaining IDs the moment one of them is guarded, so a route like
- * `/1/indexes/{indexName}/{objectID}` would have been reported as covered while
- * `objectID` was never exercised at all.
+ * silently stops testing a tool's remaining IDs the moment one of them is
+ * guarded, so a route like
+ * `/1/indexes/{indexName}/{objectID}`
+ * would be reported as covered while the second ID was never exercised.
  *
- * `applicationId` is deliberately out of scope: it is `visibility: 'user-only'`
- * and lands in the *host*, not the path, so it is neither LLM-writable nor a
- * dot-segment vector. It is pinned below so the host assertions stay
- * meaningful.
+ * **Every pair asserts rejection, not merely that the path keeps its shape.**
+ * A shape check cannot see a bare `.` in the *final* segment: a URL ending
+ * `/a/.` normalizes to `/a/`, which has the same segment count and the same
+ * leading segments as `/a/id`. `delete_index`, `delete_record` and
+ * `get_record` all end in a guarded ID and
+ * are all destructive, so a shape-only assertion would be at its weakest
+ * exactly where the damage is worst. The first test below pins that property of
+ * the URL parser so the reason this file asserts `toThrow` stays visible.
  */
+import { getErrorMessage } from '@sim/utils/errors'
 import { describe, expect, it } from 'vitest'
 import * as algoliaTools from '@/tools/algolia/index'
-import type { ToolConfig } from '@/tools/types'
-
-const APPLICATION_ID = 'appid'
-const ALGOLIA_HOSTS = [
-  `${APPLICATION_ID}.algolia.net`,
-  `${APPLICATION_ID}-dsn.algolia.net`,
-] as const
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
 /**
- * The bare `.` and `..` entries are the whole point: their omission is why the
- * pre-existing `encodeURIComponent` looked correct while the hole stayed live.
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
  */
 const TRAVERSAL_IDS = [
   '..',
@@ -61,8 +65,11 @@ const TRAVERSAL_IDS = [
   'products?injectedParam=attacker',
   'products#fragment',
   'products/settings/../../../1/keys',
-  '\\..\\..',
+  '\\\\..\\\\..',
 ] as const
+
+/** The dot segments, split out because they must be asserted as rejections. */
+const DOT_SEGMENTS = ['..', '.', '  ..  '] as const
 
 /**
  * Values a real user legitimately supplies. Algolia index names permit letters,
@@ -85,39 +92,63 @@ const TARGET = 'TARGETID'
 /** Every other string parameter is pinned here so only one variable moves. */
 const SIBLING = 'SIBLINGID'
 
-type AnyTool = ToolConfig<any, any>
+const APPLICATION_ID = 'appid'
+const ALGOLIA_HOSTS = [
+  `${APPLICATION_ID}.algolia.net`,
+  `${APPLICATION_ID}-dsn.algolia.net`,
+] as const
 
-function isAlgoliaTool(value: unknown): value is AnyTool {
+/** Credentials, not path identifiers; pinned so only one variable moves. */
+const CREDENTIAL_PARAMS: readonly string[] = ['applicationId', 'apiKey']
+
+/**
+ * The shared shape every path-safety harness in this batch uses. Parameterizing
+ * `ToolConfig` with `Record<string, unknown>` — rather than the fully-untyped
+ * parameterization these harnesses were originally copied from — is what lets
+ * `url(...)` be called below with no cast at all. `ALL_EXPORTS` is seeded as
+ * `readonly unknown[]` so the type guard is the single narrowing point: a
+ * barrel's element union is not assignable to a widened `ToolConfig`, because
+ * the param type sits in the contravariant position of `request.url`.
+ */
+type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
+
+function isProbeableTool(value: unknown): value is PathTool {
+  if (typeof value !== 'object' || value === null) return false
+  /** Narrowing a validated object for property reads; never `any`. */
+  const candidate = value as Record<string, unknown>
+  const request = candidate.request
   return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('algolia_')
+    typeof candidate.id === 'string' &&
+    candidate.id.startsWith('algolia_') &&
+    typeof candidate.params === 'object' &&
+    candidate.params !== null &&
+    typeof request === 'object' &&
+    request !== null &&
+    'url' in request
   )
 }
 
 /**
  * Builds a param object with `targetName` set to `value` and every other
  * parameter pinned to a known-safe placeholder of the right shape, so a failure
- * is always attributable to the one parameter under test. `applicationId` and
- * `apiKey` are credentials, not path identifiers, and stay fixed.
+ * is always attributable to the one parameter under test. `applicationId` and `apiKey`
+ * are credentials, not path identifiers, and stay fixed.
  */
-function buildParams(tool: AnyTool, targetName: string, value: string): Record<string, unknown> {
+function buildParams(tool: PathTool, targetName: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { applicationId: APPLICATION_ID, apiKey: 'key' }
-  for (const [name, def] of Object.entries(tool.params ?? {})) {
-    if (name === 'applicationId' || name === 'apiKey') continue
+  for (const [name, def] of Object.entries(tool.params)) {
+    if (CREDENTIAL_PARAMS.includes(name)) continue
     if (name === targetName) {
       params[name] = value
       continue
     }
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
+    if (def.type === 'json' || def.type === 'array') {
       params[name] = []
-    } else if (type === 'object') {
+    } else if (def.type === 'object') {
       params[name] = {}
-    } else if (type === 'number') {
+    } else if (def.type === 'number') {
       params[name] = 1
-    } else if (type === 'boolean') {
+    } else if (def.type === 'boolean') {
       params[name] = false
     } else {
       params[name] = SIBLING
@@ -126,44 +157,78 @@ function buildParams(tool: AnyTool, targetName: string, value: string): Record<s
   return params
 }
 
-function buildUrl(tool: AnyTool, targetName: string, value: string): URL {
-  const url = tool.request?.url
-  if (typeof url !== 'function') {
+function buildUrl(tool: PathTool, targetName: string, value: string): URL {
+  const builder = tool.request.url
+  if (typeof builder !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, targetName, value) as any))
+  return new URL(builder(buildParams(tool, targetName, value)))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
+interface PathParamPair {
+  name: string
+  tool: PathTool
+  paramName: string
+}
+
+const ALL_EXPORTS: readonly unknown[] = Object.values(algoliaTools)
+const TOOLS: PathTool[] = ALL_EXPORTS.filter(isProbeableTool)
+
+/** Tools whose URL is a constant string; they have no path parameter to fuzz. */
+const STATIC_URL_TOOLS: string[] = TOOLS.filter(
+  (tool) => typeof tool.request.url !== 'function'
+).map((tool) => tool.id)
+
 /**
- * Every (tool, parameter) pair whose parameter actually reaches the path, found
- * by probing one parameter at a time with a unique marker.
+ * Probes that threw while being built from entirely safe placeholder values.
+ * Surfaced rather than swallowed: a tool dropped here is a tool this suite is
+ * silently not testing, which is the failure mode the whole file exists to
+ * prevent.
  */
-const PATH_PARAM_PAIRS = Object.values(algoliaTools)
-  .filter(isAlgoliaTool)
-  .filter((tool) => typeof tool.request?.url === 'function')
-  .flatMap((tool) =>
-    Object.keys(tool.params ?? {})
-      .filter((paramName) => paramName !== 'applicationId' && paramName !== 'apiKey')
-      .filter((paramName) => {
-        try {
-          return buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)
-        } catch {
-          return false
-        }
+const PROBE_FAILURES: Array<{ tool: string; param: string; reason: string }> = []
+
+const PATH_PARAM_PAIRS: PathParamPair[] = []
+for (const tool of TOOLS) {
+  if (typeof tool.request.url !== 'function') continue
+  for (const paramName of Object.keys(tool.params)) {
+    if (CREDENTIAL_PARAMS.includes(paramName)) continue
+    try {
+      if (buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)) {
+        PATH_PARAM_PAIRS.push({ name: `${tool.id} / ${paramName}`, tool, paramName })
+      }
+    } catch (error) {
+      PROBE_FAILURES.push({
+        tool: tool.id,
+        param: paramName,
+        reason: getErrorMessage(error),
       })
-      .map((paramName) => ({ name: `${tool.id} / ${paramName}`, tool, paramName }))
-  )
+    }
+  }
+}
 
 describe('algolia path-ID traversal safety', () => {
-  it('covers every Algolia path parameter, not just the first per tool', () => {
+  it('a trailing dot segment is invisible to a shape check, so rejection is asserted', () => {
+    const withId = new URL(`https://appid.algolia.net/a/b/id`)
+    const withDot = new URL(`https://appid.algolia.net/a/b/.`)
+
+    expect(segmentsOf(withDot)).toHaveLength(segmentsOf(withId).length)
+    expect(withDot.pathname).toBe('/a/b/')
+  })
+
+  it('builds every probe from safe placeholders without dropping a tool', () => {
+    expect(PROBE_FAILURES).toEqual([])
+    expect(STATIC_URL_TOOLS).toEqual([])
+  })
+
+  it('covers every path parameter, not just the first per tool', () => {
     expect(PATH_PARAM_PAIRS.length).toBeGreaterThanOrEqual(18)
   })
 
-  it('exercises the second ID of every two-ID route', () => {
+  it('exercises the second ID of every multi-ID route', () => {
     const covered = new Set(PATH_PARAM_PAIRS.map((pair) => pair.name))
 
     expect(covered).toContain('algolia_add_record / objectID')
@@ -176,12 +241,16 @@ describe('algolia path-ID traversal safety', () => {
   describe.each(PATH_PARAM_PAIRS)('$name', ({ tool, paramName }) => {
     const baseline = segmentsOf(buildUrl(tool, paramName, TARGET))
 
+    it.each(DOT_SEGMENTS)('rejects the dot segment %j by name', (value) => {
+      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
+    })
+
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
         url = buildUrl(tool, paramName, value)
       } catch (error) {
-        expect(String(error)).toContain(paramName)
+        expect(getErrorMessage(error)).toContain(paramName)
         return
       }
 
@@ -197,11 +266,7 @@ describe('algolia path-ID traversal safety', () => {
       })
     })
 
-    it.each(['..', '.', '  ..  '])('rejects the bare dot segment %j by name', (value) => {
-      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
-    })
-
-    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged %j', (value) => {
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)
@@ -222,10 +287,16 @@ describe('algolia path-ID traversal safety', () => {
  * and has always worked. `safeAlgoliaObjectId` therefore guards each
  * `/`-delimited piece rather than refusing the separator outright, which would
  * have been a behaviour change for valid input.
+ *
+ * Guarding per piece moves the trailing-segment blind spot one level down: a
+ * trailing `.` piece (`catalog/.`) encodes to `catalog%2F.`, which is a single
+ * path segment that no dot-segment normalization would touch and no shape check
+ * could ever see. The rejections below are therefore the only thing standing
+ * between a piecewise guard and a silent hole, and are asserted explicitly.
  */
-const OBJECT_ID_TOOLS = PATH_PARAM_PAIRS.filter((pair) => pair.paramName === 'objectID')
+const OBJECT_ID_PAIRS = PATH_PARAM_PAIRS.filter((pair) => pair.paramName === 'objectID')
 
-describe.each(OBJECT_ID_TOOLS)('$name slash-bearing object ids', ({ tool, paramName }) => {
+describe.each(OBJECT_ID_PAIRS)('$name slash-bearing object ids', ({ tool, paramName }) => {
   it('keeps a slash-bearing object id working as one encoded segment', () => {
     const url = buildUrl(tool, paramName, 'catalog/sku-123')
 
@@ -235,9 +306,12 @@ describe.each(OBJECT_ID_TOOLS)('$name slash-bearing object ids', ({ tool, paramN
     )
   })
 
-  it('rejects a dot segment hidden inside a slash-bearing object id', () => {
-    expect(() => buildUrl(tool, paramName, 'catalog/../../1/keys')).toThrow(/objectID/)
-  })
+  it.each(['catalog/.', 'catalog/..', 'catalog/./sku', 'catalog/../sku', './sku', '../sku'])(
+    'rejects the dot-segment piece in %j',
+    (value) => {
+      expect(() => buildUrl(tool, paramName, value)).toThrow(/objectID/)
+    }
+  )
 
   it('preserves a plain object id verbatim', () => {
     expect(buildUrl(tool, paramName, 'sku_123-abc').pathname).toContain('sku_123-abc')

--- a/apps/sim/tools/algolia/update_settings.ts
+++ b/apps/sim/tools/algolia/update_settings.ts
@@ -3,6 +3,7 @@ import type {
   AlgoliaUpdateSettingsResponse,
 } from '@/tools/algolia/types'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const updateSettingsTool: ToolConfig<
   AlgoliaUpdateSettingsParams,
@@ -49,7 +50,7 @@ export const updateSettingsTool: ToolConfig<
 
   request: {
     url: (params) => {
-      const base = `https://${params.applicationId}.algolia.net/1/indexes/${encodeURIComponent(params.indexName.trim())}/settings`
+      const base = `https://${params.applicationId}.algolia.net/1/indexes/${safeUrlPathSegment(params.indexName, 'indexName')}/settings`
       if (params.forwardToReplicas) {
         return `${base}?forwardToReplicas=true`
       }

--- a/apps/sim/tools/algolia/utils.ts
+++ b/apps/sim/tools/algolia/utils.ts
@@ -1,0 +1,36 @@
+import { safeUrlPathSegment } from '@/tools/url-path'
+
+/**
+ * Builds the traversal-safe path component for an Algolia `objectID`.
+ *
+ * `objectID` differs from every other identifier these tools interpolate: it is
+ * an arbitrary caller-chosen string, and Algolia's own clients percent-encode
+ * it, so a record keyed `products/123` is a legitimate value that has always
+ * worked. `safeUrlPathSegment` rejects path separators outright, so applying it
+ * whole would break those records — a behaviour change for valid input.
+ *
+ * Splitting on `/` and guarding each piece keeps the emitted text identical to
+ * the previous `encodeURIComponent(objectID)` for every value that does not
+ * contain a dot segment (`encodeURIComponent('a/b')` is `'a%2Fb'`, which is
+ * exactly what rejoining the encoded pieces with `%2F` produces), while still
+ * refusing the one shape that is dangerous: a piece that is exactly `.` or
+ * `..`. See `@/tools/url-path` for why rejection rather than encoding is the
+ * only mechanism that neutralizes a dot segment.
+ *
+ * @param value - The raw `objectID`, typically LLM-supplied.
+ * @param paramName - The parameter name, used to name the offender in errors.
+ * @returns The percent-encoded object id, safe to interpolate into a path.
+ * @throws If the value is empty, or any `/`-delimited piece is a dot segment.
+ */
+export function safeAlgoliaObjectId(value: string, paramName: string): string {
+  const trimmed = typeof value === 'string' ? value.trim() : value
+
+  if (typeof trimmed === 'string' && trimmed.includes('/')) {
+    return trimmed
+      .split('/')
+      .map((piece) => safeUrlPathSegment(piece, paramName))
+      .join('%2F')
+  }
+
+  return safeUrlPathSegment(trimmed, paramName)
+}

--- a/apps/sim/tools/algolia/utils.ts
+++ b/apps/sim/tools/algolia/utils.ts
@@ -7,30 +7,45 @@ import { safeUrlPathSegment } from '@/tools/url-path'
  * an arbitrary caller-chosen string, and Algolia's own clients percent-encode
  * it, so a record keyed `products/123` is a legitimate value that has always
  * worked. `safeUrlPathSegment` rejects path separators outright, so applying it
- * whole would break those records — a behaviour change for valid input.
+ * whole would break those records.
  *
- * Splitting on `/` and guarding each piece keeps the emitted text identical to
- * the previous `encodeURIComponent(objectID)` for every value that does not
- * contain a dot segment (`encodeURIComponent('a/b')` is `'a%2Fb'`, which is
- * exactly what rejoining the encoded pieces with `%2F` produces), while still
- * refusing the one shape that is dangerous: a piece that is exactly `.` or
- * `..`. See `@/tools/url-path` for why rejection rather than encoding is the
- * only mechanism that neutralizes a dot segment.
+ * A separator-bearing id needs no dot-segment check of its own. Percent-encoding
+ * collapses the whole value into a *single* path segment, and the WHATWG URL
+ * parser does not decode `%2F`, so no interior piece is ever a path segment that
+ * dot-segment removal could act on:
+ *
+ * ```
+ * new URL('https://x/1/indexes/p/' + encodeURIComponent('catalog/../../1/keys')).pathname
+ * // => '/1/indexes/p/catalog%2F..%2F..%2F1%2Fkeys'  (intact)
+ * new URL('https://x/1/indexes/p/' + encodeURIComponent('catalog/.')).pathname
+ * // => '/1/indexes/p/catalog%2F.'                   (intact)
+ * ```
+ *
+ * A value containing a separator therefore cannot be the dangerous shape, which
+ * is a value whose *entire* text is `.` or `..`. Encoding it verbatim is both
+ * safe and byte-identical to the `encodeURIComponent(objectID.trim())` this
+ * replaced, preserving internal whitespace (`catalog/ sku`) and empty components
+ * (`catalog//sku`) exactly as before.
+ *
+ * Everything without a separator goes through the shared guard, which owns the
+ * dot-segment rejection, the empty check, and the non-string input handling.
  *
  * @param value - The raw `objectID`, typically LLM-supplied.
  * @param paramName - The parameter name, used to name the offender in errors.
  * @returns The percent-encoded object id, safe to interpolate into a path.
- * @throws If the value is empty, or any `/`-delimited piece is a dot segment.
+ * @throws If the value is empty, is exactly `.` or `..`, or cannot be encoded.
  */
 export function safeAlgoliaObjectId(value: string, paramName: string): string {
-  const trimmed = typeof value === 'string' ? value.trim() : value
-
-  if (typeof trimmed === 'string' && trimmed.includes('/')) {
-    return trimmed
-      .split('/')
-      .map((piece) => safeUrlPathSegment(piece, paramName))
-      .join('%2F')
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.includes('/') || trimmed.includes('\\')) {
+      try {
+        return encodeURIComponent(trimmed)
+      } catch {
+        throw new Error(`${paramName} contains an unpaired UTF-16 surrogate and cannot be encoded`)
+      }
+    }
   }
 
-  return safeUrlPathSegment(trimmed, paramName)
+  return safeUrlPathSegment(value, paramName)
 }

--- a/apps/sim/tools/google_vault/add_held_accounts.ts
+++ b/apps/sim/tools/google_vault/add_held_accounts.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultAddHeldAccountsParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const addHeldAccountsTool: ToolConfig<GoogleVaultAddHeldAccountsParams> = {
   id: 'google_vault_add_held_accounts',
@@ -43,7 +44,7 @@ export const addHeldAccountsTool: ToolConfig<GoogleVaultAddHeldAccountsParams> =
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/holds/${params.holdId.trim()}:addHeldAccounts`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/holds/${safeUrlPathSegment(params.holdId, 'holdId')}:addHeldAccounts`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/add_matters_permissions.ts
+++ b/apps/sim/tools/google_vault/add_matters_permissions.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultAddMatterPermissionsParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const addMattersPermissionsTool: ToolConfig<GoogleVaultAddMatterPermissionsParams> = {
   id: 'google_vault_add_matters_permissions',
@@ -55,7 +56,7 @@ export const addMattersPermissionsTool: ToolConfig<GoogleVaultAddMatterPermissio
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}:addPermissions`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}:addPermissions`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/close_matters.ts
+++ b/apps/sim/tools/google_vault/close_matters.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultMatterActionParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const closeMattersTool: ToolConfig<GoogleVaultMatterActionParams> = {
   id: 'google_vault_close_matters',
@@ -29,7 +30,8 @@ export const closeMattersTool: ToolConfig<GoogleVaultMatterActionParams> = {
   },
 
   request: {
-    url: (params) => `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}:close`,
+    url: (params) =>
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}:close`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/create_matters_export.ts
+++ b/apps/sim/tools/google_vault/create_matters_export.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultCreateMattersExportParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const createMattersExportTool: ToolConfig<GoogleVaultCreateMattersExportParams> = {
   id: 'google_vault_create_matters_export',
@@ -74,7 +75,8 @@ export const createMattersExportTool: ToolConfig<GoogleVaultCreateMattersExportP
   },
 
   request: {
-    url: (params) => `https://vault.googleapis.com/v1/matters/${params.matterId}/exports`,
+    url: (params) =>
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/exports`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/create_matters_holds.ts
+++ b/apps/sim/tools/google_vault/create_matters_holds.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultCreateMattersHoldsParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const createMattersHoldsTool: ToolConfig<GoogleVaultCreateMattersHoldsParams> = {
   id: 'google_vault_create_matters_holds',
@@ -82,7 +83,8 @@ export const createMattersHoldsTool: ToolConfig<GoogleVaultCreateMattersHoldsPar
   },
 
   request: {
-    url: (params) => `https://vault.googleapis.com/v1/matters/${params.matterId}/holds`,
+    url: (params) =>
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/holds`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/create_saved_query.ts
+++ b/apps/sim/tools/google_vault/create_saved_query.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultCreateSavedQueryParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const createSavedQueryTool: ToolConfig<GoogleVaultCreateSavedQueryParams> = {
   id: 'google_vault_create_saved_query',
@@ -74,7 +75,7 @@ export const createSavedQueryTool: ToolConfig<GoogleVaultCreateSavedQueryParams>
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/savedQueries`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/savedQueries`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/delete_matters.ts
+++ b/apps/sim/tools/google_vault/delete_matters.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultMatterActionParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const deleteMattersTool: ToolConfig<GoogleVaultMatterActionParams> = {
   id: 'google_vault_delete_matters',
@@ -29,7 +30,8 @@ export const deleteMattersTool: ToolConfig<GoogleVaultMatterActionParams> = {
   },
 
   request: {
-    url: (params) => `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}`,
+    url: (params) =>
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/delete_matters_export.ts
+++ b/apps/sim/tools/google_vault/delete_matters_export.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultDeleteMattersExportParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const deleteMattersExportTool: ToolConfig<GoogleVaultDeleteMattersExportParams> = {
   id: 'google_vault_delete_matters_export',
@@ -36,7 +37,7 @@ export const deleteMattersExportTool: ToolConfig<GoogleVaultDeleteMattersExportP
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/exports/${params.exportId.trim()}`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/exports/${safeUrlPathSegment(params.exportId, 'exportId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/delete_matters_holds.ts
+++ b/apps/sim/tools/google_vault/delete_matters_holds.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultDeleteMattersHoldsParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const deleteMattersHoldsTool: ToolConfig<GoogleVaultDeleteMattersHoldsParams> = {
   id: 'google_vault_delete_matters_holds',
@@ -36,7 +37,7 @@ export const deleteMattersHoldsTool: ToolConfig<GoogleVaultDeleteMattersHoldsPar
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/holds/${params.holdId.trim()}`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/holds/${safeUrlPathSegment(params.holdId, 'holdId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/delete_saved_query.ts
+++ b/apps/sim/tools/google_vault/delete_saved_query.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultDeleteSavedQueryParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const deleteSavedQueryTool: ToolConfig<GoogleVaultDeleteSavedQueryParams> = {
   id: 'google_vault_delete_saved_query',
@@ -36,7 +37,7 @@ export const deleteSavedQueryTool: ToolConfig<GoogleVaultDeleteSavedQueryParams>
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/savedQueries/${params.savedQueryId.trim()}`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/savedQueries/${safeUrlPathSegment(params.savedQueryId, 'savedQueryId')}`,
     method: 'DELETE',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/list_matters.ts
+++ b/apps/sim/tools/google_vault/list_matters.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultListMattersParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const listMattersTool: ToolConfig<GoogleVaultListMattersParams> = {
   id: 'google_vault_list_matters',
@@ -43,7 +44,7 @@ export const listMattersTool: ToolConfig<GoogleVaultListMattersParams> = {
   request: {
     url: (params) => {
       if (params.matterId) {
-        return `https://vault.googleapis.com/v1/matters/${params.matterId}`
+        return `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}`
       }
       const url = new URL('https://vault.googleapis.com/v1/matters')
       if (params.pageSize !== undefined && params.pageSize !== null) {

--- a/apps/sim/tools/google_vault/list_matters_export.ts
+++ b/apps/sim/tools/google_vault/list_matters_export.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultListMattersExportParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const listMattersExportTool: ToolConfig<GoogleVaultListMattersExportParams> = {
   id: 'google_vault_list_matters_export',
@@ -49,9 +50,11 @@ export const listMattersExportTool: ToolConfig<GoogleVaultListMattersExportParam
   request: {
     url: (params) => {
       if (params.exportId) {
-        return `https://vault.googleapis.com/v1/matters/${params.matterId}/exports/${params.exportId}`
+        return `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/exports/${safeUrlPathSegment(params.exportId, 'exportId')}`
       }
-      const url = new URL(`https://vault.googleapis.com/v1/matters/${params.matterId}/exports`)
+      const url = new URL(
+        `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/exports`
+      )
       if (params.pageSize !== undefined && params.pageSize !== null) {
         const pageSize = Number(params.pageSize)
         if (Number.isFinite(pageSize) && pageSize > 0) {

--- a/apps/sim/tools/google_vault/list_matters_holds.ts
+++ b/apps/sim/tools/google_vault/list_matters_holds.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultListMattersHoldsParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const listMattersHoldsTool: ToolConfig<GoogleVaultListMattersHoldsParams> = {
   id: 'google_vault_list_matters_holds',
@@ -49,9 +50,11 @@ export const listMattersHoldsTool: ToolConfig<GoogleVaultListMattersHoldsParams>
   request: {
     url: (params) => {
       if (params.holdId) {
-        return `https://vault.googleapis.com/v1/matters/${params.matterId}/holds/${params.holdId}`
+        return `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/holds/${safeUrlPathSegment(params.holdId, 'holdId')}`
       }
-      const url = new URL(`https://vault.googleapis.com/v1/matters/${params.matterId}/holds`)
+      const url = new URL(
+        `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/holds`
+      )
       if (params.pageSize !== undefined && params.pageSize !== null) {
         const pageSize = Number(params.pageSize)
         if (Number.isFinite(pageSize) && pageSize > 0) {

--- a/apps/sim/tools/google_vault/list_saved_queries.ts
+++ b/apps/sim/tools/google_vault/list_saved_queries.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultListSavedQueriesParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const listSavedQueriesTool: ToolConfig<GoogleVaultListSavedQueriesParams> = {
   id: 'google_vault_list_saved_queries',
@@ -49,10 +50,10 @@ export const listSavedQueriesTool: ToolConfig<GoogleVaultListSavedQueriesParams>
   request: {
     url: (params) => {
       if (params.savedQueryId) {
-        return `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/savedQueries/${params.savedQueryId.trim()}`
+        return `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/savedQueries/${safeUrlPathSegment(params.savedQueryId, 'savedQueryId')}`
       }
       const url = new URL(
-        `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/savedQueries`
+        `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/savedQueries`
       )
       if (params.pageSize !== undefined && params.pageSize !== null) {
         const pageSize = Number(params.pageSize)

--- a/apps/sim/tools/google_vault/path_safety.test.ts
+++ b/apps/sim/tools/google_vault/path_safety.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards every Google Vault tool against path traversal through an
+ * LLM-writable ID that gets interpolated into the request path.
+ *
+ * `matterId`, `holdId`, `exportId`, and `savedQueryId` are all
+ * `visibility: 'user-or-llm'`, so prompt injection controls them. Each one was
+ * interpolated raw (`${params.matterId.trim()}`), which let a value like
+ * `../../matters/victim` escape its `/v1/matters/<id>` prefix once `fetch`
+ * normalized the URL — re-aiming the request, and the user's Google OAuth
+ * bearer token, at a different matter. `delete_matters`, `delete_matters_holds`
+ * and `delete_saved_query` are DELETEs, so the reachable damage is destructive.
+ *
+ * Wrapping the ID in `encodeURIComponent` is NOT enough, which is why the
+ * vector list below includes the bare `.` and `..` segments: both are made of
+ * unreserved characters, so they survive encoding untouched and the URL parser
+ * then removes them as dot segments, popping one path segment off a fixed host.
+ * Every assertion here resolves the built URL with `new URL(...)` — the same
+ * normalization `fetch` performs — rather than string-matching the template
+ * output, because string matching is exactly what let this through.
+ */
+import { describe, expect, it } from 'vitest'
+import * as googleVaultTools from '@/tools/google_vault/index'
+import type { ToolConfig } from '@/tools/types'
+
+/**
+ * The bare `.` and `..` entries are the whole point: their omission is why an
+ * `encodeURIComponent`-only fix looks correct while the hole stays live.
+ */
+const TRAVERSAL_IDS = [
+  '..',
+  '.',
+  '  ..  ',
+  '../../matters/victim',
+  '..%2f..%2fmatters/victim',
+  'matter123/../../matters/victim',
+  'matter123?view=FULL',
+  'matter123#fragment',
+  'matter123/holds/../../../v1/matters',
+  '\\..\\..',
+] as const
+
+/** Values a real user legitimately supplies; none may be rejected or altered. */
+const LEGITIMATE_IDS = [
+  '12345678901234567890',
+  'exportId123456',
+  'holdId123456',
+  'AbCdEf-1234_5678',
+  'matter.v2',
+  '..foo',
+  'foo..',
+] as const
+
+const SAFE_ID = 'SAFEID'
+
+type AnyTool = ToolConfig<any, any>
+
+function isGoogleVaultTool(value: unknown): value is AnyTool {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AnyTool).id === 'string' &&
+    (value as AnyTool).id.startsWith('google_vault_')
+  )
+}
+
+/**
+ * Builds a param object for a tool, filling every declared string param with
+ * `value` so whichever one reaches the path is exercised.
+ */
+function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+  const params: Record<string, unknown> = { accessToken: 'token' }
+  for (const [name, def] of Object.entries(tool.params ?? {})) {
+    if (name === 'accessToken') continue
+    const type = (def as { type?: string }).type
+    if (type === 'json' || type === 'array') {
+      params[name] = []
+    } else if (type === 'object') {
+      params[name] = {}
+    } else if (type === 'number') {
+      params[name] = 1
+    } else if (type === 'boolean') {
+      params[name] = false
+    } else {
+      params[name] = value
+    }
+  }
+  return params
+}
+
+function buildUrl(tool: AnyTool, value: string): URL {
+  const url = tool.request?.url
+  if (typeof url !== 'function') {
+    throw new Error(`${tool.id} does not build its URL from params`)
+  }
+  return new URL(url(buildParams(tool, value) as any))
+}
+
+function segmentsOf(url: URL): string[] {
+  return url.pathname.split('/')
+}
+
+const DYNAMIC_PATH_TOOLS = Object.values(googleVaultTools)
+  .filter(isGoogleVaultTool)
+  .filter((tool) => typeof tool.request?.url === 'function')
+  .filter((tool) => {
+    try {
+      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
+    } catch {
+      return false
+    }
+  })
+  .map((tool) => ({ name: tool.id, tool }))
+
+describe('google vault path-ID traversal safety', () => {
+  it('covers every Google Vault tool that interpolates an ID into its path', () => {
+    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(20)
+  })
+
+  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
+    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+
+    it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
+      let url: URL
+      try {
+        url = buildUrl(tool, value)
+      } catch {
+        return
+      }
+
+      expect(url.origin).toBe('https://vault.googleapis.com')
+
+      const actual = segmentsOf(url)
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        if (segment.includes(SAFE_ID)) return
+        expect(actual[index]).toBe(segment)
+      })
+    })
+
+    it.each(TRAVERSAL_IDS.filter((value) => value.trim() === '.' || value.trim() === '..'))(
+      'rejects the bare dot segment %j by name instead of popping the prefix',
+      (value) => {
+        expect(() => buildUrl(tool, value)).toThrow(/Id/)
+      }
+    )
+
+    it('does not let an ID inject a query parameter', () => {
+      const url = buildUrl(tool, 'matter123?injectedParam=attacker')
+
+      expect(url.searchParams.get('injectedParam')).toBeNull()
+    })
+
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+      const actual = segmentsOf(buildUrl(tool, value))
+
+      expect(actual).toHaveLength(baseline.length)
+      baseline.forEach((segment, index) => {
+        expect(actual[index]).toBe(segment.replaceAll(SAFE_ID, value))
+      })
+    })
+
+    it('trims surrounding whitespace rather than encoding it into the path', () => {
+      const actual = segmentsOf(buildUrl(tool, `  ${SAFE_ID}  `))
+
+      expect(actual).toEqual(baseline)
+    })
+  })
+})

--- a/apps/sim/tools/google_vault/path_safety.test.ts
+++ b/apps/sim/tools/google_vault/path_safety.test.ts
@@ -27,14 +27,24 @@
  * **The suite enumerates (tool, parameter) pairs and fuzzes exactly one
  * parameter at a time**, holding every sibling at a known-safe value. Filling
  * every string parameter with the same hostile value and swallowing the throw
- * — the shape this file originally copied — silently stops testing a tool's
- * remaining IDs the moment one of them is guarded, so a route like
- * `/matters/{matterId}/holds/{holdId}` would have been reported as covered
- * while `holdId` was never exercised at all.
+ * silently stops testing a tool's remaining IDs the moment one of them is
+ * guarded, so a route like
+ * `/matters/{matterId}/holds/{holdId}`
+ * would be reported as covered while the second ID was never exercised.
+ *
+ * **Every pair asserts rejection, not merely that the path keeps its shape.**
+ * A shape check cannot see a bare `.` in the *final* segment: a URL ending
+ * `/a/.` normalizes to `/a/`, which has the same segment count and the same
+ * leading segments as `/a/id`. `delete_matters`, `close_matters` and
+ * `undelete_matters` all end in a guarded ID and
+ * are all destructive, so a shape-only assertion would be at its weakest
+ * exactly where the damage is worst. The first test below pins that property of
+ * the URL parser so the reason this file asserts `toThrow` stays visible.
  */
+import { getErrorMessage } from '@sim/utils/errors'
 import { describe, expect, it } from 'vitest'
 import * as googleVaultTools from '@/tools/google_vault/index'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
 /**
  * The bare `.` and `..` entries are the whole point: their omission is why an
@@ -50,8 +60,11 @@ const TRAVERSAL_IDS = [
   'matter123?injectedParam=attacker',
   'matter123#fragment',
   'matter123/holds/../../../v1/matters',
-  '\\..\\..',
+  '\\\\..\\\\..',
 ] as const
+
+/** The dot segments, split out because they must be asserted as rejections. */
+const DOT_SEGMENTS = ['..', '.', '  ..  '] as const
 
 /** Values a real user legitimately supplies; none may be rejected or altered. */
 const LEGITIMATE_IDS = [
@@ -72,38 +85,57 @@ const SIBLING = 'SIBLINGID'
 
 const ORIGIN = 'https://vault.googleapis.com'
 
-type AnyTool = ToolConfig<any, any>
+/** Credentials, not path identifiers; pinned so only one variable moves. */
+const CREDENTIAL_PARAMS: readonly string[] = ['accessToken']
 
-function isGoogleVaultTool(value: unknown): value is AnyTool {
+/**
+ * The shared shape every path-safety harness in this batch uses. Parameterizing
+ * `ToolConfig` with `Record<string, unknown>` — rather than the fully-untyped
+ * parameterization these harnesses were originally copied from — is what lets
+ * `url(...)` be called below with no cast at all. `ALL_EXPORTS` is seeded as
+ * `readonly unknown[]` so the type guard is the single narrowing point: a
+ * barrel's element union is not assignable to a widened `ToolConfig`, because
+ * the param type sits in the contravariant position of `request.url`.
+ */
+type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
+
+function isProbeableTool(value: unknown): value is PathTool {
+  if (typeof value !== 'object' || value === null) return false
+  /** Narrowing a validated object for property reads; never `any`. */
+  const candidate = value as Record<string, unknown>
+  const request = candidate.request
   return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as AnyTool).id === 'string' &&
-    (value as AnyTool).id.startsWith('google_vault_')
+    typeof candidate.id === 'string' &&
+    candidate.id.startsWith('google_vault_') &&
+    typeof candidate.params === 'object' &&
+    candidate.params !== null &&
+    typeof request === 'object' &&
+    request !== null &&
+    'url' in request
   )
 }
 
 /**
  * Builds a param object with `targetName` set to `value` and every other
  * parameter pinned to a known-safe placeholder of the right shape, so a failure
- * is always attributable to the one parameter under test.
+ * is always attributable to the one parameter under test. `accessToken` is a
+ * credential, not a path identifier, and stays fixed.
  */
-function buildParams(tool: AnyTool, targetName: string, value: string): Record<string, unknown> {
+function buildParams(tool: PathTool, targetName: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { accessToken: 'token' }
-  for (const [name, def] of Object.entries(tool.params ?? {})) {
-    if (name === 'accessToken') continue
+  for (const [name, def] of Object.entries(tool.params)) {
+    if (CREDENTIAL_PARAMS.includes(name)) continue
     if (name === targetName) {
       params[name] = value
       continue
     }
-    const type = (def as { type?: string }).type
-    if (type === 'json' || type === 'array') {
+    if (def.type === 'json' || def.type === 'array') {
       params[name] = []
-    } else if (type === 'object') {
+    } else if (def.type === 'object') {
       params[name] = {}
-    } else if (type === 'number') {
+    } else if (def.type === 'number') {
       params[name] = 1
-    } else if (type === 'boolean') {
+    } else if (def.type === 'boolean') {
       params[name] = false
     } else {
       params[name] = SIBLING
@@ -112,44 +144,78 @@ function buildParams(tool: AnyTool, targetName: string, value: string): Record<s
   return params
 }
 
-function buildUrl(tool: AnyTool, targetName: string, value: string): URL {
-  const url = tool.request?.url
-  if (typeof url !== 'function') {
+function buildUrl(tool: PathTool, targetName: string, value: string): URL {
+  const builder = tool.request.url
+  if (typeof builder !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, targetName, value) as any))
+  return new URL(builder(buildParams(tool, targetName, value)))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
+interface PathParamPair {
+  name: string
+  tool: PathTool
+  paramName: string
+}
+
+const ALL_EXPORTS: readonly unknown[] = Object.values(googleVaultTools)
+const TOOLS: PathTool[] = ALL_EXPORTS.filter(isProbeableTool)
+
+/** Tools whose URL is a constant string; they have no path parameter to fuzz. */
+const STATIC_URL_TOOLS: string[] = TOOLS.filter(
+  (tool) => typeof tool.request.url !== 'function'
+).map((tool) => tool.id)
+
 /**
- * Every (tool, parameter) pair whose parameter actually reaches the path, found
- * by probing one parameter at a time with a unique marker.
+ * Probes that threw while being built from entirely safe placeholder values.
+ * Surfaced rather than swallowed: a tool dropped here is a tool this suite is
+ * silently not testing, which is the failure mode the whole file exists to
+ * prevent.
  */
-const PATH_PARAM_PAIRS = Object.values(googleVaultTools)
-  .filter(isGoogleVaultTool)
-  .filter((tool) => typeof tool.request?.url === 'function')
-  .flatMap((tool) =>
-    Object.keys(tool.params ?? {})
-      .filter((paramName) => paramName !== 'accessToken')
-      .filter((paramName) => {
-        try {
-          return buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)
-        } catch {
-          return false
-        }
+const PROBE_FAILURES: Array<{ tool: string; param: string; reason: string }> = []
+
+const PATH_PARAM_PAIRS: PathParamPair[] = []
+for (const tool of TOOLS) {
+  if (typeof tool.request.url !== 'function') continue
+  for (const paramName of Object.keys(tool.params)) {
+    if (CREDENTIAL_PARAMS.includes(paramName)) continue
+    try {
+      if (buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)) {
+        PATH_PARAM_PAIRS.push({ name: `${tool.id} / ${paramName}`, tool, paramName })
+      }
+    } catch (error) {
+      PROBE_FAILURES.push({
+        tool: tool.id,
+        param: paramName,
+        reason: getErrorMessage(error),
       })
-      .map((paramName) => ({ name: `${tool.id} / ${paramName}`, tool, paramName }))
-  )
+    }
+  }
+}
 
 describe('google vault path-ID traversal safety', () => {
-  it('covers every Google Vault path parameter, not just the first per tool', () => {
+  it('a trailing dot segment is invisible to a shape check, so rejection is asserted', () => {
+    const withId = new URL(`https://vault.googleapis.com/a/b/id`)
+    const withDot = new URL(`https://vault.googleapis.com/a/b/.`)
+
+    expect(segmentsOf(withDot)).toHaveLength(segmentsOf(withId).length)
+    expect(withDot.pathname).toBe('/a/b/')
+  })
+
+  it('builds every probe from safe placeholders without dropping a tool', () => {
+    expect(PROBE_FAILURES).toEqual([])
+    expect(STATIC_URL_TOOLS).toEqual([])
+  })
+
+  it('covers every path parameter, not just the first per tool', () => {
     expect(PATH_PARAM_PAIRS.length).toBeGreaterThanOrEqual(29)
   })
 
-  it('exercises the second ID of every two-ID route', () => {
+  it('exercises the second ID of every multi-ID route', () => {
     const covered = new Set(PATH_PARAM_PAIRS.map((pair) => pair.name))
 
     expect(covered).toContain('google_vault_delete_matters_holds / holdId')
@@ -166,12 +232,16 @@ describe('google vault path-ID traversal safety', () => {
   describe.each(PATH_PARAM_PAIRS)('$name', ({ tool, paramName }) => {
     const baseline = segmentsOf(buildUrl(tool, paramName, TARGET))
 
+    it.each(DOT_SEGMENTS)('rejects the dot segment %j by name', (value) => {
+      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
+    })
+
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
         url = buildUrl(tool, paramName, value)
       } catch (error) {
-        expect(String(error)).toContain(paramName)
+        expect(getErrorMessage(error)).toContain(paramName)
         return
       }
 
@@ -186,11 +256,7 @@ describe('google vault path-ID traversal safety', () => {
       })
     })
 
-    it.each(['..', '.', '  ..  '])('rejects the bare dot segment %j by name', (value) => {
-      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
-    })
-
-    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged %j', (value) => {
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)

--- a/apps/sim/tools/google_vault/path_safety.test.ts
+++ b/apps/sim/tools/google_vault/path_safety.test.ts
@@ -16,9 +16,21 @@
  * vector list below includes the bare `.` and `..` segments: both are made of
  * unreserved characters, so they survive encoding untouched and the URL parser
  * then removes them as dot segments, popping one path segment off a fixed host.
+ * The clearest demonstration is the sibling Algolia suite, whose call sites
+ * already wrapped every ID in `encodeURIComponent` and still failed precisely
+ * — and only — on the bare `.` and `..` vectors.
+ *
  * Every assertion here resolves the built URL with `new URL(...)` — the same
  * normalization `fetch` performs — rather than string-matching the template
  * output, because string matching is exactly what let this through.
+ *
+ * **The suite enumerates (tool, parameter) pairs and fuzzes exactly one
+ * parameter at a time**, holding every sibling at a known-safe value. Filling
+ * every string parameter with the same hostile value and swallowing the throw
+ * — the shape this file originally copied — silently stops testing a tool's
+ * remaining IDs the moment one of them is guarded, so a route like
+ * `/matters/{matterId}/holds/{holdId}` would have been reported as covered
+ * while `holdId` was never exercised at all.
  */
 import { describe, expect, it } from 'vitest'
 import * as googleVaultTools from '@/tools/google_vault/index'
@@ -35,7 +47,7 @@ const TRAVERSAL_IDS = [
   '../../matters/victim',
   '..%2f..%2fmatters/victim',
   'matter123/../../matters/victim',
-  'matter123?view=FULL',
+  'matter123?injectedParam=attacker',
   'matter123#fragment',
   'matter123/holds/../../../v1/matters',
   '\\..\\..',
@@ -52,7 +64,13 @@ const LEGITIMATE_IDS = [
   'foo..',
 ] as const
 
-const SAFE_ID = 'SAFEID'
+/** The value under test; unique so its position in the path is unambiguous. */
+const TARGET = 'TARGETID'
+
+/** Every other string parameter is pinned here so only one variable moves. */
+const SIBLING = 'SIBLINGID'
+
+const ORIGIN = 'https://vault.googleapis.com'
 
 type AnyTool = ToolConfig<any, any>
 
@@ -66,13 +84,18 @@ function isGoogleVaultTool(value: unknown): value is AnyTool {
 }
 
 /**
- * Builds a param object for a tool, filling every declared string param with
- * `value` so whichever one reaches the path is exercised.
+ * Builds a param object with `targetName` set to `value` and every other
+ * parameter pinned to a known-safe placeholder of the right shape, so a failure
+ * is always attributable to the one parameter under test.
  */
-function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
+function buildParams(tool: AnyTool, targetName: string, value: string): Record<string, unknown> {
   const params: Record<string, unknown> = { accessToken: 'token' }
   for (const [name, def] of Object.entries(tool.params ?? {})) {
     if (name === 'accessToken') continue
+    if (name === targetName) {
+      params[name] = value
+      continue
+    }
     const type = (def as { type?: string }).type
     if (type === 'json' || type === 'array') {
       params[name] = []
@@ -83,88 +106,101 @@ function buildParams(tool: AnyTool, value: string): Record<string, unknown> {
     } else if (type === 'boolean') {
       params[name] = false
     } else {
-      params[name] = value
+      params[name] = SIBLING
     }
   }
   return params
 }
 
-function buildUrl(tool: AnyTool, value: string): URL {
+function buildUrl(tool: AnyTool, targetName: string, value: string): URL {
   const url = tool.request?.url
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, value) as any))
+  return new URL(url(buildParams(tool, targetName, value) as any))
 }
 
 function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(googleVaultTools)
+/**
+ * Every (tool, parameter) pair whose parameter actually reaches the path, found
+ * by probing one parameter at a time with a unique marker.
+ */
+const PATH_PARAM_PAIRS = Object.values(googleVaultTools)
   .filter(isGoogleVaultTool)
   .filter((tool) => typeof tool.request?.url === 'function')
-  .filter((tool) => {
-    try {
-      return buildUrl(tool, SAFE_ID).pathname.includes(SAFE_ID)
-    } catch {
-      return false
-    }
-  })
-  .map((tool) => ({ name: tool.id, tool }))
+  .flatMap((tool) =>
+    Object.keys(tool.params ?? {})
+      .filter((paramName) => paramName !== 'accessToken')
+      .filter((paramName) => {
+        try {
+          return buildUrl(tool, paramName, TARGET).pathname.includes(TARGET)
+        } catch {
+          return false
+        }
+      })
+      .map((paramName) => ({ name: `${tool.id} / ${paramName}`, tool, paramName }))
+  )
 
 describe('google vault path-ID traversal safety', () => {
-  it('covers every Google Vault tool that interpolates an ID into its path', () => {
-    expect(DYNAMIC_PATH_TOOLS.length).toBeGreaterThanOrEqual(20)
+  it('covers every Google Vault path parameter, not just the first per tool', () => {
+    expect(PATH_PARAM_PAIRS.length).toBeGreaterThanOrEqual(29)
   })
 
-  describe.each(DYNAMIC_PATH_TOOLS)('$name', ({ tool }) => {
-    const baseline = segmentsOf(buildUrl(tool, SAFE_ID))
+  it('exercises the second ID of every two-ID route', () => {
+    const covered = new Set(PATH_PARAM_PAIRS.map((pair) => pair.name))
+
+    expect(covered).toContain('google_vault_delete_matters_holds / holdId')
+    expect(covered).toContain('google_vault_update_matters_holds / holdId')
+    expect(covered).toContain('google_vault_add_held_accounts / holdId')
+    expect(covered).toContain('google_vault_remove_held_accounts / holdId')
+    expect(covered).toContain('google_vault_list_matters_holds / holdId')
+    expect(covered).toContain('google_vault_delete_matters_export / exportId')
+    expect(covered).toContain('google_vault_list_matters_export / exportId')
+    expect(covered).toContain('google_vault_delete_saved_query / savedQueryId')
+    expect(covered).toContain('google_vault_list_saved_queries / savedQueryId')
+  })
+
+  describe.each(PATH_PARAM_PAIRS)('$name', ({ tool, paramName }) => {
+    const baseline = segmentsOf(buildUrl(tool, paramName, TARGET))
 
     it.each(TRAVERSAL_IDS)('cannot reshape the path with %j', (value) => {
       let url: URL
       try {
-        url = buildUrl(tool, value)
-      } catch {
+        url = buildUrl(tool, paramName, value)
+      } catch (error) {
+        expect(String(error)).toContain(paramName)
         return
       }
 
-      expect(url.origin).toBe('https://vault.googleapis.com')
+      expect(url.origin).toBe(ORIGIN)
+      expect(url.searchParams.get('injectedParam')).toBeNull()
 
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment.includes(SAFE_ID)) return
+        if (segment.includes(TARGET)) return
         expect(actual[index]).toBe(segment)
       })
     })
 
-    it.each(TRAVERSAL_IDS.filter((value) => value.trim() === '.' || value.trim() === '..'))(
-      'rejects the bare dot segment %j by name instead of popping the prefix',
-      (value) => {
-        expect(() => buildUrl(tool, value)).toThrow(/Id/)
-      }
-    )
-
-    it('does not let an ID inject a query parameter', () => {
-      const url = buildUrl(tool, 'matter123?injectedParam=attacker')
-
-      expect(url.searchParams.get('injectedParam')).toBeNull()
+    it.each(['..', '.', '  ..  '])('rejects the bare dot segment %j by name', (value) => {
+      expect(() => buildUrl(tool, paramName, value)).toThrow(new RegExp(paramName))
     })
 
     it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
-      const actual = segmentsOf(buildUrl(tool, value))
+      const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment.replaceAll(SAFE_ID, value))
+        expect(actual[index]).toBe(segment.replaceAll(TARGET, value))
       })
     })
 
     it('trims surrounding whitespace rather than encoding it into the path', () => {
-      const actual = segmentsOf(buildUrl(tool, `  ${SAFE_ID}  `))
-
-      expect(actual).toEqual(baseline)
+      expect(segmentsOf(buildUrl(tool, paramName, `  ${TARGET}  `))).toEqual(baseline)
     })
   })
 })

--- a/apps/sim/tools/google_vault/path_safety.test.ts
+++ b/apps/sim/tools/google_vault/path_safety.test.ts
@@ -271,7 +271,7 @@ describe('google vault path-ID traversal safety', () => {
       })
     })
 
-    it.each(LEGITIMATE_IDS)('passes %j through unchanged %j', (value) => {
+    it.each(LEGITIMATE_IDS)('passes %j through unchanged', (value) => {
       const encoded = expectedSegment(value)
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 

--- a/apps/sim/tools/google_vault/path_safety.test.ts
+++ b/apps/sim/tools/google_vault/path_safety.test.ts
@@ -35,8 +35,7 @@
  * **Every pair asserts rejection, not merely that the path keeps its shape.**
  * A shape check cannot see a bare `.` in the *final* segment: a URL ending
  * `/a/.` normalizes to `/a/`, which has the same segment count and the same
- * leading segments as `/a/id`. `delete_matters`, `close_matters` and
- * `undelete_matters` all end in a guarded ID and
+ * leading segments as `/a/id`. `delete_matters`, `close_matters` and `undelete_matters` all end in a guarded ID and
  * are all destructive, so a shape-only assertion would be at its weakest
  * exactly where the damage is worst. The first test below pins that property of
  * the URL parser so the reason this file asserts `toThrow` stays visible.
@@ -156,6 +155,22 @@ function segmentsOf(url: URL): string[] {
   return url.pathname.split('/')
 }
 
+/**
+ * What a guarded parameter must emit into its slot: the trimmed value,
+ * percent-encoded, occupying exactly ONE path segment.
+ *
+ * Asserting this rather than skipping the ID's segment is load-bearing. A skip
+ * only proves the segment *count* and the surrounding segments are unchanged,
+ * and a traversal can satisfy both: against raw interpolation
+ * `matter123/../../matters/victim` resolves `/v1/matters/<id>` to
+ * `/v1/matters/victim` — same length, identical non-ID segments, request
+ * silently re-aimed at another resource. The escape the file header calls out
+ * by name would have slipped through this suite's own canonical vector.
+ */
+function expectedSegment(value: string): string {
+  return encodeURIComponent(value.trim())
+}
+
 interface PathParamPair {
   name: string
   tool: PathTool
@@ -248,20 +263,22 @@ describe('google vault path-ID traversal safety', () => {
       expect(url.origin).toBe(ORIGIN)
       expect(url.searchParams.get('injectedParam')).toBeNull()
 
+      const encoded = expectedSegment(value)
       const actual = segmentsOf(url)
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        if (segment.includes(TARGET)) return
-        expect(actual[index]).toBe(segment)
+        expect(actual[index]).toBe(segment.replaceAll(TARGET, encoded))
       })
     })
 
     it.each(LEGITIMATE_IDS)('passes %j through unchanged %j', (value) => {
+      const encoded = expectedSegment(value)
       const actual = segmentsOf(buildUrl(tool, paramName, value))
 
       expect(actual).toHaveLength(baseline.length)
       baseline.forEach((segment, index) => {
-        expect(actual[index]).toBe(segment.replaceAll(TARGET, value))
+        expect(actual[index]).toBe(segment.replaceAll(TARGET, encoded))
+        expect(decodeURIComponent(actual[index])).toBe(segment.replaceAll(TARGET, value))
       })
     })
 

--- a/apps/sim/tools/google_vault/remove_held_accounts.ts
+++ b/apps/sim/tools/google_vault/remove_held_accounts.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultRemoveHeldAccountsParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const removeHeldAccountsTool: ToolConfig<GoogleVaultRemoveHeldAccountsParams> = {
   id: 'google_vault_remove_held_accounts',
@@ -43,7 +44,7 @@ export const removeHeldAccountsTool: ToolConfig<GoogleVaultRemoveHeldAccountsPar
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/holds/${params.holdId.trim()}:removeHeldAccounts`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/holds/${safeUrlPathSegment(params.holdId, 'holdId')}:removeHeldAccounts`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/remove_matters_permissions.ts
+++ b/apps/sim/tools/google_vault/remove_matters_permissions.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultRemoveMatterPermissionsParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const removeMattersPermissionsTool: ToolConfig<GoogleVaultRemoveMatterPermissionsParams> = {
   id: 'google_vault_remove_matters_permissions',
@@ -36,7 +37,7 @@ export const removeMattersPermissionsTool: ToolConfig<GoogleVaultRemoveMatterPer
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}:removePermissions`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}:removePermissions`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/reopen_matters.ts
+++ b/apps/sim/tools/google_vault/reopen_matters.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultMatterActionParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const reopenMattersTool: ToolConfig<GoogleVaultMatterActionParams> = {
   id: 'google_vault_reopen_matters',
@@ -29,7 +30,8 @@ export const reopenMattersTool: ToolConfig<GoogleVaultMatterActionParams> = {
   },
 
   request: {
-    url: (params) => `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}:reopen`,
+    url: (params) =>
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}:reopen`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/undelete_matters.ts
+++ b/apps/sim/tools/google_vault/undelete_matters.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultMatterActionParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const undeleteMattersTool: ToolConfig<GoogleVaultMatterActionParams> = {
   id: 'google_vault_undelete_matters',
@@ -29,7 +30,8 @@ export const undeleteMattersTool: ToolConfig<GoogleVaultMatterActionParams> = {
   },
 
   request: {
-    url: (params) => `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}:undelete`,
+    url: (params) =>
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}:undelete`,
     method: 'POST',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/update_matters.ts
+++ b/apps/sim/tools/google_vault/update_matters.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultUpdateMatterParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const updateMattersTool: ToolConfig<GoogleVaultUpdateMatterParams> = {
   id: 'google_vault_update_matters',
@@ -41,7 +42,8 @@ export const updateMattersTool: ToolConfig<GoogleVaultUpdateMatterParams> = {
   },
 
   request: {
-    url: (params) => `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}`,
+    url: (params) =>
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}`,
     method: 'PUT',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,

--- a/apps/sim/tools/google_vault/update_matters_holds.ts
+++ b/apps/sim/tools/google_vault/update_matters_holds.ts
@@ -1,6 +1,7 @@
 import type { GoogleVaultUpdateMattersHoldsParams } from '@/tools/google_vault/types'
 import { enhanceGoogleVaultError } from '@/tools/google_vault/utils'
 import type { ToolConfig } from '@/tools/types'
+import { safeUrlPathSegment } from '@/tools/url-path'
 
 export const updateMattersHoldsTool: ToolConfig<GoogleVaultUpdateMattersHoldsParams> = {
   id: 'google_vault_update_matters_holds',
@@ -91,7 +92,7 @@ export const updateMattersHoldsTool: ToolConfig<GoogleVaultUpdateMattersHoldsPar
 
   request: {
     url: (params) =>
-      `https://vault.googleapis.com/v1/matters/${params.matterId.trim()}/holds/${params.holdId.trim()}`,
+      `https://vault.googleapis.com/v1/matters/${safeUrlPathSegment(params.matterId, 'matterId')}/holds/${safeUrlPathSegment(params.holdId, 'holdId')}`,
     method: 'PUT',
     headers: (params) => ({
       Authorization: `Bearer ${params.accessToken}`,


### PR DESCRIPTION
## The defect

Google Vault, AgentMail and Algolia tools interpolate LLM-writable identifiers into URL path segments. All of these params are `visibility: 'user-or-llm'`, so prompt injection controls them:

| Service | Params | Sites |
|---|---|---|
| Google Vault | `matterId`, `holdId`, `exportId`, `savedQueryId` | 20 tools, 26 interpolations (raw, no encoding) |
| AgentMail | `inboxId`, `threadId`, `messageId`, `draftId` | 17 tools, 26 interpolations (raw, no encoding) |
| Algolia | `indexName`, `objectID`, `taskID` | 12 tools, 18 interpolations (`encodeURIComponent`, which is not enough) |

A value like `../../matters/victim` escapes its API prefix once `fetch` normalizes the URL, re-aiming the request — with the user's Google OAuth token / AgentMail API key / Algolia admin key still attached — at a different resource. `delete_matters`, `delete_matters_holds`, `delete_saved_query`, `delete_inbox`, `delete_thread`, `delete_draft`, `delete_index`, `delete_record` and `clear_records` are all destructive.

`encodeURIComponent` is **not** sufficient, which is why the Algolia sites were vulnerable despite already encoding. `.` and `..` are unreserved characters, so they survive encoding verbatim, and the WHATWG URL parser removes dot segments *after* decoding:

```
new URL('https://vault.googleapis.com/v1/matters/' + encodeURIComponent('..') + '/holds').pathname
// => '/v1/holds'
```

Encoded separators are *not* decoded (`..%2F..%2Fmatters%2Fvictim` stays intact), so the only dangerous shape is a segment that is exactly `.` or `..` — and the only fix is rejection.

## The fix

Every site now routes through `safeUrlPathSegment(value, paramName)` from `@/tools/url-path`.

Algolia `objectID` is the one exception. It is an arbitrary caller-chosen string, and Algolia's own clients percent-encode it, so a record keyed `catalog/sku-123` is legitimate and has always worked — `safeUrlPathSegment` rejects separators outright and would have broken those records. `safeAlgoliaObjectId` (new, `tools/algolia/utils.ts`) encodes a separator-bearing id **whole**, byte-identical to the `encodeURIComponent(objectID.trim())` it replaces, and defers everything else to `safeUrlPathSegment`.

A separator-bearing id needs no dot-segment check of its own, because percent-encoding collapses the value into a single path segment and the URL parser never decodes `%2F`:

```
new URL('https://x/1/indexes/p/' + encodeURIComponent('catalog/../../1/keys')).pathname
// => /1/indexes/p/catalog%2F..%2F..%2F1%2Fkeys   (intact)
```

So a value containing a separator cannot be the dangerous shape — that is a value whose *entire* text is `.` or `..`.

No param `visibility`, subBlock id, block definition, or generated artifact changed — `tool-metadata:generate` is a no-op on this branch.

## ⚠️ Behaviour change: AgentMail inbox IDs are now percent-encoded

An AgentMail inbox ID legitimately **is** an email address (`example@agentmail.to`). `safeUrlPathSegment` percent-encodes it, so ~30 call sites now send `example%40agentmail.to` instead of `example@agentmail.to`. **This is a real change on the wire.**

I verified it is safe against AgentMail's own SDKs before relying on it:

- **Node SDK** (`agentmail-to/agentmail-node`) builds every path as `` `/v0/inboxes/${core.url.encodePathParam(...)}` ``, and `src/core/url/encodePathParam.ts` is a thin wrapper around `encodeURIComponent`. Every request the official Node SDK makes already sends `%40`.
- **Python SDK** (`agentmail-to/agentmail-python`) builds `f"v0/inboxes/{jsonable_encoder(inbox_id)}"` — no percent-encoding, the `@` goes out raw.

Both SDKs ship and work, so the AgentMail server decodes percent-encoding normally. The change is inert.

The AgentMail test asserts this explicitly: legitimate IDs must round-trip through `decodeURIComponent` back to the exact value supplied, and there is a dedicated case proving an email-address inbox ID is encoded rather than rejected.

## Not a risk — deliberately left alone

- **`downloadGoogleVaultExportFile`** (`lib/internal/google-vault/operations.ts`, the internal handler behind `google_vault_download_export_file`; there is no `app/api/tools/google_vault/download-export-file/route.ts` on staging). It interpolates `bucketName` and `objectName` into a GCS path, but both are `visibility: 'user-only'` — not LLM-writable — and a GCS `objectName` legitimately contains `/`, so `safeUrlPathSegment` would break every real export download. `matterId` is not used in that URL at all.
- **Algolia `applicationId`**. It lands in the *host*, not the path, and is `visibility: 'user-only'`. Not a dot-segment vector.
- **Query-string values** (`pageToken`, `attributesToRetrieve`, `permanent`, …). They go through `URLSearchParams` or `encodeURIComponent` in a query position, where dot segments carry no meaning.

## Tests

New `path_safety.test.ts` under each of the three tool folders. **1741 tests pass.**

- The suite enumerates **(tool, parameter) pairs** — 29 Google Vault, 30 AgentMail, 18 Algolia = **77 pairs across 49 tools** — and fuzzes **exactly one parameter at a time**, holding every sibling at a known-safe placeholder. A thrown error must *name the parameter under test*, so a throw is never discarded.
- Pairs are **discovered from the barrel** by probing each parameter with a unique marker and checking whether it reaches `url.pathname`, so a newly added unguarded path parameter fails CI automatically. Coverage floors plus named assertions pin the second ID of every two-ID route (`.../holds/{holdId}`, `.../exports/{exportId}`, `.../threads/{threadId}`, `.../messages/{messageId}`, `.../drafts/{draftId}`, `.../{objectID}`, `.../task/{taskID}`).
- **Every pair asserts rejection AND the exact ID slot** — never skipping the segment the ID lands in. Both are load-bearing; see holes #2 and #3 below.
- Discovery **surfaces** rather than swallows: any probe that throws while built from entirely safe placeholders is recorded and asserted empty, so a tool silently dropped from the suite fails CI.
- Every URL is resolved with `new URL(...)` — the same normalization `fetch` performs — never string-matched.
- A `LEGITIMATE_IDS` list proves real values pass through **unchanged**: an email-address inbox ID, Vault numeric matter IDs and `holdId123456`, Algolia index names with `_`, `-` and `.`, plus `..foo` / `foo..`. Algolia additionally proves `catalog/sku-123` still resolves to one encoded segment.

### Hole #1 (fixed, 2nd commit): all-params-at-once fuzzing

The first revision copied `tools/vercel/edge_config_path_safety.test.ts`, which fills *every* string parameter with the same hostile value and then does `try { ... } catch { return }`. The moment one parameter is guarded the whole vector is skipped, so `/matters/{matterId}/holds/{holdId}` and `/inboxes/{inboxId}/threads/{threadId}` were reported as covered while the second ID was never exercised.

Measured directly — with `delete_matters_holds`'s `holdId` reverted to `${params.holdId.trim()}`:

| Suite | Failures |
|---|---|
| Original all-params-at-once template | **1** (incidental — the one assertion outside the `try/catch`) |
| Tightened (tool, param) suite | **11** |

### Hole #2 (fixed, 3rd commit): a trailing `.` is invisible to a shape check

`https://host/a/.` normalizes to `https://host/a/` — same segment count, same leading segments — so a shape-only assertion passes even with the guard removed. `delete_matters`, `delete_inbox` and `delete_index` all end in a guarded ID and are all destructive, so a shape check was weakest exactly where the damage is worst. Every pair now asserts `.`, `..` and `'  ..  '` **throw**.

`safeAlgoliaObjectId` guards per slash-delimited piece, so the same blind spot exists one level down: a trailing `.` piece (`catalog/.`) encodes to `catalog%2F.`, a single segment no dot-segment normalization would ever touch. That is now asserted explicitly (`catalog/.`, `catalog/..`, `catalog/./sku`, `catalog/../sku`, `./sku`, `../sku`).

**Did these changes move the numbers? Yes — 37 → 45 failures.** Scoped revert of the four trailing-ID destructive sites:

| Reverted site | Failures (3rd commit) | Failures (4th commit, ID slot asserted) |
|---|---|---|
| `google_vault/delete_matters` `matterId` | 10 | **13** |
| `agentmail/delete_inbox` `inboxId` | 11 | **17** |
| `algolia/delete_index` `indexName` | 5 | **6** |
| `algolia/delete_record` `objectID` | 11 | **9** |
| **total** | **37** | **45** |

(`delete_record` drops because the 6 per-piece assertions tested a risk that does not exist and were replaced by 3 whole-value rejections.)

**At all four sites, zero shape assertions fail on the bare `.`** — it is caught only by rejection. And `algolia_delete_index` remains the clearest proof in the batch that encoding is not a fix: with `encodeURIComponent` restored it fails precisely — and only — on the bare `.`, `..` and `'  ..  '` vectors, passing every multi-segment escape, encoded separator, backslash, query and fragment vector, because encoding genuinely does neutralize those. That observation is recorded in all three file headers.

Guards restored, 1741/1741 green.

### Hole #3 (fixed, 4th commit): the traversal assertion skipped the ID's own segment — found by cubic

`if (segment.includes(TARGET)) return` proved only the segment *count* and the surrounding segments. A traversal can satisfy both:

```
baseline : ["","v1","matters","SAFEID"]
attack   : ["","v1","matters","victim"]     // matter123/../../matters/victim
same len : true       non-ID segments identical: true
```

The file header's own canonical escape passed against raw interpolation. Confirmed against the guard: a scoped revert of `delete_matters` produced 7 traversal failures and `matter123/../../matters/victim` was **not** among them. The ID slot is now asserted equal to `encodeURIComponent(value.trim())`, so the same revert fails **all 10** vectors — the three newly caught being cubic's vector, `matter123#fragment`, and the bare `.`.

### Hole #4 (fixed, 4th commit): `safeAlgoliaObjectId` corrupted valid object ids — found by greptile (P1) and cubic

Splitting on `/` and guarding each piece with `safeUrlPathSegment` **trims each piece** (rewriting `catalog/ sku` → `catalog/sku`) and **rejects empty ones** (`catalog//sku` and `catalog/sku/` failed with `objectID is required`). All three are legitimate ids the prior encoding preserved.

Investigating showed the split was not merely harmful but **unnecessary** — see the Algolia note above. It now encodes whole. The earlier per-piece rejection assertions tested a risk that does not exist and were replaced by parity cases: `catalog/sku-123`, `catalog/ sku`, `catalog//sku`, `catalog/.`, `catalog/..`, `catalog/../../1/keys`, `./sku`, `../sku` and a backslash-bearing id each assert equality with `encodeURIComponent(value.trim())`, while whole-value `.`, `..` and `'  ..  '` still throw.

I had claimed in an earlier revision that the trailing-dot blind spot "exists one level down" for pieces. That was wrong — `catalog%2F.` is a single segment no normalization touches. The correction is in the code, the tests and the module TSDoc.

### Typing (3rd commit)

The harnesses inherited `type AnyTool = ToolConfig<any, any>` and `as any` from the Vercel file they were copied from, which CLAUDE.md forbids. Now:

```ts
type PathTool = ToolConfig<Record<string, unknown>, ToolResponse>
const ALL_EXPORTS: readonly unknown[] = Object.values(agentmailTools)
const TOOLS: PathTool[] = ALL_EXPORTS.filter(isProbeableTool)
```

Params are built as `Record<string, unknown>` so `url(...)` needs no cast. The `readonly unknown[]` seed matters: a barrel's element union is **not** assignable to a widened `ToolConfig`, because the param type sits in the contravariant position of `request.url` — seeding as `unknown[]` makes the type guard the single narrowing point. One `as Record<string, unknown>` remains per file, inside the guard, with a one-line TSDoc.

**Note for the batch:** `apps/sim/tsconfig.json` excludes `**/*.test.ts`, so `bun run type-check` does not cover any of these harnesses and CI would not catch type errors in them. I verified with a temporary tsconfig overriding `exclude` (not committed) — it found 6 real `TS2345` errors from `as const` on `CREDENTIAL_PARAMS`, now fixed. The landed `tools/vercel/edge_config_path_safety.test.ts` and `tools/daytona/*` still carry the `ToolConfig<any, any>` / `as any` shape; out of scope here, flagging as follow-up.

## Gates

`bun run lint`, `bun run check:audits` (39 audits green including `check:api-validation:strict`, `check:tool-request-boundary`, `tool-metadata:check`), `bun run apps/sim/scripts/check-block-registry.ts origin/staging`, and `tsc --noEmit` clean across all touched files.


