### PR TITLE
fix(agent): ignore empty advanced MCP bindings

### DIFF
--- a/apps/sim/executor/handlers/agent/agent-handler.test.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.test.ts
@@ -3779,6 +3779,32 @@ describe('AgentBlockHandler', () => {
       ])
     })
 
+    it('does not create tools for a blank advanced MCP server binding', async () => {
+      await handler.execute(
+        {
+          ...mockContext,
+          workspaceId: 'test-workspace-123',
+          workflowId: 'test-workflow-456',
+        },
+        mockBlock,
+        {
+          model: 'gpt-4o',
+          userPrompt: 'Continue without MCP tools',
+          apiKey: 'test-api-key',
+          tools: [
+            {
+              type: 'mcp-server-advanced',
+              params: { serverId: '' },
+              usageControl: 'auto' as const,
+            },
+          ],
+        }
+      )
+
+      expect(mockDiscoverMcpServerToolsAsExecutor).not.toHaveBeenCalled()
+      expect(mockExecuteProviderRequest.mock.calls[0][1].tools).toEqual([])
+    })
+
     describe('customToolId resolution - DB as source of truth', () => {
       const staleInlineSchema = {
         function: {

--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -803,6 +803,8 @@ export class AgentBlockHandler implements BlockHandler {
       if (entry.tool.type === 'mcp') {
         mcpTools.push(entry)
       } else if (entry.tool.type === MCP_SERVER_ADVANCED_TOOL_TYPE) {
+        const serverId = entry.tool.params?.serverId
+        if (typeof serverId === 'string' && !serverId.trim()) continue
         advancedMcpServers.push(entry)
       } else {
         otherTools.push(entry)

--- a/apps/sim/executor/handlers/mothership/mothership-handler.test.ts
+++ b/apps/sim/executor/handlers/mothership/mothership-handler.test.ts
@@ -1030,6 +1030,25 @@ describe('MothershipBlockHandler', () => {
     ])
   })
 
+  it('does not forward tools for a blank advanced MCP server binding', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({ content: 'done', toolCalls: [] }))
+
+    await handler.execute(context, block, {
+      prompt: 'Continue without MCP tools',
+      tools: [
+        {
+          type: 'mcp-server-advanced',
+          params: { serverId: '' },
+          usageControl: 'auto',
+        },
+      ],
+    })
+
+    expect(mockDiscoverMcpServerToolsAsExecutor).not.toHaveBeenCalled()
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(options.body))).not.toHaveProperty('mcpTools')
+  })
+
   it('does not scan arbitrary Mothership metadata, attachment names, or payloads', async () => {
     const secret = 'boundary-secret'
     const registry = new ResolvedSecretTraceRegistry([

--- a/apps/sim/executor/handlers/mothership/mothership-handler.ts
+++ b/apps/sim/executor/handlers/mothership/mothership-handler.ts
@@ -161,9 +161,10 @@ async function expandMothershipMcpTools(
         throw new Error('MCP Server (Advanced) requires params.serverId')
       }
       const serverId = candidate.params.serverId
-      if (typeof serverId !== 'string' || !serverId.trim()) {
+      if (typeof serverId !== 'string') {
         throw new Error('MCP Server (Advanced) requires params.serverId')
       }
+      if (!serverId.trim()) return []
       const usageControl: 'auto' | 'force' = candidate.usageControl === 'force' ? 'force' : 'auto'
       return [{ serverId, usageControl }]
     }

--- a/apps/sim/lib/mcp/shared.test.ts
+++ b/apps/sim/lib/mcp/shared.test.ts
@@ -46,9 +46,18 @@ describe('assertValidMcpServerToolBindings', () => {
     ).not.toThrow()
   })
 
+  it('ignores server-wide bindings with blank server IDs', () => {
+    expect(() =>
+      assertValidMcpServerToolBindings([
+        { type: 'mcp-server-advanced', params: { serverId: '' } },
+        { type: 'mcp-server-advanced', params: { serverId: '   ' } },
+      ])
+    ).not.toThrow()
+  })
+
   it('fails fast on a malformed active server-wide binding', () => {
     expect(() =>
-      assertValidMcpServerToolBindings([{ type: 'mcp-server-advanced', params: { serverId: '' } }])
+      assertValidMcpServerToolBindings([{ type: 'mcp-server-advanced', params: {} }])
     ).toThrow('requires params.serverId')
   })
 })

--- a/apps/sim/lib/mcp/shared.ts
+++ b/apps/sim/lib/mcp/shared.ts
@@ -49,9 +49,10 @@ export function assertValidMcpServerToolBindings(value: unknown): void {
     }
     if (tool.type !== MCP_SERVER_ADVANCED_TOOL_TYPE) continue
     const serverId = tool.params?.serverId
-    if (typeof serverId !== 'string' || !serverId.trim()) {
+    if (typeof serverId !== 'string') {
       throw new Error('MCP Server (Advanced) requires params.serverId')
     }
+    if (!serverId.trim()) continue
     if (advancedServerIds.has(serverId)) {
       throw new Error(`Duplicate MCP Server (Advanced) binding for ${serverId}`)
     }


### PR DESCRIPTION
## Summary
- treat blank MCP Server (Advanced) bindings as inactive
- avoid MCP discovery and tool creation until a server ID is configured
- preserve fail-fast behavior for malformed non-string bindings

## Type of Change
- [x] Bug fix

## Testing
- 163 focused MCP and Agent tests passed
- lint and all 45 repository audits passed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)