### PR TITLE
docs(library): update ai-agent-ideas

### DIFF
--- a/apps/sim/content/library/ai-agent-ideas/index.mdx
+++ b/apps/sim/content/library/ai-agent-ideas/index.mdx
@@ -28,7 +28,7 @@ A good first AI agent idea has a clear trigger, a defined action, and a measurab
 
 **Last verified: August 21, 2026**
 
-## [10 AI Agent Ideas at a Glance](#10-ai-agent-ideas-at-a-glance)
+## 10 AI Agent Ideas at a Glance
 
 | Agent | Use Case | Key Integrations | Complexity | Primary Value |
 | --- | --- | --- | --- | --- |
@@ -51,7 +51,7 @@ This article presents 10 specific AI agent ideas across sales, operations, conte
 
 Each idea targets a frequent, repetitive task, connects to common workplace tools, and produces an output you can inspect and measure.
 
-## [Key Takeaways](#key-takeaways)
+## Key Takeaways
 
 - **Start with a bounded production workflow:**
     Choose a workflow with a clear trigger, action, and reviewable output. The 10 ideas below are scoped as starting points.
@@ -66,7 +66,7 @@ Each idea targets a frequent, repetitive task, connects to common workplace tool
 - **You don't need a dedicated ML team:**
     Sim's visual builder and multi-model support let you prototype an agent without writing the orchestration infrastructure. Custom logic, security reviews, and complex integrations may still require development work.
 
-## [What Makes an AI Agent Idea Worth Building](#what-makes-an-ai-agent-idea-worth-building)
+## What Makes an AI Agent Idea Worth Building
 
 A useful AI agent idea has a clear trigger, a defined action, and a measurable output. Broad concepts such as "use AI to automate marketing" do not identify a workflow that you can build or evaluate. If you cannot name all three elements in one sentence, narrow the idea before building it.
 
@@ -83,11 +83,11 @@ AI agents differ from fixed workflow automations in how they handle variable inp
 
 The 10 ideas that follow are starting points designed to get something into production quickly, so you can learn what works and expand from there.
 
-## [10 AI Agent Ideas You Can Build Today](#10-ai-agent-ideas-you-can-build-today)
+## 10 AI Agent Ideas You Can Build Today
 
 These are organized by the function they serve. For each idea, you'll find what the agent does, why it matters, the key integrations, and how to get started with Sim.
 
-### [Email Triage and Response Agent](#email-triage-and-response-agent)
+### Email Triage and Response Agent
 
 This agent monitors an inbox, classifies incoming emails by intent and urgency, drafts context-aware replies, and routes messages that need human review to the right person.
 
@@ -99,7 +99,7 @@ An email triage agent reduces the first-pass work required to classify, prioriti
 **Getting started with Sim:**
          Describe the workflow to Chat and it'll scaffold an Agent block wired to these integrations on a visual canvas. You can customize the classification logic and test it with representative messages before deployment.
 
-### [Competitor Monitoring Agent](#competitor-monitoring-agent)
+### Competitor Monitoring Agent
 
 This agent runs on a schedule to monitor competitor websites, social channels, and news sources, then summarizes changes in positioning, pricing, or product updates and delivers a digest to Slack or email.
 
@@ -111,7 +111,7 @@ Competitor monitoring is easy to neglect when someone must remember to check web
 **Getting started with Sim:**
          Pair a scheduled trigger with search integrations and an Agent block for AI summarization. Set up your target competitors, define the schedule, and let it run.
 
-### [Lead Enrichment and Qualification Agent](#lead-enrichment-and-qualification-agent)
+### Lead Enrichment and Qualification Agent
 
 This agent takes raw leads from a form submission, CRM entry, or inbound email, enriches each lead with company data and buying signals, scores it against your defined criteria, and routes qualified leads to the right sales rep with a summary.
 
@@ -123,7 +123,7 @@ Manual lead research takes time and can delay routing. This agent retrieves the 
 **Getting started with Sim:**
          Connect your CRM and enrichment tools to an Agent block, then add conditional routing logic with Sim's router blocks to score leads and send them to different reps or channels based on criteria like company size, industry, or engagement signals.
 
-### [Meeting Follow-Up Agent](#meeting-follow-up-agent)
+### Meeting Follow-Up Agent
 
 This agent receives a meeting transcript or recording, extracts action items, assigns owners based on context, drafts a follow-up email or Slack message, and optionally creates tasks in a project management tool.
 
@@ -135,7 +135,7 @@ Meeting commitments can be missed when nobody records an owner or due date. A fo
 **Getting started with Sim:**
          Wire a webhook trigger to your transcription source and an Agent block. Configure the model to identify proposed action items and owners from the participant context. Route the draft to a person for confirmation before sending it to your task management and communication tools.
 
-### [Customer Support Knowledge Agent](#customer-support-knowledge-agent)
+### Customer Support Knowledge Agent
 
 This agent answers customer questions by searching a connected knowledge base of documentation, past tickets, and FAQs. It escalates to a human only when its confidence falls below a defined threshold.
 
@@ -149,7 +149,7 @@ When connected to authorized backend systems, a support agent can also retrieve 
 **Getting started with Sim:**
          Sim's built-in Knowledge Base lets you upload documents to a vector store and configure the agent to answer questions grounded in your specific content. Set a confidence threshold for escalation and connect the output to your support channel.
 
-### [Content Research and Brief Generation Agent](#content-research-and-brief-generation-agent)
+### Content Research and Brief Generation Agent
 
 Given a topic or target keyword, this agent searches for top-ranking content, extracts key themes and gaps, pulls relevant data points, and produces a structured content brief ready for a writer.
 
@@ -161,7 +161,7 @@ Research can require substantial time when a writer must inspect search results,
 **Getting started with Sim:**
          This agent pairs naturally with Sim's search integrations and document output blocks. Connect your preferred search tools, configure the AI to analyze and synthesize results, and route the finished brief to Google Docs or Notion.
 
-### [Code Review and PR Summary Agent](#code-review-and-pr-summary-agent)
+### Code Review and PR Summary Agent
 
 Triggered by a new pull request on GitHub or GitLab, this agent reviews the diff for potential issues, summarizes the changes in plain English, checks for patterns that violate team conventions, and posts a comment directly on the PR.
 
@@ -173,7 +173,7 @@ Automated review can reduce the time people spend checking routine conventions a
 **Getting started with Sim:**
          Trigger a workflow directly off your repo's PR events. Configure the review rules (style guide, test coverage requirements, naming conventions), and the agent posts its analysis as a comment on every new PR.
 
