### PR TITLE
fix(ship): regenerate docs manifest before validation

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -37,10 +37,10 @@ When the user runs `/ship`:
   - `bun run check:migrations origin/staging` must pass (staging is the PR base). Do not silence a flagged statement with a `-- migration-safe:` annotation unless `/db-migrate` confirmed the old code no longer depends on it; otherwise split the destructive change into a later deploy.
 6. **Run pre-ship checks** from the repo root before staging. This has two phases: first **regenerate** every committed artifact so generated files never drift into a CI failure (this is what catches things like `agent-stream-docs` going stale after a `models.ts` edit), then run the **full audit suite** CI's `Lint and Test` job enforces. Both phases parallelize — but only across commands that write **disjoint** outputs — and a bare `wait` swallows child exit codes, so both phases below explicitly collect each job's status and abort ship if any failed.
 
-  **Phase A — regenerate the always-in-repo committed artifacts (parallel), then let step 7 stage whatever changed.** Regenerate only the generators whose inputs live entirely in this repo and that any ordinary code change can drift — `agent-stream-docs:generate` (derives from the provider model registry) and `skills:sync` (derives from `.agents/skills/**`). They write disjoint trees (`apps/docs/…/agent.mdx` vs the `.claude`/`.cursor` command projections), so they parallelize safely, and each is idempotent (a no-op when already in sync):
+  **Phase A — regenerate the always-in-repo committed artifacts (parallel), then let step 7 stage whatever changed.** Regenerate only the generators whose inputs live entirely in this repo and that any ordinary code change can drift — `agent-stream-docs:generate` (derives from the provider model registry), `docs-manifest:generate` (derives from docs page paths), and `skills:sync` (derives from `.agents/skills/**`). They write disjoint outputs (`apps/docs/…/agent.mdx`, `apps/sim/lib/copilot/generated/docs-manifest.ts`, and `.claude/skills` links), so they parallelize safely, and each is idempotent (a no-op when already in sync):
   ```bash
   rm -f /tmp/ship-gen-results
-  for g in agent-stream-docs:generate skills:sync; do
+  for g in agent-stream-docs:generate docs-manifest:generate skills:sync; do
     ( bun run "$g" >"/tmp/ship-gen-${g//:/-}.log" 2>&1; echo "$? $g" >>/tmp/ship-gen-results ) &
   done
   wait


### PR DESCRIPTION
## Summary

- Regenerate the docs manifest during `/ship` before checking it, using the existing generator failure-status handling.
- Keep the validation gate and document the generators' disjoint outputs. Addresses the shipping-workflow review comment on #7446.

## Type of Change

- [x] Bug fix

## Testing

- Exercised the actual Phase A command block with temporary docs-page addition, rename, and removal; verified stale checks fail before regeneration and pass afterward.
- Injected a docs-manifest generator failure and verified Phase A exits nonzero.
- Verified generation is idempotent and all temporary docs/generated changes are removed.
- Independent cleanup/minimality review; React/UI passes are not applicable to this Markdown-only change.
- `bun run lint`, `bun run lint:check`, block-registry validation, `bun run check:audits`, and `bun run docs-manifest:check` passed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing (manual regression checks; no committed test changes)
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
