### PR TITLE
fix(confluence): normalize space identifiers

### DIFF
--- a/apps/sim/blocks/blocks/confluence.test.ts
+++ b/apps/sim/blocks/blocks/confluence.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConfluenceV2Block } from '@/blocks/blocks/confluence'
+
+const { mockGetBlock } = vi.hoisted(() => ({ mockGetBlock: vi.fn() }))
+
+vi.mock('@/blocks/registry', () => ({
+  getBlock: mockGetBlock,
+  getAllBlocks: vi.fn(() => []),
+  getLatestBlock: vi.fn(() => undefined),
+  getBlockRegistry: vi.fn(() => ({})),
+  getBlockByToolName: vi.fn(() => undefined),
+  getBlocksByCategory: vi.fn(() => []),
+}))
+
+import { migrateSubblockIds } from '@/lib/workflows/migrations/subblock-migrations'
+import { extractBlockParams } from '@/serializer'
+import type { BlockState } from '@/stores/workflows/workflow/types'
+
+function legacySearchBlock(field: string, value: string, advancedMode: boolean): BlockState {
+  const values = { operation: 'search_in_space', [field]: value }
+  return {
+    id: 'block-1',
+    type: 'confluence_v2',
+    name: 'Confluence 1',
+    position: { x: 0, y: 0 },
+    advancedMode,
+    subBlocks: Object.fromEntries(
+      Object.entries(values).map(([id, fieldValue]) => [
+        id,
+        { id, type: 'short-input', value: fieldValue },
+      ])
+    ),
+    outputs: {},
+    enabled: true,
+  } as unknown as BlockState
+}
+
+function mappedSearchParams(state: BlockState): {
+  blocks: Record<string, BlockState>
+  params: Record<string, unknown>
+} {
+  const { blocks } = migrateSubblockIds({ 'block-1': state })
+  const params = extractBlockParams(blocks['block-1'])
+  const transform = ConfluenceV2Block.tools.config?.params
+  if (!transform) throw new Error('Confluence V2 block has no params transform')
+  return { blocks, params: { ...params, ...transform(params) } }
+}
+
+describe('Confluence search-in-space values saved before the selector split', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetBlock.mockReturnValue(ConfluenceV2Block)
+  })
+
+  it.each([
+    {
+      mode: 'basic',
+      source: 'spaceSelector',
+      target: 'spaceKeySelector',
+      value: 'ENG',
+      advancedMode: false,
+    },
+    {
+      mode: 'advanced',
+      source: 'spaceId',
+      target: 'manualSpaceKey',
+      value: '12345',
+      advancedMode: true,
+    },
+  ])('migrates the $mode value and sends it as spaceKey', (testCase) => {
+    const { blocks, params } = mappedSearchParams(
+      legacySearchBlock(testCase.source, testCase.value, testCase.advancedMode)
+    )
+
+    expect(blocks['block-1'].subBlocks[testCase.target]?.value).toBe(testCase.value)
+    expect(params).toMatchObject({ operation: 'search_in_space', spaceKey: testCase.value })
+    expect(params.spaceId).toBeUndefined()
+  })
+})

--- a/apps/sim/blocks/blocks/confluence.ts
+++ b/apps/sim/blocks/blocks/confluence.ts
@@ -16,6 +16,9 @@ const PAGE_FIELD = ['pageId', 'manualPageId'] as const
  */
 const SPACE_FIELD = ['spaceSelector', 'spaceId'] as const
 
+/** Canonical basic/advanced pair for V1 operations that require a space key. */
+const SPACE_KEY_FIELD = ['spaceKeySelector', 'manualSpaceKey'] as const
+
 /** Canonical upload/reference pair for an attachment's file. V2 only. */
 const ATTACHMENT_FILE_FIELD = ['attachmentFileUpload', 'attachmentFileReference'] as const
 
@@ -485,7 +488,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
           { text: ', up to', field: 'limit', after: 'results' },
         ],
         search_in_space: [
-          { text: 'Search', field: SPACE_FIELD, core: true },
+          { text: 'Search', field: SPACE_KEY_FIELD, core: true },
           { text: 'for', field: 'query' },
         ],
         list_blogposts: ['List blog posts', { text: ', up to', field: 'limit', after: 'results' }],