-### [Resume Screening Agent](#resume-screening-agent)
+### Resume Screening Agent
 
 This agent parses incoming applications from an email inbox or applicant tracking system, compares job-related information with a documented rubric, prepares a structured summary, and routes the application for recruiter review. A person should make advancement and rejection decisions.
 
@@ -185,7 +185,7 @@ An agent can reduce the administrative work involved in organizing applications 
 **Getting started with Sim:**
          An Agent block with document-parsing tools handles the parsing and criteria matching. Define a job-related rubric, exclude protected characteristics and proxies, and have the agent prepare assessments for recruiter review rather than automatically rejecting applicants.
 
-### [Data Pipeline and Report Generation Agent](#data-pipeline-and-report-generation-agent)
+### Data Pipeline and Report Generation Agent
 
 This agent pulls data from one or more sources on a schedule (database, spreadsheet, API), runs analysis or transformation logic, generates a formatted report or dashboard summary, and delivers it to the right stakeholders.
 
@@ -197,7 +197,7 @@ Recurring reports often require the same data retrieval, transformation, and for
 **Getting started with Sim:**
          Sim supports scheduled cron triggers natively, so setting up a recurring data pull is straightforward. Connect your data sources, configure the transformation and summarization logic, and schedule delivery for whatever cadence your team needs.
 
-### [Social Listening and Brand Monitoring Agent](#social-listening-and-brand-monitoring-agent)
+### Social Listening and Brand Monitoring Agent
 
 This agent monitors mentions, keywords, and trending topics across social platforms and the web, classifies sentiment and intent, filters out noise, and delivers a prioritized digest of conversations worth paying attention to.
 
@@ -209,7 +209,7 @@ Manual monitoring can miss relevant mentions or consume time when staff scan mul
 **Getting started with Sim:**
          A scheduled trigger feeding an Agent block handles the monitoring and classification pipeline. Configure your target keywords, brand names, and competitors, set up the sentiment analysis, and route the results to Slack or your preferred tracking tool.
 
-## [Choosing the Right Idea for Your Team](#choosing-the-right-idea-for-your-team)
+## Choosing the Right Idea for Your Team
 
 Choose a recurring pain point for which you already have the required data and tool access. Favor a workflow whose errors are easy to detect and correct.
 
@@ -217,7 +217,7 @@ The cost of an error should determine how much human review the workflow require
 
 Keep the first workflow narrow. Instead of building a general AI sales assistant, start with one lead source, one enrichment process, and one reviewed routing destination. Measure accuracy and time saved before expanding the workflow.
 
-## [Getting Started With Sim](#getting-started-with-sim)
+## Getting Started With Sim
 
 Sim is an open-source workspace for building, deploying, and managing AI agents. It supports more than 1,000 integrations and models from providers including OpenAI, Anthropic, Google, Mistral AI, and xAI. You can prototype the 10 workflows above without writing the underlying orchestration infrastructure.
 
@@ -247,7 +247,7 @@ Sim provides the following features for building and operating these workflows:
 
 Sim reports more than 100,000 builders across startups and Fortune 500 companies. Sim is open source and free to start.
 
-## [The Bottom Line](#the-bottom-line)
+## The Bottom Line
 
 A first AI agent is easier to evaluate when it handles one repetitive workflow, uses tools you already have, and produces an output you can review. The 10 ideas in this article provide bounded starting points rather than plans for autonomous departments.
 

--- a/apps/sim/content/library/ai-agent-ideas/index.mdx
+++ b/apps/sim/content/library/ai-agent-ideas/index.mdx
@@ -1,216 +1,258 @@
 ---
 slug: ai-agent-ideas
 title: '10 AI Agent Ideas for Real Impact: Get Started With Sim'
-description: Explore practical AI agent ideas you can build today to automate real workflows. From email triage to lead enrichment, discover use cases that deliver fast, measurable impact.
+description: 'Explore practical AI agent ideas you can build today to automate real workflows. From email triage to lead enrichment, discover use cases that deliver fast, measurable impact.'
 date: 2026-06-30
-updated: 2026-07-23
+updated: 2026-09-03
 authors:
-  - emir
-readingTime: 14
+  - andrew
+readingTime: 12
 tags: [AI Agents, Use Cases, Automation, Sim]
 ogImage: /library/ai-agent-ideas/cover.jpg
 canonical: https://www.sim.ai/library/ai-agent-ideas
 draft: false
 faq:
   - q: "What are the best AI agent ideas for beginners?"
-    a: "Start with email triage, meeting follow-ups, or report generation. These three ideas have clear inputs (an email, a transcript, a data source) and clear outputs (a classified message, a list of action items, a formatted report), which makes them easy to validate. If the agent gets something wrong, you'll notice immediately and can adjust."
+    a: "Start with email triage, meeting follow-ups, or report generation. Each has a clear input and a reviewable output, which makes errors easier to detect. In Sim, you can scaffold the workflow and connect the required tools on the visual canvas. The narrow scope helps you evaluate accuracy before adding more actions."
   - q: "How long does it take to build an AI agent from scratch?"
-    a: "With a visual builder like Sim, a working prototype can be ready in under an hour. You describe the workflow to Chat or start from a blank canvas, connect your integrations, configure the AI model, and test. Custom multi-step agents with conditional logic and multiple data sources take longer, but you're still measuring build time in days, not months."
+    a: "A simple Sim prototype may take less than an hour to scaffold, but production time varies with integration access, data quality, testing, security review, and workflow complexity. Sim can generate a first draft in Chat or let you build on a blank canvas before connecting tools and configuring a model. Separating prototype time from deployment time gives you a more realistic plan."
   - q: "Do I need coding skills to build AI agents?"
-    a: "Not to get started. Sim's drag-and-drop canvas and Chat let you build and deploy agents without writing infrastructure code. You configure blocks visually, connect integrations, and define logic through the interface. For teams that want deeper customization, custom functions and API access are available, but they're optional."
+    a: "You can build a basic agent in Sim without writing infrastructure code. The drag-and-drop canvas and Chat help you connect integrations and define the workflow. Custom functions and API access remain available when a use case requires deeper technical control."
   - q: "What is the difference between an AI agent and a workflow automation like Zapier?"
-    a: "Zapier-style tools follow fixed if-then rules: when this trigger fires, do this action, every time, the same way. An AI agent reasons over context, evaluates information, and chooses between paths based on what it finds. It can handle ambiguous inputs, make decisions, and act across multiple systems in sequence. The core distinction is reasoning versus rule-following."
+    a: "A conventional Zapier workflow follows predefined trigger-and-action rules, while an AI agent uses a model to interpret variable context and select among permitted paths. Sim can combine model calls, conditional routing, and tool actions in one workflow. That flexibility helps with ambiguous inputs, but it also requires testing and clear limits."
   - q: "Which AI agent idea has the highest ROI for a small team?"
