### PR TITLE
fix(docker): allow pruned lockfile normalization

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -73,9 +73,13 @@ COPY --from=pruner /app/bun.lock ./bun.lock
 # resolved it from the registry at build time, which pulled a different major
 # (13.x vs the pinned 12.4.0) and bypassed the `minimumReleaseAge` supply-chain
 # gate in bunfig.toml on every production image build.
+#
+# This stage contains only the pruned workspace manifests, while the full lockfile
+# still describes every workspace. Bun must be allowed to normalize that lockfile
+# to the pruned graph; the full-repository CI install owns frozen-lockfile validation.
 RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
     --mount=type=cache,id=npm-cache,target=/root/.npm \
-    HUSKY=0 bun install --frozen-lockfile --ignore-scripts --linker=hoisted && \
+    HUSKY=0 bun install --ignore-scripts --linker=hoisted && \
     cd node_modules/isolated-vm && JOBS=4 /app/node_modules/.bin/node-gyp rebuild --release
 
 # ========================================

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -17,9 +17,11 @@ COPY packages/logger/package.json ./packages/logger/package.json
 COPY packages/tsconfig/package.json ./packages/tsconfig/package.json
 COPY packages/utils/package.json ./packages/utils/package.json
 
-# Install dependencies with cache mount for faster builds
+# Install dependencies with cache mount for faster builds. This stage contains
+# only the migration workspace manifests, so Bun must normalize the full root
+# lockfile to that subset; full-repository CI owns frozen-lockfile validation.
 RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
-    bun install --frozen-lockfile --ignore-scripts
+    bun install --ignore-scripts
 
 # ========================================
 # Runner Stage: Production Environment


### PR DESCRIPTION
## Summary

- remove frozen-lockfile enforcement from the app and migrations Docker dependency stages
- document why partial workspace manifests require Bun to normalize the full root lockfile
- retain the full-repository frozen install in test-build as the canonical lockfile consistency gate

## Why

PR #7343 added frozen-lockfile enforcement to Docker stages that intentionally copy only a subset of workspace manifests. The root bun.lock describes every workspace, so Bun 1.3.14 needs to remove unrelated workspace entries before installing the app or migration dependency graph. Freezing that expected normalization caused both image builds to fail with "lockfile had changes, but lockfile is frozen" and skipped image promotion.

Failed run: https://github.com/simstudioai/sim/actions/runs/33493411083/job/99810890876
Regression commit: https://github.com/simstudioai/sim/commit/fd061f50458dc9c566a116633667f849d7bf85ea

## Verification

- Bun 1.3.14 lockfile-only install for the Turbo-pruned @sim/app graph using the hoisted linker and linux/x64 target
- Bun 1.3.14 lockfile-only install for the migrations manifest subset using the linux/x64 target
- git diff --check