### PR TITLE
fix(knowledge): grant member access as each batch is indexed instead of at the end of the run

### DIFF
--- a/apps/sim/connectors/gmail/gmail.ts
+++ b/apps/sim/connectors/gmail/gmail.ts
@@ -399,6 +399,13 @@ async function resolveLabelNames(
 }
 
 /**
+ * What a hydrated thread retains: message bodies as text, never attachments,
+ * so a generous ceiling for a long thread is still small. Lets a batch of
+ * threads hydrate together instead of one at a time.
+ */
+const ESTIMATED_THREAD_BYTES = 256 * 1024
+
+/**
  * Creates a lightweight document stub from a thread list entry.
  * Uses metadata-based contentHash for change detection without downloading content.
  */
@@ -412,6 +419,7 @@ function threadToStub(thread: {
     title: thread.snippet || 'Untitled Thread',
     content: '',
     contentDeferred: true,
+    estimatedBytes: ESTIMATED_THREAD_BYTES,
     mimeType: 'text/plain',
     sourceUrl: threadUrl(thread.id),
     contentHash: `gmail:${thread.id}:${thread.historyId ?? ''}`,

--- a/apps/sim/connectors/gmail/gmail.ts
+++ b/apps/sim/connectors/gmail/gmail.ts
@@ -4,6 +4,8 @@ import { fetchWithRetry, VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/document
 import { DEFAULT_MAX_THREADS, gmailConnectorMeta } from '@/connectors/gmail/meta'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
 import {
+  BoundedLines,
+  CONNECTOR_TEXT_DOCUMENT_MAX_BYTES,
   htmlToPlainText,
   joinTagArray,
   parseDefaultedUnlimitedSafeInteger,
@@ -323,21 +325,17 @@ function formatThread(thread: GmailThread): {
   }
   const labelIds = [...labelIdSet]
 
-  const lines: string[] = []
-  lines.push(`Subject: ${subject}`)
-  lines.push(`From: ${from}`)
+  const lines = new BoundedLines()
+  lines.push(`Subject: ${subject}`, `From: ${from}`)
   if (to) lines.push(`To: ${to}`)
-  lines.push(`Messages: ${messages.length}`)
-  lines.push('')
+  lines.push(`Messages: ${messages.length}`, '')
 
   for (const msg of messages) {
     const msgFrom = getHeader(msg.payload, 'From') || 'Unknown'
     const msgDate = getHeader(msg.payload, 'Date') || ''
     const body = msg.payload ? extractBody(msg.payload) : ''
 
-    lines.push(`--- ${msgFrom} (${msgDate}) ---`)
-    lines.push(body.trim())
-    lines.push('')
+    if (!lines.push(`--- ${msgFrom} (${msgDate}) ---`, body.trim(), '')) break
   }
 
   const firstDate = firstMessage.internalDate
@@ -348,7 +346,7 @@ function formatThread(thread: GmailThread): {
     : undefined
 
   return {
-    content: lines.join('\n').trim(),
+    content: lines.join().trim(),
     subject,
     metadata: {
       from,
@@ -399,13 +397,6 @@ async function resolveLabelNames(
 }
 
 /**
- * What a hydrated thread retains: message bodies as text, never attachments,
- * so a generous ceiling for a long thread is still small. Lets a batch of
- * threads hydrate together instead of one at a time.
- */
-const ESTIMATED_THREAD_BYTES = 256 * 1024
-
-/**
  * Creates a lightweight document stub from a thread list entry.
  * Uses metadata-based contentHash for change detection without downloading content.
  */
@@ -419,7 +410,7 @@ function threadToStub(thread: {
     title: thread.snippet || 'Untitled Thread',
     content: '',
     contentDeferred: true,
-    estimatedBytes: ESTIMATED_THREAD_BYTES,
+    estimatedBytes: CONNECTOR_TEXT_DOCUMENT_MAX_BYTES,
     mimeType: 'text/plain',
     sourceUrl: threadUrl(thread.id),
     contentHash: `gmail:${thread.id}:${thread.historyId ?? ''}`,

--- a/apps/sim/connectors/google-chat/google-chat.ts
+++ b/apps/sim/connectors/google-chat/google-chat.ts
@@ -13,6 +13,9 @@ import { parseTagDate } from '@/connectors/utils'
 
 const logger = createLogger('GoogleChatConnector')
 
+/** A hydrated space retains a bounded window of message text; lets spaces hydrate in batches. */
+const ESTIMATED_SPACE_BYTES = 1024 * 1024
+
 const CHAT_API_BASE = 'https://chat.googleapis.com/v1'
 const MS_PER_DAY = 24 * 60 * 60 * 1000
 
@@ -218,6 +221,7 @@ function spaceToStub(
     title: spaceTitle(space),
     content: '',
     contentDeferred: true,
+    estimatedBytes: ESTIMATED_SPACE_BYTES,
     mimeType: 'text/plain',
     sourceUrl: space.spaceUri,
     contentHash: buildContentHash(space, maxMessages, lookbackDays, syncContext),

--- a/apps/sim/connectors/google-chat/google-chat.ts
+++ b/apps/sim/connectors/google-chat/google-chat.ts
@@ -9,12 +9,9 @@ import {
   SPACES_PAGE_SIZE,
 } from '@/connectors/google-chat/meta'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
-import { parseTagDate } from '@/connectors/utils'
+import { BoundedLines, CONNECTOR_TEXT_DOCUMENT_MAX_BYTES, parseTagDate } from '@/connectors/utils'
 
 const logger = createLogger('GoogleChatConnector')
-
-/** A hydrated space retains a bounded window of message text; lets spaces hydrate in batches. */
-const ESTIMATED_SPACE_BYTES = 1024 * 1024
 
 const CHAT_API_BASE = 'https://chat.googleapis.com/v1'
 const MS_PER_DAY = 24 * 60 * 60 * 1000
@@ -221,7 +218,7 @@ function spaceToStub(
     title: spaceTitle(space),
     content: '',
     contentDeferred: true,
-    estimatedBytes: ESTIMATED_SPACE_BYTES,
+    estimatedBytes: CONNECTOR_TEXT_DOCUMENT_MAX_BYTES,
     mimeType: 'text/plain',
     sourceUrl: space.spaceUri,
     contentHash: buildContentHash(space, maxMessages, lookbackDays, syncContext),
@@ -328,27 +325,26 @@ function senderLabel(sender: ChatUser | undefined): string {
  * instead, which already handles size caps, OCR, and format parsing.
  */
 function formatSpaceContent(space: Space, messages: ChatMessage[]): string {
-  const parts: string[] = [`Space: ${spaceTitle(space)}`]
+  const parts = new BoundedLines()
+  parts.push(`Space: ${spaceTitle(space)}`)
   const description = space.spaceDetails?.description?.trim()
   if (description) parts.push(`Description: ${description}`)
   const guidelines = space.spaceDetails?.guidelines?.trim()
   if (guidelines) parts.push(`Guidelines: ${guidelines}`)
 
-  const lines: string[] = []
+  let headed = false
   for (const message of messages) {
     const text = message.text?.trim() || message.fallbackText?.trim()
     if (!text) continue
+    if (!headed) {
+      parts.push('', '--- Messages ---')
+      headed = true
+    }
     const timestamp = message.createTime ?? ''
-    lines.push(`[${timestamp}] ${senderLabel(message.sender)}: ${text}`)
+    if (!parts.push(`[${timestamp}] ${senderLabel(message.sender)}: ${text}`)) break
   }
 
-  if (lines.length > 0) {
-    parts.push('')
-    parts.push('--- Messages ---')
-    parts.push(...lines)
-  }
-
-  return parts.join('\n')
+  return parts.join()
 }
 
 /** Number of messages that actually contributed text to the transcript. */

--- a/apps/sim/connectors/google-chat/google-chat.ts
+++ b/apps/sim/connectors/google-chat/google-chat.ts
@@ -324,7 +324,10 @@ function senderLabel(sender: ChatUser | undefined): string {
  * that belongs in a knowledge base is synced through the Google Drive connector
  * instead, which already handles size caps, OCR, and format parsing.
  */
-function formatSpaceContent(space: Space, messages: ChatMessage[]): string {
+function formatSpaceContent(
+  space: Space,
+  messages: ChatMessage[]
+): { content: string; messageCount: number } {
   const parts = new BoundedLines()
   parts.push(`Space: ${spaceTitle(space)}`)
   const description = space.spaceDetails?.description?.trim()
@@ -332,28 +335,17 @@ function formatSpaceContent(space: Space, messages: ChatMessage[]): string {
   const guidelines = space.spaceDetails?.guidelines?.trim()
   if (guidelines) parts.push(`Guidelines: ${guidelines}`)
 
-  let headed = false
+  let messageCount = 0
   for (const message of messages) {
     const text = message.text?.trim() || message.fallbackText?.trim()
     if (!text) continue
-    if (!headed) {
-      parts.push('', '--- Messages ---')
-      headed = true
-    }
+    if (messageCount === 0) parts.push('', '--- Messages ---')
     const timestamp = message.createTime ?? ''
     if (!parts.push(`[${timestamp}] ${senderLabel(message.sender)}: ${text}`)) break
+    messageCount += 1
   }
 
-  return parts.join()
-}
-
-/** Number of messages that actually contributed text to the transcript. */
-function countIndexedMessages(messages: ChatMessage[]): number {
-  let count = 0
-  for (const message of messages) {
-    if (message.text?.trim() || message.fallbackText?.trim()) count++
-  }
-  return count
+  return { content: parts.join(), messageCount }
 }
 
 export const googleChatConnector: ConnectorConfig = {
@@ -476,12 +468,12 @@ export const googleChatConnector: ConnectorConfig = {
      * leave a previously indexed transcript in place after the space was cleared
      * or `lookbackDays` was tightened past every message.
      */
-    const messageCount = countIndexedMessages(messages)
+    const { content, messageCount } = formatSpaceContent(space, messages)
     const stub = spaceToStub(space, maxMessages, lookbackDays, syncContext)
 
     return {
       ...stub,
-      content: formatSpaceContent(space, messages),
+      content,
       contentDeferred: false,
       metadata: { ...stub.metadata, messageCount },
     }

--- a/apps/sim/connectors/outlook/outlook.ts
+++ b/apps/sim/connectors/outlook/outlook.ts
@@ -13,6 +13,9 @@ import {
 
 const logger = createLogger('OutlookConnector')
 
+/** A hydrated conversation retains message bodies as text, never attachments; lets threads hydrate in batches. */
+const ESTIMATED_CONVERSATION_BYTES = 256 * 1024
+
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0/me'
 const MESSAGES_PER_PAGE = 50
 /**
@@ -805,6 +808,7 @@ export const outlookConnector: ConnectorConfig = {
         title: subject,
         content: '',
         contentDeferred: true,
+        estimatedBytes: ESTIMATED_CONVERSATION_BYTES,
         mimeType: 'text/plain',
         sourceUrl,
         contentHash: `outlook:${convId}:${lastDate}`,

--- a/apps/sim/connectors/outlook/outlook.ts
+++ b/apps/sim/connectors/outlook/outlook.ts
@@ -4,6 +4,8 @@ import { fetchWithRetry, VALIDATE_RETRY_OPTIONS } from '@/lib/knowledge/document
 import { DEFAULT_MAX_CONVERSATIONS, outlookConnectorMeta } from '@/connectors/outlook/meta'
 import type { ConnectorConfig, ExternalDocument, ExternalDocumentList } from '@/connectors/types'
 import {
+  BoundedLines,
+  CONNECTOR_TEXT_DOCUMENT_MAX_BYTES,
   htmlToPlainText,
   isListingScopeUnavailableError,
   listingRequestError,
@@ -12,9 +14,6 @@ import {
 } from '@/connectors/utils'
 
 const logger = createLogger('OutlookConnector')
-
-/** A hydrated conversation retains message bodies as text, never attachments; lets threads hydrate in batches. */
-const ESTIMATED_CONVERSATION_BYTES = 256 * 1024
 
 const GRAPH_API_BASE = 'https://graph.microsoft.com/v1.0/me'
 const MESSAGES_PER_PAGE = 50
@@ -566,24 +565,20 @@ function formatConversation(
   const from = formatRecipient(first.from)
   const to = first.toRecipients?.map(formatRecipient).join(', ') || ''
 
-  const lines: string[] = []
-  lines.push(`Subject: ${subject}`)
-  lines.push(`From: ${from}`)
+  const lines = new BoundedLines()
+  lines.push(`Subject: ${subject}`, `From: ${from}`)
   if (to) lines.push(`To: ${to}`)
-  lines.push(`Messages: ${sorted.length}`)
-  lines.push('')
+  lines.push(`Messages: ${sorted.length}`, '')
 
   for (const msg of sorted) {
     const msgFrom = formatRecipient(msg.from)
     const msgDate = msg.receivedDateTime || ''
     const body = extractBodyText(msg.body)
 
-    lines.push(`--- ${msgFrom} (${msgDate}) ---`)
-    lines.push(body.trim())
-    lines.push('')
+    if (!lines.push(`--- ${msgFrom} (${msgDate}) ---`, body.trim(), '')) break
   }
 
-  const content = lines.join('\n').trim()
+  const content = lines.join().trim()
   if (!content) return null
 
   const categories = new Set<string>()
@@ -808,7 +803,7 @@ export const outlookConnector: ConnectorConfig = {
         title: subject,
         content: '',
         contentDeferred: true,
-        estimatedBytes: ESTIMATED_CONVERSATION_BYTES,
+        estimatedBytes: CONNECTOR_TEXT_DOCUMENT_MAX_BYTES,
         mimeType: 'text/plain',
         sourceUrl,
         contentHash: `outlook:${convId}:${lastDate}`,

--- a/apps/sim/connectors/types.ts
+++ b/apps/sim/connectors/types.ts
@@ -64,6 +64,14 @@ export interface ExternalDocument {
   /** When true, content is empty and will be fetched via getDocument for new/changed docs only */
   contentDeferred?: boolean
   /**
+   * How large the deferred content is expected to be, in bytes, when the
+   * listing cannot know exactly. Bounds how many deferred documents hydrate
+   * at once: without it a deferred document is assumed to be as large as the
+   * whole in-flight budget and hydrates alone, which turns a mailbox crawl
+   * into one thread at a time.
+   */
+  estimatedBytes?: number
+  /**
    * When set, the document was intentionally not indexed (e.g. it exceeds the
    * connector's size limit). The sync engine records it as a `failed` document
    * carrying this reason so it is visible in the knowledge base UI instead of

--- a/apps/sim/connectors/utils.test.ts
+++ b/apps/sim/connectors/utils.test.ts
@@ -63,6 +63,7 @@ import { typeformConnector } from '@/connectors/typeform/typeform'
 import {
   appendPendingMicrosoftGraphFolders,
   assertMicrosoftGraphNextLink,
+  BoundedLines,
   ConnectorFileTooLargeError,
   ConnectorListingScopeUnavailableError,
   decodeMicrosoftGraphTraversalCursor,
@@ -1637,5 +1638,28 @@ describe('isSkippableMicrosoftGraphFolderError', () => {
 
   it('never skips a fault the engine should retry', () => {
     expect(isSkippableMicrosoftGraphFolderError(new Error('500'), perMember, false)).toBe(false)
+  })
+})
+
+describe('BoundedLines', () => {
+  it('joins everything when the text fits', () => {
+    const lines = new BoundedLines(64)
+    expect(lines.push('Subject: hi', '')).toBe(true)
+    expect(lines.push('--- a ---', 'body')).toBe(true)
+    expect(lines.join()).toBe('Subject: hi\n\n--- a ---\nbody')
+  })
+
+  it('refuses a record that would cross the ceiling, whole, and says so in the output', () => {
+    const lines = new BoundedLines(20)
+    expect(lines.push('first')).toBe(true)
+    expect(lines.push('--- header ---', 'a long body')).toBe(false)
+    expect(lines.push('x')).toBe(false)
+    expect(lines.join()).toBe('first\n[Truncated: the indexed text reached the size limit]')
+  })
+
+  it('counts encoded bytes, not characters', () => {
+    const lines = new BoundedLines(6)
+    expect(lines.push('éé')).toBe(true)
+    expect(lines.push('é')).toBe(false)
   })
 })

--- a/apps/sim/connectors/utils.ts
+++ b/apps/sim/connectors/utils.ts
@@ -795,3 +795,50 @@ export function isSkippableMicrosoftGraphFolderError(
 ): boolean {
   return !isRootFolder && isListingScopeUnavailableError(error) && isPerMemberListing(syncContext)
 }
+
+/**
+ * Ceiling for a document a connector assembles from many source records (a
+ * mail thread, a chat transcript) rather than downloads as one file. Formatters
+ * enforce it through `BoundedLines`, and listings advertise it through
+ * `ExternalDocument.estimatedBytes`, so the sync engine plans hydration around
+ * a bound it can rely on: five such documents fit its 64 MiB in-flight budget
+ * and hydrate together instead of one at a time.
+ */
+export const CONNECTOR_TEXT_DOCUMENT_MAX_BYTES = 12 * 1024 * 1024
+
+const TRUNCATION_NOTICE = '[Truncated: the indexed text reached the size limit]'
+
+/**
+ * Accumulates newline-joined text under a byte ceiling. A record is appended
+ * whole or not at all, so a truncated document never ends mid-message, and the
+ * output carries a notice when something was left out.
+ */
+export class BoundedLines {
+  private readonly lines: string[] = []
+  private bytes = 0
+  private truncated = false
+
+  constructor(private readonly maxBytes = CONNECTOR_TEXT_DOCUMENT_MAX_BYTES) {}
+
+  /**
+   * Appends the lines together when they fit; otherwise marks the document
+   * truncated, appends nothing, and returns false so the caller stops.
+   */
+  push(...lines: string[]): boolean {
+    if (this.truncated) return false
+    let size = 0
+    for (const line of lines) size += Buffer.byteLength(line, 'utf8') + 1
+    if (this.bytes + size > this.maxBytes) {
+      this.truncated = true
+      return false
+    }
+    this.lines.push(...lines)
+    this.bytes += size
+    return true
+  }
+
+  /** Joins the accepted lines, ending with the truncation notice when a push was refused. */
+  join(): string {
+    return this.truncated ? [...this.lines, TRUNCATION_NOTICE].join('\n') : this.lines.join('\n')
+  }
+}

--- a/apps/sim/lib/knowledge/connectors/member-observations.ts
+++ b/apps/sim/lib/knowledge/connectors/member-observations.ts
@@ -446,7 +446,13 @@ export async function sweepStaleMemberObservations(now: Date): Promise<StaleMemb
     ${MEMBER_OBSERVATION_STALE_AFTER_HOURS} * INTERVAL '1 hour',
     2 * ${knowledgeConnector.syncIntervalMinutes} * INTERVAL '1 minute'
   )`
-  const cutoff = sql`${sql.param(now, knowledgeConnectorMember.lastStartedAt)} - ${staleWindow}`
+  /**
+   * The bound instant is cast: in `$now - GREATEST(...)` Postgres cannot see a
+   * timestamp on either side and resolves the subtraction as interval
+   * arithmetic, which makes the cutoff an interval and every comparison below
+   * fail with "operator does not exist: timestamp > interval".
+   */
+  const cutoff = sql`${sql.param(now, knowledgeConnectorMember.lastStartedAt)}::timestamp - ${staleWindow}`
   const staleMembers = await db
     .select({
       id: knowledgeConnectorMember.id,

--- a/apps/sim/lib/knowledge/connectors/member-sync-engine.test.ts
+++ b/apps/sim/lib/knowledge/connectors/member-sync-engine.test.ts
@@ -26,6 +26,7 @@ import {
   memberFailureBackoffMs,
   memberNextAttemptAt,
   nextMemberSyncTime,
+  persistedDocumentsByObserver,
   shouldListFully,
 } from '@/lib/knowledge/connectors/member-sync-engine'
 import {
@@ -270,6 +271,26 @@ describe('member sync engine decisions', () => {
       expect(union.get('b')?.observers).toEqual(['m-1'])
       expect(union.get('c')?.observers).toEqual(['m-2'])
       expect(second.retainedBytes).toBeGreaterThan(first.retainedBytes)
+    })
+
+    it('grants a persisted batch to every member who listed each document, as it lands', () => {
+      const union = new Map()
+      admitMemberListing(union, 'm-1', [doc('a'), doc('b')], 'c-1', 0)
+      admitMemberListing(union, 'm-2', [doc('a'), doc('c')], 'c-1', 0)
+
+      const byMember = persistedDocumentsByObserver(
+        [
+          { externalId: 'a', documentId: 'd-a' },
+          { externalId: 'b', documentId: 'd-b' },
+          { externalId: 'zzz', documentId: 'd-z' },
+        ],
+        union
+      )
+
+      expect([...byMember.entries()]).toEqual([
+        ['m-1', ['d-a', 'd-b']],
+        ['m-2', ['d-a']],
+      ])
     })
 
     it('counts a member once per external id even when their listing repeats it', () => {

--- a/apps/sim/lib/knowledge/connectors/member-sync-engine.ts
+++ b/apps/sim/lib/knowledge/connectors/member-sync-engine.ts
@@ -59,7 +59,10 @@ import {
   SyncLockLostException,
   stillHoldsMemberSyncLock,
 } from '@/lib/knowledge/connectors/sync-lock'
-import type { KnowledgeBaseOwner } from '@/lib/knowledge/connectors/sync-persistence'
+import type {
+  KnowledgeBaseOwner,
+  PersistedDocument,
+} from '@/lib/knowledge/connectors/sync-persistence'
 import {
   addSourcePagePayloadBytes,
   ConnectorDeletedException,
@@ -69,7 +72,6 @@ import {
   classifySuspectListing,
   createSyncRunState,
   loadOwnedCorpus,
-  type PersistedDocument,
   processDocOps,
   RETRY_WINDOW_DAYS,
   runChangeFeedPass,

--- a/apps/sim/lib/knowledge/connectors/member-sync-engine.ts
+++ b/apps/sim/lib/knowledge/connectors/member-sync-engine.ts
@@ -69,6 +69,7 @@ import {
   classifySuspectListing,
   createSyncRunState,
   loadOwnedCorpus,
+  type PersistedDocument,
   processDocOps,
   RETRY_WINDOW_DAYS,
   runChangeFeedPass,
@@ -167,6 +168,27 @@ interface MemberListingOutcome {
   suspect: boolean
   /** Cursor to store when this outcome lands: a value, null to close the feed, undefined to leave it. */
   changeCursor: string | null | undefined
+}
+
+/**
+ * The documents a batch wrote, grouped by each member who listed them, so a
+ * grant can be recorded per observer the moment the row exists. A document
+ * nobody in the union listed (it cannot happen for a persisted one, but the
+ * map is the source of truth) grants nothing.
+ */
+export function persistedDocumentsByObserver(
+  persisted: readonly PersistedDocument[],
+  union: ReadonlyMap<string, Pick<UnionEntry, 'observers'>>
+): Map<string, string[]> {
+  const byMember = new Map<string, string[]>()
+  for (const { externalId, documentId } of persisted) {
+    for (const memberId of union.get(externalId)?.observers ?? []) {
+      const documentIds = byMember.get(memberId)
+      if (documentIds) documentIds.push(documentId)
+      else byMember.set(memberId, [documentId])
+    }
+  }
+  return byMember
 }
 
 interface UnionEntry {
@@ -1550,6 +1572,33 @@ export async function executeMemberSync(
       },
       lease: run.lease,
       documentAccess: 'members',
+      /**
+       * Grants surface as each batch lands: every member who listed a document
+       * observes it the moment its row exists, and its ACL is materialised in
+       * the same lease-proved transaction. The listing's own pass below records
+       * the same observations again, idempotently, and is still what decides
+       * removals; this only brings the additions forward from the end of the
+       * run to the moment they are indexed.
+       */
+      onBatchPersisted: async (persisted) => {
+        const byMember = persistedDocumentsByObserver(persisted, union)
+        if (byMember.size === 0) return
+        await withMemberLease(run, async (tx) => {
+          for (const [memberId, documentIds] of byMember) {
+            result.observationsAdded += await recordMemberObservations(
+              tx,
+              memberId,
+              documentIds,
+              runId
+            )
+          }
+          await materializeDocumentAcls(
+            connectorId,
+            persisted.map(({ documentId }) => documentId),
+            tx
+          )
+        })
+      },
     })
 
     const documentIdByExternalId = await loadDocumentIdsByExternalId(connectorId)

--- a/apps/sim/lib/knowledge/connectors/sync-engine.test.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.test.ts
@@ -789,7 +789,7 @@ describe('persistSkippedDocuments', () => {
         'workspace',
         lease
       )
-    ).resolves.toBe(1)
+    ).resolves.toHaveLength(1)
 
     expect(dbChainMockFns.values).toHaveBeenCalledWith([
       expect.objectContaining({
@@ -835,7 +835,7 @@ describe('persistSkippedDocuments', () => {
         'workspace',
         lease
       )
-    ).resolves.toBe(1)
+    ).resolves.toHaveLength(1)
 
     expect(dbChainMockFns.set).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/sim/lib/knowledge/connectors/sync-engine.test.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-engine.test.ts
@@ -1028,6 +1028,32 @@ describe('chunkOpsByByteBudget', () => {
     expect(chunks.map((c) => c.length)).toEqual([1, 1])
   })
 
+  it('hydrates deferred documents together when the listing estimates their size', async () => {
+    const { chunkOpsByByteBudget } = await import('@/lib/knowledge/connectors/sync-primitives')
+    const deferred = (estimatedBytes?: number) => ({
+      type: 'add' as const,
+      extDoc: {
+        externalId: `d-${generateShortId()}`,
+        title: 'f',
+        content: '',
+        contentDeferred: true,
+        contentHash: 'h',
+        mimeType: 'text/plain',
+        ...(estimatedBytes != null ? { estimatedBytes } : {}),
+      },
+    })
+    // Without an estimate each unknown download is assumed to fill the budget and runs alone.
+    expect(chunkOpsByByteBudget([deferred(), deferred(), deferred()], 64 * MB, 5)).toHaveLength(3)
+    // A mail thread that says it is small shares a batch with its neighbours.
+    expect(
+      chunkOpsByByteBudget(
+        [deferred(256 * 1024), deferred(256 * 1024), deferred(256 * 1024)],
+        64 * MB,
+        5
+      )
+    ).toHaveLength(1)
+  })
+
   it('treats skip ops as zero bytes so they do not consume the budget', async () => {
     const { chunkOpsByByteBudget } = await import('@/lib/knowledge/connectors/sync-primitives')
     const chunks = chunkOpsByByteBudget(

--- a/apps/sim/lib/knowledge/connectors/sync-persistence.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-persistence.ts
@@ -247,6 +247,12 @@ function buildSkippedDocumentRow(
  *
  * Returns the number of rows recorded.
  */
+/** A document a sync wrote, by the id the source knows it by and the id the row has. */
+export interface PersistedDocument {
+  externalId: string
+  documentId: string
+}
+
 export async function persistSkippedDocuments(
   knowledgeBaseId: string,
   connectorId: string,
@@ -259,9 +265,9 @@ export async function persistSkippedDocuments(
   sourceConfig: Record<string, unknown> | undefined,
   access: SyncDocumentAccess,
   lease: SyncWriteLease
-): Promise<number> {
+): Promise<PersistedDocument[]> {
   if (skipOps.length === 0) {
-    return 0
+    return []
   }
   const inserts = skipOps
     .filter((op) => !op.existingId)
@@ -275,6 +281,12 @@ export async function persistSkippedDocuments(
         access
       )
     )
+  const persisted: PersistedDocument[] = [
+    ...inserts.map((row) => ({ externalId: row.externalId, documentId: row.id })),
+    ...skipOps
+      .filter((op): op is typeof op & { existingId: string } => Boolean(op.existingId))
+      .map((op) => ({ externalId: op.extDoc.externalId, documentId: op.existingId })),
+  ]
   const replacements = skipOps.filter((op): op is typeof op & { existingId: string } =>
     Boolean(op.existingId)
   )
@@ -363,7 +375,7 @@ export async function persistSkippedDocuments(
     }
   }
 
-  return skipOps.length
+  return persisted
 }
 
 /**

--- a/apps/sim/lib/knowledge/connectors/sync-primitives.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-primitives.ts
@@ -16,6 +16,7 @@ import { SyncLockLostException, type SyncRunLease } from '@/lib/knowledge/connec
 import {
   addDocument,
   type KnowledgeBaseOwner,
+  type PersistedDocument,
   persistSkippedDocuments,
   persistSkippedRetryHashes,
   type SyncDocumentAccess,
@@ -1497,9 +1498,13 @@ export interface ProcessDocOpsInput {
   hydration: DocOpHydration
   lease: Pick<SyncRunLease, 'beatIfDue' | 'beatLive' | 'stillHeld'>
   /**
-   * Runs after each batch's rows are written, with the documents that landed.
-   * A members-mode run grants access here, batch by batch, so a long first
-   * crawl becomes searchable as it goes rather than all at once at the end.
+   * Runs after each batch is written and dispatched, with every row that
+   * landed: hydrated documents and skipped ones alike. A members-mode run
+   * grants access here, batch by batch, so a long first crawl becomes
+   * searchable as it goes rather than all at once at the end. Best effort: a
+   * failure here is logged and the run continues, because the listing's own
+   * pass at the end of the run writes the same grants authoritatively; only a
+   * lost lease ends the run.
    */
   onBatchPersisted?: (persisted: readonly PersistedDocument[]) => Promise<void>
   /** Who may read the documents this pass writes. */
@@ -1513,12 +1518,6 @@ export interface ProcessDocOpsInput {
  * run so the connector backs off, and a lost lease, which ends it so no
  * further write lands beside the replacement run's.
  */
-/** A document a batch wrote, by the id the source knows it by and the id the row has. */
-export interface PersistedDocument {
-  externalId: string
-  documentId: string
-}
-
 export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
   const {
     connectorId,
@@ -1689,6 +1688,7 @@ export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
       }
     }
 
+    const skippedPersisted: PersistedDocument[] = []
     if (skipOps.length > 0) {
       try {
         const recorded = await persistSkippedDocuments(
@@ -1700,7 +1700,8 @@ export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
           documentAccess,
           input.lease
         )
-        result.docsSkipped += recorded
+        result.docsSkipped += recorded.length
+        skippedPersisted.push(...recorded)
       } catch (error) {
         if (error instanceof SyncLockLostException) throw error
         /**
@@ -1756,7 +1757,7 @@ export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
     if (leaseLost) throw leaseLost.reason
 
     const batchDocs: DocumentData[] = []
-    const persisted: PersistedDocument[] = []
+    const persisted: PersistedDocument[] = [...skippedPersisted]
     for (let j = 0; j < settled.length; j++) {
       const outcome = settled[j]
       if (outcome.status === 'fulfilled') {
@@ -1778,8 +1779,6 @@ export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
       }
     }
 
-    if (persisted.length > 0) await input.onBatchPersisted?.(persisted)
-
     if (batchDocs.length > 0) {
       result.processingDispatch.requested += batchDocs.length
       try {
@@ -1799,6 +1798,19 @@ export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
         logger.warn('Failed to enqueue batch for processing — will retry on next sync', {
           connectorId,
           count: batchDocs.length,
+          error: toError(error).message,
+        })
+      }
+    }
+
+    if (persisted.length > 0 && input.onBatchPersisted) {
+      try {
+        await input.onBatchPersisted(persisted)
+      } catch (error) {
+        if (error instanceof SyncLockLostException) throw error
+        logger.warn('Failed to grant access for a persisted batch — the run end will retry', {
+          connectorId,
+          count: persisted.length,
           error: toError(error).message,
         })
       }

--- a/apps/sim/lib/knowledge/connectors/sync-primitives.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-primitives.ts
@@ -503,7 +503,7 @@ function estimateOpSizeBytes(op: DocOp): number {
   if (op.type === 'skip') return 0
   if (op.extDoc.sourceFile?.bytes) return op.extDoc.sourceFile.bytes.byteLength
   if (op.extDoc.content) return Buffer.byteLength(op.extDoc.content)
-  const size = op.extDoc.metadata?.fileSize ?? op.extDoc.metadata?.size
+  const size = op.extDoc.estimatedBytes ?? op.extDoc.metadata?.fileSize ?? op.extDoc.metadata?.size
   return typeof size === 'number' && Number.isFinite(size) && size > 0
     ? size
     : DEFAULT_OP_SIZE_BYTES

--- a/apps/sim/lib/knowledge/connectors/sync-primitives.ts
+++ b/apps/sim/lib/knowledge/connectors/sync-primitives.ts
@@ -1496,6 +1496,12 @@ export interface ProcessDocOpsInput {
   state: SyncRunState
   hydration: DocOpHydration
   lease: Pick<SyncRunLease, 'beatIfDue' | 'beatLive' | 'stillHeld'>
+  /**
+   * Runs after each batch's rows are written, with the documents that landed.
+   * A members-mode run grants access here, batch by batch, so a long first
+   * crawl becomes searchable as it goes rather than all at once at the end.
+   */
+  onBatchPersisted?: (persisted: readonly PersistedDocument[]) => Promise<void>
   /** Who may read the documents this pass writes. */
   documentAccess: SyncDocumentAccess
 }
@@ -1507,6 +1513,12 @@ export interface ProcessDocOpsInput {
  * run so the connector backs off, and a lost lease, which ends it so no
  * further write lands beside the replacement run's.
  */
+/** A document a batch wrote, by the id the source knows it by and the id the row has. */
+export interface PersistedDocument {
+  externalId: string
+  documentId: string
+}
+
 export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
   const {
     connectorId,
@@ -1744,10 +1756,15 @@ export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
     if (leaseLost) throw leaseLost.reason
 
     const batchDocs: DocumentData[] = []
+    const persisted: PersistedDocument[] = []
     for (let j = 0; j < settled.length; j++) {
       const outcome = settled[j]
       if (outcome.status === 'fulfilled') {
         batchDocs.push(outcome.value)
+        persisted.push({
+          externalId: batch[j].extDoc.externalId,
+          documentId: outcome.value.documentId,
+        })
         if (batch[j].type === 'add') result.docsAdded++
         else result.docsUpdated++
       } else {
@@ -1760,6 +1777,8 @@ export async function processDocOps(input: ProcessDocOpsInput): Promise<void> {
         })
       }
     }
+
+    if (persisted.length > 0) await input.onBatchPersisted?.(persisted)
 
     if (batchDocs.length > 0) {
       result.processingDispatch.requested += batchDocs.length


### PR DESCRIPTION
## Summary

Three fixes to how a large first crawl feels and behaves in members mode, found on staging with a Gmail mailbox whose crawl had every indexed document hidden after fifteen minutes.

**Access is granted as each batch is indexed.** A members-mode run listed a member's whole source, hydrated every document, and only then wrote the member's observations and materialised ACLs. Until the run ended nothing was searchable, the Knowledge page's document list was empty, and the Sources chip read "Indexing" with nothing behind it for up to the run's 45-minute budget. The hydrate-and-persist loop now reports each batch it wrote (skipped rows included), and the member engine records the observation and materialises the ACL under its lease, best-effort, once the batch has been dispatched for processing. The listing's own pass at the end still records the same observations idempotently and remains the only thing that decides removals.

**Deferred mail and chat documents hydrate in batches, under an enforced ceiling.** A listing that defers content with no size hint was assumed to be as large as the whole in-flight budget, so every Gmail thread hydrated alone: one thread at a time, roughly 170 a minute on staging. `ExternalDocument.estimatedBytes` lets a listing say what to expect, and for text a connector assembles itself (a mail thread, a chat transcript) the estimate is now a real bound rather than a guess: `CONNECTOR_TEXT_DOCUMENT_MAX_BYTES` (12 MiB) is enforced by a shared `BoundedLines` accumulator in the Gmail, Outlook, and Google Chat formatters, which appends each message whole or not at all and marks the document as truncated. Five such documents fit the 64 MiB in-flight budget, so they hydrate together. Sources with real file sizes are unchanged.

**The member-sync scheduler no longer fails on the stale-observation sweep.** The sweep's cutoff was written as `$now - GREATEST(...)` with the bound instant untyped, which Postgres resolves as interval arithmetic and then rejects every `timestamp > interval` comparison. The instant is now cast, and the sweep runs cleanly against a real database.

## Verification

- `persistedDocumentsByObserver` is a pure helper tested with a union of two members and a document nobody listed.
- The byte-budget chunker is tested with unknown deferred documents (one per batch, as before) and estimated ones (batched together).
- `BoundedLines` is tested for whole-record refusal, the truncation notice, and byte (not character) accounting.
- The stale sweep was run end-to-end against a database before and after the cast: the untyped form fails with `42883`, the cast form returns.
- Connector suites, type-check, lint, and `check:audits` (45 audits) pass.
