### PR TITLE
fix(notion): resolve custom page title properties

### DIFF
--- a/apps/sim/lib/selectors/server/providers/notion.test.ts
+++ b/apps/sim/lib/selectors/server/providers/notion.test.ts
@@ -47,7 +47,7 @@ describe('Notion server selector adapter', () => {
           object: 'page',
           id: 'page-provider-id',
           properties: {
-            Name: { type: 'title', title: [{ plain_text: 'Planning' }] },
+            Project: { type: 'title', title: [{ plain_text: 'Planning' }] },
           },
         }),
         { status: 200 }

--- a/apps/sim/tools/notion/create_page.ts
+++ b/apps/sim/tools/notion/create_page.ts
@@ -1,5 +1,6 @@
 import type { NotionCreatePageParams, NotionResponse } from '@/tools/notion/types'
 import { PAGE_OUTPUT_PROPERTIES } from '@/tools/notion/types'
+import { extractTitle } from '@/tools/notion/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const notionCreatePageTool: ToolConfig<NotionCreatePageParams, NotionResponse> = {
@@ -105,18 +106,7 @@ export const notionCreatePageTool: ToolConfig<NotionCreatePageParams, NotionResp
 
   transformResponse: async (response: Response) => {
     const data = await response.json()
-    let pageTitle = 'Untitled'
-
-    if (data.properties?.title) {
-      const titleProperty = data.properties.title
-      if (
-        titleProperty.title &&
-        Array.isArray(titleProperty.title) &&
-        titleProperty.title.length > 0
-      ) {
-        pageTitle = titleProperty.title.map((t: any) => t.plain_text || '').join('')
-      }
-    }
+    const pageTitle = extractTitle(data.properties ?? {}) || 'Untitled'
 
     return {
       success: true,
@@ -178,18 +168,7 @@ export const notionCreatePageV2Tool: ToolConfig<
 
   transformResponse: async (response: Response) => {
     const data = await response.json()
-    let pageTitle = 'Untitled'
-
-    if (data.properties?.title) {
-      const titleProperty = data.properties.title
-      if (
-        titleProperty.title &&
-        Array.isArray(titleProperty.title) &&
-        titleProperty.title.length > 0
-      ) {
-        pageTitle = titleProperty.title.map((t: any) => t.plain_text || '').join('')
-      }
-    }
+    const pageTitle = extractTitle(data.properties ?? {}) || 'Untitled'
 
     return {
       success: true,

--- a/apps/sim/tools/notion/read.ts
+++ b/apps/sim/tools/notion/read.ts
@@ -1,5 +1,6 @@
 import type { NotionReadParams, NotionResponse } from '@/tools/notion/types'
 import { PAGE_OUTPUT_PROPERTIES } from '@/tools/notion/types'
+import { extractTitle } from '@/tools/notion/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const notionReadTool: ToolConfig<NotionReadParams, NotionResponse> = {
@@ -49,19 +50,7 @@ export const notionReadTool: ToolConfig<NotionReadParams, NotionResponse> = {
 
   transformResponse: async (response: Response, params?: NotionReadParams) => {
     const data = await response.json()
-    let pageTitle = 'Untitled'
-
-    // Extract title from properties
-    if (data.properties?.title) {
-      const titleProperty = data.properties.title
-      if (
-        titleProperty.title &&
-        Array.isArray(titleProperty.title) &&
-        titleProperty.title.length > 0
-      ) {
-        pageTitle = titleProperty.title.map((t: any) => t.plain_text || '').join('')
-      }
-    }
+    const pageTitle = extractTitle(data.properties ?? {}) || 'Untitled'
 
     // Now fetch the page content using blocks endpoint
     const pageId = params?.pageId?.trim()
@@ -199,18 +188,7 @@ export const notionReadV2Tool: ToolConfig<NotionReadParams, NotionReadV2Response
 
   transformResponse: async (response: Response, params?: NotionReadParams) => {
     const data = await response.json()
-    let pageTitle = 'Untitled'
-
-    if (data.properties?.title) {
-      const titleProperty = data.properties.title
-      if (
-        titleProperty.title &&
-        Array.isArray(titleProperty.title) &&
-        titleProperty.title.length > 0
-      ) {
-        pageTitle = titleProperty.title.map((t: any) => t.plain_text || '').join('')
-      }
-    }
+    const pageTitle = extractTitle(data.properties ?? {}) || 'Untitled'
 
     const pageId = params?.pageId?.trim()
     const accessToken = params?.accessToken

--- a/apps/sim/tools/notion/responses.test.ts
+++ b/apps/sim/tools/notion/responses.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { notionCreatePageTool, notionCreatePageV2Tool } from '@/tools/notion/create_page'
+import { notionReadTool, notionReadV2Tool } from '@/tools/notion/read'
+import { notionUpdatePageTool, notionUpdatePageV2Tool } from '@/tools/notion/update_page'
+
+const PAGE_TITLE = 'Project Apollo'
+
+function pageResponse(): Response {
+  return Response.json({
+    id: 'page-1',
+    url: 'https://www.notion.so/page-1',
+    created_time: '2026-08-01T00:00:00.000Z',
+    last_edited_time: '2026-08-02T00:00:00.000Z',
+    properties: {
+      Project: {
+        id: 'title',
+        type: 'title',
+        title: [{ plain_text: PAGE_TITLE }],
+      },
+    },
+  })
+}
+
+const responseCases = [
+  {
+    id: notionReadTool.id,
+    title: async () =>
+      (await notionReadTool.transformResponse!(pageResponse())).output.metadata.title,
+  },
+  {
+    id: notionReadV2Tool.id,
+    title: async () => (await notionReadV2Tool.transformResponse!(pageResponse())).output.title,
+  },
+  {
+    id: notionCreatePageTool.id,
+    title: async () =>
+      (await notionCreatePageTool.transformResponse!(pageResponse())).output.metadata.title,
+  },
+  {
+    id: notionCreatePageV2Tool.id,
+    title: async () =>
+      (await notionCreatePageV2Tool.transformResponse!(pageResponse())).output.title,
+  },
+  {
+    id: notionUpdatePageTool.id,
+    title: async () =>
+      (await notionUpdatePageTool.transformResponse!(pageResponse())).output.metadata.title,
+  },
+  {
+    id: notionUpdatePageV2Tool.id,
+    title: async () =>
+      (await notionUpdatePageV2Tool.transformResponse!(pageResponse())).output.title,
+  },
+]
+
+describe('Notion page title responses', () => {
+  it.each(responseCases)('$id reads a custom-named title property', async ({ title }) => {
+    await expect(title()).resolves.toBe(PAGE_TITLE)
+  })
+})

--- a/apps/sim/tools/notion/update_page.ts
+++ b/apps/sim/tools/notion/update_page.ts
@@ -1,5 +1,6 @@
 import type { NotionResponse, NotionUpdatePageParams } from '@/tools/notion/types'
 import { PAGE_OUTPUT_PROPERTIES } from '@/tools/notion/types'
+import { extractTitle } from '@/tools/notion/utils'
 import type { ToolConfig } from '@/tools/types'
 
 export const notionUpdatePageTool: ToolConfig<NotionUpdatePageParams, NotionResponse> = {
@@ -57,19 +58,7 @@ export const notionUpdatePageTool: ToolConfig<NotionUpdatePageParams, NotionResp
 
   transformResponse: async (response: Response) => {
     const data = await response.json()
-    let pageTitle = 'Untitled'
-
-    // Try to extract the title from properties
-    if (data.properties?.title) {
-      const titleProperty = data.properties.title
-      if (
-        titleProperty.title &&
-        Array.isArray(titleProperty.title) &&
-        titleProperty.title.length > 0
-      ) {
-        pageTitle = titleProperty.title.map((t: any) => t.plain_text || '').join('')
-      }
-    }
+    const pageTitle = extractTitle(data.properties ?? {}) || 'Untitled'
 
     return {
       success: true,
@@ -133,18 +122,7 @@ export const notionUpdatePageV2Tool: ToolConfig<
 
   transformResponse: async (response: Response) => {
     const data = await response.json()
-    let pageTitle = 'Untitled'
-
-    if (data.properties?.title) {
-      const titleProperty = data.properties.title
-      if (
-        titleProperty.title &&
-        Array.isArray(titleProperty.title) &&
-        titleProperty.title.length > 0
-      ) {
-        pageTitle = titleProperty.title.map((t: any) => t.plain_text || '').join('')
-      }
-    }
+    const pageTitle = extractTitle(data.properties ?? {}) || 'Untitled'
 
     return {
       success: true,


### PR DESCRIPTION
## Summary

- resolve Notion page titles by property type instead of a literal property key
- preserve legacy and V2 response shapes and the existing Untitled fallback
- cover custom-title selector hydration and all six read/create/update response transforms

## Automated validation

- bun run test -- lib/selectors/server/providers/notion.test.ts tools/notion/responses.test.ts
- bunx biome check lib/selectors/server/providers/notion.test.ts tools/notion/read.ts tools/notion/create_page.ts tools/notion/update_page.ts tools/notion/responses.test.ts
- bun run type-check
- bun run check:api-validation

All checks passed.

## Browser validation

Using a disposable Notion database whose primary title property was renamed to Project:

- the page selector listed Sim Custom Title Row
- saving and reloading the workflow hydrated the same selector label through the detail request
- a Notion Read execution returned Sim Custom Title Row as its title
- selector list and detail requests returned 200, with no related browser-console or server-log errors and no credentials exposed

The browser tooling did not expose the raw response body directly; normalized label behavior was verified through the rendered selector state, successful list/detail request logs, and focused adapter coverage.