### PR TITLE
fix(settings): align the ee field rhythm with the canonical field

### DIFF
--- a/apps/sim/ee/components/setting-row.tsx
+++ b/apps/sim/ee/components/setting-row.tsx
@@ -28,7 +28,7 @@ export function SettingRow({
   children,
 }: SettingRowProps) {
   return (
-    <div className='flex flex-col gap-1.5'>
+    <div className='flex flex-col gap-[9px]'>
       <div className='flex items-center gap-1.5'>
         <Label htmlFor={htmlFor}>
           {label}

--- a/apps/sim/ee/credential-groups/components/credential-group-detail.tsx
+++ b/apps/sim/ee/credential-groups/components/credential-group-detail.tsx
@@ -305,7 +305,6 @@ export function CredentialGroupDetail({
           onSelect: () => guard.guardBack(onBack),
         }}
         title={credentialGroup?.name ?? 'Credential group'}
-        description={credentialGroup?.description ?? undefined}
         actions={actions}
         search={
           activeTab === 'details'


### PR DESCRIPTION
## Summary
Two settings inconsistencies found while auditing the credential-groups pages against the design-system rules.

- `SettingRow` now uses the canonical `gap-[9px]` between label and control, matching `ChipModalField`
- The credential group detail header no longer duplicates the group description that its own editable field shows

## Field rhythm
`.claude/rules/sim-styling.md` pins the standalone labeled field to "`flex flex-col gap-[9px]`, muted label, `ChipInput`/`ChipTextarea` control", which is what `ChipModalField` renders. `SettingRow` used `gap-1.5` (6px), so every field on the `ee/` settings pages sat 3px tighter than the same field inside a modal — visible against `SettingsSection`'s own `mt-[9px]` divider rhythm on the same page.

One class, 94 call sites across credential groups, SSO, data drains, access control, custom blocks, whitelabeling and verified domains. 85 of them are label → control (→ error), exactly `ChipModalField`'s shape. The 9 that also pass a `description` keep it grouped between label and control, uniformly 9px on both sides rather than 6px. The label↔info-icon gap beside the label is a different measurement and is unchanged.

## Duplicated description
The group detail passed `description={credentialGroup?.description}` to `SettingsPanel`, so the description rendered as the page subtitle while the same value sat in an editable `ChipTextarea` a few hundred pixels below. The two disagreed whenever the field was dirty — the header showed the persisted value, the field the draft — and the subtitle appeared only after the data loaded, shifting the body down.

`sim-settings-pages.md` reserves `title`/`description` for a detail sub-view that needs a different heading, and says a page's header identity must stay stable while its data loads. Nothing is lost: the list row already renders the description as its subtitle and searches on it, and the Details tab still edits it.

## Considered and rejected
An audit also flagged the three render-time `throw`s in `CredentialGroupAccess` (`workflows`, `allowedWorkflowIds`, `revision`) for conversion to a `SettingsEmptyState tone='error'`, on the grounds that the props are typed `| null` so the states are reachable.

They are not reachable. Tracing the single caller against React Query 5.90.8: reaching those guards requires `loadError` falsy and `isPending` falsy, but `isPending` is `access.isPending && !access.data`, and RQ reports `status: 'pending'` whenever there is no data and no error — including a disabled query. Either `access.data` exists, in which case all three props are non-null, or the component has already returned.

So they are invariant assertions, not error states, and they were left alone. Converting them would have removed the `SettingsSectionError` boundary's `createLogger(...).error(...)` report in exchange for a muted message — and on an access-control surface, "couldn't load workflow access" reads uncomfortably close to "no workflows have access."

## Type of Change
- [x] Bug fix

## Testing
- Existing credential-groups, access-control and SSO suites pass — those are the surfaces the `SettingRow` change touches.
- Full suite, `bun run check:audits`, `bunx turbo run type-check`, `bun run lint`, `bun run docs-manifest:check`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
