### PR TITLE
fix(selectors): paginate HubSpot list options

### DIFF
--- a/apps/sim/lib/selectors/manifest.ts
+++ b/apps/sim/lib/selectors/manifest.ts
@@ -159,7 +159,7 @@ export const selectorManifest = {
     readiness: { all: ['oauthCredential', 'spreadsheetId'] },
   }),
   'harmonic.savedSearches': providerSelector([], { detail: true, unknownDetail: true }),
-  'hubspot.lists': providerSelector(),
+  'hubspot.lists': providerSelector([], { listMode: 'paginated', search: true, detail: true }),
   'hubspot.owners': providerSelector(),
   'hubspot.pipelines': providerSelector(['objectType', 'customObjectTypeId']),
   'hubspot.pipelineStages': providerSelector(['objectType', 'customObjectTypeId', 'pipelineId'], {

--- a/apps/sim/lib/selectors/server/providers/hubspot.test.ts
+++ b/apps/sim/lib/selectors/server/providers/hubspot.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment node
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockFetch, mockResolveSelectorOAuthAccessToken } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockResolveSelectorOAuthAccessToken: vi.fn(),
+}))
+
+vi.mock('@/lib/selectors/server/credentials', () => ({
+  resolveSelectorOAuthAccessToken: mockResolveSelectorOAuthAccessToken,
+}))
+
+import { createSelectorProtectedValues } from '@/lib/selectors/server/protected-values'
+import { hubspotSelectorAttachments } from '@/lib/selectors/server/providers/hubspot'
+import type { ExecuteServerSelectorArgs } from '@/lib/selectors/server/types'
+
+function args(request: ExecuteServerSelectorArgs['request']): ExecuteServerSelectorArgs {
+  return {
+    selectorKey: 'hubspot.lists',
+    context: { oauthCredential: 'credential-1' },
+    request,
+    scope: { kind: 'workspace', workspaceId: 'workspace-1' },
+    workspaceId: 'workspace-1',
+    principal: { kind: 'session', userId: 'user-1', sessionId: 'session-1' },
+    requesterUserId: 'user-1',
+    credential: { suppliedId: 'credential-1' },
+    references: new Map(),
+    protectedValues: createSelectorProtectedValues(),
+  }
+}
+
+describe('HubSpot server selector adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', mockFetch)
+    mockResolveSelectorOAuthAccessToken.mockResolvedValue('server-only-token')
+  })
+
+  afterAll(() => vi.unstubAllGlobals())
+
+  it('preserves list search and follows the response offset on demand', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            hasMore: true,
+            lists: [{ listId: 'list-1', name: 'Revenue prospects' }],
+            offset: 500,
+            total: 501,
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            hasMore: false,
+            lists: [{ listId: 'list-2', name: 'Revenue customers' }],
+            offset: 501,
+            total: 501,
+          }),
+          { status: 200 }
+        )
+      )
+
+    const first = await hubspotSelectorAttachments['hubspot.lists'].execute(
+      args({ kind: 'list', search: '  Revenue  ' })
+    )
+    const second = await hubspotSelectorAttachments['hubspot.lists'].execute(
+      args({ kind: 'list', search: '  Revenue  ', cursor: '500' })
+    )
+
+    expect(first).toEqual({
+      kind: 'list',
+      items: [{ id: 'list-1', label: 'Revenue prospects' }],
+      nextCursor: '500',
+    })
+    expect(second).toEqual({
+      kind: 'list',
+      items: [{ id: 'list-2', label: 'Revenue customers' }],
+    })
+    expect(String(mockFetch.mock.calls[0]?.[0])).toBe('https://api.hubapi.com/crm/v3/lists/search')
+    expect(JSON.parse(String(mockFetch.mock.calls[0]?.[1]?.body))).toEqual({
+      count: 500,
+      offset: 0,
+      query: 'Revenue',
+      processingTypes: ['MANUAL', 'DYNAMIC', 'SNAPSHOT'],
+    })
+    expect(JSON.parse(String(mockFetch.mock.calls[1]?.[1]?.body))).toEqual({
+      count: 500,
+      offset: 500,
+      query: 'Revenue',
+      processingTypes: ['MANUAL', 'DYNAMIC', 'SNAPSHOT'],
+    })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('hydrates a selected list directly by id', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ list: { listId: '123', name: 'Revenue prospects' } }), {
+        status: 200,
+      })
+    )
+
+    await expect(
+      hubspotSelectorAttachments['hubspot.lists'].execute(args({ kind: 'detail', id: '123' }))
+    ).resolves.toEqual({
+      kind: 'detail',
+      item: { id: '123', label: 'Revenue prospects' },
+    })
+    expect(String(mockFetch.mock.calls[0]?.[0])).toBe('https://api.hubapi.com/crm/v3/lists/123')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/sim/lib/selectors/server/providers/hubspot.ts
+++ b/apps/sim/lib/selectors/server/providers/hubspot.ts
@@ -1,4 +1,6 @@
+import { z } from 'zod'
 import { getScopesForService } from '@/lib/oauth/utils'