-    a: "Lead enrichment, email triage, and meeting follow-ups tend to deliver the highest time-reclaim per hour of build effort. Sales-related agents often show the fastest, most attributable returns because you can directly tie agent output, like qualified leads routed to reps, to pipeline and revenue metrics. For most small teams, starting with email triage or meeting follow-ups is the fastest path to visible results."
+    a: "No single agent idea has the highest return for every small company. In Sim, compare candidate workflows using task frequency, current labor time, error cost, implementation effort, and the value of the resulting action. Email triage or meeting follow-up can be practical starting points when their outputs are easy to review, but you should measure the result against your own baseline."
 ---
 
-AI agents have moved from "we should explore this" to "this is running in production" faster than most teams anticipated. Customer service, eCommerce, and operations are already seeing real returns, and the pace of adoption across the enterprise isn't slowing down. The shift is real, and it's happening fast.
+A good first AI agent idea has a clear trigger, a defined action, and a measurable output. If you can name all three in one sentence, the idea is focused enough to build and evaluate.
 
-And yet, most teams are stuck at the same frustrating starting line. You know agents are powerful. You've read the frameworks, watched the demos, and bookmarked a dozen GitHub repos. But when it comes to deciding what to actually build first, the options feel either too vague ("automate marketing") or too ambitious ("replace our entire support team").
+**Last verified: August 21, 2026**
 
