### PR TITLE
fix(ci): treat an unreadable cache size as unstable when settling

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -142,7 +142,14 @@ runs:
           prev=''; stable=0
           for _ in $(seq 1 60); do
             cur="$(total)"
-            if [ "$cur" = "$prev" ]; then
+            # An empty reading means du FAILED, never that the cache is empty:
+            # buildctl prints its `Total:` line unconditionally (cmd/buildctl
+            # diskusage.go), so an empty cache still reports `Total: 0B`. Without
+            # the -n guard the initial prev='' matched two empty readings and the
+            # loop exited after ~2s -- precisely when du is failing and the prune
+            # is most likely still deleting. Treat it as unstable and wait out the
+            # bound instead.
+            if [ -n "$cur" ] && [ "$cur" = "$prev" ]; then
               stable=$((stable + 1))
               [ "$stable" -ge 2 ] && break
             else


### PR DESCRIPTION
## Summary

cubic flagged this on #7273 and it's **correct**. Verified rather than taken on trust.

The settle loop initialises `prev=''`, and since `4795d0426f` made `total()` return empty on failure, **two consecutive failed `buildctl du` reads compare equal** and trip the stability counter:

```
du always failing -> loop exited after 2 iterations (of a possible 60)
```

So the loop gives up after ~2s instead of its 120s bound — precisely when `du` is failing and the prune is most likely still deleting, which is the exact case the wait exists to cover. Handing back early there risks the builder post-step SIGKILLing buildkitd and **skipping the sticky disk commit**.

## Why guarding on non-empty is the right fix, with no downside

An empty reading can *only* mean `du` failed. `buildctl` prints its `Total:` line **unconditionally** — `cmd/buildctl/diskusage.go:161`, outside any branch:

```go
fmt.Fprintf(tw, "Reclaimable:\t%.2f\n", units.Bytes(reclaimable))
fmt.Fprintf(tw, "Total:\t%.2f\n", units.Bytes(total))
```

So a genuinely empty cache still reports `Total: 0B` and settles normally. There's no risk of adding 120s to builds with a cold cache — which was the obvious objection to this fix.

Confirmed across all three paths:

| `du` behaviour | iterations before exit |
|---|---|
| always fails | **60** (waits the full bound) |
| steady value | 3 |
| empty cache (`Total: 0B`) | 3 |

## Severity

Lower than P1 in practice: since #7252 the step can't fail a build, so the consequence is a possibly-skipped disk commit — one run's cache lost, not a red build. But the logic is plainly wrong and the fix is one condition, so it's worth taking before promotion.

## Type of Change
- [x] Bug fix

## Testing
Reproduced the early exit and verified the fix under the exact shell flags GitHub uses (`bash -e -o pipefail`), across failing / steady / empty-cache readings. `shellcheck` clean, `actionlint` unchanged from baseline (13 pre-existing), `bun run lint` and all 39 `check:audits` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)