+import { MAX_SELECTOR_OPTIONS } from '@/lib/selectors/limits'
 import type { ServerSelectorKey } from '@/lib/selectors/manifest'
 import { resolveSelectorOAuthAccessToken } from '@/lib/selectors/server/credentials'
 import {
@@ -8,6 +10,7 @@ import {
 } from '@/lib/selectors/server/errors'
 import { fetchProviderJson } from '@/lib/selectors/server/providers/provider-http'
 import {
+  detailSelectorResult,
   type ExecuteServerSelectorArgs,
   listSelectorResult,
   requireListRequest,
@@ -29,6 +32,24 @@ const BUILT_IN_PATH: Record<string, string> = {
   deal: 'deals',
   ticket: 'tickets',
 }
+
+const HUBSPOT_LISTS_PAGE_SIZE = 500
+
+const hubspotListSchema = z.object({
+  listId: z.string().min(1).max(100),
+  name: z.string().min(1).max(1_000),
+  deletedAt: z.string().nullable().optional(),
+})
+
+const hubspotListsPageSchema = z.object({
+  hasMore: z.boolean(),
+  lists: z.array(hubspotListSchema).max(HUBSPOT_LISTS_PAGE_SIZE),
+  offset: z.number().int().nonnegative(),
+})
+
+const hubspotListDetailSchema = z.object({
+  list: hubspotListSchema,
+})
 
 function resolveObjectType(args: ExecuteServerSelectorArgs): string | null {
   const selected = args.context.objectType ?? 'contact'
@@ -78,27 +99,55 @@ async function executeProperties(args: ExecuteServerSelectorArgs) {
 }
 
 async function executeLists(args: ExecuteServerSelectorArgs) {
-  requireListRequest(args.selectorKey, args.request)
   const accessToken = await hubspotToken(args)
-  const data = await fetchProviderJson<{
-    lists?: Array<{ listId: string; name: string; deletedAt?: string | null }>
-  }>('https://api.hubapi.com/crm/v3/lists/search?count=500', {
+  if (args.request.kind === 'detail') {
+    const listId = args.request.id.trim()
+    if (!listId || listId.length > 100) throw new SelectorContextUnavailableError()
+    const body = await fetchProviderJson<unknown>(
+      `https://api.hubapi.com/crm/v3/lists/${encodeURIComponent(listId)}`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal: args.signal,
+      }
+    )
+    const parsed = hubspotListDetailSchema.safeParse(body)
+    if (!parsed.success) throw new SelectorOptionsUnavailableError()
+    const list = parsed.data.list
+    return detailSelectorResult(list.deletedAt ? null : { id: args.request.id, label: list.name })
+  }
+
+  requireListRequest(args.selectorKey, args.request)
+  const cursor = args.request.cursor
+  if (cursor && !/^\d{1,10}$/.test(cursor)) throw new SelectorContextUnavailableError()
+  const offset = cursor ? Number(cursor) : 0
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset > MAX_SELECTOR_OPTIONS) {
+    throw new SelectorContextUnavailableError()
+  }
+  const search = args.request.search?.trim()
+  const body = await fetchProviderJson<unknown>('https://api.hubapi.com/crm/v3/lists/search', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      query: '',
+      count: HUBSPOT_LISTS_PAGE_SIZE,
+      offset,
+      ...(search ? { query: search } : {}),
       processingTypes: ['MANUAL', 'DYNAMIC', 'SNAPSHOT'],
     }),
     signal: args.signal,
   })
+  const parsed = hubspotListsPageSchema.safeParse(body)
+  if (!parsed.success) throw new SelectorOptionsUnavailableError()
+  const data = parsed.data
+  if (data.hasMore && data.offset <= offset) throw new SelectorOptionsUnavailableError()
   return listSelectorResult(
-    (data.lists ?? [])
+    data.lists
       .filter((list) => !list.deletedAt && list.listId && list.name)
       .map((list) => ({ id: list.listId, label: list.name }))
-      .sort((left, right) => left.label.localeCompare(right.label))
+      .sort((left, right) => left.label.localeCompare(right.label)),
+    data.hasMore ? String(data.offset) : undefined
   )
 }
 

