### PR TITLE
fix(cloudwatch): paginate log selectors

### DIFF
--- a/apps/sim/lib/internal/cloudwatch/client.ts
+++ b/apps/sim/lib/internal/cloudwatch/client.ts
@@ -145,13 +145,23 @@ export interface DescribedLogStream {
 export async function describeLogStreams(
   client: CloudWatchLogsClient,
   logGroupName: string,
-  options?: { prefix?: string; limit?: number; suppressTruncationLog?: boolean },
+  options?: {
+    prefix?: string
+    limit?: number
+    nextToken?: string
+    suppressTruncationLog?: boolean
+  },
   signal?: AbortSignal
-): Promise<{ logStreams: DescribedLogStream[]; truncated: boolean; pages: number }> {
+): Promise<{
+  logStreams: DescribedLogStream[]
+  truncated: boolean
+  pages: number
+  nextToken?: string
+}> {
   const hasPrefix = Boolean(options?.prefix)
   const totalLimit = options?.limit
   const logStreams: DescribedLogStream[] = []
-  let nextToken: string | undefined
+  let nextToken = options?.nextToken
   let pages = 0
   let truncated = false
 
@@ -167,7 +177,7 @@ export async function describeLogStreams(
         ? { orderBy: 'LogStreamName', logStreamNamePrefix: options!.prefix }
         : { orderBy: 'LastEventTime', descending: true }),
       limit: pageLimit,
-      ...(nextToken && { nextToken }),
+      ...(nextToken !== undefined ? { nextToken } : {}),
     })
 
     const response = await client.send(command, { abortSignal: signal })
@@ -202,6 +212,7 @@ export async function describeLogStreams(
     logStreams: totalLimit !== undefined ? logStreams.slice(0, totalLimit) : logStreams,
     truncated,
     pages,
+    ...(nextToken !== undefined ? { nextToken } : {}),
   }
 }
 

--- a/apps/sim/lib/selectors/manifest.test.ts
+++ b/apps/sim/lib/selectors/manifest.test.ts
@@ -59,6 +59,11 @@ describe('selector manifest', () => {
     ])
   })
 
