### PR TITLE
fix(billing): coerce COST_MULTIPLIER to a number before sandbox pricing

### DIFF
--- a/apps/sim/lib/billing/sandbox-pricing.test.ts
+++ b/apps/sim/lib/billing/sandbox-pricing.test.ts
@@ -70,6 +70,9 @@ describe('sandbox pricing', () => {
 
       setEnv({ COST_MULTIPLIER: '-2' })
       expect(createSandboxPricing('e2b').multiplier).toBe(1)
+
+      setEnv({ COST_MULTIPLIER: '   ' })
+      expect(createSandboxPricing('e2b').multiplier).toBe(1)
     })
   })
 })

--- a/apps/sim/lib/billing/sandbox-pricing.test.ts
+++ b/apps/sim/lib/billing/sandbox-pricing.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'vitest'
+/**
+ * @vitest-environment node
+ */
+import { resetEnvMock, setEnv } from '@sim/testing/mocks/env.mock'
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.hoisted(() => {
+  vi.stubEnv('NODE_ENV', 'production')
+})
+
+vi.unmock('@/lib/core/config/env-flags')
+
 import { createSandboxPricing, priceSandboxUsage } from '@/lib/billing/sandbox-pricing'
+
+afterEach(resetEnvMock)
+afterAll(() => vi.unstubAllEnvs())
 
 describe('sandbox pricing', () => {
   it.each([
@@ -32,5 +46,30 @@ describe('sandbox pricing', () => {
     expect(() => createSandboxPricing('e2b', Number.POSITIVE_INFINITY)).toThrow(
       'finite nonnegative'
     )
+  })
+
+  describe('default multiplier from the production environment', () => {
+    it('coerces the string COST_MULTIPLIER that process.env delivers', () => {
+      setEnv({ COST_MULTIPLIER: '1.1' })
+
+      const pricing = createSandboxPricing('e2b')
+
+      expect(pricing.multiplier).toBe(1.1)
+      expect(priceSandboxUsage(pricing, 1000, 1000).billedCost).toBeCloseTo(0.0000506, 8)
+    })
+
+    it('falls back to 1 when COST_MULTIPLIER is unset', () => {
+      setEnv({ COST_MULTIPLIER: undefined })
+
+      expect(createSandboxPricing('daytona').multiplier).toBe(1)
+    })
+
+    it('falls back to 1 instead of throwing when COST_MULTIPLIER is not a nonnegative number', () => {
+      setEnv({ COST_MULTIPLIER: 'abc' })
+      expect(createSandboxPricing('e2b').multiplier).toBe(1)
+
+      setEnv({ COST_MULTIPLIER: '-2' })
+      expect(createSandboxPricing('e2b').multiplier).toBe(1)
+    })
   })
 })

--- a/apps/sim/lib/core/config/env-flags.ts
+++ b/apps/sim/lib/core/config/env-flags.ts
@@ -14,7 +14,7 @@ import {
   resolveEnterpriseEntitlement,
   resolveSandboxFeatureAvailability,
 } from './enterprise-entitlements'
-import { env, envBoolean, getEnv, isFalsy, isTruthy } from './env'
+import { env, envBoolean, envNumber, getEnv, isFalsy, isTruthy } from './env'
 import { hasEnvCapabilityValue, inspectCapability, SANDBOX_CAPABILITY } from './env-capabilities'
 
 /**
@@ -684,8 +684,13 @@ export function getAllowedMcpDomainsFromEnv(): string[] | null {
 }
 
 /**
- * Get cost multiplier based on environment
+ * Get cost multiplier based on environment.
+ *
+ * `COST_MULTIPLIER` is declared as a number but arrives as a string from
+ * `process.env` because `createEnv` skips validation, so it is normalized
+ * through {@link envNumber}. Unset, empty, non-numeric, and negative values
+ * fall back to 1.
  */
 export function getCostMultiplier(): number {
-  return isProd ? (env.COST_MULTIPLIER ?? 1) : 1
+  return isProd ? envNumber(env.COST_MULTIPLIER, 1) : 1
 }

--- a/apps/sim/lib/core/config/env.test.ts
+++ b/apps/sim/lib/core/config/env.test.ts
@@ -12,4 +12,11 @@ describe('envNumber', () => {
     expect(envNumber('5.5', 1, { min: 1, integer: true })).toBe(1)
     expect(envNumber(5.5, 1, { min: 1, integer: true })).toBe(1)
   })
+
+  it('treats whitespace-only values as unset instead of coercing them to 0', () => {
+    expect(envNumber('   ', 1)).toBe(1)
+    expect(envNumber('', 1)).toBe(1)
+    expect(envNumber(' 1.1 ', 1)).toBe(1.1)
+    expect(envNumber('0', 1)).toBe(0)
+  })
 })

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -813,7 +813,7 @@ export function envNumber(
   ) {
     return value
   }
-  if (value === undefined || value === null || value === '') return fallback
+  if (value === undefined || value === null || String(value).trim() === '') return fallback
   const parsed = Number(value)
   return Number.isFinite(parsed) && parsed >= min && (!options.integer || Number.isInteger(parsed))
     ? parsed

--- a/packages/testing/src/mocks/env.mock.ts
+++ b/packages/testing/src/mocks/env.mock.ts
@@ -136,7 +136,7 @@ export function envNumberImpl(
   ) {
     return value
   }
-  if (value === undefined || value === null || value === '') return fallback
+  if (value === undefined || value === null || String(value).trim() === '') return fallback
   const parsed = Number(value)
   return Number.isFinite(parsed) && parsed >= min && (!options.integer || Number.isInteger(parsed))
     ? parsed


### PR DESCRIPTION
## Summary
- `COST_MULTIPLIER` is declared as `z.number()` but `createEnv` runs with `skipValidation`, so the value arrives as the raw `process.env` string. Every existing consumer multiplies by it, which JS coerces silently, so the type bug was invisible until `createSandboxPricing` (#7184) added a `Number.isFinite` guard — that guard rejects the string and every metered E2B/Daytona Function block fails with `Sandbox pricing multiplier must be a finite nonnegative number`
- `getCostMultiplier` now normalizes the value through `envNumber`, the helper written for exactly this case. Unset, empty, non-numeric, and negative values fall back to 1 instead of leaking a string (or crashing) into billing math. This fixes all seven consumers at once
- Regression tests exercise the real `getCostMultiplier` under a production `NODE_ENV` with a string `COST_MULTIPLIER`; they reproduce the exact error against the previous code

## Type of Change
- [x] Bug fix

## Testing
- New tests fail on the previous code with the production error and pass with the fix
- `sandbox-pricing`, `cost-policy`, `providers/index`, and `env` suites pass (84 tests)
- `bun run lint`, block-registry check, `check:audits`, and the CI env-flag validation block pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
