### PR TITLE
fix(files): dispatch search indexing from Trigger workers

### DIFF
--- a/apps/sim/background/sandbox-image-build.ts
+++ b/apps/sim/background/sandbox-image-build.ts
@@ -1,7 +1,5 @@
 import { task } from '@trigger.dev/sdk'
 import {
-  LEGACY_SANDBOX_IMAGE_BUILD_TASK_ID,
-  PREVIOUS_SANDBOX_IMAGE_BUILD_TASK_ID,
   runSandboxImageBuild,
   SANDBOX_IMAGE_BUILD_TASK_ID,
   type SandboxImageBuildPayload,
@@ -29,38 +27,3 @@ export const sandboxImageBuildTask = task({
     await runSandboxImageBuild(payload)
   },
 })
-
-/**
- * Rollout bridge for web replicas deployed before revisioned task routing.
- * Remove only after every old web release that emits this ID has drained.
- */
-export const legacySandboxImageBuildTask = task({
-  id: LEGACY_SANDBOX_IMAGE_BUILD_TASK_ID,
-  machine: 'small-1x',
-  maxDuration: 1200,
-  retry: { maxAttempts: 1 },
-  queue: {
-    name: 'sandbox-image-build',
-    concurrencyLimit: 5,
-  },
-  run: async (payload: SandboxImageBuildPayload) => {
-    await runSandboxImageBuild(payload)
-  },
-})
-
-/** One-revision bridge for a worker-first materializer rollout. */
-export const previousSandboxImageBuildTask = PREVIOUS_SANDBOX_IMAGE_BUILD_TASK_ID
-  ? task({
-      id: PREVIOUS_SANDBOX_IMAGE_BUILD_TASK_ID,
-      machine: 'small-1x',
-      maxDuration: 1200,
-      retry: { maxAttempts: 1 },
-      queue: {
-        name: 'sandbox-image-build',
-        concurrencyLimit: 5,
-      },
-      run: async (payload: SandboxImageBuildPayload) => {
-        await runSandboxImageBuild(payload)
-      },
-    })
-  : undefined

