### PR TITLE
improvement(integrations): refine Slack AEO content

### DIFF
--- a/apps/sim/app/(landing)/integrations/(shell)/[slug]/page.tsx
+++ b/apps/sim/app/(landing)/integrations/(shell)/[slug]/page.tsx
@@ -893,6 +893,34 @@ export default async function IntegrationPage({ params }: { params: Promise<{ sl
           </section>
         )}
 
+        {seo?.narrativeComparison && (
+          <>
+            <section
+              id={seo.narrativeComparison.id}
+              aria-labelledby={`${seo.narrativeComparison.id}-heading`}
+              className='px-6 py-10'
+            >
+              <h2
+                id={`${seo.narrativeComparison.id}-heading`}
+                className='mb-4 text-[var(--text-primary)] text-xl leading-[100%] tracking-[-0.02em]'
+              >
+                {seo.narrativeComparison.heading}
+              </h2>
+              <div className='max-w-[900px] space-y-4'>
+                {seo.narrativeComparison.paragraphs.map((paragraph) => (
+                  <p
+                    key={paragraph}
+                    className='text-[var(--text-body)] text-sm leading-[150%] tracking-[0.02em]'
+                  >
+                    {paragraph}
+                  </p>
+                ))}
+              </div>
+            </section>
+            <div className='h-px w-full bg-[var(--border)]' />
+          </>
+        )}
+
         {/* FAQ - full width */}
         <section aria-labelledby='faq-heading' className='px-6 py-10'>
           <h2

--- a/apps/sim/app/(landing)/integrations/data/seo-content.ts
+++ b/apps/sim/app/(landing)/integrations/data/seo-content.ts
@@ -62,13 +62,53 @@ export const INTEGRATION_SEO: Record<string, IntegrationSeoContent> = {
     tagline:
       'Build Slack workflow automation in Sim. Send, update, delete, and read messages; manage channels, users, canvases, and modals; and trigger AI agents from mentions, messages, and reactions in real time.',
     overview:
-      'Sim automates Slack workflows that depend on conversation context, including message routing, alerts, thread summaries, ticket updates, and incident response. Slack messages and events start agent workflows that interpret what was said and choose the next action in Slack or a connected tool, so routine coordination and time-sensitive operations keep moving without anyone relaying details by hand.',
+      'Sim automates Slack workflows that route messages, trigger alerts, summarize threads, update tickets, and manage incident response. Slack messages and events start agent workflows that interpret what was said and choose the next action in Slack or a connected tool, so routine coordination and time-sensitive operations keep moving without anyone relaying details by hand.',
     triggersIntro:
       'Sim supports one real-time Slack trigger. Select the Slack events you care about, such as mentions, messages, and reactions, and Sim starts the connected workflow the moment one arrives instead of waiting for a scheduled check. A monitoring alert posted in Slack can open an incident-response workflow, and a ticketing update posted in Slack can be summarised and passed to another connected tool.',
     templatesIntro:
       'Pre-built agent templates turn common Slack workflows into editable starting points: routing templates classify messages and send them to the right channel or owner, summarisation templates condense long threads into updates that preserve decisions and action items, and ticket sync and incident response templates update connected records and coordinate follow-up. Every template is editable, so you can adapt its channels, routing rules, data sources, and approval requirements.',
     toolsSubtitleSuffix:
       ' across messaging, channels, threads, users, reactions and files, and canvases and views. Combine multiple Slack actions in one workflow to summarise a message, route it, update a ticket, and post the ticket update back in Slack',
+    narrativeComparison: {
+      id: 'slack-automation-comparison',
+      heading: 'Slack automation with Sim vs. Zapier, Make, and n8n',
+      paragraphs: [
+        'Sim is built for Slack workflows that need to interpret conversation context before choosing an action. A Sim agent can summarize a thread and determine whether it describes an incident before using a configured Slack or ticketing action.',
+        'Zapier, Make, and n8n are useful substitutes for predefined trigger-action sequences with known conditions and branches. Choose that model when each event should produce a predictable result. For example, a simple rule that posts every new message from channel X to channel Y works well as a fixed chain because it does not require interpretation. Choose Sim when the next action depends on the meaning of a Slack conversation rather than fixed keywords or predetermined branches.',
+      ],
+    },
+    faqs: [
+      {
+        question: 'What Slack workflows can Sim automate?',
+        answer:
+          'Slack workflow automation uses messages and channel events to start work in connected tools. Sim can route Slack messages, trigger alerts, summarize threads, update tickets, and coordinate incident response. You can use Sim to turn Slack conversations into tracked work without manually copying details.',
+      },
+      {
+        question: 'How does routing and alerting work in Sim?',
+        answer:
+          'Routing and alerting send selected Slack messages to the people or channels responsible for responding. Sim uses Slack events and workflow logic to route a message or send an alert based on its content. This directs requests and incidents without requiring someone to monitor every channel.',
+      },
+      {
+        question: 'Can Sim summarize Slack threads?',
+        answer:
+          'Thread summarization condenses a Slack conversation into its main points and relevant context. Sim can read a Slack thread and send the resulting summary to another Slack channel or a workflow that uses connected tools.',
+      },
+      {
+        question: 'How does Sim update tickets from Slack?',
+        answer:
+          'A Slack-to-ticket workflow transfers conversation details into a connected ticketing tool. Sim can pass information from a Slack message or thread to the ticketing tool and update the matching record. You can use Sim to keep tickets current without entering the same information twice.',
+      },
+      {
+        question: 'Does Sim support incident response in Slack?',
+        answer:
+          'Incident response workflows use Slack events to start response steps and coordinate follow-up. Sim can trigger an incident workflow from Slack and pass relevant context to connected response tools. This keeps responders informed and incident records current as the conversation develops.',
+      },
+      {
+        question: 'What is the difference between Sim and Zapier for Slack?',
+        answer:
+          'Zapier supports trigger-action automation, while Sim centers Slack automation on workflows that can include AI agents. Sim workflows can interpret a Slack incident thread before routing the relevant information or updating a ticket. You can use Sim when the workflow needs to understand conversation context before taking action.',
+      },
+    ],
   },
   'twilio-sms': {
     tagline:

--- a/apps/sim/app/(landing)/integrations/data/types.ts
+++ b/apps/sim/app/(landing)/integrations/data/types.ts
@@ -53,6 +53,12 @@ export interface IntegrationFaqContent {
   answer: string
 }
 
+export interface IntegrationNarrativeSectionContent {
+  id: string
+  heading: string
+  paragraphs: string[]
+}
+
 /**
  * Hand-authored, per-integration SEO/GEO overrides keyed by slug. Unlike
  * {@link IntegrationLandingContent}, this is consumed at render time directly by
@@ -83,6 +89,8 @@ export interface IntegrationSeoContent {
   templatesIntro?: string
   /** Optional comparison section rendered immediately before real-time triggers. */
   comparison?: IntegrationComparisonContent
+  /** Optional prose comparison rendered after the supported-tools list. */
+  narrativeComparison?: IntegrationNarrativeSectionContent
   /** Full FAQ replacement for integrations with hand-authored answers. */
   faqs?: IntegrationFaqContent[]
   /**


### PR DESCRIPTION
## Summary
- tighten the Slack overview with a direct, quotable workflow summary
- add a contextual Sim comparison and hand-authored Slack FAQs with varied closers

## Type of Change
- [x] Enhancement

## Testing
- Tested manually at desktop and mobile widths
- `bun run type-check --filter @sim/app`
- `bun run lint`
- `bun run check:audits`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)