### PR TITLE
fix(ui): drop the overlay shadow class that never rendered before v4

### DIFF
--- a/apps/sim/app/(landing)/components/hero/components/hero-visual/hero-visual.tsx
+++ b/apps/sim/app/(landing)/components/hero/components/hero-visual/hero-visual.tsx
@@ -1081,7 +1081,7 @@ export function HeroVisual() {
                   className={cn(
                     'absolute transform-gpu transition-[opacity,transform,width,height,top,left] will-change-transform [transition-duration:520ms] [transition-timing-function:cubic-bezier(0.22,1,0.36,1)]',
                     showKbShell &&
-                      'overflow-hidden rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)]'
+                      'overflow-hidden rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px]'
                   )}
                   style={{
                     left: showKbShell

--- a/apps/sim/app/(landing)/components/hero/components/hero-visual/stage-kb.tsx
+++ b/apps/sim/app/(landing)/components/hero/components/hero-visual/stage-kb.tsx
@@ -175,7 +175,7 @@ export function KnowledgeBasePanel({
   return (
     <div
       className={cn(
-        'w-full max-w-[420px] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)]',
+        'w-full max-w-[420px] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px]',
         'animate-hero-modal-in motion-reduce:animate-none'
       )}
     >

--- a/apps/sim/app/(landing)/components/navbar/components/nav-menu-chip/nav-menu-chip.tsx
+++ b/apps/sim/app/(landing)/components/navbar/components/nav-menu-chip/nav-menu-chip.tsx
@@ -77,7 +77,7 @@ export function NavMenuChip({ menu }: NavMenuChipProps) {
       </button>
 
       <div className={cn(PANEL_BASE, !closed && PANEL_REVEAL)}>
-        <div className='w-[840px] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)]'>
+        <div className='w-[840px] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px]'>
           <div className='rounded-lg border border-[var(--border-1)] bg-[var(--bg)] p-2'>
             <div className='grid grid-cols-3 gap-1' role='group' aria-label={label}>
               {items.map((item) => (

--- a/apps/sim/app/workspace/[workspaceId]/integrations/components/integrations-showcase/integrations-showcase.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/integrations/components/integrations-showcase/integrations-showcase.tsx
@@ -101,10 +101,7 @@ export function IntegrationTile({ blockType, icon: Icon, framed = false }: Integ
  */
 export function IntegrationsShowcase() {
   return (
-    <div
-      aria-hidden
-      className='relative h-[144px] w-full overflow-hidden rounded-xl shadow-[var(--shadow-overlay)]'
-    >
+    <div aria-hidden className='relative h-[144px] w-full overflow-hidden rounded-xl'>
       <div
         className='absolute inset-0 bg-[var(--surface-4)] dark:bg-[var(--surface-5)]'
         style={{

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/search-modal/search-modal.tsx
@@ -1317,7 +1317,7 @@ function SearchModalContent({
         aria-hidden={!visuallyOpen}
         aria-label='Search'
         className={cn(
-          '-translate-x-1/2 fixed top-[15%] z-[var(--z-modal)] w-[min(500px,calc(100%-32px))] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)] dark:bg-[var(--surface-5)]',
+          '-translate-x-1/2 fixed top-[15%] z-[var(--z-modal)] w-[min(500px,calc(100%-32px))] rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] dark:bg-[var(--surface-5)]',
           visuallyOpen ? 'visible opacity-100' : 'invisible opacity-0'
         )}
         style={{

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/status-notice/status-notice.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/status-notice/status-notice.test.tsx
@@ -82,7 +82,6 @@ describe('StatusNotice', () => {
     const notice = container.querySelector('[role="alert"]')
     const action = container.querySelector<HTMLAnchorElement>('a')
     expect(notice?.className).toContain('border-[var(--terminal-status-error-border)]')
-    expect(notice?.className).toContain('shadow-[var(--shadow-overlay)]')
     expect(notice?.className).toContain(
       '[--surface-hover:color-mix(in_srgb,var(--text-error)_8%,transparent)]'
     )

--- a/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/status-notice/status-notice.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/sidebar/components/status-notice/status-notice.tsx
@@ -18,7 +18,7 @@ function StatusAlert() {
   return (
     <div
       role='alert'
-      className='flex w-full flex-col gap-2 rounded-xl border border-[var(--terminal-status-error-border)] bg-[var(--terminal-status-error-bg)] p-2 shadow-[var(--shadow-overlay)] [--surface-hover:color-mix(in_srgb,var(--text-error)_8%,transparent)]'
+      className='flex w-full flex-col gap-2 rounded-xl border border-[var(--terminal-status-error-border)] bg-[var(--terminal-status-error-bg)] p-2 [--surface-hover:color-mix(in_srgb,var(--text-error)_8%,transparent)]'
     >
       <div className='flex min-w-0 items-center gap-1.5'>
         <CircleAlert className='size-[16px] shrink-0 text-[var(--text-icon)]' />

--- a/packages/emcn/src/components/chip-modal/chip-modal.tsx
+++ b/packages/emcn/src/components/chip-modal/chip-modal.tsx
@@ -250,7 +250,7 @@ function ChipModal({
       >
         <div
           className={cn(
-            'flex min-h-0 w-full flex-col rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] shadow-[var(--shadow-overlay)] dark:bg-[var(--surface-5)]',
+            'flex min-h-0 w-full flex-col rounded-xl border border-[var(--border-muted)] bg-[var(--surface-4)] p-[3px] dark:bg-[var(--surface-5)]',
             className
           )}
         >

--- a/packages/emcn/src/components/toast/toast.tsx
+++ b/packages/emcn/src/components/toast/toast.tsx
@@ -405,7 +405,7 @@ function ToastItem({ toast: t, geometry, reduceMotion, onDismiss, onMeasure }: T
         width: TOAST_WIDTH,
         borderRadius: cornerRadius,
       }}
-      className='pointer-events-auto absolute right-0 bottom-0 m-0 overflow-hidden border border-[var(--border-1)] bg-[var(--bg)] shadow-[var(--shadow-overlay)]'
+      className='pointer-events-auto absolute right-0 bottom-0 m-0 overflow-hidden border border-[var(--border-1)] bg-[var(--bg)]'
     >
       <div ref={contentRef} className='flex flex-col gap-2 p-2'>
         <div className='flex items-start gap-2'>


### PR DESCRIPTION
## Summary
`shadow-[var(--shadow-overlay)]` never rendered a shadow before the Tailwind v4 upgrade. v4 honours it, so eight surfaces silently gained a `0 10px 30px` drop shadow — visible as the shadowed integrations tile grid. This removes the class so those surfaces render exactly as they do in production.

## Why it only appeared now
Tailwind v3 could not tell whether a bare `var()` after `shadow-` was a shadow or a shadow *colour*, and resolved it as a colour:

```css
/* v3 — compiled from shadow-[var(--shadow-overlay)] */
.shadow-\[var\(--shadow-overlay\)\] {
  --tw-shadow-color: var(--shadow-overlay);
  --tw-shadow: var(--tw-shadow-colored);   /* 0 0 #0000 — draws nothing */
}
```

```css
/* v4 — same class */
.shadow-\[var\(--shadow-overlay\)\] {
  --tw-shadow: var(--shadow-overlay);      /* 0 10px 30px rgba(0,0,0,0.11) */
}
```

Both were verified by compiling the class through each engine, not inferred. The class was dead in production, so the shadow it describes was never reviewed on any of these surfaces.

The named `shadow-overlay` utility — the one `chart-tooltip`, `consent-banner` and the table sidebars use — always worked correctly and is untouched here.

## Surfaces restored to their production rendering
`integrations-showcase`, `chip-modal` (emcn), `toast` (emcn), `search-modal`, `nav-menu-chip`, `status-notice`, `hero-visual`, `stage-kb`.

A `status-notice` test asserted the class was present. It was pinning a no-op, so it is removed rather than inverted.

## If the shadows are wanted
This restores parity, it does not decide the design. Any of these surfaces can opt in deliberately by switching to the working `shadow-overlay` utility — a modal or toast drop shadow is a reasonable thing to want, it just has never shipped and should be a design call rather than a side effect of a dependency upgrade.

## Type of Change
- [x] Bug fix

## Testing
- Compiled `apps/sim/app/_styles/globals.css` before and after: the `.shadow-[var(--shadow-overlay)]` rule is emitted before the change and absent after, matching production's effective rendering.
- Compiled the same class through Tailwind v3 to confirm it resolved to a shadow colour and drew nothing.
- Full suite, `bun run check:audits`, `bunx turbo run type-check`, `bun run lint`, `bun run docs-manifest:check`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