--- a/apps/sim/lib/selectors/server/providers/pipedrive.test.ts
+++ b/apps/sim/lib/selectors/server/providers/pipedrive.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment node
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockFetch, mockResolveSelectorCredentialBundle } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  mockResolveSelectorCredentialBundle: vi.fn(),
+}))
+
+vi.mock('@/lib/selectors/server/providers/credential-bundle', () => ({
+  resolveSelectorCredentialBundle: mockResolveSelectorCredentialBundle,
+}))
+
+import { createSelectorProtectedValues } from '@/lib/selectors/server/protected-values'
+import { pipedriveSelectorAttachments } from '@/lib/selectors/server/providers/pipedrive'
+import type { ExecuteServerSelectorArgs } from '@/lib/selectors/server/types'
+
+function args(): ExecuteServerSelectorArgs {
+  return {
+    selectorKey: 'pipedrive.pipelines',
+    context: { oauthCredential: 'credential-1' },
+    request: { kind: 'list' },
+    scope: { kind: 'workspace', workspaceId: 'workspace-1' },
+    workspaceId: 'workspace-1',
+    principal: { kind: 'session', userId: 'user-1', sessionId: 'session-1' },
+    requesterUserId: 'user-1',
+    credential: { suppliedId: 'credential-1' },
+    references: new Map(),
+    protectedValues: createSelectorProtectedValues(),
+  }
+}
+
+describe('Pipedrive server selector adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', mockFetch)
+    mockResolveSelectorCredentialBundle.mockResolvedValue({ accessToken: 'server-only-token' })
+  })
+
+  afterAll(() => vi.unstubAllGlobals())
+
+  it('rejects a semantic failure instead of returning an empty pipeline list', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Requested service is not available',
+          error_info: 'Please check developers.pipedrive.com',
+          data: null,
+          additional_data: null,
+        }),
+        { status: 200 }
+      )
+    )
+
+    await expect(
+      pipedriveSelectorAttachments['pipedrive.pipelines'].execute(args())
+    ).rejects.toMatchObject({ name: 'SelectorOptionsUnavailableError' })
+  })
+})

--- a/apps/sim/triggers/hubspot/poller.ts
+++ b/apps/sim/triggers/hubspot/poller.ts
@@ -63,6 +63,7 @@ export const hubspotPollingTrigger: TriggerConfig = {
       description: 'The HubSpot list to watch for new members.',
       placeholder: 'Select a list',
       dependsOn: ['triggerCredentials'],
+      searchable: true,
       required: { field: 'objectType', value: 'list_membership' },
       mode: 'trigger',
       condition: { field: 'objectType', value: 'list_membership' },


### PR DESCRIPTION
## Summary

Fixes HubSpot list selectors so they use the documented search request body, follow HubSpot's continuation offset, and hydrate saved list labels directly by ID. The HubSpot list-membership trigger now exposes server-side search.

Pipedrive runtime behavior is unchanged because #7185 already validates its response envelope; this PR adds focused regression coverage proving an HTTP-success response with `success: false` raises the public selector error instead of becoming an empty list.

Related: #7185

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- `bun run --cwd apps/sim test lib/selectors/server/providers/hubspot.test.ts lib/selectors/server/providers/pipedrive.test.ts lib/selectors/manifest.test.ts hooks/queries/selectors.test.tsx` — 4 files, 19 tests passed.
- `bun run type-check` — 26/26 tasks passed.
- `bun run lint:check` — 26/26 tasks passed; no fixes applied.
- `bun run check:api-validation` — passed with 637/637 routes Zod-backed.
- `bun run test` — final run passed all 19 Turbo tasks; the Sim app reported 2,774 files and 38,328 tests passed (7 files and 67 tests skipped).

Provider behavior coverage is intentionally limited to three tests:

1. Pipedrive rejects an HTTP 200 envelope with `success: false`.
2. HubSpot sends `count`, trimmed `query`, and numeric `offset` in the search body, uses the first response's offset for page two, and omits the terminal cursor.
3. HubSpot fetches a selected list directly by ID for label hydration.

Live Chrome verification used a HubSpot trial portal, a temporary private app scoped only to `crm.lists.read`, and one static list named `Sim CRM selector QA 20260831-1710`. In a disposable workflow on the isolated port-3004 app:

- Exact-name server search returned the list once.
- The list was selectable.
- Reload issued a successful `hubspot.lists` detail request and preserved the label.
- No selector error appeared in the UI or browser logs.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Not applicable; this is a behavioral selector fix with no visual design change.
