### PR TITLE
docs(data-drains): describe the resolved feature, not the bare flag

### DIFF
--- a/apps/docs/content/docs/platform/enterprise/data-drains.mdx
+++ b/apps/docs/content/docs/platform/enterprise/data-drains.mdx
@@ -237,7 +237,9 @@ DATA_DRAINS_ENABLED=true
 NEXT_PUBLIC_DATA_DRAINS_ENABLED=true
 ```
 
-`DATA_DRAINS_ENABLED` shows the **Settings → Organization → Data drains** page and gates the server-side mutating endpoints and the cron dispatcher. When the feature resolves off on a self-hosted deployment — neither it nor `ENTERPRISE_ENABLED` is set, or it is set to `false` — the page is hidden, drain create/update/delete/run requests return `404`, and the dispatcher is a no-op. Set `NEXT_PUBLIC_DATA_DRAINS_ENABLED` to the same value so the browser's configuration matches the server's; on a Compose install or source checkout, `npx sim-setup doctor` reports the pair disagreeing.
+On a self-hosted deployment the feature resolves on when `DATA_DRAINS_ENABLED` is `true`, or when it is unset and `ENTERPRISE_ENABLED` is set; an explicit `false` always wins. That resolved value — not the bare variable — gates the **Settings → Organization → Data drains** page, the server-side mutating endpoints, and the cron dispatcher. When it resolves off the page is hidden, drain create/update/delete/run requests return `404`, and the dispatcher is a no-op.
+
+Inside a workspace the browser reads that resolved value from the server, so the page follows the server whether or not `NEXT_PUBLIC_DATA_DRAINS_ENABLED` is set. Set it to the same value anyway: it backs the client fallback on surfaces rendered outside a workspace, and on a Compose install or source checkout `npx sim-setup doctor` reports the pair disagreeing.
 
 ### Scheduling the dispatcher
 

--- a/apps/docs/content/docs/platform/enterprise/data-drains.mdx
+++ b/apps/docs/content/docs/platform/enterprise/data-drains.mdx
@@ -237,7 +237,7 @@ DATA_DRAINS_ENABLED=true
 NEXT_PUBLIC_DATA_DRAINS_ENABLED=true
 ```
 
-On a self-hosted deployment the feature resolves on when `DATA_DRAINS_ENABLED` is `true`, or when it is unset and `ENTERPRISE_ENABLED` is set; an explicit `false` always wins. That resolved value — not the bare variable — gates the **Settings → Organization → Data drains** page, the server-side mutating endpoints, and the cron dispatcher. When it resolves off the page is hidden, drain create/update/delete/run requests return `404`, and the dispatcher is a no-op.
+On a self-hosted deployment the feature resolves on when `DATA_DRAINS_ENABLED` is `true`, or when it is unset and `ENTERPRISE_ENABLED` is `true`. An explicit `DATA_DRAINS_ENABLED=false` wins over the master switch. That resolved value — not the bare variable — gates the **Settings → Organization → Data drains** page, the server-side mutating endpoints, and the cron dispatcher. When it resolves off the page is hidden, drain create/update/delete/run requests return `404`, and the dispatcher is a no-op.
 
 Inside a workspace the browser reads that resolved value from the server, so the page follows the server whether or not `NEXT_PUBLIC_DATA_DRAINS_ENABLED` is set. Set it to the same value anyway: it backs the client fallback on surfaces rendered outside a workspace, and on a Compose install or source checkout `npx sim-setup doctor` reports the pair disagreeing.
 


### PR DESCRIPTION
## Summary
Fixes the Data drains self-hosted flag paragraph, raised on the v0.8.22 release PR (#7473). The finding holds up on both points.

**The bare flag is not what gates the feature.** `enterpriseFeatureEnabled` resolves `explicit ?? (ENTERPRISE_ENABLED || legacyDefault)`, and `ENTERPRISE_FEATURE_LEGACY_DEFAULTS.dataDrains` is `false` — so with `DATA_DRAINS_ENABLED` unset and `ENTERPRISE_ENABLED` set, data drains are **on**. The first sentence credited the bare variable and the second sentence then contradicted it. The paragraph now leads with the resolution, including that an explicit `false` always wins.

**The reason given for the public twin was wrong.** Inside a workspace, `WorkspaceHostProvider` seeds the deployment shape from the server-resolved host context, `useDeploymentShape()` returns that seeded value, and the settings sidebar gates `'data-drains': features.dataDrains` from it (`components/settings/navigation.ts`; `settings/navigation.ts` says so in a comment: *"the sidebar applies deployment and entitlement visibility from the host context"*). So the page follows the server whether or not the twin is set, and "set it so the browser's configuration matches the server's" misdescribed what the browser reads.

The advice to set it stands, with the accurate reason: it backs `browserFallbackShape()` wherever nothing has seeded the shape, and it is what `sim-setup doctor` compares (`packages/sim-setup/src/twins.ts`).

One qualification to the original finding: it proposed treating the twin as "doctor consistency only", which understates it — the twin is still the client fallback outside a seeded workspace, so the page says both roles rather than dropping one.

## Type of Change
- [x] Bug fix (documentation accuracy)

## Testing
`bun run lint`, `bun run check:audits` (45), and `bun run docs-manifest:check` all pass. Every claim was traced to source before rewriting: `enterprise-entitlements.ts`, `env-flags.ts`, `deployment-shape.ts`, `workspace-host-provider.tsx`, `components/settings/navigation.ts`, and `sim-setup/src/twins.ts`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
