### PR TITLE
feat(analytics): add the Google Ads conversion tag to the gtag loader

### DIFF
--- a/apps/sim/lib/consent/scripts.test.ts
+++ b/apps/sim/lib/consent/scripts.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   type ConsentScriptCallbackInfo,
   GLOBAL_CONSENT_SCRIPTS,
+  GOOGLE_ADS_ID,
+  GOOGLE_ANALYTICS_ID,
   HUBSPOT_SCRIPT,
   X_PIXEL_SCRIPT,
 } from '@/lib/consent/scripts'
@@ -67,6 +69,22 @@ describe('consent scripts', () => {
       'set',
       { page_location: `${window.location.origin}/signup` },
     ])
+  })
+
+  it('configures Google Ads on the GA4 loader instead of a second gtag script', () => {
+    window.dataLayer = []
+    window.gtag = undefined
+
+    GLOBAL_CONSENT_SCRIPTS[0].onBeforeLoad?.(CALLBACK_INFO)
+
+    const configuredIds = window.dataLayer
+      .filter((entry): entry is [string, string] => Array.isArray(entry) && entry[0] === 'config')
+      .map(([, id]) => id)
+
+    expect(configuredIds).toEqual([GOOGLE_ANALYTICS_ID, GOOGLE_ADS_ID])
+    expect(GLOBAL_CONSENT_SCRIPTS.map((script) => script.src)).not.toContain(
+      `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_ID}`
+    )
   })
 
   it('gives HubSpot a query-free path before its automatic first page view', () => {

--- a/apps/sim/lib/consent/scripts.ts
+++ b/apps/sim/lib/consent/scripts.ts
@@ -3,6 +3,21 @@ import { gtag } from '@c15t/scripts/google-tag'
 import { xPixel } from '@c15t/scripts/x-pixel'
 
 export const GOOGLE_ANALYTICS_ID = 'G-DR7YBE70VS' as const
+
+/**
+ * Google Ads conversion tag. It rides the GA4 loader as a second `config`
+ * destination rather than a second `gtag/js` script, which is Google's
+ * documented pattern for sending one page to multiple Google products: a
+ * second loader would re-run the same library, and c15t derives a script's
+ * element id from the vendor name, so both entries would collide on `gtag`.
+ *
+ * Consent stays correct without a second consent category. The tag is loaded
+ * under Consent Mode v2, where `ad_storage`, `ad_user_data`, and
+ * `ad_personalization` are already mapped to the `marketing` category, so a
+ * visitor who accepts measurement but declines marketing gets a cookieless
+ * ping rather than conversion tracking.
+ */
+export const GOOGLE_ADS_ID = 'AW-17916292239' as const
 export const X_PIXEL_ID = 'q5xbl' as const
 export const X_DEMO_BOOKED_EVENT_ID = 'tw-q5xbl-q5xbn' as const
 
@@ -47,6 +62,7 @@ export const GLOBAL_CONSENT_SCRIPTS = [
         ...(referrer ? { page_referrer: referrer } : {}),
       })
       initializeGoogleAnalytics?.(info)
+      window.gtag('config', GOOGLE_ADS_ID)
     },
   },
   ahrefsAnalytics({ key: AHREFS_ANALYTICS_KEY }),

--- a/apps/sim/lib/core/security/csp.ts
+++ b/apps/sim/lib/core/security/csp.ts
@@ -78,6 +78,10 @@ const STATIC_SCRIPT_SRC = [
     ? [
         'https://www.googletagmanager.com',
         'https://www.google-analytics.com',
+        // Google Ads conversion tag — gtag.js pulls conversion_async.js from
+        // googleadservices and the remarketing tag from googleads.doubleclick
+        'https://www.googleadservices.com',
+        'https://googleads.g.doubleclick.net',
         'https://analytics.ahrefs.com',
         // HubSpot tracking (landing pages) — loader plus the
         // analytics/form-tracking/banner scripts it injects as <script> tags
@@ -128,6 +132,8 @@ const STATIC_CONNECT_SRC = [
         'https://www.google.com',
         'https://analytics.ahrefs.com',
         'https://*.g.doubleclick.net',
+        // Google Ads conversion tag — conversion beacons
+        'https://www.googleadservices.com',
         // HubSpot tracking — form-tracking API (hscollectedforms.js).
         // The visitor beacon itself is an image pixel (img-src, already
         // permitted below), not a connect-src request.
@@ -150,6 +156,11 @@ const STATIC_FRAME_SRC = [
   'https://drive.google.com',
   'https://docs.google.com',
   'https://*.google.com',
+  // Google Ads conversion tag — the conversion linker writes its cookie from
+  // a hidden iframe on these origins; without them the ping still fires but
+  // cross-domain click attribution silently drops
+  'https://td.doubleclick.net',
+  'https://www.googleadservices.com',
   'https://www.youtube.com',
   'https://player.vimeo.com',
   'https://www.dailymotion.com',

--- a/apps/sim/lib/core/security/csp.ts
+++ b/apps/sim/lib/core/security/csp.ts
@@ -158,9 +158,10 @@ const STATIC_FRAME_SRC = [
   'https://*.google.com',
   // Google Ads conversion tag — the conversion linker writes its cookie from
   // a hidden iframe on these origins; without them the ping still fires but
-  // cross-domain click attribution silently drops
-  'https://td.doubleclick.net',
-  'https://www.googleadservices.com',
+  // cross-domain click attribution silently drops. Hosted-only, like the
+  // script-src and connect-src entries: the consent provider that loads the
+  // tag never mounts off hosted, so nothing self-hosted can frame these.
+  ...(isHosted ? ['https://td.doubleclick.net', 'https://www.googleadservices.com'] : []),
   'https://www.youtube.com',
   'https://player.vimeo.com',
   'https://www.dailymotion.com',


### PR DESCRIPTION
## Summary
- Add the Google Ads conversion tag (`AW-17916292239`) site-wide, so it renders on every hosted route rather than a hand-maintained page list — partial coverage breaks `gclid` capture between the ad landing page and the conversion page
- Configure it as a second `config` destination on the existing GA4 gtag.js loader instead of adding a second `gtag/js` script. That's Google's documented pattern for sending one page to multiple Google products, and a second loader would re-run the library and collide on the `gtag` element id that c15t derives from the vendor name
- Allow the origins the Ads tag actually reaches in CSP: `googleadservices` + `googleads.g.doubleclick.net` in `script-src`, `googleadservices` in `connect-src`, and `td.doubleclick.net` + `googleadservices` in `frame-src` (the conversion linker writes its cookie from a hidden iframe). Without these the tag loads and its pings are silently blocked

Consent behavior is unchanged in shape. The tag rides the existing consent-managed loader, where Consent Mode v2 already maps `ad_storage`, `ad_user_data`, and `ad_personalization` to the `marketing` category — so someone who accepts measurement but declines marketing gets a cookieless ping, not conversion tracking. No new consent category, no unconditional script.

SPA page views are unaffected: `GoogleAnalyticsPageViewTracker` sends with `send_to` pinned to the GA4 id, so route changes don't fan out to the Ads destination.

This installs the tag only. Firing a conversion on signup or demo-booked still needs a `send_to: AW-17916292239/<label>` event with a label from the Ads UI.

## Type of Change
- [x] New feature

## Testing
Tested manually. `bun run type-check` clean; `bun run lint`, `bun run check:audits` (45 audits), block-registry check, and `docs-manifest:check` all pass. Added a unit test asserting both IDs configure on the single loader and that no second `gtag/js` src is registered — verified it fails when the `config` line is removed.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
