### PR TITLE
fix(terminal): stop duplicating agent tool calls above the output

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/output-panel/output-panel.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/terminal/components/output-panel/output-panel.tsx
@@ -25,10 +25,7 @@ import {
 } from '@sim/emcn/icons'
 import clsx from 'clsx'
 import Link from 'next/link'
-import {
-  AgentStreamThinkingChrome,
-  AgentStreamToolCallsChrome,
-} from '@/components/agent-stream/agent-stream-chrome'
+import { AgentStreamThinkingChrome } from '@/components/agent-stream/agent-stream-chrome'
 import {
   OutputContextMenu,
   StructuredOutput,
@@ -544,31 +541,14 @@ export const OutputPanel = React.memo(function OutputPanel({
           className={clsx('flex-1 overflow-y-auto', !wrapText && 'overflow-x-auto')}
           onContextMenu={handleOutputPanelContextMenu}
         >
-          {!showInput &&
-            (selectedEntry.agentStreamThinking ||
-              (selectedEntry.agentStreamToolCalls &&
-                selectedEntry.agentStreamToolCalls.length > 0)) && (
-              <div className='border-[var(--border)] border-b px-3 pt-3'>
-                {selectedEntry.agentStreamThinking ? (
-                  <AgentStreamThinkingChrome
-                    thinking={selectedEntry.agentStreamThinking}
-                    isStreaming={Boolean(
-                      selectedEntry.isRunning && selectedEntry.agentStreamActive
-                    )}
-                  />
-                ) : null}
-                {selectedEntry.agentStreamToolCalls &&
-                selectedEntry.agentStreamToolCalls.length > 0 ? (
-                  <AgentStreamToolCallsChrome
-                    toolCalls={selectedEntry.agentStreamToolCalls}
-                    isStreaming={Boolean(
-                      selectedEntry.isRunning &&
-                        selectedEntry.agentStreamToolCalls.some((t) => t.status === 'running')
-                    )}
-                  />
-                ) : null}
-              </div>
-            )}
+          {!showInput && selectedEntry.agentStreamThinking && (
+            <div className='border-[var(--border)] border-b px-3 pt-3'>
+              <AgentStreamThinkingChrome
+                thinking={selectedEntry.agentStreamThinking}
+                isStreaming={Boolean(selectedEntry.isRunning && selectedEntry.agentStreamActive)}
+              />
+            </div>
+          )}
           {shouldShowCodeDisplay ? (
             <OutputCodeContent
               code={selectedEntry.input.code}


### PR DESCRIPTION
## Summary
- Drop the `AgentStreamToolCallsChrome` header from the workflow terminal's output panel — the collapsible "Tools" list rendered above the output while the same calls stayed inline in the agent block's `toolCalls` field, so every streamed run showed them twice
- Tool calls read inline in the structured output again, the way they did before the agent-stream work landed
- The thinking chrome is unchanged, and the tool chrome itself stays for the deployed chat surface, which is its only other consumer

## Type of Change
- [x] Bug fix

## Testing
Tested manually. `bun run lint`, `bun run check:audits` (45 audits), block-registry check, and `bun run type-check` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CimY1cwvWpQs3RY5MXtdE3