### PR TITLE
chore(legal): clarify DPF certification scope

### DIFF
--- a/apps/sim/app/(landing)/privacy/privacy-content.tsx
+++ b/apps/sim/app/(landing)/privacy/privacy-content.tsx
@@ -43,7 +43,7 @@ function richText(content: string): ReactNode {
 export const PRIVACY_CONFIG: LegalPageConfig = {
   title: 'Privacy Policy',
   description: 'Sim Studio, Inc. · Operating the Sim platform (sim.ai)',
-  lastUpdated: 'August 25, 2026',
+  lastUpdated: 'September 2, 2026',
   intro: [
     {
       kind: 'paragraph',
@@ -399,7 +399,7 @@ export const PRIVACY_CONFIG: LegalPageConfig = {
         {
           kind: 'paragraph',
           content: richText(
-            'Sim subjects all Personal Data received from the European Union, the United Kingdom and Gibraltar, and Switzerland in reliance on the applicable part of the DPF program to the relevant DPF Principles. Sim Studio, Inc. has no other U.S. entities or U.S. subsidiaries covered by its certification. This public policy covers non-human-resources Personal Data. Any human-resources data covered by the certification is addressed in the applicable employee privacy notice.'
+            "Sim subjects all Personal Data received from the European Union, the United Kingdom and Gibraltar, and Switzerland in reliance on the applicable part of the DPF program to the relevant DPF Principles. Sim Studio, Inc. has no other U.S. entities or U.S. subsidiaries covered by its certification. Sim's certification under the EU-U.S. DPF, the UK Extension to the EU-U.S. DPF, and the Swiss-U.S. DPF covers non-human-resources Personal Data only. Human-resources data is not covered by this certification."
           ),
         },
         { kind: 'subheading', text: 'Notice, Use, and Choice' },


### PR DESCRIPTION
## Summary
- Update the privacy policy effective date to September 2, 2026
- Clarify that the Data Privacy Framework certification covers non-human-resources Personal Data only

## Type of Change
- [x] Maintenance

## Testing
Passed cleanup review, repository lint, block-registry audit, and the 45-check audit suite.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)