### PR TITLE
fix(cron): derive async job retention cutoffs from one clock read

### DIFF
--- a/apps/sim/app/api/cron/cleanup-stale-executions/route.ts
+++ b/apps/sim/app/api/cron/cleanup-stale-executions/route.ts
@@ -504,9 +504,10 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       })
     }
 
-    const retentionThreshold = new Date(Date.now() - JOB_RETENTION_HOURS * 60 * 60 * 1000)
+    const retentionNow = Date.now()
+    const retentionThreshold = new Date(retentionNow - JOB_RETENTION_HOURS * 60 * 60 * 1000)
     const irrecoverableCarrierRetentionThreshold = new Date(
-      Date.now() - SCHEDULE_CARRIER_IRRECOVERABLE_RETENTION_HOURS * 60 * 60 * 1000
+      retentionNow - SCHEDULE_CARRIER_IRRECOVERABLE_RETENTION_HOURS * 60 * 60 * 1000
     )
     let asyncJobsDeleted = 0
 


### PR DESCRIPTION
## Summary
- The stale-execution cleanup cron computed the async-job retention cutoff and the irrecoverable schedule-carrier cutoff from two separate `Date.now()` calls, so a millisecond tick between the statements skewed the gap between the two windows by 1 ms.
- Snapshot the clock once and derive both cutoffs from it, which also un-flakes `cleanup-stale-executions/route.test.ts` (it asserts the gap equals the constant difference).

## Type of Change
- [x] Bug fix

## Testing
Tested manually — `vitest run app/api/cron/cleanup-stale-executions/route.test.ts` (15/15), `bun run lint`, block-registry check, and `bun run check:audits` (39 audits) all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)