### PR TITLE
fix(monday): forward users through app installation

### DIFF
--- a/apps/sim/lib/auth/connectors/providers.ts
+++ b/apps/sim/lib/auth/connectors/providers.ts
@@ -1754,6 +1754,7 @@ export function buildConnectorProviders(): GenericOAuthConfig[] {
       pkce: true,
       authentication: 'post',
       redirectURI: `${getBaseUrl()}/api/auth/oauth2/callback/monday`,
+      authorizationUrlParams: { force_install_if_needed: 'true' },
       getToken: async ({ code, codeVerifier, redirectURI }) => {
         if (!codeVerifier) {
           throw new Error('Monday OAuth token exchange requires a PKCE verifier')

--- a/apps/sim/lib/oauth/oauth.test.ts
+++ b/apps/sim/lib/oauth/oauth.test.ts
@@ -1,5 +1,7 @@
 import { createMockFetch, resetEnvMock, setEnv } from '@sim/testing'
-import { createAuthorizationURL, getOAuth2Tokens } from 'better-auth/oauth2'
+import { getOAuth2Tokens } from 'better-auth/oauth2'
+import { genericOAuth } from 'better-auth/plugins'
+import { getTestInstance } from 'better-auth/test'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 beforeAll(() => {
@@ -180,21 +182,19 @@ describe('Monday OAuth connector', () => {
       redirectURI: 'http://localhost:3000/api/auth/oauth2/callback/monday',
       authorizationUrlParams: { force_install_if_needed: 'true' },
     })
-    const authorizationUrl = await createAuthorizationURL({
-      id: connector.providerId,
-      options: {
-        clientId: connector.clientId,
-        clientSecret: connector.clientSecret,
-        redirectURI: connector.redirectURI,
-      },
-      authorizationEndpoint: connector.authorizationUrl!,
-      state: 'state-1',
-      codeVerifier: 'a'.repeat(128),
-      scopes: connector.scopes,
-      redirectURI: connector.redirectURI!,
-      responseType: connector.responseType,
-      additionalParams: connector.authorizationUrlParams,
+    const { auth, signInWithTestUser } = await getTestInstance({
+      baseURL: 'http://localhost:3000',
+      plugins: [genericOAuth({ config: [connector] })],
     })
+    const { headers } = await signInWithTestUser()
+    const { url } = await auth.api.oAuth2LinkAccount({
+      body: {
+        providerId: connector.providerId,
+        callbackURL: 'http://localhost:3000/workspace',
+      },
+      headers,
+    })
+    const authorizationUrl = new URL(url)
 
     expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(
       'http://localhost:3000/api/auth/oauth2/callback/monday'

--- a/apps/sim/lib/oauth/oauth.test.ts
+++ b/apps/sim/lib/oauth/oauth.test.ts
@@ -178,6 +178,7 @@ describe('Monday OAuth connector', () => {
       pkce: true,
       authentication: 'post',
       redirectURI: 'http://localhost:3000/api/auth/oauth2/callback/monday',
+      authorizationUrlParams: { force_install_if_needed: 'true' },
     })
     const authorizationUrl = await createAuthorizationURL({
       id: connector.providerId,
@@ -192,12 +193,14 @@ describe('Monday OAuth connector', () => {
       scopes: connector.scopes,
       redirectURI: connector.redirectURI!,
       responseType: connector.responseType,
+      additionalParams: connector.authorizationUrlParams,
     })
 
     expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(
       'http://localhost:3000/api/auth/oauth2/callback/monday'
     )
     expect(authorizationUrl.searchParams.get('scope')).toBe(connector.scopes?.join(' '))
+    expect(authorizationUrl.searchParams.get('force_install_if_needed')).toBe('true')
     expect(authorizationUrl.searchParams.get('code_challenge_method')).toBe('S256')
     expect(authorizationUrl.searchParams.get('code_challenge')).toBeTruthy()
   })


### PR DESCRIPTION
## Summary

- Add the documented Monday OAuth authorization parameter `force_install_if_needed=true`.
- When the Sim app is not installed in a Monday account, Monday can now route an account admin through installation and then resume OAuth instead of stopping at the blocking App is not installed screen.
- Keep the parameter in the shared Monday connector configuration so ordinary and managed OAuth flows both inherit it.
- Verify the parameter on the real generated Monday authorization URL.

This does not bypass Monday account policy: a non-admin still needs an account admin to install the app, and the Monday app/version must be available to that account.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Focused OAuth tests: 69 passed
- [x] Full apps/sim Vitest suite: 40,552 passed, 67 skipped
- [x] `bun run --cwd apps/sim type-check`
- [x] `bun run --cwd apps/sim lint:check`
- [x] `bun run check:api-validation`
- [x] `bun run check`

## Checklist

- [x] Code follows the existing connector configuration pattern
- [x] Tests cover the generated authorization URL
- [x] No database, environment, callback, or API-key behavior changes