### PR TITLE
feat(models): add Muse Spark 1.3

### DIFF
--- a/apps/docs/content/docs/workflows/blocks/agent.mdx
+++ b/apps/docs/content/docs/workflows/blocks/agent.mdx
@@ -117,7 +117,7 @@ Live tool-call chips stream for **OpenAI, Anthropic, Azure Anthropic, Google, Ve
 | DeepSeek | Full thinking deltas | `deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-reasoner` |
 | xAI | Full thinking deltas | `grok-4.6`, `grok-4.5`, `grok-4.3`, `grok-4.20-multi-agent-0309` |
 | Groq | Full thinking deltas | `groq/openai/gpt-oss-120b`, `groq/openai/gpt-oss-20b`, `groq/openai/gpt-oss-safeguard-20b`, `groq/qwen/qwen3.6-27b` |
-| Meta | Not streamed | `muse-spark-1.1` |
+| Meta | Not streamed | `muse-spark-1.3`, `muse-spark-1.1` |
 | Kimi | Full thinking deltas | `kimi-k2.6` |
 | Z.ai | Full thinking deltas | `glm-5.3`, `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5-air` |
 

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -2814,7 +2814,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
     id: 'meta',
     name: 'Meta',
     description: "Meta's Muse Spark models via the Meta Model API (OpenAI-compatible)",
-    defaultModel: 'muse-spark-1.1',
+    defaultModel: 'muse-spark-1.3',
     modelPatterns: [/^muse-spark/],
     icon: MetaIcon,
     color: '#0082FB',
@@ -2823,6 +2823,23 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
       toolUsageControl: true,
     },
     models: [
+      {
+        id: 'muse-spark-1.3',
+        pricing: {
+          input: 1.25,
+          cachedInput: 0.15,
+          output: 4.25,
+          updatedAt: '2026-09-02',
+        },
+        capabilities: {
+          reasoningEffort: {
+            values: ['minimal', 'low', 'medium', 'high', 'xhigh'],
+          },
+        },
+        contextWindow: 1048576,
+        releaseDate: '2026-09-02',
+        recommended: true,
+      },
       {
         id: 'muse-spark-1.1',
         pricing: {
@@ -2838,7 +2855,6 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1048576,
         releaseDate: '2026-07-09',
-        recommended: true,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Add `muse-spark-1.3` to the Meta provider — \$1.25/\$0.15/\$4.25 per 1M input/cached/output, 1,048,576-token context, reasoning effort `minimal | low | medium | high | xhigh`, released 2026-09-02
- Promote it to the provider `defaultModel` and `recommended` flagship; `muse-spark-1.1` stays available but drops the `recommended` flag
- Regenerate the Agent block streamed-thinking docs table

Values verified against Meta's Model API docs (models index, pricing/rate-limits, reasoning) and cross-checked with OpenRouter. Meta stays BYOK-only — `getHostedModels()` doesn't expand the provider, so no hosted-billing change. No max output token cap is documented, so `maxOutputTokens` is omitted.

## Type of Change
- [x] New feature

## Testing
- `bun run lint`
- `bun run type-check`
- `bun run check:audits` — 45/45 pass (incl. `agent-stream-docs:check`)
- `vitest run providers/models.test.ts providers/utils.test.ts` — 219 pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)