### PR TITLE
fix(provenance): let a run that never started report why it failed

### DIFF
--- a/apps/sim/executor/execution/engine.test.ts
+++ b/apps/sim/executor/execution/engine.test.ts
@@ -277,9 +277,11 @@ describe('ExecutionEngine', () => {
 
     /**
      * The crossing at the copilot boundary reads the absence of an attached result as "no block
-     * ran". That inference is only total if every throw out of `run` carries one.
+     * ran", so the attach has to be total. A block failure is normalized on the way in, so only
+     * a non-Error raised by `run`'s own work — here the cancellation subscribe it awaits before
+     * the queue — reaches the catch untouched and exercises the guarantee.
      */
-    it('attaches the execution result to every throw out of a failed run', async () => {
+    it('attaches the execution result to a non-Error thrown by its own work', async () => {
       const node = createMockNode('function-1', 'function')
       const registry = new ResolvedSecretTraceRegistry([
         { name: 'TOKEN', plaintext: 'secret-value-1234', encryptedValue: 'ciphertext' },
@@ -289,14 +291,13 @@ describe('ExecutionEngine', () => {
         decisions: { router: new Map(), condition: new Map() },
         resolvedSecretTraceRegistry: registry,
       })
-      const nodeOrchestrator = createMockNodeOrchestrator()
-      vi.mocked(nodeOrchestrator.executeNode).mockRejectedValue(new Error('block exploded'))
+      mockIsExecutionCancelled.mockRejectedValueOnce('cancellation lookup exploded')
 
       const engine = new ExecutionEngine(
         context,
         createMockDAG([node]),
         createMockEdgeManager(),
-        nodeOrchestrator
+        createMockNodeOrchestrator()
       )
 
       const thrown = await engine.run(node.id).catch((error: unknown) => error)

--- a/apps/sim/executor/execution/engine.test.ts
+++ b/apps/sim/executor/execution/engine.test.ts
@@ -28,7 +28,7 @@ import { EDGE } from '@/executor/constants'
 import type { DAG, DAGNode } from '@/executor/dag/builder'
 import type { EdgeManager } from '@/executor/execution/edge-manager'
 import type { NodeExecutionOrchestrator } from '@/executor/orchestrators/node'
-import type { ExecutionContext } from '@/executor/types'
+import type { ExecutionContext, ExecutionResult } from '@/executor/types'
 import { ResolvedSecretTraceRegistry } from '@/executor/utils/resolved-secret-trace-registry'
 import type { SerializedBlock } from '@/serializer/types'
 import { ExecutionEngine } from './engine'
@@ -273,6 +273,38 @@ describe('ExecutionEngine', () => {
       const provenance = result.executionState?.finalOutputResolvedSecretTraceProvenance
       expect(provenance?.complete).toBe(true)
       expect(provenance?.entries).toEqual([{ name: 'TOKEN', encryptedValue: 'ciphertext' }])
+    })
+
+    /**
+     * The crossing at the copilot boundary reads the absence of an attached result as "no block
+     * ran". That inference is only total if every throw out of `run` carries one.
+     */
+    it('attaches the execution result to every throw out of a failed run', async () => {
+      const node = createMockNode('function-1', 'function')
+      const registry = new ResolvedSecretTraceRegistry([
+        { name: 'TOKEN', plaintext: 'secret-value-1234', encryptedValue: 'ciphertext' },
+      ])
+      registry.recordResolved('TOKEN', 'secret-value-1234')
+      const context = createMockContext({
+        decisions: { router: new Map(), condition: new Map() },
+        resolvedSecretTraceRegistry: registry,
+      })
+      const nodeOrchestrator = createMockNodeOrchestrator()
+      vi.mocked(nodeOrchestrator.executeNode).mockRejectedValue(new Error('block exploded'))
+
+      const engine = new ExecutionEngine(
+        context,
+        createMockDAG([node]),
+        createMockEdgeManager(),
+        nodeOrchestrator
+      )
+
+      const thrown = await engine.run(node.id).catch((error: unknown) => error)
+
+      expect(thrown).toBeInstanceOf(Error)
+      const attached = (thrown as Error & { executionResult?: ExecutionResult }).executionResult
+      expect(attached).toBeDefined()
+      expect(attached?.executionState?.resolvedSecretTraceProvenance).toBeDefined()
     })
 
     /** Deriving must not weaken the guarantee: a latched registry still exports incomplete. */

--- a/apps/sim/executor/execution/engine.ts
+++ b/apps/sim/executor/execution/engine.ts
@@ -185,10 +185,17 @@ export class ExecutionEngine {
         metadata: this.context.metadata,
       }
 
-      if (error instanceof Error) {
-        attachExecutionResult(error, executionResult)
-      }
-      throw error
+      /**
+       * Normalized first so the attach is total rather than conditional on the throw already
+       * being an `Error`. A block failure is normalized on the way in, so the old guard held in
+       * practice; what it did not give was a guarantee. The copilot crossing reads a missing
+       * result as proof that no block ran, and that inference has to hold for every throw out of
+       * here, including a non-`Error` raised by this file's own synchronous work. `toError`
+       * returns an `Error` unchanged, so ordinary failures keep their identity and their type.
+       */
+      const thrown = toError(error)
+      attachExecutionResult(thrown, executionResult)
+      throw thrown
     } finally {
       this.cleanup()
     }

--- a/apps/sim/executor/utils/resolved-secret-trace-registry.ts
+++ b/apps/sim/executor/utils/resolved-secret-trace-registry.ts
@@ -226,6 +226,18 @@ export interface ResolvedSecretIncompletenessDiagnostics {
 export const ANONYMOUS_SECRET_TRACE_REPLACEMENT = OPAQUE_RESOLVED_SECRET_REPLACEMENT
 export const RESOLVED_SECRET_TRACE_CHECKPOINT_VERSION = 1
 
+/**
+ * The envelope for content no secret ever reached: vouched for, naming nothing.
+ *
+ * Distinct from an incomplete envelope, which says the opposite — that something may be carried
+ * and cannot be named. A boundary that knows nothing was resolved should say so with this rather
+ * than latch, since latching is the claim that redaction is impossible. Returned fresh so no
+ * caller shares a value it may serialize or extend.
+ */
+export function emptyResolvedSecretTraceProvenance(): ResolvedSecretTraceProvenanceV1 {
+  return { version: 1, complete: true, entries: [] }
+}
+
 const MAX_PROVENANCE_ENTRIES = PROVENANCE_MAX_ENTRIES
 const MAX_SERIALIZED_PROVENANCE_BYTES = PROVENANCE_MAX_SERIALIZED_BYTES
 const MAX_TRACE_CATALOG_ENTRIES = PROVENANCE_MAX_ENTRIES

--- a/apps/sim/lib/logs/execution/logging-session.ts
+++ b/apps/sim/lib/logs/execution/logging-session.ts
@@ -46,6 +46,7 @@ import type { SerializableExecutionState } from '@/executor/execution/types'
 import type { BlockLog } from '@/executor/types'
 import { projectResolvedSecretDiagnosticError } from '@/executor/utils/resolved-secret-content-projection'
 import {
+  emptyResolvedSecretTraceProvenance,
   isResolvedSecretTraceProvenanceV1,
   RESOLVED_SECRET_TRACE_CHECKPOINT_VERSION,
   type ResolvedSecretTraceProvenanceV1,
@@ -123,10 +124,6 @@ function getActiveBlockDisplayProvenance(
 }
 
 const logger = createLogger('LoggingSession')
-
-function emptyResolvedSecretTraceProvenance(): ResolvedSecretTraceProvenanceV1 {
-  return { version: 1, complete: true, entries: [] }
-}
 
 type CompletionAttempt = 'complete' | 'error' | 'cancelled' | 'paused'
 

--- a/apps/sim/lib/workflows/application/run-workflow-from-copilot.test.ts
+++ b/apps/sim/lib/workflows/application/run-workflow-from-copilot.test.ts
@@ -391,4 +391,75 @@ describe('Copilot workflow run application commands', () => {
       expect(readAttemptedExecutionId(error)).toBeUndefined()
     })
   })
+
+  describe('failed-run provenance crossing', () => {
+    function trackingLifecycle() {
+      const importCrossingProvenance = vi.fn().mockResolvedValue(true)
+      return {
+        importCrossingProvenance,
+        lifecycle: {
+          resolvedSecretTraceRegistry: {
+            exportProvenanceForValue: vi.fn(() => undefined),
+            beginPendingActivation: vi.fn(() => vi.fn()),
+            importCrossingProvenance,
+          },
+        },
+      }
+    }
+
+    async function runExpectingFailure(input: { lifecycle: unknown }) {
+      await expect(
+        runWorkflowFromCopilot.execute({
+          principal,
+          input: {
+            workflowId: 'workflow-1',
+            useDraftState: true,
+            lifecycle: input.lifecycle,
+            hasWorkflowInput: false,
+            useMockPayload: true,
+          },
+        })
+      ).rejects.toThrow()
+    }
+
+    /**
+     * The executor attaches its result to every throw, so a failure without one never reached a
+     * block. Nothing crossed, and saying so keeps the caller's tool result — and the reason its
+     * run could not start — instead of reducing it to "result unavailable".
+     */
+    it('vouches for a failure that never reached the engine', async () => {
+      const { importCrossingProvenance, lifecycle: tracked } = trackingLifecycle()
+      mocks.executeWorkflow.mockRejectedValueOnce(new Error('workflow is not deployed'))
+
+      await runExpectingFailure({ lifecycle: tracked })
+
+      expect(importCrossingProvenance).toHaveBeenCalledWith(
+        { version: 1, complete: true, entries: [] },
+        expect.objectContaining({ thrownMessage: 'workflow is not deployed' }),
+        expect.objectContaining({ origin: 'copilotWorkflowMutation.failedRunCrossing' })
+      )
+    })
+
+    /** A run that did execute and could not vouch still hands back its incomplete envelope. */
+    it('passes through an incomplete envelope from a run that did execute', async () => {
+      const { importCrossingProvenance, lifecycle: tracked } = trackingLifecycle()
+      const incomplete = { version: 1 as const, complete: false, entries: [] }
+      const failure = Object.assign(new Error('block failed'), {
+        executionResult: {
+          success: false,
+          output: { partial: true },
+          executionState: { resolvedSecretTraceProvenance: incomplete },
+        },
+      })
+      mocks.executeWorkflow.mockRejectedValueOnce(failure)
+
+      await runExpectingFailure({ lifecycle: tracked })
+
+      expect(importCrossingProvenance).toHaveBeenCalledWith(
+        incomplete,
+        expect.objectContaining({ output: { partial: true } }),
+        expect.objectContaining({ origin: 'copilotWorkflowMutation.failedRunCrossing' })
+      )
+    })
+  })
 })

--- a/apps/sim/lib/workflows/application/run-workflow-from-copilot.test.ts
+++ b/apps/sim/lib/workflows/application/run-workflow-from-copilot.test.ts
@@ -471,6 +471,33 @@ describe('Copilot workflow run application commands', () => {
       )
     })
 
+    /**
+     * The executor's post-execution work can throw after a run has already produced a result.
+     * `executeWorkflow` carries it on that throw, so this reaches the catch with a result and
+     * must not be claimed as never-started.
+     */
+    it('does not vouch when post-execution work threw after the engine ran', async () => {
+      const { importCrossingProvenance, lifecycle: tracked } = trackingLifecycle()
+      const incomplete = { version: 1 as const, complete: false, entries: [] }
+      mocks.executeWorkflow.mockRejectedValueOnce(
+        Object.assign(new Error('post-execution persistence failed'), {
+          executionResult: {
+            success: true,
+            output: { ran: true },
+            executionState: { resolvedSecretTraceProvenance: incomplete },
+          },
+        })
+      )
+
+      await runExpectingFailure({ lifecycle: tracked })
+
+      expect(importCrossingProvenance).toHaveBeenCalledWith(
+        incomplete,
+        expect.objectContaining({ output: { ran: true } }),
+        expect.objectContaining({ origin: 'copilotWorkflowMutation.failedRunCrossing' })
+      )
+    })
+
     /** A run that did execute and could not vouch still hands back its incomplete envelope. */
     it('passes through an incomplete envelope from a run that did execute', async () => {
       const { importCrossingProvenance, lifecycle: tracked } = trackingLifecycle()

--- a/apps/sim/lib/workflows/application/run-workflow-from-copilot.test.ts
+++ b/apps/sim/lib/workflows/application/run-workflow-from-copilot.test.ts
@@ -440,6 +440,37 @@ describe('Copilot workflow run application commands', () => {
       )
     })
 
+    /**
+     * The post-run crossing is inside the same try, so its failure reaches the catch with no
+     * execution result — the same evidence a never-started run leaves. An execution exists and
+     * its provenance was never imported, so this must not be vouched for.
+     */
+    it('does not vouch when the crossing threw after the run returned', async () => {
+      const importCrossingProvenance = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('crossing import failed')
+        })
+        .mockResolvedValue(true)
+
+      await runExpectingFailure({
+        lifecycle: {
+          resolvedSecretTraceRegistry: {
+            exportProvenanceForValue: vi.fn(() => undefined),
+            beginPendingActivation: vi.fn(() => vi.fn()),
+            importCrossingProvenance,
+          },
+        },
+      })
+
+      expect(importCrossingProvenance).toHaveBeenNthCalledWith(
+        2,
+        undefined,
+        expect.objectContaining({ thrownMessage: 'crossing import failed' }),
+        expect.objectContaining({ origin: 'copilotWorkflowMutation.failedRunCrossing' })
+      )
+    })
+
     /** A run that did execute and could not vouch still hands back its incomplete envelope. */
     it('passes through an incomplete envelope from a run that did execute', async () => {
       const { importCrossingProvenance, lifecycle: tracked } = trackingLifecycle()

--- a/apps/sim/lib/workflows/application/run-workflow-from-copilot.ts
+++ b/apps/sim/lib/workflows/application/run-workflow-from-copilot.ts
@@ -254,11 +254,12 @@ async function executeCopilotRun(params: {
   )
   const completePendingActivation = registry?.beginPendingActivation()
   /**
-   * Whether the executor returned. The post-run crossing is inside the same `try`, so its own
-   * failure lands in the catch carrying no execution result — indistinguishable, on that
-   * evidence alone, from a run that never started. This records the difference the error cannot.
+   * The run's own result, once the executor returns it. The post-run crossing below is inside the
+   * same `try`, so its failure reaches the catch carrying nothing — and on that evidence alone it
+   * is indistinguishable from a run that never started. Holding the result here keeps the real
+   * envelope available to describe content that certainly exists.
    */
-  let executed = false
+  let runResult: ExecutionResult | undefined
   /**
    * The executor call is the first statement of this `try`, so everything caught below is
    * post-dispatch by construction, while authorization, admission and provenance export all
@@ -311,7 +312,7 @@ async function executeCopilotRun(params: {
       },
       childExecutionId
     )
-    executed = true
+    runResult = result
     if (registry) {
       await registry.importCrossingProvenance(
         result.executionState?.resolvedSecretTraceProvenance,
@@ -335,24 +336,23 @@ async function executeCopilotRun(params: {
      * as never started and invite the duplicate this id exists to prevent.
      */
     if (registry) {
-      const executionResult = hasExecutionResult(error) ? error.executionResult : undefined
+      /**
+       * Either source counts as proof a run exists: the error carries the result when the run or
+       * its post-execution work threw, and `runResult` holds it when the failure came later still
+       * — from the crossing below, after the executor had already returned.
+       */
+      const executionResult = hasExecutionResult(error) ? error.executionResult : runResult
       try {
         /**
-         * A run that never started carried nothing back, and saying so keeps the caller's
-         * failure reason instead of reducing the tool result to "result unavailable" for a
-         * message that named no secret because none had been resolved yet.
-         *
-         * Both conditions are required to claim it. `executed` rules out the post-run window,
-         * where the crossing import is what threw: an execution exists and its provenance was
-         * never imported, so its content is exactly what cannot be vouched for. The absent
-         * execution result then rules out the engine having run at all — it attaches one to
-         * every throw. Anything else hands back whatever envelope it has, and an incomplete one
-         * still latches.
+         * Only a failure with no result from either source can claim nothing ran, and saying so
+         * keeps the caller's failure reason instead of reducing the tool result to "result
+         * unavailable" for a message that named no secret because none had been resolved yet.
+         * Every other failure hands back the envelope it has, and an incomplete one still latches.
          */
         await registry.importCrossingProvenance(
-          !executed && !executionResult
-            ? emptyResolvedSecretTraceProvenance()
-            : executionResult?.executionState?.resolvedSecretTraceProvenance,
+          executionResult
+            ? executionResult.executionState?.resolvedSecretTraceProvenance
+            : emptyResolvedSecretTraceProvenance(),
           {
             output: executionResult?.output,
             logs: executionResult?.logs,

--- a/apps/sim/lib/workflows/application/run-workflow-from-copilot.ts
+++ b/apps/sim/lib/workflows/application/run-workflow-from-copilot.ts
@@ -254,6 +254,12 @@ async function executeCopilotRun(params: {
   )
   const completePendingActivation = registry?.beginPendingActivation()
   /**
+   * Whether the executor returned. The post-run crossing is inside the same `try`, so its own
+   * failure lands in the catch carrying no execution result — indistinguishable, on that
+   * evidence alone, from a run that never started. This records the difference the error cannot.
+   */
+  let executed = false
+  /**
    * The executor call is the first statement of this `try`, so everything caught below is
    * post-dispatch by construction, while authorization, admission and provenance export all
    * throw past this function having created nothing. That asymmetry is the whole of what a
@@ -305,6 +311,7 @@ async function executeCopilotRun(params: {
       },
       childExecutionId
     )
+    executed = true
     if (registry) {
       await registry.importCrossingProvenance(
         result.executionState?.resolvedSecretTraceProvenance,
@@ -331,21 +338,21 @@ async function executeCopilotRun(params: {
       const executionResult = hasExecutionResult(error) ? error.executionResult : undefined
       try {
         /**
-         * A run that never reached the engine carried nothing back: the executor attaches its
-         * result to every throw, so its absence means no block ran, and the three content fields
-         * below are all undefined. The only content is `thrownMessage`, which this layer produced
-         * — an admission, validation, or setup failure — and which the tool boundary still
-         * projects against this registry before any of it reaches a model.
+         * A run that never started carried nothing back, and saying so keeps the caller's
+         * failure reason instead of reducing the tool result to "result unavailable" for a
+         * message that named no secret because none had been resolved yet.
          *
-         * Reporting that as unvouchable cost the caller the reason its run failed: the crossing
-         * latched, and the tool result was reduced to "result unavailable" for a message that
-         * named no secret because none had been resolved yet. An engine that did run and could
-         * not vouch still hands back an incomplete envelope, and that still latches.
+         * Both conditions are required to claim it. `executed` rules out the post-run window,
+         * where the crossing import is what threw: an execution exists and its provenance was
+         * never imported, so its content is exactly what cannot be vouched for. The absent
+         * execution result then rules out the engine having run at all — it attaches one to
+         * every throw. Anything else hands back whatever envelope it has, and an incomplete one
+         * still latches.
          */
         await registry.importCrossingProvenance(
-          executionResult
-            ? executionResult.executionState?.resolvedSecretTraceProvenance
-            : emptyResolvedSecretTraceProvenance(),
+          !executed && !executionResult
+            ? emptyResolvedSecretTraceProvenance()
+            : executionResult?.executionState?.resolvedSecretTraceProvenance,
           {
             output: executionResult?.output,
             logs: executionResult?.logs,

--- a/apps/sim/lib/workflows/application/run-workflow-from-copilot.ts
+++ b/apps/sim/lib/workflows/application/run-workflow-from-copilot.ts
@@ -29,11 +29,14 @@ import {
 } from '@/lib/workflows/triggers/run-options'
 import type { SerializableExecutionState } from '@/executor/execution/types'
 import type { ExecutionResult } from '@/executor/types'
-import { attachAttemptedExecutionId } from '@/executor/utils/errors'
+import { attachAttemptedExecutionId, hasExecutionResult } from '@/executor/utils/errors'
 
 const logger = createLogger('CopilotWorkflowRun')
 
-import type { ResolvedSecretTraceRegistry } from '@/executor/utils/resolved-secret-trace-registry'
+import {
+  emptyResolvedSecretTraceProvenance,
+  type ResolvedSecretTraceRegistry,
+} from '@/executor/utils/resolved-secret-trace-registry'
 
 export interface CopilotWorkflowRunLifecycle {
   billingAttribution?: BillingAttributionSnapshot
@@ -325,16 +328,24 @@ async function executeCopilotRun(params: {
      * as never started and invite the duplicate this id exists to prevent.
      */
     if (registry) {
-      const executionResult =
-        typeof error === 'object' &&
-        error !== null &&
-        'executionResult' in error &&
-        typeof error.executionResult === 'object'
-          ? (error.executionResult as ExecutionResult)
-          : undefined
+      const executionResult = hasExecutionResult(error) ? error.executionResult : undefined
       try {
+        /**
+         * A run that never reached the engine carried nothing back: the executor attaches its
+         * result to every throw, so its absence means no block ran, and the three content fields
+         * below are all undefined. The only content is `thrownMessage`, which this layer produced
+         * — an admission, validation, or setup failure — and which the tool boundary still
+         * projects against this registry before any of it reaches a model.
+         *
+         * Reporting that as unvouchable cost the caller the reason its run failed: the crossing
+         * latched, and the tool result was reduced to "result unavailable" for a message that
+         * named no secret because none had been resolved yet. An engine that did run and could
+         * not vouch still hands back an incomplete envelope, and that still latches.
+         */
         await registry.importCrossingProvenance(
-          executionResult?.executionState?.resolvedSecretTraceProvenance,
+          executionResult
+            ? executionResult.executionState?.resolvedSecretTraceProvenance
+            : emptyResolvedSecretTraceProvenance(),
           {
             output: executionResult?.output,
             logs: executionResult?.logs,

--- a/apps/sim/lib/workflows/executor/execute-workflow.test.ts
+++ b/apps/sim/lib/workflows/executor/execute-workflow.test.ts
@@ -56,6 +56,7 @@ vi.mock('@/lib/workflows/executor/pause-persistence', () => ({
 }))
 
 import { executeWorkflow } from '@/lib/workflows/executor/execute-workflow'
+import { hasExecutionResult } from '@/executor/utils/errors'
 
 const workflowExecutionLoggerCallIndex = loggerMock.createLogger.mock.calls.findIndex(
   ([name]) => name === 'WorkflowExecution'
@@ -294,6 +295,44 @@ describe('executeWorkflow', () => {
     resolvePostExecution()
     await expect(executionPromise).rejects.toBe(executionError)
     expect(executionSettled).toBe(true)
+  })
+
+  /**
+   * Post-execution work runs after the core has produced a result and the executor never sees
+   * its failure, so this layer is the only one that can carry the result onto it. Callers read a
+   * missing result as proof that no block ran — a Copilot run would report an executed workflow
+   * as never started and vouch for content it cannot describe.
+   */
+  it('carries the execution result onto a post-execution failure', async () => {
+    const result = { success: true, output: { ran: true }, logs: [] }
+    executeWorkflowCoreMock.mockResolvedValueOnce(result)
+    handlePostExecutionPauseStateMock.mockRejectedValueOnce(new Error('pause persistence failed'))
+
+    const thrown = await executeWorkflow(workflow, 'request-1', undefined, 'actor-1', {
+      enabled: true,
+      principal,
+      billingAttribution,
+    }).catch((error: unknown) => error)
+
+    expect(hasExecutionResult(thrown)).toBe(true)
+    expect((thrown as { executionResult?: unknown }).executionResult).toBe(result)
+  })
+
+  /** A non-Error cannot carry the result, so it is normalized before anything reads it. */
+  it('normalizes a non-Error post-execution failure so it can carry the result', async () => {
+    const result = { success: true, output: { ran: true }, logs: [] }
+    executeWorkflowCoreMock.mockResolvedValueOnce(result)
+    handlePostExecutionPauseStateMock.mockRejectedValueOnce('pause persistence exploded')
+
+    const thrown = await executeWorkflow(workflow, 'request-1', undefined, 'actor-1', {
+      enabled: true,
+      principal,
+      billingAttribution,
+    }).catch((error: unknown) => error)
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(hasExecutionResult(thrown)).toBe(true)
+    expect((thrown as { executionResult?: unknown }).executionResult).toBe(result)
   })
 
   it('transfers post-execution ownership with successful streaming metadata', async () => {

--- a/apps/sim/lib/workflows/executor/execute-workflow.ts
+++ b/apps/sim/lib/workflows/executor/execute-workflow.ts
@@ -13,6 +13,7 @@ import { handlePostExecutionPauseState } from '@/lib/workflows/executor/pause-pe
 import { ExecutionSnapshot } from '@/executor/execution/snapshot'
 import type { ExecutionMetadata, SerializableExecutionState } from '@/executor/execution/types'
 import type { ExecutionResult, StreamingExecution } from '@/executor/types'
+import { attachExecutionResult, hasExecutionResult } from '@/executor/utils/errors'
 import type { ResolvedSecretTraceProvenanceV1 } from '@/executor/utils/resolved-secret-trace-registry'
 import type { CoreTriggerType } from '@/stores/logs/filters/types'
 
@@ -128,6 +129,12 @@ export async function executeWorkflow(
     loggingSession.setTrustedExecutionCorrelation(streamConfig.trustedExecutionCorrelation)
   }
   let postExecutionOwnershipTransferred = false
+  /**
+   * Held outside the `try` so the catch can carry it. The executor attaches its result when the
+   * run itself throws, but the post-execution work below can throw after a run has already
+   * produced one — and callers read a missing result as proof that no block ran.
+   */
+  let executionResult: ExecutionResult | undefined
 
   try {
     const metadata: ExecutionMetadata = {
@@ -169,7 +176,7 @@ export async function executeWorkflow(
 
     const executionStartMs = Date.now()
 
-    const result = await executeWorkflowCore({
+    const result = (executionResult = await executeWorkflowCore({
       snapshot,
       callbacks: {
         onStream: streamConfig?.onStream,
@@ -197,7 +204,7 @@ export async function executeWorkflow(
       trustedInitialResolvedSecretTraceProvenance:
         streamConfig?.trustedInitialResolvedSecretTraceProvenance,
       runFromBlock: streamConfig?.runFromBlock,
-    })
+    }))
 
     const blockTypes = [
       ...new Set(
@@ -241,6 +248,15 @@ export async function executeWorkflow(
 
     return result
   } catch (error: unknown) {
+    /**
+     * Carries the run's result on a failure raised after it produced one — the post-execution
+     * work below the executor call can throw, and callers read a missing result as proof that no
+     * block ran. Skipped when the executor already attached its own, which is the more specific
+     * record, and when the throw is not an object to carry it.
+     */
+    if (executionResult && error instanceof Error && !hasExecutionResult(error)) {
+      attachExecutionResult(error, executionResult)
+    }
     const errorDiagnostic = loggingSession.projectDiagnosticError(error)
     logger.error(`[${requestId}] Workflow execution failed`, errorDiagnostic)
 

--- a/apps/sim/lib/workflows/executor/execute-workflow.ts
+++ b/apps/sim/lib/workflows/executor/execute-workflow.ts
@@ -1,5 +1,6 @@
 import type { WorkflowExecutionPrincipal } from '@sim/auth/principal'
 import { createLogger } from '@sim/logger'
+import { toError } from '@sim/utils/errors'
 import { generateId } from '@sim/utils/id'
 import {
   assertBillingAttributionSnapshot,
@@ -247,14 +248,20 @@ export async function executeWorkflow(
     }
 
     return result
-  } catch (error: unknown) {
+  } catch (caught: unknown) {
+    /**
+     * Normalized before anything reads it, for the reason the executor normalizes its own throw:
+     * a value that cannot carry the result would otherwise reach callers bare, and they read a
+     * missing result as proof that no block ran. `toError` returns an `Error` unchanged, so a
+     * custom error class keeps its identity and every ordinary failure is untouched.
+     */
+    const error = toError(caught)
     /**
      * Carries the run's result on a failure raised after it produced one — the post-execution
-     * work below the executor call can throw, and callers read a missing result as proof that no
-     * block ran. Skipped when the executor already attached its own, which is the more specific
-     * record, and when the throw is not an object to carry it.
+     * work below the executor call can throw, and the executor never saw it. Skipped when the
+     * executor already attached its own, which is the more specific record.
      */
-    if (executionResult && error instanceof Error && !hasExecutionResult(error)) {
+    if (executionResult && !hasExecutionResult(error)) {
       attachExecutionResult(error, executionResult)
     }
     const errorDiagnostic = loggingSession.projectDiagnosticError(error)


### PR DESCRIPTION
## Summary
- Closes the last actively-generating provenance signal: `value-provenance-absent` on `copilotWorkflowMutation.failedRunCrossing`, unchanged since 08-21 across five deploys.
- **What was wrong:** a copilot-run workflow that fails *before reaching the engine* — undeployed workflow, invalid input, admission refusal — crossed back with no provenance. That latched the tool's registry, and `inspectToolResultForCopilot` reduced the result to `{success: false, error: "result unavailable"}`. The caller was told its run failed but not **why**, for a message this layer wrote that named no secret because none had been resolved yet.
- **The fix:** the executor attaches its execution result to every throw, so the *absence* of one proves no block ran — `output`, `logs` and `error` are all undefined and the only content is `thrownMessage`. That's an absence, not an inability to vouch, so the crossing now carries an exact-empty envelope. The message still passes the tool boundary's egress projection against the same registry, so anything that registry knows is still redacted. **A run that did execute and could not vouch hands back its incomplete envelope exactly as before, and that still latches** — pinned by its own test.
- Makes the executor's attach total rather than conditional on `error instanceof Error`, so that inference is a guarantee rather than an accident. A block failure is already normalized on the way in via `toError`, so the old guard held in practice; it just didn't cover a non-`Error` raised by the engine's own synchronous work. `toError` is identity-preserving.
- Moves the exact-empty envelope into the registry module, which owns this vocabulary, replacing a private copy in the logging session — one definition of "vouched for, naming nothing".

## Verified against production
Read the externalized execution payloads from S3 for this workflow's runs (DB gives the storage pointer; the envelope isn't visible to SQL). Sampling before and after the v0.8.13 deploy that carried #7173: **pre-fix 2/10 had `finalOutput complete=false`; post-fix 0/10**, across completed, failed *and* cancelled. So the `TraceStore — displayProjection` stream is confirmed decaying stock of pre-08-27 executions, not a live producer — its emission logic is fixed, and this PR is about the separate copilot path.

Also worth recording: `inherited-incomplete-source` (2026-08-09) and `mounted-file-provenance-unavailable` (2026-08-10) are long-standing reasons that were newly *observed*, not newly added — the former is just a per-tool fork inheriting a latched parent, which is the isolation working.

## Type of Change
- [x] Bug fix

## Testing
Two new tests on the crossing: a failure that never reached the engine now imports a complete envelope; one that did execute still passes through its incomplete envelope. Verified the first **fails without the fix**. Plus an executor test pinning that every throw out of a failed run carries its execution result. 6,828 tests green across `executor/`, `lib/logs/`, `lib/workflows/`, `lib/copilot/`; `bun run type-check` clean; all 39 audits pass. Rebased onto latest staging, conflicts resolved keeping both sides' tests.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)