### PR TITLE
fix(copilot): pin a restored table view so a stale views list cannot strand it

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.test.tsx
@@ -51,6 +51,21 @@ describe('ResourceContent table view handoff', () => {
     })
   }
 
+  it('hands off a restored view the table is mounted with', () => {
+    // The table can only honour `initialViewId` while its views query already
+    // lists that id. Reopening a chat against a cached list from before the
+    // agent's write would otherwise strand the restored view.
+    render({ type: 'table', id: 'table-1', title: 'Invoices', viewId: 'view-restored' })
+
+    expect(useTableViewPinStore.getState().pins['table-1']?.viewId).toBe('view-restored')
+  })
+
+  it('does not pin a table opened without a saved view', () => {
+    render({ type: 'table', id: 'table-1', title: 'Invoices' })
+
+    expect(useTableViewPinStore.getState().pins['table-1']).toBeUndefined()
+  })
+
   it('hands off a saved view that arrives after the embedded table mounts', () => {
     const table: MothershipResource = {
       type: 'table',

--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/resource-content/resource-content.tsx
@@ -179,9 +179,7 @@ export const ResourceContent = memo(function ResourceContent({
   visible = true,
   onBrowserOverlayControllerChange,
 }: ResourceContentProps) {
-  const observedTableViewRef = useRef(
-    resource.type === 'table' ? { tableId: resource.id, viewId: resource.viewId } : null
-  )
+  const observedTableViewRef = useRef<{ tableId: string; viewId?: string } | null>(null)
 
   useEffect(() => {
     const previous = observedTableViewRef.current
@@ -192,8 +190,13 @@ export const ResourceContent = memo(function ResourceContent({
       return
     }
     /**
-     * `initialViewId` owns the first table adoption. If refreshed chat data
-     * supplies it later, use the same one-shot handoff as live stream events.
+     * Pinned on mount as well as on later changes. `initialViewId` alone is not
+     * enough: the table honours it only while its views query already carries
+     * that id, and a cached list from before the agent wrote the view resolves
+     * it to nothing. Adoption then settles on the default and never revisits
+     * the id, so the restored view is lost until the tab is reopened. The pin
+     * waits for the refetch instead, and costs nothing when adoption already
+     * applied the same view — the table consumes it without touching the URL.
      */
     useTableViewPinStore.getState().pin(next.tableId, next.viewId)
   }, [resource.id, resource.type, resource.viewId])


### PR DESCRIPTION
## Summary
- Reopening a chat restores a table's saved view through `initialViewId`, which the table honours only while its views query already lists that id. A cached list from before the agent created the view resolves it to nothing, adoption settles on the default and stamps itself closed, and nothing revisits the id when the refetch lands — the restored view is lost until the tab is reopened.
- Pin the view on mount as well as on later changes, so the handoff waits for the list that carries it. Adoption that already applied the same view consumes the pin without touching the URL, and a table opened with no saved view still pins nothing.
- Behavior change worth a look: on a reload where the URL names a view picked by hand and the chat resource carries an agent pin, the pin now wins. A tab switch already behaves this way, so this makes a first mount agree with it.
- Raised by cubic on #7446 (P2, `resource-content.tsx`).

## Type of Change
- [x] Bug fix

## Testing
- `bunx vitest run` over the resource-content, view-pin store, view-state, copilot resources, and resource-event suites — 241 tests passing
- New test fails against the unfixed component and passes with it
- `bunx tsc --noEmit` and `bun run lint` clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwmaLmAXSK2hsPBGZmkPnT