### PR TITLE
feat(resources): remember list preferences

### DIFF
--- a/.claude/rules/sim-url-state.md
+++ b/.claude/rules/sim-url-state.md
@@ -53,8 +53,9 @@ Files, Tables, and Knowledge may persist their last-used filter/sort snapshot th
 
 - nuqs remains authoritative while the module is open.
 - Zustand is consulted once on a clean module entry, after persisted state hydrates.
-- Effective URL filter/sort state wins as one complete snapshot and becomes the remembered value;
-  omitted fields use URL defaults rather than merging with storage.
+- An explicit URL filter/sort parameter wins even when it resolves to the module default. The
+  complete resolved URL snapshot becomes the remembered value; omitted fields use URL defaults
+  rather than merging with storage.
 - Explicit filter/sort gestures commit the same complete snapshot to nuqs and Zustand together.
 - Never mirror subsequent URL changes with a synchronization effect or `popstate` listener.
 - Search and folder navigation remain URL-only and are excluded from the persisted snapshot.

--- a/.claude/rules/sim-url-state.md
+++ b/.claude/rules/sim-url-state.md
@@ -46,6 +46,19 @@ These reads/mutations are **not** anti-patterns and stay as-is:
 - **Route navigations** — `router.push('/path/[id]?folderId=x')` that changes the route *path*, not just the current query. A nuqs setter only mutates the query on the current path; cross-path navigation stays on `router`.
 - **Read-once auth / redirect signals** — `token`, `callbackUrl`, `redirect`, `error`, `invite_flow`, `new` (invite signup flow), `upgraded`, `redirect_workflow`, etc. These are navigation signals consumed once (often read-then-strip), not synced view-state. Leave them on `useSearchParams`. Key names are per-surface: files' `new` is a genuine nuqs param (`files/search-params.ts`), while invite's `new` is a one-shot signup signal.
 
+### Remembered list-preference exception
+
+Files, Tables, and Knowledge may persist their last-used filter/sort snapshot through
+`useResourceListPreferences`. This is a fallback preference, not a second live source of truth:
+
+- nuqs remains authoritative while the module is open.
+- Zustand is consulted once on a clean module entry, after persisted state hydrates.
+- Effective URL filter/sort state wins as one complete snapshot and becomes the remembered value;
+  omitted fields use URL defaults rather than merging with storage.
+- Explicit filter/sort gestures commit the same complete snapshot to nuqs and Zustand together.
+- Never mirror subsequent URL changes with a synchronization effect or `popstate` listener.
+- Search and folder navigation remain URL-only and are excluded from the persisted snapshot.
+
 ## Per-feature `search-params.ts` — single source of truth
 
 Co-locate a `search-params.ts` next to the feature. Export the parser map (and shared options). Both the client (`useQueryStates`/`useQueryState`) and any server component (`createSearchParamsCache` from `nuqs/server`) import from this one file. Import parsers from `nuqs/server` so the module is safe to import in both client and server contexts.

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -425,7 +425,6 @@ export function Files() {
     dir: sortDirection,
     activeSort,
     onSort: applyUrlSort,
-    onClear: clearUrlSort,
   } = useUrlSort(filesSortParams, filesFilterUrlKeys)
 
   const currentListPreference = useMemo<ResourceListPreference>(
@@ -447,17 +446,9 @@ export function Files() {
         size: [...preference.filters.size],
         uploadedBy: [...preference.filters.uploadedBy],
       })
-      const defaultSort = filesListPreferenceConfig.defaultPreference.sort
-      if (
-        preference.sort.column === defaultSort.column &&
-        preference.sort.direction === defaultSort.direction
-      ) {
-        clearUrlSort()
-      } else {
-        applyUrlSort(preference.sort.column, preference.sort.direction)
-      }
+      applyUrlSort(preference.sort.column, preference.sort.direction)
     },
-    [applyUrlSort, clearUrlSort, setFileFilters]
+    [applyUrlSort, setFileFilters]
   )
 
   const {

--- a/apps/sim/app/workspace/[workspaceId]/files/files.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/files.tsx
@@ -115,9 +115,11 @@ import { FileDocRoomProvider } from '@/app/workspace/[workspaceId]/files/compone
 import { FilesListContextMenu } from '@/app/workspace/[workspaceId]/files/components/files-list-context-menu'
 import { ShareModal } from '@/app/workspace/[workspaceId]/files/components/share-modal'
 import { useWorkspaceFilesRoom } from '@/app/workspace/[workspaceId]/files/hooks/use-workspace-files-room'
+import FilesLoading from '@/app/workspace/[workspaceId]/files/loading'
 import {
   filesFilterParsers,
   filesFilterUrlKeys,
+  filesListPreferenceConfig,
   filesParsers,
   filesSortParams,
   filesUrlKeys,
@@ -152,8 +154,10 @@ import { useContextMenu } from '@/hooks/use-context-menu'
 import { useDebouncedSearchSetter } from '@/hooks/use-debounced-search-setter'
 import { useInlineRename } from '@/hooks/use-inline-rename'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
+import { useResourceListPreferences } from '@/hooks/use-resource-list-preferences'
 import { useSearchFilterValue } from '@/hooks/use-search-filter-value'
 import { useUrlSort } from '@/hooks/use-url-sort'
+import type { ResourceListPreference } from '@/stores/resource-list-preferences'
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 type FileResourceItem =
@@ -420,21 +424,67 @@ export function Files() {
     sort: sortColumn,
     dir: sortDirection,
     activeSort,
-    onSort,
-    onClear,
+    onSort: applyUrlSort,
+    onClear: clearUrlSort,
   } = useUrlSort(filesSortParams, filesFilterUrlKeys)
 
+  const currentListPreference = useMemo<ResourceListPreference>(
+    () => ({
+      sort: { column: sortColumn, direction: sortDirection },
+      filters: {
+        type: typeFilter,
+        size: sizeFilter,
+        uploadedBy: uploadedByFilter,
+      },
+    }),
+    [sortColumn, sortDirection, typeFilter, sizeFilter, uploadedByFilter]
+  )
+
+  const applyListPreference = useCallback(
+    (preference: ResourceListPreference) => {
+      void setFileFilters({
+        type: [...preference.filters.type],
+        size: [...preference.filters.size],
+        uploadedBy: [...preference.filters.uploadedBy],
+      })
+      const defaultSort = filesListPreferenceConfig.defaultPreference.sort
+      if (
+        preference.sort.column === defaultSort.column &&
+        preference.sort.direction === defaultSort.direction
+      ) {
+        clearUrlSort()
+      } else {
+        applyUrlSort(preference.sort.column, preference.sort.direction)
+      }
+    },
+    [applyUrlSort, clearUrlSort, setFileFilters]
+  )
+
+  const {
+    isReady: isListPreferenceReady,
+    setFilter: setListFilter,
+    clearFilters: clearFileFilters,
+    setSort: setListSort,
+    clearSort: clearListSort,
+  } = useResourceListPreferences({
+    workspaceId,
+    config: filesListPreferenceConfig,
+    preference: currentListPreference,
+    applyPreference: applyListPreference,
+    enabled: fileIdFromRoute === null,
+  })
+
   const setTypeFilter = useCallback(
-    (next: string[]) => setFileFilters({ type: next }),
-    [setFileFilters]
+    (next: string[]) => setListFilter('type', next),
+    [setListFilter]
   )
   const setSizeFilter = useCallback(
-    (next: string[]) => setFileFilters({ size: next }),
-    [setFileFilters]
+    (next: string[]) => setListFilter('size', next),
+    [setListFilter]
   )
   const setUploadedByFilter = useCallback(
-    (next: string[]) => setFileFilters({ uploadedBy: next }),
-    [setFileFilters]
+    (next: string[]) => setListFilter('uploadedBy', next),
+    [setListFilter]
   )
 
   const [creatingFile, setCreatingFile] = useState(false)
@@ -1904,10 +1954,10 @@ export function Files() {
         { id: 'owner', label: 'Owner' },
       ],
       active: activeSort,
-      onSort,
-      onClear,
+      onSort: setListSort,
+      onClear: clearListSort,
     }),
-    [activeSort, onSort, onClear]
+    [activeSort, setListSort, clearListSort]
   )
 
   const hasActiveFilters =
@@ -2004,11 +2054,7 @@ export function Files() {
         {hasActiveFilters && (
           <Button
             variant='ghost'
-            onClick={() => {
-              setTypeFilter([])
-              setSizeFilter([])
-              setUploadedByFilter([])
-            }}
+            onClick={clearFileFilters}
             className='h-[32px] w-full text-caption hover-hover:bg-[var(--surface-active)]'
           >
             Clear all filters
@@ -2016,7 +2062,18 @@ export function Files() {
         )}
       </div>
     )
-  }, [typeFilter, sizeFilter, uploadedByFilter, memberOptions, membersById, hasActiveFilters])
+  }, [
+    typeFilter,
+    sizeFilter,
+    uploadedByFilter,
+    memberOptions,
+    membersById,
+    hasActiveFilters,
+    setTypeFilter,
+    setSizeFilter,
+    setUploadedByFilter,
+    clearFileFilters,
+  ])
 
   /** Stable identity so the memoized `Resource.Options` can bail; an inline object cannot. */
   const filterConfig = useMemo(() => ({ content: filterContent }), [filterContent])
