### PR TITLE
fix(executor): stop resolved data from breaking out of generated condition and function code

### DIFF
--- a/apps/sim/executor/handlers/condition/condition-handler.test.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.test.ts
@@ -202,6 +202,50 @@ describe('ConditionBlockHandler', () => {
     )
   })
 
+  it('mounts only the secrets the condition names', async () => {
+    mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+
+    const conditions = [
+      { id: 'cond1', title: 'if', value: '"{{ROUTE_KEY}}" === "beta"' },
+      { id: 'else1', title: 'else', value: '' },
+    ]
+
+    await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
+
+    const [, toolParams] = mockExecuteTool.mock.calls[0]
+    expect(toolParams.secretScope).toBe('selected')
+    expect(toolParams.mountedSecrets).toEqual(['ROUTE_KEY'])
+  })
+
+  it('denies every secret to a condition that names none', async () => {
+    mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+
+    const conditions = [
+      { id: 'cond1', title: 'if', value: 'context.value > 5' },
+      { id: 'else1', title: 'else', value: '' },
+    ]
+
+    await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
+
+    const [, toolParams] = mockExecuteTool.mock.calls[0]
+    expect(toolParams.secretScope).toBe('selected')
+    expect(toolParams.mountedSecrets).toEqual([])
+  })
+
+  it('keeps the whole environment for a condition that reads the environment directly', async () => {
+    mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+
+    const conditions = [
+      { id: 'cond1', title: 'if', value: 'environmentVariables.ROUTE_KEY === "beta"' },
+      { id: 'else1', title: 'else', value: '' },
+    ]
+
+    await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
+
+    const [, toolParams] = mockExecuteTool.mock.calls[0]
+    expect(toolParams.secretScope).toBe('all')
+  })
+
   it('should never forward collected block outputs in the request body', async () => {
     mockCollectBlockData.mockReturnValueOnce({
       blockData: { 'huge-block': { payload: 'x'.repeat(1024) } },

--- a/apps/sim/executor/handlers/condition/condition-handler.test.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.test.ts
@@ -256,6 +256,28 @@ describe('ConditionBlockHandler', () => {
     expect(toolParams.mountedSecrets).toEqual([])
   })
 
+  it('trusts the resolver record over the word appearing in a resolved expression', async () => {
+    // The resolver saw the author's text before any value was inlined; the expression by now
+    // carries trigger data, where the same word means nothing.
+    mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+
+    const conditions = [
+      {
+        id: 'cond1',
+        title: 'if',
+        value: `'environmentVariables.OPENAI_API_KEY' === 'x'`,
+        _readsEnvironmentVariables: false,
+      },
+      { id: 'else1', title: 'else', value: '' },
+    ]
+
+    await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
+
+    const [, toolParams] = mockExecuteTool.mock.calls[0]
+    expect(toolParams.secretScope).toBe('selected')
+    expect(toolParams.mountedSecrets).toEqual([])
+  })
+
   it('keeps the whole environment for a condition that reads the environment directly', async () => {
     // Every shape an expression can reach the map through, including the ones a member-access
     // pattern would miss — narrowing one of those would route the run silently.

--- a/apps/sim/executor/handlers/condition/condition-handler.test.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.test.ts
@@ -254,17 +254,28 @@ describe('ConditionBlockHandler', () => {
   })
 
   it('keeps the whole environment for a condition that reads the environment directly', async () => {
-    mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
-
-    const conditions = [
-      { id: 'cond1', title: 'if', value: 'environmentVariables.ROUTE_KEY === "beta"' },
-      { id: 'else1', title: 'else', value: '' },
+    // Every shape an expression can reach the map through, including the ones a member-access
+    // pattern would miss — narrowing one of those would route the run silently.
+    const reads = [
+      'environmentVariables.ROUTE_KEY === "beta"',
+      'environmentVariables["ROUTE_KEY"] === "beta"',
+      'environmentVariables?.ROUTE_KEY === "beta"',
+      'Object.keys(environmentVariables).length > 0',
     ]
 
-    await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
+    for (const value of reads) {
+      mockExecuteTool.mockReset()
+      mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+      const conditions = [
+        { id: 'cond1', title: 'if', value },
+        { id: 'else1', title: 'else', value: '' },
+      ]
 
-    const [, toolParams] = mockExecuteTool.mock.calls[0]
-    expect(toolParams.secretScope).toBe('all')
+      await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
+
+      const [, toolParams] = mockExecuteTool.mock.calls[0]
+      expect(toolParams.secretScope, `condition ${value}`).toBe('all')
+    }
   })
 
   it('should never forward collected block outputs in the request body', async () => {

--- a/apps/sim/executor/handlers/condition/condition-handler.test.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.test.ts
@@ -232,10 +232,13 @@ describe('ConditionBlockHandler', () => {
     expect(toolParams.mountedSecrets).toEqual([])
   })
 
-  it('does not let resolved data widen the mounted secrets by naming the environment', async () => {
+  it('does not let resolved data decide which secrets the sandbox holds', async () => {
+    // The script carries the source block's output as data. Reading that data for either
+    // signal would let a caller pick what materializes beside it — the whole map by naming
+    // the global, or one secret by naming its placeholder.
     mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
     mockContext.blockStates.set('source-block-1', {
-      output: { text: 'environmentVariables.OPENAI_API_KEY' },
+      output: { text: 'environmentVariables.OPENAI_API_KEY {{OPENAI_API_KEY}}' },
       executed: true,
       executionTime: 0,
     } as BlockState)
@@ -248,7 +251,7 @@ describe('ConditionBlockHandler', () => {
     await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
 
     const [, toolParams] = mockExecuteTool.mock.calls[0]
-    expect(toolParams.code).toContain('environmentVariables.OPENAI_API_KEY')
+    expect(toolParams.code).toContain('{{OPENAI_API_KEY}}')
     expect(toolParams.secretScope).toBe('selected')
     expect(toolParams.mountedSecrets).toEqual([])
   })

--- a/apps/sim/executor/handlers/condition/condition-handler.test.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.test.ts
@@ -232,6 +232,27 @@ describe('ConditionBlockHandler', () => {
     expect(toolParams.mountedSecrets).toEqual([])
   })
 
+  it('does not let resolved data widen the mounted secrets by naming the environment', async () => {
+    mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+    mockContext.blockStates.set('source-block-1', {
+      output: { text: 'environmentVariables.OPENAI_API_KEY' },
+      executed: true,
+      executionTime: 0,
+    } as BlockState)
+
+    const conditions = [
+      { id: 'cond1', title: 'if', value: `context.text === 'x'` },
+      { id: 'else1', title: 'else', value: '' },
+    ]
+
+    await handler.execute(mockContext, mockBlock, { conditions: JSON.stringify(conditions) })
+
+    const [, toolParams] = mockExecuteTool.mock.calls[0]
+    expect(toolParams.code).toContain('environmentVariables.OPENAI_API_KEY')
+    expect(toolParams.secretScope).toBe('selected')
+    expect(toolParams.mountedSecrets).toEqual([])
+  })
+
   it('keeps the whole environment for a condition that reads the environment directly', async () => {
     mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
 

--- a/apps/sim/executor/handlers/condition/condition-handler.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.ts
@@ -92,21 +92,26 @@ function buildConditionScript(expressions: string[], evalContext: Record<string,
 /**
  * Narrows the secrets a condition evaluation can read to the ones its script names.
  *
- * A condition reaches a secret by writing `{{NAME}}`, which the execution-boundary
- * compiler binds. Nothing else in the script needs the workspace's other secrets, so
- * handing the sandbox the full environment only widens what a future defect in this
- * path could reach — the whole map was readable as the `environmentVariables` global.
+ * A condition reaches a secret by writing `{{NAME}}`, which the execution-boundary compiler
+ * binds. Nothing else in the script needs the workspace's other secrets, so handing the
+ * sandbox the full environment only widens what a future defect in this path could reach —
+ * the whole map was readable as the `environmentVariables` global.
  *
- * Scanning the built script rather than the expressions covers the batched and
- * per-branch scripts with one rule, and mounts exactly the set the compiler could
- * substitute. A script that reads the `environmentVariables` global directly keeps the
- * full map: that access is undocumented for conditions but costs nothing to preserve.
+ * The two scans read different text on purpose. Placeholders are read from the built script,
+ * which is exactly what the compiler substitutes over, so a mounted set derived from anything
+ * narrower would silently stop resolving a placeholder the compiler still expands. The direct
+ * `environmentVariables` read is looked for in the expressions alone, and only as a member
+ * access: the script also carries the source block's output as data, so scanning it would let
+ * a payload that merely contains the word restore the full map.
  */
-function scopeConditionSecrets(code: string): {
+function scopeConditionSecrets(
+  code: string,
+  expressions: string[]
+): {
   secretScope: 'all' | 'selected'
   mountedSecrets: string[]
 } {
-  if (/\benvironmentVariables\b/.test(code)) {
+  if (expressions.some((expression) => /\benvironmentVariables\s*[.[]/.test(expression))) {
     return { secretScope: 'all', mountedSecrets: [] }
   }
 
@@ -129,10 +134,11 @@ function scopeConditionSecrets(code: string): {
 async function runConditionCode(
   ctx: ExecutionContext,
   code: string,
+  expressions: string[],
   currentNodeId?: string
 ): Promise<ToolResponse> {
   const { blockNameMapping, blockOutputSchemas } = collectBlockData(ctx, currentNodeId)
-  const { secretScope, mountedSecrets } = scopeConditionSecrets(code)
+  const { secretScope, mountedSecrets } = scopeConditionSecrets(code, expressions)
 
   return executeTool(
     'function_execute',
@@ -182,6 +188,7 @@ async function evaluateConditionList(
   const result = await runConditionCode(
     ctx,
     buildConditionScript(expressions, evalContext),
+    expressions,
     currentNodeId
   )
 
@@ -266,7 +273,7 @@ async function evaluateSingleCondition(
   currentNodeId?: string
 ): Promise<boolean> {
   const code = `const context = ${JSON.stringify(evalContext)};\nreturn ${buildBooleanTest(expression)}`
-  const result = await runConditionCode(ctx, code, currentNodeId)
+  const result = await runConditionCode(ctx, code, [expression], currentNodeId)
 
   if (!result.success) {
     if (result.retryable === false) {

--- a/apps/sim/executor/handlers/condition/condition-handler.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.ts
@@ -17,6 +17,7 @@ import {
   extractBranchIndex,
   isBranchNodeId,
 } from '@/executor/utils/subflow-utils'
+import { CONDITION_READS_ENVIRONMENT_KEY } from '@/executor/variables/resolver'
 import type { SerializedBlock } from '@/serializer/types'
 import { executeTool } from '@/tools'
 import type { ToolResponse } from '@/tools/types'
@@ -29,6 +30,8 @@ interface ConditionEntry {
   id: string
   title: string
   value: string
+  /** Set by the resolver from the author's pre-resolution expression. */
+  [CONDITION_READS_ENVIRONMENT_KEY]?: boolean
 }
 
 /** Verdict for a whole condition list evaluated in one function execution. */
@@ -97,32 +100,36 @@ function buildConditionScript(expressions: string[], evalContext: Record<string,
  * sandbox the full environment only widens what a future defect in this path could reach —
  * the whole map was readable as the `environmentVariables` global.
  *
- * Both scans read the expressions rather than the built script, which also carries the source
- * block's output as data. Reading that data would let it decide what the sandbox holds: a
- * payload containing the word `environmentVariables` would restore the whole map, and one
- * containing `{{SECRET}}` would mount that secret and have the compiler expand it into the
- * data — a caller choosing which secret materializes next to it. Every legitimate route to a
- * secret runs through an expression, including a workflow variable holding `{{NAME}}`, because
- * the resolver inlines that value into the expression before this runs.
+ * Neither signal is read from the built script, which also carries the source block's output as
+ * data. Reading that data would let it decide what the sandbox holds — a payload containing
+ * `{{SECRET}}` would mount that secret and have the compiler expand it beside the payload.
+ * Placeholders are therefore read from the expressions, which is where every legitimate route
+ * to a secret passes, including a workflow variable holding `{{NAME}}`: the resolver inlines
+ * that value into the expression before this runs.
  *
- * Within an expression the bare `environmentVariables` identifier is enough, rather than a
- * member access. Narrowing the secrets an expression can see when it does reach for the map by
- * some shape the pattern did not anticipate — `environmentVariables?.FLAG`, or a read through
- * `Object.keys` — would route the run down a branch the author did not write, silently.
- * Matching too widely only costs the narrowing itself, and never mounts more than this path
- * already mounted.
+ * A direct read of the environment map is not read from the resolved expression either, for the
+ * same reason one step further in: resolved data is quoted inside it, so a payload containing
+ * the word would be indistinguishable from the author reaching for the map. The resolver
+ * records the answer from the author's pre-resolution text instead. When that record is absent
+ * — a caller that did not resolve through it — the expression is scanned as a fallback, because
+ * narrowing a read this missed would route the run down a branch the author did not write,
+ * silently, while matching too widely only costs the narrowing.
  */
-function scopeConditionSecrets(expressions: string[]): {
+function scopeConditionSecrets(conditions: ConditionEntry[]): {
   secretScope: 'all' | 'selected'
   mountedSecrets: string[]
 } {
-  if (expressions.some((expression) => /\benvironmentVariables\b/.test(expression))) {
+  const readsEnvironment = conditions.some((condition) => {
+    const recorded = condition[CONDITION_READS_ENVIRONMENT_KEY]
+    return recorded ?? /\benvironmentVariables\b/.test(condition.value)
+  })
+  if (readsEnvironment) {
     return { secretScope: 'all', mountedSecrets: [] }
   }
 
   const named = new Set<string>()
-  for (const expression of expressions) {
-    for (const match of expression.matchAll(createEnvVarPattern())) {
+  for (const condition of conditions) {
+    for (const match of String(condition.value ?? '').matchAll(createEnvVarPattern())) {
       named.add(String(match[1]).trim())
     }
   }
@@ -141,11 +148,11 @@ function scopeConditionSecrets(expressions: string[]): {
 async function runConditionCode(
   ctx: ExecutionContext,
   code: string,
-  expressions: string[],
+  conditions: ConditionEntry[],
   currentNodeId?: string
 ): Promise<ToolResponse> {
   const { blockNameMapping, blockOutputSchemas } = collectBlockData(ctx, currentNodeId)
-  const { secretScope, mountedSecrets } = scopeConditionSecrets(expressions)
+  const { secretScope, mountedSecrets } = scopeConditionSecrets(conditions)
 
   return executeTool(
     'function_execute',
@@ -188,14 +195,15 @@ function isTimeoutFailure(error: string | undefined): boolean {
 /** Evaluates the whole condition list in a single function execution. */
 async function evaluateConditionList(
   ctx: ExecutionContext,
-  expressions: string[],
+  conditions: ConditionEntry[],
   evalContext: Record<string, unknown>,
   currentNodeId?: string
 ): Promise<ConditionEvaluation> {
+  const expressions = conditions.map((condition) => String(condition.value || ''))
   const result = await runConditionCode(
     ctx,
     buildConditionScript(expressions, evalContext),
-    expressions,
+    conditions,
     currentNodeId
   )
 
@@ -275,12 +283,13 @@ async function evaluateConditionList(
  */
 async function evaluateSingleCondition(
   ctx: ExecutionContext,
-  expression: string,
+  condition: ConditionEntry,
   evalContext: Record<string, unknown>,
   currentNodeId?: string
 ): Promise<boolean> {
+  const expression = String(condition.value || '')
   const code = `const context = ${JSON.stringify(evalContext)};\nreturn ${buildBooleanTest(expression)}`
-  const result = await runConditionCode(ctx, code, [expression], currentNodeId)
+  const result = await runConditionCode(ctx, code, [condition], currentNodeId)
 
   if (!result.success) {
     if (result.retryable === false) {
@@ -464,11 +473,9 @@ export class ConditionBlockHandler implements BlockHandler {
   ): Promise<ConditionEntry | null> {
     if (conditions.length === 0) return null
 
-    const expressions = conditions.map((condition) => String(condition.value || ''))
-
     let evaluation: ConditionEvaluation
     try {
-      evaluation = await evaluateConditionList(ctx, expressions, evalContext, currentNodeId)
+      evaluation = await evaluateConditionList(ctx, conditions, evalContext, currentNodeId)
     } catch (error) {
       if (isNonRetryableExecutionError(error)) throw error
       evaluation = {
@@ -520,7 +527,7 @@ export class ConditionBlockHandler implements BlockHandler {
       try {
         const conditionMet = await evaluateSingleCondition(
           ctx,
-          String(condition.value || ''),
+          condition,
           evalContext,
           currentNodeId
         )

--- a/apps/sim/executor/handlers/condition/condition-handler.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.ts
@@ -100,9 +100,15 @@ function buildConditionScript(expressions: string[], evalContext: Record<string,
  * The two scans read different text on purpose. Placeholders are read from the built script,
  * which is exactly what the compiler substitutes over, so a mounted set derived from anything
  * narrower would silently stop resolving a placeholder the compiler still expands. The direct
- * `environmentVariables` read is looked for in the expressions alone, and only as a member
- * access: the script also carries the source block's output as data, so scanning it would let
- * a payload that merely contains the word restore the full map.
+ * `environmentVariables` read is looked for in the expressions alone: the script also carries
+ * the source block's output as data, so scanning that too would let a payload which merely
+ * contains the word restore the full map.
+ *
+ * Within an expression the bare identifier is enough, rather than a member access. Narrowing
+ * the secrets an expression can see when it does reach for the map by some shape the pattern
+ * did not anticipate — `environmentVariables?.FLAG`, or a read through `Object.keys` — would
+ * route the run down a branch the author did not write, silently. Matching too widely only
+ * costs the narrowing itself, and never mounts more than this path already mounted.
  */
 function scopeConditionSecrets(
   code: string,
@@ -111,7 +117,7 @@ function scopeConditionSecrets(
   secretScope: 'all' | 'selected'
   mountedSecrets: string[]
 } {
-  if (expressions.some((expression) => /\benvironmentVariables\s*[.[]/.test(expression))) {
+  if (expressions.some((expression) => /\benvironmentVariables\b/.test(expression))) {
     return { secretScope: 'all', mountedSecrets: [] }
   }
 

--- a/apps/sim/executor/handlers/condition/condition-handler.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.ts
@@ -97,23 +97,22 @@ function buildConditionScript(expressions: string[], evalContext: Record<string,
  * sandbox the full environment only widens what a future defect in this path could reach —
  * the whole map was readable as the `environmentVariables` global.
  *
- * The two scans read different text on purpose. Placeholders are read from the built script,
- * which is exactly what the compiler substitutes over, so a mounted set derived from anything
- * narrower would silently stop resolving a placeholder the compiler still expands. The direct
- * `environmentVariables` read is looked for in the expressions alone: the script also carries
- * the source block's output as data, so scanning that too would let a payload which merely
- * contains the word restore the full map.
+ * Both scans read the expressions rather than the built script, which also carries the source
+ * block's output as data. Reading that data would let it decide what the sandbox holds: a
+ * payload containing the word `environmentVariables` would restore the whole map, and one
+ * containing `{{SECRET}}` would mount that secret and have the compiler expand it into the
+ * data — a caller choosing which secret materializes next to it. Every legitimate route to a
+ * secret runs through an expression, including a workflow variable holding `{{NAME}}`, because
+ * the resolver inlines that value into the expression before this runs.
  *
- * Within an expression the bare identifier is enough, rather than a member access. Narrowing
- * the secrets an expression can see when it does reach for the map by some shape the pattern
- * did not anticipate — `environmentVariables?.FLAG`, or a read through `Object.keys` — would
- * route the run down a branch the author did not write, silently. Matching too widely only
- * costs the narrowing itself, and never mounts more than this path already mounted.
+ * Within an expression the bare `environmentVariables` identifier is enough, rather than a
+ * member access. Narrowing the secrets an expression can see when it does reach for the map by
+ * some shape the pattern did not anticipate — `environmentVariables?.FLAG`, or a read through
+ * `Object.keys` — would route the run down a branch the author did not write, silently.
+ * Matching too widely only costs the narrowing itself, and never mounts more than this path
+ * already mounted.
  */
-function scopeConditionSecrets(
-  code: string,
-  expressions: string[]
-): {
+function scopeConditionSecrets(expressions: string[]): {
   secretScope: 'all' | 'selected'
   mountedSecrets: string[]
 } {
@@ -122,8 +121,10 @@ function scopeConditionSecrets(
   }
 
   const named = new Set<string>()
-  for (const match of code.matchAll(createEnvVarPattern())) {
-    named.add(String(match[1]).trim())
+  for (const expression of expressions) {
+    for (const match of expression.matchAll(createEnvVarPattern())) {
+      named.add(String(match[1]).trim())
+    }
   }
   return { secretScope: 'selected', mountedSecrets: [...named] }
 }
@@ -144,7 +145,7 @@ async function runConditionCode(
   currentNodeId?: string
 ): Promise<ToolResponse> {
   const { blockNameMapping, blockOutputSchemas } = collectBlockData(ctx, currentNodeId)
-  const { secretScope, mountedSecrets } = scopeConditionSecrets(code, expressions)
+  const { secretScope, mountedSecrets } = scopeConditionSecrets(expressions)
 
   return executeTool(
     'function_execute',

--- a/apps/sim/executor/handlers/condition/condition-handler.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.ts
@@ -10,6 +10,7 @@ import type { BlockOutput } from '@/blocks/types'
 import { BlockType, DEFAULTS, EDGE } from '@/executor/constants'
 import type { BlockHandler, ExecutionContext } from '@/executor/types'
 import { collectBlockData } from '@/executor/utils/block-data'
+import { createEnvVarPattern } from '@/executor/utils/reference-validation'
 import {
   buildBranchNodeId,
   extractBaseBlockId,
@@ -89,6 +90,34 @@ function buildConditionScript(expressions: string[], evalContext: Record<string,
 }
 
 /**
+ * Narrows the secrets a condition evaluation can read to the ones its script names.
+ *
+ * A condition reaches a secret by writing `{{NAME}}`, which the execution-boundary
+ * compiler binds. Nothing else in the script needs the workspace's other secrets, so
+ * handing the sandbox the full environment only widens what a future defect in this
+ * path could reach — the whole map was readable as the `environmentVariables` global.
+ *
+ * Scanning the built script rather than the expressions covers the batched and
+ * per-branch scripts with one rule, and mounts exactly the set the compiler could
+ * substitute. A script that reads the `environmentVariables` global directly keeps the
+ * full map: that access is undocumented for conditions but costs nothing to preserve.
+ */
+function scopeConditionSecrets(code: string): {
+  secretScope: 'all' | 'selected'
+  mountedSecrets: string[]
+} {
+  if (/\benvironmentVariables\b/.test(code)) {
+    return { secretScope: 'all', mountedSecrets: [] }
+  }
+
+  const named = new Set<string>()
+  for (const match of code.matchAll(createEnvVarPattern())) {
+    named.add(String(match[1]).trim())
+  }
+  return { secretScope: 'selected', mountedSecrets: [...named] }
+}
+
+/**
  * Runs condition code through the shared function execution boundary.
  *
  * `blockData` is deliberately empty: the resolver already inlines every
@@ -103,12 +132,15 @@ async function runConditionCode(
   currentNodeId?: string
 ): Promise<ToolResponse> {
   const { blockNameMapping, blockOutputSchemas } = collectBlockData(ctx, currentNodeId)
+  const { secretScope, mountedSecrets } = scopeConditionSecrets(code)
 
   return executeTool(
     'function_execute',
     {
       code,
       timeout: CONDITION_TIMEOUT_MS,
+      secretScope,
+      mountedSecrets,
       envVars: normalizeStringRecord(ctx.environmentVariables),
       workflowVariables: normalizeWorkflowVariables(ctx.workflowVariables),
       blockData: {},

--- a/apps/sim/executor/utils/code-formatting.ts
+++ b/apps/sim/executor/utils/code-formatting.ts
@@ -46,3 +46,36 @@ export function formatLiteralForCode(value: unknown, language: 'javascript' | 'p
   }
   return JSON.stringify(value)
 }
+
+/**
+ * Escapes text so it cannot terminate whatever JavaScript literal it is spliced into.
+ *
+ * Condition expressions are user-authored JavaScript into which resolved references are
+ * inlined as source, so the author's quoting — not this module's — decides which string
+ * context the value lands in. Escaping only the quote the emitted literal opens leaves
+ * `"`, a backtick, `${`, and `/` live, and `"<start.input>".includes('urgent')` then lets
+ * trigger data close the author's string and run as code in the condition sandbox.
+ *
+ * So every terminator of every JavaScript string context is escaped, not just the one the
+ * emitted literal opens. `\"`, `` \` ``, `\$`, and `\/` are identity escapes in JavaScript,
+ * so the value a condition compares is byte-identical to what it was before — this is a
+ * syntax guard, not a value transform.
+ *
+ * JavaScript only: `\$`, `` \` `` and `\/` are not identity escapes in Python, where they
+ * would change the value. Code blocks bind their values as runtime context variables
+ * instead of splicing them, which is why they need no escaping in any language.
+ */
+export function escapeInertStringContent(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/['"`$/]/g, '\\$&')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+}
+
+/** Wraps {@link escapeInertStringContent} output as a complete JavaScript string literal. */
+export function formatInertStringLiteral(value: string, quote: '"' | "'" = "'"): string {
+  return `${quote}${escapeInertStringContent(value)}${quote}`
+}

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -947,6 +947,23 @@ describe('VariableResolver function block inputs', () => {
     expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_1"]) + '')`)
   })
 
+  it('does not read a method named after a keyword as a control-flow head', async () => {
+    const { block, ctx, resolver } = createResolver('javascript')
+
+    const result = await resolver.resolveInputsForFunctionBlock(
+      ctx,
+      'function',
+      { code: `const n = params.p.catch(() => 0) / 2 + Number('<producer.result>')` },
+      block
+    )
+
+    // `.catch(…)` is a call, so the slash after it divides — it must not open a regex that
+    // runs over the quotes around the reference.
+    expect(result.resolvedInputs.code).toContain(
+      `Number('' + JSON.stringify(globalThis["__blockRef_0"]) + '')`
+    )
+  })
+
   it('binds a workflow variable carrying quote characters instead of splicing it into code', async () => {
     // A Variables block can assign trigger data at runtime, so a variable's value is not
     // necessarily the author's. Inlined as a literal it closed the string it landed in.

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -984,6 +984,9 @@ describe('VariableResolver function block inputs', () => {
         code: [
           `/* lead */ if (params.a) /['"]/.test('<producer.result>')`,
           `const n = params.p./* mid */catch(() => 0) / 2 + Number('<producer.result>')`,
+          // A comment body may contain another opening delimiter; the comment still ends at
+          // the first `*/`, which only the scan that passed through it knows.
+          `const m = params.q./* a /* b */catch(() => 0) / 2 + Number('<producer.result>')`,
         ].join('\n'),
       },
       block
@@ -994,6 +997,7 @@ describe('VariableResolver function block inputs', () => {
     const code = result.resolvedInputs.code as string
     expect(code).toContain(`.test('' + JSON.stringify(globalThis["__blockRef_0"]) + '')`)
     expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_1"]) + '')`)
+    expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_2"]) + '')`)
   })
 
   it('does not read a method named after a keyword as a control-flow head', async () => {

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -885,6 +885,34 @@ describe('VariableResolver function block inputs', () => {
     expect(result.contextVariables).toEqual({ __blockRef_0: ref })
   })
 
+  it('reads the context of a reference that follows a statement-position regex', async () => {
+    // `)` ends a value in `(a + b) / 2` and a control-flow head in `if (a) /re/.test(b)`, and
+    // the closing parenthesis alone does not say which. Guessing either way misreads one of
+    // them, and a quote inside the regex then decides how every later reference is spliced.
+    const { block, ctx, resolver } = createResolver('javascript')
+
+    // Both cases stay on one line: a string mode ends at a newline, so only a reference sharing
+    // the line with the misread slash sees the wrong context.
+    const result = await resolver.resolveInputsForFunctionBlock(
+      ctx,
+      'function',
+      {
+        code: [
+          `if (params.a) /['"]/.test('<producer.result>')`,
+          `const divided = (params.c + 1) / 2 + Number('<producer.result>')`,
+          'return divided',
+        ].join('\n'),
+      },
+      block
+    )
+
+    const code = result.resolvedInputs.code as string
+    // Statement-position regex: the reference after it is inside the author's quotes.
+    expect(code).toContain(`.test('' + JSON.stringify(globalThis["__blockRef_0"]) + '')`)
+    // Division after a value: the slash must not open a regex that swallows the quotes.
+    expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_1"]) + '')`)
+  })
+
   it('binds a workflow variable carrying quote characters instead of splicing it into code', async () => {
     // A Variables block can assign trigger data at runtime, so a variable's value is not
     // necessarily the author's. Inlined as a literal it closed the string it landed in.

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -964,6 +964,28 @@ describe('VariableResolver function block inputs', () => {
     )
   })
 
+  it('binds a run value that names a secret instead of expanding it', async () => {
+    const { block, ctx, resolver } = createResolver('javascript')
+    ctx.workflowVariables = {
+      'var-1': { id: 'var-1', name: 'authTemplate', type: 'string', value: 'Bearer {{API_KEY}}' },
+    }
+
+    const result = await resolver.resolveInputsForFunctionBlock(
+      ctx,
+      'function',
+      { code: `const header = '<variable.authTemplate>'; const item = <producer.result>` },
+      block
+    )
+
+    // An author-configured variable keeps its placeholder in source, where the boundary
+    // compiler expands it; a run value naming a secret binds instead, so whoever supplies
+    // the text cannot pick what the compiler materializes next to it.
+    const code = result.resolvedInputs.code as string
+    expect(code).toContain('{{API_KEY}}')
+    expect(code).toContain('const item = globalThis["__blockRef_0"]')
+    expect(result.contextVariables).toEqual({ __blockRef_0: 'hello world' })
+  })
+
   it('binds a workflow variable carrying quote characters instead of splicing it into code', async () => {
     // A Variables block can assign trigger data at runtime, so a variable's value is not
     // necessarily the author's. Inlined as a literal it closed the string it landed in.

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -280,6 +280,33 @@ describe('VariableResolver function block inputs', () => {
     expect(resolvedConditions[1].value).toContain('environmentVariables.OPENAI_API_KEY')
   })
 
+  it('counts an environment read only where it can execute', async () => {
+    const { ctx, resolver } = createResolver()
+    const conditionBlock = createBlock('condition', 'Condition', BlockType.CONDITION)
+    const conditions = [
+      // Reads, in the shapes a pattern would have to anticipate.
+      { id: 'c1', title: 'if', value: `environmentVariables?.FLAG === 'on'` },
+      { id: 'c2', title: 'else if', value: 'Object.keys(environmentVariables).length > 0' },
+      // Mentions: text, not code.
+      { id: 'c3', title: 'else if', value: `'environmentVariables.FLAG' === 'x'` },
+      { id: 'c4', title: 'else if', value: '`environmentVariables` === "x"' },
+      { id: 'c5', title: 'else if', value: `/environmentVariables/.test('x')` },
+    ]
+
+    const result = await resolver.resolveInputs(
+      ctx,
+      conditionBlock.id,
+      { conditions: JSON.stringify(conditions) },
+      conditionBlock
+    )
+
+    expect(
+      (result.conditions as Array<Record<string, unknown>>).map(
+        (condition) => condition._readsEnvironmentVariables
+      )
+    ).toEqual([true, true, false, false, false])
+  })
+
   it('preserves legacy condition outcomes end to end through the boundary compiler', async () => {
     const environmentVariables = {
       API_KEY: 'token',
@@ -944,6 +971,28 @@ describe('VariableResolver function block inputs', () => {
     // Statement-position regex: the reference after it is inside the author's quotes.
     expect(code).toContain(`.test('' + JSON.stringify(globalThis["__blockRef_0"]) + '')`)
     // Division after a value: the slash must not open a regex that swallows the quotes.
+    expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_1"]) + '')`)
+  })
+
+  it('steps over a comment rather than reading it as the preceding token', async () => {
+    const { block, ctx, resolver } = createResolver('javascript')
+
+    const result = await resolver.resolveInputsForFunctionBlock(
+      ctx,
+      'function',
+      {
+        code: [
+          `/* lead */ if (params.a) /['"]/.test('<producer.result>')`,
+          `const n = params.p./* mid */catch(() => 0) / 2 + Number('<producer.result>')`,
+        ].join('\n'),
+      },
+      block
+    )
+
+    // A comment before a control-flow keyword leaves it a head; one hiding a property dot
+    // still leaves the call a call.
+    const code = result.resolvedInputs.code as string
+    expect(code).toContain(`.test('' + JSON.stringify(globalThis["__blockRef_0"]) + '')`)
     expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_1"]) + '')`)
   })
 

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -144,6 +144,43 @@ async function resolveConditionExpression(
   return (result.conditions as Array<{ value: string }>)[0].value
 }
 
+/** Resolves one condition expression against a producer output an attacker supplied. */
+async function resolveConditionWithBlockOutput(value: string, result: unknown): Promise<string> {
+  const { ctx, resolver, state } = createResolver()
+  state.setBlockOutput('producer', { result } as never)
+  const conditionBlock = createBlock('condition', 'Condition', BlockType.CONDITION)
+  const resolved = await resolver.resolveInputs(
+    ctx,
+    conditionBlock.id,
+    { conditions: JSON.stringify([{ id: 'condition-1', title: 'if', value }]) },
+    conditionBlock
+  )
+  return (resolved.conditions as Array<{ value: string }>)[0].value
+}
+
+const INJECTION_CANARY = '__conditionInjectionCanary'
+
+/**
+ * Evaluates a resolved expression inside the same `Boolean(...)` wrapper the handler builds,
+ * reporting both the branch verdict and whether anything the resolved data carried executed.
+ */
+function runResolvedCondition(expression: string): { matched: boolean; injected: boolean } {
+  Reflect.set(globalThis, INJECTION_CANARY, 'not-executed')
+  try {
+    const matched = Boolean(
+      new Function(`const context = {};\nreturn Boolean(\n${expression}\n)`)()
+    )
+    return { matched, injected: Reflect.get(globalThis, INJECTION_CANARY) !== 'not-executed' }
+  } catch {
+    return {
+      matched: false,
+      injected: Reflect.get(globalThis, INJECTION_CANARY) !== 'not-executed',
+    }
+  } finally {
+    Reflect.deleteProperty(globalThis, INJECTION_CANARY)
+  }
+}
+
 /**
  * Completes the round trip a condition actually takes: resolver, then the execution-boundary
  * compiler, then evaluation of the same `Boolean(...)` wrapper `condition-handler.ts` builds.
@@ -253,6 +290,60 @@ describe('VariableResolver function block inputs', () => {
     await expect(
       evaluateResolvedCondition(`'{{NAME}}' === 'a\\nb'`, { NAME: 'a\nb' })
     ).resolves.toBe(true)
+  })
+
+  it('stops trigger data from breaking out of a quoted condition reference', async () => {
+    // Every quoting an author can put around a reference. The author picks the context;
+    // the resolved value must be data in all of them, not just the one it wraps itself in.
+    const quotings = [
+      `"<producer.result>".includes('urgent')`,
+      '"<producer.result>" === "admin"',
+      '`<producer.result>`.length > 0',
+      '/<producer.result>/.test("x")',
+      `<producer.result> === 'admin'`,
+    ]
+    const payloads = [
+      `" + (globalThis.${INJECTION_CANARY} = "ran") + "`,
+      `\${(globalThis.${INJECTION_CANARY} = "ran")}`,
+      `' + (globalThis.${INJECTION_CANARY} = "ran") + '`,
+      `/ + (globalThis.${INJECTION_CANARY} = "ran") + /`,
+    ]
+
+    for (const value of quotings) {
+      for (const payload of payloads) {
+        const expression = await resolveConditionWithBlockOutput(value, payload)
+        expect(
+          runResolvedCondition(expression).injected,
+          `condition ${value} executed trigger data: ${expression}`
+        ).toBe(false)
+      }
+    }
+  })
+
+  it('stops a trigger-supplied object from closing the string it is quoted inside', async () => {
+    // JSON's own structural quotes close the author's string, and the key is the attacker's.
+    const expression = await resolveConditionWithBlockOutput('"<producer.result>" === "{}"', {
+      [`+(globalThis.${INJECTION_CANARY}=1)+`]: 1,
+    })
+    expect(runResolvedCondition(expression).injected).toBe(false)
+  })
+
+  it('keeps quoted and bare condition references comparing what they compared before', async () => {
+    const cases: Array<{ value: string; result: unknown; expected: boolean }> = [
+      { value: `<producer.result> === 'urgent'`, result: 'urgent', expected: true },
+      { value: `<producer.result> === 'urgent'`, result: 'other', expected: false },
+      { value: `"<producer.result>".includes('urgent')`, result: 'urgent ticket', expected: true },
+      { value: `"<producer.result>".includes('urgent')`, result: 'calm ticket', expected: false },
+      { value: '`<producer.result>`.length > 3', result: 'hello', expected: true },
+      { value: `<producer.result> === 'a"b'`, result: 'a"b', expected: true },
+      { value: '<producer.result> === `a$b/c`', result: 'a$b/c', expected: true },
+      { value: `<producer.result>.count === 2`, result: { count: 2 }, expected: true },
+    ]
+
+    for (const { value, result, expected } of cases) {
+      const expression = await resolveConditionWithBlockOutput(value, result)
+      expect(runResolvedCondition(expression).matched, `condition ${value}`).toBe(expected)
+    }
   })
 
   it('compares a bare string placeholder instead of throwing a reference error', async () => {
@@ -719,6 +810,28 @@ describe('VariableResolver function block inputs', () => {
     expect(result.contextVariables).toEqual({ __blockRef_0: ref })
   })
 
+  it('binds a workflow variable carrying quote characters instead of splicing it into code', async () => {
+    // A Variables block can assign trigger data at runtime, so a variable's value is not
+    // necessarily the author's. Inlined as a literal it closed the string it landed in.
+    const { block, ctx, resolver } = createResolver('javascript')
+    const payload = `' + (globalThis.__functionInjection = 1) + '`
+    ctx.workflowVariables = {
+      'var-1': { id: 'var-1', name: 'userinput', type: 'string', value: payload },
+    }
+
+    const result = await resolver.resolveInputsForFunctionBlock(
+      ctx,
+      'function',
+      { code: `const x = '<variable.userinput>'; return x` },
+      block
+    )
+
+    expect(result.resolvedInputs.code).toBe(
+      `const x = '' + JSON.stringify(globalThis["__blockRef_0"]) + ''; return x`
+    )
+    expect(result.contextVariables).toEqual({ __blockRef_0: payload })
+  })
+
   it('rewrites whole manifest workflow variables to lazy JavaScript array reads', async () => {
     const { block, ctx, resolver } = createResolver('javascript')
     const manifest = createTestManifest()
@@ -791,8 +904,11 @@ describe('VariableResolver function block inputs', () => {
       ['0', 'key'],
       expect.objectContaining({ allowLargeValueRefs: true })
     )
-    expect(result.resolvedInputs.code).toBe('return "SIM-0"')
-    expect(result.contextVariables).toEqual({})
+    // The navigated element binds like any other resolved value; what must not appear is
+    // the manifest, or the array it stands for.
+    expect(result.resolvedInputs.code).toBe('return globalThis["__blockRef_0"]')
+    expect(result.displayInputs.code).toBe('return "SIM-0"')
+    expect(result.contextVariables).toEqual({ __blockRef_0: 'SIM-0' })
   })
 
   it('resolves named loop result bracket paths in function code', async () => {

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -328,6 +328,41 @@ describe('VariableResolver function block inputs', () => {
     expect(runResolvedCondition(expression).injected).toBe(false)
   })
 
+  it('stops a trigger-supplied object from escaping wherever the quote scanner mis-reads', async () => {
+    // A regex literal is not tracked by the quote scanner, and a quote inside one
+    // desynchronizes it for everything that follows, so the emitted object must be inert
+    // whichever context the scanner reports.
+    const payloads = [
+      { [`+(globalThis.${INJECTION_CANARY}=1)+`]: 1 },
+      { forged: `/ + (globalThis.${INJECTION_CANARY}=1) + /` },
+      { closed: `" + (globalThis.${INJECTION_CANARY}=1) + "` },
+    ]
+    const quotings = [
+      '/<producer.result>/.test("x")',
+      `/['"]/.test('a') && <producer.result>.count === 2`,
+      `/['"]/.test('a') && "<producer.result>" === "{}"`,
+      '<producer.result>.count === 2',
+    ]
+
+    for (const value of quotings) {
+      for (const payload of payloads) {
+        const expression = await resolveConditionWithBlockOutput(value, payload)
+        expect(
+          runResolvedCondition(expression).injected,
+          `condition ${value} executed object data: ${expression}`
+        ).toBe(false)
+      }
+    }
+  })
+
+  it('keeps navigating an object reference the scanner reports as unquoted', async () => {
+    const expression = await resolveConditionWithBlockOutput('<producer.result>.count === 2', {
+      count: 2,
+      note: `a "quoted" / slashed ' value`,
+    })
+    expect(runResolvedCondition(expression).matched).toBe(true)
+  })
+
   it('keeps quoted and bare condition references comparing what they compared before', async () => {
     const cases: Array<{ value: string; result: unknown; expected: boolean }> = [
       { value: `<producer.result> === 'urgent'`, result: 'urgent', expected: true },

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -1000,6 +1000,25 @@ describe('VariableResolver function block inputs', () => {
     expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_2"]) + '')`)
   })
 
+  it('starts a new identifier at a line break rather than continuing the last one', async () => {
+    const { block, ctx, resolver } = createResolver('javascript')
+
+    const result = await resolver.resolveInputsForFunctionBlock(
+      ctx,
+      'function',
+      {
+        // `if` begins a statement here; reading the previous *significant* character would
+        // see the `b` of `params.b` and carry its property-access answer into this token.
+        code: ['const seen = params.a.b', `if (seen) /['"]/.test('<producer.result>')`].join('\n'),
+      },
+      block
+    )
+
+    expect(result.resolvedInputs.code).toContain(
+      `.test('' + JSON.stringify(globalThis["__blockRef_0"]) + '')`
+    )
+  })
+
   it('divides after a postfix update rather than opening a regex', async () => {
     const { block, ctx, resolver } = createResolver('javascript')
 

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -363,6 +363,46 @@ describe('VariableResolver function block inputs', () => {
     expect(runResolvedCondition(expression).matched).toBe(true)
   })
 
+  it('evaluates references that follow a regex literal, quote-bearing or not', async () => {
+    // A regex body is the one place a lone quote is not a string delimiter. Reading it as one
+    // left every later reference formatted for a context it was not in — a quoted object
+    // reference stayed raw source, and a bare one was emitted as escaped JSON that cannot parse.
+    const cases: Array<{ value: string; result: unknown; expected: boolean }> = [
+      // Every case reaches its reference — a short-circuit would pass on a formatter that
+      // emits source the sandbox cannot parse, which is the failure being pinned here.
+      {
+        value: `/['"a]/.test('a') && <producer.result>.count === 2`,
+        result: { count: 2 },
+        expected: true,
+      },
+      { value: `/['"]/.test('a') || <producer.result> === 'x'`, result: 'x', expected: true },
+      {
+        value: `/it's/.test('a') || "<producer.result>".includes('b')`,
+        result: 'abc',
+        expected: true,
+      },
+      {
+        value: `/[a-z]/.test('a') && <producer.result>.count === 2`,
+        result: { count: 2 },
+        expected: true,
+      },
+      // Division, not a regex: the scan must not swallow the rest of the expression.
+      { value: `<producer.result>.total / 2 === 5`, result: { total: 10 }, expected: true },
+      {
+        value: `(<producer.result>.total / 2) === 5 && '<producer.result>'.length > 0`,
+        result: { total: 10 },
+        expected: true,
+      },
+    ]
+
+    for (const { value, result, expected } of cases) {
+      const expression = await resolveConditionWithBlockOutput(value, result)
+      const verdict = runResolvedCondition(expression)
+      expect(verdict.injected, `condition ${value} executed data: ${expression}`).toBe(false)
+      expect(verdict.matched, `condition ${value} resolved to: ${expression}`).toBe(expected)
+    }
+  })
+
   it('keeps quoted and bare condition references comparing what they compared before', async () => {
     const cases: Array<{ value: string; result: unknown; expected: boolean }> = [
       { value: `<producer.result> === 'urgent'`, result: 'urgent', expected: true },

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -1000,6 +1000,27 @@ describe('VariableResolver function block inputs', () => {
     expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_2"]) + '')`)
   })
 
+  it('divides after a postfix update rather than opening a regex', async () => {
+    const { block, ctx, resolver } = createResolver('javascript')
+
+    const result = await resolver.resolveInputsForFunctionBlock(
+      ctx,
+      'function',
+      {
+        code: [
+          `let i = params.i; const half = i++ / 2 + Number('<producer.result>')`,
+          // The same characters as an operator still precede a regex.
+          `const hit = params.n + /['"]/.test('<producer.result>')`,
+        ].join('\n'),
+      },
+      block
+    )
+
+    const code = result.resolvedInputs.code as string
+    expect(code).toContain(`Number('' + JSON.stringify(globalThis["__blockRef_0"]) + '')`)
+    expect(code).toContain(`.test('' + JSON.stringify(globalThis["__blockRef_1"]) + '')`)
+  })
+
   it('does not read a method named after a keyword as a control-flow head', async () => {
     const { block, ctx, resolver } = createResolver('javascript')
 

--- a/apps/sim/executor/variables/resolver.test.ts
+++ b/apps/sim/executor/variables/resolver.test.ts
@@ -236,14 +236,48 @@ describe('VariableResolver function block inputs', () => {
     )
 
     expect(result.conditions).toEqual([
-      { id: 'condition-1', title: 'if', value: '123 === 123' },
-      { id: 'condition-2', title: 'else if', value: 'true === true' },
+      { id: 'condition-1', title: 'if', value: '123 === 123', _readsEnvironmentVariables: false },
+      {
+        id: 'condition-2',
+        title: 'else if',
+        value: 'true === true',
+        _readsEnvironmentVariables: false,
+      },
       {
         id: 'condition-3',
         title: 'else if',
         value: '"Bearer {{API_KEY}}" === "Bearer token"',
+        _readsEnvironmentVariables: false,
       },
     ])
+  })
+
+  it('records whether the author, not the trigger data, reads the environment map', async () => {
+    const { ctx, resolver } = createResolver()
+    ctx.environmentVariables = {}
+    const conditionBlock = createBlock('condition', 'Condition', BlockType.CONDITION)
+    // The second branch only quotes a producer output that happens to contain the word.
+    const conditions = [
+      { id: 'c1', title: 'if', value: `environmentVariables.FLAG === 'on'` },
+      { id: 'c2', title: 'else if', value: `"<producer.result>" === 'x'` },
+    ]
+    ;(ctx.blockStates as Map<string, any>).set('producer', {
+      output: { result: 'environmentVariables.OPENAI_API_KEY' },
+      executed: true,
+      executionTime: 0,
+    })
+
+    const result = await resolver.resolveInputs(
+      ctx,
+      conditionBlock.id,
+      { conditions: JSON.stringify(conditions) },
+      conditionBlock
+    )
+
+    const resolvedConditions = result.conditions as Array<Record<string, unknown>>
+    expect(resolvedConditions[0]._readsEnvironmentVariables).toBe(true)
+    expect(resolvedConditions[1]._readsEnvironmentVariables).toBe(false)
+    expect(resolvedConditions[1].value).toContain('environmentVariables.OPENAI_API_KEY')
   })
 
   it('preserves legacy condition outcomes end to end through the boundary compiler', async () => {

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -1204,47 +1204,34 @@ export class VariableResolver {
   }
 
   /**
-   * Whether the `(` at this index opens a control-flow head rather than a value.
+   * Whether a `(` opens a control-flow head rather than a value.
    *
    * What follows the matching `)` differs entirely between the two — a statement, where a regex
    * literal may begin, versus an operator, where a `/` divides — and the closing parenthesis
-   * carries no trace of which it was. Reading the keyword in front of the opening one is what
-   * lets `if (a) /re/.test(b)` and `(a + b) / 2` both scan correctly.
+   * carries no trace of which it was. The keyword in front of the opening one is what tells
+   * them apart, so `if (a) /re/.test(b)` and `(a + b) / 2` both scan correctly.
+   *
+   * Both inputs come from the forward scan rather than a walk back through the source: the
+   * scan already knows which characters were code and which sat inside a comment, and reading
+   * backwards cannot recover that — the opener of `/* a /* b *\/` is its first delimiter, not
+   * its last, and only the scan that passed through knows the difference.
    */
-  private opensControlFlowHead(template: string, index: number): boolean {
-    let end = index
-    while (end > 0 && WHITESPACE_CHAR.test(template[end - 1])) {
-      end--
+  private opensControlFlowHead(
+    template: string,
+    previousSignificantIndex: number,
+    precededByPropertyAccess: boolean
+  ): boolean {
+    if (precededByPropertyAccess || previousSignificantIndex < 0) {
+      return false
     }
-    let start = end
+    if (!this.isJavaScriptIdentifierChar(template[previousSignificantIndex])) {
+      return false
+    }
+    let start = previousSignificantIndex
     while (start > 0 && this.isJavaScriptIdentifierChar(template[start - 1])) {
       start--
     }
-    if (!CONTROL_FLOW_HEAD_KEYWORDS.has(template.slice(start, end))) {
-      return false
-    }
-
-    // `p.catch(fn)` is a method call whose name happens to be a keyword, and what follows its
-    // `)` is an operator, not a statement. A control-flow head can never be a property access,
-    // and a comment can stand between the two (`p./* c */catch(fn)`), so a comment is stepped
-    // over rather than treated as an answer — `/* c */ if (x)` is still a head.
-    let before = this.skipWhitespaceBackward(template, start)
-    while (template[before - 1] === '/' && template[before - 2] === '*') {
-      const opening = template.lastIndexOf('/*', before - 2)
-      if (opening < 0) {
-        return true
-      }
-      before = this.skipWhitespaceBackward(template, opening)
-    }
-    return template[before - 1] !== '.'
-  }
-
-  private skipWhitespaceBackward(template: string, index: number): number {
-    let cursor = index
-    while (cursor > 0 && WHITESPACE_CHAR.test(template[cursor - 1])) {
-      cursor--
-    }
-    return cursor
+    return CONTROL_FLOW_HEAD_KEYWORDS.has(template.slice(start, previousSignificantIndex + 1))
   }
 
   private matchesKeywordAt(template: string, index: number, keyword: string): boolean {
@@ -1376,6 +1363,7 @@ export class VariableResolver {
     const modes: CodeScanMode[] = [{ type: 'normal' }]
     let lastSignificantIndex = -1
     const openParenIsControlHead: boolean[] = []
+    let identifierFollowsPropertyAccess = false
     const controlHeadParenCloses = new Set<number>()
     const regexCloseIndices = new Set<number>()
 
@@ -1483,8 +1471,21 @@ export class VariableResolver {
         if (!WHITESPACE_CHAR.test(char)) {
           lastSignificantIndex = i
         }
-        if (char === '(') {
-          openParenIsControlHead.push(this.opensControlFlowHead(template, i))
+        if (this.isJavaScriptIdentifierChar(char)) {
+          if (
+            previousSignificantIndex < 0 ||
+            !this.isJavaScriptIdentifierChar(template[previousSignificantIndex])
+          ) {
+            identifierFollowsPropertyAccess = template[previousSignificantIndex] === '.'
+          }
+        } else if (char === '(') {
+          openParenIsControlHead.push(
+            this.opensControlFlowHead(
+              template,
+              previousSignificantIndex,
+              identifierFollowsPropertyAccess
+            )
+          )
         } else if (char === ')') {
           if (openParenIsControlHead.pop()) controlHeadParenCloses.add(i)
         }
@@ -1552,8 +1553,21 @@ export class VariableResolver {
       if (!WHITESPACE_CHAR.test(char)) {
         lastSignificantIndex = i
       }
-      if (char === '(') {
-        openParenIsControlHead.push(this.opensControlFlowHead(template, i))
+      if (this.isJavaScriptIdentifierChar(char)) {
+        if (
+          previousSignificantIndex < 0 ||
+          !this.isJavaScriptIdentifierChar(template[previousSignificantIndex])
+        ) {
+          identifierFollowsPropertyAccess = template[previousSignificantIndex] === '.'
+        }
+      } else if (char === '(') {
+        openParenIsControlHead.push(
+          this.opensControlFlowHead(
+            template,
+            previousSignificantIndex,
+            identifierFollowsPropertyAccess
+          )
+        )
       } else if (char === ')') {
         if (openParenIsControlHead.pop()) controlHeadParenCloses.add(i)
       }

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -172,8 +172,16 @@ type CodeScanMode =
  * a string, and every reference past that point was then formatted for the wrong context.
  * Division always follows a value — an identifier, literal, `)`, or `]` — so anything else
  * ending the preceding token means a regex may start.
+ *
+ * `)` is the one that is not decidable from the character alone: it ends a value in
+ * `(a + b) / 2` and a control-flow head in `if (a) /re/.test(b)`. Reading it as either one
+ * unconditionally breaks the other, so the scan remembers which kind of parenthesis each `)`
+ * closed rather than guessing — see {@link CONTROL_FLOW_HEAD_KEYWORDS}.
  */
 const JAVASCRIPT_REGEX_ALLOWED_AFTER = new Set('(,=:[!&|?{};+-*%^~<>/'.split(''))
+
+/** Keywords whose parenthesized head is followed by a statement, where a regex may start. */
+const CONTROL_FLOW_HEAD_KEYWORDS = new Set(['if', 'while', 'for', 'switch', 'catch', 'with'])
 
 const WHITESPACE_CHAR = /\s/
 
@@ -1118,11 +1126,18 @@ export class VariableResolver {
    * anything else means a regex may start. Guessing wrong is not silent — the scan would swallow
    * text up to the next `/` — so the check reads the actual preceding token rather than assuming.
    */
-  private canStartJavaScriptRegex(template: string, previousSignificantIndex: number): boolean {
+  private canStartJavaScriptRegex(
+    template: string,
+    previousSignificantIndex: number,
+    controlHeadParenCloses: ReadonlySet<number>
+  ): boolean {
     if (previousSignificantIndex < 0) {
       return true
     }
     const previous = template[previousSignificantIndex]
+    if (previous === ')') {
+      return controlHeadParenCloses.has(previousSignificantIndex)
+    }
     if (JAVASCRIPT_REGEX_ALLOWED_AFTER.has(previous)) {
       return true
     }
@@ -1137,6 +1152,26 @@ export class VariableResolver {
     return JAVASCRIPT_REGEX_ALLOWED_AFTER_KEYWORDS.has(
       template.slice(start, previousSignificantIndex + 1)
     )
+  }
+
+  /**
+   * Whether the `(` at this index opens a control-flow head rather than a value.
+   *
+   * What follows the matching `)` differs entirely between the two — a statement, where a regex
+   * literal may begin, versus an operator, where a `/` divides — and the closing parenthesis
+   * carries no trace of which it was. Reading the keyword in front of the opening one is what
+   * lets `if (a) /re/.test(b)` and `(a + b) / 2` both scan correctly.
+   */
+  private opensControlFlowHead(template: string, index: number): boolean {
+    let end = index
+    while (end > 0 && WHITESPACE_CHAR.test(template[end - 1])) {
+      end--
+    }
+    let start = end
+    while (start > 0 && this.isJavaScriptIdentifierChar(template[start - 1])) {
+      start--
+    }
+    return CONTROL_FLOW_HEAD_KEYWORDS.has(template.slice(start, end))
   }
 
   private matchesKeywordAt(template: string, index: number, keyword: string): boolean {
@@ -1267,6 +1302,8 @@ export class VariableResolver {
     const isPython = language === 'python'
     const modes: CodeScanMode[] = [{ type: 'normal' }]
     let lastSignificantIndex = -1
+    const openParenIsControlHead: boolean[] = []
+    const controlHeadParenCloses = new Set<number>()
 
     for (let i = 0; i < index; i++) {
       const char = template[i]
@@ -1369,10 +1406,15 @@ export class VariableResolver {
         if (!WHITESPACE_CHAR.test(char)) {
           lastSignificantIndex = i
         }
+        if (char === '(') {
+          openParenIsControlHead.push(this.opensControlFlowHead(template, i))
+        } else if (char === ')') {
+          if (openParenIsControlHead.pop()) controlHeadParenCloses.add(i)
+        }
         if (
           !isPython &&
           char === '/' &&
-          this.canStartJavaScriptRegex(template, previousSignificantIndex)
+          this.canStartJavaScriptRegex(template, previousSignificantIndex, controlHeadParenCloses)
         ) {
           modes.push({ type: 'regex', inCharacterClass: false })
           continue
@@ -1430,10 +1472,15 @@ export class VariableResolver {
       if (!WHITESPACE_CHAR.test(char)) {
         lastSignificantIndex = i
       }
+      if (char === '(') {
+        openParenIsControlHead.push(this.opensControlFlowHead(template, i))
+      } else if (char === ')') {
+        if (openParenIsControlHead.pop()) controlHeadParenCloses.add(i)
+      }
       if (
         !isPython &&
         char === '/' &&
-        this.canStartJavaScriptRegex(template, previousSignificantIndex)
+        this.canStartJavaScriptRegex(template, previousSignificantIndex, controlHeadParenCloses)
       ) {
         modes.push({ type: 'regex', inCharacterClass: false })
         continue

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -36,6 +36,18 @@ import {
 import { WorkflowResolver } from '@/executor/variables/resolvers/workflow'
 import type { SerializedBlock, SerializedWorkflow } from '@/serializer/types'
 
+/**
+ * Marks a Condition branch whose author-written expression reads the environment map.
+ *
+ * Carried per branch because only the pre-resolution text can answer it: the handler decides
+ * which secrets to mount, and by the time it runs, resolved trigger data quoted inside the
+ * expression would read the same as the author reaching for the map.
+ */
+export const CONDITION_READS_ENVIRONMENT_KEY = '_readsEnvironmentVariables'
+
+/** The sandbox global holding the run's secrets, in whatever shape an expression reaches it. */
+const ENVIRONMENT_MAP_IDENTIFIER = /\benvironmentVariables\b/
+
 /** Key used to carry pre-resolved context variables through the inputs map. */
 export const FUNCTION_BLOCK_CONTEXT_VARS_KEY = '_runtimeContextVars'
 /** Key used to carry display-resolved code through the function execution path. */
@@ -346,6 +358,11 @@ export class VariableResolver {
             const value = Reflect.get(condition, 'value')
             return {
               ...condition,
+              // Recorded before resolution: once values are inlined, an expression that reads
+              // the environment map is indistinguishable from one that merely quotes trigger
+              // data containing the word, and the handler decides what to mount from this.
+              [CONDITION_READS_ENVIRONMENT_KEY]:
+                typeof value === 'string' && ENVIRONMENT_MAP_IDENTIFIER.test(value),
               value:
                 typeof value === 'string'
                   ? await this.resolveTemplateWithoutConditionFormatting(
@@ -1129,14 +1146,17 @@ export class VariableResolver {
   private canStartJavaScriptRegex(
     template: string,
     previousSignificantIndex: number,
-    controlHeadParenCloses: ReadonlySet<number>
+    closes: { controlHeadParenCloses: ReadonlySet<number>; regexCloseIndices: ReadonlySet<number> }
   ): boolean {
     if (previousSignificantIndex < 0) {
       return true
     }
     const previous = template[previousSignificantIndex]
     if (previous === ')') {
-      return controlHeadParenCloses.has(previousSignificantIndex)
+      return closes.controlHeadParenCloses.has(previousSignificantIndex)
+    }
+    if (previous === '/' && closes.regexCloseIndices.has(previousSignificantIndex)) {
+      return false
     }
     if (JAVASCRIPT_REGEX_ALLOWED_AFTER.has(previous)) {
       return true
@@ -1304,6 +1324,7 @@ export class VariableResolver {
     let lastSignificantIndex = -1
     const openParenIsControlHead: boolean[] = []
     const controlHeadParenCloses = new Set<number>()
+    const regexCloseIndices = new Set<number>()
 
     for (let i = 0; i < index; i++) {
       const char = template[i]
@@ -1346,6 +1367,9 @@ export class VariableResolver {
         }
         if (char === '/' && !mode.inCharacterClass) {
           modes.pop()
+          // The literal that just closed is a value, so the next `/` divides it.
+          regexCloseIndices.add(i)
+          lastSignificantIndex = i
         }
         continue
       }
@@ -1414,7 +1438,10 @@ export class VariableResolver {
         if (
           !isPython &&
           char === '/' &&
-          this.canStartJavaScriptRegex(template, previousSignificantIndex, controlHeadParenCloses)
+          this.canStartJavaScriptRegex(template, previousSignificantIndex, {
+            controlHeadParenCloses,
+            regexCloseIndices,
+          })
         ) {
           modes.push({ type: 'regex', inCharacterClass: false })
           continue
@@ -1480,7 +1507,10 @@ export class VariableResolver {
       if (
         !isPython &&
         char === '/' &&
-        this.canStartJavaScriptRegex(template, previousSignificantIndex, controlHeadParenCloses)
+        this.canStartJavaScriptRegex(template, previousSignificantIndex, {
+          controlHeadParenCloses,
+          regexCloseIndices,
+        })
       ) {
         modes.push({ type: 'regex', inCharacterClass: false })
         continue

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -1191,7 +1191,17 @@ export class VariableResolver {
     while (start > 0 && this.isJavaScriptIdentifierChar(template[start - 1])) {
       start--
     }
-    return CONTROL_FLOW_HEAD_KEYWORDS.has(template.slice(start, end))
+    if (!CONTROL_FLOW_HEAD_KEYWORDS.has(template.slice(start, end))) {
+      return false
+    }
+
+    // `p.catch(fn)` is a method call whose name happens to be a keyword, and what follows its
+    // `)` is an operator, not a statement. A control-flow head can never be a property access.
+    let before = start
+    while (before > 0 && WHITESPACE_CHAR.test(template[before - 1])) {
+      before--
+    }
+    return template[before - 1] !== '.'
   }
 
   private matchesKeywordAt(template: string, index: number, keyword: string): boolean {

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -687,7 +687,7 @@ export class VariableResolver {
           throw getNestedLargeValueMaterializationError()
         }
 
-        if (this.canInlineResolvedCodeLiteral(effectiveValue)) {
+        if (this.canInlineResolvedCodeLiteral(effectiveValue, match)) {
           const replacement = this.blockResolver.formatValueForBlock(
             effectiveValue,
             BlockType.FUNCTION,
@@ -976,12 +976,19 @@ export class VariableResolver {
    * Everything else binds, which is what block outputs have always done. Inlining the rest
    * is what let a runtime-assigned variable or loop item carrying trigger data close the
    * string it landed in and run as code.
+   *
+   * The placeholder case is admitted only for a workflow variable, never for a loop item or
+   * any other run value. Whoever supplies the text picks which secret the compiler expands
+   * into the generated source, so that choice stays with the surface an author configures.
    */
-  private canInlineResolvedCodeLiteral(value: unknown): boolean {
+  private canInlineResolvedCodeLiteral(value: unknown, reference: string): boolean {
     if (value === null || typeof value === 'number' || typeof value === 'boolean') {
       return true
     }
     if (typeof value !== 'string') {
+      return false
+    }
+    if (parseReferencePath(reference)[0] !== REFERENCE.PREFIX.VARIABLE) {
       return false
     }
     return createEnvVarPattern().test(value) && !/['"`$\\\n\r\u2028\u2029]/.test(value)
@@ -1196,10 +1203,16 @@ export class VariableResolver {
     }
 
     // `p.catch(fn)` is a method call whose name happens to be a keyword, and what follows its
-    // `)` is an operator, not a statement. A control-flow head can never be a property access.
+    // `)` is an operator, not a statement. A control-flow head can never be a property access,
+    // and a comment can hide the dot (`p./* c */catch(fn)`), so a comment ending here is read
+    // as the method call it usually is: the wrong guess there costs a division scanned as a
+    // regex, while this way it costs nothing a regex-free line would notice.
     let before = start
     while (before > 0 && WHITESPACE_CHAR.test(template[before - 1])) {
       before--
+    }
+    if (template[before - 1] === '/' && template[before - 2] === '*') {
+      return false
     }
     return template[before - 1] !== '.'
   }

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -188,6 +188,7 @@ const JAVASCRIPT_REGEX_ALLOWED_AFTER_KEYWORDS = new Set([
   'delete',
   'void',
   'case',
+  'throw',
   'do',
   'else',
   'yield',

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -18,6 +18,10 @@ import { isLikelyReferenceSegment } from '@/lib/workflows/sanitization/reference
 import { BlockType, parseReferencePath, REFERENCE } from '@/executor/constants'
 import type { ExecutionState, LoopScope } from '@/executor/execution/state'
 import type { ExecutionContext, UserFile } from '@/executor/types'
+import {
+  escapeInertStringContent,
+  formatInertStringLiteral,
+} from '@/executor/utils/code-formatting'
 import { createEnvVarPattern, createReferencePattern } from '@/executor/utils/reference-validation'
 import { BlockResolver } from '@/executor/variables/resolvers/block'
 import { EnvResolver } from '@/executor/variables/resolvers/env'
@@ -621,34 +625,31 @@ export class VariableResolver {
           throw getNestedLargeValueMaterializationError()
         }
 
-        if (
-          this.isWorkflowVariableReference(match) &&
-          this.shouldUseContextVariable(effectiveValue)
-        ) {
-          const varName = `__blockRef_${Object.keys(contextVarAccumulator).length}`
-          contextVarAccumulator[varName] = effectiveValue
-          const replacement = this.formatContextVariableReference(
-            varName,
-            language,
-            template,
-            index,
-            effectiveValue
-          )
-          displayResult += this.formatDisplayValueForCodeContext(
+        if (this.canInlineResolvedCodeLiteral(effectiveValue)) {
+          const replacement = this.blockResolver.formatValueForBlock(
             effectiveValue,
-            language,
-            template,
-            index
+            BlockType.FUNCTION,
+            language
           )
+          displayResult += replacement
           return replacement
         }
 
-        const replacement = this.blockResolver.formatValueForBlock(
-          effectiveValue,
-          BlockType.FUNCTION,
-          language
+        const varName = `__blockRef_${Object.keys(contextVarAccumulator).length}`
+        contextVarAccumulator[varName] = effectiveValue
+        const replacement = this.formatContextVariableReference(
+          varName,
+          language,
+          template,
+          index,
+          effectiveValue
         )
-        displayResult += replacement
+        displayResult += this.formatDisplayValueForCodeContext(
+          effectiveValue,
+          language,
+          template,
+          index
+        )
         return replacement
       } catch (error) {
         replacementError = error instanceof Error ? error : new Error(String(error))
@@ -898,13 +899,30 @@ export class VariableResolver {
     })
   }
 
-  private isWorkflowVariableReference(reference: string): boolean {
-    const parts = parseReferencePath(reference)
-    return parts[0] === REFERENCE.PREFIX.VARIABLE
-  }
-
-  private shouldUseContextVariable(value: unknown): boolean {
-    return typeof value === 'object' && value !== null
+  /**
+   * Whether a resolved value may stay a literal in generated code rather than being bound
+   * as a context variable.
+   *
+   * Splicing a value into user-authored code hands the author's quoting the decision of how
+   * that value parses, so only values that cannot terminate a literal may stay inline.
+   * Numbers, booleans, and null render as digits or keywords. A string qualifies only when
+   * it names an environment variable and carries no character that could close a string in
+   * any supported language: that shape has to stay in source because the placeholder, never
+   * the secret, is what gets inlined, and the execution-boundary compiler binds it
+   * downstream — that is how `<variable.indirectSecret>` reaches its value.
+   *
+   * Everything else binds, which is what block outputs have always done. Inlining the rest
+   * is what let a runtime-assigned variable or loop item carrying trigger data close the
+   * string it landed in and run as code.
+   */
+  private canInlineResolvedCodeLiteral(value: unknown): boolean {
+    if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+      return true
+    }
+    if (typeof value !== 'string') {
+      return false
+    }
+    return createEnvVarPattern().test(value) && !/['"`$\\\n\r\u2028\u2029]/.test(value)
   }
 
   private formatJavaScriptAsyncExpression(
@@ -1532,19 +1550,12 @@ export class VariableResolver {
         }
 
         if (typeof resolved === 'string') {
-          const escaped = resolved
-            .replace(/\\/g, '\\\\')
-            .replace(/'/g, "\\'")
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/\u2028/g, '\\u2028')
-            .replace(/\u2029/g, '\\u2029')
-          const formatted = `'${escaped}'`
+          const formatted = formatInertStringLiteral(resolved)
           projectedReferenceResult += containsResolvedSecret ? match : formatted
           return formatted
         }
         if (typeof resolved === 'object' && resolved !== null) {
-          const formatted = JSON.stringify(resolved)
+          const formatted = this.formatConditionJson(resolved, template, index)
           projectedReferenceResult += containsResolvedSecret ? match : formatted
           return formatted
         }
@@ -1574,6 +1585,22 @@ export class VariableResolver {
       projectedReferenceResult
     )
     return result
+  }
+
+  /**
+   * Renders a resolved object for a Condition expression.
+   *
+   * In expression position the author is comparing or navigating the object itself, so the
+   * JSON has to stay a literal. Inside a quoted string the same text is data, and its own
+   * structural quotes would close the author's string — `"<start.body>" === "{}"` with a
+   * crafted key emits `"{"+attackerCode()+":1}"`, which parses as concatenation and runs.
+   * Escaping the text there keeps it inside the string the author opened, which is also the
+   * only reading of a quoted object reference that is not a syntax error.
+   */
+  private formatConditionJson(value: object, template: string, matchIndex: number): string {
+    const json = JSON.stringify(value)
+    const quoteContext = this.getCodeStringQuoteContext(template, matchIndex, 'javascript')
+    return quoteContext === null ? json : escapeInertStringContent(json)
   }
 
   private async resolveReference(reference: string, context: ResolutionContext): Promise<any> {

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -46,7 +46,7 @@ import type { SerializedBlock, SerializedWorkflow } from '@/serializer/types'
 export const CONDITION_READS_ENVIRONMENT_KEY = '_readsEnvironmentVariables'
 
 /** The sandbox global holding the run's secrets, in whatever shape an expression reaches it. */
-const ENVIRONMENT_MAP_IDENTIFIER = /\benvironmentVariables\b/
+const ENVIRONMENT_MAP_IDENTIFIER = /\benvironmentVariables\b/g
 
 /** Key used to carry pre-resolved context variables through the inputs map. */
 export const FUNCTION_BLOCK_CONTEXT_VARS_KEY = '_runtimeContextVars'
@@ -362,7 +362,7 @@ export class VariableResolver {
               // the environment map is indistinguishable from one that merely quotes trigger
               // data containing the word, and the handler decides what to mount from this.
               [CONDITION_READS_ENVIRONMENT_KEY]:
-                typeof value === 'string' && ENVIRONMENT_MAP_IDENTIFIER.test(value),
+                typeof value === 'string' && this.readsEnvironmentMap(value),
               value:
                 typeof value === 'string'
                   ? await this.resolveTemplateWithoutConditionFormatting(
@@ -1182,6 +1182,28 @@ export class VariableResolver {
   }
 
   /**
+   * Whether a Condition expression reads the run's secrets off the environment map.
+   *
+   * The name is only a read where it can execute, so each occurrence is placed with the same
+   * scanner that decides how references are spliced — a mention inside a string, a template,
+   * or a regex is text and mounts nothing. No shape of the read itself is assumed:
+   * `environmentVariables?.FLAG` and `Object.keys(environmentVariables)` both count, because
+   * narrowing an expression that does reach the map would route the run down a branch the
+   * author did not write, silently, while admitting one too many only costs the narrowing.
+   */
+  private readsEnvironmentMap(expression: string): boolean {
+    ENVIRONMENT_MAP_IDENTIFIER.lastIndex = 0
+    let match = ENVIRONMENT_MAP_IDENTIFIER.exec(expression)
+    while (match !== null) {
+      if (this.getCodeStringQuoteContext(expression, match.index, 'javascript') === null) {
+        return true
+      }
+      match = ENVIRONMENT_MAP_IDENTIFIER.exec(expression)
+    }
+    return false
+  }
+
+  /**
    * Whether the `(` at this index opens a control-flow head rather than a value.
    *
    * What follows the matching `)` differs entirely between the two — a statement, where a regex
@@ -1204,17 +1226,25 @@ export class VariableResolver {
 
     // `p.catch(fn)` is a method call whose name happens to be a keyword, and what follows its
     // `)` is an operator, not a statement. A control-flow head can never be a property access,
-    // and a comment can hide the dot (`p./* c */catch(fn)`), so a comment ending here is read
-    // as the method call it usually is: the wrong guess there costs a division scanned as a
-    // regex, while this way it costs nothing a regex-free line would notice.
-    let before = start
-    while (before > 0 && WHITESPACE_CHAR.test(template[before - 1])) {
-      before--
-    }
-    if (template[before - 1] === '/' && template[before - 2] === '*') {
-      return false
+    // and a comment can stand between the two (`p./* c */catch(fn)`), so a comment is stepped
+    // over rather than treated as an answer — `/* c */ if (x)` is still a head.
+    let before = this.skipWhitespaceBackward(template, start)
+    while (template[before - 1] === '/' && template[before - 2] === '*') {
+      const opening = template.lastIndexOf('/*', before - 2)
+      if (opening < 0) {
+        return true
+      }
+      before = this.skipWhitespaceBackward(template, opening)
     }
     return template[before - 1] !== '.'
+  }
+
+  private skipWhitespaceBackward(template: string, index: number): number {
+    let cursor = index
+    while (cursor > 0 && WHITESPACE_CHAR.test(template[cursor - 1])) {
+      cursor--
+    }
+    return cursor
   }
 
   private matchesKeywordAt(template: string, index: number, keyword: string): boolean {

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -1479,10 +1479,10 @@ export class VariableResolver {
           lastSignificantIndex = i
         }
         if (this.isJavaScriptIdentifierChar(char)) {
-          if (
-            previousSignificantIndex < 0 ||
-            !this.isJavaScriptIdentifierChar(template[previousSignificantIndex])
-          ) {
+          // An identifier continues only when the character right before it is part of the same
+          // token. Asking the previous *significant* character instead treats a name after a
+          // line break as a continuation and leaves it carrying the last one's answer.
+          if (i === 0 || !this.isJavaScriptIdentifierChar(template[i - 1])) {
             identifierFollowsPropertyAccess = template[previousSignificantIndex] === '.'
           }
         } else if (char === '(') {
@@ -1561,10 +1561,10 @@ export class VariableResolver {
         lastSignificantIndex = i
       }
       if (this.isJavaScriptIdentifierChar(char)) {
-        if (
-          previousSignificantIndex < 0 ||
-          !this.isJavaScriptIdentifierChar(template[previousSignificantIndex])
-        ) {
+        // An identifier continues only when the character right before it is part of the same
+        // token. Asking the previous *significant* character instead treats a name after a
+        // line break as a continuation and leaves it carrying the last one's answer.
+        if (i === 0 || !this.isJavaScriptIdentifierChar(template[i - 1])) {
           identifierFollowsPropertyAccess = template[previousSignificantIndex] === '.'
         }
       } else if (char === '(') {

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -1165,6 +1165,13 @@ export class VariableResolver {
     if (previous === '/' && closes.regexCloseIndices.has(previousSignificantIndex)) {
       return false
     }
+    // `+` and `-` precede a regex as operators but end a value when doubled: `i++ / 2` divides.
+    if (
+      (previous === '+' || previous === '-') &&
+      template[previousSignificantIndex - 1] === previous
+    ) {
+      return false
+    }
     if (JAVASCRIPT_REGEX_ALLOWED_AFTER.has(previous)) {
       return true
     }

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -1590,17 +1590,22 @@ export class VariableResolver {
   /**
    * Renders a resolved object for a Condition expression.
    *
-   * In expression position the author is comparing or navigating the object itself, so the
-   * JSON has to stay a literal. Inside a quoted string the same text is data, and its own
-   * structural quotes would close the author's string — `"<start.body>" === "{}"` with a
-   * crafted key emits `"{"+attackerCode()+":1}"`, which parses as concatenation and runs.
-   * Escaping the text there keeps it inside the string the author opened, which is also the
-   * only reading of a quoted object reference that is not a syntax error.
+   * Inside a quoted string the object is data, so its JSON is escaped to stay inside the
+   * string the author opened: raw, the JSON's own structural quotes close that string, and
+   * `"<start.body>" === "{}"` with a crafted key emits `"{"+attackerCode()+":1}"`, which
+   * parses as concatenation and runs.
+   *
+   * Everywhere else the object is parsed at runtime rather than spliced as source. The value
+   * is identical to the object literal it replaces, but the payload is a fully escaped
+   * literal, so a crafted key can neither close a string nor forge a regex delimiter — which
+   * matters because the emitted form must be safe even when the quote scanner reads the
+   * surrounding context wrongly, and a quote inside a regex literal is enough to do that.
+   * Splicing raw JSON would make that heuristic load-bearing for injection.
    */
   private formatConditionJson(value: object, template: string, matchIndex: number): string {
-    const json = JSON.stringify(value)
+    const escaped = escapeInertStringContent(JSON.stringify(value))
     const quoteContext = this.getCodeStringQuoteContext(template, matchIndex, 'javascript')
-    return quoteContext === null ? json : escapeInertStringContent(json)
+    return quoteContext === null ? `JSON.parse('${escaped}')` : escaped
   }
 
   private async resolveReference(reference: string, context: ResolutionContext): Promise<any> {

--- a/apps/sim/executor/variables/resolver.ts
+++ b/apps/sim/executor/variables/resolver.ts
@@ -146,7 +146,12 @@ function isStructurallyInertConditionLiteral(value: string): boolean {
 }
 
 type ShellQuoteContext = 'single' | 'double' | null
-type CodeStringQuoteContext = ShellQuoteContext | 'triple-single' | 'triple-double' | 'template'
+type CodeStringQuoteContext =
+  | ShellQuoteContext
+  | 'triple-single'
+  | 'triple-double'
+  | 'template'
+  | 'regex'
 type CodeScanMode =
   | { type: 'normal' }
   | { type: 'single' }
@@ -157,6 +162,37 @@ type CodeScanMode =
   | { type: 'template-expression'; depth: number }
   | { type: 'line-comment' }
   | { type: 'block-comment' }
+  | { type: 'regex'; inCharacterClass: boolean }
+
+/**
+ * Characters after which a `/` opens a regular expression rather than dividing.
+ *
+ * The scanner has to tell the two apart, because a regex body is the one place a lone quote
+ * is not a string delimiter: `/['"]/` left the scan believing everything after it sat inside
+ * a string, and every reference past that point was then formatted for the wrong context.
+ * Division always follows a value — an identifier, literal, `)`, or `]` — so anything else
+ * ending the preceding token means a regex may start.
+ */
+const JAVASCRIPT_REGEX_ALLOWED_AFTER = new Set('(,=:[!&|?{};+-*%^~<>/'.split(''))
+
+const WHITESPACE_CHAR = /\s/
+
+/** Keywords a regex may directly follow, where the preceding token is a word rather than punctuation. */
+const JAVASCRIPT_REGEX_ALLOWED_AFTER_KEYWORDS = new Set([
+  'return',
+  'typeof',
+  'instanceof',
+  'in',
+  'of',
+  'new',
+  'delete',
+  'void',
+  'case',
+  'do',
+  'else',
+  'yield',
+  'await',
+])
 
 export class VariableResolver {
   private resolvers: Resolver[]
@@ -1073,6 +1109,35 @@ export class VariableResolver {
     )
   }
 
+  /**
+   * Whether a `/` at this point opens a regular expression rather than dividing.
+   *
+   * Division always follows a value, so the preceding token decides: an identifier that is not
+   * one of the keywords a regex may follow, a number, a `)`, or a `]` means division, and
+   * anything else means a regex may start. Guessing wrong is not silent — the scan would swallow
+   * text up to the next `/` — so the check reads the actual preceding token rather than assuming.
+   */
+  private canStartJavaScriptRegex(template: string, previousSignificantIndex: number): boolean {
+    if (previousSignificantIndex < 0) {
+      return true
+    }
+    const previous = template[previousSignificantIndex]
+    if (JAVASCRIPT_REGEX_ALLOWED_AFTER.has(previous)) {
+      return true
+    }
+    if (!this.isJavaScriptIdentifierChar(previous)) {
+      return false
+    }
+
+    let start = previousSignificantIndex
+    while (start > 0 && this.isJavaScriptIdentifierChar(template[start - 1])) {
+      start--
+    }
+    return JAVASCRIPT_REGEX_ALLOWED_AFTER_KEYWORDS.has(
+      template.slice(start, previousSignificantIndex + 1)
+    )
+  }
+
   private matchesKeywordAt(template: string, index: number, keyword: string): boolean {
     if (!template.startsWith(keyword, index)) {
       return false
@@ -1200,6 +1265,7 @@ export class VariableResolver {
   ): CodeStringQuoteContext {
     const isPython = language === 'python'
     const modes: CodeScanMode[] = [{ type: 'normal' }]
+    let lastSignificantIndex = -1
 
     for (let i = 0; i < index; i++) {
       const char = template[i]
@@ -1217,6 +1283,31 @@ export class VariableResolver {
         if (char === '*' && next === '/') {
           modes.pop()
           i++
+        }
+        continue
+      }
+
+      if (mode.type === 'regex') {
+        if (char === '\\') {
+          i++
+          continue
+        }
+        // A regex literal cannot span a line, so an unterminated one means the `/` was
+        // division after all; dropping the mode keeps the rest of the scan honest.
+        if (char === '\n') {
+          modes.pop()
+          continue
+        }
+        if (char === '[') {
+          mode.inCharacterClass = true
+          continue
+        }
+        if (char === ']') {
+          mode.inCharacterClass = false
+          continue
+        }
+        if (char === '/' && !mode.inCharacterClass) {
+          modes.pop()
         }
         continue
       }
@@ -1273,6 +1364,18 @@ export class VariableResolver {
           i++
           continue
         }
+        const previousSignificantIndex = lastSignificantIndex
+        if (!WHITESPACE_CHAR.test(char)) {
+          lastSignificantIndex = i
+        }
+        if (
+          !isPython &&
+          char === '/' &&
+          this.canStartJavaScriptRegex(template, previousSignificantIndex)
+        ) {
+          modes.push({ type: 'regex', inCharacterClass: false })
+          continue
+        }
         if (isPython && char === "'" && next === "'" && template[i + 2] === "'") {
           modes.push({ type: 'triple-single' })
           i += 2
@@ -1322,6 +1425,18 @@ export class VariableResolver {
         i++
         continue
       }
+      const previousSignificantIndex = lastSignificantIndex
+      if (!WHITESPACE_CHAR.test(char)) {
+        lastSignificantIndex = i
+      }
+      if (
+        !isPython &&
+        char === '/' &&
+        this.canStartJavaScriptRegex(template, previousSignificantIndex)
+      ) {
+        modes.push({ type: 'regex', inCharacterClass: false })
+        continue
+      }
       if (isPython && char === "'" && next === "'" && template[i + 2] === "'") {
         modes.push({ type: 'triple-single' })
         i += 2
@@ -1338,6 +1453,9 @@ export class VariableResolver {
     }
 
     const mode = modes[modes.length - 1]
+    if (mode.type === 'regex') {
+      return 'regex'
+    }
     if (
       mode.type === 'single' ||
       mode.type === 'double' ||

--- a/apps/sim/executor/variables/resolvers/block.test.ts
+++ b/apps/sim/executor/variables/resolvers/block.test.ts
@@ -711,6 +711,17 @@ describe('BlockResolver', () => {
       expect(resolver.formatValueForBlock('tab\there', 'condition')).toBe('"tab\there"')
     })
 
+    it.concurrent('should escape the quotes it does not open for condition block', () => {
+      // The author's quoting decides which literal this lands in, so escaping only the
+      // double quote this wrapper opens leaves the other contexts breakable.
+      const resolver = new BlockResolver(createTestWorkflow())
+      expect(resolver.formatValueForBlock("' + evil() + '", 'condition')).toBe(
+        '"\\\' + evil() + \\\'"'
+      )
+      expect(resolver.formatValueForBlock(`\${evil()}`, 'condition')).toBe(`"\\\${evil()}"`)
+      expect(resolver.formatValueForBlock('`evil()`', 'condition')).toBe('"\\`evil()\\`"')
+    })
+
     it.concurrent('should format object for condition block', () => {
       const resolver = new BlockResolver(createTestWorkflow())
       const result = resolver.formatValueForBlock({ key: 'value' }, 'condition')

--- a/apps/sim/executor/variables/resolvers/block.ts
+++ b/apps/sim/executor/variables/resolvers/block.ts
@@ -13,7 +13,7 @@ import {
   resolveBlockReference,
   resolveBlockReferenceAsync,
 } from '@/executor/utils/block-reference'
-import { formatLiteralForCode } from '@/executor/utils/code-formatting'
+import { formatInertStringLiteral, formatLiteralForCode } from '@/executor/utils/code-formatting'
 import { buildClonedSubflowId, extractOuterBranchIndex } from '@/executor/utils/subflow-utils'
 import {
   type AsyncPathNavigator,
@@ -414,12 +414,7 @@ export class BlockResolver implements Resolver {
 
   private stringifyForCondition(value: any): string {
     if (typeof value === 'string') {
-      const sanitized = value
-        .replace(/\\/g, '\\\\')
-        .replace(/"/g, '\\"')
-        .replace(/\n/g, '\\n')
-        .replace(/\r/g, '\\r')
-      return `"${sanitized}"`
+      return formatInertStringLiteral(value, '"')
     }
     if (value === null) {
       return 'null'


### PR DESCRIPTION
## Problem

A Condition expression is compiled by inlining each resolved reference into the author's JavaScript as source text. The literal that gets emitted only ever anticipated the quoting it chose itself — it escapes `\`, `'`, and line terminators, then wraps in `'…'` — but the **author's** quoting decides which context the value actually lands in.

So trigger data (webhook body, chat message, form field) could close the author's string and execute:

```
author  : "<start.input>".includes('urgent')
payload : " + (globalThis.__pwned = Object.keys(environmentVariables).join(",")) + "
resolved: "'" + (globalThis.__pwned = Object.keys(environmentVariables).join(",")) + "'".includes('urgent')
verdict : {"matchedIndex":0}        ← branch still matched, run continued
__pwned : OPENAI_API_KEY,DB_URL     ← injected code ran
```

That runs in the condition sandbox, which is handed the run's whole decrypted environment (`{...personalDecrypted, ...workspaceDecrypted}` from `execution-core.ts`) as the `environmentVariables` global, inside an async wrapper where `await fetch(...)` is available. The branch verdict is unaffected, so nothing in the run log shows it happened.

Four shapes reached it — double-quoted, template literal, regex literal, and a crafted key on a quoted object reference. The dangerous ones are the shapes that also behave *correctly* with benign data, so they survive in production: `"<x>".includes(…)`, `"<x>".toLowerCase().includes(…)`, `` `<x>`.length > n ``, `/<x>/.test(…)`. (`"<x>" === "admin"` injects too, but is always false even benignly, so an author would have abandoned it.) A bare `<x> === 'admin'` was never vulnerable, and `'<x>' === 'admin'` is a syntax error today, so it never ships.

Same root cause, second site: Function blocks bind block outputs as runtime context variables (safe), but inlined the remaining resolved values as literals. A Variables block can assign trigger data into a workflow variable at runtime, and `WorkflowResolver` reads the live map — so `const x = '<variable.userinput>'` spliced attacker text into code. Loop items reached the same path, in JavaScript, Python, and shell.

## Fix

**Conditions — one shared literal formatter, no behavior change.** `escapeInertStringContent` escapes every terminator of every JavaScript string context, not just the one the emitted literal opens. `\"`, `` \` ``, `\$`, and `\/` are identity escapes, so a condition compares byte-for-byte what it compared before; only its ability to parse as anything but data changes. Both condition formatters use it — `resolveTemplateWithoutConditionFormatting` (the live path) and `stringifyForCondition` (the fallback, which had the mirrored blind spot: wraps in `"`, escaped only `"`).

Deliberately **not** the quote-context rewrite (`getCodeStringQuoteContext` + `quote + JSON.stringify(v) + quote`) that the code-block path uses: it would make `"<x>" === "admin"` start matching where today it is always false. That is the correct long-term semantics, but it re-routes live workflows and belongs in its own announced change, not a security patch.

A quoted **object** reference additionally escapes its JSON, since JSON's own structural quotes close the author's string. In expression position the JSON stays a literal (unchanged). In a quoted position the previous output was either a syntax error or an injection, so the escaped form is the only reading that was not already broken.

**Function blocks — bind instead of splice.** Resolved values now bind as context variables like block outputs always have. Same runtime value, never source. Two exceptions stay inline: numbers/booleans/null (digits and keywords cannot terminate a literal), and a string that names an environment variable and carries no quote — that shape has to stay in source because the placeholder, never the secret, is what is inlined, and the execution-boundary compiler binds it downstream (this is how `<variable.indirectSecret>` reaches its value).

**Defence in depth.** Condition evaluation stops shipping the full secret map to the sandbox: it mounts only the names its script references (`secretScope: 'selected'`). A script that reads the `environmentVariables` global directly keeps the full map, so nothing that works today breaks.

## Tests

- `resolver.test.ts` — 5 quotings × 4 payloads must not execute; a crafted-key object must not close the string it is quoted inside; bare and quoted references must still compare what they compared before (including values carrying `"`, `$`, `/`). Both injection tests were confirmed to **fail** without their respective fix.
- `condition-handler.test.ts` — mounts only named secrets, denies all when none are named, keeps `all` for direct `environmentVariables` access.
- `block.test.ts` — the fallback formatter escapes the quotes it does not open.
- One existing assertion updated: the navigated manifest element now binds rather than splices (`contextVariables` holds the element, never the manifest or its array).

`bun run test` (apps/sim), `bun run type-check`, `biome check`, and `bun run check:api-validation` all pass.

## Blast radius

Bare references (the documented form, `<agent.score> > 75`) are byte-identical. Quoted references keep the same runtime value. Function-block generated code changes shape for spliced scalars/strings — values and display source are unchanged. Quoted **object** references in conditions change from "syntax error / injectable" to "well-formed string compare".