--- a/apps/sim/lib/execution/remote-sandbox/image-registry.test.ts
+++ b/apps/sim/lib/execution/remote-sandbox/image-registry.test.ts
@@ -119,13 +119,10 @@ import {
   cleanupSandboxImages,
   ensureSandboxImage,
   FAILED_BUILD_RETRY_COOLDOWN_MS,
-  LEGACY_SANDBOX_IMAGE_BUILD_TASK_ID,
-  PREVIOUS_SANDBOX_IMAGE_BUILD_TASK_ID,
   releaseSandboxImage,
   runSandboxImageBuild,
   SANDBOX_IMAGE_BUILD_TASK_ID,
   sandboxBuildIdempotencyKey,
-  sandboxImageBuildTaskIds,
 } from '@/lib/execution/remote-sandbox/image-registry'
 
 const READY_IMAGE = {
@@ -519,15 +516,8 @@ describe('runSandboxImageBuild attempt ownership', () => {
     systemPackages: [],
   }
 
-  it('routes each renderer revision to a distinct Trigger.dev task ID', () => {
-    expect(SANDBOX_IMAGE_BUILD_TASK_ID).toBe('sandbox-image-build-v2')
-    expect(PREVIOUS_SANDBOX_IMAGE_BUILD_TASK_ID).toBe('sandbox-image-build-v1')
-    expect(LEGACY_SANDBOX_IMAGE_BUILD_TASK_ID).toBe('sandbox-image-build')
-    expect(sandboxImageBuildTaskIds(2)).toEqual({
-      current: 'sandbox-image-build-v2',
-      previous: 'sandbox-image-build-v1',
-      legacy: 'sandbox-image-build',
-    })
+  it('uses one stable Trigger.dev task ID', () => {
+    expect(SANDBOX_IMAGE_BUILD_TASK_ID).toBe('sandbox-image-build')
   })
 
   it('refuses an app-new/task-old renderer mismatch before claiming the row', async () => {

--- a/apps/sim/lib/execution/remote-sandbox/image-registry.ts
+++ b/apps/sim/lib/execution/remote-sandbox/image-registry.ts
@@ -17,7 +17,6 @@ import {
   providerBuildError,
   type SandboxBuildError,
 } from '@/lib/execution/remote-sandbox/build-errors'
-import { FUNCTION_SANDBOX_MATERIALIZER_REVISION } from '@/lib/execution/remote-sandbox/function-resources'
 import { resolveProvider } from '@/lib/execution/remote-sandbox/provider'
 import { invalidateSandboxResolution } from '@/lib/execution/remote-sandbox/resolve'
 import type { SandboxSpec } from '@/lib/execution/remote-sandbox/sandbox-spec'
@@ -44,23 +43,7 @@ const STALE_BUILD_MS = BUILD_POLL_CAP_MS * 2
 const POLL_BASE_MS = 3_000
 const POLL_MAX_MS = 20_000
 
-/** Task IDs kept live together so either web-first or worker-first rollouts drain safely. */
-export function sandboxImageBuildTaskIds(rendererRevision: number): {
-  current: string
-  previous?: string
-  legacy: string
-} {
-  return {
-    current: `sandbox-image-build-v${rendererRevision}`,
-    ...(rendererRevision > 1 ? { previous: `sandbox-image-build-v${rendererRevision - 1}` } : {}),
-    legacy: 'sandbox-image-build',
-  }
-}
-
-const SANDBOX_IMAGE_TASK_IDS = sandboxImageBuildTaskIds(FUNCTION_SANDBOX_MATERIALIZER_REVISION)
-export const SANDBOX_IMAGE_BUILD_TASK_ID = SANDBOX_IMAGE_TASK_IDS.current
-export const PREVIOUS_SANDBOX_IMAGE_BUILD_TASK_ID = SANDBOX_IMAGE_TASK_IDS.previous
-export const LEGACY_SANDBOX_IMAGE_BUILD_TASK_ID = SANDBOX_IMAGE_TASK_IDS.legacy
+export const SANDBOX_IMAGE_BUILD_TASK_ID = 'sandbox-image-build'
 
 export interface SandboxImageBuildPayload {
   provider: SandboxProviderId

--- a/apps/sim/lib/workspace-files/search/dispatcher.test.ts
+++ b/apps/sim/lib/workspace-files/search/dispatcher.test.ts
@@ -4,20 +4,14 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildWorkspaceFileSearchTriggerItems,
-  resolveWorkspaceFileSearchDispatchLimit,
+  shouldUseWorkspaceFileSearchTrigger,
 } from '@/lib/workspace-files/search/dispatcher'
 
 describe('workspace file search dispatch policy', () => {
-  it('admits no more than two outstanding revisions from one workspace', () => {
-    expect(resolveWorkspaceFileSearchDispatchLimit(0, 100)).toBe(2)
-    expect(resolveWorkspaceFileSearchDispatchLimit(1, 100)).toBe(1)
-    expect(resolveWorkspaceFileSearchDispatchLimit(2, 100)).toBe(0)
-  })
-
-  it('also respects remaining bounded global queue capacity', () => {
-    expect(resolveWorkspaceFileSearchDispatchLimit(0, 1)).toBe(1)
-    expect(resolveWorkspaceFileSearchDispatchLimit(0, 0)).toBe(0)
-    expect(resolveWorkspaceFileSearchDispatchLimit(0, -1)).toBe(0)
+  it('uses Trigger.dev from inside a task even when the deployment flag is absent', () => {
+    expect(shouldUseWorkspaceFileSearchTrigger(false, true)).toBe(true)
+    expect(shouldUseWorkspaceFileSearchTrigger(true, false)).toBe(true)
+    expect(shouldUseWorkspaceFileSearchTrigger(false, false)).toBe(false)
   })
 
   it('deduplicates each immutable revision without including file contents', () => {

--- a/apps/sim/lib/workspace-files/search/dispatcher.ts
+++ b/apps/sim/lib/workspace-files/search/dispatcher.ts
@@ -25,6 +25,7 @@ import {
   sql,
 } from 'drizzle-orm'
 import { isTriggerDevEnabled } from '@/lib/core/config/env-flags'
+import { isInsideTriggerRun } from '@/lib/core/config/trigger-runtime'
 import { runDetached } from '@/lib/core/utils/background'
 import type { DbTransaction } from '@/lib/db/types'
 import {
@@ -65,14 +66,11 @@ export interface WorkspaceFileSearchDispatchResult {
   lockAcquired: boolean
 }
 
-export function resolveWorkspaceFileSearchDispatchLimit(
-  workspaceOutstanding: number,
-  remainingGlobalCapacity: number
-): number {
-  return Math.min(
-    Math.max(0, FILE_SEARCH_INDEX_WORKSPACE_OUTSTANDING - workspaceOutstanding),
-    Math.max(0, remainingGlobalCapacity)
-  )
+export function shouldUseWorkspaceFileSearchTrigger(
+  triggerDevEnabled: boolean,
+  insideTriggerRun: boolean
+): boolean {
+  return triggerDevEnabled || insideTriggerRun
 }
 
 export function buildWorkspaceFileSearchTriggerItems(
@@ -459,7 +457,7 @@ async function dispatchPreparedJobs(
   payloads: readonly WorkspaceFileSearchIndexPayload[]
 ): Promise<number> {
   if (payloads.length === 0) return 0
-  if (!isTriggerDevEnabled) {
+  if (!shouldUseWorkspaceFileSearchTrigger(isTriggerDevEnabled, isInsideTriggerRun())) {
     runDetached('workspace-file-search-index', async () => {
       for (const payload of payloads) {
         try {


### PR DESCRIPTION
## Summary

- dispatch workspace file indexing as Trigger.dev child tasks when already inside a Trigger run
- add regression coverage and remove the unused dispatch-limit helper
- simplify sandbox image builds to one stable Trigger.dev task ID

## Type of Change

- [x] Bug fix

## Testing

- focused Vitest suite: 3 files, 49 tests
- `bun run lint`
- `bun run type-check`
- `bun run check:audits` (39 audits)
- block registry validation against `origin/staging`

## Checklist

- [x] Code follows project conventions
- [x] Tests added or updated and passing
- [x] Full lint, type-check, and audit checks pass
- [x] Branch is based on the latest `staging`