@@ -2056,7 +2113,15 @@ export function Files() {
       tags.push({ label, onRemove: () => setUploadedByFilter([]) })
     }
     return tags
-  }, [typeFilter, sizeFilter, uploadedByFilter, membersById])
+  }, [
+    typeFilter,
+    sizeFilter,
+    uploadedByFilter,
+    membersById,
+    setTypeFilter,
+    setSizeFilter,
+    setUploadedByFilter,
+  ])
 
   const listState = resourceListState({
     rowCount: rows.length,
@@ -2071,8 +2136,10 @@ export function Files() {
 
   const clearSearchAndFilters = () => {
     setSearchTerm('')
-    void setFileFilters({ type: null, size: null, uploadedBy: null })
+    clearFileFilters()
   }
+
+  if (!isListPreferenceReady) return <FilesLoading />
 
   if (fileIdFromRoute && !selectedFile && isLoading) {
     return (

--- a/apps/sim/app/workspace/[workspaceId]/files/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/search-params.ts
@@ -1,5 +1,6 @@
 import { createParser, parseAsArrayOf, parseAsString } from 'nuqs/server'
 import { createSortParams } from '@/lib/url-state'
+import type { ResourceListPreferenceConfig } from '@/stores/resource-list-preferences'
 
 /** Sortable list columns, matching the `Resource.Options` sort menu. */
 export const FILE_SORT_COLUMNS = ['name', 'size', 'type', 'created', 'owner', 'updated'] as const
@@ -81,6 +82,16 @@ export const filesSortParams = createSortParams(FILE_SORT_COLUMNS, {
   column: 'updated',
   direction: 'desc',
 })
+
+export const filesListPreferenceConfig = {
+  module: 'files',
+  sortColumns: FILE_SORT_COLUMNS,
+  filterKeys: ['type', 'size', 'uploadedBy'],
+  defaultPreference: {
+    sort: filesSortParams.default,
+    filters: { type: [], size: [], uploadedBy: [] },
+  },
+} satisfies ResourceListPreferenceConfig
 
 /** Filter/search/sort view-state: clean URLs, no back-stack churn. */
 export const filesFilterUrlKeys = {

--- a/apps/sim/app/workspace/[workspaceId]/files/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/search-params.ts
@@ -94,7 +94,7 @@ export const filesListPreferenceConfig = {
     sort: filesSortParams.default,
     filters: { type: [], size: [], uploadedBy: [] },
   },
-} satisfies ResourceListPreferenceConfig
+} as const satisfies ResourceListPreferenceConfig
 
 /** Filter/search/sort view-state: clean URLs, no back-stack churn. */
 export const filesFilterUrlKeys = {

--- a/apps/sim/app/workspace/[workspaceId]/files/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/search-params.ts
@@ -83,10 +83,13 @@ export const filesSortParams = createSortParams(FILE_SORT_COLUMNS, {
   direction: 'desc',
 })
 
+const filesFilterUrlKeyMap = { uploadedBy: 'uploaded-by' } as const
+
 export const filesListPreferenceConfig = {
   module: 'files',
   sortColumns: FILE_SORT_COLUMNS,
   filterKeys: ['type', 'size', 'uploadedBy'],
+  preferenceUrlKeys: filesFilterUrlKeyMap,
   defaultPreference: {
     sort: filesSortParams.default,
     filters: { type: [], size: [], uploadedBy: [] },
@@ -98,5 +101,5 @@ export const filesFilterUrlKeys = {
   history: 'replace',
   shallow: true,
   clearOnDefault: true,
-  urlKeys: { uploadedBy: 'uploaded-by' },
+  urlKeys: filesFilterUrlKeyMap,
 } as const

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx
@@ -285,7 +285,6 @@ export function Knowledge() {
     dir: sortDirection,
     activeSort,
     onSort: applyUrlSort,
-    onClear: clearUrlSort,
   } = useUrlSort(knowledgeSortParams, knowledgeUrlKeys)
 
   const currentListPreference = useMemo<ResourceListPreference>(
@@ -307,17 +306,9 @@ export function Knowledge() {
         content: [...preference.filters.content],
         owner: [...preference.filters.owner],
       })
-      const defaultSort = knowledgeListPreferenceConfig.defaultPreference.sort
-      if (
-        preference.sort.column === defaultSort.column &&
-        preference.sort.direction === defaultSort.direction
-      ) {
-        clearUrlSort()
-      } else {
-        applyUrlSort(preference.sort.column, preference.sort.direction)
-      }
+      applyUrlSort(preference.sort.column, preference.sort.direction)
     },
-    [applyUrlSort, clearUrlSort, setKnowledgeFilters]
+    [applyUrlSort, setKnowledgeFilters]
   )
 
   const {

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/knowledge.tsx
@@ -72,7 +72,9 @@ import {
   KnowledgeBaseContextMenu,
   KnowledgeListContextMenu,
 } from '@/app/workspace/[workspaceId]/knowledge/components'
+import KnowledgeLoading from '@/app/workspace/[workspaceId]/knowledge/loading'
 import {
+  knowledgeListPreferenceConfig,
   knowledgeParsers,
   knowledgeSortParams,
   knowledgeUrlKeys,
@@ -95,9 +97,11 @@ import { useContextMenu } from '@/hooks/use-context-menu'
 import { useDebouncedSearchSetter } from '@/hooks/use-debounced-search-setter'
 import { useInlineRename } from '@/hooks/use-inline-rename'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
+import { useResourceListPreferences } from '@/hooks/use-resource-list-preferences'
 import { useSearchFilterValue } from '@/hooks/use-search-filter-value'
 import { useUrlSort } from '@/hooks/use-url-sort'
 import type { WorkflowFolder } from '@/stores/folders/types'
+import type { ResourceListPreference } from '@/stores/resource-list-preferences'
 
 const logger = createLogger('Knowledge')
 
@@ -280,21 +284,66 @@ export function Knowledge() {
     sort: sortColumn,
     dir: sortDirection,
     activeSort,
-    onSort: onSortColumn,
-    onClear: onClearSort,
+    onSort: applyUrlSort,
+    onClear: clearUrlSort,
   } = useUrlSort(knowledgeSortParams, knowledgeUrlKeys)
 
+  const currentListPreference = useMemo<ResourceListPreference>(
+    () => ({
+      sort: { column: sortColumn, direction: sortDirection },
+      filters: {
+        connector: connectorFilter,
+        content: contentFilter,
+        owner: ownerFilter,
+      },
+    }),
+    [sortColumn, sortDirection, connectorFilter, contentFilter, ownerFilter]
+  )
+
+  const applyListPreference = useCallback(
+    (preference: ResourceListPreference) => {
+      void setKnowledgeFilters({
+        connector: [...preference.filters.connector],
+        content: [...preference.filters.content],
+        owner: [...preference.filters.owner],
+      })
+      const defaultSort = knowledgeListPreferenceConfig.defaultPreference.sort
+      if (
+        preference.sort.column === defaultSort.column &&
+        preference.sort.direction === defaultSort.direction
+      ) {
+        clearUrlSort()
+      } else {
+        applyUrlSort(preference.sort.column, preference.sort.direction)
+      }
+    },
+    [applyUrlSort, clearUrlSort, setKnowledgeFilters]
+  )
+
+  const {
+    isReady: isListPreferenceReady,
+    setFilter: setListFilter,
+    clearFilters: clearKnowledgeFilters,
+    setSort: setListSort,
+    clearSort: clearListSort,
+  } = useResourceListPreferences({
+    workspaceId,
+    config: knowledgeListPreferenceConfig,
+    preference: currentListPreference,
+    applyPreference: applyListPreference,
+  })
+
   const setConnectorFilter = useCallback(
-    (next: string[]) => setKnowledgeFilters({ connector: next }),
-    [setKnowledgeFilters]
+    (next: string[]) => setListFilter('connector', next),
+    [setListFilter]
   )
   const setContentFilter = useCallback(
-    (next: string[]) => setKnowledgeFilters({ content: next }),
-    [setKnowledgeFilters]
+    (next: string[]) => setListFilter('content', next),
+    [setListFilter]
   )
   const setOwnerFilter = useCallback(
-    (next: string[]) => setKnowledgeFilters({ owner: next }),
-    [setKnowledgeFilters]
+    (next: string[]) => setListFilter('owner', next),
+    [setListFilter]
   )
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
@@ -1229,10 +1278,10 @@ export function Knowledge() {
         { id: 'updated', label: 'Last Updated' },
       ],
       active: activeSort,
-      onSort: onSortColumn,
-      onClear: onClearSort,
+      onSort: setListSort,
+      onClear: clearListSort,
     }),
-    [activeSort, onSortColumn, onClearSort]
+    [activeSort, setListSort, clearListSort]
   )
 
   const memberOptions: ChipDropdownOption[] = useMemo(
@@ -1319,7 +1368,15 @@ export function Knowledge() {
         )}
       </div>
     ),
-    [connectorFilter, contentFilter, ownerFilter, memberOptions]
+    [
+      connectorFilter,
+      contentFilter,
+      ownerFilter,
+      memberOptions,
+      setConnectorFilter,
+      setContentFilter,
+      setOwnerFilter,
+    ]
   )
 
   /** Stable identity so the memoized `Resource.Options` can bail; an inline object cannot. */
@@ -1376,7 +1433,15 @@ export function Knowledge() {
       tags.push({ label, onRemove: () => setOwnerFilter([]) })
     }
     return tags
-  }, [connectorFilter, contentFilter, ownerFilter, members])
+  }, [
+    connectorFilter,
+    contentFilter,
+    ownerFilter,
+    members,
+    setConnectorFilter,
+    setContentFilter,
+    setOwnerFilter,
+  ])
 
   const listState = resourceListState({
     rowCount: rows.length,
@@ -1391,8 +1456,10 @@ export function Knowledge() {
 
   const clearSearchAndFilters = () => {
     setSearchQuery('')
-    void setKnowledgeFilters({ connector: null, content: null, owner: null })
+    clearKnowledgeFilters()
   }
+
+  if (!isListPreferenceReady) return <KnowledgeLoading />
 
   return (
     <>

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/search-params.ts
@@ -1,5 +1,6 @@
 import { parseAsArrayOf, parseAsString } from 'nuqs/server'
 import { createSortParams } from '@/lib/url-state'
+import type { ResourceListPreferenceConfig } from '@/stores/resource-list-preferences'
 
 /** Sortable knowledge base columns, matching the `Resource.Options` sort menu. */
 export const KNOWLEDGE_SORT_COLUMNS = [
@@ -42,6 +43,16 @@ export const knowledgeParsers = {
   content: parseAsArrayOf(parseAsString).withDefault([]),
   owner: parseAsArrayOf(parseAsString).withDefault([]),
 } as const
+
+export const knowledgeListPreferenceConfig = {
+  module: 'knowledge',
+  sortColumns: KNOWLEDGE_SORT_COLUMNS,
+  filterKeys: ['connector', 'content', 'owner'],
+  defaultPreference: {
+    sort: knowledgeSortParams.default,
+    filters: { connector: [], content: [], owner: [] },
+  },
+} satisfies ResourceListPreferenceConfig
 
 /** Filter/search/sort view-state: clean URLs, no back-stack churn. */
 export const knowledgeUrlKeys = {

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/search-params.ts
@@ -52,7 +52,7 @@ export const knowledgeListPreferenceConfig = {
     sort: knowledgeSortParams.default,
     filters: { connector: [], content: [], owner: [] },
   },
-} satisfies ResourceListPreferenceConfig
+} as const satisfies ResourceListPreferenceConfig
 
 /** Filter/search/sort view-state: clean URLs, no back-stack churn. */
 export const knowledgeUrlKeys = {

--- a/apps/sim/app/workspace/[workspaceId]/tables/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/search-params.ts
@@ -54,7 +54,7 @@ export const tablesListPreferenceConfig = {
     sort: tablesSortParams.default,
     filters: { rows: [], owner: [] },
   },
-} satisfies ResourceListPreferenceConfig
+} as const satisfies ResourceListPreferenceConfig
 
 /** Filter/search/sort view-state: clean URLs, no back-stack churn. */
 export const tablesUrlKeys = {

--- a/apps/sim/app/workspace/[workspaceId]/tables/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/tables/search-params.ts
@@ -1,5 +1,6 @@
 import { parseAsArrayOf, parseAsString } from 'nuqs/server'
 import { createSortParams } from '@/lib/url-state'
+import type { ResourceListPreferenceConfig } from '@/stores/resource-list-preferences'
 
 /** Sortable table columns, matching the `Resource.Options` sort menu. */
 export const TABLE_SORT_COLUMNS = [
@@ -44,6 +45,16 @@ export const tablesParsers = {
   rows: parseAsArrayOf(parseAsString).withDefault([]),
   owner: parseAsArrayOf(parseAsString).withDefault([]),
 } as const
+
+export const tablesListPreferenceConfig = {
+  module: 'tables',
+  sortColumns: TABLE_SORT_COLUMNS,
+  filterKeys: ['rows', 'owner'],
+  defaultPreference: {
+    sort: tablesSortParams.default,
+    filters: { rows: [], owner: [] },
+  },
+} satisfies ResourceListPreferenceConfig
 
 /** Filter/search/sort view-state: clean URLs, no back-stack churn. */
 export const tablesUrlKeys = {

--- a/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
@@ -72,7 +72,9 @@ import {
 } from '@/app/workspace/[workspaceId]/tables/components'
 import { TableContextMenu } from '@/app/workspace/[workspaceId]/tables/components/table-context-menu'
 import { useWorkspaceTablesRoom } from '@/app/workspace/[workspaceId]/tables/hooks/use-workspace-tables-room'
+import TablesLoading from '@/app/workspace/[workspaceId]/tables/loading'
 import {
+  tablesListPreferenceConfig,
   tablesParsers,
   tablesSortParams,
   tablesUrlKeys,
@@ -96,9 +98,11 @@ import { useContextMenu } from '@/hooks/use-context-menu'
 import { useDebouncedSearchSetter } from '@/hooks/use-debounced-search-setter'
 import { useInlineRename } from '@/hooks/use-inline-rename'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
+import { useResourceListPreferences } from '@/hooks/use-resource-list-preferences'
 import { useSearchFilterValue } from '@/hooks/use-search-filter-value'
 import { useUrlSort } from '@/hooks/use-url-sort'
 import type { WorkflowFolder } from '@/stores/folders/types'
+import type { ResourceListPreference } from '@/stores/resource-list-preferences'
 import { useImportTrayStore } from '@/stores/table/import-tray/store'
 
 const logger = createLogger('Tables')
@@ -251,9 +255,49 @@ export function Tables() {
     sort: sortColumn,
     dir: sortDirection,
     activeSort,
-    onSort,
-    onClear,
+    onSort: applyUrlSort,
+    onClear: clearUrlSort,
   } = useUrlSort(tablesSortParams, tablesUrlKeys)
+
+  const currentListPreference = useMemo<ResourceListPreference>(
+    () => ({
+      sort: { column: sortColumn, direction: sortDirection },
+      filters: { rows: rowCountFilter, owner: ownerFilter },
+    }),
+    [sortColumn, sortDirection, rowCountFilter, ownerFilter]
+  )
+
+  const applyListPreference = useCallback(
+    (preference: ResourceListPreference) => {
+      void setTableFilters({
+        rows: [...preference.filters.rows],
+        owner: [...preference.filters.owner],
+      })
+      const defaultSort = tablesListPreferenceConfig.defaultPreference.sort
+      if (
+        preference.sort.column === defaultSort.column &&
+        preference.sort.direction === defaultSort.direction
+      ) {
+        clearUrlSort()
+      } else {
+        applyUrlSort(preference.sort.column, preference.sort.direction)
+      }
+    },
+    [applyUrlSort, clearUrlSort, setTableFilters]
+  )
+
+  const {
+    isReady: isListPreferenceReady,
+    setFilter: setListFilter,
+    clearFilters: clearTableFilters,
+    setSort: setListSort,
+    clearSort: clearListSort,
+  } = useResourceListPreferences({
+    workspaceId,
+    config: tablesListPreferenceConfig,
+    preference: currentListPreference,
+    applyPreference: applyListPreference,
+  })
 
   /**
    * The input is controlled directly by the instant nuqs value; only the URL
@@ -266,12 +310,12 @@ export function Tables() {
   const debouncedSearchTerm = useSearchFilterValue(urlSearchTerm, SEARCH_DEBOUNCE_MS)
 
   const setRowCountFilter = useCallback(
-    (next: string[]) => setTableFilters({ rows: next }),
-    [setTableFilters]
+    (next: string[]) => setListFilter('rows', next),
+    [setListFilter]
   )
   const setOwnerFilter = useCallback(
-    (next: string[]) => setTableFilters({ owner: next }),
-    [setTableFilters]
+    (next: string[]) => setListFilter('owner', next),
+    [setListFilter]
   )
 
   const [uploadProgress, setUploadProgress] = useState({ completed: 0, total: 0 })
@@ -641,10 +685,10 @@ export function Tables() {
         { id: 'updated', label: 'Last Updated' },
       ],
       active: activeSort,
-      onSort,
-      onClear,
+      onSort: setListSort,
+      onClear: clearListSort,
     }),
-    [activeSort, onSort, onClear]
+    [activeSort, setListSort, clearListSort]
   )
 
   const rowCountDisplayLabel = useMemo(() => {
@@ -720,10 +764,7 @@ export function Tables() {
         {hasActiveFilters && (
           <button
             type='button'
-            onClick={() => {
-              setRowCountFilter([])
-              setOwnerFilter([])
-            }}
+            onClick={clearTableFilters}
             className='flex h-[32px] w-full items-center justify-center rounded-md text-[var(--text-secondary)] text-caption transition-colors hover-hover:bg-[var(--surface-active)]'
           >
             Clear all filters
@@ -740,6 +781,7 @@ export function Tables() {
       hasActiveFilters,
       setRowCountFilter,
       setOwnerFilter,
+      clearTableFilters,
     ]
   )
 
@@ -776,7 +818,7 @@ export function Tables() {
 
   const clearSearchAndFilters = () => {
     setSearchTerm('')
-    void setTableFilters({ rows: null, owner: null })
+    clearTableFilters()
   }
 
   const handleContentContextMenu = useCallback(
@@ -1299,6 +1341,8 @@ export function Tables() {
     ]
   )
   const filterConfig = useMemo(() => ({ content: filterContent }), [filterContent])
+
+  if (!isListPreferenceReady) return <TablesLoading />
 
   return (
     <>

--- a/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/tables/tables.tsx
@@ -256,7 +256,6 @@ export function Tables() {
     dir: sortDirection,
     activeSort,
     onSort: applyUrlSort,
-    onClear: clearUrlSort,
   } = useUrlSort(tablesSortParams, tablesUrlKeys)
 
   const currentListPreference = useMemo<ResourceListPreference>(
@@ -273,17 +272,9 @@ export function Tables() {
         rows: [...preference.filters.rows],
         owner: [...preference.filters.owner],
       })
-      const defaultSort = tablesListPreferenceConfig.defaultPreference.sort
-      if (
-        preference.sort.column === defaultSort.column &&
-        preference.sort.direction === defaultSort.direction
-      ) {
-        clearUrlSort()
-      } else {
-        applyUrlSort(preference.sort.column, preference.sort.direction)
-      }
+      applyUrlSort(preference.sort.column, preference.sort.direction)
     },
-    [applyUrlSort, clearUrlSort, setTableFilters]
+    [applyUrlSort, setTableFilters]
   )
 
   const {

--- a/apps/sim/hooks/use-resource-list-preferences.test.tsx
+++ b/apps/sim/hooks/use-resource-list-preferences.test.tsx
@@ -1,0 +1,311 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { filesListPreferenceConfig } from '@/app/workspace/[workspaceId]/files/search-params'
+import { knowledgeListPreferenceConfig } from '@/app/workspace/[workspaceId]/knowledge/search-params'
+import { tablesListPreferenceConfig } from '@/app/workspace/[workspaceId]/tables/search-params'
+import { useResourceListPreferences } from '@/hooks/use-resource-list-preferences'
+import {
+  RESOURCE_LIST_PREFERENCES_STORAGE_KEY,
+  type ResourceListPreference,
+  useResourceListPreferencesStore,
+} from '@/stores/resource-list-preferences'
+
+const defaultPreference = filesListPreferenceConfig.defaultPreference
+const filesConfig = filesListPreferenceConfig
+
+const filteredPreference: ResourceListPreference = {
+  sort: { column: 'name', direction: 'asc' },
+  filters: { type: ['document'], size: [], uploadedBy: ['user-1'] },
+}
+
+interface HookProps {
+  preference: ResourceListPreference
+  applyPreference: (preference: ResourceListPreference) => void
+  enabled?: boolean
+}
+
+const mountedRoots: Root[] = []
+
+function renderPreferenceHook(props: HookProps) {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const root = createRoot(document.createElement('div'))
+  mountedRoots.push(root)
+  let result: ReturnType<typeof useResourceListPreferences>
+  let currentProps = props
+
+  function Probe() {
+    result = useResourceListPreferences({
+      workspaceId: 'workspace-1',
+      config: filesConfig,
+      ...currentProps,
+    })
+    return null
+  }
+
+  act(() => root.render(<Probe />))
+  return {
+    get current() {
+      return result
+    },
+    rerender(nextProps: HookProps) {
+      currentProps = nextProps
+      act(() => root.render(<Probe />))
+    },
+  }
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function seedPreference(preference: ResourceListPreference, version = 1) {
+  localStorage.setItem(
+    RESOURCE_LIST_PREFERENCES_STORAGE_KEY,
+    JSON.stringify({
+      state: { preferences: { 'workspace-1': { files: preference } } },
+      version,
+    })
+  )
+}
+
+describe('useResourceListPreferences', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useResourceListPreferencesStore.setState({ preferences: {}, _hasHydrated: false })
+    void useResourceListPreferencesStore.persist.clearStorage()
+  })
+
+  afterEach(() => {
+    act(() => {
+      for (const root of mountedRoots.splice(0)) root.unmount()
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('uses module defaults on a clean first visit without a saved preference', async () => {
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+
+    await flushEffects()
+
+    expect(result.current.isReady).toBe(true)
+    expect(applyPreference).not.toHaveBeenCalled()
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({})
+  })
+
+  it('shows effective URL state immediately and remembers it after hydration', async () => {
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: filteredPreference, applyPreference })
+
+    expect(result.current.isReady).toBe(true)
+    await flushEffects()
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({
+      'workspace-1': { files: filteredPreference },
+    })
+    expect(applyPreference).not.toHaveBeenCalled()
+  })
+
+  it('starts restoring a saved preference once on a clean visit', async () => {
+    seedPreference(filteredPreference)
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+
+    await flushEffects()
+    expect(applyPreference).toHaveBeenCalledWith(filteredPreference)
+    expect(result.current.isReady).toBe(false)
+    expect(applyPreference).toHaveBeenCalledOnce()
+  })
+
+  it('stays unready until the restored URL snapshot becomes current', async () => {
+    seedPreference(filteredPreference)
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+
+    await flushEffects()
+
+    expect(applyPreference).toHaveBeenCalledWith(filteredPreference)
+    expect(result.current.isReady).toBe(false)
+
+    result.rerender({ preference: filteredPreference, applyPreference })
+    await flushEffects()
+
+    expect(result.current.isReady).toBe(true)
+    expect(applyPreference).toHaveBeenCalledOnce()
+  })
+
+  it('stays unready while a clean entry waits for hydration', () => {
+    vi.spyOn(useResourceListPreferencesStore.persist, 'rehydrate').mockImplementation(
+      () => new Promise(() => undefined)
+    )
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+
+    expect(result.current.isReady).toBe(false)
+    expect(applyPreference).not.toHaveBeenCalled()
+  })
+
+  it('replaces a saved preference with the complete effective URL snapshot', async () => {
+    seedPreference(filteredPreference)
+    const urlPreference: ResourceListPreference = {
+      sort: { column: 'size', direction: 'desc' },
+      filters: { type: [], size: [], uploadedBy: [] },
+    }
+    const applyPreference = vi.fn()
+    renderPreferenceHook({ preference: urlPreference, applyPreference })
+
+    await flushEffects()
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({
+      'workspace-1': { files: urlPreference },
+    })
+    expect(applyPreference).not.toHaveBeenCalled()
+  })
+
+  it('does not merge omitted filters from a saved preference into a partial deep link', async () => {
+    seedPreference(filteredPreference)
+    const partialDeepLink: ResourceListPreference = {
+      sort: { column: 'name', direction: 'desc' },
+      filters: { type: [], size: [], uploadedBy: [] },
+    }
+    renderPreferenceHook({
+      preference: partialDeepLink,
+      applyPreference: vi.fn(),
+    })
+
+    await flushEffects()
+    expect(useResourceListPreferencesStore.getState().preferences['workspace-1']?.files).toEqual(
+      partialDeepLink
+    )
+  })
+
+  it('discards module-incompatible saved state instead of applying it', async () => {
+    seedPreference({
+      sort: { column: 'unknown', direction: 'asc' },
+      filters: { type: [], size: [], uploadedBy: [] },
+    })
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+
+    await flushEffects()
+    expect(result.current.isReady).toBe(true)
+    expect(applyPreference).not.toHaveBeenCalled()
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({})
+  })
+
+  it('commits URL and stored state together and removes the default snapshot', async () => {
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+    await flushEffects()
+    expect(useResourceListPreferencesStore.getState()._hasHydrated).toBe(true)
+
+    act(() => result.current.commitPreference(filteredPreference))
+
+    expect(applyPreference).toHaveBeenCalledWith(filteredPreference)
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({
+      'workspace-1': { files: filteredPreference },
+    })
+
+    act(() => result.current.commitPreference(defaultPreference))
+
+    expect(applyPreference).toHaveBeenCalledWith(defaultPreference)
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({})
+  })
+
+  it('builds complete snapshots for filter and sort gestures', async () => {
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+    await flushEffects()
+
+    act(() => result.current.setFilter('type', ['image']))
+
+    const filterPreference: ResourceListPreference = {
+      ...defaultPreference,
+      filters: { ...defaultPreference.filters, type: ['image'] },
+    }
+    expect(applyPreference).toHaveBeenLastCalledWith(filterPreference)
+    expect(useResourceListPreferencesStore.getState().preferences['workspace-1']?.files).toEqual(
+      filterPreference
+    )
+
+    act(() => result.current.setSort('name', 'asc'))
+
+    const sortPreference: ResourceListPreference = {
+      ...defaultPreference,
+      sort: { column: 'name', direction: 'asc' },
+    }
+    expect(applyPreference).toHaveBeenLastCalledWith(sortPreference)
+    expect(useResourceListPreferencesStore.getState().preferences['workspace-1']?.files).toEqual(
+      sortPreference
+    )
+  })
+
+  it('keeps URL commits working when localStorage writes fail', async () => {
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+    await flushEffects()
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage is full', 'QuotaExceededError')
+    })
+
+    act(() => result.current.setFilter('type', ['image']))
+
+    expect(applyPreference).toHaveBeenCalledWith({
+      ...defaultPreference,
+      filters: { ...defaultPreference.filters, type: ['image'] },
+    })
+  })
+
+  it('clears filters and sort back to their complete module defaults', async () => {
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: filteredPreference, applyPreference })
+    await flushEffects()
+
+    act(() => result.current.clearFilters())
+    expect(applyPreference).toHaveBeenLastCalledWith({
+      ...filteredPreference,
+      filters: { type: [], size: [], uploadedBy: [] },
+    })
+
+    act(() => result.current.clearSort())
+    expect(applyPreference).toHaveBeenLastCalledWith({
+      ...filteredPreference,
+      sort: defaultPreference.sort,
+    })
+  })
+
+  it('does not reconcile or persist when the module list is disabled', async () => {
+    seedPreference(filteredPreference)
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({
+      preference: defaultPreference,
+      applyPreference,
+      enabled: false,
+    })
+
+    expect(result.current.isReady).toBe(true)
+    await flushEffects()
+    expect(applyPreference).not.toHaveBeenCalled()
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({})
+  })
+})
+
+describe('module list preference configs', () => {
+  it.each([
+    [filesListPreferenceConfig, 'files', ['type', 'size', 'uploadedBy']],
+    [tablesListPreferenceConfig, 'tables', ['rows', 'owner']],
+    [knowledgeListPreferenceConfig, 'knowledge', ['connector', 'content', 'owner']],
+  ])('defines the complete %s filter snapshot and shared default sort', (config, module, keys) => {
+    expect(config.module).toBe(module)
+    expect(config.filterKeys).toEqual(keys)
+    expect(config.defaultPreference).toEqual({
+      sort: { column: 'updated', direction: 'desc' },
+      filters: Object.fromEntries(keys.map((key) => [key, []])),
+    })
+  })
+})

--- a/apps/sim/hooks/use-resource-list-preferences.test.tsx
+++ b/apps/sim/hooks/use-resource-list-preferences.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { act } from 'react'
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { filesListPreferenceConfig } from '@/app/workspace/[workspaceId]/files/search-params'
@@ -30,12 +31,13 @@ interface HookProps {
 
 const mountedRoots: Root[] = []
 
-function renderPreferenceHook(props: HookProps) {
+function renderPreferenceHook(props: HookProps, searchParams = '') {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
   const root = createRoot(document.createElement('div'))
   mountedRoots.push(root)
   let result: ReturnType<typeof useResourceListPreferences>
   let currentProps = props
+  let currentSearchParams = searchParams
 
   function Probe() {
     result = useResourceListPreferences({
@@ -46,14 +48,21 @@ function renderPreferenceHook(props: HookProps) {
     return null
   }
 
-  act(() => root.render(<Probe />))
+  const renderProbe = () => (
+    <NuqsTestingAdapter hasMemory searchParams={currentSearchParams}>
+      <Probe />
+    </NuqsTestingAdapter>
+  )
+
+  act(() => root.render(renderProbe()))
   return {
     get current() {
       return result
     },
-    rerender(nextProps: HookProps) {
+    rerender(nextProps: HookProps, nextSearchParams = currentSearchParams) {
       currentProps = nextProps
-      act(() => root.render(<Probe />))
+      currentSearchParams = nextSearchParams
+      act(() => root.render(renderProbe()))
     },
   }
 }
@@ -112,6 +121,23 @@ describe('useResourceListPreferences', () => {
     expect(applyPreference).not.toHaveBeenCalled()
   })
 
+  it.each(['sort=updated&dir=desc', 'uploaded-by='])(
+    'honors explicitly default-valued URL state instead of restoring a saved preference (%s)',
+    async (searchParams) => {
+      seedPreference(filteredPreference)
+      const applyPreference = vi.fn()
+      const result = renderPreferenceHook(
+        { preference: defaultPreference, applyPreference },
+        searchParams
+      )
+
+      expect(result.current.isReady).toBe(true)
+      await flushEffects()
+      expect(applyPreference).not.toHaveBeenCalled()
+      expect(useResourceListPreferencesStore.getState().preferences).toEqual({})
+    }
+  )
+
   it('starts restoring a saved preference once on a clean visit', async () => {
     seedPreference(filteredPreference)
     const applyPreference = vi.fn()
@@ -138,6 +164,23 @@ describe('useResourceListPreferences', () => {
 
     expect(result.current.isReady).toBe(true)
     expect(applyPreference).toHaveBeenCalledOnce()
+  })
+
+  it('lets an explicit URL change cancel a pending saved-preference restoration', async () => {
+    seedPreference(filteredPreference)
+    const applyPreference = vi.fn()
+    const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
+
+    await flushEffects()
+    expect(result.current.isReady).toBe(false)
+    expect(applyPreference).toHaveBeenCalledWith(filteredPreference)
+
+    result.rerender({ preference: defaultPreference, applyPreference }, 'sort=updated&dir=desc')
+    await flushEffects()
+
+    expect(result.current.isReady).toBe(true)
+    expect(applyPreference).toHaveBeenCalledOnce()
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({})
   })
 
   it('stays unready while a clean entry waits for hydration', () => {
@@ -307,5 +350,9 @@ describe('module list preference configs', () => {
       sort: { column: 'updated', direction: 'desc' },
       filters: Object.fromEntries(keys.map((key) => [key, []])),
     })
+  })
+
+  it('reuses the Files filter URL alias when detecting explicit preferences', () => {
+    expect(filesListPreferenceConfig.preferenceUrlKeys).toEqual({ uploadedBy: 'uploaded-by' })
   })
 })

--- a/apps/sim/hooks/use-resource-list-preferences.test.tsx
+++ b/apps/sim/hooks/use-resource-list-preferences.test.tsx
@@ -247,14 +247,18 @@ describe('useResourceListPreferences', () => {
     await flushEffects()
     expect(useResourceListPreferencesStore.getState()._hasHydrated).toBe(true)
 
-    act(() => result.current.commitPreference(filteredPreference))
+    act(() => result.current.setFilter('type', ['document']))
 
-    expect(applyPreference).toHaveBeenCalledWith(filteredPreference)
+    const filterPreference: ResourceListPreference = {
+      ...defaultPreference,
+      filters: { ...defaultPreference.filters, type: ['document'] },
+    }
+    expect(applyPreference).toHaveBeenCalledWith(filterPreference)
     expect(useResourceListPreferencesStore.getState().preferences).toEqual({
-      'workspace-1': { files: filteredPreference },
+      'workspace-1': { files: filterPreference },
     })
 
-    act(() => result.current.commitPreference(defaultPreference))
+    act(() => result.current.clearFilters())
 
     expect(applyPreference).toHaveBeenCalledWith(defaultPreference)
     expect(useResourceListPreferencesStore.getState().preferences).toEqual({})

--- a/apps/sim/hooks/use-resource-list-preferences.test.tsx
+++ b/apps/sim/hooks/use-resource-list-preferences.test.tsx
@@ -292,7 +292,7 @@ describe('useResourceListPreferences', () => {
     const applyPreference = vi.fn()
     const result = renderPreferenceHook({ preference: defaultPreference, applyPreference })
     await flushEffects()
-    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    const storageWrite = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
       throw new DOMException('Storage is full', 'QuotaExceededError')
     })
 
@@ -302,6 +302,7 @@ describe('useResourceListPreferences', () => {
       ...defaultPreference,
       filters: { ...defaultPreference.filters, type: ['image'] },
     })
+    storageWrite.mockRestore()
   })
 
   it('clears filters and sort back to their complete module defaults', async () => {

--- a/apps/sim/hooks/use-resource-list-preferences.ts
+++ b/apps/sim/hooks/use-resource-list-preferences.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { parseAsString, useQueryStates } from 'nuqs'
 import type {
   ResourceListPreference,
   ResourceListPreferenceConfig,
@@ -86,6 +87,12 @@ export function useResourceListPreferences({
   )
   const setPreference = useResourceListPreferencesStore((state) => state.setPreference)
   const removePreference = useResourceListPreferencesStore((state) => state.removePreference)
+  const preferenceQueryParsers = Object.fromEntries(
+    ['sort', 'dir', ...config.filterKeys].map((queryKey) => [queryKey, parseAsString])
+  )
+  const [preferenceQuery] = useQueryStates(preferenceQueryParsers, {
+    urlKeys: config.preferenceUrlKeys,
+  })
 
   const defaultPreference = useMemo(
     () => normalizePreference(config.defaultPreference, config),
@@ -100,6 +107,8 @@ export function useResourceListPreferences({
       defaultPreference &&
       !resourceListPreferencesEqual(currentPreference, defaultPreference)
   )
+  const hasExplicitUrlPreference = Object.values(preferenceQuery).some((value) => value !== null)
+  const hasUrlPreference = hasExplicitUrlPreference || hasEffectiveUrlPreference
 
   const rememberPreference = useCallback(
     (normalizedPreference: ResourceListPreference) => {
@@ -129,6 +138,10 @@ export function useResourceListPreferences({
       ) {
         setPendingRestoration(null)
         setReadyKey(key)
+      } else if (currentPreference && hasExplicitUrlPreference) {
+        setPendingRestoration(null)
+        rememberPreference(currentPreference)
+        setReadyKey(key)
       }
       return
     }
@@ -142,7 +155,7 @@ export function useResourceListPreferences({
       return
     }
 
-    if (!resourceListPreferencesEqual(currentPreference, defaultPreference)) {
+    if (hasUrlPreference) {
       rememberPreference(currentPreference)
       setReadyKey(key)
       return
@@ -163,7 +176,9 @@ export function useResourceListPreferences({
     currentPreference,
     defaultPreference,
     enabled,
+    hasExplicitUrlPreference,
     hasHydrated,
+    hasUrlPreference,
     key,
     pendingRestoration,
     rememberPreference,
@@ -215,10 +230,7 @@ export function useResourceListPreferences({
   }, [commitPreference, currentPreference, defaultPreference])
 
   return {
-    isReady:
-      !enabled ||
-      (pendingRestoration?.key !== key && hasEffectiveUrlPreference) ||
-      readyKey === key,
+    isReady: !enabled || (pendingRestoration?.key !== key && hasUrlPreference) || readyKey === key,
     commitPreference,
     setFilter,
     clearFilters,

--- a/apps/sim/hooks/use-resource-list-preferences.ts
+++ b/apps/sim/hooks/use-resource-list-preferences.ts
@@ -1,0 +1,228 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type {
+  ResourceListPreference,
+  ResourceListPreferenceConfig,
+} from '@/stores/resource-list-preferences'
+import { useResourceListPreferencesStore } from '@/stores/resource-list-preferences'
+import { resourceListPreferencesEqual } from '@/stores/resource-list-preferences/utils'
+
+interface UseResourceListPreferencesProps {
+  workspaceId: string
+  config: ResourceListPreferenceConfig
+  preference: ResourceListPreference
+  applyPreference: (preference: ResourceListPreference) => unknown
+  enabled?: boolean
+}
+
+interface UseResourceListPreferencesReturn {
+  isReady: boolean
+  commitPreference: (preference: ResourceListPreference) => void
+  setFilter: (filterKey: string, values: string[]) => void
+  clearFilters: () => void
+  setSort: (column: string, direction: ResourceListPreference['sort']['direction']) => void
+  clearSort: () => void
+}
+
+interface PendingRestoration {
+  key: string
+  preference: ResourceListPreference
+}
+
+function normalizePreference(
+  preference: ResourceListPreference | undefined,
+  config: ResourceListPreferenceConfig
+): ResourceListPreference | null {
+  if (
+    !preference ||
+    !config.sortColumns.includes(preference.sort.column) ||
+    (preference.sort.direction !== 'asc' && preference.sort.direction !== 'desc')
+  ) {
+    return null
+  }
+
+  const filterKeys = Object.keys(preference.filters)
+  if (
+    filterKeys.length !== config.filterKeys.length ||
+    !config.filterKeys.every((key) => filterKeys.includes(key))
+  ) {
+    return null
+  }
+
+  for (const key of config.filterKeys) {
+    const values = preference.filters[key]
+    if (!Array.isArray(values) || !values.every((value) => typeof value === 'string')) return null
+  }
+
+  return {
+    sort: { ...preference.sort },
+    filters: Object.fromEntries(
+      config.filterKeys.map((key) => [key, [...preference.filters[key]]])
+    ),
+  }
+}
+
+/**
+ * Reconciles a module's URL-owned list state with its last-used local preference.
+ * Zustand is read only during initial entry and explicit user commits; it never
+ * becomes a live mirror of URL changes or browser history navigation.
+ */
+export function useResourceListPreferences({
+  workspaceId,
+  config,
+  preference,
+  applyPreference,
+  enabled = true,
+}: UseResourceListPreferencesProps): UseResourceListPreferencesReturn {
+  const key = `${workspaceId}:${config.module}`
+  const initializedKeyRef = useRef<string | null>(null)
+  const hydrationRequestedRef = useRef(false)
+  const [readyKey, setReadyKey] = useState<string | null>(null)
+  const [pendingRestoration, setPendingRestoration] = useState<PendingRestoration | null>(null)
+  const hasHydrated = useResourceListPreferencesStore((state) => state._hasHydrated)
+  const savedPreference = useResourceListPreferencesStore(
+    (state) => state.preferences[workspaceId]?.[config.module]
+  )
+  const setPreference = useResourceListPreferencesStore((state) => state.setPreference)
+  const removePreference = useResourceListPreferencesStore((state) => state.removePreference)
+
+  const defaultPreference = useMemo(
+    () => normalizePreference(config.defaultPreference, config),
+    [config]
+  )
+  const currentPreference = useMemo(
+    () => normalizePreference(preference, config),
+    [config, preference]
+  )
+  const hasEffectiveUrlPreference = Boolean(
+    currentPreference &&
+      defaultPreference &&
+      !resourceListPreferencesEqual(currentPreference, defaultPreference)
+  )
+
+  const rememberPreference = useCallback(
+    (normalizedPreference: ResourceListPreference) => {
+      if (!defaultPreference) return
+      if (resourceListPreferencesEqual(normalizedPreference, defaultPreference)) {
+        removePreference(workspaceId, config.module)
+      } else {
+        setPreference(workspaceId, config.module, normalizedPreference)
+      }
+    },
+    [config.module, defaultPreference, removePreference, setPreference, workspaceId]
+  )
+
+  useEffect(() => {
+    if (!enabled || hasHydrated || hydrationRequestedRef.current) return
+    hydrationRequestedRef.current = true
+    void useResourceListPreferencesStore.persist.rehydrate()
+  }, [enabled, hasHydrated])
+
+  useEffect(() => {
+    if (!enabled || !hasHydrated) return
+
+    if (pendingRestoration?.key === key) {
+      if (
+        currentPreference &&
+        resourceListPreferencesEqual(currentPreference, pendingRestoration.preference)
+      ) {
+        setPendingRestoration(null)
+        setReadyKey(key)
+      }
+      return
+    }
+
+    if (pendingRestoration) setPendingRestoration(null)
+    if (initializedKeyRef.current === key) return
+    initializedKeyRef.current = key
+
+    if (!currentPreference || !defaultPreference) {
+      setReadyKey(key)
+      return
+    }
+
+    if (!resourceListPreferencesEqual(currentPreference, defaultPreference)) {
+      rememberPreference(currentPreference)
+      setReadyKey(key)
+      return
+    }
+
+    const normalizedSaved = normalizePreference(savedPreference, config)
+    if (!normalizedSaved || resourceListPreferencesEqual(normalizedSaved, defaultPreference)) {
+      if (savedPreference) removePreference(workspaceId, config.module)
+      setReadyKey(key)
+      return
+    }
+
+    setPendingRestoration({ key, preference: normalizedSaved })
+    void applyPreference(normalizedSaved)
+  }, [
+    applyPreference,
+    config,
+    currentPreference,
+    defaultPreference,
+    enabled,
+    hasHydrated,
+    key,
+    pendingRestoration,
+    rememberPreference,
+    removePreference,
+    savedPreference,
+    workspaceId,
+  ])
+
+  const commitPreference = useCallback(
+    (nextPreference: ResourceListPreference) => {
+      const normalized = normalizePreference(nextPreference, config)
+      if (!normalized) return
+      rememberPreference(normalized)
+      void applyPreference(normalized)
+    },
+    [applyPreference, config, rememberPreference]
+  )
+
+  const setFilter = useCallback(
+    (filterKey: string, values: string[]) => {
+      if (!currentPreference || !config.filterKeys.includes(filterKey)) return
+      commitPreference({
+        ...currentPreference,
+        filters: { ...currentPreference.filters, [filterKey]: values },
+      })
+    },
+    [commitPreference, config.filterKeys, currentPreference]
+  )
+
+  const clearFilters = useCallback(() => {
+    if (!currentPreference) return
+    commitPreference({
+      ...currentPreference,
+      filters: Object.fromEntries(config.filterKeys.map((filterKey) => [filterKey, []])),
+    })
+  }, [commitPreference, config.filterKeys, currentPreference])
+
+  const setSort = useCallback(
+    (column: string, direction: ResourceListPreference['sort']['direction']) => {
+      if (!currentPreference) return
+      commitPreference({ ...currentPreference, sort: { column, direction } })
+    },
+    [commitPreference, currentPreference]
+  )
+
+  const clearSort = useCallback(() => {
+    if (!currentPreference || !defaultPreference) return
+    commitPreference({ ...currentPreference, sort: { ...defaultPreference.sort } })
+  }, [commitPreference, currentPreference, defaultPreference])
+
+  return {
+    isReady:
+      !enabled ||
+      (pendingRestoration?.key !== key && hasEffectiveUrlPreference) ||
+      readyKey === key,
+    commitPreference,
+    setFilter,
+    clearFilters,
+    setSort,
+    clearSort,
+  }
+}

--- a/apps/sim/hooks/use-resource-list-preferences.ts
+++ b/apps/sim/hooks/use-resource-list-preferences.ts
@@ -19,7 +19,6 @@ interface UseResourceListPreferencesProps {
 
 interface UseResourceListPreferencesReturn {
   isReady: boolean
-  commitPreference: (preference: ResourceListPreference) => void
   setFilter: (filterKey: string, values: string[]) => void
   clearFilters: () => void
   setSort: (column: string, direction: ResourceListPreference['sort']['direction']) => void
@@ -231,7 +230,6 @@ export function useResourceListPreferences({
 
   return {
     isReady: !enabled || (pendingRestoration?.key !== key && hasUrlPreference) || readyKey === key,
-    commitPreference,
     setFilter,
     clearFilters,
     setSort,

--- a/apps/sim/stores/resource-list-preferences/index.ts
+++ b/apps/sim/stores/resource-list-preferences/index.ts
@@ -1,0 +1,12 @@
+export {
+  RESOURCE_LIST_PREFERENCES_STORAGE_KEY,
+  useResourceListPreferencesStore,
+} from '@/stores/resource-list-preferences/store'
+export type {
+  ResourceListModule,
+  ResourceListPreference,
+  ResourceListPreferenceConfig,
+  ResourceListPreferencesByWorkspace,
+  ResourceListPreferencesState,
+} from '@/stores/resource-list-preferences/types'
+export { RESOURCE_LIST_MODULES } from '@/stores/resource-list-preferences/types'

--- a/apps/sim/stores/resource-list-preferences/store.test.ts
+++ b/apps/sim/stores/resource-list-preferences/store.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  RESOURCE_LIST_PREFERENCES_STORAGE_KEY,
+  useResourceListPreferencesStore,
+} from '@/stores/resource-list-preferences'
+import { resetRegisteredUserData } from '@/stores/user-data-reset-registry'
+
+const filesPreference = {
+  sort: { column: 'name', direction: 'asc' as const },
+  filters: { type: ['document'], size: [], uploadedBy: ['user-1'] },
+}
+
+const tablesPreference = {
+  sort: { column: 'rows', direction: 'desc' as const },
+  filters: { rows: ['large'], owner: [] },
+}
+
+function persistedValue() {
+  const value = localStorage.getItem(RESOURCE_LIST_PREFERENCES_STORAGE_KEY)
+  return value ? JSON.parse(value) : null
+}
+
+describe('resource list preferences store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useResourceListPreferencesStore.setState({ preferences: {}, _hasHydrated: false })
+    void useResourceListPreferencesStore.persist.clearStorage()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps preferences independent by workspace and module', () => {
+    const store = useResourceListPreferencesStore.getState()
+
+    store.setPreference('workspace-1', 'files', filesPreference)
+    store.setPreference('workspace-1', 'tables', tablesPreference)
+    store.setPreference('workspace-2', 'files', {
+      ...filesPreference,
+      filters: { ...filesPreference.filters, uploadedBy: ['user-2'] },
+    })
+
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({
+      'workspace-1': { files: filesPreference, tables: tablesPreference },
+      'workspace-2': {
+        files: {
+          ...filesPreference,
+          filters: { ...filesPreference.filters, uploadedBy: ['user-2'] },
+        },
+      },
+    })
+  })
+
+  it('removes one preference without disturbing sibling entries', () => {
+    const store = useResourceListPreferencesStore.getState()
+    store.setPreference('workspace-1', 'files', filesPreference)
+    store.setPreference('workspace-1', 'tables', tablesPreference)
+
+    store.removePreference('workspace-1', 'files')
+
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({
+      'workspace-1': { tables: tablesPreference },
+    })
+  })
+
+  it('persists only the preference map', () => {
+    useResourceListPreferencesStore
+      .getState()
+      .setPreference('workspace-1', 'files', filesPreference)
+
+    expect(persistedValue()).toEqual({
+      state: { preferences: { 'workspace-1': { files: filesPreference } } },
+      version: 1,
+    })
+  })
+
+  it('does not publish a redundant state update for an unchanged preference', () => {
+    const store = useResourceListPreferencesStore.getState()
+    store.setPreference('workspace-1', 'files', filesPreference)
+    const stateAfterFirstWrite = useResourceListPreferencesStore.getState()
+
+    store.setPreference('workspace-1', 'files', structuredClone(filesPreference))
+
+    expect(useResourceListPreferencesStore.getState()).toBe(stateAfterFirstWrite)
+  })
+
+  it('hydrates a valid saved preference and marks hydration complete', async () => {
+    localStorage.setItem(
+      RESOURCE_LIST_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        state: { preferences: { 'workspace-1': { files: filesPreference } } },
+        version: 1,
+      })
+    )
+
+    await useResourceListPreferencesStore.persist.rehydrate()
+
+    expect(useResourceListPreferencesStore.getState()).toMatchObject({
+      preferences: { 'workspace-1': { files: filesPreference } },
+      _hasHydrated: true,
+    })
+  })
+
+  it('drops malformed persisted entries while preserving valid siblings', async () => {
+    localStorage.setItem(
+      RESOURCE_LIST_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          preferences: {
+            'workspace-1': {
+              files: { sort: { column: 42, direction: 'up' }, filters: [] },
+              tables: tablesPreference,
+            },
+          },
+        },
+        version: 1,
+      })
+    )
+
+    await useResourceListPreferencesStore.persist.rehydrate()
+
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({
+      'workspace-1': { tables: tablesPreference },
+    })
+  })
+
+  it('recovers from invalid JSON with an empty hydrated store', async () => {
+    localStorage.setItem(RESOURCE_LIST_PREFERENCES_STORAGE_KEY, '{not-json')
+
+    await useResourceListPreferencesStore.persist.rehydrate()
+
+    expect(useResourceListPreferencesStore.getState()).toMatchObject({
+      preferences: {},
+      _hasHydrated: true,
+    })
+    expect(localStorage.getItem(RESOURCE_LIST_PREFERENCES_STORAGE_KEY)).toBeNull()
+  })
+
+  it('hydrates an empty store when localStorage reads throw', async () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage is blocked', 'SecurityError')
+    })
+
+    await expect(useResourceListPreferencesStore.persist.rehydrate()).resolves.toBeUndefined()
+
+    expect(useResourceListPreferencesStore.getState()).toMatchObject({
+      preferences: {},
+      _hasHydrated: true,
+    })
+  })
+
+  it('keeps in-memory preferences when localStorage writes throw', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage is full', 'QuotaExceededError')
+    })
+
+    expect(() =>
+      useResourceListPreferencesStore
+        .getState()
+        .setPreference('workspace-1', 'files', filesPreference)
+    ).not.toThrow()
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({
+      'workspace-1': { files: filesPreference },
+    })
+  })
+
+  it('completes malformed-state recovery when localStorage removal throws', async () => {
+    localStorage.setItem(RESOURCE_LIST_PREFERENCES_STORAGE_KEY, '{not-json')
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('Storage is blocked', 'SecurityError')
+    })
+
+    await expect(useResourceListPreferencesStore.persist.rehydrate()).resolves.toBeUndefined()
+
+    expect(useResourceListPreferencesStore.getState()).toMatchObject({
+      preferences: {},
+      _hasHydrated: true,
+    })
+  })
+
+  it.each([0, 2])('discards preferences from incompatible storage version %i', async (version) => {
+    localStorage.setItem(
+      RESOURCE_LIST_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        state: { preferences: { 'workspace-1': { files: filesPreference } } },
+        version,
+      })
+    )
+
+    await useResourceListPreferencesStore.persist.rehydrate()
+
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({})
+    expect(persistedValue()).toEqual({ state: { preferences: {} }, version: 1 })
+  })
+
+  it('clears in-memory and persisted identity-scoped values on user reset', () => {
+    useResourceListPreferencesStore
+      .getState()
+      .setPreference('workspace-1', 'files', filesPreference)
+
+    resetRegisteredUserData()
+
+    expect(useResourceListPreferencesStore.getState().preferences).toEqual({})
+    expect(localStorage.getItem(RESOURCE_LIST_PREFERENCES_STORAGE_KEY)).toBeNull()
+  })
+})

