### PR TITLE
fix(chat): preserve queued edits and render quoted source chips

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-content.test.ts
@@ -2,8 +2,8 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
+import { sanitizeChatDisplayContent } from '@/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-sanitize'
 import { scalingRatioOver4x } from '@/app/workspace/[workspaceId]/home/components/message-content/components/scaling-test-helpers'
-import { sanitizeChatDisplayContent } from './chat-sanitize'
 
 describe('sanitizeChatDisplayContent', () => {
   it('unwraps workspace resource tags from inline code spans', () => {
@@ -21,6 +21,35 @@ describe('sanitizeChatDisplayContent', () => {
     expect(sanitizeChatDisplayContent(content)).toBe(
       'Block them first. <source>{"url":"https://docs.github.com/a"}</source>'
     )
+  })
+
+  it.each(['source', 'workspace_resource'])('preserves backticks inside %s JSON strings', (tag) => {
+    const payload = JSON.stringify({
+      title: 'Run `bun test`',
+      snippet: 'Quoted "commands" and a \\path with `backticks`',
+    })
+    const chip = `<${tag}>${payload}</${tag}>`
+
+    expect(sanitizeChatDisplayContent(`\`Evidence ${chip}.\``)).toBe(`Evidence ${chip}.`)
+    expect(sanitizeChatDisplayContent(`\`${chip} done`)).toBe(`${chip} done`)
+    expect(sanitizeChatDisplayContent(`${chip}\` done`)).toBe(`${chip} done`)
+    expect(sanitizeChatDisplayContent(`\`before\`${chip}\`after\``)).toBe(
+      `\`before\`${chip}\`after\``
+    )
+  })
+
+  it('treats tag markers inside JSON strings as payload', () => {
+    const payload = JSON.stringify({ snippet: 'Use `<source>` and `</source>` markers' })
+    const chip = `<source>${payload}</source>`
+
+    expect(sanitizeChatDisplayContent(`\`See ${chip}\``)).toBe(`See ${chip}`)
+  })
+
+  it('leaves a fenced source example with payload backticks intact', () => {
+    const payload = JSON.stringify({ snippet: 'Run `bun test`' })
+    const content = `Example:\n\`\`\`json\n<source>${payload}</source>\n\`\`\`\nDone.`
+
+    expect(sanitizeChatDisplayContent(content)).toBe(content)
   })
 
   it('removes hidden internal references wrapped in inline code', () => {
@@ -103,6 +132,16 @@ describe('sanitizeChatDisplayContent', () => {
     // Asserted as a scaling ratio, not a wall-clock ceiling — see
     // {@link scalingRatioOver4x} for why.
     expect(scalingRatioOver4x((content) => sanitizeChatDisplayContent(content))).toBeLessThan(8)
+  })
+
+  it('stays linear on repeated unclosed JSON chip bodies', () => {
+    expect(
+      scalingRatioOver4x((content) =>
+        sanitizeChatDisplayContent(
+          content.replaceAll('The <workspace_resource> tag is used here. ', '<source>{"snippet":"')
+        )
+      )
+    ).toBeLessThan(8)
   })
 
   it('still unwraps a real tag that carries a stray backtick on one side only', () => {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-sanitize.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/message-content/components/chat-content/chat-sanitize.ts
@@ -1,65 +1,66 @@
 const HIDDEN_INLINE_REFERENCE_PATTERN =
   /`[^`\n]*(?:internal\/tool-results\/|internal\/blocktips\/|components\/integrations\/[^`\n]*README)[^`\n]*`/g
 
-/**
- * A complete inline-chip tag — `<workspace_resource>` or `<source>` — as
- * opener, payload, closer. Both are JSON-bodied tags the model places inside a
- * sentence, so both attract the same stray backticks.
- *
- * Two constraints on the payload, both load-bearing:
- *
- * - **No backtick.** A payload is JSON and carries none, so this is what tells a
- *   real tag from prose MENTIONING the tag name — a message explaining the
- *   syntax writes the opener and the closer as two separately backticked spans.
- * - **No nested opener**, via the negative lookahead. A cost bound rather than a
- *   correctness rule: a lazy scan allowed to cross an opener restarts from every
- *   opener, so a message repeating the tag name is quadratic — on the main
- *   thread, for every streamed chunk.
- *
- * Accepted trade: a resource whose title or path itself contains a backtick is
- * not matched, so it renders as text rather than a chip. That costs one chip and
- * is rare; the failure it replaces corrupts a whole message and is common.
- */
-const COMPLETE_TAG_SOURCE =
-  '<(?<chipTag>workspace_resource|source)>(?:(?!<\\k<chipTag>>)[^`])*?<\\/\\k<chipTag>>'
-
-/** Non-global so {@link RegExp.test} has no `lastIndex` to carry between calls. */
-const COMPLETE_INLINE_CHIP_TAG = new RegExp(COMPLETE_TAG_SOURCE)
+/** JSON strings own their escaped quotes, backticks, and any quoted tag markers. */
+const JSON_STRING_SOURCE = String.raw`"(?:[^"\\\r\n]|\\[^\r\n])*"`
 
 /**
- * One left-to-right pass over the two things that can own a backtick: an inline
- * code span, and a tag with a stray backtick pressed against it.
- *
- * ONE pass is the design. Two separate passes each have to guess which backticks
- * belong together, and every previous arrangement of this file got a different
- * case wrong — a span two words away, a code fence, then a span sitting flush
- * against the tag. Here a span consumes its own delimiters as the scan reaches
- * them, so `` `config.json`<tag> `` keeps its pair without a special case.
- *
- * The trailing backtick is only taken when no further backtick follows on the
- * line; otherwise it is not a stray at all but the opener of the next span, and
- * `` <tag>`config.json` `` would lose that span's delimiter. A LEADING backtick
- * needs no such guard, because a backtick that closes a span is consumed as part
- * of that span. Of the two, only the trailing lookahead is pinned by a test —
- * swapping the alternatives changes behaviour only for a span that both opens
- * flush against a tag and closes elsewhere, which no fixture covers.
+ * Complete chip tags consume JSON strings atomically. Outside strings, a new
+ * opener or backtick ends the candidate, so prose mentions cannot join into a
+ * tag and repeated unclosed openers cannot repeatedly scan the same suffix.
  */
-const CODE_SPAN_OR_FLANKED_TAG = new RegExp(
-  `\`[^\`\\n]*\`|\`?(${COMPLETE_TAG_SOURCE})(?:\`(?![^\`\\n]*\`))?`,
-  'g'
-)
+const COMPLETE_TAG_SOURCE = `<(?<chipTag>workspace_resource|source)>\\s*\\{(?:${JSON_STRING_SOURCE}|[^"\`<])*?\\}\\s*</\\k<chipTag>>`
 
+const CHIP_OR_CODE_DELIMITER = new RegExp(`${COMPLETE_TAG_SOURCE}|\`|\n`, 'g')
+
+/**
+ * Pair Markdown delimiters outside chip payloads in one forward pass. A pair
+ * containing a chip is unwrapped; a lone delimiter is removed only when flush
+ * against a chip. Neighbouring code spans and multiline fences keep their pairs.
+ */
 export function sanitizeChatDisplayContent(content: string): string {
-  return content
-    .replace(CODE_SPAN_OR_FLANKED_TAG, (match, tag?: string) => {
-      // A tag with stray backticks against it: keep the tag, drop the strays.
-      if (tag !== undefined) return tag
+  const removedDelimiters: number[] = []
+  let openingTick = -1
+  let containsChip = false
+  let adjacentToChip = false
+  let lastChipEnd = -1
 
-      // A code span. Unwrap it only when it genuinely holds a tag — the parser
-      // lifts the tag out either way, so leaving the delimiters would strand a
-      // pair of backticks around a hole. Anything else is someone else's span.
-      const inner = match.slice(1, -1)
-      return COMPLETE_INLINE_CHIP_TAG.test(inner) ? inner : match
-    })
-    .replace(HIDDEN_INLINE_REFERENCE_PATTERN, '')
+  for (const match of content.matchAll(CHIP_OR_CODE_DELIMITER)) {
+    const index = match.index
+    if (match.groups?.chipTag) {
+      if (openingTick !== -1) {
+        containsChip = true
+        adjacentToChip ||= index === openingTick + 1
+      }
+      lastChipEnd = index + match[0].length
+      continue
+    }
+
+    if (match[0] === '\n') {
+      if (openingTick !== -1 && adjacentToChip) removedDelimiters.push(openingTick)
+      openingTick = -1
+      lastChipEnd = -1
+      continue
+    }
+
+    if (openingTick === -1) {
+      openingTick = index
+      containsChip = false
+      adjacentToChip = lastChipEnd === index
+    } else {
+      if (containsChip) removedDelimiters.push(openingTick, index)
+      openingTick = -1
+    }
+  }
+
+  if (openingTick !== -1 && adjacentToChip) removedDelimiters.push(openingTick)
+
+  const parts: string[] = []
+  let start = 0
+  for (const index of removedDelimiters) {
+    parts.push(content.slice(start, index))
+    start = index + 1
+  }
+  parts.push(content.slice(start))
+  return parts.join('').replace(HIDDEN_INLINE_REFERENCE_PATTERN, '')
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/components/suggested-actions/suggested-actions.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/suggested-actions/suggested-actions.test.tsx
@@ -7,14 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockCaptureEvent, modeState } = vi.hoisted(() => ({
   mockCaptureEvent: vi.fn(),
-  /** The URL `mode` param as the nuqs mock serves it; `set` is the live setter once mounted. */
   modeState: { initial: 'build', set: (_next: string) => {} },
 }))
 
-vi.mock('nuqs', async () => {
+vi.mock('@/app/workspace/[workspaceId]/home/hooks/use-mothership-mode', async () => {
   const { useState } = await import('react')
   return {
-    useQueryState: () => {
+    useMothershipMode: () => {
       const [mode, setMode] = useState(modeState.initial)
       modeState.set = setMode
       return [mode, setMode]

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/mode-switcher/mode-switcher.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/mode-switcher/mode-switcher.test.tsx
@@ -2,34 +2,19 @@
  * @vitest-environment jsdom
  */
 import { act } from 'react'
+import { NuqsTestingAdapter, type UrlUpdateEvent } from 'nuqs/adapters/testing'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockCaptureEvent, mockSetSearchQuery, mockSetSearchFilters, modeState } = vi.hoisted(
-  () => ({
-    mockCaptureEvent: vi.fn(),
-    mockSetSearchQuery: vi.fn(),
-    mockSetSearchFilters: vi.fn(),
-    /** The URL `mode` param as the nuqs mock serves it; `set` is the live setter once mounted. */
-    modeState: { initial: 'build', set: (_next: string) => {} },
-  })
-)
+const { mockCaptureEvent, mockLeaveSearch } = vi.hoisted(() => ({
+  mockCaptureEvent: vi.fn(),
+  mockLeaveSearch: vi.fn(),
+}))
+const mockUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>()
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ workspaceId: 'workspace-1' }),
 }))
-vi.mock('nuqs', async () => {
-  const { useState } = await import('react')
-  return {
-    useQueryState: (key: string) => {
-      const [mode, setMode] = useState(modeState.initial)
-      if (key !== 'mode') return [null, mockSetSearchQuery]
-      modeState.set = setMode
-      return [mode, setMode]
-    },
-    useQueryStates: () => [{}, mockSetSearchFilters],
-  }
-})
 vi.mock('posthog-js/react', () => ({ usePostHog: () => null }))
 vi.mock('@/lib/posthog/client', () => ({ captureEvent: mockCaptureEvent }))
 
@@ -38,12 +23,18 @@ import { ModeSwitcher } from '@/app/workspace/[workspaceId]/home/components/user
 let root: Root | null = null
 let container: HTMLDivElement | null = null
 
-function mount() {
+function mount(searchParams = '') {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
-  act(() => root?.render(<ModeSwitcher />))
+  act(() =>
+    root?.render(
+      <NuqsTestingAdapter hasMemory searchParams={searchParams} onUrlUpdate={mockUrlUpdate}>
+        <ModeSwitcher onLeaveSearch={mockLeaveSearch} />
+      </NuqsTestingAdapter>
+    )
+  )
 }
 
 function trigger(): HTMLButtonElement {
@@ -63,17 +54,18 @@ function items(): HTMLElement[] {
   return Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]'))
 }
 
-function select(index: number) {
-  act(() => {
+async function select(index: number) {
+  await act(async () => {
     items()[index].dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }))
+    await vi.advanceTimersByTimeAsync(1)
   })
 }
 
 beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
   mockCaptureEvent.mockClear()
-  mockSetSearchQuery.mockClear()
-  mockSetSearchFilters.mockClear()
-  modeState.initial = 'build'
+  mockLeaveSearch.mockClear()
+  mockUrlUpdate.mockClear()
 })
 
 afterEach(() => {
@@ -81,6 +73,7 @@ afterEach(() => {
   container?.remove()
   root = null
   container = null
+  vi.useRealTimers()
 })
 
 describe('ModeSwitcher', () => {
@@ -108,47 +101,52 @@ describe('ModeSwitcher', () => {
     expect(rows[2].querySelector('svg')).toBeNull()
   })
 
-  it('writes the chosen mode to the URL and reports the change', () => {
+  it('writes the chosen mode to the URL and reports the change', async () => {
     mount()
     openMenu()
-    select(1)
+    await select(1)
 
     expect(trigger().textContent).toBe('Search')
     expect(mockCaptureEvent).toHaveBeenCalledWith(null, 'chat_mode_changed', {
       workspace_id: 'workspace-1',
       mode: 'search',
     })
-    expect(mockSetSearchQuery).not.toHaveBeenCalled()
+    expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.get('mode')).toBe('search')
+    expect(mockLeaveSearch).not.toHaveBeenCalled()
   })
 
   it('reads the mode from the URL on mount', () => {
-    modeState.initial = 'assistant'
-    mount()
+    mount('?mode=assistant')
 
     expect(trigger().textContent).toBe('Assistant')
     expect(trigger().getAttribute('aria-label')).toBe('Mode: Assistant')
   })
 
-  it('drops the search query from the URL when leaving Search', () => {
-    modeState.initial = 'search'
-    mount()
+  it('clears the composer and search parameters together when leaving Search', async () => {
+    mount('?mode=search&q=budget&source=upload&updated=7d&resource=report')
     openMenu()
-    select(0)
+    await select(0)
 
     expect(trigger().textContent).toBe('Build')
-    expect(mockSetSearchQuery).toHaveBeenCalledWith(null, { history: 'replace', scroll: false })
-    expect(mockSetSearchFilters).toHaveBeenCalledWith(
-      { source: null, updated: null },
-      { history: 'replace', scroll: false }
+    expect(mockLeaveSearch).toHaveBeenCalledOnce()
+    expect(mockUrlUpdate).toHaveBeenCalledOnce()
+    expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.toString()).toBe('resource=report')
+    expect(mockUrlUpdate.mock.lastCall?.[0].options).toMatchObject({
+      history: 'replace',
+      scroll: false,
+    })
+    expect(mockLeaveSearch.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUrlUpdate.mock.invocationCallOrder[0]
     )
   })
 
-  it('does not report re-selecting the active mode', () => {
+  it('does not report re-selecting the active mode', async () => {
     mount()
     openMenu()
-    select(0)
+    await select(0)
 
     expect(trigger().textContent).toBe('Build')
     expect(mockCaptureEvent).not.toHaveBeenCalled()
+    expect(mockLeaveSearch).not.toHaveBeenCalled()
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/mode-switcher/mode-switcher.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/mode-switcher/mode-switcher.tsx
@@ -11,23 +11,22 @@ import {
 } from '@sim/emcn'
 import { Check } from '@sim/emcn/icons'
 import { useParams } from 'next/navigation'
-import { useQueryState, useQueryStates } from 'nuqs'
 import { usePostHog } from 'posthog-js/react'
 import { captureEvent } from '@/lib/posthog/client'
 import { useMothershipMode } from '@/app/workspace/[workspaceId]/home/hooks/use-mothership-mode'
 import {
-  CLEARED_SEARCH_FILTERS,
   MOTHERSHIP_MODES,
   type MothershipMode,
-  resourceUrlKeys,
-  searchFilterParsers,
-  searchQueryParam,
 } from '@/app/workspace/[workspaceId]/home/search-params'
 
 const MODE_LABELS: Record<MothershipMode, string> = {
   build: 'Build',
   search: 'Search',
   assistant: 'Assistant',
+}
+
+interface ModeSwitcherProps {
+  onLeaveSearch?: () => void
 }
 
 /**
@@ -37,22 +36,15 @@ const MODE_LABELS: Record<MothershipMode, string> = {
  * round controls — opening a menu that checks the active mode, as
  * `ChipDropdown` does.
  */
-export const ModeSwitcher = memo(function ModeSwitcher() {
+export const ModeSwitcher = memo(function ModeSwitcher({ onLeaveSearch }: ModeSwitcherProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const posthog = usePostHog()
   const [mode, setMode] = useMothershipMode()
 
-  const [, setSearchQueryParam] = useQueryState(searchQueryParam.key, searchQueryParam.parser)
-  const [, setSearchFilters] = useQueryStates(searchFilterParsers, resourceUrlKeys)
-
-  /** Leaving Search drops the query from the URL, so a clean URL always means no search is showing. */
   const handleSelect = (next: MothershipMode) => {
     if (next === mode) return
+    if (mode === 'search' && next !== 'search') onLeaveSearch?.()
     void setMode(next)
-    if (next !== 'search') {
-      void setSearchQueryParam(null, { history: 'replace', scroll: false })
-      void setSearchFilters(CLEARED_SEARCH_FILTERS, { history: 'replace', scroll: false })
-    }
     captureEvent(posthog, 'chat_mode_changed', { workspace_id: workspaceId, mode: next })
   }
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createRef, useRef } from 'react'
+import { useQueryState } from 'nuqs'
+import { NuqsTestingAdapter, type UrlUpdateEvent } from 'nuqs/adapters/testing'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PromptEditorInstance } from '@/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor'
+import type { QueuedMessage } from '@/app/workspace/[workspaceId]/home/types'
+
+const { mockSubmit, mockResetTranscript } = vi.hoisted(() => ({
+  mockSubmit: vi.fn(),
+  mockResetTranscript: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({ useParams: () => ({ workspaceId: 'workspace-1' }) }))
+vi.mock('posthog-js/react', () => ({ usePostHog: () => null }))
+vi.mock('@/lib/posthog/client', () => ({ captureEvent: vi.fn() }))
+vi.mock('@/hooks/use-settings-navigation', () => ({
+  useSettingsNavigation: () => ({ navigateToSettings: vi.fn() }),
+}))
+vi.mock('@/hooks/use-speech-to-text', () => ({
+  useSpeechToText: () => ({ isSupported: false, resetTranscript: mockResetTranscript }),
+}))
+vi.mock('@/hooks/queries/skills', () => ({ useSkills: () => ({ data: [] }) }))
+vi.mock('@/hooks/queries/mcp', () => ({ useMcpToolServers: () => ({ data: [] }) }))
+vi.mock('@/blocks/integration-matcher', () => ({
+  getIntegrationMatcher: () => ({ regex: null, byName: new Map() }),
+  mentionifyIntegrations: (text: string) => text,
+}))
+vi.mock('@/app/workspace/[workspaceId]/home/components/chat-surface-context', () => ({
+  useChatSurface: () => ({}),
+}))
+vi.mock(
+  '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments',
+  async () => {
+    const { useRef, useState } = await import('react')
+    return {
+      useFileAttachments: () => {
+        const [attachedFiles, restoreAttachedFiles] = useState<
+          import('@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments').AttachedFile[]
+        >([])
+        return {
+          attachedFiles,
+          restoreAttachedFiles,
+          clearAttachedFiles: () => restoreAttachedFiles([]),
+          fileInputRef: useRef<HTMLInputElement>(null),
+          isDragging: false,
+        }
+      },
+    }
+  }
+)
+vi.mock('@/app/workspace/[workspaceId]/home/components/user-input/components', async () => {
+  const { usePromptEditor } = await import(
+    '@/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor'
+  )
+  const { ModeSwitcher } = await import(
+    '@/app/workspace/[workspaceId]/home/components/user-input/components/mode-switcher/mode-switcher'
+  )
+  return {
+    usePromptEditor,
+    ModeSwitcher,
+    PromptEditor: ({ editor }: { editor: PromptEditorInstance }) => (
+      <textarea ref={editor.textareaRef} value={editor.value} onChange={editor.handleInputChange} />
+    ),
+    SendButton: ({ onSubmit }: { onSubmit: () => void }) => (
+      <button type='button' onClick={onSubmit}>
+        Send
+      </button>
+    ),
+    AnimatedPlaceholderEffect: () => null,
+    AttachedFilesList: () => null,
+    DropOverlay: () => null,
+    MicButton: () => null,
+    MicrophonePermissionHelp: () => null,
+  }
+})
+
+import {
+  UserInput,
+  type UserInputHandle,
+} from '@/app/workspace/[workspaceId]/home/components/user-input/user-input'
+import { useMothershipMode } from '@/app/workspace/[workspaceId]/home/hooks/use-mothership-mode'
+import { searchQueryParam } from '@/app/workspace/[workspaceId]/home/search-params'
+
+const mockUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>()
+const QUEUED_MESSAGE: QueuedMessage = {
+  id: 'queued-1',
+  content: 'Write the report',
+  fileAttachments: [
+    { id: 'file-1', key: 'file-key', filename: 'notes.txt', media_type: 'text/plain', size: 12 },
+  ],
+}
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function mount(requestMode?: QueuedMessage['requestMode']) {
+  const inputRef = createRef<UserInputHandle>()
+
+  function Composer() {
+    const [mode, setMode] = useMothershipMode()
+    const [query] = useQueryState(searchQueryParam.key, searchQueryParam.parser)
+    const modes = useRef<string[]>([])
+    modes.current.push(`${mode}:${query ?? ''}`)
+    return (
+      <>
+        <output>{modes.current.join('|')}</output>
+        <button
+          type='button'
+          onClick={() => {
+            void setMode(requestMode === 'ask' ? 'assistant' : 'build')
+            inputRef.current?.loadQueuedMessage({ ...QUEUED_MESSAGE, requestMode })
+          }}
+        >
+          Edit queued
+        </button>
+        <UserInput
+          ref={inputRef}
+          defaultValue={query ?? ''}
+          onSubmit={mockSubmit}
+          isSending={false}
+          onStopGeneration={vi.fn()}
+          canSearch
+          clearOnSubmit={mode !== 'search'}
+        />
+      </>
+    )
+  }
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(
+      <NuqsTestingAdapter
+        hasMemory
+        searchParams='?mode=search&q=budget&source=upload&updated=7d&resource=report'
+        onUrlUpdate={mockUrlUpdate}
+      >
+        <Composer />
+      </NuqsTestingAdapter>
+    )
+  })
+  return inputRef
+}
+
+function textarea() {
+  const input = container?.querySelector('textarea')
+  if (!input) throw new Error('Composer did not render')
+  return input
+}
+
+async function clickButton(label: string) {
+  const button = Array.from(container?.querySelectorAll('button') ?? []).find(
+    (candidate) => candidate.textContent === label
+  )
+  if (!button) throw new Error(`Button ${label} did not render`)
+  await act(async () => {
+    button.click()
+    await vi.advanceTimersByTimeAsync(1)
+  })
+}
+
+async function selectMode(label: string) {
+  const trigger = container?.querySelector('[aria-label="Mode: Search"]')
+  if (!trigger) throw new Error('Mode switcher did not render')
+  act(() => {
+    trigger.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+  })
+  const item = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+    (candidate) => candidate.textContent === label
+  )
+  if (!item) throw new Error(`Mode ${label} did not render`)
+  await act(async () => {
+    item.click()
+    await vi.advanceTimersByTimeAsync(1)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  mockSubmit.mockClear()
+  mockUrlUpdate.mockClear()
+  mockResetTranscript.mockClear()
+})
+
+afterEach(() => {
+  if (root) act(() => root?.unmount())
+  container?.remove()
+  root = null
+  container = null
+  vi.useRealTimers()
+})
+
+describe('search composer transitions', () => {
+  it.each(['Build', 'Assistant'])('clears the query when the menu selects %s', async (mode) => {
+    mount()
+    expect(textarea().value).toBe('budget')
+
+    await selectMode(mode)
+
+    expect(textarea().value).toBe('')
+    expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.has('q')).toBe(false)
+    expect(mockSubmit).not.toHaveBeenCalled()
+  })
+
+  it.each([undefined, 'ask'] as const)(
+    'retains queued content and files after restoring request mode %s',
+    async (requestMode) => {
+      mount(requestMode)
+
+      await clickButton('Edit queued')
+
+      expect(textarea().value).toBe(QUEUED_MESSAGE.content)
+      expect(container?.querySelector('output')?.textContent).not.toContain('build:budget')
+      expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.toString()).toBe(
+        requestMode === 'ask' ? 'mode=assistant&resource=report' : 'resource=report'
+      )
+      await clickButton('Send')
+      expect(mockSubmit).toHaveBeenCalledWith(
+        QUEUED_MESSAGE.content,
+        QUEUED_MESSAGE.fileAttachments,
+        undefined
+      )
+    }
+  )
+
+  it('keeps files available when leaving Search', async () => {
+    const inputRef = mount()
+    act(() => inputRef.current?.loadQueuedMessage({ ...QUEUED_MESSAGE, content: 'budget' }))
+
+    await selectMode('Build')
+    await clickButton('Send')
+
+    expect(mockSubmit).toHaveBeenCalledWith('', QUEUED_MESSAGE.fileAttachments, undefined)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -323,6 +323,8 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
    * landing prompt panel as well as curated CTAs. Curated producers opt their
    * bare names in at the store seam (`storeCuratedPrompt`), so prose seeded here
    * is never bare-chipped (the scunthorpe constraint).
+   * An empty seed must not erase a queued message loaded in the same event
+   * that clears the search URL. The mode menu clears its query explicitly.
    */
   useEffect(() => {
     if (defaultValue === prevDefaultValueRef.current) return
@@ -572,6 +574,13 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
     filesRef.current.clearAttachedFiles()
   }, [resetTranscript])
 
+  /** Discards the search query while keeping files available for the next agent turn. */
+  const handleLeaveSearch = useCallback(() => {
+    editorRef.current.setValue('')
+    sttPrefixRef.current = ''
+    resetTranscript()
+  }, [resetTranscript])
+
   const handleSubmit = useCallback(() => {
     const currentFiles = filesRef.current
     const currentEditor = editorRef.current
@@ -726,7 +735,7 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
           </Tooltip.Root>
         </div>
         <div className='flex items-center gap-1.5'>
-          {canSearch && <ModeSwitcher />}
+          {canSearch && <ModeSwitcher onLeaveSearch={handleLeaveSearch} />}
           {isSttSupported && (
             <MicButton
               audioLevelsRef={audioLevelsRef}

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -569,7 +569,6 @@ export function Home({ chatId, userName, userId }: HomeProps) {
    */
   const handleSummarize = (prompt: string) => {
     void setComposerMode('assistant')
-    setSearchQuery('')
     initialViewUserInputRef.current?.clear()
     chatViewUserInputRef.current?.clear()
     void handleSubmit(prompt, undefined, undefined, 'assistant')

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.ts
@@ -1,7 +1,13 @@
 'use client'
 
-import { useQueryState } from 'nuqs'
-import { modeParam } from '@/app/workspace/[workspaceId]/home/search-params'
+import { useCallback } from 'react'
+import { useQueryStates } from 'nuqs'
+import {
+  CLEARED_SEARCH_FILTERS,
+  composerModeParsers,
+  type MothershipMode,
+  resourceUrlKeys,
+} from '@/app/workspace/[workspaceId]/home/search-params'
 
 /**
  * The composer's mode, read from and written to the URL's `mode` param so a
@@ -9,5 +15,18 @@ import { modeParam } from '@/app/workspace/[workspaceId]/home/search-params'
  * separate Search and Assistant routes do. Build is the clean URL.
  */
 export function useMothershipMode() {
-  return useQueryState(modeParam.key, modeParam.parser)
+  const [{ mode }, setParams] = useQueryStates(composerModeParsers, resourceUrlKeys)
+  const setMode = useCallback(
+    (next: MothershipMode) =>
+      setParams(
+        {
+          mode: next,
+          ...(next === 'search' ? {} : { q: null, ...CLEARED_SEARCH_FILTERS }),
+        },
+        { history: 'replace', scroll: false }
+      ),
+    [setParams]
+  )
+
+  return [mode, setMode] as const
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/search-params.ts
@@ -76,3 +76,10 @@ export const searchFilterParsers = {
 
 /** Every search param at its default: what leaving a search writes. */
 export const CLEARED_SEARCH_FILTERS = { source: null, updated: null } as const
+
+/** A mode transition clears its search query and filters in the same URL update. */
+export const composerModeParsers = {
+  [modeParam.key]: modeParam.parser,
+  [searchQueryParam.key]: searchQueryParam.parser,
+  ...searchFilterParsers,
+} as const


### PR DESCRIPTION
## Summary
- Update composer mode and Search URL state atomically so a queued Build edit cannot be forced back into Search.
- Clear Search text when leaving through the mode menu while preserving attachments, ordinary agent drafts, and restored queued messages.
- Preserve citation and resource chips whose JSON contains backticks without consuming adjacent code spans or fenced code.

Knowledge access, Slack, and related documentation fixes from #7446 are covered separately by #7451.

## Type of Change
- [x] Bug fix

## Testing
Passed 189 focused tests across six suites, all 45 repository audits, lint, docs-manifest validation, and the app type-check. Regression assertions fail against the previous behavior. The retained changes completed all eight cleanup passes and a simplification review; malformed chip inputs also retain bounded scanning behavior.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
