### PR TITLE
perf(tests): drop dead upload-context re-exports and unify the CI dummy key

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -190,7 +190,7 @@ jobs:
           NODE_OPTIONS: '--no-warnings --max-old-space-size=8192'
           NEXT_PUBLIC_APP_URL: 'https://www.sim.ai'
           DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/simstudio'
-          ENCRYPTION_KEY: '7cf672e460e430c1fba707575c2b0e2ad5a99dddf9b7b7e3b5646e630861db1c' # dummy key for CI only
+          ENCRYPTION_KEY: '0000000000000000000000000000000000000000000000000000000000000000' # dummy key for CI only
           TURBO_CACHE_DIR: .turbo
           SIM_TEST_SHARD: 1/2
         run: bun run test
@@ -360,6 +360,6 @@ jobs:
           STRIPE_WEBHOOK_SECRET: 'dummy_secret_for_ci_only'
           RESEND_API_KEY: 'dummy_key_for_ci_only'
           AWS_REGION: 'us-west-2'
-          ENCRYPTION_KEY: '7cf672e460e430c1fba707575c2b0e2ad5a99dddf9b7b7e3b5646e630861db1c' # dummy key for CI only
+          ENCRYPTION_KEY: '0000000000000000000000000000000000000000000000000000000000000000' # dummy key for CI only
           TURBO_CACHE_DIR: .turbo
         run: bunx turbo run build --filter=@sim/app

--- a/apps/sim/lib/uploads/index.ts
+++ b/apps/sim/lib/uploads/index.ts
@@ -5,8 +5,6 @@ export {
 } from '@/lib/uploads/config'
 export * as ChatFiles from '@/lib/uploads/contexts/chat'
 export * as CopilotFiles from '@/lib/uploads/contexts/copilot'
-export * as ExecutionFiles from '@/lib/uploads/contexts/execution'
-export * as WorkspaceFiles from '@/lib/uploads/contexts/workspace'
 export {
   getFileMetadata,
   getServePathPrefix,


### PR DESCRIPTION
## Summary
- `@/lib/uploads` re-exported all four upload contexts as namespaces, but nothing imports `WorkspaceFiles` or `ExecutionFiles` through the barrel (consumers import those modules directly). The workspace context is the heavy one — it reaches billing storage, encryption, and input validation — so every consumer of the barrel paid for it. Removing the two dead re-exports takes the barrel from ~180ms to ~30ms per test file; 167 test files reach it.
- The three CI test/build jobs now share one obviously-dummy `ENCRYPTION_KEY` instead of two different values; the app only requires ≥32 characters.

Follow-up to #7367. Two other candidates were measured and rejected rather than shipped: switching the 229 jsdom suites to happy-dom fails 11 files on real DOM behavior differences for an 18% gain on that subset, and running the 23 whole-registry sweep suites in a non-isolated Vitest project leaks mocks across files (8 fail) with no wall-time gain.

Local full run: 2,855 files, 212s -> 195s wall; cumulative import 1,212s -> 1,108s.

## Type of Change
- [x] Performance / CI

## Testing
Full apps/sim suite green locally (39,369 tests), `bun run check:audits`, `bun run lint:check`, `bun run type-check`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
