### PR TITLE
fix(helm): bump chart appVersion to the release it ships with

### DIFF
--- a/helm/sim/Chart.yaml
+++ b/helm/sim/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sim
 description: A Helm chart for Sim - the open-source AI workspace where teams build, deploy, and manage AI agents
 type: application
-version: 1.6.3
-appVersion: "v0.7.44"
+version: 1.6.4
+appVersion: "v0.8.18"
 kubeVersion: ">=1.25.0-0"
 home: https://sim.ai
 icon: https://raw.githubusercontent.com/simstudioai/sim/main/apps/sim/public/logo/primary/primary.svg

--- a/helm/sim/README.md
+++ b/helm/sim/README.md
@@ -515,6 +515,10 @@ kubectl --namespace sim logs deploy/sim-app -c migrations
 
 ---
 
+## Upgrading to 1.6.4
+
+* `appVersion` — the default image tag for every first-party image (`app`, `realtime`, `migrations`, `pii`, `copilot`) when `image.tag` is unset — moves from `v0.7.44` to `v0.8.18`. It had not been bumped since chart 1.2.0, so an unpinned install deployed an application dozens of releases behind the chart it shipped with, and values keys added by newer charts had no effect because the running image did not read them. **An unpinned release rolls every first-party pod on upgrade.** Installs that pin `image.tag` or `image.digest` are unaffected; pinning explicitly remains the recommendation for production.
+
 ## Upgrading to 1.5.0
 
 Two changes alter behavior on an existing release. Neither requires action, but read both.

--- a/helm/sim/ci/kind-values.yaml
+++ b/helm/sim/ci/kind-values.yaml
@@ -1,7 +1,18 @@
 # CI-only overlay for the kind install test: shrink resource requests so the
 # default configuration schedules on a small CI runner. Layered on top of
 # ci/default-values.yaml. Dummy sizing — never use in a deployment.
+
+# Pin every first-party image to the published :latest rather than letting the
+# tag default to Chart.AppVersion. appVersion names the release the chart ships
+# WITH, and version tags are cut by the main-branch merge commit that releases
+# it (detect-version in ci.yml) — so on the PR that raises appVersion, the tag
+# it names does not exist yet and the install would sit in ImagePullBackOff
+# until --wait times out. That circularity is why appVersion went unbumped from
+# chart 1.2.0 to 1.6.3. This test asks whether the chart installs, not which
+# application build it installs, so any published image answers it.
 app:
+  image:
+    tag: "latest"
   resources:
     requests:
       cpu: 200m
@@ -11,6 +22,8 @@ app:
       memory: 2Gi
 
 realtime:
+  image:
+    tag: "latest"
   resources:
     requests:
       cpu: 50m
@@ -20,6 +33,8 @@ realtime:
       memory: 512Mi
 
 migrations:
+  image:
+    tag: "latest"
   resources:
     requests:
       cpu: 100m

--- a/helm/sim/values.yaml
+++ b/helm/sim/values.yaml
@@ -20,7 +20,7 @@ app:
   # Image configuration
   image:
     repository: simstudioai/simstudio
-    # tag defaults to Chart.AppVersion. Override with a release tag (e.g. "v0.7.44") or pin via image.digest.
+    # tag defaults to Chart.AppVersion. Override with a release tag (e.g. "v0.8.18") or pin via image.digest.
     tag: ""
     # Optional image digest pin: "sha256:..." — when set, overrides tag.
     digest: ""


### PR DESCRIPTION
Closes the one helm finding on the v0.8.18 release PR (#7283).

## The defect

`helm/sim/Chart.yaml` has carried `appVersion: "v0.7.44"` since chart **1.2.0**, through forty-odd application releases. `appVersion` is not decoration — `sim.image` uses it as the default tag whenever `image.tag` and `image.digest` are both unset, which is the case for every first-party image in the shipped `values.yaml`:

```
app.image.tag: ""          -> simstudio:v0.7.44
realtime.image.tag: ""     -> realtime:v0.7.44
migrations.image.tag: ""   -> migrations:v0.7.44
pii.image.tag: ""          -> pii:v0.7.44
copilot.server.image.tag: "" / copilot.migrations.image.tag: ""
```

So `helm install sim helm/sim` without pinning a tag deploys a v0.7.44 application from a chart that ships v0.8.18 features. The second-order effect is worse than the version skew: **every values key added by a newer chart is silently inert**, because the image being deployed has no code that reads it. A key documented in `values.yaml` appears to be set, the pod starts clean, and nothing happens. `packages/sim-setup` already names this failure mode in a troubleshooting hint — *"ImagePullBackOff on ghcr.io/simstudioai/* usually means the chart appVersion tag was never published — check Chart.yaml against ghcr"*.

## Why it stayed frozen for four minor versions

The chart CI's kind install test runs the **default** configuration, so it resolved its images through `appVersion` too. Version tags are cut by `detect-version` in `ci.yml`, which matches `^(vX.Y.Z):` against the **main-branch merge commit message** — so on the very PR that raises `appVersion`, the tag it now names does not exist yet, and `helm install --wait` sits in ImagePullBackOff until the 15-minute timeout. Bumping `appVersion` was self-failing, and it silently stopped being bumped.

That circularity is fixed here, not worked around: `ci/kind-values.yaml` pins the three first-party images to the published `:latest`. The job asks whether the chart installs, not which application build it installs, so any published image answers it — and the answer no longer depends on an unpublished tag.

## Changes

- `appVersion` → `v0.8.18`, `version` 1.6.3 → 1.6.4 (required by the chart's own version-bump gate).
- `ci/kind-values.yaml` pins `app`/`realtime`/`migrations` to `:latest`, with the reasoning in a comment so the next person does not re-couple them.
- `README.md` gains an "Upgrading to 1.6.4" entry, matching the existing per-version convention — an unpinned release rolls every first-party pod on upgrade, so it is a documented behavior change.
- The stale `e.g. "v0.7.44"` in the `values.yaml` example comment moves with it.

## Verification

- `helm lint --values ci/default-values.yaml` — clean
- `helm template` against `ci/default-values.yaml`, `ci/full-values.yaml`, and every `examples/values-*.yaml` — all render
  - default install resolves `ghcr.io/simstudioai/{simstudio,realtime,migrations}:v0.8.18`
  - with the kind overlay it resolves `:latest`, as the install job needs
- `scripts/check-cron-parity.ts` — 20 jobs match
- GHCR probe: `v0.7.44`, `v0.8.16`, `v0.8.17`, `latest` all resolve; `v0.8.18` 404s until this release merges to main, which is the commit that publishes it
- No chart test or CI values file asserted the old tag (`grep` over `tests/`, `ci/`, `examples/`)

Nothing in CI *enforces* that `appVersion` matches the release being cut — this removes the reason it could not be bumped, not the need to remember. Worth a follow-up if that should be a gate rather than a habit.