+  it('declares both CloudWatch selectors as paginated', () => {
+    expect(selectorManifest['cloudwatch.logGroups'].listMode).toBe('paginated')
+    expect(selectorManifest['cloudwatch.logStreams'].listMode).toBe('paginated')
+  })
+
   /**
    * `serviceIds` names which credentials a selector accepts; the integration
    * allowlist has to judge which resource it *reaches*, and for a shared

--- a/apps/sim/lib/selectors/manifest.ts
+++ b/apps/sim/lib/selectors/manifest.ts
@@ -321,6 +321,7 @@ export const selectorManifest = {
     {
       readiness: { all: ['awsAccessKeyId', 'awsSecretAccessKey', 'awsRegion'] },
       sensitive: ['awsAccessKeyId', 'awsSecretAccessKey'],
+      listMode: 'paginated',
       search: true,
       detail: true,
     }
@@ -332,6 +333,7 @@ export const selectorManifest = {
         all: ['awsAccessKeyId', 'awsSecretAccessKey', 'awsRegion', 'logGroupName'],
       },
       sensitive: ['awsAccessKeyId', 'awsSecretAccessKey'],
+      listMode: 'paginated',
       search: true,
       detail: true,
     }

--- a/apps/sim/lib/selectors/server/providers/cloudwatch.test.ts
+++ b/apps/sim/lib/selectors/server/providers/cloudwatch.test.ts
@@ -37,6 +37,13 @@ function logGroupArgs(signal?: AbortSignal): ExecuteServerSelectorArgs {
   }
 }
 
+function logStreamArgs(): ExecuteServerSelectorArgs {
+  const args = logGroupArgs()
+  args.selectorKey = 'cloudwatch.logStreams'
+  args.context.logGroupName = '/aws/lambda/example'
+  return args
+}
+
 function cloudWatchError(status: number): CloudWatchLogsServiceException {
   return new CloudWatchLogsServiceException({
     name: 'CloudWatchLogsError',
@@ -45,7 +52,7 @@ function cloudWatchError(status: number): CloudWatchLogsServiceException {
   })
 }
 
-describe('CloudWatch server selector adapter errors', () => {
+describe('CloudWatch server selector adapter', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it.each([
@@ -93,6 +100,47 @@ describe('CloudWatch server selector adapter errors', () => {
     ).resolves.toEqual({ kind: 'detail', item: null })
     expect(mockListCloudWatchLogGroups).toHaveBeenCalledWith(
       expect.objectContaining({ prefix: '/aws/missing' })
+    )
+  })
+
+  it.each([
+    {
+      selectorKey: 'cloudwatch.logGroups' as const,
+      mockListing: mockListCloudWatchLogGroups,
+      args: logGroupArgs,
+      providerField: 'logGroupName' as const,
+      binding: {},
+    },
+    {
+      selectorKey: 'cloudwatch.logStreams' as const,
+      mockListing: mockListCloudWatchLogStreams,
+      args: logStreamArgs,
+      providerField: 'logStreamName' as const,
+      binding: { logGroupName: '/aws/lambda/example' },
+    },
+  ])('forwards opaque cursors for $selectorKey', async (testCase) => {
+    testCase.mockListing.mockResolvedValueOnce({
+      items: [{ [testCase.providerField]: 'target' }],
+      pages: 20,
+      truncated: true,
+      nextToken: 'opaque::next+=',
+    })
+    const args = testCase.args()
+    args.request = { kind: 'list', search: 'target', cursor: 'opaque::start+=' }
+
+    await expect(
+      cloudWatchSelectorAttachments[testCase.selectorKey].execute(args)
+    ).resolves.toEqual({
+      kind: 'list',
+      items: [{ id: 'target', label: 'target' }],
+      nextCursor: 'opaque::next+=',
+    })
+    expect(testCase.mockListing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: 'target',
+        nextToken: 'opaque::start+=',
+        ...testCase.binding,
+      })
     )
   })
 

--- a/apps/sim/lib/selectors/server/providers/cloudwatch.ts
+++ b/apps/sim/lib/selectors/server/providers/cloudwatch.ts
@@ -81,11 +81,12 @@ export const cloudWatchSelectorAttachments = {
           match?.logGroupName ? { id: match.logGroupName, label: match.logGroupName } : null
         )
       }
-      const search = args.request.search
+      const { search, cursor } = args.request
       const groups = await executeCloudWatchListing(args.signal, () =>
         listCloudWatchLogGroups({
           credentials: listingCredentials,
           prefix: search,
+          nextToken: cursor,
           signal: args.signal,
           suppressTruncationLog: true,
         })
@@ -94,10 +95,7 @@ export const cloudWatchSelectorAttachments = {
         groups.items
           .filter((group) => group.logGroupName)
           .map((group) => ({ id: group.logGroupName, label: group.logGroupName })),
-        undefined,
-        groups.truncated
-          ? { truncated: { reason: 'provider-cap', pages: groups.pages } }
-          : undefined
+        groups.nextToken
       )
     },
   },
@@ -122,12 +120,13 @@ export const cloudWatchSelectorAttachments = {
           match?.logStreamName ? { id: match.logStreamName, label: match.logStreamName } : null
         )
       }
-      const search = args.request.search
+      const { search, cursor } = args.request
       const streams = await executeCloudWatchListing(args.signal, () =>
         listCloudWatchLogStreams({
           credentials: listingCredentials,
           logGroupName: args.context.logGroupName!,
           prefix: search,
+          nextToken: cursor,
           signal: args.signal,
           suppressTruncationLog: true,
         })
@@ -136,10 +135,7 @@ export const cloudWatchSelectorAttachments = {
         streams.items
           .filter((stream) => stream.logStreamName)
           .map((stream) => ({ id: stream.logStreamName, label: stream.logStreamName })),
-        undefined,
-        streams.truncated
-          ? { truncated: { reason: 'provider-cap', pages: streams.pages } }
-          : undefined
+        streams.nextToken
       )
     },
   },

--- a/apps/sim/tools/cloudwatch/listing.test.ts
+++ b/apps/sim/tools/cloudwatch/listing.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createCloudWatchLogsClient: vi.fn(),
+  destroy: vi.fn(),
+  send: vi.fn(),
+}))
+
+vi.mock('@/lib/internal/cloudwatch/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/internal/cloudwatch/client')>()),
+  createCloudWatchLogsClient: mocks.createCloudWatchLogsClient,
+}))
+
+import { listCloudWatchLogGroups, listCloudWatchLogStreams } from '@/tools/cloudwatch/listing'
+
+const CREDENTIALS = {
+  region: 'us-east-1',
+  accessKeyId: 'access-key',
+  secretAccessKey: 'secret-key',
+}
+
+function mockTwentyPages(
+  collection: 'logGroups' | 'logStreams',
+  name: 'logGroupName' | 'logStreamName',
+  finalToken: string
+) {
+  let page = 0
+  mocks.send.mockImplementation(async () => {
+    page += 1
+    return {
+      [collection]: [{ [name]: `item-${page}` }],
+      nextToken: page === 20 ? finalToken : `page-${page + 1}`,
+    }
+  })
+}
+
+describe('CloudWatch shared listings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createCloudWatchLogsClient.mockReturnValue({
+      send: mocks.send,
+      destroy: mocks.destroy,
+    })
+  })
+
+  it('continues log groups from an opaque token and exposes page twenty continuation', async () => {
+    mockTwentyPages('logGroups', 'logGroupName', 'opaque::group/after-20+=')
+
+    const result = await listCloudWatchLogGroups({
+      credentials: CREDENTIALS,
+      prefix: '/aws/lambda/',
+      nextToken: 'opaque::group/start+=',
+      suppressTruncationLog: true,
+    })
+
+    expect(result).toMatchObject({
+      pages: 20,
+      truncated: true,
+      nextToken: 'opaque::group/after-20+=',
+    })
+    expect(result.items).toHaveLength(20)
+    expect(mocks.send).toHaveBeenCalledTimes(20)
+    expect(mocks.send.mock.calls[0]?.[0].input).toMatchObject({
+      logGroupNamePrefix: '/aws/lambda/',
+      limit: 50,
+      nextToken: 'opaque::group/start+=',
+    })
+  })
+
+  it('continues streams within their group and prefix and exposes page twenty continuation', async () => {
+    mockTwentyPages('logStreams', 'logStreamName', 'opaque::stream/after-20+=')
+
+    const result = await listCloudWatchLogStreams({
+      credentials: CREDENTIALS,
+      logGroupName: '/aws/lambda/example',
+      prefix: '2026/09/',
+      nextToken: 'opaque::stream/start+=',
+      suppressTruncationLog: true,
+    })
+
+    expect(result).toMatchObject({
+      pages: 20,
+      truncated: true,
+      nextToken: 'opaque::stream/after-20+=',
+    })
+    expect(result.items).toHaveLength(20)
+    expect(mocks.send).toHaveBeenCalledTimes(20)
+    expect(mocks.send.mock.calls[0]?.[0].input).toMatchObject({
+      logGroupName: '/aws/lambda/example',
+      logStreamNamePrefix: '2026/09/',
+      orderBy: 'LogStreamName',
+      limit: 50,
+      nextToken: 'opaque::stream/start+=',
+    })
+  })
+})

--- a/apps/sim/tools/cloudwatch/listing.ts
+++ b/apps/sim/tools/cloudwatch/listing.ts
@@ -28,19 +28,21 @@ export interface CloudWatchListingResult<T> {
   items: T[]
   truncated: boolean
   pages: number
+  nextToken?: string
 }
 
 export async function listCloudWatchLogGroups(input: {
   credentials: CloudWatchListingCredentials
   prefix?: string
   limit?: number
+  nextToken?: string
   signal?: AbortSignal
   suppressTruncationLog?: boolean
 }): Promise<CloudWatchListingResult<DescribedLogGroup>> {
   const client = createCloudWatchLogsClient(input.credentials)
   try {
     const groups: DescribedLogGroup[] = []
-    let nextToken: string | undefined
+    let nextToken = input.nextToken
     let pages = 0
     let truncated = false
     for (let page = 0; page < MAX_PAGES; page += 1) {
@@ -50,7 +52,7 @@ export async function listCloudWatchLogGroups(input: {
         new DescribeLogGroupsCommand({
           ...(input.prefix ? { logGroupNamePrefix: input.prefix } : {}),
           limit: Math.min(PAGE_SIZE, remaining),
-          ...(nextToken ? { nextToken } : {}),
+          ...(nextToken !== undefined ? { nextToken } : {}),
         }),
         input.signal ? { abortSignal: input.signal } : undefined
       )
@@ -80,6 +82,7 @@ export async function listCloudWatchLogGroups(input: {
       items: input.limit === undefined ? groups : groups.slice(0, input.limit),
       truncated,
       pages,
+      ...(nextToken !== undefined ? { nextToken } : {}),
     }
   } finally {
     client.destroy()
@@ -91,6 +94,7 @@ export async function listCloudWatchLogStreams(input: {
   logGroupName: string
   prefix?: string
   limit?: number
+  nextToken?: string
   signal?: AbortSignal
   suppressTruncationLog?: boolean
 }): Promise<CloudWatchListingResult<DescribedLogStream>> {
@@ -102,6 +106,7 @@ export async function listCloudWatchLogStreams(input: {
       {
         prefix: input.prefix,
         limit: input.limit,
+        ...(input.nextToken !== undefined ? { nextToken: input.nextToken } : {}),
         ...(input.suppressTruncationLog !== undefined
           ? { suppressTruncationLog: input.suppressTruncationLog }
           : {}),
@@ -112,6 +117,7 @@ export async function listCloudWatchLogStreams(input: {
       items: result.logStreams,
       truncated: result.truncated ?? false,
       pages: result.pages ?? 0,
+      ...(result.nextToken !== undefined ? { nextToken: result.nextToken } : {}),
     }
   } finally {
     client.destroy()


### PR DESCRIPTION
## Summary
- expose the final AWS CloudWatch nextToken from the existing bounded log-group and log-stream listing helpers
- make both CloudWatch selectors cursor-backed while retaining their current 20-request aggregation window
- preserve runtime tool and route output contracts, prefix/detail behavior, server-only credentials, context binding, and abort propagation

No linked issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other

## Testing
- bun run --cwd apps/sim test -- tools/cloudwatch/listing.test.ts lib/selectors/server/providers/cloudwatch.test.ts lib/selectors/manifest.test.ts lib/internal/cloudwatch/operations.test.ts lib/internal/cloudwatch/execute-tool.test.ts
- bun run --cwd apps/sim type-check
- bun run --cwd apps/sim lint:check
- bun run check
- bun run check:api-validation

Focused tests cover opaque cursor input/output through page 20, stream log-group and prefix binding, selector cursor mapping, and paginated manifests. Existing runtime operation and executor contract tests pass unchanged.

Live high-cardinality AWS validation was not run because this environment has no AWS credentials or region configured.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the Contributor License Agreement

## Screenshots/Videos
Not applicable; no UI changes.