--- a/apps/sim/stores/resource-list-preferences/store.ts
+++ b/apps/sim/stores/resource-list-preferences/store.ts
@@ -1,0 +1,178 @@
+'use client'
+
+import { createLogger } from '@sim/logger'
+import { toError } from '@sim/utils/errors'
+import { isRecordLike } from '@sim/utils/object'
+import { create } from 'zustand'
+import { createJSONStorage, devtools, persist } from 'zustand/middleware'
+import type {
+  ResourceListModule,
+  ResourceListPreference,
+  ResourceListPreferencesByWorkspace,
+  ResourceListPreferencesState,
+} from '@/stores/resource-list-preferences/types'
+import { RESOURCE_LIST_MODULES } from '@/stores/resource-list-preferences/types'
+import { resourceListPreferencesEqual } from '@/stores/resource-list-preferences/utils'
+import { registerUserDataReset } from '@/stores/user-data-reset-registry'
+
+export const RESOURCE_LIST_PREFERENCES_STORAGE_KEY = 'resource-list-preferences'
+
+const logger = createLogger('ResourceListPreferencesStore')
+const RESOURCE_LIST_MODULE_SET = new Set<string>(RESOURCE_LIST_MODULES)
+
+const initialState = {
+  preferences: {} as ResourceListPreferencesByWorkspace,
+  _hasHydrated: false,
+}
+
+/** Keeps device-local preferences best-effort when browser storage is unavailable or full. */
+const safeLocalStorage = {
+  getItem: (name: string): string | null => {
+    try {
+      if (typeof localStorage === 'undefined') return null
+      return localStorage.getItem(name)
+    } catch (error) {
+      logger.warn('Failed to read resource list preferences from localStorage', toError(error))
+      return null
+    }
+  },
+  setItem: (name: string, value: string): void => {
+    try {
+      if (typeof localStorage === 'undefined') return
+      localStorage.setItem(name, value)
+    } catch (error) {
+      logger.warn('Failed to persist resource list preferences to localStorage', toError(error))
+    }
+  },
+  removeItem: (name: string): void => {
+    try {
+      if (typeof localStorage === 'undefined') return
+      localStorage.removeItem(name)
+    } catch (error) {
+      logger.warn('Failed to remove resource list preferences from localStorage', toError(error))
+    }
+  },
+}
+
+function isResourceListModule(value: string): value is ResourceListModule {
+  return RESOURCE_LIST_MODULE_SET.has(value)
+}
+
+function sanitizePreference(value: unknown): ResourceListPreference | null {
+  if (!isRecordLike(value) || !isRecordLike(value.sort) || !isRecordLike(value.filters)) {
+    return null
+  }
+
+  const { column, direction } = value.sort
+  if (
+    typeof column !== 'string' ||
+    column.length === 0 ||
+    (direction !== 'asc' && direction !== 'desc')
+  ) {
+    return null
+  }
+
+  const filters: Record<string, string[]> = {}
+  for (const [key, filterValue] of Object.entries(value.filters)) {
+    if (!Array.isArray(filterValue) || !filterValue.every((item) => typeof item === 'string')) {
+      return null
+    }
+    filters[key] = [...filterValue]
+  }
+
+  return { sort: { column, direction }, filters }
+}
+
+function sanitizePreferences(value: unknown): ResourceListPreferencesByWorkspace {
+  if (!isRecordLike(value)) return {}
+
+  const preferences: ResourceListPreferencesByWorkspace = {}
+  for (const [workspaceId, workspaceValue] of Object.entries(value)) {
+    if (workspaceId.length === 0 || !isRecordLike(workspaceValue)) continue
+
+    const workspacePreferences: Partial<Record<ResourceListModule, ResourceListPreference>> = {}
+    for (const [module, preferenceValue] of Object.entries(workspaceValue)) {
+      if (!isResourceListModule(module)) continue
+      const preference = sanitizePreference(preferenceValue)
+      if (preference) workspacePreferences[module] = preference
+    }
+
+    if (Object.keys(workspacePreferences).length > 0) {
+      preferences[workspaceId] = workspacePreferences
+    }
+  }
+
+  return preferences
+}
+
+export const useResourceListPreferencesStore = create<ResourceListPreferencesState>()(
+  devtools(
+    persist(
+      (set, get) => ({
+        ...initialState,
+        setPreference: (workspaceId, module, preference) => {
+          const currentPreference = get().preferences[workspaceId]?.[module]
+          if (currentPreference && resourceListPreferencesEqual(currentPreference, preference)) {
+            return
+          }
+          set((state) => ({
+            preferences: {
+              ...state.preferences,
+              [workspaceId]: {
+                ...state.preferences[workspaceId],
+                [module]: structuredClone(preference),
+              },
+            },
+          }))
+        },
+        removePreference: (workspaceId, module) => {
+          if (!get().preferences[workspaceId]?.[module]) return
+          set((state) => {
+            const workspacePreferences = state.preferences[workspaceId] ?? {}
+            const nextWorkspacePreferences = { ...workspacePreferences }
+            delete nextWorkspacePreferences[module]
+
+            const preferences = { ...state.preferences }
+            if (Object.keys(nextWorkspacePreferences).length === 0) {
+              delete preferences[workspaceId]
+            } else {
+              preferences[workspaceId] = nextWorkspacePreferences
+            }
+            return { preferences }
+          })
+        },
+        reset: () => set({ preferences: {} }),
+        setHasHydrated: (_hasHydrated) => set({ _hasHydrated }),
+      }),
+      {
+        name: RESOURCE_LIST_PREFERENCES_STORAGE_KEY,
+        storage: createJSONStorage(() => safeLocalStorage),
+        version: 1,
+        skipHydration: true,
+        partialize: (state) => ({ preferences: state.preferences }),
+        migrate: () => ({ preferences: {} }),
+        merge: (persisted, current) => {
+          const persistedState = isRecordLike(persisted) ? persisted : {}
+          return {
+            ...current,
+            preferences: sanitizePreferences(persistedState.preferences),
+          }
+        },
+        onRehydrateStorage: () => (state, error) => {
+          if (error) {
+            useResourceListPreferencesStore.setState({ preferences: {}, _hasHydrated: true })
+            void useResourceListPreferencesStore.persist.clearStorage()
+            return
+          }
+          state?.setHasHydrated(true)
+        },
+      }
+    ),
+    { name: 'resource-list-preferences' }
+  )
+)
+
+registerUserDataReset(RESOURCE_LIST_PREFERENCES_STORAGE_KEY, () => {
+  useResourceListPreferencesStore.getState().reset()
+  void useResourceListPreferencesStore.persist.clearStorage()
+})