-That's what this article delivers: 10 specific AI agent ideas, each one mapped to a real workflow, connected to tools your team already uses, and buildable without a dedicated ML team. These aren't hypothetical. They're the kind of agents that generate measurable output from day one. We've organized them by use case area (sales, ops, content, engineering, support) and for each one, we cover what the agent does, what it connects to, and how to get started with Sim.
-
-The selection filter is simple. Every idea on this list handles a high-frequency, repetitive task. Every idea connects to systems you probably already pay for. And every idea produces results that are easy to observe, measure, and improve.
-
-## Key Takeaways
-
-- **AI agents are production-ready in 2026:** The question is no longer "should we build agents?" but "which agent should we build first?" These 10 ideas are scoped for fast time-to-value.
-- **Good agent ideas share three traits:** They handle repetitive, high-frequency tasks, connect to your existing tools, and produce outputs you can measure and improve.
-- **Agents reason; automations follow rules:** Unlike a static Zapier zap, an AI agent can evaluate context, choose between paths, and act across multiple systems before returning a result.
-- **Start narrow, then expand:** One trigger, one action, one output. The biggest mistake teams make is trying to automate an entire department in their first agent.
-- **Most of these ideas can be live in under an hour:** Sim's Chat can scaffold a first draft of any of these workflows from a plain-language description, and there are 1,000+ integrations you can connect on a drag-and-drop canvas.
-- **You don't need a dedicated ML team:** Visual builders and multi-model support mean developers and operators can go from idea to deployed agent without writing infrastructure code.
-
-## What Makes an AI Agent Idea Worth Building
-
-Not every agent idea deserves your time. The space is flooded with vague concepts ("use AI to automate marketing") that sound impressive in a pitch deck and go nowhere in production. A useful AI agent idea has three concrete elements: a clear trigger, a defined action, and a measurable output. If you can't name all three in a single sentence, the idea isn't ready to build.
-
-Here's the filter we apply to every idea on this list:
-
-- **High-frequency, repetitive task:** The agent should handle something your team does over and over, often enough that the time savings compound.
-- **Connects to existing systems:** The best agents plug into tools your team already uses: Gmail, Slack, HubSpot, GitHub, and Google Sheets.
-- **Observable success and failure:** You need to be able to tell, quickly, whether the agent is working. Did it route the lead to the right rep? Did the summary capture the action items?
-
-It's also worth drawing a clear line between AI agents and basic workflow automation. A static Zapier automation fires when X happens and does Y. Always the same X, always the same Y. An AI agent is different: it reasons over context, decides between paths based on what it finds, and can act across multiple systems in sequence before returning a result. Agentic AI can plan, make decisions, use tools, and execute multi-step tasks to achieve objectives with minimal human supervision.
-
-The 10 ideas that follow are starting points designed to get something into production quickly, so you can learn what works and expand from there.
-
-## 10 AI Agent Ideas You Can Build Today
-
-These are organized by the function they serve. For each idea, you'll find what the agent does, why it matters, the key integrations, and how to get started with Sim.
-
-### Email Triage and Response Agent
-
-This agent monitors an inbox, classifies incoming emails by intent and urgency, drafts context-aware replies, and routes messages that need human review to the right person.
-
-The value here is pure time reclamation. On the support side, manual triage slows down rapidly as volume rises because every message must be read, interpreted, prioritized, and assigned individually. An email triage agent handles that first pass so humans can focus on the messages that require judgment.
-
-**Key integrations:** Gmail or Microsoft Outlook, a CRM like HubSpot or Salesforce for context lookup, Slack for escalation alerts.
-
-**Getting started with Sim:** Describe the workflow to Chat and it'll scaffold an Agent block wired to these integrations on a visual canvas. You can customize the classification logic and deploy it in under an hour.
-
-### Competitor Monitoring Agent
-
-This agent runs on a schedule to monitor competitor websites, social channels, and news sources, then summarizes changes in positioning, pricing, or product updates and delivers a digest to Slack or email.
-
-Competitive intelligence typically falls into one of two categories: expensive (a dedicated analyst or agency) or neglected (someone checks a competitor's homepage when they remember). This agent fills the gap by delivering a weekly signal automatically, so your team always knows when a competitor ships a new feature, changes pricing, or launches a campaign.
-
-**Key integrations:** Web search tools (Tavily, Exa, or Google Search), Slack for delivery, Notion or a Google Sheet for tracking changes over time.
-
-**Getting started with Sim:** Pair a scheduled trigger with search integrations and an Agent block for AI summarization. Set up your target competitors, define the schedule, and let it run.
-
-### Lead Enrichment and Qualification Agent
-
-This agent takes raw leads from a form submission, CRM entry, or inbound email, enriches each lead with company data and buying signals, scores it against your defined criteria, and routes qualified leads to the right sales rep with a summary.
-
-Sales teams lose hours every week on manual research and misrouted leads. A rep might spend 15 minutes researching a company only to discover it's a two-person consultancy in the wrong vertical. This agent does that enrichment and qualification instantly, ensuring reps spend their time only on high-quality opportunities.
-
-**Key integrations:** HubSpot or Salesforce, Apollo or Hunter.io for enrichment data, Slack for routing notifications, and Google Sheets or Airtable for logging.
-
-**Getting started with Sim:** Connect your CRM and enrichment tools to an Agent block, then add conditional routing logic with Sim's router blocks to score leads and send them to different reps or channels based on criteria like company size, industry, or engagement signals.
-
-### Meeting Follow-Up Agent
-
-This agent receives a meeting transcript or recording, extracts action items, assigns owners based on context, drafts a follow-up email or Slack message, and optionally creates tasks in a project management tool.
-
-Action items from meetings routinely evaporate. Someone said they'd "send that doc by Friday," and by Monday, nobody remembers who, what, or when. This agent turns every meeting into a structured set of next steps without requiring anyone to take notes or remember to send a recap.
-
-**Key integrations:** Transcription tools or calendar triggers, Slack, Notion, Linear, or Jira for task creation, Gmail for follow-up emails.
-
-**Getting started with Sim:** Wire a webhook trigger to your transcription source and an Agent block. You configure the AI model to identify action items, assign them based on participant context, and route the output to your preferred task management and communication tools.
-
-### Customer Support Knowledge Agent
-
-This agent answers customer questions by searching a connected knowledge base of documentation, past tickets, and FAQs. It escalates to a human only when its confidence falls below a defined threshold.
-
-Support teams consistently spend a disproportionate share of their time on questions that already have documented answers. "How do I reset my password?" "What's your refund policy?" "Where do I find the API docs?" These are the queries that eat hours and don't require human judgment. A knowledge agent handles tier-1 queries end-to-end.
-
-Modern support agents have also matured well past simple FAQ bots. They can check order status, look up account details, and process standard requests by connecting to backend systems, all while knowing when to hand off to a human for anything complex or sensitive.
-
-**Key integrations:** A vector knowledge base (Sim's built-in Knowledge Base, or Pinecone/Qdrant), Slack or a chat interface for customer-facing interaction, and a ticketing system for escalation.
-
-**Getting started with Sim:** Sim's built-in Knowledge Base lets you upload documents to a vector store and configure the agent to answer questions grounded in your specific content. Set a confidence threshold for escalation and connect the output to your support channel.
-
-### Content Research and Brief Generation Agent
-
-Given a topic or target keyword, this agent searches for top-ranking content, extracts key themes and gaps, pulls relevant data points, and produces a structured content brief ready for a writer.
-
-Content teams and agencies routinely spend two to four hours on research before a single word of a draft gets written. Scanning competitors, pulling statistics, identifying subtopics, and organizing references. This agent compresses the research phase into minutes, delivering a brief with sources, suggested structure, and angle recommendations.
-
-**Key integrations:** Web search tools (Tavily, Exa, Perplexity), Google Docs or Notion for brief output, Slack for team delivery.
-
-**Getting started with Sim:** This agent pairs naturally with Sim's search integrations and document output blocks. Connect your preferred search tools, configure the AI to analyze and synthesize results, and route the finished brief to Google Docs or Notion.
-
-### Code Review and PR Summary Agent
-
-Triggered by a new pull request on GitHub or GitLab, this agent reviews the diff for potential issues, summarizes the changes in plain English, checks for patterns that violate team conventions, and posts a comment directly on the PR.
-
-Code review is a bottleneck in most engineering teams. Reviewers queue up PRs, context-switch between their own work and someone else's diff, and often catch the same surface-level issues (naming conventions, missing tests, formatting) over and over. This agent handles that first pass so human reviewers can focus on logic, architecture, and design.
-
-**Key integrations:** GitHub or GitLab (Sim has native integrations for both), Slack for reviewer notifications.
-
-**Getting started with Sim:** Trigger a workflow directly off your repo's PR events. Configure the review rules (style guide, test coverage requirements, naming conventions), and the agent posts its analysis as a comment on every new PR.
-
-### Resume Screening Agent
-
-This agent processes incoming applications from an email inbox or ATS, scores each resume against a defined job criteria rubric, flags top candidates with a structured summary, and sends rejection or next-step emails.
-
-Early-stage screening consumes a significant portion of recruiter time. When you're hiring for a popular role and receive hundreds of applications, the vast majority won't meet baseline criteria. This agent handles that initial filter, so recruiters focus their attention on the candidates who actually warrant a closer look.
-
-**Key integrations:** Gmail for application intake, Google Sheets or Airtable for candidate tracking, Slack for recruiter alerts.
-
-**Getting started with Sim:** An Agent block with document-parsing tools handles the parsing and criteria matching. Define your rubric (years of experience, required skills, education), and the agent scores and routes each application automatically.
-
-### Data Pipeline and Report Generation Agent
-
-This agent pulls data from one or more sources on a schedule (database, spreadsheet, API), runs analysis or transformation logic, generates a formatted report or dashboard summary, and delivers it to the right stakeholders.
-
-Every team has a recurring "pull the numbers" task. The Monday morning sales report. The weekly churn metrics. The monthly board dashboard. When these reports require manual data pulls and formatting, someone spends hours on a task that follows the same steps every time. This agent eliminates that entire loop.
-
-**Key integrations:** PostgreSQL, MySQL, Google Sheets, Airtable, or Supabase as data sources; Google Docs or Notion for report output; Slack or email for delivery.
-
-**Getting started with Sim:** Sim supports scheduled cron triggers natively, so setting up a recurring data pull is straightforward. Connect your data sources, configure the transformation and summarization logic, and schedule delivery for whatever cadence your team needs.
-
-### Social Listening and Brand Monitoring Agent
-
-This agent monitors mentions, keywords, and trending topics across social platforms and the web, classifies sentiment and intent, filters out noise, and delivers a prioritized digest of conversations worth paying attention to.
-
-Brand and marketing teams either miss important conversations entirely or spend hours manually scanning platforms for relevant mentions. A product launch getting unexpected traction? A customer complaint going viral? A competitor's campaign generating buzz? This agent surfaces only what matters and delivers it in a format that's ready to act on.
-
-**Key integrations:** Social listening data sources, web search tools (Tavily, Exa), Slack for delivery, Notion or Airtable for trend logging.
-
-**Getting started with Sim:** A scheduled trigger feeding an Agent block handles the monitoring and classification pipeline. Configure your target keywords, brand names, and competitors, set up the sentiment analysis, and route the results to Slack or your preferred tracking tool.
-
-## Choosing the Right Idea for Your Team
-
-With 10 options on the table, the natural question is: which one should I build first? Here's a comparison to help you narrow it down.
+## [10 AI Agent Ideas at a Glance](#10-ai-agent-ideas-at-a-glance)
 
 | Agent | Use Case | Key Integrations | Complexity | Primary Value |
 | --- | --- | --- | --- | --- |
 | Email Triage & Response | Sales / Support | Gmail, CRM, Slack | Starter | Hours reclaimed from manual inbox sorting |
 | Competitor Monitoring | Strategy / Marketing | Search tools, Slack, Notion | Starter | Automated competitive intelligence |
 | Lead Enrichment & Qualification | Sales | CRM, Apollo/Hunter, Slack | Intermediate | Higher rep efficiency, better lead routing |
-| Meeting Follow-Up | Ops / Cross-functional | Transcription, Slack, Linear/Jira | Starter | Zero lost action items |
+| Meeting Follow-Up | Ops / Cross-functional | Transcription, Slack, Linear/Jira | Starter | Fewer missed action items |
 | Customer Support Knowledge | Support | Knowledge base, Slack, Ticketing | Intermediate | Tier-1 deflection, faster resolution |
 | Content Research & Brief Gen | Content / Marketing | Search tools, Google Docs, Notion | Intermediate | Research time reduced by hours |
 | Code Review & PR Summary | Engineering | GitHub/GitLab, Slack | Intermediate | Faster review cycles |
 | Resume Screening | HR / Recruiting | Gmail, Sheets/Airtable, Slack | Starter | Recruiter time focused on top candidates |
-| Data Pipeline & Report Gen | Ops / Finance | Databases, Sheets, Slack | Advanced | Recurring reports fully automated |
-| Social Listening & Brand Monitoring | Marketing | Search tools, Slack, Airtable | Intermediate | Real-time brand awareness |
+| Data Pipeline & Report Gen | Ops / Finance | Databases, Sheets, Slack | Advanced | Less manual work on recurring reports |
+| Social Listening & Brand Monitoring | Marketing | Search tools, Slack, Airtable | Intermediate | Faster detection of relevant brand mentions |
 
-Here's a simple selection framework. Start with the idea that maps to a pain point your team already complains about. Then check: do you already have the data and tools in place? And if the agent gets something wrong, is it easy to catch and correct?
+AI agents can now handle bounded production workflows in customer service, eCommerce, and operations. The most practical first projects use a clear trigger, a defined action, and an output that a person can review.
 
-That third question matters more than people realize. An email triage agent that misroutes a message to the wrong Slack channel is a minor inconvenience. A resume screening agent that incorrectly rejects a strong candidate has bigger consequences. Start where the cost of a wrong answer is low, and the feedback loop is tight.
+Choosing the first workflow is often harder than understanding the technology. Broad goals such as "automate marketing" are difficult to test, while projects such as replacing an entire support function carry too much scope and consequence for an initial build.
 
-The most common mistake is trying to automate an entire department with your first agent. Don't build "the AI sales assistant." Build the agent that enriches one lead from one form and routes it to one Slack channel. Get that working, measure the results, and expand from there.
+This article presents 10 specific AI agent ideas across sales, operations, content, engineering, and support. Each idea identifies the workflow, required integrations, expected output, and a way to prototype it in Sim without building the underlying infrastructure yourself.
 
-## Getting Started With Sim
+Each idea targets a frequent, repetitive task, connects to common workplace tools, and produces an output you can inspect and measure.
 
-Sim is the open-source AI workspace where teams build, deploy, and manage AI agents, connecting 1,000+ integrations and every major LLM: OpenAI, Anthropic Claude, Google Gemini, Mistral, and xAI Grok. It covers all 10 ideas above without requiring you to write infrastructure code.
+## [Key Takeaways](#key-takeaways)
 
-The path from idea to deployed agent looks like this:
+- **Start with a bounded production workflow:**
+    Choose a workflow with a clear trigger, action, and reviewable output. The 10 ideas below are scoped as starting points.
+- **Good agent ideas share three traits:**
+    They handle repetitive, high-frequency tasks, connect to your existing tools, and produce outputs you can measure and improve.
+- **Agents reason; automations follow rules:**
+    Unlike a static Zapier zap, an AI agent can evaluate context, choose between paths, and act across multiple systems before returning a result.
+- **Start narrow, then expand:**
+    One trigger, one action, one output. The biggest mistake teams make is trying to automate an entire department in their first agent.
+- **Sim can scaffold an initial prototype:**
+    Sim's Chat can scaffold a first draft from a plain-language description, and its visual canvas supports connections to more than 1,000 integrations. Production deployment still requires testing, access controls, and review criteria appropriate to the workflow.
+- **You don't need a dedicated ML team:**
+    Sim's visual builder and multi-model support let you prototype an agent without writing the orchestration infrastructure. Custom logic, security reviews, and complex integrations may still require development work.
 
-- **Open the Sim canvas:** Start from a blank workflow, or describe it to Chat and let Sim scaffold the first draft.
-- **Connect your integrations:** Drag and drop the tools your agent needs (Gmail, Slack, GitHub, your CRM, databases).
-- **Configure the AI model:** Choose from OpenAI, Claude, Gemini, Mistral, xAI, or local models via Ollama. Swap models anytime without rebuilding your workflow.
-- **Test with real data:** Run the workflow against actual inputs to validate the output before going live.
-- **Deploy:** Launch via chat interface, REST API, webhook, or scheduled cron job, depending on your use case.
+## [What Makes an AI Agent Idea Worth Building](#what-makes-an-ai-agent-idea-worth-building)
 
-Several Sim features accelerate each step:
+A useful AI agent idea has a clear trigger, a defined action, and a measurable output. Broad concepts such as "use AI to automate marketing" do not identify a workflow that you can build or evaluate. If you cannot name all three elements in one sentence, narrow the idea before building it.
 
-- **1,000+ integrations:** Connect Slack, Gmail, GitHub, GitLab, Notion, HubSpot, Salesforce, Airtable, Linear, Jira, PostgreSQL, Supabase, and hundreds more via drag-and-drop.
-- **Multi-model support:** Run OpenAI, Claude, Gemini, Mistral, or xAI models in the same workflow. Bring your own API keys or use Sim's hosted keys.
-- **Chat:** Talk to Sim in Chat to generate nodes, fix errors, and iterate on flows directly from natural language. Describe what you want, and Sim proposes the workflow changes.
-- **Knowledge Base and Tables:** Upload documents to a vector store and let agents answer questions grounded in your specific content. Tables provide structured data storage for agents that need memory.
+Here's the filter we apply to every idea on this list:
 
-Sim is trusted by over 100,000 builders at startups and Fortune 500 companies, and is SOC2 compliant. It's also open-source and free to start, removing the evaluation friction for teams with security requirements or budget constraints.
+- **High-frequency, repetitive task:**
+    The agent should handle something your team does over and over, often enough that the time savings compound.
+- **Connects to existing systems:**
+    Prefer workflows that connect to tools you already use, such as Gmail, Slack, HubSpot, GitHub, or Google Sheets.
+- **Observable success and failure:**
+    You need to be able to tell, quickly, whether the agent is working. Did it route the lead to the right rep? Did the summary capture the action items?
 
-## The Bottom Line
+AI agents differ from fixed workflow automations in how they handle variable inputs. A basic Zapier workflow executes predefined steps when a trigger occurs. An agent can use a model to interpret context, select among permitted actions, and call multiple tools, although its autonomy depends on the workflow's configuration and controls.
 
-The gap between "AI agents sound useful" and "we have an agent running in production" is smaller than most teams think. The 10 AI agent ideas in this article are designed to close that gap quickly: each one targets a specific, repetitive workflow, connects to tools you already use, and produces output you can measure from day one.
+The 10 ideas that follow are starting points designed to get something into production quickly, so you can learn what works and expand from there.
 
-The teams seeing the best results in 2026 aren't building grand autonomous systems. They're prioritizing task-specific, governed AI agents that integrate with real business systems rather than broad autonomous experimentation. They're starting narrow, proving value, and expanding.
+## [10 AI Agent Ideas You Can Build Today](#10-ai-agent-ideas-you-can-build-today)
 
-Pick the idea that matches your team's biggest pain point. Open Sim, build the workflow, and deploy your first agent today. You'll learn more in that first hour of building than in another month of reading about what's possible.
+These are organized by the function they serve. For each idea, you'll find what the agent does, why it matters, the key integrations, and how to get started with Sim.
 
-Not sure an agent is the right shape for your problem? [AI agent vs chatbot](/library/ai-agent-vs-chatbot) draws the line, and [AI agents vs RPA](/library/ai-agents-vs-rpa) covers where rule-based automation still wins. When you're ready to build, [how to build AI agents](/library/how-to-create-an-ai-agent) is the step-by-step, and [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026) compares where to build it.
+### [Email Triage and Response Agent](#email-triage-and-response-agent)
+
+This agent monitors an inbox, classifies incoming emails by intent and urgency, drafts context-aware replies, and routes messages that need human review to the right person.
+
+An email triage agent reduces the first-pass work required to classify, prioritize, and assign incoming messages. People can then review drafted replies and focus on cases that require judgment.
+
+**Key integrations:**
+         Gmail or Microsoft Outlook, a CRM like HubSpot or Salesforce for context lookup, Slack for escalation alerts.
+
+**Getting started with Sim:**
+         Describe the workflow to Chat and it'll scaffold an Agent block wired to these integrations on a visual canvas. You can customize the classification logic and test it with representative messages before deployment.
+
+### [Competitor Monitoring Agent](#competitor-monitoring-agent)
+
+This agent runs on a schedule to monitor competitor websites, social channels, and news sources, then summarizes changes in positioning, pricing, or product updates and delivers a digest to Slack or email.
+
+Competitor monitoring is easy to neglect when someone must remember to check websites, news, and social channels manually. A scheduled agent can collect specified changes and deliver a weekly digest, giving you a consistent record to review.
+
+**Key integrations:**
+         Web search tools (Tavily, Exa, or Google Search), Slack for delivery, Notion or a Google Sheet for tracking changes over time.
+
+**Getting started with Sim:**
+         Pair a scheduled trigger with search integrations and an Agent block for AI summarization. Set up your target competitors, define the schedule, and let it run.
+
+### [Lead Enrichment and Qualification Agent](#lead-enrichment-and-qualification-agent)
+
+This agent takes raw leads from a form submission, CRM entry, or inbound email, enriches each lead with company data and buying signals, scores it against your defined criteria, and routes qualified leads to the right sales rep with a summary.
+
+Manual lead research takes time and can delay routing. This agent retrieves the selected company data, applies your qualification criteria, and sends the result to a sales representative for review.
+
+**Key integrations:**
+         HubSpot or Salesforce, Apollo or Hunter.io for enrichment data, Slack for routing notifications, and Google Sheets or Airtable for logging.
+
+**Getting started with Sim:**
+         Connect your CRM and enrichment tools to an Agent block, then add conditional routing logic with Sim's router blocks to score leads and send them to different reps or channels based on criteria like company size, industry, or engagement signals.
+
+### [Meeting Follow-Up Agent](#meeting-follow-up-agent)
+
+This agent receives a meeting transcript or recording, extracts action items, assigns owners based on context, drafts a follow-up email or Slack message, and optionally creates tasks in a project management tool.
+
+Meeting commitments can be missed when nobody records an owner or due date. A follow-up agent can extract proposed action items from a transcript and draft a recap, but participants should confirm assignments and deadlines before tasks are created.
+
+**Key integrations:**
+         Transcription tools or calendar triggers, Slack, Notion, Linear, or Jira for task creation, Gmail for follow-up emails.
+
+**Getting started with Sim:**
+         Wire a webhook trigger to your transcription source and an Agent block. Configure the model to identify proposed action items and owners from the participant context. Route the draft to a person for confirmation before sending it to your task management and communication tools.
+
+### [Customer Support Knowledge Agent](#customer-support-knowledge-agent)
+
+This agent answers customer questions by searching a connected knowledge base of documentation, past tickets, and FAQs. It escalates to a human only when its confidence falls below a defined threshold.
+
+A knowledge agent can answer routine questions that already have documented responses, such as password-reset instructions or refund policies. It can draft or send answers for approved topics while routing ambiguous, complex, or sensitive cases to a person.
+
+When connected to authorized backend systems, a support agent can also retrieve order status or account details and process selected standard requests. Permissions and escalation rules should limit which data and actions the agent can access.
+
+**Key integrations:**
+         A vector knowledge base (Sim's built-in Knowledge Base, or Pinecone/Qdrant), Slack or a chat interface for customer-facing interaction, and a ticketing system for escalation.
+
+**Getting started with Sim:**
+         Sim's built-in Knowledge Base lets you upload documents to a vector store and configure the agent to answer questions grounded in your specific content. Set a confidence threshold for escalation and connect the output to your support channel.
+
+### [Content Research and Brief Generation Agent](#content-research-and-brief-generation-agent)
+
+Given a topic or target keyword, this agent searches for top-ranking content, extracts key themes and gaps, pulls relevant data points, and produces a structured content brief ready for a writer.
+
+Research can require substantial time when a writer must inspect search results, verify statistics, identify subtopics, and organize references manually. This agent can prepare a sourced first-pass brief for a writer to verify and refine.
+
+**Key integrations:**
+         Web search tools (Tavily, Exa, Perplexity), Google Docs or Notion for brief output, Slack for team delivery.
+
+**Getting started with Sim:**
+         This agent pairs naturally with Sim's search integrations and document output blocks. Connect your preferred search tools, configure the AI to analyze and synthesize results, and route the finished brief to Google Docs or Notion.
+
+### [Code Review and PR Summary Agent](#code-review-and-pr-summary-agent)
+
+Triggered by a new pull request on GitHub or GitLab, this agent reviews the diff for potential issues, summarizes the changes in plain English, checks for patterns that violate team conventions, and posts a comment directly on the PR.
+
+Automated review can reduce the time people spend checking routine conventions and summarizing a pull request. The agent can flag possible naming, formatting, or test issues, while human reviewers remain responsible for logic, architecture, security, and design decisions.
+
+**Key integrations:**
+         GitHub or GitLab (Sim has native integrations for both), Slack for reviewer notifications.
+
+**Getting started with Sim:**
+         Trigger a workflow directly off your repo's PR events. Configure the review rules (style guide, test coverage requirements, naming conventions), and the agent posts its analysis as a comment on every new PR.
+
+### [Resume Screening Agent](#resume-screening-agent)
+
+This agent parses incoming applications from an email inbox or applicant tracking system, compares job-related information with a documented rubric, prepares a structured summary, and routes the application for recruiter review. A person should make advancement and rejection decisions.
+
+An agent can reduce the administrative work involved in organizing applications and checking for explicitly stated, job-related criteria. Recruiters should validate each assessment, monitor for disparate outcomes, and provide an accessible path for candidates who need accommodation or correction.
+
+**Key integrations:**
+         Gmail for application intake, Google Sheets or Airtable for candidate tracking, Slack for recruiter alerts.
+
+**Getting started with Sim:**
+         An Agent block with document-parsing tools handles the parsing and criteria matching. Define a job-related rubric, exclude protected characteristics and proxies, and have the agent prepare assessments for recruiter review rather than automatically rejecting applicants.
+
+### [Data Pipeline and Report Generation Agent](#data-pipeline-and-report-generation-agent)
+
+This agent pulls data from one or more sources on a schedule (database, spreadsheet, API), runs analysis or transformation logic, generates a formatted report or dashboard summary, and delivers it to the right stakeholders.
+
+Recurring reports often require the same data retrieval, transformation, and formatting steps. An agent can prepare a draft report on a schedule, while a designated owner checks data quality, calculations, and commentary before distribution.
+
+**Key integrations:**
+         PostgreSQL, MySQL, Google Sheets, Airtable, or Supabase as data sources. Use Google Docs or Notion for report output and Slack or email for delivery.
+
+**Getting started with Sim:**
+         Sim supports scheduled cron triggers natively, so setting up a recurring data pull is straightforward. Connect your data sources, configure the transformation and summarization logic, and schedule delivery for whatever cadence your team needs.
+
+### [Social Listening and Brand Monitoring Agent](#social-listening-and-brand-monitoring-agent)
+
+This agent monitors mentions, keywords, and trending topics across social platforms and the web, classifies sentiment and intent, filters out noise, and delivers a prioritized digest of conversations worth paying attention to.
+
+Manual monitoring can miss relevant mentions or consume time when staff scan multiple platforms. A monitoring agent can prioritize conversations based on defined keywords, sources, sentiment, and reach, but coverage will depend on the connected data providers.
+
+**Key integrations:**
+         Social listening data sources, web search tools (Tavily, Exa), Slack for delivery, Notion or Airtable for trend logging.
+
+**Getting started with Sim:**
+         A scheduled trigger feeding an Agent block handles the monitoring and classification pipeline. Configure your target keywords, brand names, and competitors, set up the sentiment analysis, and route the results to Slack or your preferred tracking tool.
+
+## [Choosing the Right Idea for Your Team](#choosing-the-right-idea-for-your-team)
+
+Choose a recurring pain point for which you already have the required data and tool access. Favor a workflow whose errors are easy to detect and correct.
+
+The cost of an error should determine how much human review the workflow requires. Misrouting an internal message may be easy to correct, while incorrectly screening out a qualified applicant can have serious consequences and requires stronger oversight.
+
+Keep the first workflow narrow. Instead of building a general AI sales assistant, start with one lead source, one enrichment process, and one reviewed routing destination. Measure accuracy and time saved before expanding the workflow.
+
+## [Getting Started With Sim](#getting-started-with-sim)
+
+Sim is an open-source workspace for building, deploying, and managing AI agents. It supports more than 1,000 integrations and models from providers including OpenAI, Anthropic, Google, Mistral AI, and xAI. You can prototype the 10 workflows above without writing the underlying orchestration infrastructure.
+
+Use the following process to build and test an agent in Sim:
+
+- **Open the Sim canvas:**
+    Start from a blank workflow, or describe it to Chat and let Sim scaffold the first draft.
+- **Connect your integrations:**
+    Drag and drop the tools your agent needs (Gmail, Slack, GitHub, your CRM, databases).
+- **Configure the AI model:**
+    Choose from OpenAI, Claude, Gemini, Mistral, xAI, or local models via Ollama. Swap models anytime without rebuilding your workflow.
+- **Test with real data:**
+    Run the workflow against representative test inputs, including edge cases, before using live or sensitive data. Confirm the output, permissions, escalation path, and failure behavior before deployment.
+- **Deploy:**
+    Launch via chat interface, REST API, webhook, or scheduled cron job, depending on your use case.
+
+Sim provides the following features for building and operating these workflows:
+
+- **1,000+ integrations:**
+    Connect Slack, Gmail, GitHub, GitLab, Notion, HubSpot, Salesforce, Airtable, Linear, Jira, PostgreSQL, Supabase, and hundreds more via drag-and-drop.
+- **Multi-model support:**
+    Run OpenAI, Claude, Gemini, Mistral, or xAI models in the same workflow. Bring your own API keys or use Sim's hosted keys.
+- **Chat:**
+    Talk to Sim in Chat to generate nodes, fix errors, and iterate on flows directly from natural language. Describe what you want, and Sim proposes the workflow changes.
+- **Knowledge Base and Tables:**
+    Upload documents to a vector store and let agents answer questions grounded in your specific content. Tables provide structured data storage for agents that need memory.
+
+Sim reports more than 100,000 builders across startups and Fortune 500 companies. Sim is open source and free to start.
+
+## [The Bottom Line](#the-bottom-line)
+
+A first AI agent is easier to evaluate when it handles one repetitive workflow, uses tools you already have, and produces an output you can review. The 10 ideas in this article provide bounded starting points rather than plans for autonomous departments.
+
+Task-specific agents are easier to test and govern than broad autonomous systems. Start with a narrow workflow, measure its accuracy and operational effect, and expand only after the controls work.
+
+Choose a low-consequence workflow with clear review criteria, then prototype it in Sim. Test the agent with representative inputs and deploy it only after you have defined permissions, escalation rules, and an owner.
+
+Use [AI agent vs chatbot](/library/ai-agent-vs-chatbot) to distinguish conversational interfaces from agents, and read [AI agents vs RPA](/library/ai-agents-vs-rpa) for workflows better suited to fixed rules. For implementation guidance, see [how to build AI agents](/library/how-to-create-an-ai-agent) and [the best AI agent platforms in 2026](/library/best-ai-agent-platforms-2026).


### PR DESCRIPTION
Content update to `apps/sim/content/library/ai-agent-ideas`: The supplied replacement article below is the CURRENT article text, which contains a completed rewrite pass PLUS leftover old fragments sitting next to each new sentence. Your job is to publish the cleaned version: apply the following keep/cut breakdown, deleting every 'cut' fragment and keeping every 'new' sentence. Also delete the stray editorial note in the Getting Started closing paragraph ('Link the current SOC 2 report or trust center here so readers can verify the scope and status of the compliance claim.') outright. Move the '## FAQ' section into frontmatter faq entries as the workflow rules require — keep all 5 FAQs, each with only the cleaned front half of the answer. Do not add new content beyond these deletions.

Here's the keep/cut breakdown, section by section. "New" = the clean sentence the review pass wrote. "Old" = the leftover fragment sitting next to it that needs deletion.

**Opening (after the table)**
- Keep: "AI agents can now handle bounded production workflows in customer service, eCommerce, and operations. The most practical first projects use a clear trigger, a defined action, and an output that a person can review."
- Cut: `"we should explore this" to "this is running in production" faster than most teams anticipated. Customer service, eCommerce, and operations are already seeing real returns, and the pace of adoption across the enterprise isn't slowing down. The shift is real, and it's happening fast.`

- Keep: "Choosing the first workflow is often harder than understanding the technology. Broad goals such as 'automate marketing' are difficult to test, while projects such as replacing an entire support function carry too much scope and consequence for an initial build."
- Cut: `at the same frustrating starting line. You know agents are powerful. You've read the frameworks, watched the demos, and bookmarked a dozen GitHub repos. But when it comes to deciding what to actually build first, the options feel either too vague ("automate marketing") or too ambitious ("replace our entire support team").`

- Keep: "This article presents 10 specific AI agent ideas across sales, operations, content, engineering, and support. Each idea identifies the workflow, required integrations, expected output, and a way to prototype it in Sim without building the underlying infrastructure yourself."
- Cut everything after that colon: `: 10 specific AI agent ideas, each one mapped to a real workflow... how to get started with Sim.`

- Keep: "Each idea targets a frequent, repetitive task, connects to common workplace tools, and produces an output you can inspect and measure."
- Cut: `Every idea on this list handles a high-frequency, repetitive task. Every idea connects to systems you probably already pay for. And every idea produces results that are easy to observe, measure, and improve.` (pure restatement, adds nothing)

**Key Takeaways bullets** — same pattern in 3 of 5 bullets: keep the first clean sentence(s), cut the quoted/run-on fragment after.
- "Start with a bounded production workflow" — cut: `"should we build agents?" but "which agent should we build first?" These 10 ideas are scoped for fast time-to-value.`
- "Sim can scaffold an initial prototype" — cut: `a first draft of any of these workflows from a plain-language description, and there are 1,000+ integrations you can connect on a drag-and-drop canvas.`
- "You don't need a dedicated ML team" — cut: `developers and operators can go from idea to deployed agent without writing infrastructure code.`

**"What Makes an AI Agent Idea Worth Building"**
- Keep the new opening two sentences; cut the old paragraph starting `your time. The space is flooded with vague concepts...` through `...isn't ready to build.`
- In the filter bullets, "Connects to existing systems" — keep the new sentence, cut the trailing `tools your team already uses: Gmail, Slack, HubSpot, GitHub, and Google Sheets.`
- Final paragraph — keep the new explanation, cut `a clear line between AI agents and basic workflow automation. A static Zapier automation fires when X happens...` through `...minimal human supervision.`

**Every per-idea section (all 10)** follow the identical shape: new explanatory paragraph, then leftover old fragment starting mid-sentence (often lowercase, e.g. `time reclamation.`, `into one of two categories`, `on manual research and misrouted leads.`). Keep the new paragraph in each, cut everything from the lowercase fragment to the end of that paragraph. A few "Getting started with Sim" blocks also have a trailing duplicate clause (e.g. Meeting Follow-Up ends with `to identify action items, assign them based on...` repeating what was just said) — cut those too.

**"Choosing the Right Idea"** — same pattern, 3 paragraphs, keep new/cut old each time (cut fragments: `more than people realize...`, `trying to automate an entire department...`).

**"Getting Started With Sim"**
- Keep new opening 2 sentences, cut `where teams build, deploy, and manage AI agents, connecting 1,000+ integrations...requiring you to write infrastructure code.`
- "Test with real data" bullet — cut trailing `to validate the output before going live.`
- Closing paragraph — keep new version, cut `builders at startups and Fortune 500 companies, and is SOC2 compliant...budget constraints.` Also flag: the new sentence has a stray editorial note — `Link the current SOC 2 report or trust center here so readers can verify the scope and status of the compliance claim.` — that's a note-to-self that got left in the copy and must be deleted outright, not kept.

**"The Bottom Line"** — same pattern all 3 paragraphs, keep new/cut old.

**Closing links paragraph** — keep the new clean version with inline links; cut the duplicate `the right shape for your problem?` paragraph that repeats the same 4 links with clunkier phrasing.

**FAQ** — all 5 answers follow the pattern: keep the new front half, cut the old back half starting mid-sentence lowercase (e.g. `(an email, a transcript...`, `, a working prototype can be ready...`, `Sim's drag-and-drop canvas and Chat let you build...` — note FAQ 3 actually has the old text repeating almost the same claim as the new, so just cut it — same for FAQ 4 and 5).

- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)