### PR TITLE
fix(copilot): stop async chat auto-titling from clobbering an explicit rename

### DIFF
--- a/apps/sim/lib/copilot/request/lifecycle/start.ts
+++ b/apps/sim/lib/copilot/request/lifecycle/start.ts
@@ -3,7 +3,7 @@ import { db } from '@sim/db'
 import { copilotChats } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
-import { eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import {
   assertBillingAttributionSnapshot,
   type BillingAttributionSnapshot,
@@ -489,7 +489,17 @@ function fireTitleGeneration(params: {
   })
     .then(async (title) => {
       if (!title) return
-      await db.update(copilotChats).set({ title }).where(eq(copilotChats.id, chatId))
+      // Only stamp the generated title while the chat has none. Title
+      // generation is fired at turn start and resolves asynchronously, so a
+      // user could rename the chat in the meantime; the `isNull` guard makes
+      // the write lose that race instead of clobbering the explicit rename.
+      const stamped = await db
+        .update(copilotChats)
+        .set({ title })
+        .where(and(eq(copilotChats.id, chatId), isNull(copilotChats.title)))
+        .returning({ id: copilotChats.id })
+      // The rename won — do not announce a title the row no longer holds.
+      if (stamped.length === 0) return
       await publisher.publish({
         type: MothershipStreamV1EventType.session,
         payload: { kind: MothershipStreamV1SessionKind.title, title },

--- a/apps/sim/lib/mothership/inbox/executor.ts
+++ b/apps/sim/lib/mothership/inbox/executor.ts
@@ -2,7 +2,7 @@ import { copilotChats, db, mothershipInboxTask, user, workspace } from '@sim/db'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
 import { generateId } from '@sim/utils/id'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { getActivelyBannedUserIds, isEmailBlocked } from '@/lib/auth/ban'
 import { resolveBillingAttribution } from '@/lib/billing/core/billing-attribution'
 import { resolveOrCreateChat } from '@/lib/copilot/chat/lifecycle'
@@ -167,7 +167,17 @@ export async function executeInboxTask(taskId: string): Promise<void> {
       })
         .then(async (title) => {
           if (title && chatId) {
-            await db.update(copilotChats).set({ title }).where(eq(copilotChats.id, chatId))
+            // Only stamp the generated title while the chat has none. This
+            // resolves asynchronously, so a user could rename the chat in the
+            // meantime; the `isNull` guard makes the write lose that race
+            // instead of clobbering the explicit rename.
+            const stamped = await db
+              .update(copilotChats)
+              .set({ title })
+              .where(and(eq(copilotChats.id, chatId), isNull(copilotChats.title)))
+              .returning({ id: copilotChats.id })
+            // The rename won — do not announce a title the row no longer holds.
+            if (stamped.length === 0) return
             chatPubSub?.publishStatusChanged({
               workspaceId: ws.id,
               chatId,


### PR DESCRIPTION
## Summary

Chat title generation is fired at turn **start** and resolves **asynchronously**, but its write was unconditional:

```ts
await db.update(copilotChats).set({ title }).where(eq(copilotChats.id, chatId))
```

The guard that decides whether to generate a title (`if (!chatId || currentChat?.title || !isNewChat) return`) evaluates a snapshot taken at request start. The write then happens much later with no re-check — a classic check-then-write (TOCTOU) race. If a user renames the chat while the title is being generated, the generated title lands afterward and **silently overwrites the rename**.

This is reachable in normal use: rename a chat shortly after sending the first message and the rename can disappear.

## Fix

Make the write conditional on the title still being unset, so a generated title can only ever fill an empty slot:

```ts
.where(and(eq(copilotChats.id, chatId), isNull(copilotChats.title)))
```

`copilotChats.title` is nullable with no default, so `isNull` is exactly the "no title yet" state. The update is atomic, so the explicit rename deterministically wins. When the write loses the race (0 rows), the follow-up title notification is skipped as well — we should not announce a title the row no longer holds.

**Both** auto-title call sites are fixed, since they had the identical unconditional write:
- `lib/copilot/request/lifecycle/start.ts` — the interactive turn path
- `lib/mothership/inbox/executor.ts` — the inbox task path

## Why not "eliminate the race" instead

The concurrency is inherent — an async background title generator runs alongside user actions, and awaiting it would block the turn on a title LLM call. The race cannot be removed, only made well-defined; a conditional (compare-and-set) update is the standard way to do that, and it makes the outcome deterministic: an explicit title always wins, a generated one only fills a gap.

## Testing

`tsc --noEmit` and `biome` clean. Existing unit tests for both changed paths pass (`start.test.ts`, `executor.test.ts` — 13 tests). This also removes the root cause of a flaky integration check that asserted a forked chat inherits its parent's renamed title.

## Type of change

- [x] Bug fix (non-breaking)