### PR TITLE
fix(selectors): paginate HubSpot owner options

### DIFF
--- a/apps/sim/lib/selectors/manifest.ts
+++ b/apps/sim/lib/selectors/manifest.ts
@@ -162,7 +162,7 @@ export const selectorManifest = {
   }),
   'harmonic.savedSearches': providerSelector([], { detail: true, unknownDetail: true }),
   'hubspot.lists': providerSelector([], { listMode: 'paginated', search: true, detail: true }),
-  'hubspot.owners': providerSelector(),
+  'hubspot.owners': providerSelector([], { listMode: 'paginated', detail: true }),
   'hubspot.pipelines': providerSelector(['objectType', 'customObjectTypeId']),
   'hubspot.pipelineStages': providerSelector(['objectType', 'customObjectTypeId', 'pipelineId'], {
     readiness: { all: ['oauthCredential', 'pipelineId'] },

--- a/apps/sim/lib/selectors/server/providers/hubspot.test.ts
+++ b/apps/sim/lib/selectors/server/providers/hubspot.test.ts
@@ -16,9 +16,12 @@ import { createSelectorProtectedValues } from '@/lib/selectors/server/protected-
 import { hubspotSelectorAttachments } from '@/lib/selectors/server/providers/hubspot'
 import type { ExecuteServerSelectorArgs } from '@/lib/selectors/server/types'
 
-function args(request: ExecuteServerSelectorArgs['request']): ExecuteServerSelectorArgs {
+function args(
+  request: ExecuteServerSelectorArgs['request'],
+  selectorKey: ExecuteServerSelectorArgs['selectorKey'] = 'hubspot.lists'
+): ExecuteServerSelectorArgs {
   return {
-    selectorKey: 'hubspot.lists',
+    selectorKey,
     context: { oauthCredential: 'credential-1' },
     request,
     scope: { kind: 'workspace', workspaceId: 'workspace-1' },
@@ -111,6 +114,69 @@ describe('HubSpot server selector adapter', () => {
       item: { id: '123', label: 'Revenue prospects' },
     })
     expect(String(mockFetch.mock.calls[0]?.[0])).toBe('https://api.hubapi.com/crm/v3/lists/123')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('paginates active owners through the HubSpot continuation cursor on demand', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            results: [
+              { id: '100', firstName: 'Former', lastName: 'Owner', archived: true },
+              { id: '101', firstName: 'Ada', lastName: 'Lovelace', archived: false },
+            ],
+            paging: { next: { after: 'owner-page-2' } },
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ results: [{ id: '102', email: 'grace@example.com' }] }), {
+          status: 200,
+        })
+      )
+
+    const first = await hubspotSelectorAttachments['hubspot.owners'].execute(
+      args({ kind: 'list' }, 'hubspot.owners')
+    )
+    const second = await hubspotSelectorAttachments['hubspot.owners'].execute(
+      args({ kind: 'list', cursor: 'owner-page-2' }, 'hubspot.owners')
+    )
+
+    expect(first).toEqual({
+      kind: 'list',
+      items: [{ id: '101', label: 'Ada Lovelace' }],
+      nextCursor: 'owner-page-2',
+    })
+    expect(second).toEqual({
+      kind: 'list',
+      items: [{ id: '102', label: 'grace@example.com' }],
+    })
+    const firstUrl = new URL(String(mockFetch.mock.calls[0]?.[0]))
+    const secondUrl = new URL(String(mockFetch.mock.calls[1]?.[0]))
+    expect(firstUrl.searchParams.get('limit')).toBe('100')
+    expect(firstUrl.searchParams.has('after')).toBe(false)
+    expect(secondUrl.searchParams.get('after')).toBe('owner-page-2')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('hydrates a selected owner directly by id', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: '777', firstName: 'Katherine', lastName: 'Johnson' }), {
+        status: 200,
+      })
+    )
+
+    await expect(
+      hubspotSelectorAttachments['hubspot.owners'].execute(
+        args({ kind: 'detail', id: '777' }, 'hubspot.owners')
+      )
+    ).resolves.toEqual({
+      kind: 'detail',
+      item: { id: '777', label: 'Katherine Johnson' },
+    })
+    expect(String(mockFetch.mock.calls[0]?.[0])).toBe('https://api.hubapi.com/crm/v3/owners/777')
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/sim/lib/selectors/server/providers/hubspot.test.ts
+++ b/apps/sim/lib/selectors/server/providers/hubspot.test.ts
@@ -170,13 +170,13 @@ describe('HubSpot server selector adapter', () => {
 
     await expect(
       hubspotSelectorAttachments['hubspot.owners'].execute(
-        args({ kind: 'detail', id: '777' }, 'hubspot.owners')
+        args({ kind: 'detail', id: '000777' }, 'hubspot.owners')
       )
     ).resolves.toEqual({
       kind: 'detail',
-      item: { id: '777', label: 'Katherine Johnson' },
+      item: { id: '000777', label: 'Katherine Johnson' },
     })
-    expect(String(mockFetch.mock.calls[0]?.[0])).toBe('https://api.hubapi.com/crm/v3/owners/777')
+    expect(String(mockFetch.mock.calls[0]?.[0])).toBe('https://api.hubapi.com/crm/v3/owners/000777')
     expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/sim/lib/selectors/server/providers/hubspot.ts
+++ b/apps/sim/lib/selectors/server/providers/hubspot.ts
@@ -158,6 +158,21 @@ interface HubSpotPipeline {
   archived?: boolean
 }
 
+interface HubSpotOwner {
+  id: string
+  email?: string
+  firstName?: string
+  lastName?: string
+  archived?: boolean
+}
+
+function hubspotOwnerOption(owner: HubSpotOwner) {
+  return {
+    id: owner.id,
+    label: [owner.firstName, owner.lastName].filter(Boolean).join(' ') || owner.email || owner.id,
+  }
+}
+
 async function loadPipelines(args: ExecuteServerSelectorArgs): Promise<HubSpotPipeline[]> {
   const objectType = resolveObjectType(args)
   if (!objectType) return []
@@ -194,37 +209,34 @@ async function executePipelineStages(args: ExecuteServerSelectorArgs) {
 }
 
 async function executeOwners(args: ExecuteServerSelectorArgs) {
-  requireListRequest(args.selectorKey, args.request)
   const accessToken = await hubspotToken(args)
-  const owners: Array<{
-    id: string
-    email?: string
-    firstName?: string
-    lastName?: string
-    archived?: boolean
-  }> = []
-  let after: string | undefined
-  for (let page = 0; page < 10; page++) {
-    const url = new URL('https://api.hubapi.com/crm/v3/owners')
-    url.searchParams.set('limit', '100')
-    if (after) url.searchParams.set('after', after)
-    const data = await fetchProviderJson<{
-      results?: typeof owners
-      paging?: { next?: { after?: string } }
-    }>(url, { headers: { Authorization: `Bearer ${accessToken}` }, signal: args.signal })
-    owners.push(...(data.results ?? []))
-    after = data.paging?.next?.after
-    if (!after) break
+  if (args.request.kind === 'detail') {
+    const ownerId = args.request.id.trim()
+    if (!ownerId || ownerId.length > 100) throw new SelectorContextUnavailableError()
+    const owner = await fetchProviderJson<HubSpotOwner>(
+      `https://api.hubapi.com/crm/v3/owners/${encodeURIComponent(ownerId)}`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal: args.signal,
+      }
+    )
+    return detailSelectorResult(owner.archived || !owner.id ? null : hubspotOwnerOption(owner))
   }
+
+  requireListRequest(args.selectorKey, args.request)
+  const url = new URL('https://api.hubapi.com/crm/v3/owners')
+  url.searchParams.set('limit', '100')
+  if (args.request.cursor) url.searchParams.set('after', args.request.cursor)
+  const data = await fetchProviderJson<{
+    results?: HubSpotOwner[]
+    paging?: { next?: { after?: string } }
+  }>(url, { headers: { Authorization: `Bearer ${accessToken}` }, signal: args.signal })
   return listSelectorResult(
-    owners
+    (data.results ?? [])
       .filter((owner) => !owner.archived && owner.id)
-      .map((owner) => ({
-        id: owner.id,
-        label:
-          [owner.firstName, owner.lastName].filter(Boolean).join(' ') || owner.email || owner.id,
-      }))
-      .sort((left, right) => left.label.localeCompare(right.label))
+      .map(hubspotOwnerOption)
+      .sort((left, right) => left.label.localeCompare(right.label)),
+    data.paging?.next?.after
   )
 }
 

--- a/apps/sim/lib/selectors/server/providers/hubspot.ts
+++ b/apps/sim/lib/selectors/server/providers/hubspot.ts
@@ -220,7 +220,9 @@ async function executeOwners(args: ExecuteServerSelectorArgs) {
         signal: args.signal,
       }
     )
-    return detailSelectorResult(owner.archived || !owner.id ? null : hubspotOwnerOption(owner))
+    return detailSelectorResult(
+      owner.archived || !owner.id ? null : { ...hubspotOwnerOption(owner), id: ownerId }
+    )
   }
 
   requireListRequest(args.selectorKey, args.request)


### PR DESCRIPTION
## Summary

- paginate HubSpot owner options through the existing selector cursor contract
- hydrate saved owners directly through the HubSpot owner detail endpoint
- preserve active-owner filtering, credential binding, page limits, and abort propagation

## Tests

- pagination behavior: exposes the first continuation cursor, omits an archived fixture without dropping continuation, and forwards the supplied cursor as HubSpot after
- direct-detail behavior: hydrates a saved owner by ID without traversing owner list pages

## Validation

- `bun run --cwd apps/sim test -- lib/selectors/server/providers/hubspot.test.ts lib/webhooks/polling/hubspot.test.ts`
- `./node_modules/.bin/biome check apps/sim/lib/selectors/manifest.ts apps/sim/lib/selectors/server/providers/hubspot.ts apps/sim/lib/selectors/server/providers/hubspot.test.ts`
- `bun run --cwd apps/sim type-check`
- `bun run check:api-validation`

## Browser validation

- [ ] With a connected HubSpot portal containing more than 100 owners, confirm Load more / Load all appears.
- [ ] Select a later-page owner.
- [ ] Save and reload, then confirm direct hydration preserves the owner label.

The available authenticated staging workspace has no connected HubSpot integration, so these portal-dependent checks remain pending.