### PR TITLE
fix(chat): scope selection clipboard chips to workspace

### DIFF
--- a/apps/sim/app/_shell/paste-admission-guard.test.tsx
+++ b/apps/sim/app/_shell/paste-admission-guard.test.tsx
@@ -17,6 +17,18 @@ import { PasteAdmissionGuard } from '@/app/_shell/paste-admission-guard'
 let host: HTMLDivElement
 let root: Root
 
+const selectionContext = {
+  kind: 'table_selection',
+  tableId: 'table-1',
+  tableName: 'Large table',
+  rowIds: ['row-1'],
+  label: 'Large table (1 row)',
+}
+
+function selectionPayload(sourceWorkspaceId = 'ws-1'): string {
+  return JSON.stringify({ version: 1, sourceWorkspaceId, context: selectionContext })
+}
+
 function dispatchPaste(
   target: Element,
   text: string,
@@ -116,32 +128,33 @@ describe('PasteAdmissionGuard', () => {
   it('lets a prompt consume a compact Sim selection reference before its large plain text', () => {
     const input = document.createElement('textarea')
     input.dataset.pasteMaxBytes = '4'
-    input.dataset.pasteSelectionContext = 'reference'
+    input.dataset.pasteSelectionContext = 'ws-1'
     host.appendChild(input)
-    const selectionContext = JSON.stringify({
-      kind: 'table_selection',
-      tableId: 'table-1',
-      tableName: 'Large table',
-      rowIds: ['row-1'],
-      label: 'Large table (1 row)',
-    })
 
-    expect(dispatchPaste(input, '12345', { selectionContext }).defaultPrevented).toBe(false)
+    expect(
+      dispatchPaste(input, '12345', { selectionContext: selectionPayload() }).defaultPrevented
+    ).toBe(false)
+  })
+
+  it('still bounds a cross-workspace selection plain-text representation', () => {
+    const input = document.createElement('textarea')
+    input.dataset.pasteMaxBytes = '4'
+    input.dataset.pasteSelectionContext = 'ws-2'
+    host.appendChild(input)
+
+    expect(
+      dispatchPaste(input, '12345', { selectionContext: selectionPayload() }).defaultPrevented
+    ).toBe(true)
   })
 
   it('still bounds a Sim selection plain-text representation outside the prompt', () => {
     const input = document.createElement('textarea')
     input.dataset.pasteMaxBytes = '4'
     host.appendChild(input)
-    const selectionContext = JSON.stringify({
-      kind: 'table_selection',
-      tableId: 'table-1',
-      tableName: 'Large table',
-      rowIds: ['row-1'],
-      label: 'Large table (1 row)',
-    })
 
-    expect(dispatchPaste(input, '12345', { selectionContext }).defaultPrevented).toBe(true)
+    expect(
+      dispatchPaste(input, '12345', { selectionContext: selectionPayload() }).defaultPrevented
+    ).toBe(true)
   })
 
   it('bounds rich HTML separately from its smaller plain-text representation', () => {

--- a/apps/sim/app/_shell/paste-admission-guard.tsx
+++ b/apps/sim/app/_shell/paste-admission-guard.tsx
@@ -43,7 +43,15 @@ export function PasteAdmissionGuard() {
       }
 
       const acceptsSelectionContext = event.target.closest('[data-paste-selection-context]')
-      if (acceptsSelectionContext && readSelectionContextFromClipboard(event.clipboardData)) return
+      const destinationWorkspaceId = acceptsSelectionContext?.getAttribute(
+        'data-paste-selection-context'
+      )
+      if (
+        destinationWorkspaceId &&
+        readSelectionContextFromClipboard(event.clipboardData, destinationWorkspaceId)
+      ) {
+        return
+      }
 
       const handlesImageFiles = event.target.closest('[data-paste-handles-images="true"]')
       if (handlesImageFiles && clipboardHasImageFile(event.clipboardData)) return

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -1213,7 +1213,7 @@ export function LoadedRichMarkdownEditor({
     if (context) addToChat(context)
   }
 
-  useSelectionCopyBridge(containerRef, buildSelectionContext)
+  useSelectionCopyBridge(containerRef, buildSelectionContext, workspaceId)
 
   // Show the read-only placeholder (the already-fetched markdown) whenever a collaborative doc has not yet
   // seeded — including during an agent stream that begins before the seed lands. Streamed diffs are held

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -493,7 +493,7 @@ export const TextEditor = memo(function TextEditor({
 
   // Enable once content has loaded — the container (and Monaco) only mount after
   // the `isContentLoading` early return below, so the bridge must (re-)attach then.
-  useSelectionCopyBridge(containerRef, buildSelectionContext, !isContentLoading)
+  useSelectionCopyBridge(containerRef, buildSelectionContext, workspaceId, !isContentLoading)
 
   useEffect(() => {
     if (lastEditorValueRef.current === content) return

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-selection-copy-bridge.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-selection-copy-bridge.test.tsx
@@ -26,7 +26,7 @@ let buildContext: ReturnType<typeof vi.fn>
  * textarea, and its find widget is a real input nested in the same container.
  */
 function Host() {
-  useSelectionCopyBridge(containerRef, buildContext as () => ChatContext | null)
+  useSelectionCopyBridge(containerRef, buildContext as () => ChatContext | null, 'ws-1')
   return (
     <div ref={containerRef}>
       <textarea id='editor-surface' />
@@ -74,7 +74,10 @@ describe('useSelectionCopyBridge', () => {
     const written = dispatchCopy('editor-surface')
 
     expect(buildContext).toHaveBeenCalled()
-    expect(written[SIM_SELECTION_MIME]).toContain('file_selection')
+    expect(JSON.parse(written[SIM_SELECTION_MIME])).toMatchObject({
+      sourceWorkspaceId: 'ws-1',
+      context: selection,
+    })
   })
 
   it('ignores a copy from a nested input such as the find box', () => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-selection-copy-bridge.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-selection-copy-bridge.ts
@@ -13,6 +13,7 @@ import type { ChatContext } from '@/stores/panel'
  * `text/plain`, so the custom type must be added last to survive.
  *
  * @param buildContext - Returns null when there is no non-empty selection.
+ * @param workspaceId - Workspace that owns the selected resource.
  * @param enabled - Re-runs the effect for a container that mounts late (behind a
  * loading gate); a ref isn't reactive, so the effect would otherwise bail on the
  * first render and never re-attach.
@@ -20,6 +21,7 @@ import type { ChatContext } from '@/stores/panel'
 export function useSelectionCopyBridge(
   containerRef: RefObject<HTMLElement | null>,
   buildContext: () => ChatContext | null,
+  workspaceId: string,
   enabled = true
 ): void {
   useEffect(() => {
@@ -36,9 +38,9 @@ export function useSelectionCopyBridge(
       // main copy path this hook exists for.
       if ((e.target as HTMLElement | null)?.tagName === 'INPUT') return
       const context = buildContext()
-      if (context) attachSelectionContextToClipboard(e.clipboardData, context)
+      if (context) attachSelectionContextToClipboard(e.clipboardData, context, workspaceId)
     }
     dom.addEventListener('copy', onCopy)
     return () => dom.removeEventListener('copy', onCopy)
-  }, [containerRef, buildContext, enabled])
+  }, [containerRef, buildContext, workspaceId, enabled])
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/prompt-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/prompt-editor.tsx
@@ -253,7 +253,7 @@ export function PromptEditor({
           onPaste={readOnly ? undefined : editor.handlePaste}
           data-paste-max-bytes={PASTE_LIMITS.CHAT_BYTES}
           data-paste-max-characters={PASTE_LIMITS.CHAT_CHARACTERS}
-          data-paste-selection-context='reference'
+          data-paste-selection-context={editor.workspaceId}
           onCopy={editor.handleCopy}
           onCut={readOnly ? undefined : editor.handleCut}
           onSelect={readOnly ? undefined : editor.handleSelectAdjust}

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx
@@ -20,6 +20,10 @@ import {
 import type { SkillsMenuHandle } from '@/app/workspace/[workspaceId]/home/components/user-input/components/skills-menu-dropdown/skills-menu-dropdown'
 import type { ChatContext } from '@/stores/panel'
 
+function selectionPayload(context: ChatContext, sourceWorkspaceId = 'ws-1'): string {
+  return JSON.stringify({ version: 1, sourceWorkspaceId, context })
+}
+
 /**
  * Mounts `usePromptEditor` in a real React 19 root under jsdom (no
  * `@testing-library/react` in this repo — see `hooks/queries/unsubscribe.test.tsx`
@@ -300,7 +304,7 @@ describe('usePromptEditor context insertion', () => {
         clipboardData: {
           getData: (type: string) => {
             if (type === 'text/plain') return 'x'.repeat(1_000_001)
-            if (type === SIM_SELECTION_MIME) return JSON.stringify(context)
+            if (type === SIM_SELECTION_MIME) return selectionPayload(context)
             return ''
           },
         },
@@ -311,6 +315,37 @@ describe('usePromptEditor context insertion', () => {
     expect(preventDefault).toHaveBeenCalledOnce()
     expect(result().value).toBe('@Large table (1 row) ')
     expect(result().contexts).toEqual([context])
+
+    unmount()
+  })
+
+  it('leaves a cross-workspace selection to the ordinary plain-text paste path', () => {
+    const context = {
+      kind: 'file_selection',
+      fileId: 'file-1',
+      fileName: 'notes.md',
+      label: 'notes.md:1',
+      text: 'ordinary text',
+    } satisfies ChatContext
+    const { result, textarea, unmount } = renderPromptEditor({ workspaceId: 'ws-2' })
+    const preventDefault = vi.fn()
+
+    act(() => {
+      result().handlePaste({
+        currentTarget: textarea,
+        clipboardData: {
+          getData: (type: string) => {
+            if (type === 'text/plain') return context.text
+            if (type === SIM_SELECTION_MIME) return selectionPayload(context)
+            return ''
+          },
+        },
+        preventDefault,
+      } as unknown as React.ClipboardEvent<HTMLTextAreaElement>)
+    })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(result().contexts).toEqual([])
 
     unmount()
   })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
@@ -174,6 +174,8 @@ export function usePromptEditor({
   const [value, setValueState] = useState(initialValue)
   const valueRef = useRef(value)
   valueRef.current = value
+  const workspaceIdRef = useRef(workspaceId)
+  workspaceIdRef.current = workspaceId
 
   /**
    * Commits a new text value, keeping {@link valueRef} in lockstep with state so
@@ -1000,7 +1002,10 @@ export function usePromptEditor({
     // is already attached there is nothing to add, and claiming the event anyway
     // would swallow the keystroke entirely — no chip and no text. Falling through
     // pastes the selection's plain text, which is what the user asked for.
-    const selectionContext = readSelectionContextFromClipboard(e.clipboardData)
+    const selectionContext = readSelectionContextFromClipboard(
+      e.clipboardData,
+      workspaceIdRef.current
+    )
     const preparedSelection = selectionContext
       ? prepareContextForInsert(selectionContext, contextManagementRef.current.selectedContexts)
       : null
@@ -1151,7 +1156,11 @@ export function usePromptEditor({
       if (soleSelectionChip) {
         e.preventDefault()
         e.clipboardData.setData('text/plain', selected)
-        attachSelectionContextToClipboard(e.clipboardData, selectionChips[0])
+        attachSelectionContextToClipboard(
+          e.clipboardData,
+          selectionChips[0],
+          workspaceIdRef.current
+        )
         return true
       }
       const serialized = serializeSelectionForClipboard(selected, contexts)

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -344,6 +344,7 @@ function cellToText(value: unknown, column?: DisplayColumn): string {
  */
 function writeLoadedRowsWithChip(opts: {
   clipboardData: DataTransfer | null
+  workspaceId: string
   rows: TableRowType[]
   complete: boolean
   buildCells: (row: TableRowType) => string[]
@@ -364,7 +365,7 @@ function writeLoadedRowsWithChip(opts: {
     'text/plain',
     rows.map((row) => opts.buildCells(row).join('\t')).join('\n')
   )
-  attachSelectionContextToClipboard(opts.clipboardData, context)
+  attachSelectionContextToClipboard(opts.clipboardData, context, opts.workspaceId)
   toast.success(`Copied ${rows.length} ${rows.length === 1 ? 'row' : 'rows'}`)
   return true
 }
@@ -3402,6 +3403,7 @@ export function TableGrid({
           const selectedRows = currentRows.filter((row) => rowSelectionIncludes(rowSel, row.id))
           const handled = writeLoadedRowsWithChip({
             clipboardData: e.clipboardData,
+            workspaceId,
             rows: selectedRows,
             complete: true,
             buildCells: (row) => cols.map((col) => cellToText(row.data[col.key], col)),
@@ -3449,6 +3451,7 @@ export function TableGrid({
         // in the rest — so the chip path applies only once all of them are here.
         const handled = writeLoadedRowsWithChip({
           clipboardData: e.clipboardData,
+          workspaceId,
           rows: currentRows,
           complete: currentRows.length >= selectAllTotalRef.current,
           buildCells: (row) =>
@@ -3486,7 +3489,9 @@ export function TableGrid({
         rowIds: rangeRowIds,
         columnIds: selectedColumnIds(cols, sel),
       })
-      if (rangeContext) attachSelectionContextToClipboard(e.clipboardData, rangeContext)
+      if (rangeContext) {
+        attachSelectionContextToClipboard(e.clipboardData, rangeContext, workspaceId)
+      }
 
       const lines: string[] = []
       for (let r = sel.startRow; r <= sel.endRow; r++) {

--- a/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/[tableId]/components/table-grid/table-grid.tsx
@@ -478,6 +478,10 @@ export function TableGrid({
   const params = useParams()
   const workspaceId = propWorkspaceId || (params.workspaceId as string)
   const tableId = propTableId || (params.tableId as string)
+  const workspaceIdRef = useRef(workspaceId)
+  workspaceIdRef.current = workspaceId
+  const tableIdRef = useRef(tableId)
+  tableIdRef.current = tableId
   const posthog = usePostHog()
 
   useEffect(() => {
@@ -3403,12 +3407,12 @@ export function TableGrid({
           const selectedRows = currentRows.filter((row) => rowSelectionIncludes(rowSel, row.id))
           const handled = writeLoadedRowsWithChip({
             clipboardData: e.clipboardData,
-            workspaceId,
+            workspaceId: workspaceIdRef.current,
             rows: selectedRows,
             complete: true,
             buildCells: (row) => cols.map((col) => cellToText(row.data[col.key], col)),
             context: buildTableSelectionContext({
-              tableId,
+              tableId: tableIdRef.current,
               tableName: tableNameRef.current,
               // Every selected id, not just the loaded page: the chip carries
               // ids and the server re-fetches them, so an unloaded row still
@@ -3451,13 +3455,13 @@ export function TableGrid({
         // in the rest — so the chip path applies only once all of them are here.
         const handled = writeLoadedRowsWithChip({
           clipboardData: e.clipboardData,
-          workspaceId,
+          workspaceId: workspaceIdRef.current,
           rows: currentRows,
           complete: currentRows.length >= selectAllTotalRef.current,
           buildCells: (row) =>
             colNames.map((name) => cellToText(row.data[name], colByKey.get(name))),
           context: buildTableSelectionContext({
-            tableId,
+            tableId: tableIdRef.current,
             tableName: tableNameRef.current,
             rowIds: currentRows.map((row) => row.id),
             columnIds: selectedColumnIds(cols, sel),
@@ -3484,13 +3488,13 @@ export function TableGrid({
         if (row) rangeRowIds.push(row.id)
       }
       const rangeContext = buildTableSelectionContext({
-        tableId,
+        tableId: tableIdRef.current,
         tableName: tableNameRef.current,
         rowIds: rangeRowIds,
         columnIds: selectedColumnIds(cols, sel),
       })
       if (rangeContext) {
-        attachSelectionContextToClipboard(e.clipboardData, rangeContext, workspaceId)
+        attachSelectionContextToClipboard(e.clipboardData, rangeContext, workspaceIdRef.current)
       }
 
       const lines: string[] = []

--- a/apps/sim/lib/copilot/chat/selection-clipboard.test.ts
+++ b/apps/sim/lib/copilot/chat/selection-clipboard.test.ts
@@ -38,63 +38,87 @@ const tableSelection: ChatContext = {
   rowIds: ['r1', 'r2'],
 }
 
+function selectionPayload(context: unknown, sourceWorkspaceId = 'ws-1'): string {
+  return JSON.stringify({ version: 1, sourceWorkspaceId, context })
+}
+
 describe('selection clipboard codec', () => {
   it('round-trips a file selection through the custom MIME type', () => {
     const dt = fakeClipboard()
-    attachSelectionContextToClipboard(dt, fileSelection)
+    attachSelectionContextToClipboard(dt, fileSelection, 'ws-1')
     expect(dt.getData(SIM_SELECTION_MIME)).toContain('file_selection')
-    expect(readSelectionContextFromClipboard(dt)).toEqual(fileSelection)
+    expect(readSelectionContextFromClipboard(dt, 'ws-1')).toEqual(fileSelection)
   })
 
   it('round-trips a table selection', () => {
     const dt = fakeClipboard()
-    attachSelectionContextToClipboard(dt, tableSelection)
-    expect(readSelectionContextFromClipboard(dt)).toEqual(tableSelection)
+    attachSelectionContextToClipboard(dt, tableSelection, 'ws-1')
+    expect(readSelectionContextFromClipboard(dt, 'ws-1')).toEqual(tableSelection)
   })
 
   it('does not touch text/plain (rides alongside it)', () => {
     const dt = fakeClipboard({ 'text/plain': 'the exact passage' })
-    attachSelectionContextToClipboard(dt, fileSelection)
+    attachSelectionContextToClipboard(dt, fileSelection, 'ws-1')
     expect(dt.getData('text/plain')).toBe('the exact passage')
   })
 
+  it('rejects cross-workspace and legacy selection payloads', () => {
+    expect(
+      readSelectionContextFromClipboard(
+        fakeClipboard({ [SIM_SELECTION_MIME]: selectionPayload(fileSelection) }),
+        'ws-2'
+      )
+    ).toBeNull()
+    expect(
+      readSelectionContextFromClipboard(
+        fakeClipboard({ [SIM_SELECTION_MIME]: JSON.stringify(fileSelection) }),
+        'ws-1'
+      )
+    ).toBeNull()
+  })
+
   it('returns null when the custom type is absent (plain paste)', () => {
-    expect(readSelectionContextFromClipboard(fakeClipboard({ 'text/plain': 'hi' }))).toBeNull()
+    expect(
+      readSelectionContextFromClipboard(fakeClipboard({ 'text/plain': 'hi' }), 'ws-1')
+    ).toBeNull()
   })
 
   it('returns null on malformed JSON', () => {
     expect(
-      readSelectionContextFromClipboard(fakeClipboard({ [SIM_SELECTION_MIME]: '{not json' }))
+      readSelectionContextFromClipboard(
+        fakeClipboard({ [SIM_SELECTION_MIME]: '{not json' }),
+        'ws-1'
+      )
     ).toBeNull()
   })
 
   it('rejects a file selection missing its text', () => {
     const dt = fakeClipboard({
-      [SIM_SELECTION_MIME]: JSON.stringify({
+      [SIM_SELECTION_MIME]: selectionPayload({
         kind: 'file_selection',
         fileId: 'wf_1',
         fileName: 'notes.md',
         label: 'x',
       }),
     })
-    expect(readSelectionContextFromClipboard(dt)).toBeNull()
+    expect(readSelectionContextFromClipboard(dt, 'ws-1')).toBeNull()
   })
 
   it('rejects a selection missing the resource name the chip renders from', () => {
     const dt = fakeClipboard({
-      [SIM_SELECTION_MIME]: JSON.stringify({
+      [SIM_SELECTION_MIME]: selectionPayload({
         kind: 'file_selection',
         fileId: 'wf_1',
         label: 'x',
         text: 'passage',
       }),
     })
-    expect(readSelectionContextFromClipboard(dt)).toBeNull()
+    expect(readSelectionContextFromClipboard(dt, 'ws-1')).toBeNull()
   })
 
   it('rejects a table selection with no rows', () => {
     const dt = fakeClipboard({
-      [SIM_SELECTION_MIME]: JSON.stringify({
+      [SIM_SELECTION_MIME]: selectionPayload({
         kind: 'table_selection',
         tableId: 'tbl_1',
         tableName: 'Sales',
@@ -102,13 +126,17 @@ describe('selection clipboard codec', () => {
         rowIds: [],
       }),
     })
-    expect(readSelectionContextFromClipboard(dt)).toBeNull()
+    expect(readSelectionContextFromClipboard(dt, 'ws-1')).toBeNull()
   })
 
   it('rejects an unrelated context kind', () => {
     const dt = fakeClipboard({
-      [SIM_SELECTION_MIME]: JSON.stringify({ kind: 'file', fileId: 'wf_1', label: 'x' }),
+      [SIM_SELECTION_MIME]: selectionPayload({
+        kind: 'file',
+        fileId: 'wf_1',
+        label: 'x',
+      }),
     })
-    expect(readSelectionContextFromClipboard(dt)).toBeNull()
+    expect(readSelectionContextFromClipboard(dt, 'ws-1')).toBeNull()
   })
 })

--- a/apps/sim/lib/copilot/chat/selection-clipboard.ts
+++ b/apps/sim/lib/copilot/chat/selection-clipboard.ts
@@ -8,6 +8,14 @@ import type { ChatContext } from '@/stores/panel'
  */
 export const SIM_SELECTION_MIME = 'text/x-sim-selection'
 
+const SIM_SELECTION_CLIPBOARD_VERSION = 1
+
+interface SelectionClipboardEnvelope {
+  version: typeof SIM_SELECTION_CLIPBOARD_VERSION
+  sourceWorkspaceId: string
+  context: ChatContext
+}
+
 /**
  * Attaches a selection context to a copy event's clipboard. Adds the custom MIME
  * type WITHOUT calling `preventDefault`, so the editor's own copy handler (Monaco,
@@ -16,11 +24,17 @@ export const SIM_SELECTION_MIME = 'text/x-sim-selection'
  */
 export function attachSelectionContextToClipboard(
   clipboardData: DataTransfer | null,
-  context: ChatContext
+  context: ChatContext,
+  sourceWorkspaceId: string
 ): void {
-  if (!clipboardData) return
+  if (!clipboardData || !sourceWorkspaceId) return
   try {
-    clipboardData.setData(SIM_SELECTION_MIME, JSON.stringify(context))
+    const envelope: SelectionClipboardEnvelope = {
+      version: SIM_SELECTION_CLIPBOARD_VERSION,
+      sourceWorkspaceId,
+      context,
+    }
+    clipboardData.setData(SIM_SELECTION_MIME, JSON.stringify(envelope))
   } catch {
     // Some browsers reject custom types mid-gesture; degrade to plain-text copy.
   }
@@ -32,13 +46,21 @@ export function attachSelectionContextToClipboard(
  * no (or an invalid) selection payload.
  */
 export function readSelectionContextFromClipboard(
-  clipboardData: DataTransfer | null
+  clipboardData: DataTransfer | null,
+  destinationWorkspaceId: string
 ): ChatContext | null {
   const raw = clipboardData?.getData(SIM_SELECTION_MIME)
   if (!raw) return null
   try {
-    const parsed = JSON.parse(raw) as ChatContext
-    if (!parsed || typeof parsed.label !== 'string') return null
+    const envelope = JSON.parse(raw) as Partial<SelectionClipboardEnvelope>
+    if (
+      envelope.version !== SIM_SELECTION_CLIPBOARD_VERSION ||
+      envelope.sourceWorkspaceId !== destinationWorkspaceId
+    ) {
+      return null
+    }
+    const parsed = envelope.context
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.label !== 'string') return null
     // Require each kind's resolving field so a chip never pastes only to
     // resolve to nothing server-side.
     if (


### PR DESCRIPTION
## Summary

- wrap file and table selection clipboard contexts in a versioned envelope containing the source workspace
- create Chat context chips only when the source and destination workspaces match
- fall back to ordinary plain-text paste for cross-workspace, legacy, or malformed payloads while preserving existing server-side authorization

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- `bun run --cwd apps/sim test lib/copilot/chat/selection-clipboard.test.ts app/_shell/paste-admission-guard.test.tsx 'app/workspace/[workspaceId]/files/components/file-viewer/use-selection-copy-bridge.test.tsx' 'app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx'` (32 tests)
- `bun run --cwd apps/sim type-check`
- Biome check on all 12 changed TypeScript files
- `bun run check:api-validation`
- Browser verification on localhost across two authenticated local workspaces: an exact `text/x-sim-selection` payload rendered as a chip in its source workspace and as ordinary text in the other workspace. The local fixtures had no workspace files or tables, so the Chat clipboard boundary was exercised directly without creating data.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
