### PR TITLE
fix(copilot): reject unresolved image references

### DIFF
--- a/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
@@ -2641,8 +2641,10 @@ export const GenerateImage: ToolCatalogEntry = {
               },
               required: ['path'],
             },
+            minItems: 1,
           },
         },
+        required: ['files'],
       },
       outputs: {
         type: 'object',

--- a/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
@@ -2577,8 +2577,10 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
                 },
                 required: ['path'],
               },
+              minItems: 1,
             },
           },
+          required: ['files'],
         },
         outputs: {
           type: 'object',

--- a/apps/sim/lib/copilot/tools/server/image/generate-image.test.ts
+++ b/apps/sim/lib/copilot/tools/server/image/generate-image.test.ts
@@ -1,0 +1,265 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  assertOpaqueWorkspaceFileModelSafeMock,
+  createWorkspaceFileSecretProvenanceFromRegistryMock,
+  executeCopilotFileUseCaseMock,
+  generateContentMock,
+  resolveCopilotWorkspaceFileReferenceMock,
+  writeCopilotWorkspaceFileByPathMock,
+} = vi.hoisted(() => ({
+  assertOpaqueWorkspaceFileModelSafeMock: vi.fn(),
+  createWorkspaceFileSecretProvenanceFromRegistryMock: vi.fn(),
+  executeCopilotFileUseCaseMock: vi.fn(),
+  generateContentMock: vi.fn(),
+  resolveCopilotWorkspaceFileReferenceMock: vi.fn(),
+  writeCopilotWorkspaceFileByPathMock: vi.fn(),
+}))
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class GoogleGenAI {
+    models = { generateContent: generateContentMock }
+  },
+}))
+
+vi.mock('@/lib/copilot/application/execute-file-use-case', () => ({
+  executeCopilotFileUseCase: (...args: unknown[]) => executeCopilotFileUseCaseMock(...args),
+  resolveCopilotWorkspaceFileReference: (...args: unknown[]) =>
+    resolveCopilotWorkspaceFileReferenceMock(...args),
+}))
+
+vi.mock('@/lib/copilot/generated/tool-catalog-v1', () => ({
+  GenerateImage: { id: 'generate_image' },
+}))
+
+vi.mock('@/lib/copilot/tools/server/model-input', () => ({
+  assertOpaqueWorkspaceFileModelSafe: (...args: unknown[]) =>
+    assertOpaqueWorkspaceFileModelSafeMock(...args),
+}))
+
+vi.mock('@/lib/copilot/vfs/resource-writer', () => ({
+  writeCopilotWorkspaceFileByPath: (...args: unknown[]) =>
+    writeCopilotWorkspaceFileByPathMock(...args),
+}))
+
+vi.mock('@/lib/core/config/api-keys', () => ({
+  getRotatingApiKey: vi.fn(() => 'api-key'),
+}))
+
+vi.mock('@/lib/uploads/contexts/workspace/workspace-file-secret-provenance', () => ({
+  createWorkspaceFileSecretProvenanceFromRegistry: (...args: unknown[]) =>
+    createWorkspaceFileSecretProvenanceFromRegistryMock(...args),
+}))
+
+vi.mock('@/lib/workspace-files/application/operations', () => ({
+  fileOperations: { readContent: { id: 'file.readContent' } },
+}))
+
+vi.mock('@/lib/workspace-files/application/read-workspace-file-content', () => ({
+  readWorkspaceFileContent: { execute: vi.fn() },
+}))
+
+import type { ServerToolContext } from '@/lib/copilot/tools/server/base-tool'
+import { generateImageServerTool } from '@/lib/copilot/tools/server/image/generate-image'
+
+const context: ServerToolContext = {
+  userId: 'user-1',
+  workspaceId: 'workspace-1',
+  toolCallId: 'tool-1',
+  copilotToolExecution: true,
+}
+
+const referenceFile = {
+  id: 'file-1',
+  workspaceId: 'workspace-1',
+  name: 'reference.png',
+  key: 'workspace/workspace-1/reference.png',
+  path: '/api/files/serve/reference.png',
+  size: 9,
+  type: 'image/png',
+  uploadedBy: 'user-1',
+  uploadedAt: new Date('2026-08-31T00:00:00.000Z'),
+  updatedAt: new Date('2026-08-31T00:00:00.000Z'),
+  storageContext: 'workspace' as const,
+}
+
+describe('generateImageServerTool reference inputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveCopilotWorkspaceFileReferenceMock.mockResolvedValue(referenceFile)
+    assertOpaqueWorkspaceFileModelSafeMock.mockResolvedValue(undefined)
+    executeCopilotFileUseCaseMock.mockResolvedValue({
+      file: referenceFile,
+      content: Buffer.from('reference'),
+    })
+    generateContentMock.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [{ inlineData: { data: 'Z2VuZXJhdGVk', mimeType: 'image/png' } }],
+          },
+        },
+      ],
+    })
+    createWorkspaceFileSecretProvenanceFromRegistryMock.mockResolvedValue({
+      safe: true,
+      provenance: { status: 'exact', entries: [] },
+    })
+    writeCopilotWorkspaceFileByPathMock.mockResolvedValue({
+      id: 'output-1',
+      name: 'generated-image.png',
+      size: 9,
+      contentType: 'image/png',
+      vfsPath: 'files/generated-image.png',
+      downloadUrl: '/api/files/serve/generated-image.png',
+      mode: 'create',
+    })
+  })
+
+  it('keeps inputs optional for text-to-image generation', async () => {
+    const result = await generateImageServerTool.execute({ prompt: 'Draw a lighthouse' }, context)
+
+    expect(result.success).toBe(true)
+    expect(resolveCopilotWorkspaceFileReferenceMock).not.toHaveBeenCalled()
+    expect(generateContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contents: [
+          expect.objectContaining({
+            parts: [
+              expect.objectContaining({ text: expect.stringContaining('Draw a lighthouse') }),
+            ],
+          }),
+        ],
+      })
+    )
+  })
+
+  it.each([{ inputs: {} }, { inputs: { files: [] } }])(
+    'rejects supplied inputs without files before calling the provider',
+    async ({ inputs }) => {
+      const result = await generateImageServerTool.execute(
+        { prompt: 'Edit this image', inputs },
+        context
+      )
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: false,
+          message: expect.stringContaining('inputs.files'),
+        })
+      )
+      expect(generateContentMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it('loads a valid reference into inlineData before calling the provider', async () => {
+    const result = await generateImageServerTool.execute(
+      {
+        prompt: 'Turn the sky purple',
+        inputs: { files: [{ path: 'files/reference.png' }] },
+      },
+      context
+    )
+
+    expect(result.success).toBe(true)
+    expect(generateContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contents: [
+          expect.objectContaining({
+            parts: [
+              { inlineData: { mimeType: 'image/png', data: 'cmVmZXJlbmNl' } },
+              expect.objectContaining({ text: expect.stringContaining('Turn the sky purple') }),
+            ],
+          }),
+        ],
+      })
+    )
+    expect(result.message).toContain('edited')
+  })
+
+  it('fails when a reference cannot be resolved before calling the provider', async () => {
+    resolveCopilotWorkspaceFileReferenceMock.mockRejectedValue(new Error('File not found'))
+
+    const result = await generateImageServerTool.execute(
+      {
+        prompt: 'Edit this image',
+        inputs: { files: [{ path: 'files/missing.png' }] },
+      },
+      context
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining('File not found'),
+      })
+    )
+    expect(generateContentMock).not.toHaveBeenCalled()
+  })
+
+  it('does not generate from a partial list when any reference is missing', async () => {
+    resolveCopilotWorkspaceFileReferenceMock
+      .mockResolvedValueOnce(referenceFile)
+      .mockRejectedValueOnce(new Error('Second file not found'))
+
+    const result = await generateImageServerTool.execute(
+      {
+        prompt: 'Combine these images',
+        inputs: {
+          files: [{ path: 'files/reference.png' }, { path: 'files/missing.png' }],
+        },
+      },
+      context
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining('Second file not found'),
+      })
+    )
+    expect(generateContentMock).not.toHaveBeenCalled()
+  })
+
+  it('fails when reference bytes cannot be read before calling the provider', async () => {
+    executeCopilotFileUseCaseMock.mockRejectedValue(new Error('Unable to read file'))
+
+    const result = await generateImageServerTool.execute(
+      {
+        prompt: 'Edit this image',
+        inputs: { files: [{ path: 'files/reference.png' }] },
+      },
+      context
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining('Unable to read file'),
+      })
+    )
+    expect(generateContentMock).not.toHaveBeenCalled()
+  })
+
+  it('explains how to save an uploaded image before using it as a reference', async () => {
+    const result = await generateImageServerTool.execute(
+      {
+        prompt: 'Edit this image',
+        inputs: { files: [{ path: 'uploads/reference.png' }] },
+      },
+      context
+    )
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringMatching(/save_upload[\s\S]*files\//),
+      })
+    )
+    expect(resolveCopilotWorkspaceFileReferenceMock).not.toHaveBeenCalled()
+    expect(generateContentMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/lib/copilot/tools/server/image/generate-image.ts
+++ b/apps/sim/lib/copilot/tools/server/image/generate-image.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI, type Part } from '@google/genai'
 import { createLogger } from '@sim/logger'