@@ -834,7 +837,6 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
           'update_space',
           'delete_space',
           'list_pages_in_space',
-          'search_in_space',
           'create_blogpost',
           'list_blogposts_in_space',
           'list_space_labels',
@@ -861,7 +863,6 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
           'update_space',
           'delete_space',
           'list_pages_in_space',
-          'search_in_space',
           'create_blogpost',
           'list_blogposts_in_space',
           'list_space_labels',
@@ -871,6 +872,29 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
           'delete_space_property',
         ],
       },
+    },
+    {
+      id: 'spaceKeySelector',
+      title: 'Space',
+      type: 'project-selector',
+      canonicalParamId: 'selectedSpaceKey',
+      serviceId: 'confluence',
+      selectorKey: 'confluence.spaces',
+      placeholder: 'Select Confluence space',
+      dependsOn: ['credential', 'domain'],
+      mode: 'basic',
+      required: true,
+      condition: { field: 'operation', value: 'search_in_space' },
+    },
+    {
+      id: 'manualSpaceKey',
+      title: 'Space Key',
+      type: 'short-input',
+      canonicalParamId: 'selectedSpaceKey',
+      placeholder: 'Enter Confluence space key',
+      mode: 'advanced',
+      required: true,
+      condition: { field: 'operation', value: 'search_in_space' },
     },
     {
       id: 'blogPostId',
@@ -1461,6 +1485,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
           taskAssignedTo,
           spaceName,
           spaceKey,
+          selectedSpaceKey,
           spaceDescription,
           spacePropertyKey,
           spacePropertyValue,
@@ -1626,6 +1651,15 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
           }
         }
 
