### PR TITLE
fix(connectors): keep rate limits out of failure breaker

### DIFF
--- a/apps/sim/lib/knowledge/connectors/sync-engine.test.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.test.ts
@@ -1257,9 +1257,16 @@ describe('executeSync deferred hydration rate limits', () => {
     expect(dbChainMockFns.set).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'error',
-        nextSyncAt: new Date(NOW.getTime() + 45 * 60 * 1000),
+        consecutiveFailures: 0,
       })
     )
+    const failureUpdate = dbChainMockFns.set.mock.calls.find(
+      ([update]) => update.status === 'error'
+    )?.[0]
+    expect(failureUpdate?.nextSyncAt.getTime()).toBeGreaterThanOrEqual(
+      NOW.getTime() + 45 * 60 * 1000
+    )
+    expect(failureUpdate?.nextSyncAt.getTime()).toBeLessThanOrEqual(NOW.getTime() + 46 * 60 * 1000)
   })
 })
 
@@ -2386,6 +2393,43 @@ describe('buildSyncFailureUpdate', () => {
     expect(buildSyncFailureUpdate(now, MAX_CONSECUTIVE_FAILURES, 'boom').lastSyncError).toBe(
       CONNECTOR_AUTO_DISABLED_ERROR
     )
+  })
+})
+
+describe('buildSyncRateLimitUpdate', () => {
+  const now = new Date('2026-08-20T00:00:00.000Z')
+
+  it('preserves the failure counter and schedules after the provider deadline', async () => {
+    const { buildSyncRateLimitUpdate } = await import('@/lib/knowledge/connectors/sync-engine')
+    const providerDelayMs = 45 * 60 * 1000
+    const update = buildSyncRateLimitUpdate(now, 9, 'rate limited', providerDelayMs)
+
+    expect(update.status).toBe('error')
+    expect(update.lastSyncError).toBe('rate limited')
+    expect(update.consecutiveFailures).toBe(9)
+    expect(update.nextSyncAt.getTime()).toBeGreaterThanOrEqual(now.getTime() + providerDelayMs)
+    expect(update.nextSyncAt.getTime()).toBeLessThanOrEqual(
+      now.getTime() + providerDelayMs + 60_000
+    )
+  })
+
+  it('uses a conservative fallback without consuming the breaker', async () => {
+    const { buildSyncRateLimitUpdate } = await import('@/lib/knowledge/connectors/sync-engine')
+    const update = buildSyncRateLimitUpdate(now, null, 'rate limited')
+    const fallbackMs = 30 * 60 * 1000
+
+    expect(update.consecutiveFailures).toBe(0)
+    expect(update.nextSyncAt.getTime()).toBeGreaterThanOrEqual(now.getTime() + fallbackMs)
+    expect(update.nextSyncAt.getTime()).toBeLessThanOrEqual(now.getTime() + fallbackMs + 60_000)
+  })
+
+  it('caps the provider deadline and releases the sync lease', async () => {
+    const { buildSyncRateLimitUpdate } = await import('@/lib/knowledge/connectors/sync-engine')
+    const update = buildSyncRateLimitUpdate(now, 4, 'rate limited', 30 * 24 * 60 * 60 * 1000)
+
+    expect(update.nextSyncAt).toEqual(new Date(now.getTime() + 24 * 60 * 60 * 1000))
+    expect(update.syncLockToken).toBeNull()
+    expect(update.syncLockLeaseAt).toBeNull()
   })
 })
 

--- a/apps/sim/lib/knowledge/connectors/sync-engine.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.ts
@@ -71,6 +71,8 @@ import { hasIndexablePayload } from '@/connectors/utils'
 
 const logger = createLogger('ConnectorSyncEngine')
 
+const RATE_LIMIT_RETRY_JITTER_MAX_MS = 60_000
+
 /**
  * Raised when a run discovers mid-flight that it no longer holds its sync lock.
  *
@@ -1352,6 +1354,40 @@ export function buildSyncFailureUpdate(
     consecutiveFailures: failures,
     // Releases the lock so a stale token can never match a later run, and closes
     // its lease so the reaper is not left waiting out a TTL on a finished run.
+    syncLockToken: null,
+    syncLockLeaseAt: null,
+    updatedAt: now,
+  }
+}
+
+/**
+ * The connector row written after a provider positively identifies throttling.
+ *
+ * Structured throttling is a transient quota or availability condition, so it
+ * must not consume the breaker reserved for persistent connector failures. The
+ * provider deadline remains authoritative, with a short post-deadline jitter
+ * to avoid releasing every connector sharing the same quota window at once.
+ * When the provider omits a usable deadline, the first rung of the ordinary
+ * failure ladder provides a conservative fallback.
+ */
+export function buildSyncRateLimitUpdate(
+  now: Date,
+  previousFailures: number | null | undefined,
+  errorMessage: string,
+  retryAfterMs?: number
+) {
+  const maximumBackoffMs = CONNECTOR_FAILURE_BACKOFF_CAP_MINUTES * 60 * 1000
+  const providerBackoffMs =
+    typeof retryAfterMs === 'number' && Number.isFinite(retryAfterMs) && retryAfterMs > 0
+      ? retryAfterMs
+      : connectorFailureBackoffMinutes(1) * 60 * 1000
+  const jitterMs = randomInt(0, RATE_LIMIT_RETRY_JITTER_MAX_MS + 1)
+
+  return {
+    status: 'error' as const,
+    lastSyncError: errorMessage,
+    nextSyncAt: new Date(now.getTime() + Math.min(providerBackoffMs + jitterMs, maximumBackoffMs)),
+    consecutiveFailures: previousFailures ?? 0,
     syncLockToken: null,
     syncLockLeaseAt: null,
     updatedAt: now,
@@ -3181,6 +3217,7 @@ export async function executeSync(
 
     const errorMessage = toError(error).message
     const retryAfterMs = getRetryAfterMs(error)
+    const rateLimited = isRateLimitError(error)
     logger.error('Sync failed', {
       connectorId,
       error: errorMessage,
@@ -3193,12 +3230,19 @@ export async function executeSync(
       const failureUpdate =
         error instanceof ConnectorSyncCapacityError
           ? buildSyncCapacityUpdate(new Date(), connector.consecutiveFailures, errorMessage)
-          : buildSyncFailureUpdate(
-              new Date(),
-              connector.consecutiveFailures,
-              errorMessage,
-              retryAfterMs
-            )
+          : rateLimited
+            ? buildSyncRateLimitUpdate(
+                new Date(),
+                connector.consecutiveFailures,
+                errorMessage,
+                retryAfterMs
+              )
+            : buildSyncFailureUpdate(
+                new Date(),
+                connector.consecutiveFailures,
+                errorMessage,
+                retryAfterMs
+              )
 
       if (failureUpdate.status === 'disabled') {
         logger.warn('Connector disabled after repeated failures', {


### PR DESCRIPTION
## Summary
- Keep structured provider throttling out of the permanent connector failure breaker
- Honor provider retry deadlines with bounded post-reset jitter and a conservative fallback

## Type of Change
- [x] Bug fix

## Testing
- bun run lint
- bun run check:audits
- bun run --cwd apps/sim test -- lib/knowledge/connectors/sync-engine.test.ts lib/knowledge/documents/utils.test.ts
- bun run --cwd apps/sim type-check

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)