--- a/apps/sim/stores/resource-list-preferences/types.ts
+++ b/apps/sim/stores/resource-list-preferences/types.ts
@@ -21,6 +21,7 @@ export interface ResourceListPreferenceConfig {
   module: ResourceListModule
   sortColumns: readonly string[]
   filterKeys: readonly string[]
+  preferenceUrlKeys?: Readonly<Record<string, string>>
   defaultPreference: ResourceListPreference
 }
 

--- a/apps/sim/stores/resource-list-preferences/types.ts
+++ b/apps/sim/stores/resource-list-preferences/types.ts
@@ -1,0 +1,38 @@
+import type { SortDirection } from '@/lib/url-state'
+
+export const RESOURCE_LIST_MODULES = ['files', 'tables', 'knowledge'] as const
+
+export type ResourceListModule = (typeof RESOURCE_LIST_MODULES)[number]
+
+export interface ResourceListPreference {
+  sort: {
+    column: string
+    direction: SortDirection
+  }
+  filters: Record<string, string[]>
+}
+
+export type ResourceListPreferencesByWorkspace = Record<
+  string,
+  Partial<Record<ResourceListModule, ResourceListPreference>>
+>
+
+export interface ResourceListPreferenceConfig {
+  module: ResourceListModule
+  sortColumns: readonly string[]
+  filterKeys: readonly string[]
+  defaultPreference: ResourceListPreference
+}
+
+export interface ResourceListPreferencesState {
+  preferences: ResourceListPreferencesByWorkspace
+  _hasHydrated: boolean
+  setPreference: (
+    workspaceId: string,
+    module: ResourceListModule,
+    preference: ResourceListPreference
+  ) => void
+  removePreference: (workspaceId: string, module: ResourceListModule) => void
+  reset: () => void
+  setHasHydrated: (hasHydrated: boolean) => void
+}

