### PR TITLE
docs(consent): add the Google Ads cookie inventory to the Cookie Policy

### DIFF
--- a/apps/sim/app/(landing)/cookie-policy/cookie-policy-content.tsx
+++ b/apps/sim/app/(landing)/cookie-policy/cookie-policy-content.tsx
@@ -44,7 +44,7 @@ export const COOKIE_POLICY_CONFIG: LegalPageConfig = {
   title: 'Cookie Policy',
   description:
     'What cookies Sim sets, why, how long they last, and how to change your choice at any time.',
-  lastUpdated: 'August 24, 2026',
+  lastUpdated: 'September 3, 2026',
   intro: [
     {
       kind: 'paragraph',
@@ -121,7 +121,9 @@ export const COOKIE_POLICY_CONFIG: LegalPageConfig = {
             </>,
             <>
               <strong>Marketing</strong> — measuring which campaigns bring builders to Sim and
-              showing relevant ads on other sites.
+              showing relevant ads on other sites. Google Ads loads with ad storage denied and
+              cannot set conversion cookies until this category is allowed; before then, it may send
+              limited cookieless consent signals.
             </>,
           ],
         },
@@ -200,6 +202,24 @@ export const COOKIE_POLICY_CONFIG: LegalPageConfig = {
         ]),
         cookieTable('Marketing', [
           [
+            '_gcl_au',
+            'Google Ads',
+            'Links a Google ad click to a later sign-up or demo booking on sim.ai.',
+            '90 days',
+          ],
+          [
+            '_gcl_aw / _gcl_gs',
+            'Google Ads',
+            'Stores the click identifier from a Google ad that brought you to sim.ai.',
+            '90 days',
+          ],
+          [
+            'IDE',
+            'Google (doubleclick.net)',
+            'Measures ad conversions and limits how often the same ad is shown.',
+            '13 months',
+          ],
+          [
             'guest_id',
             'X (Twitter)',
             'Identifies a browser to the X conversion pixel.',
@@ -248,7 +268,8 @@ export const COOKIE_POLICY_CONFIG: LegalPageConfig = {
               <ProseLink href='https://tools.google.com/dlpage/gaoptout'>
                 Google Analytics
               </ProseLink>
-              , <ProseLink href='https://x.com/settings/privacy_and_safety'>X (Twitter)</ProseLink>,{' '}
+              , <ProseLink href='https://adssettings.google.com'>Google Ads</ProseLink>,{' '}
+              <ProseLink href='https://x.com/settings/privacy_and_safety'>X (Twitter)</ProseLink>,{' '}
               <ProseLink href='https://legal.hubspot.com/privacy-policy'>HubSpot</ProseLink>, and{' '}
               <ProseLink href='https://posthog.com/privacy'>PostHog</ProseLink>.
             </>
@@ -270,7 +291,7 @@ export const COOKIE_POLICY_CONFIG: LegalPageConfig = {
             <>
               The providers currently in use are{' '}
               <ProseLink href='https://policies.google.com/technologies/cookies'>Google</ProseLink>{' '}
-              (Analytics),{' '}
+              (Analytics and Ads),{' '}
               <ProseLink href='https://legal.hubspot.com/privacy-policy'>HubSpot</ProseLink>,{' '}
               <ProseLink href='https://x.com/en/privacy'>X (Twitter)</ProseLink>,{' '}
               <ProseLink href='https://ahrefs.com/privacy'>Ahrefs</ProseLink>,{' '}

--- a/apps/sim/app/(landing)/cookie-policy/cookie-policy-content.tsx
+++ b/apps/sim/app/(landing)/cookie-policy/cookie-policy-content.tsx
@@ -217,7 +217,7 @@ export const COOKIE_POLICY_CONFIG: LegalPageConfig = {
             'IDE',
             'Google (doubleclick.net)',
             'Measures ad conversions and limits how often the same ad is shown.',
-            '13 months',
+            '13 months in the EEA and UK; 24 months elsewhere',
           ],
           [
             'guest_id',


### PR DESCRIPTION
## Summary
- Add the Google Ads cookies (`_gcl_au`, `_gcl_aw` / `_gcl_gs`, `IDE`) to the Marketing table of the Cookie Policy with provider, purpose, and retention, matching the conversion tag added in #7466
- Note in the Marketing category that Google Ads loads with ad storage denied and cannot set conversion cookies until that category is allowed
- Add the Google Ads opt-out link and list Google as an Ads provider in the third-party section
- Bump the "Last updated" date

## Type of Change
- [x] Documentation

## Testing
Lint, block-registry check, `check:audits`, and `docs-manifest:check` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
