### PR TITLE
fix(selectors): normalize Bitbucket workspace UUIDs

### DIFF
--- a/apps/sim/lib/selectors/server/providers/bitbucket.test.ts
+++ b/apps/sim/lib/selectors/server/providers/bitbucket.test.ts
@@ -150,11 +150,14 @@ describe('Bitbucket server selector adapters', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 
-  it('resolves a workspace UUID before listing its repositories', async () => {
-    const workspaceUuid = '{a15fb181-db1f-48f7-b41f-e1eff06929d6}'
+  it.each([
+    ['braced', '{a15fb181-db1f-48f7-b41f-e1eff06929d6}'],
+    ['unbraced', 'a15fb181-db1f-48f7-b41f-e1eff06929d6'],
+  ])('resolves a %s workspace UUID before listing its repositories', async (_, workspaceUuid) => {
+    const providerUuid = '{a15fb181-db1f-48f7-b41f-e1eff06929d6}'
     mockFetch
       .mockResolvedValueOnce(
-        providerResponse({ slug: 'acme-platform', uuid: workspaceUuid, name: 'Acme' })
+        providerResponse({ slug: 'acme-platform', uuid: providerUuid, name: 'Acme' })
       )
       .mockResolvedValueOnce(providerResponse({ values: [] }))
 
@@ -167,7 +170,7 @@ describe('Bitbucket server selector adapters', () => {
     ).resolves.toEqual({ kind: 'list', items: [] })
 
     expect(new URL(String(mockFetch.mock.calls[0]?.[0])).pathname).toBe(
-      `/2.0/workspaces/${encodeURIComponent(workspaceUuid)}`
+      `/2.0/workspaces/${encodeURIComponent(providerUuid)}`
     )
     expect(new URL(String(mockFetch.mock.calls[1]?.[0])).pathname).toBe(
       '/2.0/repositories/acme-platform'

--- a/apps/sim/lib/selectors/server/providers/bitbucket.ts
+++ b/apps/sim/lib/selectors/server/providers/bitbucket.ts
@@ -106,6 +106,10 @@ function normalizeBitbucketUuid(value: string): string {
   return value.replace(/^\{?|\}?$/g, '').toLowerCase()
 }
 
+function formatBitbucketUuid(value: string): string {
+  return `{${normalizeBitbucketUuid(value)}}`
+}
+
 function requireCursorParams(cursor: string): URLSearchParams {
   if (!cursor || cursor.length > BITBUCKET_CURSOR_MAX_LENGTH) {
     throw new SelectorContextUnavailableError()
@@ -193,7 +197,13 @@ async function getWorkspace(
   identifier: string,
   accessToken: string
 ): Promise<z.infer<typeof workspaceDetailSchema>> {
-  const url = new URL(`/2.0/workspaces/${encodeURIComponent(identifier)}`, BITBUCKET_API_ORIGIN)
+  const providerIdentifier = isBitbucketUuid(identifier)
+    ? formatBitbucketUuid(identifier)
+    : identifier
+  const url = new URL(
+    `/2.0/workspaces/${encodeURIComponent(providerIdentifier)}`,
+    BITBUCKET_API_ORIGIN
+  )
   url.searchParams.set('fields', 'slug,uuid,name')
   const body = await fetchProviderJson<unknown>(url, {
     headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },


### PR DESCRIPTION
## Summary
- Normalizes UUID-shaped Bitbucket workspace identifiers into Bitbucket Cloud canonical braced form for provider lookup.
- Leaves saved workspace slugs, UUIDs, and environment references unchanged.
- Extends the existing adapter behavior test to cover both braced and unbraced UUID input.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- bun run --cwd apps/sim test lib/selectors/server/providers/bitbucket.test.ts
- bun run --cwd apps/sim type-check
- bun run check:api-validation:strict
- bun run check:fork-dependent-coverage
- bun run check:client-boundary
- git diff --check

Browser verification was not performed; it was waived for this focused server-side change.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the Contributor License Agreement

## Screenshots/Videos
Not applicable; there are no UI changes.