### PR TITLE
Reject live mode for table workflow tools

### DIFF
--- a/apps/sim/lib/copilot/tools/server/table/user-table.test.ts
+++ b/apps/sim/lib/copilot/tools/server/table/user-table.test.ts
@@ -960,23 +960,40 @@ describe('userTableServerTool workflow scope', () => {
     expect(mockAddWorkflowGroup).not.toHaveBeenCalled()
   })
 
-  it('does not pass a legacy deployment mode into workflow group creation', async () => {
+  it.each([
+    {
+      operation: 'add_workflow_group',
+      args: {
+        tableId: 'tbl_1',
+        workflowId: 'workflow-1',
+        outputs: [{ blockId: 'block-1', path: 'content' }],
+        deploymentMode: 'live',
+      },
+    },
+    {
+      operation: 'update_workflow_group',
+      args: {
+        tableId: 'tbl_1',
+        groupId: 'group-1',
+        deploymentMode: 'live',
+      },
+    },
+  ])('rejects a legacy live deployment mode for $operation', async ({ operation, args }) => {
     const result = await userTableServerTool.execute(
       {
-        operation: 'add_workflow_group',
-        args: {
-          tableId: 'tbl_1',
-          workflowId: 'workflow-1',
-          outputs: [{ blockId: 'block-1', path: 'content' }],
-          deploymentMode: 'live',
-        },
+        operation,
+        args,
       },
       buildToolContext()
     )
 
-    expect(result.success).toBe(true)
-    expect(mockAddWorkflowGroup).toHaveBeenCalledTimes(1)
-    expect(mockAddWorkflowGroup.mock.calls[0][0].group).not.toHaveProperty('deploymentMode')
+    expect(result).toEqual({
+      success: false,
+      message:
+        'deploymentMode "live" is not supported; table workflow groups only run the latest active deployment. Deploy the workflow, then retry without deploymentMode.',
+    })
+    expect(mockResolveWorkflowContext).not.toHaveBeenCalled()
+    expect(mockAddWorkflowGroup).not.toHaveBeenCalled()
   })
 
   it('conceals unknown application failures from tool output', async () => {

--- a/apps/sim/lib/copilot/tools/server/table/user-table.ts
+++ b/apps/sim/lib/copilot/tools/server/table/user-table.ts
@@ -202,6 +202,20 @@ export const userTableServerTool: BaseServerTool<UserTableArgs, UserTableResult>
     const workspaceId = context.workspaceId
     const assertNotAborted = () =>
       assertServerToolNotAborted(context, 'Request aborted before table mutation could be applied.')
+
+    // A stale Mothership may still send the removed selector. Never report success
+    // after silently changing its requested semantics from draft to deployed.
+    if (
+      (operation === 'add_workflow_group' || operation === 'update_workflow_group') &&
+      args.deploymentMode === 'live'
+    ) {
+      return {
+        success: false,
+        message:
+          'deploymentMode "live" is not supported; table workflow groups only run the latest active deployment. Deploy the workflow, then retry without deploymentMode.',
+      }
+    }
+
     try {
       switch (operation) {
         case 'create': {


### PR DESCRIPTION
## Summary

- Reject legacy deploymentMode live calls for add_workflow_group and update_workflow_group at the Copilot table-tool boundary.
- Return an actionable error explaining that table workflow groups use the latest active deployment.
- Keep the public table HTTP contracts unchanged.

This closes the rolling-version case where an older Mothership could request draft semantics and Sim would silently report success while actually using deployed state.

Companion Mothership PR: https://github.com/simstudioai/mothership/pull/466

## Tests

- bunx biome check on the changed files
- bun run --cwd apps/sim test for user-table and table-split suites: 68 tests
- bun run --cwd apps/sim type-check
- git diff --check