### PR TITLE
fix(cli): document Yarn Classic upgrades

### DIFF
--- a/apps/docs/content/docs/cli/troubleshooting.mdx
+++ b/apps/docs/content/docs/cli/troubleshooting.mdx
@@ -100,7 +100,7 @@ sim --version
 Then upgrade with the package manager you installed it with — using a different
 one installs a second copy instead of replacing the executable on your `PATH`:
 
-<Tabs items={['npm', 'pnpm', 'bun']}>
+<Tabs items={['npm', 'pnpm', 'bun', 'Yarn Classic']}>
   <Tab value="npm">
     ```bash
     npm install -g sim@latest
@@ -114,6 +114,11 @@ one installs a second copy instead of replacing the executable on your `PATH`:
   <Tab value="bun">
     ```bash
     bun add -g sim@latest
+    ```
+  </Tab>
+  <Tab value="Yarn Classic">
+    ```bash
+    yarn global add sim@latest
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

- Add the missing Yarn Classic upgrade tab to CLI troubleshooting, matching the command already emitted by the updater.
- Label the tab explicitly because modern Yarn no longer supports global installs.
- Address the CLI documentation finding in #7446.

## Type of Change

- [x] Bug fix

## Testing

- Updater unit tests: 59 passed.
- Troubleshooting MDX compiled; docs type-check passed.
- Root lint and lint:check, block-registry audit, all 45 repository audits, and docs-manifest check passed.
- Verified against the [Yarn Classic global command docs](https://classic.yarnpkg.com/lang/en/docs/cli/global/) and [modern Yarn migration guide](https://yarnpkg.com/migration/guide#use-yarn-dlx-instead-of-yarn-global).
- Two independent reviews found no additional issues. Documentation-only; no runtime changes.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing (existing tests pass; documentation-only change)
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)