### PR TITLE
fix(credential-groups): raise OAuth code cap so Atlassian callbacks validate

### DIFF
--- a/apps/sim/lib/api/contracts/credential-groups.test.ts
+++ b/apps/sim/lib/api/contracts/credential-groups.test.ts
@@ -5,6 +5,7 @@ import {
   credentialGroupAccessResponseSchema,
   credentialGroupEnrollmentDetailSchema,
   credentialGroupEnrollmentListQuerySchema,
+  credentialGroupOAuthCallbackQuerySchema,
   credentialGroupSchema,
   inviteCredentialGroupEnrollmentsBodySchema,
   sharedCredentialGroupOAuthCallbackContract,
@@ -291,5 +292,23 @@ describe('credential group contracts', () => {
         document: { version: 1, resource: { type: 'credential_group', id: 'group-1' } },
       }).success
     ).toBe(false)
+  })
+
+  it('accepts an Atlassian-sized authorization code', () => {
+    const parsed = credentialGroupOAuthCallbackQuerySchema.safeParse({
+      state: `cg_${'a'.repeat(36)}`,
+      code: 'a'.repeat(4096),
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it('still rejects an unbounded authorization code', () => {
+    const parsed = credentialGroupOAuthCallbackQuerySchema.safeParse({
+      state: `cg_${'a'.repeat(36)}`,
+      code: 'a'.repeat(8193),
+    })
+
+    expect(parsed.success).toBe(false)
   })
 })

--- a/apps/sim/lib/api/contracts/credential-groups.ts
+++ b/apps/sim/lib/api/contracts/credential-groups.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod'
-import { workflowIdSchema, workspaceIdSchema } from '@/lib/api/contracts/primitives'
+import {
+  MAX_OAUTH_CODE_LENGTH,
+  workflowIdSchema,
+  workspaceIdSchema,
+} from '@/lib/api/contracts/primitives'
 import { defineRouteContract } from '@/lib/api/contracts/types'
 import {
   CREDENTIAL_GROUP_MCP_SERVER_LIMIT,
@@ -234,7 +238,7 @@ export const startCredentialGroupMcpOAuthParamsSchema =
 export const credentialGroupOAuthCallbackQuerySchema = z
   .object({
     state: z.string().min(1, 'OAuth state is required').max(512),
-    code: z.string().min(1).max(2048).optional(),
+    code: z.string().min(1).max(MAX_OAUTH_CODE_LENGTH, 'Authorization code is too long').optional(),
     error: z.string().min(1).max(256).optional(),
     error_description: z.string().max(1000).optional(),
   })

--- a/apps/sim/lib/api/contracts/oauth-connections.ts
+++ b/apps/sim/lib/api/contracts/oauth-connections.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { workspaceIdSchema } from '@/lib/api/contracts/primitives'
+import { MAX_OAUTH_CODE_LENGTH, workspaceIdSchema } from '@/lib/api/contracts/primitives'
 import type {
   ContractBody,
   ContractBodyInput,
@@ -223,7 +223,6 @@ export const trelloCallbackContract = defineRouteContract({
 })
 
 const MAX_OAUTH_RETURN_URL_LENGTH = 2048
-const MAX_OAUTH_CODE_LENGTH = 8192
 const MAX_OAUTH_STATE_LENGTH = 256
 const MAX_OAUTH_ERROR_LENGTH = 2048
 

--- a/apps/sim/lib/api/contracts/primitives.ts
+++ b/apps/sim/lib/api/contracts/primitives.ts
@@ -238,6 +238,17 @@ export function withMissingFieldMessage<TSchema extends z.ZodString>(
 export const MAX_ID_LENGTH = 128
 
 /**
+ * Bound for an OAuth `code` callback parameter, shared by every callback contract.
+ *
+ * Authorization codes have no length ceiling in RFC 6749, and providers differ by
+ * orders of magnitude: Slack's are tens of characters while Atlassian returns a
+ * signed JWT that routinely exceeds 2KB. The bound exists to keep an unbounded
+ * string out of a token exchange, so it is sized above the largest real code
+ * rather than around any one provider.
+ */
+export const MAX_OAUTH_CODE_LENGTH = 8192
+
+/**
  * Builds a required, non-empty string schema whose message covers **both**
  * failure modes.
  *

--- a/apps/sim/lib/api/contracts/primitives.ts
+++ b/apps/sim/lib/api/contracts/primitives.ts
@@ -238,7 +238,7 @@ export function withMissingFieldMessage<TSchema extends z.ZodString>(
 export const MAX_ID_LENGTH = 128
 
 /**
- * Bound for an OAuth `code` callback parameter, shared by every callback contract.
+ * Bound for an OAuth `code` callback parameter.
  *
  * Authorization codes have no length ceiling in RFC 6749, and providers differ by
  * orders of magnitude: Slack's are tens of characters while Atlassian returns a


### PR DESCRIPTION
## Summary
- The managed credential-group OAuth callback capped the `code` query param at 2048 characters, so providers that return a signed JWT as their authorization code (Atlassian's Confluence/Jira among them) failed validation before the token exchange ran.
- That bound dates from when the flow only supported Slack, whose codes are short. It was never revisited as more OAuth providers were added to credential groups.
- Shared a single `MAX_OAUTH_CODE_LENGTH` (8192) from the contract primitives and used it on both callback paths. `oauth-connections.ts` already used 8192 for the same field via its own private literal; the two contracts had drifted, and this collapses them onto one constant so they can't again.
- Only the credential-group enrollment path was affected. Ordinary OAuth connections fork to Better Auth earlier in the shared callback and never hit this schema, which is why the bug went unnoticed.

## Type of Change
- [x] Bug fix

## Testing
Tested manually. Added two contract tests: a JWT-sized code now parses, and a code past the new bound is still rejected. Verified the first test fails against the old 2048 cap and passes with the fix.

`bun run lint`, `bun run check:audits` (45 audits), and `check:api-validation:strict` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013e5sXbYST2R4qNzM996GFg