### PR TITLE
fix(chat): restore assistant feedback actions

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/message-actions/message-actions.tsx
@@ -34,7 +34,7 @@ interface MessageActionsProps {
   getCopyContent?: () => string
   hasCopyContent?: boolean
   prepareContentForCopy?: (content: string) => ClipboardContent
-  userQuery?: string
+  userQuery: string | undefined
   requestId?: string
   messageId?: string
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-chat/mothership-chat.tsx
@@ -211,6 +211,7 @@ interface AssistantMessageRowProps {
   prepareContentForCopy: (content: string) => ClipboardContent
   isStreaming: boolean
   isLast: boolean
+  precedingUserContent: string | undefined
   /** Transcript-derived answers for this message's question card (renders the recap). */
   questionAnswers?: string[]
   /** Transcript-derived status payload for this message's credential card. */
@@ -227,6 +228,7 @@ const AssistantMessageRow = memo(function AssistantMessageRow({
   prepareContentForCopy,
   isStreaming,
   isLast,
+  precedingUserContent,
   questionAnswers,
   credentialSubmission,
   credentialAbandoned,
@@ -311,6 +313,7 @@ const AssistantMessageRow = memo(function AssistantMessageRow({
               getCopyContent={getCopyContent}
               hasCopyContent={Boolean(getOrchestratorMessageText(blocks, message.content).trim())}
               prepareContentForCopy={prepareContentForCopy}
+              userQuery={precedingUserContent}
               requestId={message.requestId}
               messageId={message.id}
             />
@@ -562,6 +565,16 @@ export function MothershipChat({
     return out
   }, [messages])
 
+  const precedingUserContentByIndex = useMemo(() => {
+    const out: Array<string | undefined> = []
+    let lastUserContent: string | undefined
+    for (const [index, message] of messages.entries()) {
+      out[index] = lastUserContent
+      if (message.role === 'user') lastUserContent = message.content
+    }
+    return out
+  }, [messages])
+
   /**
    * Pairs each assistant question/credential card with the user message that
    * completed it. The paired user message is hidden — the answered card IS the
@@ -809,6 +822,7 @@ export function MothershipChat({
                         prepareContentForCopy={prepareContentForCopy}
                         isStreaming={isStreamActive && isLast}
                         isLast={isLast}
+                        precedingUserContent={precedingUserContentByIndex[index]}
                         questionAnswers={interactionPairing.answersByIndex[index]}
                         credentialSubmission={interactionPairing.credentialSubmissionByIndex[index]}
                         credentialAbandoned={interactionPairing.credentialAbandonedByIndex[index]}


### PR DESCRIPTION
## Summary
- Restore the preceding user query when rendering assistant message actions
- Require explicit feedback-query plumbing so missing call-site data fails type-checking

## Type of Change
- [x] Bug fix

## Testing
- Targeted Vitest suite
- Sim app type-check
- Lint and repository audit suite

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)