### PR TITLE
feat(providers): make the agent tool-call ceiling configurable

### DIFF
--- a/apps/docs/content/docs/platform/self-hosting/environment-variables.mdx
+++ b/apps/docs/content/docs/platform/self-hosting/environment-variables.mdx
@@ -63,6 +63,10 @@ import { Callout } from 'fumadocs-ui/components/callout'
   In Docker, use `OLLAMA_URL=http://host.docker.internal:11434` for host-machine Ollama.
 </Callout>
 
+<Callout type="info">
+  **Agent tool-call depth.** An Agent block ends its run after 20 model round trips of tool calling. Raise the ceiling with `MAX_TOOL_ITERATIONS` (for example `MAX_TOOL_ITERATIONS=50`). Every extra iteration is another model call, so raise it deliberately.
+</Callout>
+
 ### AWS Bedrock
 
 | Variable | Description |

--- a/apps/sim/.env.example
+++ b/apps/sim/.env.example
@@ -227,3 +227,7 @@ CRON_SECRET=your_cron_secret # Use `openssl rand -hex 32` to generate. Authentic
 # TABLE_DISPATCH_CONCURRENCY_FREE=20    # Rows one table run executes in parallel on free tier
 # TABLE_DISPATCH_CONCURRENCY_PAID=50    # Rows one table run executes in parallel on paid tiers (billing disabled uses this)
 # FREE_STORAGE_LIMIT_GB=5               # File storage quota in GB
+
+# Agent tool-call loop (Optional). Model round trips one Agent block takes before it
+# must answer. Defaults to 20; raise it for agents that chain many tool calls.
+# MAX_TOOL_ITERATIONS=20

--- a/apps/sim/lib/core/config/env.ts
+++ b/apps/sim/lib/core/config/env.ts
@@ -416,6 +416,9 @@ export const env = createEnv({
     EXECUTION_TIMEOUT_ASYNC_TEAM:          z.string().optional().default('5400'),  // 90 minutes
     EXECUTION_TIMEOUT_ASYNC_ENTERPRISE:    z.string().optional().default('5400'),  // 90 minutes
 
+    // Agent Tool-Call Loop
+    MAX_TOOL_ITERATIONS:                   z.string().optional(),                  // Max model round trips per Agent block tool-call loop (default 20)
+
     // Isolated-VM Worker Pool Configuration
     IVM_POOL_SIZE:                         z.string().optional().default('4'),      // Max worker processes in pool
     IVM_MAX_CONCURRENT:                    z.string().optional().default('10000'),  // Max concurrent executions globally

--- a/apps/sim/providers/index.ts
+++ b/apps/sim/providers/index.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sim/logger'
 import { toError } from '@sim/utils/errors'
 import { getApiKeyWithBYOK } from '@/lib/api-key/byok'
+import { env, envNumber } from '@/lib/core/config/env'
 import { filterModelSafeWorkspaceFileAttachments } from '@/lib/uploads/contexts/workspace/workspace-file-secret-provenance'
 import type { StreamingExecution } from '@/executor/types'
 import {
@@ -76,11 +77,21 @@ async function omitUnsafeProviderFileAttachments(
   }
 }
 
+/** Round trips an Agent block's tool loop takes before it is forced to answer. */
+const DEFAULT_MAX_TOOL_ITERATIONS = 20
+
 /**
  * Maximum number of iterations for tool call loops to prevent infinite loops.
  * Used across all providers that support tool/function calling.
+ *
+ * Self-hosted deployments that need longer agent runs raise it with the
+ * `MAX_TOOL_ITERATIONS` env var; a value that is not a positive integer falls
+ * back to {@link DEFAULT_MAX_TOOL_ITERATIONS}.
  */
-export const MAX_TOOL_ITERATIONS = 20
+export const MAX_TOOL_ITERATIONS = envNumber(env.MAX_TOOL_ITERATIONS, DEFAULT_MAX_TOOL_ITERATIONS, {
+  min: 1,
+  integer: true,
+})
 
 /**
  * Normalizes a model-tuning level that may have arrived from a variable or block reference

--- a/helm/sim/Chart.yaml
+++ b/helm/sim/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sim
 description: A Helm chart for Sim - the open-source AI workspace where teams build, deploy, and manage AI agents
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: "v0.8.18"
 kubeVersion: ">=1.25.0-0"
 home: https://sim.ai

--- a/helm/sim/values.yaml
+++ b/helm/sim/values.yaml
@@ -400,6 +400,9 @@ app:
     EXECUTION_TIMEOUT_ASYNC_TEAM: "5400"                  # Team tier async timeout (90 minutes)
     EXECUTION_TIMEOUT_ASYNC_ENTERPRISE: "5400"            # Enterprise tier async timeout (90 minutes)
 
+    # Agent tool-call loop
+    # MAX_TOOL_ITERATIONS: "20"                           # Model round trips per Agent block tool-call loop
+
     # Table Feature Limits (per workspace, per plan)
     # FREE_TABLES_LIMIT: "3"                              # Opt-in; unset means no cap on a self-host
     # FREE_TABLE_ROWS_LIMIT: "1000"                       # Opt-in; unset means no cap on a self-host


### PR DESCRIPTION
## Summary
- `MAX_TOOL_ITERATIONS` now reads from an env var of the same name, defaulting to 20 — no behavior change unless it is set
- Self-hosted deployments can raise the agent tool-call loop without maintaining a custom build (fixes #7428)
- Non-numeric, zero, negative, or fractional values fall back to the 20 default via `envNumber`
- Documented in `.env.example`, the self-hosting env-var docs, and the Helm values file

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
Tested manually. `bun run type-check`, `bun run lint`, and `bun run check:audits` (45 audits) all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm2sCA6iswCvNT33eNRrix