-import { getErrorMessage, toError } from '@sim/utils/errors'
+import { getErrorMessage } from '@sim/utils/errors'
 import {
   executeCopilotFileUseCase,
   resolveCopilotWorkspaceFileReference,
@@ -11,10 +11,7 @@ import {
   type BaseServerTool,
   type ServerToolContext,
 } from '@/lib/copilot/tools/server/base-tool'
-import {
-  assertOpaqueWorkspaceFileModelSafe,
-  ServerToolModelInputError,
-} from '@/lib/copilot/tools/server/model-input'
+import { assertOpaqueWorkspaceFileModelSafe } from '@/lib/copilot/tools/server/model-input'
 import { writeCopilotWorkspaceFileByPath } from '@/lib/copilot/vfs/resource-writer'
 import { getRotatingApiKey } from '@/lib/core/config/api-keys'
 import { MAX_MEDIA_BYTES } from '@/lib/media/falai'
@@ -79,58 +76,65 @@ export const generateImageServerTool: BaseServerTool<GenerateImageArgs, Generate
 
     try {
       const prompt = params.prompt
-      const apiKey = getRotatingApiKey('gemini')
-      const ai = new GoogleGenAI({ apiKey })
-
       const aspectRatio = params.aspectRatio || '1:1'
       const sizeHint = ASPECT_RATIO_TO_SIZE[aspectRatio]
 
       const parts: Part[] = []
+      const referenceFiles = params.inputs?.files
 
-      const referencePaths = params.inputs?.files?.map((file) => file.path) ?? []
+      if (params.inputs !== undefined && !referenceFiles?.length) {
+        throw new Error('inputs.files must contain at least one reference image when inputs is set')
+      }
 
-      if (referencePaths.length) {
-        for (const filePath of referencePaths) {
-          try {
-            const fileRecord = await resolveCopilotWorkspaceFileReference(
-              context,
-              fileOperations.readContent,
-              {
-                workspaceId,
-                reference: filePath,
-              }
-            )
-            await assertOpaqueWorkspaceFileModelSafe({ workspaceId, file: fileRecord })
-            const { content: buffer } = await executeCopilotFileUseCase(
-              context,
-              readWorkspaceFileContent,
-              {
-                fileId: fileRecord.id,
-                assertedWorkspaceId: workspaceId,
-                maxBytes: MAX_MEDIA_BYTES,
-              },
-              { fileId: fileRecord.id }
-            )
-            const base64 = buffer.toString('base64')
-            const mime = fileRecord.type || 'image/png'
-            parts.push({
-              inlineData: { mimeType: mime, data: base64 },
-            })
-            logger.info('Loaded reference image', {
-              filePath,
-              name: fileRecord.name,
-              size: buffer.length,
-              mimeType: mime,
-            })
-          } catch (err) {
-            if (err instanceof ServerToolModelInputError) throw err
-            logger.warn('Failed to load reference image, skipping', {
-              filePath,
-              error: toError(err).message,
-            })
-          }
+      for (const { path: filePath } of referenceFiles ?? []) {
+        if (filePath.startsWith('uploads/')) {
+          throw new Error(
+            `Reference image "${filePath}" is still a chat upload. Run save_upload first, then use its canonical files/... path in generate_image inputs.files.`
+          )
+        }
+
+        try {
+          const fileRecord = await resolveCopilotWorkspaceFileReference(
+            context,
+            fileOperations.readContent,
+            {
+              workspaceId,
+              reference: filePath,
+            }
+          )
+          await assertOpaqueWorkspaceFileModelSafe({ workspaceId, file: fileRecord })
+          const { content: buffer } = await executeCopilotFileUseCase(
+            context,
+            readWorkspaceFileContent,
+            {
+              fileId: fileRecord.id,
+              assertedWorkspaceId: workspaceId,
+              maxBytes: MAX_MEDIA_BYTES,
+            },
+            { fileId: fileRecord.id }
+          )
+          const base64 = buffer.toString('base64')
+          const mime = fileRecord.type || 'image/png'
+          parts.push({
+            inlineData: { mimeType: mime, data: base64 },
+          })
+          logger.info('Loaded reference image', {
+            filePath,
+            name: fileRecord.name,
+            size: buffer.length,
+            mimeType: mime,
+          })
+        } catch (error) {
+          throw new Error(
+            `Failed to load reference image "${filePath}": ${getErrorMessage(error, 'Unknown error')}`
+          )
         }
       }
+
+      const loadedReferenceCount = parts.length
+
+      const apiKey = getRotatingApiKey('gemini')
+      const ai = new GoogleGenAI({ apiKey })
 
       const sizeInstruction = sizeHint
         ? ` Generate the image at ${sizeHint} resolution with a ${aspectRatio} aspect ratio.`
@@ -142,7 +146,7 @@ export const generateImageServerTool: BaseServerTool<GenerateImageArgs, Generate
         model: NANO_BANANA_MODEL,
         aspectRatio,
         promptLength: prompt.length,
-        referenceImageCount: referencePaths.length,
+        referenceImageCount: loadedReferenceCount,
       })
 
       const response = await ai.models.generateContent({
@@ -220,7 +224,7 @@ export const generateImageServerTool: BaseServerTool<GenerateImageArgs, Generate
 
       return {
         success: true,
-        message: `Image ${referencePaths.length ? 'edited' : 'generated'} and ${written.mode === 'overwrite' ? 'updated' : 'saved'} at "${written.vfsPath}" (${imageBuffer.length} bytes)`,
+        message: `Image ${loadedReferenceCount ? 'edited' : 'generated'} and ${written.mode === 'overwrite' ? 'updated' : 'saved'} at "${written.vfsPath}" (${imageBuffer.length} bytes)`,
         fileId: written.id,
         fileName: written.name,
         vfsPath: written.vfsPath,


### PR DESCRIPTION
## Summary

When `generate_image` declares reference files, Sim now either loads every reference or fails before calling Gemini. A missing or unreadable image can no longer be silently dropped and turn an intended image edit into an unrelated text-only generation. Text-to-image remains unchanged when `inputs` is omitted.

This supersedes #5615. The existing production `save_upload` flow already promotes uploads to canonical workspace files, so this replacement preserves that boundary instead of making `uploads/...` a second first-class media path.

Related contract and agent-guidance change: https://github.com/simstudioai/mothership/pull/465

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation-only change

## Changes

- Reject a supplied but empty `inputs.files` array.
- Reject direct `uploads/...` references with guidance to use `save_upload` and the returned `files/...` path.
- Resolve, safety-check, and read every declared image before initializing or invoking the provider.
- Abort on the first unresolved or unreadable reference instead of silently continuing.
- Update the generated tool catalog and schema with the non-empty `generate_image.inputs.files` contract.
- Preserve Sim-local table TTL catalog descriptions so the generated diff stays scoped to this fix.

## Testing

- `cd apps/sim && bun run test lib/copilot/tools/server/image/generate-image.test.ts lib/copilot/tools/server/media/model-boundaries.test.ts` — 14 tests passed.
- `bunx biome check` passed for all four changed Sim files.
- `bun run check:api-validation` passed.
- `git diff --check` passed.
- Paired code review: ready to merge, with no actionable findings.

The repository-wide typecheck is currently blocked by unrelated existing dependency drift, including missing `@sim/deployment-config` and browser-protocol packages. Filtering its diagnostics produced no errors for the changed image-generation or generated-contract files.

## Post-Deploy Monitoring & Validation

- For 24 hours after deploy, search `GenerateImageTool` logs for `Failed to load reference image`, `inputs.files must contain at least one`, and `save_upload` guidance.
- Healthy behavior: image edits report `referenceImageCount >= 1`, while text-to-image calls continue succeeding with no `inputs` object.
- Failure signal: a sustained increase in image-tool failures or agents repeatedly retrying the upload-promotion sequence.
- Owner: Copilot/media on-call. If those signals regress, roll back this PR and mothership#465 together.

## Checklist

- [x] Focused tests cover empty, upload, unresolved, unsafe, unreadable, and successful multi-reference inputs.
- [x] API validation and formatting checks pass.
- [x] No database schema changes.

## Screenshots / Videos

Not applicable; this is a server-side runtime and generated-contract change.

---
[![Compound Engineering](https://img.shields.io/badge/Compound%20Engineering-111827?style=flat&logo=github&logoColor=white)](https://github.com/EveryInc/compound-engineering-plugin)
