### PR TITLE
fix(settings): gate workspace sections on the deployment the same way the sidebar does

### DIFF
--- a/apps/sim/components/settings/navigation.test.ts
+++ b/apps/sim/components/settings/navigation.test.ts
@@ -50,8 +50,18 @@ const SELF_HOSTED: DeploymentShape = {
 
 const HOSTED: DeploymentShape = { ...SELF_HOSTED, hosted: true, billingEnabled: true }
 
+/** A self-hosted deployment with every feature override on. */
+const SELF_HOSTED_ALL_FEATURES: DeploymentShape = {
+  ...SELF_HOSTED,
+  features: { ...SELF_HOSTED.features, customBlocks: true },
+}
+
+/** Every workspace-plane section a self-hosted deployment offers; BYOK is Sim Cloud only. */
+const SELF_HOSTED_WORKSPACE_SECTIONS = WORKSPACE_SETTINGS_ITEMS.map(({ id }) => id).filter(
+  (id) => id !== 'byok'
+)
+
 const ALL_ENTITLEMENTS = {
-  byok: true,
   credentialGroups: true,
   customBlocks: true,
   forks: true,
@@ -148,7 +158,7 @@ describe('settings navigation boundaries', () => {
         permission: 'admin',
         permissionConfig: {},
         entitlements: ALL_ENTITLEMENTS,
-        hosted: false,
+        deployment: SELF_HOSTED,
       }).map(({ id }) => id)
     ).toContain('sandboxes')
   })