+        if (operation === 'search_in_space') {
+          return {
+            credential: oauthCredential,
+            operation,
+            spaceKey: selectedSpaceKey,
+            ...rest,
+          }
+        }
+
         if (operation === 'update_space') {
           return {
             credential: oauthCredential,
@@ -1730,6 +1764,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
     oauthCredential: { type: 'string', description: 'Confluence access token' },
     pageId: { type: 'string', description: 'Page identifier' },
     spaceId: { type: 'string', description: 'Space identifier' },
+    selectedSpaceKey: { type: 'string', description: 'Selected space key' },
     blogPostId: { type: 'string', description: 'Blog post identifier' },
     versionNumber: { type: 'number', description: 'Page version number' },
     accountId: { type: 'string', description: 'Atlassian account ID' },
@@ -1758,7 +1793,7 @@ export const ConfluenceV2Block: BlockConfig<ConfluenceResponse> = {
     taskStatus: { type: 'string', description: 'Task status (complete or incomplete)' },
     taskAssignedTo: { type: 'string', description: 'Filter tasks by assignee account ID' },
     spaceName: { type: 'string', description: 'Space name for create/update' },
-    spaceKey: { type: 'string', description: 'Space key for create' },
+    spaceKey: { type: 'string', description: 'Space key for create or scoped search' },
     spaceDescription: { type: 'string', description: 'Space description' },
     spacePropertyKey: { type: 'string', description: 'Space property key' },
     spacePropertyValue: { type: 'json', description: 'Space property value' },

--- a/apps/sim/lib/internal/confluence/operations.test.ts
+++ b/apps/sim/lib/internal/confluence/operations.test.ts
@@ -24,6 +24,8 @@ vi.mock('@/lib/uploads/utils/file-utils.server', () => ({
 import { ConfluenceOperationError } from '@/lib/internal/confluence/errors'
 import {
   executeConfluenceListLabels,
+  executeConfluenceListPagesInSpace,
+  executeConfluenceSearchInSpace,
   executeConfluenceUploadAttachment,
 } from '@/lib/internal/confluence/operations'
 
@@ -81,6 +83,63 @@ describe('Confluence operations', () => {
       expect.objectContaining({ signal: controller.signal })
     )
     expect(response.bodyUsed).toBe(true)
+  })
+
+  it.each([
+    { selectedValue: 'ENG', expectedCalls: 2 },
+    { selectedValue: '12345', expectedCalls: 1 },
+  ])(
+    'uses numeric space IDs for V2 requests when the selected value is $selectedValue',
+    async ({ selectedValue, expectedCalls }) => {
+      const fetchMock = vi.fn(async (request: string | URL | Request) => {
+        const url = String(request)
+        if (url.includes('/spaces?')) {
+          return Response.json({
+            results: [{ id: '12345', key: 'ENG', name: 'Engineering', status: 'current' }],
+          })
+        }
+        return Response.json({ results: [] })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(
+        executeConfluenceListPagesInSpace(
+          { ...CONNECTION, spaceId: selectedValue, limit: 25 },
+          { headers: new Headers(), requestId: 'request-1' }
+        )
+      ).resolves.toEqual({ pages: [], nextCursor: null })
+
+      expect(fetchMock).toHaveBeenCalledTimes(expectedCalls)
+      const urls = fetchMock.mock.calls.map(([request]) => String(request))
+      expect(urls.at(-1)).toContain('/spaces/12345/pages?limit=25')
+      if (selectedValue === 'ENG') {
+        expect(urls[0]).toContain('/spaces?keys=ENG&limit=1&status=current')
+      }
+    }
+  )
+
+  it('resolves a legacy numeric space value before constructing key-based CQL', async () => {
+    const fetchMock = vi.fn(async (request: string | URL | Request) => {
+      const url = String(request)
+      if (url.includes('/api/v2/spaces/12345')) {
+        return Response.json({ id: '12345', key: 'ENG', name: 'Engineering' })
+      }
+      return Response.json({ results: [], totalSize: 0 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      executeConfluenceSearchInSpace(
+        { ...CONNECTION, spaceKey: '12345', query: 'release notes', limit: 25 },
+        { headers: new Headers(), requestId: 'request-1' }
+      )
+    ).resolves.toEqual({ results: [], spaceKey: 'ENG', totalSize: 0 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const searchUrl = String(fetchMock.mock.calls[1][0])
+    expect(new URL(searchUrl).searchParams.get('cql')).toBe(
+      'space = "ENG" AND text ~ "release notes"'
+    )
   })
 
   it('fails closed before downloading a stored file without an acting user', async () => {

--- a/apps/sim/lib/internal/confluence/operations.ts
+++ b/apps/sim/lib/internal/confluence/operations.ts
@@ -52,6 +52,7 @@ import { isPayloadSizeLimitError } from '@/lib/core/utils/stream-limits'
 import {
   asArray,
   asObject,
+  type ConfluenceClient,
   createConfluenceClient,
   type JsonObject,
   nested,
@@ -120,6 +121,71 @@ function mappedPage(value: unknown): JsonObject {
     version: page.version ?? null,
     webUrl: nested(page, '_links', 'webui') ?? null,
   }
+}
+
+const NUMERIC_SPACE_ID_PATTERN = /^[1-9][0-9]{0,19}$/
+const SPACE_STATUSES = ['current', 'archived'] as const
+
+function normalizedConfluenceSpaceKey(value: string): string {
+  const spaceKey = value.trim()
+  if (!spaceKey || spaceKey.length > 255 || spaceKey.includes('\0')) {
+    throw new ConfluenceOperationError('Invalid Confluence space key', 400)
+  }
+  return spaceKey
+}
+
+async function findConfluenceSpaceByKey(
+  client: ConfluenceClient,
+  spaceKey: string,
+  signal?: AbortSignal
+): Promise<JsonObject | null> {
+  for (const status of SPACE_STATUSES) {
+    const query = new URLSearchParams({ keys: spaceKey, limit: '1', status })
+    const data = await client.json(client.apiV2(`/spaces?${query}`), {}, signal)
+    const match = asArray(data.results)
+      .map(asObject)
+      .find((space) => space.key === spaceKey)
+    if (match) return match
+  }
+  return null
+}
+
+async function resolveConfluenceSpaceId(
+  client: ConfluenceClient,
+  value: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const spaceIdentifier = value.trim()
+  if (NUMERIC_SPACE_ID_PATTERN.test(spaceIdentifier)) return spaceIdentifier
+
+  const spaceKey = normalizedConfluenceSpaceKey(spaceIdentifier)
+  const space = await findConfluenceSpaceByKey(client, spaceKey, signal)
+  const resolvedId = space?.id
+  if (
+    (typeof resolvedId !== 'string' && typeof resolvedId !== 'number') ||
+    !NUMERIC_SPACE_ID_PATTERN.test(String(resolvedId))
+  ) {
+    throw new ConfluenceOperationError(`Confluence space key "${spaceKey}" was not found`, 404)
+  }
+  return String(resolvedId)
+}
+
+async function resolveConfluenceSpaceKey(
+  client: ConfluenceClient,
+  value: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const spaceIdentifier = normalizedConfluenceSpaceKey(value)
+  if (!NUMERIC_SPACE_ID_PATTERN.test(spaceIdentifier)) return spaceIdentifier
+
+  const space = await client.json(client.apiV2(`/spaces/${spaceIdentifier}`), {}, signal)
+  if (typeof space.key !== 'string' || !space.key) {
+    throw new ConfluenceOperationError(
+      `Confluence space ID "${spaceIdentifier}" did not return a space key`,
+      422
+    )
+  }
+  return space.key
 }
 
 export async function executeConfluenceRetrievePage(
@@ -208,17 +274,11 @@ export async function executeConfluenceCreatePage(
   input: ConfluenceCreatePageBody,
   context: ConfluenceOperationContext
 ) {
-  if (!/^\d+$/.test(String(input.spaceId))) {
-    throw new ConfluenceOperationError(
-      'Invalid Space ID. The Space ID must be a numeric value, not the space key from the URL. Use the "list" operation to get all spaces with their numeric IDs.',
-      400
-    )
-  }
-  assertId(input.spaceId, 'spaceId')
-  if (input.parentId) assertId(input.parentId, 'parentId')
   const client = await createConfluenceClient(input, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
+  if (input.parentId) assertId(input.parentId, 'parentId')
   const body: JsonObject = {
-    spaceId: input.spaceId,
+    spaceId,
     status: 'current',
     title: input.title,
     body: { representation: 'storage', value: input.content },
@@ -853,9 +913,9 @@ export async function executeConfluenceSearchInSpace(
   input: ConfluenceSearchInSpaceBody,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceKey, 'spaceKey')
   const client = await createConfluenceClient(input, context.signal)
-  let cql = `space = "${escapeCql(input.spaceKey)}"`
+  const spaceKey = await resolveConfluenceSpaceKey(client, input.spaceKey, context.signal)
+  let cql = `space = "${escapeCql(spaceKey)}"`
   if (input.query) cql += ` AND text ~ "${escapeCql(input.query)}"`
   if (input.contentType) cql += ` AND type = "${escapeCql(input.contentType)}"`
   const query = new URLSearchParams({ cql, limit: cappedLimit(input.limit) })
@@ -873,21 +933,21 @@ export async function executeConfluenceSearchInSpace(
       lastModified: result.lastModified ?? null,
     }
   })
-  return { results, spaceKey: input.spaceKey, totalSize: data.totalSize ?? results.length }
+  return { results, spaceKey, totalSize: data.totalSize ?? results.length }
 }
 
 export async function executeConfluenceListBlogPostsInSpace(
   input: ConfluenceSpaceBlogPostsBody,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceId, 'spaceId')
   const client = await createConfluenceClient(input, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
   const query = new URLSearchParams({ limit: cappedLimit(input.limit) })
   if (input.status) query.set('status', input.status)
   if (input.bodyFormat) query.set('body-format', input.bodyFormat)
   if (input.cursor) query.set('cursor', input.cursor)
   const data = await client.json(
-    client.apiV2(`/spaces/${input.spaceId}/blogposts?${query}`),
+    client.apiV2(`/spaces/${spaceId}/blogposts?${query}`),
     {},
     context.signal
   )
@@ -914,14 +974,14 @@ export async function executeConfluenceListPagesInSpace(
   input: ConfluenceSpacePagesBody,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceId, 'spaceId')
   const client = await createConfluenceClient(input, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
   const query = new URLSearchParams({ limit: cappedLimit(input.limit) })
   if (input.status) query.set('status', input.status)
   if (input.bodyFormat) query.set('body-format', input.bodyFormat)
   if (input.cursor) query.set('cursor', input.cursor)
   const data = await client.json(
-    client.apiV2(`/spaces/${input.spaceId}/pages?${query}`),
+    client.apiV2(`/spaces/${spaceId}/pages?${query}`),
     {},
     context.signal
   )
@@ -938,12 +998,12 @@ export async function executeConfluenceListSpaceLabels(
   input: ConfluenceSpaceLabelsQuery,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceId, 'spaceId')
   const client = await createConfluenceClient(input, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
   const query = new URLSearchParams({ limit: cappedLimit(input.limit) })
   if (input.cursor) query.set('cursor', input.cursor)
   const data = await client.json(
-    client.apiV2(`/spaces/${input.spaceId}/labels?${query}`),
+    client.apiV2(`/spaces/${spaceId}/labels?${query}`),
     {},
     context.signal
   )
@@ -952,7 +1012,7 @@ export async function executeConfluenceListSpaceLabels(
       const label = asObject(value)
       return { id: label.id, name: label.name, prefix: label.prefix || 'global' }
     }),
-    spaceId: input.spaceId,
+    spaceId,
     nextCursor: nextCursor(data),
   }
 }
@@ -961,13 +1021,13 @@ export async function executeConfluenceListSpacePermissions(
   input: ConfluenceSpacePermissionsBody,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceId, 'spaceId')
   assertCursor(input.cursor)
   const client = await createConfluenceClient(input, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
   const query = new URLSearchParams({ limit: cappedLimit(input.limit) })
   if (input.cursor) query.set('cursor', input.cursor)
   const data = await client.json(
-    client.apiV2(`/spaces/${input.spaceId}/permissions?${query}`),
+    client.apiV2(`/spaces/${spaceId}/permissions?${query}`),
     {},
     context.signal
   )
@@ -984,7 +1044,7 @@ export async function executeConfluenceListSpacePermissions(
         unlicensedAccess: permission.unlicensedAccess ?? false,
       }
     }),
-    spaceId: input.spaceId,
+    spaceId,
     nextCursor: nextCursor(data),
   }
 }
@@ -1025,10 +1085,11 @@ export async function executeConfluenceCreateBlogPost(
     throw new ConfluenceOperationError('Invalid create blog post request', 400)
   }
   const client = await createConfluenceClient(input, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
   const data = await client.json(
     client.apiV2('/blogposts'),
     jsonInit('POST', {
-      spaceId: input.spaceId,
+      spaceId,
       status: input.status || 'current',
       title: input.title,
       body: { representation: 'storage', value: input.content },
@@ -1123,9 +1184,9 @@ export async function executeConfluenceGetSpace(
   input: ConfluenceGetSpaceQuery,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceId, 'spaceId')
   const client = await createConfluenceClient(input, context.signal)
-  return client.json(client.apiV2(`/spaces/${input.spaceId}`), {}, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
+  return client.json(client.apiV2(`/spaces/${spaceId}`), {}, context.signal)
 }
 
 export async function executeConfluenceCreateSpace(
@@ -1144,7 +1205,6 @@ export async function executeConfluenceUpdateSpace(
   input: ConfluenceUpdateSpaceBody,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceId, 'spaceId')
   if (!input.name && input.description === undefined) {
     throw new ConfluenceOperationError(
       'At least one of name or description is required for update',
@@ -1152,7 +1212,8 @@ export async function executeConfluenceUpdateSpace(
     )
   }
   const client = await createConfluenceClient(input, context.signal)
-  const current = await client.json(client.apiV2(`/spaces/${input.spaceId}`), {}, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
+  const current = await client.json(client.apiV2(`/spaces/${spaceId}`), {}, context.signal)
   const body: JsonObject = { name: input.name || current.name }
   if (input.description !== undefined) {
     body.description = { plain: { value: input.description, representation: 'plain' } }
@@ -1168,9 +1229,9 @@ export async function executeConfluenceDeleteSpace(
   input: ConfluenceDeleteSpaceBody,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceId, 'spaceId')
   const client = await createConfluenceClient(input, context.signal)
-  const current = await client.json(client.apiV2(`/spaces/${input.spaceId}`), {}, context.signal)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
+  const current = await client.json(client.apiV2(`/spaces/${spaceId}`), {}, context.signal)
   const response = await client.fetch(
     client.rest(`/space/${encodeURIComponent(String(current.key))}`),
     { method: 'DELETE' },
@@ -1190,7 +1251,7 @@ export async function executeConfluenceDeleteSpace(
     context.signal?.throwIfAborted()
   }
   return {
-    spaceId: input.spaceId,
+    spaceId,
     deleted: true,
     longTaskId: longTask.id,
     longTaskStatusLink: nested(longTask, 'links', 'status'),
@@ -1228,16 +1289,16 @@ export async function executeConfluenceSpaceProperties(
   input: ConfluenceSpacePropertiesBody,
   context: ConfluenceOperationContext
 ) {
-  assertId(input.spaceId, 'spaceId')
   const client = await createConfluenceClient(input, context.signal)
-  const base = client.apiV2(`/spaces/${input.spaceId}/properties`)
+  const spaceId = await resolveConfluenceSpaceId(client, input.spaceId, context.signal)
+  const base = client.apiV2(`/spaces/${spaceId}/properties`)
   if (input.action === 'delete') {
     if (!input.propertyId) {
       throw new ConfluenceOperationError('Property ID is required for delete action', 400)
     }
     assertId(input.propertyId, 'propertyId')
     await client.delete(`${base}/${encodeURIComponent(input.propertyId)}`, context.signal)
-    return { spaceId: input.spaceId, propertyId: input.propertyId, deleted: true }
+    return { spaceId, propertyId: input.propertyId, deleted: true }
   }
   if (input.action === 'create') {
     if (!input.key) {
@@ -1248,7 +1309,7 @@ export async function executeConfluenceSpaceProperties(
       jsonInit('POST', { key: input.key, value: input.value ?? {} }),
       context.signal
     )
-    return { propertyId: data.id, key: data.key, value: data.value ?? null, spaceId: input.spaceId }
+    return { propertyId: data.id, key: data.key, value: data.value ?? null, spaceId }
   }
   assertCursor(input.cursor)
   const query = new URLSearchParams({ limit: cappedLimit(input.limit) })
@@ -1259,7 +1320,7 @@ export async function executeConfluenceSpaceProperties(
       const property = asObject(value)
       return { id: property.id, key: property.key, value: property.value ?? null }
     }),
-    spaceId: input.spaceId,
+    spaceId,
     nextCursor: nextCursor(data),
   }
 }

--- a/apps/sim/lib/selectors/server/providers/confluence.test.ts
+++ b/apps/sim/lib/selectors/server/providers/confluence.test.ts
@@ -127,6 +127,25 @@ describe('Confluence server selector adapters', () => {
     expect(String(mockFetch.mock.calls[0]?.[0])).toContain('/wiki/api/v2/spaces/12345')
   })
 
+  it('hydrates a legacy numeric value in the key selector without rewriting it', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: '12345', key: 'ENG', name: 'Engineering' }), {
+        status: 200,
+      })
+    )
+
+    await expect(
+      confluenceSelectorAttachments['confluence.spaces'].execute({
+        ...spaceDetailArgs(),
+        request: { kind: 'detail', id: '12345' },
+      })
+    ).resolves.toEqual({
+      kind: 'detail',
+      item: { id: '12345', label: 'Engineering (ENG)' },
+    })
+    expect(String(mockFetch.mock.calls[0]?.[0])).toContain('/wiki/api/v2/spaces/12345')
+  })
+
   it('projects provider IDs for block space lists while key selectors remain unchanged', async () => {
     mockFetch
       .mockResolvedValueOnce(

--- a/apps/sim/lib/selectors/server/providers/confluence.ts
+++ b/apps/sim/lib/selectors/server/providers/confluence.ts
@@ -124,7 +124,7 @@ async function executeSpaces(args: ExecuteServerSelectorArgs, identifier: 'key' 
   if (args.request.kind === 'detail') {
     const requestedId = args.request.id.trim()
     if (!requestedId || requestedId.length > 255) throw new SelectorContextUnavailableError()
-    if (identifier === 'id' && /^[1-9][0-9]{0,19}$/.test(requestedId)) {
+    if (/^[1-9][0-9]{0,19}$/.test(requestedId)) {
       const space = await fetchProviderJson<ConfluenceSpace>(
         `https://api.atlassian.com/ex/confluence/${auth.cloudId}/wiki/api/v2/spaces/${requestedId}`,
         {
@@ -133,7 +133,10 @@ async function executeSpaces(args: ExecuteServerSelectorArgs, identifier: 'key' 
         }
       )
       if (!space.id || !space.key || !space.name) throw new SelectorOptionsUnavailableError()
-      return detailSelectorResult(spaceOption(space, space.status ?? 'current', 'id'))
+      return detailSelectorResult({
+        ...spaceOption(space, space.status ?? 'current', identifier),
+        id: requestedId,
+      })
     }
 
     const key = requestedId

--- a/apps/sim/lib/workflows/migrations/subblock-migrations.ts
+++ b/apps/sim/lib/workflows/migrations/subblock-migrations.ts
@@ -140,6 +140,14 @@ export const SUBBLOCK_ID_MIGRATIONS: Record<string, readonly SubblockIdMigration
     { from: 'folderId', to: 'folderSelector' },
     { from: 'listId', to: 'listSelector' },
   ],
+  confluence_v2: [
+    {
+      from: 'spaceSelector',
+      to: 'spaceKeySelector',
+      whenOperation: ['search_in_space'],
+    },
+    { from: 'spaceId', to: 'manualSpaceKey', whenOperation: ['search_in_space'] },
+  ],
   apollo: [
     { from: 'contact_ids_bulk', to: 'contacts' },
     { from: 'account_ids_bulk', to: 'accounts' },


### PR DESCRIPTION
## Summary

Fixes Confluence workflow failures caused by mixing human-readable space keys with numeric Confluence Cloud space IDs.

The mismatch pre-existed PR #7185: selectors could save a key such as `ENG`, while the Confluence V2 runtime paths and bodies require the numeric space ID. This PR:

- keeps numeric-ID selector semantics for V2 operations;
- gives `search_in_space` a key-based selector because V1 CQL searches by space key;
- migrates legacy saved search fields without changing public tool contracts;
- resolves legacy keys to numeric IDs for V2 calls, and legacy numeric IDs to keys for V1 search;
- checks current and archived spaces and requires an exact key match;
- leaves Confluence connectors unchanged because their CQL and sync behavior intentionally uses space keys.

### Affected operations

Numeric V2 ID semantics:

- `create_page`
- `get_space`
- `update_space`
- `delete_space`
- `list_pages_in_space`
- `create_blogpost`
- `list_blogposts_in_space`
- `list_space_labels`
- `list_space_permissions`
- `list_space_properties`
- `create_space_property`
- `delete_space_property`

Key semantics:

- `search_in_space`

### Atlassian API evidence

- [V2 Space API](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/) documents numeric IDs for space paths and supports filtering the space collection by key.
- [V2 Page API](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/) documents an integer space path ID for pages in a space.
- [V2 Blog Post API](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-blog-post/) documents an integer space path ID and `spaceId` request fields.
- [V2 Space Properties API](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space-properties/) uses space IDs in property paths.
- [V1 Search API](https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-search/) accepts CQL.
- [CQL Space field](https://developer.atlassian.com/cloud/confluence/cql-fields/#space) explicitly searches by space key.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

Focused behavior-level coverage was added without duplicating every operation:

- legacy basic and advanced search values migrate, serialize, and reach the tool as `spaceKey`;
- a representative V2 operation resolves `ENG` to `12345`, uses `/spaces/12345/pages`, and passes numeric `12345` through without lookup;
- legacy numeric search input resolves to `ENG` before constructing key-based V1 CQL.

Validation completed:

- `bun run test -- blocks/blocks/confluence.test.ts lib/internal/confluence/operations.test.ts lib/internal/confluence/execute-tool.test.ts lib/selectors/server/providers/confluence.test.ts connectors/confluence/confluence.test.ts blocks/blocks.test.ts` — 6 files, 199 tests passed
- `bun run apps/sim/scripts/check-canvas-sentences.ts --block=confluence_v2` — 46/46 passed
- targeted Biome checks — passed
- `bun run type-check` — passed
- `bun run check:api-validation` — passed
- `git diff --check` — passed

Browser validation was attempted, but the stored Confluence OAuth credential returned Atlassian HTTP 401. No live provider result or screenshots are included; the PR was opened after that browser gate was explicitly waived.

Reviewers should focus on selector value semantics, the search-only subblock migration, exact-match legacy normalization, and unchanged connector behavior.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Not included: live browser validation was blocked by the expired Confluence OAuth credential.