--- a/apps/sim/stores/resource-list-preferences/utils.ts
+++ b/apps/sim/stores/resource-list-preferences/utils.ts
@@ -1,0 +1,24 @@
+import type { ResourceListPreference } from '@/stores/resource-list-preferences/types'
+
+export function resourceListPreferencesEqual(
+  left: ResourceListPreference,
+  right: ResourceListPreference
+): boolean {
+  if (left.sort.column !== right.sort.column || left.sort.direction !== right.sort.direction) {
+    return false
+  }
+
+  const leftFilterKeys = Object.keys(left.filters)
+  const rightFilterKeys = Object.keys(right.filters)
+  if (leftFilterKeys.length !== rightFilterKeys.length) return false
+
+  return leftFilterKeys.every((key) => {
+    const leftValues = left.filters[key]
+    const rightValues = right.filters[key]
+    return (
+      Array.isArray(rightValues) &&
+      leftValues.length === rightValues.length &&
+      leftValues.every((value, index) => value === rightValues[index])
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- remember Files, Tables, and Knowledge filter and sort preferences per workspace
- restore saved preferences through URL state without rendering temporary defaults
- treat any explicit filter or sort query parameter as authoritative, including parameters that resolve to module defaults
- keep partial deep links complete and clear saved preferences on identity reset

## Type of Change
- [x] Feature

## Testing
- `bun run test -- hooks/use-resource-list-preferences.test.tsx stores/resource-list-preferences/store.test.ts` from `apps/sim` (33 tests)
- `bun run lint`
- `bun run lint:check`
- `bun run check:audits` (44 audits)
- `bun run apps/sim/scripts/check-block-registry.ts origin/staging`
- `bun run check:zustand-v5`
- `bun run check:api-validation`
- Known baseline: app type checking still reports unrelated existing errors in the Pi SDK and MySQL client

## Post-Deploy Monitoring & Validation
- No server logs or operational metrics are expected because this changes device-local list preference reconciliation only.
- Smoke-test Files, Tables, and Knowledge: clean URLs restore saved preferences, while explicit default query parameters override and clear the saved preference.
- Healthy behavior: each module becomes ready without a default-state flash, repeated URL writes, or a stuck loading state.
- Roll back the latest fix commit if an explicit URL is overridden by storage or module loading remains blocked.
- Validation window and owner: first post-deploy smoke test by the feature owner.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement](./CONTRIBUTING.md#contributor-license-agreement-cla)