@@ -160,16 +170,43 @@ describe('settings navigation boundaries', () => {
    * drop it there.
    */
   it('shows the Self-host section only on a self-hosted deployment', () => {
-    const navigate = (hosted: boolean) =>
+    const navigate = (deployment: DeploymentShape) =>
       resolveWorkspaceNavigation({
         permission: 'admin',
         permissionConfig: {},
         entitlements: ALL_ENTITLEMENTS,
-        hosted,
+        deployment,
       }).map(({ id }) => id)
 
-    expect(navigate(false)).toContain('self-host')
-    expect(navigate(true)).not.toContain('self-host')
+    expect(navigate(SELF_HOSTED)).toContain('self-host')
+    expect(navigate(HOSTED)).not.toContain('self-host')
+  })
+
+  /**
+   * The route gate and the sidebar must agree on deployment-gated sections: a
+   * hosted-only section is offered on a self-hosted deployment only when its
+   * feature override resolves on, so a direct link cannot open what the sidebar
+   * hides. BYOK has no override and stays Sim Cloud only.
+   */
+  it('offers hosted-only workspace sections on self-hosted only through their override', () => {
+    const navigate = (deployment: DeploymentShape) =>
+      resolveWorkspaceNavigation({
+        permission: 'admin',
+        permissionConfig: {},
+        entitlements: ALL_ENTITLEMENTS,
+        deployment,
+      }).map(({ id }) => id)
+
+    const inboxDisabled: DeploymentShape = {
+      ...SELF_HOSTED,
+      features: { ...SELF_HOSTED.features, inbox: false },
+    }
+    expect(navigate(inboxDisabled)).not.toContain('inbox')
+    expect(navigate(SELF_HOSTED)).toContain('inbox')
+    expect(navigate({ ...HOSTED, features: inboxDisabled.features })).toContain('inbox')
+
+    expect(navigate(SELF_HOSTED)).not.toContain('byok')
+    expect(navigate(HOSTED)).toContain('byok')
   })
 
   /**
@@ -457,7 +494,6 @@ describe('settings navigation boundaries', () => {
       visible: [
         'teammates',
         'secrets',
-        'byok',
         'sandboxes',
         'custom-tools',
         'mcp',
@@ -475,7 +511,6 @@ describe('settings navigation boundaries', () => {
       visible: [
         'teammates',
         'secrets',
-        'byok',
         'sandboxes',
         'custom-tools',
         'mcp',
@@ -490,8 +525,8 @@ describe('settings navigation boundaries', () => {
     },
     {
       permission: 'admin' as const,
-      visible: WORKSPACE_SETTINGS_ITEMS.map(({ id }) => id),
-      mutable: WORKSPACE_SETTINGS_ITEMS.map(({ id }) => id),
+      visible: SELF_HOSTED_WORKSPACE_SECTIONS,
+      mutable: SELF_HOSTED_WORKSPACE_SECTIONS,
     },
   ])(
     'makes workspace $permission navigation and mutation chrome explicit',
@@ -500,7 +535,7 @@ describe('settings navigation boundaries', () => {
         permission,
         permissionConfig: {},
         entitlements: ALL_ENTITLEMENTS,
-        hosted: false,
+        deployment: SELF_HOSTED_ALL_FEATURES,
       })
 
       expect(items.map(({ id }) => id)).toEqual(visible)
@@ -520,12 +555,11 @@ describe('settings navigation boundaries', () => {
         hideSandboxesTab: true,
       },
       entitlements: ALL_ENTITLEMENTS,
-      hosted: false,
+      deployment: SELF_HOSTED_ALL_FEATURES,
     })
 
     expect(items.map(({ id }) => id)).toEqual([
       'teammates',
-      'byok',
       'credential-groups',
       'workflow-mcp-servers',
       'recently-deleted',

--- a/apps/sim/components/settings/navigation.ts
+++ b/apps/sim/components/settings/navigation.ts
@@ -992,7 +992,6 @@ export function workspaceSectionUsesPermissionConfig(section: WorkspaceSettingsS
 }
 
 export interface WorkspaceSettingsEntitlements {
-  byok: boolean
   credentialGroups: boolean
   customBlocks: boolean
   forks: boolean
@@ -1017,8 +1016,40 @@ interface ResolveWorkspaceNavigationOptions {
   permission: PermissionType
   permissionConfig: WorkspacePermissionConfig
   entitlements: WorkspaceSettingsEntitlements
-  /** Sim Cloud drops the Self hosting section, which the managed service owns there. */
-  hosted: boolean
+  /** Resolves the catalog's deployment gates the same way the sidebar does. */
+  deployment: DeploymentShape
+}
+
+/**
+ * Unified projection of each workspace-plane section, so the route gate reads the
+ * deployment requirements (`requiresHosted`, `requiresSelfHosted`, `selfHostedOverride`)
+ * from the same catalog entry the sidebar filters on. Nav and server then agree: a
+ * section is reachable exactly when it is listed.
+ */
+const WORKSPACE_UNIFIED_PROJECTIONS: Readonly<
+  Partial<Record<WorkspaceSettingsSection, UnifiedSettingsProjection>>
+> = Object.fromEntries(
+  SETTINGS_SECTION_REGISTRY.flatMap((entry) => {
+    const workspaceSection = entry.planes?.workspace?.id
+    return workspaceSection && entry.unified ? [[workspaceSection, entry.unified] as const] : []
+  })
+)
+
+/**
+ * Whether the deployment itself offers a workspace section, before viewer permission
+ * and plan entitlement are considered. Mirrors the sidebar's deployment pass.
+ */
+function isWorkspaceSectionOfferedByDeployment(
+  section: WorkspaceSettingsSection,
+  deployment: DeploymentShape
+): boolean {
+  const unified = WORKSPACE_UNIFIED_PROJECTIONS[section]
+  if (!unified) return true
+  if (unified.requiresSelfHosted && deployment.hosted) return false
+  if (unified.requiresHosted && !deployment.hosted) {
+    return isSelfHostedOverrideEnabled(unified.selfHostedOverride, deployment)
+  }
+  return true
 }
 
 export interface ResolvedWorkspaceNavigationItem
@@ -1062,9 +1093,10 @@ export function resolveWorkspaceNavigation({
   permission,
   permissionConfig,
   entitlements,
-  hosted,
+  deployment,
 }: ResolveWorkspaceNavigationOptions): ResolvedWorkspaceNavigationItem[] {
   return WORKSPACE_SETTINGS_ITEMS.flatMap((item) => {
+    if (!isWorkspaceSectionOfferedByDeployment(item.id, deployment)) return []
     const permissionConfigKey = WORKSPACE_PERMISSION_CONFIG_KEYS[item.id]
     if (permissionConfigKey && permissionConfig[permissionConfigKey]) return []
     if (item.id === 'forks' && (permission !== 'admin' || !entitlements.forks)) return []
@@ -1074,10 +1106,7 @@ export function resolveWorkspaceNavigation({
     ) {
       return []
     }
-    if (item.id === 'byok' && !entitlements.byok) return []
     if (item.id === 'custom-blocks' && !entitlements.customBlocks) return []
-    // Absent on Sim Cloud, where the managed service owns these settings.
-    if (item.id === 'self-host' && hosted) return []
 
     const lockedBy = LOCKABLE_WORKSPACE_SECTIONS[item.id]
     const locked = lockedBy !== undefined && !entitlements[lockedBy]

--- a/apps/sim/lib/settings/application/workspace-section-access.test.ts
+++ b/apps/sim/lib/settings/application/workspace-section-access.test.ts
@@ -219,8 +219,8 @@ describe('authorizeWorkspaceSettingsSection', () => {
     await authorize('secrets')
     expect(mocks.resolveWorkspaceNavigation).toHaveBeenCalledWith(
       expect.objectContaining({
-        hosted: true,
-        entitlements: expect.objectContaining({ byok: true }),
+        deployment: mocks.deploymentShape,
+        entitlements: expect.objectContaining({ inbox: true }),
       })
     )
 

--- a/apps/sim/lib/settings/application/workspace-section-access.ts
+++ b/apps/sim/lib/settings/application/workspace-section-access.ts
@@ -66,9 +66,8 @@ async function canOpenWorkspaceSection(
   const navigation = resolveWorkspaceNavigation({
     permission,
     permissionConfig: accessControl?.config ?? {},
-    hosted: deployment.hosted,
+    deployment,
     entitlements: {
-      byok: deployment.hosted,
       credentialGroups: credentialGroupsAvailable,
       inbox: true,
       customBlocks: customBlocksAvailable,


### PR DESCRIPTION
## Summary
- The workspace settings route gate hardcoded the inbox entitlement, so on a self-hosted deployment with the inbox feature off a direct link to `/settings/inbox` was authorized and rendered an upgrade notice while the sidebar hid the section
- `resolveWorkspaceNavigation` now takes the server-resolved deployment shape and reads each section's `requiresHosted` / `requiresSelfHosted` / `selfHostedOverride` from the catalog, the same entry the sidebar filters on, so an unavailable section redirects to General
- Drops the hand-rolled `self-host` and `byok` rules in favor of that shared gate; `byok` leaves the entitlement bag since the catalog already says it is hosted-only

## Type of Change
- [x] Bug fix

## Testing
- Added navigation tests covering inbox on self-hosted with the override off and on, on Sim Cloud, and BYOK on both deployments
- `vitest` for settings navigation, the section gate, the settings pages, and the settings sidebar: 201 passing
- `bun run type-check`, `bun run lint`, `bun run check:audits`, `docs-manifest:check`, block-registry check all pass

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)