### PR TITLE
test(tools): type the path-safety harnesses instead of erasing with any

### DIFF
--- a/apps/sim/tools/daytona/sandbox_path_safety.test.ts
+++ b/apps/sim/tools/daytona/sandbox_path_safety.test.ts
@@ -16,7 +16,7 @@
 import { describe, expect, it } from 'vitest'
 import * as daytonaTools from '@/tools/daytona/index'
 import { daytonaToolboxUrl, encodeSandboxId } from '@/tools/daytona/utils'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 
 const TOOLBOX_PREFIX = '/toolbox/'
 const API_PREFIX = '/api/sandbox/'
@@ -48,7 +48,14 @@ const LEGITIMATE_IDS = [
 
 const SAFE_ID = 'SAFEID'
 
-type AnyTool = ToolConfig<any, any>
+/**
+ * The slice of a tool this harness reads. `ToolConfig`'s param type sits in the
+ * contravariant position of `request.url`, so no concrete member of the barrel's
+ * union is assignable to a widened `ToolConfig<Record<string, unknown>, …>`. The
+ * barrel is therefore seeded as `unknown` below and narrowed by {@link isDaytonaTool},
+ * which is the single point where the type is established.
+ */
+type AnyTool = ToolConfig<Record<string, unknown>, ToolResponse>
 
 function isDaytonaTool(value: unknown): value is AnyTool {
   return (
@@ -82,14 +89,14 @@ function buildPath(tool: AnyTool, sandboxId: string): string {
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, sandboxId) as any)).pathname
+  return new URL(url(buildParams(tool, sandboxId))).pathname
 }
 
 function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-const SANDBOX_SCOPED_TOOLS = Object.values(daytonaTools)
+const SANDBOX_SCOPED_TOOLS = Object.values<unknown>(daytonaTools)
   .filter(isDaytonaTool)
   .filter((tool) => typeof tool.request?.url === 'function')
   .filter((tool) => {

--- a/apps/sim/tools/vercel/edge_config_path_safety.test.ts
+++ b/apps/sim/tools/vercel/edge_config_path_safety.test.ts
@@ -21,7 +21,7 @@
  * output, because string matching is exactly what let this through.
  */
 import { describe, expect, it } from 'vitest'
-import type { ToolConfig } from '@/tools/types'
+import type { ToolConfig, ToolResponse } from '@/tools/types'
 import { vercelDeleteEdgeConfigTool } from '@/tools/vercel/delete_edge_config'
 import { vercelGetEdgeConfigTool } from '@/tools/vercel/get_edge_config'
 import { vercelGetEdgeConfigItemsTool } from '@/tools/vercel/get_edge_config_items'
@@ -64,7 +64,14 @@ const LEGITIMATE_IDS = [
 
 const SAFE_ID = 'SAFEID'
 
-type AnyTool = ToolConfig<any, any>
+/**
+ * The slice of a tool this harness reads. `ToolConfig`'s param type sits in the
+ * contravariant position of `request.url`, so no concrete member of the barrel's
+ * union is assignable to a widened `ToolConfig<Record<string, unknown>, …>`. The
+ * barrel is therefore seeded as `unknown` below and narrowed by {@link isVercelTool},
+ * which is the single point where the type is established.
+ */
+type AnyTool = ToolConfig<Record<string, unknown>, ToolResponse>
 
 function isVercelTool(value: unknown): value is AnyTool {
   return (
@@ -102,14 +109,14 @@ function buildPath(tool: AnyTool, value: string): string {
   if (typeof url !== 'function') {
     throw new Error(`${tool.id} does not build its URL from params`)
   }
-  return new URL(url(buildParams(tool, value) as any)).pathname
+  return new URL(url(buildParams(tool, value))).pathname
 }
 
 function segmentsOf(pathname: string): string[] {
   return pathname.split('/')
 }
 
-const DYNAMIC_PATH_TOOLS = Object.values(vercelTools)
+const DYNAMIC_PATH_TOOLS = Object.values<unknown>(vercelTools)
   .filter(isVercelTool)
   .filter((tool) => typeof tool.request?.url === 'function')
   .filter((tool) => {


### PR DESCRIPTION
These two files are the template every service copied during the path-hardening sweep, and both open with:

```ts
type AnyTool = ToolConfig<any, any>
// ...
return new URL(url(buildParams(tool, value) as any)).pathname
```

CLAUDE.md forbids `any` outright ("No `any` — use proper types or `unknown` with type guards"). Because these are the *template*, the violation propagated into ten in-flight PRs before review caught it there. Fixing the source stops the next copy inheriting it.

## Why the obvious repair doesn't compile

Swapping in `ToolConfig<Record<string, unknown>, ToolResponse>` on its own fails across the whole barrel union:

```
Type '(params: VercelAddProjectDomainParams) => string' is not assignable to
type '(params: Record<string, unknown>) => string'
```

`ToolConfig` takes its param type in the **contravariant** position of `request.url`, so no concrete member is assignable to the widened alias. And `filter`'s type-predicate overload *intersects* rather than replaces, so filtering the union directly leaves the mismatch standing.

Seeding the enumeration as `Object.values<unknown>(...)` makes the existing `isVercelTool` / `isDaytonaTool` predicate the single narrowing point — the `unknown`-plus-type-guard form the guidelines actually prescribe — and removes the need for a cast at the call site entirely.

## These files have no type coverage in CI

Worth recording, because it is why the pattern survived: `apps/sim/tsconfig.json` excludes `**/*.test.ts`, and vitest does not typecheck. So neither direction would have flagged this.

I verified with a temporary tsconfig lifting the exclusion, and confirmed via `--listFiles` that both files were genuinely in the program — an empty program also reports zero errors, which is an easy way to fool yourself here. Zero errors in both. That config was not committed.

## Checks

- `vitest run tools/vercel tools/daytona` — **1129 pass, identical to before** (pure typing change, no behavioural effect)
- `bun run lint` — clean
- `bun run check:audits` — 39/39
- `check-block-registry.ts origin/staging` — pass
- Type-check with the test exclusion lifted — zero errors in both harnesses