### PR TITLE
fix(file-editor): preserve drafts and harden editing behavior

### DIFF
--- a/apps/sim/app/api/workspaces/[id]/files/[fileId]/content/route.test.ts
+++ b/apps/sim/app/api/workspaces/[id]/files/[fileId]/content/route.test.ts
@@ -44,6 +44,7 @@ const RECORD = {
   folderId: null,
   uploadedAt: new Date('2026-08-04T00:00:00.000Z'),
   updatedAt: new Date('2026-08-04T00:00:00.000Z'),
+  contentUpdatedAt: new Date('2026-09-03T20:00:01.000Z'),
 }
 
 const routeContext = { params: Promise.resolve({ id: WORKSPACE_ID, fileId: FILE_ID }) }
@@ -133,6 +134,43 @@ describe('PUT /api/workspaces/[id]/files/[fileId]/content', () => {
       },
       request,
     })
+  })
+
+  it('passes the content-version precondition to the existing authorized use case', async () => {
+    const expectedUpdatedAt = '2026-09-03T20:00:00.000Z'
+    const response = await PUT(
+      createRequest({ content: 'edited', expectedUpdatedAt }),
+      routeContext
+    )
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      file: { contentUpdatedAt: RECORD.contentUpdatedAt.toISOString() },
+    })
+    expect(mocks.updateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        principal: PRINCIPAL,
+        input: expect.objectContaining({ expectedUpdatedAt: new Date(expectedUpdatedAt) }),
+      })
+    )
+  })
+
+  it('rejects invalid content-version tokens before performing a write', async () => {
+    const response = await PUT(
+      createRequest({ content: 'edited', expectedUpdatedAt: 'yesterday' }),
+      routeContext
+    )
+    expect(response.status).toBe(400)
+    expect(mocks.updateContent).not.toHaveBeenCalled()
+  })
+
+  it('preserves a CAS conflict as 409', async () => {
+    mocks.updateContent.mockRejectedValueOnce(new OrchestrationError('conflict', 'File changed'))
+    const response = await PUT(
+      createRequest({ content: 'edited', expectedUpdatedAt: '2026-09-03T20:00:00.000Z' }),
+      routeContext
+    )
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({ error: 'File changed' })
   })
 
   it('allows a base64 JSON body up to what the proxy forwards intact', async () => {

--- a/apps/sim/app/api/workspaces/[id]/files/[fileId]/content/route.ts
+++ b/apps/sim/app/api/workspaces/[id]/files/[fileId]/content/route.ts
@@ -34,6 +34,7 @@ export const PUT = defineInternalJsonRoute({
     assertedWorkspaceId: params.id,
     content: body.content,
     encoding: body.encoding === 'base64' ? ('base64' as const) : ('utf-8' as const),
+    ...(body.expectedUpdatedAt ? { expectedUpdatedAt: new Date(body.expectedUpdatedAt) } : {}),
   }),
   useCase: updateWorkspaceFileContent,
   present: internalFilePresenters.successFile,

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-save-conflict.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/file-save-conflict.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Chip, toast } from '@sim/emcn'
+import { getErrorMessage } from '@sim/utils/errors'
+
+interface FileSaveConflictProps {
+  isReloading: boolean
+  reloadLatestContent: () => Promise<void>
+  downloadDraft: () => void
+}
+
+/** Keeps both versions recoverable until the user explicitly replaces the local draft. */
+export function FileSaveConflict({
+  isReloading,
+  reloadLatestContent,
+  downloadDraft,
+}: FileSaveConflictProps) {
+  return (
+    <div
+      role='alert'
+      className='flex shrink-0 flex-wrap items-center gap-2 border-[var(--border)] border-b px-4 py-2 text-[13px] text-[var(--text-body)]'
+    >
+      <p className='min-w-0 flex-1'>
+        Saving paused: the file changed elsewhere. Your local draft is preserved. Reload replaces it
+        with the latest version.
+      </p>
+      <Chip onClick={downloadDraft}>Download local draft</Chip>
+      <Chip
+        disabled={isReloading}
+        onClick={() => {
+          void reloadLatestContent().catch((error) =>
+            toast.error(
+              getErrorMessage(error, 'Could not reload the file. Your local draft is unchanged.')
+            )
+          )
+        }}
+      >
+        {isReloading ? 'Reloading…' : 'Discard draft and reload'}
+      </Chip>
+    </div>
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/block-mover.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/block-mover.test.ts
@@ -1,0 +1,158 @@
+/** @vitest-environment jsdom */
+import { Editor } from '@tiptap/core'
+import { GapCursor } from '@tiptap/pm/gapcursor'
+import { NodeSelection, TextSelection } from '@tiptap/pm/state'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+
+let editor: Editor | undefined
+afterEach(() => {
+  editor?.destroy()
+  editor = undefined
+})
+
+function mount(content: string): Editor {
+  editor = new Editor({ extensions: createMarkdownEditorExtensions({ placeholder: '' }), content })
+  return editor
+}
+
+function findText(ed: Editor, text: string): number {
+  let position = -1
+  ed.state.doc.descendants((node, pos) => {
+    if (node.isText && node.text === text) position = pos
+  })
+  expect(position).toBeGreaterThan(-1)
+  return position
+}
+
+function move(ed: Editor, direction: 'up' | 'down'): boolean {
+  return direction === 'up' ? ed.commands.moveBlockUp() : ed.commands.moveBlockDown()
+}
+
+describe('block movement across leaf siblings', () => {
+  it.each(['<hr>', '<img src="https://example.com/picture.png">'])(
+    'moves text across %s in both directions',
+    (leaf) => {
+      const ed = mount(`${leaf}<p>abcdef</p><p>tail</p>`)
+      ed.commands.setTextSelection(findText(ed, 'abcdef') + 3)
+      const before = ed.getJSON()
+
+      expect(ed.commands.moveBlockUp()).toBe(true)
+      expect(ed.state.doc.firstChild?.textContent).toBe('abcdef')
+      expect(ed.state.selection.$from.parentOffset).toBe(3)
+      expect(ed.commands.moveBlockDown()).toBe(true)
+      expect(ed.getJSON()).toEqual(before)
+      expect(ed.state.selection.$from.parentOffset).toBe(3)
+    }
+  )
+
+  it.each(['<hr>', '<img src="https://example.com/picture.png">'])(
+    'moves selected %s without replacing node selection with a caret',
+    (leaf) => {
+      const ed = mount(`<p>before</p>${leaf}<p>after</p>`)
+      const leafPosition = ed.state.doc.firstChild?.nodeSize ?? 0
+      ed.commands.setNodeSelection(leafPosition)
+      const before = ed.getJSON()
+      const selectedType = (ed.state.selection as NodeSelection).node.type.name
+
+      expect(ed.commands.moveBlockUp()).toBe(true)
+      expect(ed.state.selection instanceof NodeSelection).toBe(true)
+      expect(ed.state.selection.from).toBe(0)
+      expect(ed.state.doc.firstChild?.type.name).toBe(selectedType)
+      expect(ed.commands.moveBlockDown()).toBe(true)
+      expect(ed.getJSON()).toEqual(before)
+      expect(ed.state.selection instanceof NodeSelection).toBe(true)
+      expect(ed.state.selection.from).toBe(leafPosition)
+    }
+  )
+
+  it('supports the actual keyboard chord on a selected divider', () => {
+    const ed = mount('<p>before</p><hr><p>after</p>')
+    ed.commands.setNodeSelection(8)
+    ed.view.dom.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowUp',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(ed.state.doc.firstChild?.type.name).toBe('horizontalRule')
+    expect(ed.state.selection instanceof NodeSelection).toBe(true)
+    expect(ed.state.selection.from).toBe(0)
+  })
+})
+
+describe('block movement preserves selection intent', () => {
+  it.each(['up', 'down'] as const)(
+    'preserves a backwards selected text range when moving %s',
+    (direction) => {
+      const ed = mount('<p>before</p><p>abcdef</p><p>after</p>')
+      const pos = findText(ed, 'abcdef')
+      ed.commands.setTextSelection({ from: pos + 5, to: pos + 1 })
+      const before = ed.getJSON()
+
+      expect(move(ed, direction)).toBe(true)
+      expect(ed.state.selection instanceof TextSelection).toBe(true)
+      expect(ed.state.doc.textBetween(ed.state.selection.from, ed.state.selection.to)).toBe('bcde')
+      expect(ed.state.selection.anchor).toBeGreaterThan(ed.state.selection.head)
+      expect(ed.commands.undo()).toBe(true)
+      expect(ed.getJSON()).toEqual(before)
+      expect(ed.state.selection.anchor).toBe(pos + 5)
+      expect(ed.state.selection.head).toBe(pos + 1)
+      expect(ed.commands.redo()).toBe(true)
+      expect(ed.state.doc.textBetween(ed.state.selection.from, ed.state.selection.to)).toBe('bcde')
+    }
+  )
+
+  it.each(['up', 'down'] as const)(
+    'moves all selected blocks together %s, retaining their order',
+    (direction) => {
+      const ed = mount('<p>before</p><p>first</p><hr><p>second</p><p>after</p>')
+      const start = findText(ed, 'first') + 2
+      const end = findText(ed, 'second') + 4
+      ed.commands.setTextSelection({ from: end, to: start })
+      const selected = ed.state.doc.textBetween(start, end, '\n')
+
+      expect(move(ed, direction)).toBe(true)
+      const nodes: string[] = []
+      ed.state.doc.forEach((node) => nodes.push(node.textContent || node.type.name))
+      expect(nodes).toEqual(
+        direction === 'up'
+          ? ['first', 'horizontalRule', 'second', 'before', 'after']
+          : ['before', 'after', 'first', 'horizontalRule', 'second']
+      )
+      expect(ed.state.doc.textBetween(ed.state.selection.from, ed.state.selection.to, '\n')).toBe(
+        selected
+      )
+      expect(ed.state.selection.anchor).toBeGreaterThan(ed.state.selection.head)
+    }
+  )
+
+  it('keeps nested selection and descendant marks inside the moved list', () => {
+    const ed = mount(
+      '<p>before</p><ul><li><p>parent</p><ul><li><p><strong>child</strong></p></li></ul></li></ul><p>after</p>'
+    )
+    const pos = findText(ed, 'child')
+    ed.commands.setTextSelection({ from: pos, to: pos + 5 })
+    const listBefore = ed.state.doc.child(1).toJSON()
+
+    expect(ed.commands.moveBlockUp()).toBe(true)
+    expect(ed.state.doc.firstChild?.toJSON()).toEqual(listBefore)
+    expect(ed.state.doc.textBetween(ed.state.selection.from, ed.state.selection.to)).toBe('child')
+    expect(ed.state.selection.$from.depth).toBe(5)
+  })
+
+  it('returns false at the document edge and for a root gap without a selected block', () => {
+    const ed = mount('<hr><p>last</p>')
+    ed.commands.setNodeSelection(0)
+    expect(ed.can().moveBlockUp()).toBe(false)
+    expect(ed.commands.moveBlockUp()).toBe(false)
+    ed.view.dispatch(ed.state.tr.setSelection(new GapCursor(ed.state.doc.resolve(0))))
+    expect(ed.commands.moveBlockDown()).toBe(false)
+    ed.commands.setTextSelection(findText(ed, 'last'))
+    expect(ed.commands.moveBlockDown()).toBe(false)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/block-mover.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/block-mover.ts
@@ -1,54 +1,58 @@
 import { Extension } from '@tiptap/core'
+import { Slice } from '@tiptap/pm/model'
 import type { EditorState, Transaction } from '@tiptap/pm/state'
-import { TextSelection } from '@tiptap/pm/state'
+import { NodeSelection } from '@tiptap/pm/state'
+import { ReplaceAroundStep, StepMap } from '@tiptap/pm/transform'
 
-/** The position range of the depth-1 block containing the cursor, or null at the document root. */
-function currentTopLevelBlock(state: EditorState): { from: number; to: number } | null {
-  const { $from } = state.selection
-  if ($from.depth === 0) return null
-  return { from: $from.before(1), to: $from.after(1) }
+/** The contiguous top-level blocks touched by a text range or node selection. */
+function currentTopLevelBlocks(state: EditorState): { from: number; to: number } | null {
+  const { selection } = state
+  const { $from, $to } = selection
+  if ($from.depth === 0 && !(selection instanceof NodeSelection)) return null
+  return {
+    from: $from.depth > 0 ? $from.before(1) : $from.pos,
+    to: $to.depth > 0 ? $to.after(1) : $to.pos,
+  }
 }
 
 /**
- * Swaps the current top-level block with its neighbour in `direction`, keeping the caret on the moved
- * block. Adjacent top-level blocks share a boundary position (no separator token between them), so the
- * move is a single `replaceWith` of the two-block span with the pair reordered. No-ops (returns false)
- * at the matching document edge or when the neighbour isn't a top-level block. `newBefore` is the moved
- * block's new `before(1)` position; adding the caret's original offset (`selection.from - from`, also
- * measured from `before(1)`) re-anchors the caret at the same spot within the block.
+ * Swaps the selected block range with its immediate sibling, including one-position leaf nodes.
+ * The replace-around step maps positions inside the moved content. A translated selection bookmark
+ * preserves selection kind, both endpoints, and direction instead of collapsing a range to a caret.
  */
 function moveBlock(
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | undefined,
   direction: 'up' | 'down'
 ): boolean {
-  const block = currentTopLevelBlock(state)
+  const block = currentTopLevelBlocks(state)
   if (!block) return false
   const { from, to } = block
   const up = direction === 'up'
 
   if (up ? from === 0 : to >= state.doc.content.size) return false
-  const $neighbour = state.doc.resolve(up ? from - 1 : to + 1)
-  if ($neighbour.depth === 0) return false
+  const boundary = state.doc.resolve(up ? from : to)
+  const sibling = up ? boundary.nodeBefore : boundary.nodeAfter
+  if (!sibling) return false
   if (!dispatch) return true
 
-  const spanFrom = up ? $neighbour.before(1) : from
-  const spanTo = up ? to : $neighbour.after(1)
-  const moving = state.doc.slice(from, to).content
+  const spanFrom = up ? from - sibling.nodeSize : from
+  const spanTo = up ? to : to + sibling.nodeSize
   const neighbour = up
     ? state.doc.slice(spanFrom, from).content
     : state.doc.slice(to, spanTo).content
-  const tr = state.tr.replaceWith(
-    spanFrom,
-    spanTo,
-    up ? moving.append(neighbour) : neighbour.append(moving)
+  const tr = state.tr.step(
+    new ReplaceAroundStep(
+      spanFrom,
+      spanTo,
+      from,
+      to,
+      new Slice(neighbour, 0, 0),
+      up ? 0 : neighbour.size
+    )
   )
-
-  const newBefore = up ? spanFrom : spanFrom + neighbour.size
-  const offset = state.selection.from - from
-  tr.setSelection(
-    TextSelection.near(tr.doc.resolve(Math.min(newBefore + offset, newBefore + moving.size)))
-  )
+  const offset = up ? -sibling.nodeSize : sibling.nodeSize
+  tr.setSelection(state.selection.getBookmark().map(StepMap.offset(offset)).resolve(tr.doc))
   dispatch(tr.scrollIntoView())
   return true
 }
@@ -56,18 +60,17 @@ function moveBlock(
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     blockMover: {
-      /** Move the current top-level block up one position, carrying the caret. */
+      /** Move the selected top-level block range up one position, preserving the selection. */
       moveBlockUp: () => ReturnType
-      /** Move the current top-level block down one position, carrying the caret. */
+      /** Move the selected top-level block range down one position, preserving the selection. */
       moveBlockDown: () => ReturnType
     }
   }
 }
 
 /**
- * Reorders the current top-level block with `Mod-Shift-ArrowUp`/`ArrowDown` — the standard
- * keyboard block-move affordance (Notion/Obsidian). Pure UI interaction: no schema change, and the
- * caret rides along with the block. A no-op (returns false, falling through) at the document edges.
+ * Reorders the selected top-level blocks with `Mod-Shift-ArrowUp`/`ArrowDown`, keeping their order
+ * and selection. Returns false at document edges and for root gap cursors with no selected block.
  */
 export const BlockMover = Extension.create({
   name: 'blockMover',

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list.test.ts
@@ -50,14 +50,14 @@ describe('typed bullet list joining', () => {
     expect(ed.view.dom.querySelectorAll(':scope > ul')).toHaveLength(1)
   })
 
-  it('joins both neighbors when turning their separating paragraph into a bullet', () => {
+  it('joins the preceding list without merging two existing roots', () => {
     const ed = mount('<ul><li><p>one</p></li></ul><p></p><ul><li><p>two</p></li></ul>')
     ed.commands.setTextSelection(10)
     typeBullet(ed)
     ed.commands.insertContent('new')
 
-    expect(ed.getJSON().content?.filter((node) => node.type === 'bulletList')).toHaveLength(1)
-    expect(ed.getMarkdown().trim()).toBe('- one\n- new\n- two')
+    expect(ed.getJSON().content?.filter((node) => node.type === 'bulletList')).toHaveLength(2)
+    expect(ed.getMarkdown().trim()).toBe('- one\n- new\n\n- two')
   })
 
   it('does not join across an intentional blank paragraph', () => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { Editor } from '@tiptap/core'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+
+let editor: Editor | undefined
+
+afterEach(() => {
+  editor?.destroy()
+  editor = undefined
+})
+
+function mount(content: string): Editor {
+  editor = new Editor({ extensions: createMarkdownContentExtensions(), content })
+  return editor
+}
+
+/** Runs the real text-input rules; insertContent alone does not trigger them. */
+function typeBullet(ed: Editor, marker = '-'): void {
+  ed.commands.insertContent(marker)
+  const { from, to } = ed.state.selection
+  expect(
+    ed.view.someProp('handleTextInput', (handler) =>
+      handler(ed.view, from, to, ' ', () => ed.state.tr)
+    )
+  ).toBe(true)
+}
+
+describe('typed bullet list joining', () => {
+  it.each(['-', '+', '*'])('joins %s typed after a heading to the following list', (marker) => {
+    const ed = mount('<h2>Todos:</h2><ul><li><p>one</p></li><li><p>two</p></li></ul>')
+    ed.commands.setTextSelection(7)
+    ed.commands.keyboardShortcut('Enter')
+    typeBullet(ed, marker)
+    ed.commands.insertContent('new')
+
+    expect(
+      ed
+        .getJSON()
+        .content?.slice(0, 2)
+        .map((node) => node.type)
+    ).toEqual(['heading', 'bulletList'])
+    expect(ed.getJSON().content?.filter((node) => node.type === 'bulletList')).toHaveLength(1)
+    expect(ed.getJSON().content?.[1].content).toHaveLength(3)
+    expect(ed.getMarkdown().trim()).toBe('## Todos:\n\n- new\n- one\n- two')
+    expect(ed.state.selection.$from.parent.textContent).toBe('new')
+    expect(ed.view.dom.querySelectorAll(':scope > ul')).toHaveLength(1)
+  })
+
+  it('joins both neighbors when turning their separating paragraph into a bullet', () => {
+    const ed = mount('<ul><li><p>one</p></li></ul><p></p><ul><li><p>two</p></li></ul>')
+    ed.commands.setTextSelection(10)
+    typeBullet(ed)
+    ed.commands.insertContent('new')
+
+    expect(ed.getJSON().content?.filter((node) => node.type === 'bulletList')).toHaveLength(1)
+    expect(ed.getMarkdown().trim()).toBe('- one\n- new\n- two')
+  })
+
+  it('does not join across an intentional blank paragraph', () => {
+    const ed = mount('<p></p><p></p><ul><li><p>one</p></li></ul>')
+    ed.commands.setTextSelection(1)
+    typeBullet(ed)
+    ed.commands.insertContent('new')
+
+    expect(
+      ed
+        .getJSON()
+        .content?.slice(0, 3)
+        .map((node) => node.type)
+    ).toEqual(['bulletList', 'paragraph', 'bulletList'])
+  })
+
+  it('joins a nested list without changing its depth or dropping formatted content', () => {
+    const ed = mount(
+      '<ul><li><p>parent</p><p></p><ul><li><p><strong>child</strong></p></li></ul></li></ul>'
+    )
+    ed.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph' && node.content.size === 0) {
+        ed.commands.setTextSelection(pos + 1)
+      }
+    })
+    typeBullet(ed)
+    ed.commands.insertContent('new child')
+
+    const parent = ed.getJSON().content?.[0].content?.[0]
+    expect(parent?.content?.map((node) => node.type)).toEqual(['paragraph', 'bulletList'])
+    expect(parent?.content?.[1].content).toHaveLength(2)
+    expect(ed.getMarkdown().trim()).toBe('- parent\n  - new child\n  - **child**')
+    expect(ed.state.selection.$from.depth).toBe(5)
+  })
+
+  it('does not absorb a following numbered list', () => {
+    const ed = mount('<p></p><ol start="3"><li><p>one</p></li></ol>')
+    ed.commands.setTextSelection(1)
+    typeBullet(ed)
+
+    expect(
+      ed
+        .getJSON()
+        .content?.slice(0, 2)
+        .map((node) => node.type)
+    ).toEqual(['bulletList', 'orderedList'])
+    expect(ed.getJSON().content?.[1].attrs?.start).toBe(3)
+  })
+
+  it('undoes the input rule and its join together without losing the following items', () => {
+    const ed = mount('<p></p><ul><li><p>one</p></li><li><p>two</p></li></ul>')
+    ed.commands.setTextSelection(1)
+    typeBullet(ed)
+    expect(ed.commands.undoInputRule()).toBe(true)
+
+    expect(
+      ed
+        .getJSON()
+        .content?.slice(0, 2)
+        .map((node) => node.type)
+    ).toEqual(['paragraph', 'bulletList'])
+    expect(ed.state.doc.firstChild?.textContent).toBe('- ')
+    expect(ed.getJSON().content?.[1].content).toHaveLength(2)
+  })
+
+  it.each(['-', '+', '*'])(
+    'Backspace restores the typed %s marker before a following list',
+    (marker) => {
+      editor = new Editor({
+        extensions: createMarkdownEditorExtensions({ placeholder: '' }),
+        content: '<h2>Todos:</h2><ul><li><p>one</p></li><li><p>two</p></li></ul>',
+      })
+      editor.commands.setTextSelection(7)
+      editor.view.dom.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+      )
+      typeBullet(editor, marker)
+      editor.view.dom.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true })
+      )
+
+      expect(
+        editor
+          .getJSON()
+          .content?.slice(0, 3)
+          .map((node) => node.type)
+      ).toEqual(['heading', 'paragraph', 'bulletList'])
+      expect(editor.state.selection.$from.parent.textContent).toBe(`${marker} `)
+      expect(editor.state.selection.$from.parentOffset).toBe(2)
+      expect(editor.state.doc.child(2).textContent).toBe('onetwo')
+    }
+  )
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list.ts
@@ -1,0 +1,13 @@
+import { BulletList } from '@tiptap/extension-list'
+import { joinListInputRules } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules'
+
+/**
+ * Extends the stock input rules, which only join a preceding list, to also join an immediately
+ * following bullet list. Keeping the join in the input-rule transaction preserves undo and the
+ * caret, without merging across paragraphs or rewriting unrelated lists on every edit.
+ */
+export const JoiningBulletList = BulletList.extend({
+  addInputRules() {
+    return joinListInputRules(this.parent?.() ?? [], this.type)
+  },
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions.ts
@@ -5,28 +5,32 @@ import Placeholder from '@tiptap/extension-placeholder'
 import type { Awareness } from 'y-protocols/awareness'
 import type * as Y from 'yjs'
 import { withAlpha } from '@/lib/workspaces/colors'
-import { BlockMover } from './block-mover'
-import { CodeBlockWithLanguage } from './code-block'
-import { CodeBlockHighlight } from './code-highlight'
+import { BlockMover } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/block-mover'
+import { CodeBlockWithLanguage } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/code-block'
+import { CodeBlockHighlight } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/code-highlight'
 import {
   createCaretActivityExtension,
   DEFAULT_CARET_COLOR,
   renderCaret,
-} from './collaboration/caret-presence'
-import { LinkEmbed } from './embed/link-embed'
-import { createMarkdownContentExtensions } from './extensions'
-import { RichMarkdownFind } from './find'
-import { ResizableImage } from './image'
-import { RichMarkdownKeymap } from './keymap'
-import { MarkdownPaste } from './markdown-paste'
-import { Mention } from './mention/mention'
-import { MentionChip } from './mention/mention-chip'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/caret-presence'
+import { LinkEmbed } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/embed/link-embed'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { RichMarkdownFind } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/find'
+import { ResizableImage } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image'
+import { ImageUploadPlaceholders } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload'
+import { RichMarkdownKeymap } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap'
+import { MarkdownPaste } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste'
+import { Mention } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention'
+import { MentionChip } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-chip'
 import {
   createRichMarkdownPasteAdmission,
   type RichMarkdownPasteAdmissionOptions,
-} from './paste-admission'
-import { FootnoteDefWithView, RawHtmlBlockWithView } from './raw-markdown-snippet'
-import { SlashCommand } from './slash-command/slash-command'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission'
+import {
+  FootnoteDefWithView,
+  RawHtmlBlockWithView,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/raw-markdown-snippet'
+import { SlashCommand } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/slash-command/slash-command'
 
 /** Live collaboration binding for the editor. When present, the editor's history
  * is Yjs-backed and remote carets/selection render via CollaborationCaret. */
@@ -100,6 +104,7 @@ export function createMarkdownEditorExtensions({
     Mention,
     RichMarkdownKeymap,
     BlockMover,
+    ImageUploadPlaceholders,
     ...(pasteAdmission ? [createRichMarkdownPasteAdmission(pasteAdmission)] : []),
     MarkdownPaste,
     Placeholder.configure({ placeholder }),

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
@@ -1,0 +1,361 @@
+/** @vitest-environment jsdom */
+import { act, Suspense, startTransition } from 'react'
+import { toast } from '@sim/emcn'
+import { PASTE_RENDER_THRESHOLDS } from '@sim/utils/paste'
+import { type Editor, Extension } from '@tiptap/core'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { ImageUploadPlaceholders } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload'
+import {
+  createRichMarkdownPasteAdmission,
+  type RichMarkdownPasteAdmissionOptions,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission'
+import { LoadedRichMarkdownEditor } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor'
+
+const { uploadFile } = vi.hoisted(() => ({ uploadFile: vi.fn() }))
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('@/lib/auth/auth-client', () => ({ useSession: () => ({ data: null, isPending: false }) }))
+vi.mock('@/hooks/queries/workspace-files', () => ({
+  useUploadWorkspaceFile: () => ({ mutateAsync: uploadFile }),
+}))
+vi.mock('@/hooks/use-add-to-chat', () => ({ useAddToChat: () => vi.fn() }))
+vi.mock('@/hooks/use-file-content-source', () => ({
+  useFileContentSource: () => ({ resolveImageSrc: (src: string) => src }),
+}))
+vi.mock('@/app/workspace/[workspaceId]/components', () => ({ FindBar: () => null }))
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content',
+  () => ({ useEditableFileContent: vi.fn() })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/use-selection-copy-bridge',
+  () => ({ useSelectionCopyBridge: vi.fn() })
+)
+vi.mock('@/app/workspace/[workspaceId]/files/components/file-viewer/text-editor', () => ({
+  TextEditor: () => null,
+}))
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions',
+  () => ({
+    createMarkdownEditorExtensions: (options: {
+      pasteAdmission?: RichMarkdownPasteAdmissionOptions
+    }) => [
+      ...createMarkdownContentExtensions(),
+      ImageUploadPlaceholders,
+      ...(options.pasteAdmission ? [createRichMarkdownPasteAdmission(options.pasteAdmission)] : []),
+      Extension.create({ name: 'slashCommand', addStorage: () => ({ insertImage: null }) }),
+    ],
+  })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/use-file-doc-collaboration',
+  () => ({ useFileDocCollaboration: () => null })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/find',
+  () => ({ useMarkdownFind: () => ({ isOpen: false }) })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention',
+  () => ({ useEditorMentions: vi.fn() })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu',
+  () => ({ EditorBubbleMenu: () => null })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu',
+  () => ({ TableBubbleMenu: () => null })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card',
+  () => ({ LinkHoverCard: () => null })
+)
+
+const FILE: WorkspaceFileRecord = {
+  id: 'file-1',
+  workspaceId: 'workspace-1',
+  name: 'notes.md',
+  type: 'text/markdown',
+  key: 'version-1',
+  path: '/notes.md',
+  size: 30,
+  uploadedBy: 'user-1',
+  uploadedAt: new Date('2026-09-03T20:00:00Z'),
+}
+let root: Root
+let container: HTMLDivElement
+const onChange = vi.fn()
+const onEditSource = vi.fn()
+const onClientAutosaveChange = vi.fn()
+const onSaveShortcut = vi.fn()
+const onSuspendedRender = vi.fn()
+const pendingRender = new Promise<void>(() => {})
+
+interface SuspendAfterEditorProps {
+  active: boolean
+}
+
+function SuspendAfterEditor({ active }: SuspendAfterEditorProps) {
+  if (active) {
+    onSuspendedRender()
+    throw pendingRender
+  }
+  return null
+}
+
+interface RenderOptions {
+  onChange?: typeof onChange
+  onSaveShortcut?: typeof onSaveShortcut
+  suspend?: boolean
+}
+
+async function render(
+  content: string,
+  acceptedBaselineContent = content,
+  canEdit = true,
+  options: RenderOptions = {}
+) {
+  await act(async () => {
+    const update = () =>
+      root.render(
+        <Suspense fallback='Loading editor'>
+          <LoadedRichMarkdownEditor
+            file={FILE}
+            workspaceId={FILE.workspaceId}
+            content={content}
+            acceptedBaselineContent={acceptedBaselineContent}
+            isStreaming={false}
+            canEdit={canEdit}
+            userId='user-1'
+            userName='User'
+            enableFind={false}
+            onChange={options.onChange ?? onChange}
+            onEditSource={onEditSource}
+            onClientAutosaveChange={onClientAutosaveChange}
+            onSaveShortcut={options.onSaveShortcut ?? onSaveShortcut}
+          />
+          <SuspendAfterEditor active={options.suspend ?? false} />
+        </Suspense>
+      )
+    if (options.suspend) startTransition(update)
+    else update()
+  })
+}
+
+function getEditor() {
+  const element = container.querySelector<HTMLElement & { editor: Editor }>('.tiptap')
+  expect(element).not.toBeNull()
+  return element!.editor
+}
+
+async function pasteImage(editor: Editor) {
+  const image = new File(['image'], 'image.png', { type: 'image/png' })
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', {
+    value: { files: [image], items: [], types: ['Files'], getData: () => '' },
+  })
+  await act(async () => editor.view.dom.dispatchEvent(event))
+  expect(event.defaultPrevented).toBe(true)
+  expect(uploadFile).toHaveBeenCalledExactlyOnceWith({
+    workspaceId: FILE.workspaceId,
+    file: image,
+    folderId: null,
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(toast, 'warning').mockReturnValue('test-toast')
+  vi.spyOn(toast, 'info').mockReturnValue('uploading-toast')
+  vi.spyOn(toast, 'dismiss').mockImplementation(() => {})
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+describe('loaded rich editor lifecycle', () => {
+  it.each(['cancel', 'invalidate'] as const)(
+    'explains a completed upload without inserting after its anchor is %s',
+    async (action) => {
+      const pending = Promise.withResolvers<{ file: { url: string } }>()
+      uploadFile.mockReturnValueOnce(pending.promise)
+      await render('before TARGET after')
+      const editor = getEditor()
+      await act(async () => editor.commands.setTextSelection({ from: 8, to: 14 }))
+      await pasteImage(editor)
+      expect(editor.getText()).toBe('before TARGET after')
+
+      await act(async () => {
+        if (action === 'cancel') {
+          const cancel = editor.view.dom.querySelector<HTMLButtonElement>('button')
+          expect(cancel?.textContent).toBe('Cancel insertion')
+          cancel!.click()
+        } else {
+          editor.commands.insertContentAt(10, 'edited')
+        }
+      })
+      const beforeCompletion = editor.getJSON()
+      await act(async () => pending.resolve({ file: { url: '/image.png' } }))
+
+      expect(editor.getJSON()).toEqual(beforeCompletion)
+      expect(editor.view.dom.querySelector('img')).toBeNull()
+      expect(editor.view.dom.querySelector('button')).toBeNull()
+      expect(toast.dismiss).toHaveBeenCalledWith('uploading-toast')
+      expect(toast.info).toHaveBeenLastCalledWith(
+        'The image was uploaded to the workspace but was not inserted.'
+      )
+    }
+  )
+
+  it('inserts a completed upload without reporting cancellation when its anchor survives', async () => {
+    const pending = Promise.withResolvers<{ file: { url: string } }>()
+    uploadFile.mockReturnValueOnce(pending.promise)
+    await render('before TARGET after')
+    const editor = getEditor()
+    await act(async () => editor.commands.setTextSelection({ from: 8, to: 14 }))
+    await pasteImage(editor)
+    await act(async () => pending.resolve({ file: { url: '/image.png' } }))
+
+    expect(editor.view.dom.querySelector('img')?.getAttribute('src')).toBe('/image.png')
+    expect(editor.getText()).not.toContain('TARGET')
+    expect(editor.view.dom.querySelector('button')).toBeNull()
+    expect(toast.dismiss).toHaveBeenCalledWith('uploading-toast')
+    expect(toast.info).toHaveBeenCalledExactlyOnceWith('Uploading "image.png"…', { duration: 0 })
+  })
+
+  it('keeps callbacks and frontmatter tied to the committed editor during a suspended render', async () => {
+    const committed = '---\ntitle: committed\n---\n\nbody'
+    await render(committed)
+    const editor = getEditor()
+    const abandonedOnChange = vi.fn()
+    const abandonedSave = vi.fn()
+    const abandoned = '---\ntitle: abandoned\n---\n\nother body'
+    await render(abandoned, abandoned, true, {
+      onChange: abandonedOnChange,
+      onSaveShortcut: abandonedSave,
+      suspend: true,
+    })
+    expect(onSuspendedRender).toHaveBeenCalled()
+    expect(getEditor()).toBe(editor)
+    expect(editor.getText()).toBe('body')
+    await act(async () => editor.commands.insertContent('edited '))
+    expect(onChange).toHaveBeenLastCalledWith(expect.stringContaining('title: committed'))
+    expect(onChange.mock.lastCall?.[0]).not.toContain('title: abandoned')
+    editor.view.dom.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true })
+    )
+    expect(onSaveShortcut).toHaveBeenCalledOnce()
+    expect(abandonedOnChange).not.toHaveBeenCalled()
+    expect(abandonedSave).not.toHaveBeenCalled()
+  })
+
+  it('budgets paste using the latest accepted frontmatter without recreating the editor', async () => {
+    await render('---\ntitle: first\n---\n\nbody')
+    const editor = getEditor()
+    const baseline = `---\ntitle: ${'x'.repeat(1000)}\n---\n\nbody`
+    await render(baseline)
+    expect(getEditor()).toBe(editor)
+    const before = editor.getJSON()
+    await act(async () =>
+      editor.view.dispatch(
+        editor.state.tr
+          .insertText('x'.repeat(PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS - 500), 1)
+          .setMeta('uiEvent', 'paste')
+      )
+    )
+    expect(editor.getJSON()).toEqual(before)
+  })
+
+  it('does not steal formatting or composing chords for Save', async () => {
+    await render('body')
+    for (const extra of [
+      { shiftKey: true },
+      { altKey: true },
+      { isComposing: true },
+      { keyCode: 229 },
+    ]) {
+      getEditor().view.dom.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 's',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+          ...extra,
+        })
+      )
+    }
+    expect(onSaveShortcut).not.toHaveBeenCalled()
+    getEditor().view.dom.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true, cancelable: true })
+    )
+    expect(onSaveShortcut).toHaveBeenCalledOnce()
+  })
+
+  it('uses accepted external frontmatter on the next edit, not the original copy', async () => {
+    await render('---\ntitle: first\n---\n\nbody')
+    await render('---\ntitle: second\n---\n\nnew body')
+    await act(async () => getEditor().commands.insertContent('edited '))
+    expect(onChange).toHaveBeenLastCalledWith(expect.stringContaining('title: second'))
+    expect(onChange.mock.lastCall?.[0]).not.toContain('title: first')
+  })
+
+  it('does not recompute safety from a local serialization echo or overwrite the caret', async () => {
+    const baseline = '---\ntitle: first\n---\n\nbody'
+    await render(baseline)
+    await act(async () => getEditor().commands.insertContent('edited '))
+    const selection = getEditor().state.selection.from
+    await render(onChange.mock.lastCall![0], baseline)
+    expect(getEditor().state.selection.from).toBe(selection)
+    expect(getEditor().isEditable).toBe(true)
+  })
+
+  it('exposes named multiline textbox semantics and read-only state', async () => {
+    await render('body')
+    const editable = getEditor().view.dom
+    expect(editable.getAttribute('role')).toBe('textbox')
+    expect(editable.getAttribute('aria-label')).toBe('notes.md document body')
+    expect(editable.getAttribute('aria-multiline')).toBe('true')
+    expect(editable.getAttribute('aria-readonly')).toBe('false')
+    await render('body', 'body', false)
+    expect(editable.getAttribute('aria-readonly')).toBe('true')
+    expect(getEditor().isEditable).toBe(false)
+  })
+
+  it.each([
+    '[unused]: https://example.com',
+    '1. [![foo][image]](/dest)\n\n[image]: /url',
+    '- [ ] [foo][link]\n\n[link]: /dest',
+    '| header |\n| --- |\n| <img src="/image"> |',
+  ])('offers source editing without mutating unsupported content: %s', async (content) => {
+    await render(content)
+    expect(getEditor().isEditable).toBe(false)
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'Edit source'
+    )
+    expect(button).toBeDefined()
+    await act(async () => button!.click())
+    expect(onEditSource).toHaveBeenCalledOnce()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('updates editing eligibility and accessibility when an accepted baseline becomes unsupported', async () => {
+    await render('body')
+    await render('[unused]: https://example.com')
+    expect(getEditor().isEditable).toBe(false)
+    expect(getEditor().view.dom.getAttribute('aria-readonly')).toBe('true')
+    expect(container.textContent).toContain('Edit source')
+    await render('restored body')
+    expect(getEditor().isEditable).toBe(true)
+    expect(getEditor().view.dom.getAttribute('aria-readonly')).toBe('false')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
@@ -184,6 +184,27 @@ afterEach(async () => {
 })
 
 describe('loaded rich editor lifecycle', () => {
+  it('explains a picker selection whose insertion anchor was invalidated', async () => {
+    await render('before TARGET after')
+    const editor = getEditor()
+    await act(async () => {
+      editor.commands.setTextSelection({ from: 8, to: 14 })
+      editor.storage.slashCommand.insertImage?.(8)
+      editor.commands.insertContentAt({ from: 7, to: 15 }, 'changed')
+    })
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]')!
+    Object.defineProperty(input, 'files', {
+      value: [new File(['image'], 'image.png', { type: 'image/png' })],
+    })
+    await act(async () => input.dispatchEvent(new Event('change', { bubbles: true })))
+    expect(uploadFile).not.toHaveBeenCalled()
+    expect(toast.info).toHaveBeenLastCalledWith(
+      'The insertion location changed. Choose a new location and select the image again.'
+    )
+    expect(editor.getText()).toContain('changed')
+    expect(input.value).toBe('')
+  })
+
   it.each(['cancel', 'invalidate'] as const)(
     'explains a completed upload without inserting after its anchor is %s',
     async (action) => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions.ts
@@ -1,28 +1,32 @@
-import type { Extensions, JSONContent, MarkdownRendererHelpers, Node } from '@tiptap/core'
+import { Extension, type Extensions, type JSONContent, type Node } from '@tiptap/core'
 import { Code } from '@tiptap/extension-code'
+import { Document } from '@tiptap/extension-document'
+import { HardBreak } from '@tiptap/extension-hard-break'
 import { TaskItem, TaskList } from '@tiptap/extension-list'
 import { Paragraph } from '@tiptap/extension-paragraph'
-import {
-  renderTableToMarkdown,
-  Table,
-  TableCell,
-  TableHeader,
-  TableRow,
-} from '@tiptap/extension-table'
+import { TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
 import { Markdown } from '@tiptap/markdown'
 import StarterKit from '@tiptap/starter-kit'
-import { MarkdownCodeBlock } from './code-block-schema'
-import { Highlight } from './highlight'
-import { MarkdownImage } from './image-schema'
-import { MarkdownLinkInputRule } from './link-input-rule'
-import { MarkdownMention } from './mention/mention-node'
-import { SIM_LINK_SCHEME } from './mention/sim-link'
+import { JoiningBulletList } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list'
+import { MarkdownCodeBlock } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/code-block-schema'
+import { Highlight } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/highlight'
+import { MarkdownImage } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-schema'
+import { MarkdownLinkInputRule } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/link-input-rule'
+import { joinListInputRules } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules'
+import { MarkdownMention } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-node'
+import { SIM_LINK_SCHEME } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/sim-link'
+import { createJoiningOrderedList } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/ordered-list'
 import {
   FootnoteDef,
   FootnoteRef,
   RawHtmlBlock,
   RawInlineHtml,
-} from './raw-markdown-snippet-schema'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/raw-markdown-snippet-schema'
+import {
+  createMarkdownTable,
+  excludeTableBlockInputRules,
+  selectionTouchesTable,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table'
 
 /**
  * The `@`-mention link scheme, registered on the Link mark — without it the schema strips the
@@ -38,30 +42,74 @@ const SIM_LINK_PROTOCOL = { scheme: SIM_LINK_SCHEME, optionalSlashes: true } as 
  */
 const InlineCode = Code.extend({ excludes: '' })
 
+/** GFM's inline HTML keeps consecutive/leading/trailing breaks in one paragraph on reload. */
+const MarkdownHardBreak = HardBreak.extend({ renderMarkdown: () => '<br>' })
+
+const TABLE_BLOCK_PREFIX_NODES = new Set(['heading', 'blockquote', 'horizontalRule'])
+
+/** Input rules must respect the same table capabilities as toolbar and keyboard commands. */
+const TableAwareStarterKit = StarterKit.extend({
+  addExtensions() {
+    return (this.parent?.() ?? []).map((extension) =>
+      extension.type === 'node' && TABLE_BLOCK_PREFIX_NODES.has(extension.name)
+        ? extension.extend({
+            addCommands() {
+              const parent = this.parent?.()
+              if (this.name !== 'horizontalRule') return parent ?? {}
+              return {
+                ...parent,
+                setHorizontalRule: () => (props) =>
+                  !selectionTouchesTable(props.state) &&
+                  (parent?.setHorizontalRule?.()(props) ?? false),
+              }
+            },
+            addInputRules() {
+              return excludeTableBlockInputRules(this.parent?.() ?? [])
+            },
+          })
+        : extension
+    )
+  },
+})
+
+/** Standard HTML represents a structural empty paragraph where Markdown whitespace is ambiguous. */
+const EmptyParagraphMarkdown = Extension.create({
+  name: 'emptyParagraphMarkdown',
+  markdownTokenName: 'html',
+  parseMarkdown: (token) =>
+    token.block && /^\s*<p>[ \t]*<\/p>\s*$/.test(token.raw ?? '') ? { type: 'paragraph' } : [],
+})
+
 /**
- * Table that escapes interior `|` characters when serializing cells. The upstream serializer
- * joins cells with `|` without escaping, so a cell containing a literal pipe silently splits
- * into phantom columns on round-trip (data loss). Escaping must happen on the `table` node —
- * `tableCell`/`tableHeader` have no markdown renderer; the table renders cell children directly. Only
- * `|` is escaped — `renderChildren` already escapes backslashes, so escaping them again would
- * double-escape and break round-trip idempotency (CodeQL's "missing backslash escape" is a false
- * positive here; covered by the table round-trip tests).
- *
- * The upstream serializer also wraps the table in its own leading/trailing blank lines; left in,
- * the block joiner adds another, so an interior table churns its surrounding whitespace to
- * `\n\n\n` on the first edit. Trimming the table's own output lets the joiner own the single
- * blank-line separator — without touching blank lines inside fenced code (those live in the code
- * node's text, not here).
+ * Blank lines between lists are loose-list spacing in CommonMark, not a paragraph. Serialize an
+ * explicit empty element for that structural boundary, while retaining ordinary document spacing
+ * and omitting the editor's final typing placeholder from the persisted content.
  */
-const PipeSafeTable = Table.extend({
-  renderMarkdown: (node: JSONContent, h: MarkdownRendererHelpers) =>
-    renderTableToMarkdown(node, {
-      ...h,
-      renderChildren: (nodes, separator) =>
-        h.renderChildren(nodes, separator).replace(/\|/g, '\\|'),
-    })
-      .replace(/^\n+/, '')
-      .replace(/\n+$/, ''),
+const MarkdownDocument = Document.extend({
+  renderMarkdown: (node: JSONContent, h) => {
+    const content = node.content ?? []
+    let lastContentIndex = content.length - 1
+    while (
+      lastContentIndex >= 0 &&
+      content[lastContentIndex].type === 'paragraph' &&
+      !content[lastContentIndex].content?.length
+    ) {
+      lastContentIndex--
+    }
+    return content
+      .map((child, index, siblings) => {
+        if (
+          child.type === 'paragraph' &&
+          !child.content?.length &&
+          index < lastContentIndex &&
+          ['bulletList', 'orderedList', 'taskList'].includes(siblings[index - 1]?.type ?? '')
+        ) {
+          return '<p></p>'
+        }
+        return h.renderChild?.(child, index) ?? h.renderChildren([child])
+      })
+      .join('\n\n')
+  },
 })
 
 /**
@@ -78,8 +126,9 @@ const PipeSafeTable = Table.extend({
  *   ProseMirror text never carries it and re-serialization is stable.
  */
 function guardParagraphLeading(text: string): string {
+  if (!text.trim()) return text
   const stripped = text.replace(/^[ \t]+/, '')
-  if (/^(#{1,6}([ \t]|$)|[-+][ \t]|-(?:[ \t]*-){2,}[ \t]*$)/.test(stripped)) {
+  if (/^(#{1,6}([ \t]|$)|[-+][ \t]|-(?:[ \t]*-){2,}[ \t]*$|=+[ \t]*$)/.test(stripped)) {
     return `\\${stripped}`
   }
   const ordered = /^(\d{1,9})([.)][ \t])/.exec(stripped)
@@ -93,8 +142,23 @@ function guardParagraphLeading(text: string): string {
  * paragraph renders as just its inline children; this override wraps that with the leading guard.
  */
 const BlockSafeParagraph = Paragraph.extend({
-  renderMarkdown: (node: JSONContent, h: MarkdownRendererHelpers) =>
-    guardParagraphLeading(h.renderChildren(node.content ?? [])),
+  renderMarkdown: (node: JSONContent, h, context) => {
+    if (!node.content?.length && context.parentType === 'blockquote') return '<p></p>'
+    const rendered = h.renderChildren(node.content ?? [])
+    let codeDelimiter = 0
+    return rendered
+      .split('\n')
+      .map((line) => {
+        const guarded = codeDelimiter === 0 ? guardParagraphLeading(line) : line
+        for (const match of line.matchAll(/\\.|`+/g)) {
+          if (match[0][0] !== '`') continue
+          if (codeDelimiter === 0) codeDelimiter = match[0].length
+          else if (codeDelimiter === match[0].length) codeDelimiter = 0
+        }
+        return guarded
+      })
+      .join('\n')
+  },
 })
 
 /**
@@ -126,29 +190,55 @@ export function createMarkdownContentExtensions(
   nodeViews: ContentNodeViews = {},
   options: { disableHistory?: boolean } = {}
 ): Extensions {
-  const codeBlock = (nodeViews.codeBlock ?? MarkdownCodeBlock).configure({
-    HTMLAttributes: { class: 'code-editor-theme' },
-  })
+  const codeBlock = (nodeViews.codeBlock ?? MarkdownCodeBlock)
+    .extend({
+      addInputRules() {
+        return excludeTableBlockInputRules(this.parent?.() ?? [])
+      },
+    })
+    .configure({ HTMLAttributes: { class: 'code-editor-theme' } })
   return [
-    StarterKit.configure({
+    TableAwareStarterKit.configure({
       link: { openOnClick: false, protocols: [SIM_LINK_PROTOCOL] },
       underline: false,
       codeBlock: false,
       code: false,
       paragraph: false,
-      // Collaboration provides its own (Yjs-backed) undo/redo — disabling the
-      // built-in history avoids the two fighting over the shared document.
+      bulletList: false,
+      orderedList: false,
+      document: false,
+      hardBreak: false,
+      /** Collaboration owns undo/redo whenever the document is shared. */
       ...(options.disableHistory ? { undoRedo: false as const } : {}),
     }),
+    MarkdownDocument,
     BlockSafeParagraph,
+    EmptyParagraphMarkdown,
+    JoiningBulletList.extend({
+      addInputRules() {
+        return excludeTableBlockInputRules(this.parent?.() ?? [])
+      },
+    }),
+    createJoiningOrderedList(),
+    MarkdownHardBreak,
     InlineCode,
     Highlight,
     codeBlock,
     (nodeViews.image ?? MarkdownImage).configure({ allowBase64: true }),
     nodeViews.mention ?? MarkdownMention,
     TaskList,
-    TaskItem.configure({ nested: true }),
-    PipeSafeTable.configure({ resizable: true }),
+    TaskItem.extend({
+      addInputRules() {
+        return excludeTableBlockInputRules(
+          joinListInputRules(
+            this.parent?.() ?? [],
+            this.editor.schema.nodes[this.options.taskListTypeName],
+            { joinBefore: true }
+          )
+        )
+      },
+    }).configure({ nested: true }),
+    createMarkdownTable().configure({ resizable: false }),
     TableRow,
     TableHeader,
     TableCell,

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.test.ts
@@ -1,0 +1,242 @@
+/** @vitest-environment jsdom */
+import { Editor } from '@tiptap/core'
+import { undoDepth } from '@tiptap/pm/history'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import {
+  beginImageUploads,
+  findImageUpload,
+  findImageUploadRange,
+  finishImageUpload,
+  ImageUploadPlaceholders,
+  removeImageUpload,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload'
+
+let editor: Editor
+afterEach(() => editor?.destroy())
+
+function mount(content = '<p>abcd</p>') {
+  editor = new Editor({
+    extensions: [...createMarkdownContentExtensions(), ImageUploadPlaceholders],
+    content,
+  })
+  return editor
+}
+
+describe('image upload anchors', () => {
+  it('replaces selected text only on success and never serializes the placeholder', () => {
+    const editor = mount('<p>before REPLACE after</p>')
+    const [id] = beginImageUploads(editor, { from: 8, to: 15 }, ['image.png'])
+    expect(editor.state.doc.textContent).toBe('before REPLACE after')
+    expect(undoDepth(editor.state)).toBe(0)
+    expect(editor.getMarkdown()).not.toContain('Uploading')
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(true)
+    expect(editor.getMarkdown()).toContain('![image](/image.png)')
+    expect(editor.state.doc.textContent).not.toContain('REPLACE')
+    expect(findImageUpload(editor, id)).toBeNull()
+  })
+
+  it('leaves a selected replacement intact when the upload fails or is cancelled', () => {
+    const editor = mount('<p>before REPLACE after</p>')
+    const [id] = beginImageUploads(editor, { from: 8, to: 15 }, ['image.png'])
+    removeImageUpload(editor, id)
+    expect(editor.state.doc.textContent).toBe('before REPLACE after')
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+    expect(undoDepth(editor.state)).toBe(0)
+  })
+
+  it('cancels replacement when Undo removes the selected content', () => {
+    const editor = mount('<p>before after</p>')
+    editor.commands.insertContentAt(8, 'REPLACE ')
+    const [id] = beginImageUploads(editor, { from: 8, to: 15 }, ['image.png'])
+    expect(editor.commands.undo()).toBe(true)
+    expect(editor.state.doc.textContent).toBe('before after')
+    expect(findImageUpload(editor, id)).toBeNull()
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+  })
+
+  it('undoes successful replacement in one step without reviving the pending upload', () => {
+    const editor = mount('<p>before REPLACE after</p>')
+    const [id] = beginImageUploads(editor, { from: 8, to: 15 }, ['image.png'])
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(true)
+    expect(editor.commands.undo()).toBe(true)
+    expect(editor.state.doc.textContent).toBe('before REPLACE after')
+    expect(editor.getMarkdown()).not.toContain('/image.png')
+    expect(findImageUpload(editor, id)).toBeNull()
+    expect(editor.commands.redo()).toBe(true)
+    expect(editor.getMarkdown()).toContain('/image.png')
+  })
+
+  it.each(['text', 'marks', 'deletion'] as const)(
+    'cancels the entire replacement batch when selected %s changes',
+    (change) => {
+      const editor = mount('<p>before REPLACE after</p>')
+      const ids = beginImageUploads(editor, { from: 8, to: 15 }, ['first', 'second'])
+      const transaction = editor.state.tr
+      if (change === 'text') transaction.insertText('new', 10)
+      else if (change === 'marks') transaction.addMark(9, 11, editor.schema.marks.bold.create())
+      else transaction.delete(9, 11)
+      editor.view.dispatch(transaction)
+      const edited = editor.getJSON()
+      for (const id of ids) {
+        expect(findImageUpload(editor, id)).toBeNull()
+        expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+      }
+      expect(editor.getJSON()).toEqual(edited)
+    }
+  )
+
+  it('maps a replacement through edits before it and excludes typing at either boundary', () => {
+    const editor = mount('<p>before REPLACE after</p>')
+    const [id] = beginImageUploads(editor, { from: 8, to: 15 }, ['image.png'])
+    editor.view.dispatch(editor.state.tr.insertText('PREFIX ', 1))
+    editor.view.dispatch(editor.state.tr.insertText('LEFT ', 15))
+    editor.view.dispatch(editor.state.tr.insertText(' RIGHT', 27))
+    expect(findImageUpload(editor, id)).toBe(20)
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(true)
+    expect(editor.state.doc.textContent).toBe('PREFIX before LEFT  RIGHT after')
+    expect(editor.getMarkdown()).not.toContain('REPLACE')
+  })
+
+  it('hands the mapped picker range to a new upload without reducing it to a caret', () => {
+    const editor = mount('<p>before REPLACE after</p>')
+    const [picker] = beginImageUploads(editor, { from: 8, to: 15 }, [''])
+    editor.view.dispatch(editor.state.tr.insertText('PREFIX ', 1))
+    const range = findImageUploadRange(editor, picker)
+    expect(range).toEqual({ from: 15, to: 22 })
+    removeImageUpload(editor, picker)
+    if (!range) throw new Error('Expected a surviving picker range')
+    const [upload] = beginImageUploads(editor, range, ['image.png'])
+    expect(finishImageUpload(editor, upload, '/image.png', 'image')).toBe(true)
+    expect(editor.state.doc.textContent).toBe('PREFIX before  after')
+    expect(findImageUploadRange(editor, picker)).toBeNull()
+  })
+
+  it('maps the anchor through typing before it and keeps the current caret', () => {
+    const editor = mount()
+    const [id] = beginImageUploads(editor, { from: 3, to: 3 }, ['image.png'])
+    editor.view.dispatch(editor.state.tr.insertText('PREFIX ', 1))
+    const position = findImageUpload(editor, id)
+    expect(position).toBe(10)
+    editor.commands.setTextSelection(2)
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(true)
+    expect(editor.state.selection.from).toBe(2)
+    expect(editor.state.doc.firstChild?.textContent).toBe('PREFIX ab')
+  })
+
+  it('drops uploads whose surrounding content was deleted', () => {
+    const editor = mount()
+    const [id] = beginImageUploads(editor, { from: 3, to: 3 }, ['image.png'])
+    editor.view.dispatch(editor.state.tr.delete(1, 5))
+    expect(findImageUpload(editor, id)).toBeNull()
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+    expect(editor.getMarkdown()).not.toContain('/image.png')
+  })
+
+  it('maps every queued upload before any file finishes and preserves their order', () => {
+    const editor = mount()
+    const ids = beginImageUploads(editor, { from: 3, to: 3 }, ['first', 'second'])
+    editor.view.dispatch(editor.state.tr.insertText('prefix', 1))
+    for (const [index, id] of ids.entries()) {
+      expect(finishImageUpload(editor, id, `/image-${index}.png`, String(index))).toBe(true)
+    }
+    const sources: string[] = []
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'image') sources.push(node.attrs.src)
+    })
+    expect(sources).toEqual(['/image-0.png', '/image-1.png'])
+  })
+
+  it('replaces a batch selection only once, even when the first upload fails', () => {
+    const editor = mount('<p>before REPLACE after</p>')
+    const ids = beginImageUploads(editor, { from: 8, to: 15 }, ['failed', 'second', 'third'])
+    removeImageUpload(editor, ids[0])
+    expect(editor.state.doc.textContent).toBe('before REPLACE after')
+    for (const [index, id] of ids.slice(1).entries()) {
+      expect(finishImageUpload(editor, id, `/image-${index}.png`, String(index))).toBe(true)
+    }
+    const sources: string[] = []
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'image') sources.push(node.attrs.src)
+    })
+    expect(sources).toEqual(['/image-0.png', '/image-1.png'])
+    expect(editor.state.doc.textContent).toBe('before  after')
+  })
+
+  it('keeps queued images in an empty paragraph after the first image replaces that paragraph', () => {
+    const editor = mount('<p></p>')
+    const ids = beginImageUploads(editor, editor.state.selection, ['first', 'second'])
+    for (const [index, id] of ids.entries()) {
+      expect(finishImageUpload(editor, id, `/image-${index}.png`, String(index))).toBe(true)
+    }
+    expect(editor.state.doc.childCount).toBe(3)
+    expect(editor.state.doc.firstChild?.attrs.src).toBe('/image-0.png')
+    expect(editor.state.doc.child(1).attrs.src).toBe('/image-1.png')
+    expect(editor.state.doc.lastChild?.type.name).toBe('paragraph')
+  })
+
+  it('does not add a document undo entry for a collapsed pending upload', () => {
+    const editor = mount()
+    const [id] = beginImageUploads(editor, { from: 3, to: 3 }, ['image.png'])
+    expect(undoDepth(editor.state)).toBe(0)
+    expect(editor.commands.undo()).toBe(false)
+    expect(findImageUpload(editor, id)).toBe(3)
+    editor.view.dom.querySelector<HTMLButtonElement>('button')?.click()
+    expect(findImageUpload(editor, id)).toBeNull()
+    expect(editor.state.doc.textContent).toBe('abcd')
+  })
+
+  it('cancels failed uploads without modifying document content', () => {
+    const editor = mount()
+    const [id] = beginImageUploads(editor, { from: 3, to: 3 }, ['image.png'])
+    removeImageUpload(editor, id)
+    expect(findImageUpload(editor, id)).toBeNull()
+    expect(editor.state.doc.textContent).toBe('abcd')
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+  })
+
+  it('cancels insertion without claiming to cancel the workspace upload', () => {
+    const editor = mount()
+    const [id] = beginImageUploads(editor, { from: 3, to: 3 }, ['image.png'])
+    const cancel = editor.view.dom.querySelector<HTMLButtonElement>('button')
+    expect(cancel?.textContent).toBe('Cancel insertion')
+    expect(cancel?.getAttribute('aria-label')).toBe('Cancel insertion of image.png')
+    expect(cancel?.title).toBe('The file may still finish uploading to the workspace.')
+    expect(cancel?.classList.contains('focus-visible:outline-2')).toBe(true)
+    expect(cancel?.classList.contains('focus-visible:outline-[var(--selection)]')).toBe(true)
+    cancel?.click()
+    expect(findImageUpload(editor, id)).toBeNull()
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+    expect(editor.state.doc.textContent).toBe('abcd')
+    expect(undoDepth(editor.state)).toBe(0)
+  })
+
+  it('leaves Enter on the cancel button to native activation instead of editing the document', () => {
+    const editor = mount('<p>before REPLACE after</p>')
+    document.body.append(editor.view.dom)
+    const before = editor.getJSON()
+    const [id] = beginImageUploads(editor, { from: 8, to: 15 }, ['image.png'])
+    const cancel = editor.view.dom.querySelector<HTMLButtonElement>('button')!
+    cancel.focus()
+    const enter = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    cancel.dispatchEvent(enter)
+    expect(enter.defaultPrevented).toBe(false)
+    expect(editor.getJSON()).toEqual(before)
+    cancel.click()
+    expect(document.activeElement).toBe(editor.view.dom)
+    expect(findImageUpload(editor, id)).toBeNull()
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+    expect(editor.getJSON()).toEqual(before)
+    editor.view.dom.remove()
+  })
+
+  it('does not mutate a destroyed or newly read-only editor', () => {
+    const editor = mount()
+    const [id] = beginImageUploads(editor, { from: 3, to: 3 }, ['image.png'])
+    editor.setEditable(false)
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+    editor.destroy()
+    expect(() => removeImageUpload(editor, id)).not.toThrow()
+    expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.test.ts
@@ -1,7 +1,9 @@
 /** @vitest-environment jsdom */
 import { Editor } from '@tiptap/core'
+import Collaboration from '@tiptap/extension-collaboration'
 import { undoDepth } from '@tiptap/pm/history'
 import { afterEach, describe, expect, it } from 'vitest'
+import * as Y from 'yjs'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
 import {
   beginImageUploads,
@@ -24,6 +26,40 @@ function mount(content = '<p>abcd</p>') {
 }
 
 describe('image upload anchors', () => {
+  it.each([false, true])(
+    'safely cancels an anchor replaced by a peer update (unrelated paragraph=%s)',
+    (unrelated) => {
+      const localDoc = new Y.Doc()
+      const remoteDoc = new Y.Doc()
+      const extensions = (doc: Y.Doc) => [
+        ...createMarkdownContentExtensions({}, { disableHistory: true }),
+        Collaboration.configure({ document: doc }),
+        ImageUploadPlaceholders,
+      ]
+      editor = new Editor({ extensions: extensions(localDoc) })
+      editor.commands.setContent('<p>before TARGET after</p><p>other</p>')
+      Y.applyUpdate(remoteDoc, Y.encodeStateAsUpdate(localDoc))
+      const peer = new Editor({ extensions: extensions(remoteDoc) })
+      try {
+        const [id] = beginImageUploads(editor, { from: 8, to: 14 }, ['image.png'])
+        const position = unrelated ? peer.state.doc.content.size - 1 : 10
+        peer.commands.insertContentAt(position, 'PEER ')
+        Y.applyUpdate(localDoc, Y.encodeStateAsUpdate(remoteDoc))
+        const updated = editor.getJSON()
+        expect(updated).toEqual(peer.getJSON())
+        expect(editor.getText()).toContain('PEER ')
+        expect(findImageUploadRange(editor, id)).toBeNull()
+        expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(false)
+        expect(editor.getJSON()).toEqual(updated)
+      } finally {
+        peer.destroy()
+        editor.destroy()
+        localDoc.destroy()
+        remoteDoc.destroy()
+      }
+    }
+  )
+
   it('replaces selected text only on success and never serializes the placeholder', () => {
     const editor = mount('<p>before REPLACE after</p>')
     const [id] = beginImageUploads(editor, { from: 8, to: 15 }, ['image.png'])
@@ -122,6 +158,8 @@ describe('image upload anchors', () => {
     expect(finishImageUpload(editor, id, '/image.png', 'image')).toBe(true)
     expect(editor.state.selection.from).toBe(2)
     expect(editor.state.doc.firstChild?.textContent).toBe('PREFIX ab')
+    expect(editor.state.doc.child(1).type.name).toBe('image')
+    expect(editor.state.doc.lastChild?.textContent).toBe('cd')
   })
 
   it('drops uploads whose surrounding content was deleted', () => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.ts
@@ -1,0 +1,183 @@
+import { generateShortId } from '@sim/utils/id'
+import { type Editor, Extension, type Range } from '@tiptap/core'
+import type { Slice } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+interface PendingImageUpload extends Range {
+  id: string
+  batchId: string
+  label: string
+  replacement: Slice | null
+  side: -1 | 1
+}
+
+interface ImageUploadState {
+  uploads: ReadonlyMap<string, PendingImageUpload>
+  decorations: DecorationSet
+}
+
+interface UploadPlaceholderAction {
+  add?: PendingImageUpload[]
+  remove?: string
+  complete?: string
+}
+
+const uploadPlaceholderKey = new PluginKey<ImageUploadState>('imageUploadPlaceholders')
+
+function uploadDecoration({ id, from, label, side }: PendingImageUpload): Decoration {
+  return Decoration.widget(
+    from,
+    (view) => {
+      const placeholder = document.createElement('span')
+      placeholder.contentEditable = 'false'
+      if (label) {
+        placeholder.className =
+          'mx-1 rounded border border-[var(--border)] px-2 py-1 text-[var(--text-muted)] text-small'
+        placeholder.setAttribute('role', 'status')
+        placeholder.textContent = `Uploading ${label}…`
+        const cancel = document.createElement('button')
+        cancel.type = 'button'
+        cancel.className =
+          'ml-2 underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--selection)]'
+        cancel.textContent = 'Cancel insertion'
+        cancel.setAttribute('aria-label', `Cancel insertion of ${label}`)
+        cancel.title = 'The file may still finish uploading to the workspace.'
+        cancel.addEventListener('mousedown', (event) => event.preventDefault())
+        cancel.addEventListener('click', () => {
+          const restoreFocus = document.activeElement === cancel
+          view.dispatch(view.state.tr.setMeta(uploadPlaceholderKey, { remove: id }))
+          if (restoreFocus) view.focus()
+        })
+        placeholder.append(cancel)
+      }
+      return placeholder
+    },
+    { id, key: id, side, stopEvent: () => true }
+  )
+}
+
+/** Local-only upload anchors follow document transactions without persisting temporary URLs. */
+export const ImageUploadPlaceholders = Extension.create({
+  name: 'imageUploadPlaceholders',
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<ImageUploadState>({
+        key: uploadPlaceholderKey,
+        state: {
+          init: () => ({ uploads: new Map(), decorations: DecorationSet.empty }),
+          apply(transaction, previous) {
+            const action = transaction.getMeta(uploadPlaceholderKey) as
+              | UploadPlaceholderAction
+              | undefined
+            const completed = action?.complete ? previous.uploads.get(action.complete) : undefined
+            const uploads = new Map<string, PendingImageUpload>()
+            for (const [id, upload] of previous.uploads) {
+              if (id === action?.remove || id === action?.complete) continue
+              if (completed?.batchId === upload.batchId) {
+                const position = transaction.mapping.map(upload.to, 1)
+                /** Queued siblings stay before trailing paragraphs appended after this image. */
+                uploads.set(id, {
+                  ...upload,
+                  from: position,
+                  to: position,
+                  replacement: null,
+                  side: -1,
+                })
+                continue
+              }
+              const from = transaction.mapping.mapResult(upload.from, upload.side)
+              const to = upload.replacement ? transaction.mapping.mapResult(upload.to, -1) : from
+              if (from.deleted || to.deleted) continue
+              if (
+                upload.replacement &&
+                (from.pos >= to.pos ||
+                  !transaction.doc.slice(from.pos, to.pos).eq(upload.replacement))
+              )
+                continue
+              uploads.set(id, { ...upload, from: from.pos, to: to.pos })
+            }
+            for (const upload of action?.add ?? []) uploads.set(upload.id, upload)
+            return {
+              uploads,
+              decorations: DecorationSet.create(
+                transaction.doc,
+                Array.from(uploads.values(), uploadDecoration)
+              ),
+            }
+          },
+        },
+        props: { decorations: (state) => uploadPlaceholderKey.getState(state)?.decorations },
+      }),
+    ]
+  },
+})
+
+/**
+ * Anchor queued uploads without changing selected content before success.
+ * Cancel replacement when a transaction deletes or changes the captured range.
+ */
+export function beginImageUploads(editor: Editor, range: Range, labels: string[]): string[] {
+  if (editor.isDestroyed || !editor.isEditable || labels.length === 0) return []
+  const transaction = editor.state.tr
+  const batchId = generateShortId()
+  const replacement = range.from === range.to ? null : transaction.doc.slice(range.from, range.to)
+  const placeholders = labels.map((label) => ({
+    id: generateShortId(),
+    batchId,
+    from: range.from,
+    to: range.to,
+    label,
+    replacement,
+    side: 1 as const,
+  }))
+  transaction.setMeta(uploadPlaceholderKey, { add: placeholders } satisfies UploadPlaceholderAction)
+  editor.view.dispatch(transaction)
+  return placeholders.map(({ id }) => id)
+}
+
+export function findImageUpload(editor: Editor, id: string): number | null {
+  return findImageUploadRange(editor, id)?.from ?? null
+}
+
+/** Reads the current replacement range without exposing the plugin's pending state. */
+export function findImageUploadRange(editor: Editor, id: string): Range | null {
+  if (editor.isDestroyed) return null
+  const upload = uploadPlaceholderKey.getState(editor.state)?.uploads.get(id)
+  return upload ? { from: upload.from, to: upload.to } : null
+}
+
+export function removeImageUpload(editor: Editor, id: string): void {
+  if (editor.isDestroyed) return
+  editor.view.dispatch(
+    editor.state.tr.setMeta(uploadPlaceholderKey, { remove: id } satisfies UploadPlaceholderAction)
+  )
+}
+
+/**
+ * Commit one image at its surviving range. The first successful image replaces the captured content;
+ * its queued siblings become insertion anchors after it. Cancellation and failure never delete text.
+ */
+export function finishImageUpload(editor: Editor, id: string, src: string, alt: string): boolean {
+  if (editor.isDestroyed) return false
+  const upload = uploadPlaceholderKey.getState(editor.state)?.uploads.get(id)
+  if (!upload) return false
+  if (!editor.isEditable) {
+    removeImageUpload(editor, id)
+    return false
+  }
+  const inserted = editor
+    .chain()
+    .insertContentAt(
+      { from: upload.from, to: upload.to },
+      { type: 'image', attrs: { src, alt } },
+      { updateSelection: false }
+    )
+    .command(({ tr }) => {
+      tr.setMeta(uploadPlaceholderKey, { complete: id } satisfies UploadPlaceholderAction)
+      return true
+    })
+    .run()
+  if (!inserted) removeImageUpload(editor, id)
+  return inserted
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap.test.ts
@@ -10,10 +10,13 @@ import { Editor } from '@tiptap/core'
 import { GapCursor } from '@tiptap/pm/gapcursor'
 import { AllSelection, NodeSelection } from '@tiptap/pm/state'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMarkdownEditorExtensions } from './editor-extensions'
-import { postProcessSerializedMarkdown } from './markdown-fidelity'
-import { MENTION_PLUGIN_KEY } from './mention'
-import { SLASH_COMMAND_PLUGIN_KEY } from './slash-command/slash-command'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+import { postProcessSerializedMarkdown } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import { parseMarkdownToDoc } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+import {
+  MENTION_PLUGIN_KEY,
+  SLASH_COMMAND_PLUGIN_KEY,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/suggestion-plugin-keys'
 
 function editorWith(content: string): Editor {
   return new Editor({ extensions: createMarkdownEditorExtensions({ placeholder: '' }), content })
@@ -87,6 +90,7 @@ describe('suggestion-aware arrow keymap', () => {
     editor.commands.insertContent('@gma')
 
     expect(MENTION_PLUGIN_KEY.getState(editor.state)?.active).toBe(true)
+    expect(MENTION_PLUGIN_KEY.get(editor.state)?.spec.key).toBe(MENTION_PLUGIN_KEY)
     editor.destroy()
   })
 
@@ -96,6 +100,7 @@ describe('suggestion-aware arrow keymap', () => {
     editor.commands.insertContent('/')
 
     expect(SLASH_COMMAND_PLUGIN_KEY.getState(editor.state)?.active).toBe(true)
+    expect(SLASH_COMMAND_PLUGIN_KEY.get(editor.state)?.spec.key).toBe(SLASH_COMMAND_PLUGIN_KEY)
     editor.destroy()
   })
 
@@ -351,7 +356,9 @@ describe('list Backspace (clear / outdent)', () => {
     expect(editor.state.selection.empty).toBe(true)
     expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
     expect(editor.state.selection.$from.parent.textContent).toBe('')
-    expect(editor.getMarkdown().trim()).toBe('- one')
+    const saved = postProcessSerializedMarkdown(editor.getMarkdown())
+    editor.commands.setContent(parseMarkdownToDoc(saved))
+    expect(blockShape(editor)).toEqual(['bulletList', 'paragraph'])
     editor.destroy()
   })
 
@@ -508,20 +515,46 @@ describe('empty list-item Enter', () => {
     Element.prototype.scrollIntoView = vi.fn()
   })
 
-  it('removes an empty MIDDLE item instead of splitting the list into a stranded paragraph', () => {
+  it.each([
+    ['bulletList', '- one\n- two\n- three'],
+    ['orderedList', '1. one\n2. two\n3. three'],
+    ['taskList', '- [ ] one\n- [ ] two\n- [x] three'],
+  ])('removes an empty middle %s item without splitting the list', (listType, markdown) => {
     const editor = editorWith('')
-    editor.commands.setContent('- one\n- two\n- three', { contentType: 'markdown' })
+    editor.commands.setContent(markdown, { contentType: 'markdown' })
     editor.commands.focus()
     emptyItem(editor, 'two')
     pressKey(editor, 'Enter')
 
-    const { md, reparsed } = markdownRoundTrip(editor)
-    expect(md.trim()).toBe('- one\n- three')
-    expect(reparsed).toBe(md)
+    expect(editor.state.doc.child(0).type.name).toBe(listType)
+    expect(editor.state.doc.child(0).childCount).toBe(2)
+    expect(editor.state.selection.$from.parent.textContent).toBe('one')
+
+    const saved = postProcessSerializedMarkdown(editor.getMarkdown())
+    editor.commands.setContent(parseMarkdownToDoc(saved))
+    expect(editor.state.doc.child(0).type.name).toBe(listType)
+    expect(editor.state.doc.child(0).childCount).toBe(2)
+    expect(postProcessSerializedMarkdown(editor.getMarkdown())).toBe(saved)
     editor.destroy()
   })
 
-  it('leaves an empty TRAILING item to the default (exits the list)', () => {
+  it('Enter twice after a middle bullet preserves the existing whole-list behavior', () => {
+    const editor = editorWith('')
+    editor.commands.setContent('- one\n- two', { contentType: 'markdown' })
+    editor.commands.setTextSelection(6)
+    pressKey(editor, 'Enter')
+    expect(editor.isActive('listItem')).toBe(true)
+    expect(editor.state.selection.$from.parent.textContent).toBe('')
+    pressKey(editor, 'Enter')
+
+    expect(editor.isActive('listItem')).toBe(true)
+    expect(editor.state.selection.$from.parent.textContent).toBe('one')
+    expect(editor.state.selection.$from.parentOffset).toBe(3)
+    expect(editor.getMarkdown().trim()).toBe('- one\n- two')
+    editor.destroy()
+  })
+
+  it('exits an empty trailing item into a paragraph', () => {
     const editor = editorWith('')
     editor.commands.setContent('- one\n- two', { contentType: 'markdown' })
     editor.commands.focus()
@@ -577,6 +610,91 @@ describe('empty list-item Enter', () => {
     expect(editor.state.doc.textContent).toBe('more')
     const list = editor.getJSON().content?.find((n) => n.type === 'bulletList')
     expect(list?.content).toHaveLength(1)
+    editor.destroy()
+  })
+})
+
+describe('list item descendant preservation', () => {
+  it.each(['Backspace', 'Enter'])(
+    '%s preserves nested descendants without lifting their parent',
+    (key) => {
+      const editor = editorWith(
+        '<ul><li><p>one</p></li><li><p></p><ul><li><p><strong>child</strong></p><ul><li><p>grandchild</p></li></ul></li></ul></li><li><p>three</p></li></ul>'
+      )
+      editor.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'paragraph' && node.content.size === 0) {
+          editor.commands.setTextSelection(pos + 1)
+        }
+      })
+      const before = editor.getJSON()
+      pressKey(editor, key)
+
+      expect(editor.state.selection.$from.parent.textContent).toBe('one')
+      expect(editor.state.doc.textContent).toBe('onechildgrandchildthree')
+      expect(editor.getHTML()).toContain('<strong>child</strong>')
+      expect(editor.state.doc.child(0).type.name).toBe('bulletList')
+      expect(editor.state.doc.child(0).childCount).toBe(3)
+      expect(editor.state.doc.child(0).child(1).textContent).toBe('childgrandchild')
+      expect(editor.commands.undo()).toBe(true)
+      expect(editor.getJSON()).toEqual(before)
+      editor.destroy()
+    }
+  )
+
+  it.each(['Backspace', 'Enter'])(
+    '%s removes a replaceable leading paragraph while retaining the whole list',
+    (key) => {
+      const editor = editorWith(
+        '<ul><li><p>one</p></li><li><p></p><p>continuation</p></li><li><p>three</p></li></ul>'
+      )
+      editor.state.doc.descendants((node, pos) => {
+        if (node.type.name === 'paragraph' && node.content.size === 0) {
+          editor.commands.setTextSelection(pos + 1)
+        }
+      })
+      pressKey(editor, key)
+
+      expect(editor.state.selection.$from.parent.textContent).toBe('one')
+      expect(editor.state.selection.$from.parentOffset).toBe(3)
+      expect(editor.state.doc.child(0).child(1).childCount).toBe(1)
+      expect(editor.state.doc.textContent).toBe('onecontinuationthree')
+      editor.destroy()
+    }
+  )
+})
+
+describe('code select-all boundaries', () => {
+  function selectAllKey(editor: Editor): void {
+    editor.view.dom.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'a',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+  }
+
+  it('does not shrink a selection that spans a code block and prose', () => {
+    const editor = editorWith('<pre><code>alpha</code></pre><p>beta</p>')
+    editor.commands.setTextSelection({ from: 2, to: 10 })
+    selectAllKey(editor)
+
+    expect(editor.state.selection instanceof AllSelection).toBe(true)
+    expect(editor.state.selection.from).toBe(0)
+    expect(editor.state.selection.to).toBe(editor.state.doc.content.size)
+    editor.destroy()
+  })
+
+  it('selects code first and the document on the second press', () => {
+    const editor = editorWith('<pre><code>alpha</code></pre><p>beta</p>')
+    editor.commands.setTextSelection(3)
+    selectAllKey(editor)
+
+    expect(editor.state.selection.from).toBe(1)
+    expect(editor.state.selection.to).toBe(6)
+    selectAllKey(editor)
+    expect(editor.state.selection instanceof AllSelection).toBe(true)
     editor.destroy()
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap.ts
@@ -4,8 +4,10 @@ import { GapCursor } from '@tiptap/pm/gapcursor'
 import type { ResolvedPos } from '@tiptap/pm/model'
 import { NodeSelection, Plugin, PluginKey, Selection } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
-import { MENTION_PLUGIN_KEY } from './mention'
-import { SLASH_COMMAND_PLUGIN_KEY } from './slash-command/slash-command'
+import {
+  MENTION_PLUGIN_KEY,
+  SLASH_COMMAND_PLUGIN_KEY,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/suggestion-plugin-keys'
 
 /** Leaf nodes that have no text position, so they can only be reached as a NodeSelection. */
 const SELECTABLE_LEAVES = new Set(['horizontalRule', 'image'])
@@ -58,7 +60,7 @@ function getListItemContext($from: ResolvedPos): ListItemContext | null {
       blockEmpty: $from.parent.content.size === 0,
       hasSiblingBlocks: item.childCount > 1,
       isTrailing: $from.index(listDepth) === list.childCount - 1,
-      isFirstBlock: $from.index(depth) === 0,
+      isFirstBlock: $from.depth === depth + 1 && $from.index(depth) === 0,
     }
   }
   return null
@@ -177,42 +179,16 @@ function selectAdjacentSelectedLeaf(editor: Editor, direction: 'up' | 'down'): b
 }
 
 /**
- * Editor-specific keyboard behavior layered on top of StarterKit's defaults:
+ * Keyboard behavior layered over StarterKit. Backspace first undoes autoformatting, then clears
+ * headings, outdents list items, and handles empty wrappers without selecting unrelated content.
+ * Enter exits trailing empty items and outdents nested items. Empty middle items retain the existing
+ * removal behavior: lifting them splits the list and can discard delayed collaborative edits.
+ * Multi-block items remove only the empty block. Code select-all is scoped only while both
+ * endpoints remain inside the same code block, then expands to the document on a second press.
  *
- * - **Backspace** at the start of a heading reverts it to a paragraph (ProseMirror's default joins or
- *   no-ops, stranding the heading style; a second Backspace then merges as usual). At the start of a
- *   *list or task item* it outdents or clears in place via {@link getListItemContext}: a nested item outdents one
- *   level, a top-level item with text lifts out of the list into a paragraph (keeping the text), and a
- *   top-level *empty trailing* (or sole) item lifts into an empty paragraph in place — so the blank
- *   bullet made by pressing Enter can be cleared back to normal text on the same line instead of being
- *   deleted with the caret jumping to the previous block. The one case lift can't take is a top-level
- *   *empty, non-trailing* item: lifting it strands an empty paragraph between the two list halves, which
- *   re-parses to a different markdown document (an empty line between list items is a loose list, not a
- *   break); that item is removed via {@link removeEmptyWrappedBlock} instead, keeping the list whole. An
- *   empty block inside a *blockquote* is likewise removed via {@link removeEmptyWrappedBlock}. At the
- *   start of a block whose previous sibling is a divider or image, where ProseMirror's `joinBackward`
- *   can't cross the leaf and no-ops: an *empty* block is deleted (clearing the blank line between/below
- *   dividers without touching the divider itself), while a *non-empty* block selects the leaf — so a
- *   first Backspace highlights what a second deletes, the same highlight-before-delete affordance as
- *   clicking it and parity with the arrow-key leaf selection.
- * - **Enter** on an empty *nested* list/task item outdents it one level, on an empty
- *   *non-trailing top-level* item removes it ({@link removeEmptyWrappedBlock}) rather than splitting the
- *   list around a stranded empty paragraph (which does not round-trip), and on an empty *trailing* item
- *   falls through to the default, which exits the list — the standard "press Enter on a blank bullet to
- *   leave the list".
- * - **Mod-A** inside a code block selects only that block's contents; pressing it again (when the
- *   block is already fully selected) falls through to the default whole-document select-all, the
- *   same scoped behavior as a code editor.
- * - **ArrowUp/ArrowDown** select an adjacent divider or image, whether arrowing off a textblock edge
- *   ({@link selectAdjacentLeaf}) or stepping from one already-selected leaf to the next
- *   ({@link selectAdjacentSelectedLeaf}). (The `Mod-Shift-Arrow` block-reorder chords live separately
- *   in `./block-mover.ts`.)
- *
- * Plus a plugin that (a) highlights dividers/images falling inside a focused range selection (e.g.
- * select-all), which the browser's native text highlight skips because leaves carry no text; hiding
- * that custom decoration on blur keeps it in sync with the native text highlight, and (b) flags the
- * editor (`data-gap-between-leaves`) while a gap cursor sits between two leaves, so the CSS can hide
- * its otherwise-stray caret.
+ * Leaf arrow navigation and focused-range decorations provide keyboard selection for images and
+ * dividers. Suggestions retain their own arrow handling. A root gap between leaves is tagged so
+ * the editor's local styles can suppress a duplicate caret.
  */
 export const RichMarkdownKeymap = Extension.create({
   name: 'richMarkdownKeymap',
@@ -221,13 +197,11 @@ export const RichMarkdownKeymap = Extension.create({
   addKeyboardShortcuts() {
     return {
       Backspace: ({ editor }) => {
+        if (editor.commands.undoInputRule()) return true
         const { selection, doc } = editor.state
         if (!selection.empty || selection.$from.parentOffset !== 0) return false
         const { $from } = selection
-        // A gap cursor at the start of the doc resolves at the top level (`depth === 0`, offset 0):
-        // `$from.before(0)` below throws, and falling through instead is no better — TipTap's
-        // blockquote Backspace handler crashes on the same resolution (`$from.node(-1)` is
-        // undefined). There is nothing before the gap for Backspace to act on, so consume the key.
+        /** Root gaps have no parent boundary and no preceding content to remove. */
         if ($from.depth === 0) return true
         if ($from.parent.type.name === 'heading') {
           return editor.commands.setParagraph()
@@ -235,20 +209,6 @@ export const RichMarkdownKeymap = Extension.create({
         const listCtx = getListItemContext($from)
         if (listCtx?.isFirstBlock) {
           const { itemType, isNested, blockEmpty, hasSiblingBlocks, isTrailing } = listCtx
-          // Backspace at the start of a bullet outdents or clears it in place rather than
-          // deleting the row and jumping the caret to the previous block.
-          // - Nested item → outdent one level (empty or not).
-          // - Top-level item whose first line has content (text OR an inline image/mention) → lift out of
-          //   the list into a paragraph, keeping that content.
-          // - Top-level item whose empty first block has *sibling* blocks (a continuation paragraph, a
-          //   block image, a nested list) → remove only that empty first block via {@link
-          //   removeEmptyWrappedBlock}, leaving the rest of the item intact (never lift the whole item).
-          // - Top-level empty single-block item that is trailing (or the sole item) → lift into an empty
-          //   paragraph in place, so a fresh bullet made with Enter can be cleared to normal text in place.
-          // A top-level *empty, non-trailing* single-block item is the one case lift can't take: it strands
-          // an empty paragraph between the two list halves, which re-parses to a different markdown document
-          // (an empty line between list items is a loose list, not a break). That case removes the row via
-          // {@link removeEmptyWrappedBlock} instead, which keeps the list whole and round-trips.
           if (isNested || !blockEmpty) return editor.commands.liftListItem(itemType)
           if (hasSiblingBlocks) return removeEmptyWrappedBlock(editor, $from)
           if (isTrailing) return editor.commands.liftListItem(itemType)
@@ -280,20 +240,14 @@ export const RichMarkdownKeymap = Extension.create({
         if ($from.parent.content.size !== 0) return false
         const listCtx = getListItemContext($from)
         if (!listCtx?.isFirstBlock) return false
-        // Enter on an empty item, mirroring the Backspace cases above: a nested item outdents one level;
-        // an empty first block that has *sibling* blocks (continuation paragraph, block image, nested
-        // list) removes only that empty block in place, keeping the rest of the item — never exiting the
-        // list or splitting it; a trailing single-block item falls through to the default (exits the
-        // list); and a non-trailing single-block item is removed rather than splitting the list around a
-        // stranded empty paragraph (which does not round-trip).
         if (listCtx.isNested) return editor.commands.liftListItem(listCtx.itemType)
         if (listCtx.hasSiblingBlocks) return removeEmptyWrappedBlock(editor, $from)
         if (listCtx.isTrailing) return false
         return removeEmptyWrappedBlock(editor, $from)
       },
       'Mod-a': ({ editor }) => {
-        const { $from } = editor.state.selection
-        if ($from.parent.type.name !== 'codeBlock') return false
+        const { $from, $to } = editor.state.selection
+        if ($from.parent.type.name !== 'codeBlock' || !$from.sameParent($to)) return false
         const from = $from.start($from.depth)
         const to = $from.end($from.depth)
         if (editor.state.selection.from === from && editor.state.selection.to === to) return false

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-collaboration.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-collaboration.test.ts
@@ -1,0 +1,161 @@
+/** @vitest-environment jsdom */
+import { Editor } from '@tiptap/core'
+import { yUndoPluginKey } from '@tiptap/y-tiptap'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Awareness } from 'y-protocols/awareness'
+import * as Y from 'yjs'
+import { markdownToYDoc } from '@/lib/collab-doc/converter'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+
+interface Peer {
+  doc: Y.Doc
+  editor: Editor
+  updates: Uint8Array[]
+}
+
+const cleanups: Array<() => void> = []
+afterEach(() => cleanups.splice(0).forEach((cleanup) => cleanup()))
+
+function pair(): { a: Peer; b: Peer } {
+  document.elementFromPoint ??= () => null
+  const seed = markdownToYDoc('## Todos\n\n- one\n- two\n- three')
+  const make = (): Peer => {
+    const doc = new Y.Doc()
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(seed))
+    const awareness = new Awareness(doc)
+    const editor = new Editor({
+      extensions: createMarkdownEditorExtensions({
+        placeholder: '',
+        collaboration: { doc, awareness, user: { name: 'User', color: '#ffffff' } },
+      }),
+    })
+    const updates: Uint8Array[] = []
+    doc.on('update', (update: Uint8Array, origin: unknown) => {
+      if (origin !== 'remote') updates.push(update)
+    })
+    cleanups.push(() => {
+      editor.destroy()
+      awareness.destroy()
+      doc.destroy()
+    })
+    return { doc, editor, updates }
+  }
+  const a = make()
+  const b = make()
+  seed.destroy()
+  return { a, b }
+}
+
+function findText(editor: Editor, text: string): number {
+  let position = -1
+  editor.state.doc.descendants((node, pos) => {
+    if (node.isText && node.text === text) position = pos
+  })
+  expect(position).toBeGreaterThan(-1)
+  return position
+}
+
+function key(editor: Editor, name: string): void {
+  editor.view.dom.dispatchEvent(
+    new KeyboardEvent('keydown', { key: name, bubbles: true, cancelable: true })
+  )
+}
+
+/** Delivers independently authored changes, including patches arriving before their prerequisites. */
+function reconnect(a: Peer, b: Peer, reversed: boolean): void {
+  const changesA = a.updates.slice()
+  const changesB = b.updates.slice()
+  if (reversed) {
+    changesA.reverse()
+    changesB.reverse()
+  }
+  for (const update of changesA) Y.applyUpdate(b.doc, update, 'remote')
+  for (const update of changesB) Y.applyUpdate(a.doc, update, 'remote')
+  expect(a.editor.getJSON()).toEqual(b.editor.getJSON())
+}
+
+describe('list editing with delayed peer updates', () => {
+  it.each([false, true])(
+    'joining above a list retains every peer insertion (reordered=%s)',
+    (reversed) => {
+      const { a, b } = pair()
+      for (const word of ['one', 'two', 'three']) {
+        b.editor.commands.insertContentAt(findText(b.editor, word), 'PEER ')
+      }
+      a.editor.commands.setTextSelection(findText(a.editor, 'Todos') + 5)
+      key(a.editor, 'Enter')
+      a.editor.commands.insertContent('-')
+      const { from, to } = a.editor.state.selection
+      expect(
+        a.editor.view.someProp('handleTextInput', (handler) =>
+          handler(a.editor.view, from, to, ' ', () => a.editor.state.tr)
+        )
+      ).toBe(true)
+      a.editor.commands.insertContent('new item')
+      reconnect(a, b, reversed)
+
+      for (const word of ['one', 'two', 'three']) {
+        expect(a.editor.state.doc.textContent).toContain(`PEER ${word}`)
+      }
+      expect(a.editor.state.doc.textContent).toContain('new item')
+    }
+  )
+
+  it('retains peer text when an empty middle item is removed without reparenting its siblings', () => {
+    const { a, b } = pair()
+    b.editor.commands.insertContentAt(findText(b.editor, 'one'), 'PEER ')
+    a.editor.commands.setTextSelection(findText(a.editor, 'one') + 3)
+    key(a.editor, 'Enter')
+    const { $from } = a.editor.state.selection
+    a.editor.commands.deleteRange({ from: $from.before(-1), to: $from.after(-1) })
+    reconnect(a, b, true)
+
+    expect(a.editor.state.doc.textContent).toContain('PEER one')
+  })
+
+  it('undoes a local bullet join without undoing received peer text', () => {
+    const { a, b } = pair()
+    const history: { undoManager: Y.UndoManager } = yUndoPluginKey.getState(a.editor.state)
+    history.undoManager.clear()
+    a.editor.commands.setTextSelection(findText(a.editor, 'Todos') + 5)
+    key(a.editor, 'Enter')
+    a.editor.commands.insertContent('-')
+    const { from, to } = a.editor.state.selection
+    a.editor.view.someProp('handleTextInput', (handler) =>
+      handler(a.editor.view, from, to, ' ', () => a.editor.state.tr)
+    )
+    a.editor.commands.insertContent('new item')
+    b.editor.commands.insertContentAt(findText(b.editor, 'one'), 'PEER ')
+    reconnect(a, b, true)
+    history.undoManager.stopCapturing()
+
+    expect(a.editor.commands.undo()).toBe(true)
+    reconnect(a, b, false)
+    expect(a.editor.state.doc.textContent).toContain('PEER one')
+    expect(a.editor.state.doc.textContent).not.toContain('new item')
+  })
+
+  /**
+   * Keep the middle list intact until lifting can preserve delayed edits: the binding copies one
+   * half of a split list into new CRDT identities. Convergence alone does not prove preservation.
+   * https://github.com/yjs/y-prosemirror/blob/master/CAVEATS.md#node-splitting-merging-and-lifting
+   */
+  it.each([false, true])(
+    'clearing a new middle item retains concurrent text in every sibling (reordered=%s)',
+    (reversed) => {
+      const { a, b } = pair()
+      for (const word of ['one', 'two', 'three']) {
+        b.editor.commands.insertContentAt(findText(b.editor, word), 'PEER ')
+        expect(b.editor.state.doc.textContent).toContain(`PEER ${word}`)
+      }
+      a.editor.commands.setTextSelection(findText(a.editor, 'one') + 3)
+      key(a.editor, 'Enter')
+      key(a.editor, 'Enter')
+      reconnect(a, b, reversed)
+
+      for (const word of ['one', 'two', 'three']) {
+        expect(a.editor.state.doc.textContent).toContain(`PEER ${word}`)
+      }
+    }
+  )
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-collaboration.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-collaboration.test.ts
@@ -16,9 +16,9 @@ interface Peer {
 const cleanups: Array<() => void> = []
 afterEach(() => cleanups.splice(0).forEach((cleanup) => cleanup()))
 
-function pair(): { a: Peer; b: Peer } {
+function pair(content = '## Todos\n\n- one\n- two\n- three', html = false): { a: Peer; b: Peer } {
   document.elementFromPoint ??= () => null
-  const seed = markdownToYDoc('## Todos\n\n- one\n- two\n- three')
+  const seed = markdownToYDoc(html ? '' : content)
   const make = (): Peer => {
     const doc = new Y.Doc()
     Y.applyUpdate(doc, Y.encodeStateAsUpdate(seed))
@@ -41,6 +41,11 @@ function pair(): { a: Peer; b: Peer } {
     return { doc, editor, updates }
   }
   const a = make()
+  if (html) {
+    a.editor.commands.setContent(content)
+    Y.applyUpdate(seed, Y.encodeStateAsUpdate(a.doc))
+    a.updates.length = 0
+  }
   const b = make()
   seed.destroy()
   return { a, b }
@@ -75,6 +80,57 @@ function reconnect(a: Peer, b: Peer, reversed: boolean): void {
 }
 
 describe('list editing with delayed peer updates', () => {
+  describe.each(['bullet', 'ordered', 'task'] as const)('%s list boundaries', (kind) => {
+    it.each(
+      [1, 2].flatMap((beforeCount) =>
+        [false, true].flatMap((nested) =>
+          [false, true].map((reversed) => ({ beforeCount, nested, reversed }))
+        )
+      )
+    )(
+      'retains both existing roots ($beforeCount items, nested=$nested, reversed=$reversed)',
+      ({ beforeCount, nested, reversed }) => {
+        const words = [...['one', 'two'].slice(0, beforeCount), 'three', 'four']
+        const list = (items: string[], start: number) => {
+          const tag = kind === 'ordered' ? 'ol' : 'ul'
+          const attrs =
+            kind === 'task'
+              ? ' data-type="taskList"'
+              : kind === 'ordered'
+                ? ` start="${start}"`
+                : ''
+          const itemAttrs = kind === 'task' ? ' data-type="taskItem" data-checked="false"' : ''
+          return `<${tag}${attrs}>${items.map((word) => `<li${itemAttrs}><p>${word}</p></li>`).join('')}</${tag}>`
+        }
+        const marker = kind === 'ordered' ? `${beforeCount + 1}.` : kind === 'task' ? '[ ]' : '-'
+        const content = `${list(words.slice(0, beforeCount), 1)}<p>${marker}</p>${list(words.slice(beforeCount), beforeCount + 2)}`
+        const { a, b } = pair(nested ? `<ul><li><p>parent</p>${content}</li></ul>` : content, true)
+        for (const word of words) {
+          b.editor.commands.insertContentAt(findText(b.editor, word), 'PEER ')
+        }
+        a.editor.commands.setTextSelection(findText(a.editor, marker) + marker.length)
+        const { from, to } = a.editor.state.selection
+        expect(
+          a.editor.view.someProp('handleTextInput', (handler) =>
+            handler(a.editor.view, from, to, ' ', () => a.editor.state.tr)
+          )
+        ).toBe(true)
+        a.editor.commands.insertContent('new item')
+        const container = nested ? a.editor.state.doc.firstChild!.firstChild! : a.editor.state.doc
+        const listType =
+          kind === 'task' ? 'taskList' : kind === 'ordered' ? 'orderedList' : 'bulletList'
+        const lists = Array.from({ length: container.childCount }, (_, index) =>
+          container.child(index)
+        ).filter((node) => node.type.name === listType)
+        expect(lists.map((node) => node.childCount)).toEqual([beforeCount + 1, 2])
+        expect(a.editor.state.selection.$from.parent.textContent).toBe('new item')
+        reconnect(a, b, reversed)
+        for (const word of words) expect(a.editor.state.doc.textContent).toContain(`PEER ${word}`)
+        expect(a.editor.state.doc.textContent).toContain('new item')
+      }
+    )
+  })
+
   it.each([false, true])(
     'joining above a list retains every peer insertion (reordered=%s)',
     (reversed) => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules.test.ts
@@ -83,7 +83,7 @@ describe('typed numbered list joining', () => {
     expect(ed.getMarkdown().trim()).toBe(`${start}. new\n${start + 1}. **one**\n${start + 2}. two`)
   })
 
-  it('joins both neighbors only when both numbering boundaries continue', () => {
+  it('joins a preceding continuation without merging two existing roots', () => {
     const ed = mount(
       '<ol start="4"><li><p>one</p></li></ol><p></p><ol start="6"><li><p>three</p></li></ol>'
     )
@@ -91,8 +91,8 @@ describe('typed numbered list joining', () => {
     expect(typeMarker(ed, '5.')).toBe(true)
     ed.commands.insertContent('two')
 
-    expect(ed.getJSON().content?.filter((node) => node.type === 'orderedList')).toHaveLength(1)
-    expect(ed.getMarkdown().trim()).toBe('4. one\n5. two\n6. three')
+    expect(ed.getJSON().content?.filter((node) => node.type === 'orderedList')).toHaveLength(2)
+    expect(ed.getMarkdown().trim()).toBe('4. one\n5. two\n\n6) three')
   })
 
   it.each([1, 3, 7])('preserves a following explicit restart at %s', (nextStart) => {
@@ -149,20 +149,17 @@ describe('typed task list joining', () => {
     }
   )
 
-  it('joins checklists on both sides of the new item', () => {
+  it('joins the preceding checklist without merging two existing roots', () => {
     const ed = mount(`${TASKS}<p></p>${TASKS}`)
     selectEmptyParagraph(ed)
     expect(typeMarker(ed, '[ ]')).toBe(true)
     ed.commands.insertContent('new')
 
     const lists = ed.getJSON().content?.filter((node) => node.type === 'taskList')
-    expect(lists).toHaveLength(1)
-    expect(lists?.[0].content?.map((node) => node.attrs?.checked)).toEqual([
-      true,
-      false,
-      false,
-      true,
-      false,
+    expect(lists).toHaveLength(2)
+    expect(lists?.map((list) => list.content?.map((node) => node.attrs?.checked))).toEqual([
+      [true, false, false],
+      [true, false],
     ])
     expect(ed.state.selection.$from.parent.textContent).toBe('new')
   })
@@ -182,19 +179,22 @@ describe('list input-rule boundaries and undo', () => {
   it.each([
     ['5.', '<ol start="4"><li><p>one</p></li></ol>', '<ol start="6"><li><p>three</p></li></ol>'],
     ['[x]', TASKS, TASKS],
-  ])('undoes both adjacent joins together for %s', (marker, before, after) => {
-    const ed = mount(`${before}<p></p>${after}`)
-    const originalBefore = ed.state.doc.child(0).toJSON()
-    const originalAfter = ed.state.doc.child(2).toJSON()
-    selectEmptyParagraph(ed)
-    expect(typeMarker(ed, marker)).toBe(true)
-    expect(ed.commands.undoInputRule()).toBe(true)
+  ])(
+    'undoes the preceding join while retaining the following list for %s',
+    (marker, before, after) => {
+      const ed = mount(`${before}<p></p>${after}`)
+      const originalBefore = ed.state.doc.child(0).toJSON()
+      const originalAfter = ed.state.doc.child(2).toJSON()
+      selectEmptyParagraph(ed)
+      expect(typeMarker(ed, marker)).toBe(true)
+      expect(ed.commands.undoInputRule()).toBe(true)
 
-    expect(ed.state.doc.child(0).toJSON()).toEqual(originalBefore)
-    expect(ed.state.doc.child(1).textContent).toBe(`${marker} `)
-    expect(ed.state.doc.child(2).toJSON()).toEqual(originalAfter)
-    expect(ed.state.selection.$from.parent.textContent).toBe(`${marker} `)
-  })
+      expect(ed.state.doc.child(0).toJSON()).toEqual(originalBefore)
+      expect(ed.state.doc.child(1).textContent).toBe(`${marker} `)
+      expect(ed.state.doc.child(2).toJSON()).toEqual(originalAfter)
+      expect(ed.state.selection.$from.parent.textContent).toBe(`${marker} `)
+    }
+  )
 
   it.each([
     ['1.', '<ol start="2"><li><p>one</p></li></ol>', 'orderedList'],

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules.test.ts
@@ -1,0 +1,266 @@
+/** @vitest-environment jsdom */
+import { Editor } from '@tiptap/core'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+
+let editor: Editor | undefined
+
+afterEach(() => {
+  editor?.destroy()
+  editor = undefined
+})
+
+function mount(content: string): Editor {
+  editor = new Editor({
+    extensions: createMarkdownEditorExtensions({ placeholder: '' }),
+    content,
+  })
+  return editor
+}
+
+function selectEmptyParagraph(ed: Editor): void {
+  let position: number | undefined
+  ed.state.doc.descendants((node, pos) => {
+    if (position === undefined && node.type.name === 'paragraph' && !node.content.size) {
+      position = pos + 1
+    }
+  })
+  expect(position).toBeDefined()
+  ed.commands.setTextSelection(position ?? 1)
+}
+
+/** Runs the real input-rule handler for the final space, as browser typing does. */
+function typeMarker(ed: Editor, marker: string): boolean {
+  ed.commands.insertContent(marker)
+  const { from, to } = ed.state.selection
+  return (
+    ed.view.someProp('handleTextInput', (handler) =>
+      handler(ed.view, from, to, ' ', () => ed.state.tr)
+    ) ?? false
+  )
+}
+
+const TASKS =
+  '<ul data-type="taskList"><li data-type="taskItem" data-checked="true"><p><strong>done</strong></p></li><li data-type="taskItem" data-checked="false"><p>todo</p></li></ul>'
+
+describe('typed numbered list joining', () => {
+  it('parses different standard decimal delimiters as separate lists', () => {
+    const ed = mount('<p></p>')
+    ed.commands.setContent('1. first\n\n7) second', { contentType: 'markdown' })
+    expect(
+      ed
+        .getJSON()
+        .content?.filter((node) => node.type === 'orderedList')
+        .map((node) => node.attrs?.start)
+    ).toEqual([1, 7])
+  })
+
+  it('retains separate restart nodes when reloading the serialized markdown', () => {
+    const ed = mount('<p></p><ol start="7"><li><p>one</p></li></ol>')
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, '1.')).toBe(true)
+    ed.commands.insertContent('new')
+    const original = ed.getJSON().content?.slice(0, 2)
+    ed.commands.setContent(ed.getMarkdown(), { contentType: 'markdown' })
+    expect(ed.getJSON().content?.slice(0, 2)).toEqual(original)
+  })
+
+  it.each([0, 1, 4, 9, 99])('joins a following continuation when typing %s.', (start) => {
+    const ed = mount(
+      `<p></p><ol start="${start + 1}"><li><p><strong>one</strong></p></li><li><p>two</p></li></ol>`
+    )
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, `${start}.`)).toBe(true)
+    ed.commands.insertContent('new')
+
+    expect(ed.getJSON().content?.filter((node) => node.type === 'orderedList')).toHaveLength(1)
+    expect(ed.state.doc.firstChild?.attrs.start).toBe(start)
+    expect(ed.state.doc.firstChild?.childCount).toBe(3)
+    expect(ed.state.doc.firstChild?.child(1).firstChild?.firstChild?.marks[0].type.name).toBe(
+      'bold'
+    )
+    expect(ed.state.selection.$from.parent.textContent).toBe('new')
+    expect(ed.getMarkdown().trim()).toBe(`${start}. new\n${start + 1}. **one**\n${start + 2}. two`)
+  })
+
+  it('joins both neighbors only when both numbering boundaries continue', () => {
+    const ed = mount(
+      '<ol start="4"><li><p>one</p></li></ol><p></p><ol start="6"><li><p>three</p></li></ol>'
+    )
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, '5.')).toBe(true)
+    ed.commands.insertContent('two')
+
+    expect(ed.getJSON().content?.filter((node) => node.type === 'orderedList')).toHaveLength(1)
+    expect(ed.getMarkdown().trim()).toBe('4. one\n5. two\n6. three')
+  })
+
+  it.each([1, 3, 7])('preserves a following explicit restart at %s', (nextStart) => {
+    const ed = mount(`<p></p><ol start="${nextStart}"><li><p>one</p></li></ol>`)
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, '1.')).toBe(true)
+
+    expect(ed.getJSON().content?.filter((node) => node.type === 'orderedList')).toHaveLength(2)
+    expect(ed.state.doc.child(1).attrs.start).toBe(nextStart)
+  })
+
+  it('does not convert the styling of a following alphabetic list', () => {
+    const ed = mount('<p></p><ol start="2" type="a"><li><p>one</p></li></ol>')
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, '1.')).toBe(true)
+
+    expect(ed.getJSON().content?.filter((node) => node.type === 'orderedList')).toHaveLength(2)
+    expect(ed.state.doc.child(1).attrs.type).toBe('a')
+  })
+
+  it('joins a nested continuation at its existing depth', () => {
+    const ed = mount(
+      '<ul><li><p>parent</p><p></p><ol start="2"><li><p>child</p></li></ol></li></ul>'
+    )
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, '1.')).toBe(true)
+    ed.commands.insertContent('new')
+
+    expect(ed.state.doc.firstChild?.firstChild?.childCount).toBe(2)
+    expect(ed.state.doc.firstChild?.firstChild?.child(1).childCount).toBe(2)
+    expect(ed.state.selection.$from.depth).toBe(5)
+  })
+})
+
+describe('typed task list joining', () => {
+  it.each([
+    ['[ ]', false],
+    ['[x]', true],
+  ] as const)(
+    'joins %s to the following checklist without changing checked states',
+    (marker, checked) => {
+      const ed = mount(`<p></p>${TASKS}`)
+      selectEmptyParagraph(ed)
+      expect(typeMarker(ed, marker)).toBe(true)
+      ed.commands.insertContent('new')
+
+      const lists = ed.getJSON().content?.filter((node) => node.type === 'taskList')
+      expect(lists).toHaveLength(1)
+      expect(lists?.[0].content?.map((node) => node.attrs?.checked)).toEqual([checked, true, false])
+      expect(ed.state.doc.firstChild?.child(1).firstChild?.firstChild?.marks[0].type.name).toBe(
+        'bold'
+      )
+      expect(ed.state.selection.$from.parent.textContent).toBe('new')
+    }
+  )
+
+  it('joins checklists on both sides of the new item', () => {
+    const ed = mount(`${TASKS}<p></p>${TASKS}`)
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, '[ ]')).toBe(true)
+    ed.commands.insertContent('new')
+
+    const lists = ed.getJSON().content?.filter((node) => node.type === 'taskList')
+    expect(lists).toHaveLength(1)
+    expect(lists?.[0].content?.map((node) => node.attrs?.checked)).toEqual([
+      true,
+      false,
+      false,
+      true,
+      false,
+    ])
+    expect(ed.state.selection.$from.parent.textContent).toBe('new')
+  })
+
+  it('joins nested checklists without lifting or absorbing their parent', () => {
+    const ed = mount(`<ul><li><p>parent</p><p></p>${TASKS}</li></ul>`)
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, '[ ]')).toBe(true)
+
+    expect(ed.state.doc.firstChild?.firstChild?.childCount).toBe(2)
+    expect(ed.state.doc.firstChild?.firstChild?.child(1).childCount).toBe(3)
+    expect(ed.state.selection.$from.depth).toBe(5)
+  })
+})
+
+describe('list input-rule boundaries and undo', () => {
+  it.each([
+    ['5.', '<ol start="4"><li><p>one</p></li></ol>', '<ol start="6"><li><p>three</p></li></ol>'],
+    ['[x]', TASKS, TASKS],
+  ])('undoes both adjacent joins together for %s', (marker, before, after) => {
+    const ed = mount(`${before}<p></p>${after}`)
+    const originalBefore = ed.state.doc.child(0).toJSON()
+    const originalAfter = ed.state.doc.child(2).toJSON()
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, marker)).toBe(true)
+    expect(ed.commands.undoInputRule()).toBe(true)
+
+    expect(ed.state.doc.child(0).toJSON()).toEqual(originalBefore)
+    expect(ed.state.doc.child(1).textContent).toBe(`${marker} `)
+    expect(ed.state.doc.child(2).toJSON()).toEqual(originalAfter)
+    expect(ed.state.selection.$from.parent.textContent).toBe(`${marker} `)
+  })
+
+  it.each([
+    ['1.', '<ol start="2"><li><p>one</p></li></ol>', 'orderedList'],
+    ['[ ]', TASKS, 'taskList'],
+  ])('does not join %s across an intentional empty paragraph', (marker, list, type) => {
+    const ed = mount(`<p></p><p></p>${list}`)
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, marker)).toBe(true)
+    expect(
+      ed
+        .getJSON()
+        .content?.slice(0, 3)
+        .map((node) => node.type)
+    ).toEqual([type, 'paragraph', type])
+  })
+
+  it.each([
+    ['1.', TASKS, 'orderedList', 'taskList'],
+    ['[ ]', '<ol start="2"><li><p>one</p></li></ol>', 'taskList', 'orderedList'],
+    ['[ ]', '<ul><li><p>one</p></li></ul>', 'taskList', 'bulletList'],
+  ])('does not merge a typed %s into another list type', (marker, list, type, nextType) => {
+    const ed = mount(`<p></p>${list}`)
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, marker)).toBe(true)
+    expect(
+      ed
+        .getJSON()
+        .content?.slice(0, 2)
+        .map((node) => node.type)
+    ).toEqual([type, nextType])
+  })
+
+  it.each([
+    ['1.', '<ol start="2"><li><p>one</p></li></ol>'],
+    ['[ ]', TASKS],
+    ['[x]', TASKS],
+  ])('Backspace restores %s and the untouched following list', (marker, list) => {
+    const ed = mount(`<p></p>${list}`)
+    const original = ed.state.doc.child(1).toJSON()
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, marker)).toBe(true)
+    ed.view.dom.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true })
+    )
+
+    expect(ed.state.doc.firstChild?.type.name).toBe('paragraph')
+    expect(ed.state.doc.firstChild?.textContent).toBe(`${marker} `)
+    expect(ed.state.doc.child(1).toJSON()).toEqual(original)
+    expect(ed.state.selection.$from.parentOffset).toBe(marker.length + 1)
+  })
+
+  it.each(['1.', '[ ]', '[x]'])('leaves %s literal inside a table', (marker) => {
+    const ed = mount(
+      '<table><tbody><tr><th><p></p></th></tr><tr><td><p>body</p></td></tr></tbody></table>'
+    )
+    selectEmptyParagraph(ed)
+    expect(typeMarker(ed, marker)).toBe(false)
+    expect(ed.state.selection.$from.parent.textContent).toBe(marker)
+    expect(ed.state.selection.$from.depth).toBe(4)
+  })
+
+  it.each(['1.', '[ ]', '[x]'])('leaves %s literal inside a code block', (marker) => {
+    const ed = mount('<pre><code></code></pre>')
+    ed.commands.setTextSelection(1)
+    expect(typeMarker(ed, marker)).toBe(false)
+    expect(ed.state.doc.firstChild?.type.name).toBe('codeBlock')
+    expect(ed.state.doc.firstChild?.textContent).toBe(marker)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules.ts
@@ -47,6 +47,9 @@ export function joinListInputRules(
             }
           }
 
+          /** A backward join now includes an existing root; merging another can lose delayed Yjs edits. */
+          if (list.node.childCount !== 1) return
+
           const after = list.pos + list.node.nodeSize
           const next = tr.doc.nodeAt(after)
           if (next && compatible(list.node, next) && canJoin(tr.doc, after)) tr.join(after)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules.ts
@@ -1,0 +1,56 @@
+import { findParentNode, InputRule } from '@tiptap/core'
+import type { NodeType, Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { canJoin } from '@tiptap/pm/transform'
+
+interface ListJoinOptions {
+  joinBefore?: boolean
+  compatible?: (list: ProseMirrorNode, next: ProseMirrorNode) => boolean
+}
+
+/** Mirrors the stock backward join without renumbering a restart or changing list styling. */
+export function orderedListContinues(list: ProseMirrorNode, next: ProseMirrorNode): boolean {
+  return (
+    (!list.attrs.type || list.attrs.type === '1') &&
+    next.attrs.start === list.attrs.start + list.childCount &&
+    list.hasMarkup(next.type, { ...next.attrs, start: list.attrs.start }, next.marks)
+  )
+}
+
+/**
+ * Keeps adjacent-list joins in the original input-rule transaction so undo restores the marker
+ * and the neighboring lists together. Only the newly wrapped list's immediate siblings qualify;
+ * paragraphs, incompatible list types, and explicit numbering restarts remain boundaries.
+ */
+export function joinListInputRules(
+  rules: InputRule[],
+  listType: NodeType,
+  { joinBefore = false, compatible = (list, next) => next.sameMarkup(list) }: ListJoinOptions = {}
+): InputRule[] {
+  return rules.map(
+    (rule) =>
+      new InputRule({
+        find: rule.find,
+        undoable: rule.undoable,
+        handler: (props) => {
+          if (rule.handler(props) === null) return null
+
+          const { tr } = props.state
+          let list = findParentNode((node) => node.type === listType)(tr.selection)
+          if (!list) return
+
+          if (joinBefore) {
+            const previous = tr.doc.resolve(list.pos).nodeBefore
+            if (previous && compatible(previous, list.node) && canJoin(tr.doc, list.pos)) {
+              tr.join(list.pos)
+              list = findParentNode((node) => node.type === listType)(tr.selection)
+              if (!list) return
+            }
+          }
+
+          const after = list.pos + list.node.nodeSize
+          const next = tr.doc.nodeAt(after)
+          if (next && compatible(list.node, next) && canJoin(tr.doc, after)) tr.join(after)
+        },
+      })
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse.test.ts
@@ -3,9 +3,13 @@
  */
 import { Editor } from '@tiptap/core'
 import { afterAll, describe, expect, it } from 'vitest'
-import { createMarkdownContentExtensions } from './extensions'
-import { parseMarkdownToDoc, serializeMarkdownBody, splitMarkdownBlocks } from './markdown-parse'
-import { isRoundTripSafe } from './round-trip-safety'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import {
+  parseMarkdownToDoc,
+  serializeMarkdownBody,
+  splitMarkdownBlocks,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+import { isRoundTripSafe } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety'
 
 /** Mirror of the production `isEmptyParagraph` (not exported): the shape a blank line reconstructs to. */
 const isEmptyPara = (n: { type?: string; content?: unknown[] }): boolean =>
@@ -167,17 +171,15 @@ describe('parseMarkdownToDoc (chunked)', () => {
       expect(serializeMarkdownBody(once)).toBe(once)
     })
 
-    // The whole-document path hands blank runs to @tiptap/markdown, which keeps them after a paragraph
-    // but swallows them after a heading/ordered list/table. Preserving only some would break the fixpoint
-    // for the same document, so that path keeps none — consistently zero, which IS a fixpoint.
+    /** Whole-document parsing now preserves authored spacing as well as structural paragraphs. */
     it.each([
-      ['block HTML', '# H\n\n\n\ntext\n\n<div>x</div>', 'heading,paragraph,rawHtmlBlock'],
+      ['block HTML', '# H\n\n\n\ntext\n\n<div>x</div>', 'heading,∅,paragraph,rawHtmlBlock'],
       [
         'a reference definition',
         '# H\n\n\n\nsee [y][r]\n\n[r]: https://e.com',
-        'heading,paragraph',
+        'heading,∅,paragraph',
       ],
-    ])('a document that must parse whole keeps no empty paragraphs: %s', (_label, md, expected) => {
+    ])('preserves empty paragraphs when parsing whole: %s', (_label, md, expected) => {
       expect(shapeOf(md)).toBe(expected)
       const once = serializeMarkdownBody(md)
       expect(serializeMarkdownBody(once)).toBe(once)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse.ts
@@ -1,10 +1,10 @@
 import { Editor, type JSONContent } from '@tiptap/core'
-import { createMarkdownContentExtensions } from './extensions'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
 import {
   applyFrontmatter,
   postProcessSerializedMarkdown,
   splitFrontmatter,
-} from './markdown-fidelity'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
 
 /**
  * A single reused editor for chunked markdown parse/serialize, created lazily so importing this
@@ -30,17 +30,16 @@ function markdownManager() {
 
 /**
  * Constructs whose meaning spans blank-line boundaries, so the document can't be split into blocks
- * without changing how they parse — these documents parse whole (correct, if slower; they're
- * uncommon and almost always round-trip-unsafe and read-only anyway):
+ * without changing how they parse — these documents parse whole:
  * - A link/image *reference definition* (`[id]: url`) or footnote definition can sit far from its
  *   `[text][id]` / `[^id]` use; splitting them apart would drop the reference. The editor never
  *   *emits* reference-style links, so this only matters on the first open of such a file.
  * - A block-level HTML element (`<div>…</div>`, `<table>…`) or HTML comment can wrap blank lines; the
  *   splitter would shatter it (matched here by a line that opens an HTML tag/comment, not inline
- *   `<https://…>` autolinks).
+ *   `<https://…>` autolinks). The structural empty `<p></p>` element is atomic and remains chunkable.
  */
 const NON_CHUNKABLE =
-  /^[ ]{0,3}(?:\[(?:\^[^\]]+|[^\]^][^\]]*)\]:\s|<(?:!--|\/?[a-zA-Z][a-zA-Z0-9-]*[\s/>]))/m
+  /^[ ]{0,3}(?:\[(?:\^[^\]]+|[^\]^][^\]]*)\]:\s|<(?!p>[ \t]*<\/p>[ \t]*$)(?:!--|\/?[a-zA-Z][a-zA-Z0-9-]*[\s/>]))/m
 
 const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/
 const FENCE_CLOSE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
@@ -200,13 +199,10 @@ export function splitMarkdownBlocks(body: string): string[] {
  * the editor renders the spacing that is actually in the file — on the very first paint, with no reflow
  * once a collaborative doc settles.
  *
- * The whole-document path CANNOT do that. It hands blank runs to `@tiptap/markdown`, whose handling is
- * not self-consistent (see {@link emptyBlockCount}), so a blank line there survives after a paragraph but
- * is swallowed after a heading, an ordered list, or a table. Preserving it on only some of those would
- * make parse stop inverting serialize for the same document — the file would never reach a fixpoint and
- * would open read-only. So that path keeps NO empty paragraphs: consistently zero is a fixpoint, and a
- * document whose spacing cannot be represented is better rendered the way every other markdown renderer
- * shows it than rendered one way and saved another.
+ * The whole-document path retains the current Markdown parser's empty paragraphs too. Structural
+ * list boundaries and nested empty paragraphs serialize as standard `<p></p>` elements, so they do
+ * not depend on whether the lexer interprets a blank run as spacing within a list. Both paths apply
+ * the same document budget and discard trailing typing placeholders.
  */
 export function parseMarkdownToDoc(body: string): JSONContent {
   const manager = markdownManager()
@@ -214,7 +210,9 @@ export function parseMarkdownToDoc(body: string): JSONContent {
   // the chunker and parser do — a classic `\r`-only body would otherwise slip past the reference-def /
   // block-HTML guard and be chunked, shattering a construct that must parse whole.
   const normalized = body.replace(/\r\n?/g, '\n')
-  if (NON_CHUNKABLE.test(normalized)) return boundEmptyParagraphs(manager.parse(normalized), 0)
+  if (NON_CHUNKABLE.test(normalized)) {
+    return boundEmptyParagraphs(manager.parse(normalized), MAX_EMPTY_PARAGRAPHS_PER_DOC)
+  }
   try {
     const content: JSONContent[] = []
     for (const block of splitMarkdownBlocks(normalized)) {
@@ -229,7 +227,7 @@ export function parseMarkdownToDoc(body: string): JSONContent {
     }
     return boundEmptyParagraphs({ type: 'doc', content }, MAX_EMPTY_PARAGRAPHS_PER_DOC)
   } catch {
-    return boundEmptyParagraphs(manager.parse(normalized), 0)
+    return boundEmptyParagraphs(manager.parse(normalized), MAX_EMPTY_PARAGRAPHS_PER_DOC)
   }
 }
 
@@ -240,7 +238,7 @@ function isEmptyParagraph(node: JSONContent): boolean {
 
 /**
  * Bound the top-level empty paragraphs of a parsed doc to `budget` in total, and drop trailing ones
- * entirely. `budget` is 0 for the whole-document path, which cannot represent them at all.
+ * entirely. The same budget applies to chunked and whole-document parsing.
  *
  * The per-gap ceiling in {@link emptyBlockCount} bounds one run; this bounds the DOCUMENT. Without it the
  * ceiling buys nothing against the shape a real artifact takes — an export that puts a moderate blank run

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste.test.ts
@@ -5,9 +5,12 @@
  * `[text](url)` text — except inside a code block, where it must stay literal.
  */
 import { Editor } from '@tiptap/core'
-import { afterEach, describe, expect, it } from 'vitest'
-import { createMarkdownContentExtensions } from './extensions'
-import { MarkdownPaste } from './markdown-paste'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import {
+  isPlainTextPaste,
+  MarkdownPaste,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste'
 
 let editor: Editor | null = null
 
@@ -17,7 +20,30 @@ afterEach(() => {
 })
 
 function mount(editable = true): Editor {
-  return new Editor({ extensions: [...createMarkdownContentExtensions(), MarkdownPaste], editable })
+  return new Editor({
+    extensions: [...createMarkdownContentExtensions(), MarkdownPaste],
+    enablePasteRules: false,
+    editable,
+  })
+}
+
+function dispatchPaste(
+  ed: Editor,
+  text: string,
+  html = '',
+  extra: Record<string, string> = {},
+  files: File[] = []
+) {
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      getData: (type: string) =>
+        type === 'text/plain' ? text : type === 'text/html' ? html : (extra[type] ?? ''),
+      files,
+      items: [],
+    },
+  })
+  ed.view.dom.dispatchEvent(event)
 }
 
 /** Run the plugin paste handlers the way ProseMirror would, with a mocked clipboard. */
@@ -47,6 +73,83 @@ function transformHtml(ed: Editor, html: string): string {
 }
 
 describe('markdown paste', () => {
+  it.each(['ctrlKey', 'metaKey'] as const)(
+    'shares %s plain-paste intent with higher-precedence image handlers',
+    (modifier) => {
+      const upload = vi.fn()
+      editor = mount()
+      const ed = editor
+      ed.setOptions({
+        editorProps: {
+          handlePaste: (_view, event) => {
+            if (isPlainTextPaste(ed)) return false
+            if (event.clipboardData?.files.length) {
+              upload()
+              return true
+            }
+            return false
+          },
+        },
+      })
+      ed.commands.setContent('<p>keep selected text</p>')
+      ed.commands.setTextSelection({ from: 1, to: 19 })
+      const image = new File(['image'], 'image.png', { type: 'image/png' })
+      const plainPasteShortcut = () => {
+        ed.view.dom.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'V',
+            [modifier]: true,
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      }
+
+      plainPasteShortcut()
+      expect(isPlainTextPaste(ed)).toBe(true)
+      dispatchPaste(ed, '', '<img src="/image.png">', {}, [image])
+      expect(upload).not.toHaveBeenCalled()
+      expect(ed.state.doc.textContent).toBe('keep selected text')
+      expect(ed.state.doc.childCount).toBe(1)
+      expect(ed.state.doc.firstChild?.type.name).toBe('paragraph')
+      expect(isPlainTextPaste(ed)).toBe(false)
+
+      plainPasteShortcut()
+      dispatchPaste(ed, 'caption', '<img src="/image.png">', {}, [image])
+      expect(upload).not.toHaveBeenCalled()
+      expect(ed.state.doc.textContent).toBe('caption')
+      dispatchPaste(ed, '', '<img src="/image.png">', {}, [image])
+      expect(upload).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('keeps plain-paste intent per editor and clears it on keyup or blur', () => {
+    editor = mount()
+    const other = mount()
+    try {
+      const startPlainPaste = () =>
+        editor?.view.dom.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'V',
+            ctrlKey: true,
+            shiftKey: true,
+            bubbles: true,
+          })
+        )
+      startPlainPaste()
+      expect(isPlainTextPaste(editor)).toBe(true)
+      expect(isPlainTextPaste(other)).toBe(false)
+      editor.view.dom.dispatchEvent(new KeyboardEvent('keyup', { key: 'V', bubbles: true }))
+      expect(isPlainTextPaste(editor)).toBe(false)
+      startPlainPaste()
+      editor.view.dom.dispatchEvent(new Event('blur'))
+      expect(isPlainTextPaste(editor)).toBe(false)
+    } finally {
+      other.destroy()
+    }
+  })
+
   it('renders a pasted inline link as a link mark', () => {
     editor = mount()
     expect(paste(editor, '[inline link](https://example.com)')).toBe(true)
@@ -69,18 +172,18 @@ describe('markdown paste', () => {
     expect(paste(editor, 'just a normal sentence with no syntax')).toBe(false)
   })
 
-  it("prefers the markdown parser over DOM mapping when the HTML sibling's plain-text side also looks like markdown", () => {
+  it('preserves the rich HTML sibling even when its plain text resembles Markdown', () => {
     editor = mount()
-    expect(paste(editor, '# heading', '<h1>heading</h1>')).toBe(true)
+    dispatchPaste(editor, '# heading', '<h1>heading</h1>')
     const json = JSON.stringify(editor.getJSON())
     expect(json).toContain('"type":"heading"')
   })
 
-  it('preserves GFM table alignment on a paste that carries both text/plain and text/html', () => {
+  it('preserves GFM alignment when VSCode explicitly identifies Markdown source', () => {
     editor = mount()
     const table = '| a | b |\n| :-- | --: |\n| 1 | 2 |'
     const html = '<table><tr><td>a</td><td>b</td></tr><tr><td>1</td><td>2</td></tr></table>'
-    expect(paste(editor, table, html)).toBe(true)
+    expect(paste(editor, table, html, { 'vscode-editor-data': '{"mode":"markdown"}' })).toBe(true)
     const json = JSON.stringify(editor.getJSON())
     expect(json).toContain('"align":"left"')
     expect(json).toContain('"align":"right"')
@@ -173,15 +276,53 @@ describe('markdown paste', () => {
     expect(editor.getText()).toBe(text)
   })
 
-  it('parses markdown-shaped plain text even when an HTML sibling is present', () => {
+  it('pastes rendered document structure from HTML instead of reinterpreting its plain text', () => {
     editor = mount()
     const html = '<h1>Title</h1><ul><li>a</li><li>b</li></ul>'
-    expect(paste(editor, '# Title\n\n- a\n- b', html)).toBe(true)
+    dispatchPaste(editor, '# Title\n\n- a\n- b', html)
     const json = JSON.stringify(editor.getJSON())
     expect(json).toContain('"type":"heading"')
     expect(json).toContain('"type":"bulletList"')
     expect(json).not.toContain('# Title')
   })
+
+  it('does not flatten a rich table containing literal Markdown-shaped cell text', () => {
+    editor = mount()
+    dispatchPaste(
+      editor,
+      'Label\tValue\n**literal**\t42',
+      '<table><tr><th>Label</th><th>Value</th></tr><tr><td>**literal**</td><td>42</td></tr></table>'
+    )
+    expect(editor.state.doc.firstChild?.type.name).toBe('table')
+    expect(editor.state.doc.textContent).toContain('**literal**')
+    expect(JSON.stringify(editor.getJSON())).not.toContain('"type":"bold"')
+  })
+
+  it.each(['# literal', '**literal**', 'https://example.com'])(
+    'honors paste without formatting for %s and replaces the selection',
+    (text) => {
+      editor = mount()
+      editor.commands.setContent('<p>replace</p>')
+      editor.commands.setTextSelection({ from: 1, to: 8 })
+      editor.view.dom.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'V',
+          ctrlKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        })
+      )
+      dispatchPaste(editor, text, `<h1>${text}</h1>`, {
+        'vscode-editor-data': '{"mode":"typescript"}',
+      })
+      expect(editor.state.doc.firstChild?.type.name).toBe('paragraph')
+      expect(editor.state.doc.textContent).toBe(text)
+      expect(editor.state.doc.firstChild?.firstChild?.marks).toEqual([])
+      dispatchPaste(editor, '# Heading')
+      expect(editor.isActive('heading')).toBe(true)
+    }
+  )
 
   it('preserves the structural blocks of a multi-block document, in order, on paste', () => {
     editor = mount()

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste.ts
@@ -1,7 +1,22 @@
-import { Extension } from '@tiptap/core'
+import { type Editor, Extension } from '@tiptap/core'
 import { Plugin } from '@tiptap/pm/state'
-import { normalizeLinkHref } from './markdown-fidelity'
-import { parseMarkdownToDoc } from './markdown-parse'
+import { normalizeLinkHref } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import { parseMarkdownToDoc } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+
+interface MarkdownPasteStorage {
+  pasteWithoutFormatting: boolean
+}
+
+declare module '@tiptap/core' {
+  interface Storage {
+    markdownPaste: MarkdownPasteStorage
+  }
+}
+
+/** Lets higher-precedence image handlers defer to the same per-editor clipboard intent. */
+export function isPlainTextPaste(editor: Editor): boolean {
+  return editor.storage.markdownPaste?.pasteWithoutFormatting ?? false
+}
 
 /**
  * A single link the paste can wrap a selection in: an http(s) URL, a `mailto:` to a real address, a bare
@@ -27,9 +42,8 @@ function pastedLinkHref(text: string): string | null {
 
 /**
  * Structural markdown — strong signals the plain text is genuinely markdown (a link, image, badge,
- * list, heading, blockquote, fenced block, or GFM table). Our parser round-trips these more faithfully
- * than generic HTML→DOM mapping (GFM alignment, escaping, the `./raw-markdown-snippet.ts` constructs),
- * so they are parsed even when the clipboard also carries an HTML sibling.
+ * list, heading, blockquote, fenced block, or GFM table). Only used after clipboard provenance has
+ * established that the source is plain text or explicitly Markdown.
  */
 const STRUCTURAL_MARKDOWN_HINTS: ReadonlyArray<RegExp> = [
   /^#{1,6}\s/m,
@@ -78,19 +92,15 @@ const VSCODE_LANGUAGE_ALIASES: Readonly<Record<string, string>> = {
 }
 
 /**
- * Extracts the source language from VSCode's `vscode-editor-data` clipboard payload (a JSON blob with a
- * `mode` field), mapping the few ids that differ from our code-block values. Returns `''` when the
- * payload is absent, unparseable, or a non-code mode (plaintext/markdown). A real code language makes
- * the paste handler emit a fenced code block — otherwise VSCode's per-token colored-span HTML would
- * fall through to ProseMirror's default parser and flatten into plain paragraphs — while an empty
- * result falls through so markdown copied from VSCode still parses as markdown.
+ * Reads VSCode's raw clipboard mode. The caller distinguishes Markdown provenance from code
+ * language aliases; absent or malformed metadata returns an empty mode.
  */
-function parseVscodeLanguage(data: string | undefined): string {
+function parseVscodeMode(data: string | undefined): string {
   if (!data) return ''
   try {
     const mode = (JSON.parse(data) as { mode?: unknown }).mode
     if (typeof mode !== 'string') return ''
-    return VSCODE_LANGUAGE_ALIASES[mode] ?? mode
+    return mode
   } catch {
     return ''
   }
@@ -146,28 +156,70 @@ function stripNonContentHtml(html: string): string {
  * untouched (code is meant to stay literal).
  *
  * Provenance decides plain-text-vs-HTML: a `text/html` sibling (copied from a browser, Slack, Notion,
- * GitHub, or this editor) is the signal the source was rich. Structural markdown is still parsed from
- * the plain-text sibling regardless — our parser is more faithful for GFM tables and escaping. But
- * inline-only marks are equally expressible in HTML, so when a rich sibling is present we defer to the
- * DOM path, which preserves structure the plain text can't encode. A plain-text-only clipboard (a
- * terminal, a code editor, a `.md` file) always parses.
+ * GitHub, or this editor) is the signal the source was rich. Defer to that structure even when literal
+ * cell text resembles Markdown. VSCode's explicit Markdown mode is the exception: its colored-span
+ * HTML represents source, not a rendered document. Explicit paste-without-formatting bypasses every
+ * transformation, including link wrapping and source-language code blocks.
  *
  * The strictness of the parse matters: `marked` follows CommonMark flanking rules, so `*text*` becomes
  * emphasis but a space-flanked `5 * width * height` stays literal. The editor sets `enablePasteRules:
  * false` so StarterKit's lenient mark paste rules (which would mangle that expression on either path)
  * never run — emphasis is owned by this parser on the plain path and by real HTML tags on the DOM path.
  */
-export const MarkdownPaste = Extension.create({
+export const MarkdownPaste = Extension.create<Record<string, never>, MarkdownPasteStorage>({
   name: 'markdownPaste',
+  /** Clipboard intent must run before Link's selection-wrapping paste handler. */
+  priority: 1_100,
+
+  addStorage() {
+    return { pasteWithoutFormatting: false }
+  },
 
   addProseMirrorPlugins() {
-    const { editor } = this
+    const { editor, storage } = this
     return [
       new Plugin({
         props: {
+          handleDOMEvents: {
+            keydown: (_view, event) => {
+              storage.pasteWithoutFormatting =
+                !event.isComposing &&
+                event.keyCode !== 229 &&
+                event.key.toLowerCase() === 'v' &&
+                (event.metaKey || event.ctrlKey) &&
+                event.shiftKey
+              return false
+            },
+            keyup: () => {
+              storage.pasteWithoutFormatting = false
+              return false
+            },
+            blur: () => {
+              storage.pasteWithoutFormatting = false
+              return false
+            },
+          },
           transformPastedHTML: (html) => stripNonContentHtml(html),
-          handlePaste: (view, event) => {
+          handlePaste: (view, event, slice) => {
+            const pasteWithoutFormatting = storage.pasteWithoutFormatting
+            storage.pasteWithoutFormatting = false
             if (!editor.isEditable) return false
+            if (pasteWithoutFormatting) {
+              const text =
+                event.clipboardData?.getData('text/plain') ||
+                event.clipboardData?.getData('Text') ||
+                event.clipboardData?.getData('text/uri-list')
+              if (!text) return true
+              view.dispatch(
+                view.state.tr
+                  .replaceSelection(slice)
+                  .setMeta('paste', true)
+                  .setMeta('uiEvent', 'paste')
+                  .setMeta('preventAutolink', true)
+                  .scrollIntoView()
+              )
+              return true
+            }
             if (editor.isActive('codeBlock') || editor.isActive('code')) return false
             const text = event.clipboardData?.getData('text/plain')
             if (!text) return false
@@ -181,7 +233,8 @@ export const MarkdownPaste = Extension.create({
               const safeHref = href ? normalizeLinkHref(href) : ''
               if (safeHref) return editor.commands.setLink({ href: safeHref })
             }
-            const language = parseVscodeLanguage(event.clipboardData?.getData('vscode-editor-data'))
+            const mode = parseVscodeMode(event.clipboardData?.getData('vscode-editor-data'))
+            const language = VSCODE_LANGUAGE_ALIASES[mode] ?? mode
             if (language) {
               return editor.commands.insertContent({
                 type: 'codeBlock',
@@ -189,10 +242,10 @@ export const MarkdownPaste = Extension.create({
                 content: [{ type: 'text', text }],
               })
             }
-            if (!hasAny(STRUCTURAL_MARKDOWN_HINTS, text)) {
-              if (!hasAny(INLINE_MARK_HINTS, text)) return false
-              if (event.clipboardData?.getData('text/html')) return false
-            }
+            const isMarkdownSource = mode === 'markdown' || mode === 'md' || mode === 'mdx'
+            if (event.clipboardData?.getData('text/html') && !isMarkdownSource) return false
+            if (!hasAny(STRUCTURAL_MARKDOWN_HINTS, text) && !hasAny(INLINE_MARK_HINTS, text))
+              return false
             const doc = parseMarkdownToDoc(text)
             if (!doc.content?.length) return false
             return editor.commands.insertContent(doc)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-storage.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-storage.test.ts
@@ -1,0 +1,333 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { Editor, type JSONContent } from '@tiptap/core'
+import { CellSelection } from '@tiptap/pm/tables'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { RichMarkdownKeymap } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap'
+import { postProcessSerializedMarkdown } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import { editorNormalForm } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+import { isRoundTripSafe } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety'
+
+const editors: Editor[] = []
+
+afterEach(() => {
+  for (const editor of editors.splice(0)) editor.destroy()
+})
+
+function mount(content: string | JSONContent): Editor {
+  const editor = new Editor({
+    extensions: [...createMarkdownContentExtensions(), RichMarkdownKeymap],
+    enablePasteRules: false,
+    content: typeof content === 'string' ? editorNormalForm(content) : content,
+  })
+  editors.push(editor)
+  return editor
+}
+
+function press(editor: Editor, key: string, options: KeyboardEventInit = {}): boolean {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...options })
+  editor.view.dom.dispatchEvent(event)
+  return event.defaultPrevented
+}
+
+function pasteHtml(editor: Editor, html: string): void {
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', {
+    value: { getData: (type: string) => (type === 'text/html' ? html : '') },
+  })
+  editor.view.dom.dispatchEvent(event)
+}
+
+function selectText(editor: Editor, text: string, offset = 0): void {
+  let position = -1
+  editor.state.doc.descendants((node, pos) => {
+    const index = node.isText ? (node.text?.indexOf(text) ?? -1) : -1
+    if (position < 0 && index >= 0) position = pos + index + offset
+  })
+  expect(position).toBeGreaterThan(-1)
+  editor.commands.setTextSelection(position)
+}
+
+function expectPreserved(editor: Editor): string {
+  const before = editor.getJSON()
+  const markdown = postProcessSerializedMarkdown(editor.getMarkdown())
+  const reopened = mount(markdown)
+  expect(reopened.getJSON()).toEqual(before)
+  expect(postProcessSerializedMarkdown(reopened.getMarkdown())).toBe(markdown)
+  expect(isRoundTripSafe(markdown)).toBe(true)
+  return markdown
+}
+
+describe('structural paragraphs survive storage', () => {
+  it.each([
+    ['plain document', '- one\n- two\n- three\n\nfollowing'],
+    ['HTML elsewhere', '<!-- comment -->\n\n- one\n- two\n- three\n\nfollowing'],
+    ['footnote elsewhere', 'note[^a]\n\n- one\n- two\n- three\n\nfollowing\n\n[^a]: note'],
+    ['blockquote', '> - one\n> - two\n> - three\n>\n> following'],
+    ['nested blockquote', '> > - one\n> > - two\n> > - three\n> >\n> > following'],
+  ])('keeps a trailing list-exit paragraph in %s', (_label, markdown) => {
+    const editor = mount(markdown)
+    selectText(editor, 'three')
+    editor.commands.deleteRange({
+      from: editor.state.selection.from,
+      to: editor.state.selection.from + 5,
+    })
+    expect(press(editor, 'Enter')).toBe(true)
+    expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+    expect(expectPreserved(editor)).toContain('<p></p>')
+  })
+
+  it('treats an actual empty HTML paragraph as a paragraph without claiming other raw HTML', () => {
+    const editor = mount('before\n\n<p></p>\n\n<div>raw</div>\n\nafter')
+    expect(editor.getJSON().content?.map((node) => node.type)).toEqual([
+      'paragraph',
+      'paragraph',
+      'rawHtmlBlock',
+      'paragraph',
+    ])
+    expect(editor.getText()).toContain('<div>raw</div>')
+  })
+
+  it('does not store the trailing typing placeholder after a list as HTML', () => {
+    const editor = mount('- one')
+    expect(editor.getMarkdown()).not.toContain('<p></p>')
+  })
+})
+
+describe('paragraph hard-break fidelity', () => {
+  it.each(['# heading', '###### heading', '- item', '+ item', '1. item', '1) item', '---', '==='])(
+    'preserves literal %s typed after Shift+Enter',
+    (literal) => {
+      const editor = mount('first')
+      selectText(editor, 'first', 5)
+      expect(press(editor, 'Enter', { shiftKey: true })).toBe(true)
+      editor.commands.insertContent({ type: 'text', text: literal })
+      expectPreserved(editor)
+    }
+  )
+
+  it('preserves marked text and inline-code literals across hard breaks', () => {
+    const editor = mount('first')
+    selectText(editor, 'first', 5)
+    press(editor, 'Enter', { shiftKey: true })
+    editor.commands.insertContent([
+      { type: 'text', text: '# heading', marks: [{ type: 'code' }] },
+      { type: 'hardBreak' },
+      { type: 'text', text: '- item', marks: [{ type: 'bold' }] },
+    ])
+    expectPreserved(editor)
+  })
+
+  it('preserves consecutive hard breaks instead of reparsing them as separate paragraphs', () => {
+    const editor = mount('first')
+    selectText(editor, 'first', 5)
+    press(editor, 'Enter', { shiftKey: true })
+    press(editor, 'Enter', { shiftKey: true })
+    editor.commands.insertContent('next')
+    expectPreserved(editor)
+  })
+})
+
+describe('GFM table capabilities', () => {
+  const markdown = '| heading | value |\n| --- | --- |\n| one | two |'
+
+  it.each([false, true])('cell Enter with shift=%s creates a persistent hard break', (shiftKey) => {
+    const editor = mount(markdown)
+    selectText(editor, 'one', 3)
+    expect(press(editor, 'Enter', { shiftKey })).toBe(true)
+    editor.commands.insertContent('next')
+    expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+    expect(expectPreserved(editor)).toContain('one<br>next')
+  })
+
+  it('does not let a heading shortcut or command create a nonpersistent block in a cell', () => {
+    const editor = mount(markdown)
+    selectText(editor, 'one')
+    press(editor, '1', { ctrlKey: true, altKey: true })
+    expect(editor.commands.toggleHeading({ level: 1 })).toBe(false)
+    expect(editor.commands.toggleBulletList()).toBe(false)
+    expect(editor.commands.toggleOrderedList()).toBe(false)
+    expect(editor.commands.toggleTaskList()).toBe(false)
+    expect(editor.commands.toggleBlockquote()).toBe(false)
+    expect(editor.commands.setCodeBlock()).toBe(false)
+    expect(editor.commands.setHorizontalRule()).toBe(false)
+    expect(editor.commands.insertTable()).toBe(false)
+    expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+    expectPreserved(editor)
+  })
+
+  it.each(['#', '-', '+', '*', '1.', '>', '```', '- [ ]'])(
+    'leaves a typed %s block prefix as literal text in a cell',
+    (prefix) => {
+      const editor = mount(markdown)
+      selectText(editor, 'one')
+      editor.commands.deleteRange({
+        from: editor.state.selection.from,
+        to: editor.state.selection.from + 3,
+      })
+      editor.commands.insertContent({ type: 'text', text: prefix })
+      const { from, to } = editor.state.selection
+      const handled = editor.view.someProp('handleTextInput', (handler) =>
+        handler(editor.view, from, to, ' ', () => editor.state.tr)
+      )
+      expect(handled).not.toBe(true)
+      editor.commands.insertContent({ type: 'text', text: ' literal' })
+      expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+      expectPreserved(editor)
+    }
+  )
+
+  it('gates structural header removal, merged cells, and persistent-width commands', () => {
+    const editor = mount(markdown)
+    selectText(editor, 'heading')
+    expect(editor.can().addRowBefore()).toBe(false)
+    expect(editor.can().deleteRow()).toBe(false)
+    expect(editor.commands.toggleHeaderRow()).toBe(false)
+    expect(editor.commands.toggleHeaderColumn()).toBe(false)
+    expect(editor.commands.toggleHeaderCell()).toBe(false)
+    expect(editor.commands.mergeCells()).toBe(false)
+    expect(editor.commands.setCellAttribute('colwidth', [240])).toBe(false)
+    expectPreserved(editor)
+  })
+
+  it('preserves ordinary row and column editing through save and reopen', () => {
+    const editor = mount(markdown)
+    selectText(editor, 'one')
+    expect(editor.commands.addRowBefore()).toBe(true)
+    expect(editor.commands.addRowAfter()).toBe(true)
+    expect(editor.commands.addColumnAfter()).toBe(true)
+    expectPreserved(editor)
+    selectText(editor, 'one')
+    expect(editor.commands.deleteRow()).toBe(true)
+    expectPreserved(editor)
+  })
+
+  it('new rows inherit column alignment so it stays identical after reload', () => {
+    const editor = mount('| heading | value |\n| :---: | ---: |\n| one | two |')
+    selectText(editor, 'one')
+    expect(editor.commands.addRowBefore()).toBe(true)
+    expect(editor.commands.addRowAfter()).toBe(true)
+    expectPreserved(editor)
+  })
+
+  it('retains legacy rich cell nodes in the collaborative schema', () => {
+    const editor = mount(markdown)
+    const content = editor.getJSON()
+    const cell = content.content?.[0].content?.[1].content?.[0]
+    expect(cell).toBeDefined()
+    if (!cell) return
+    cell.content = [
+      { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'legacy heading' }] },
+      { type: 'paragraph', content: [{ type: 'text', text: 'legacy paragraph' }] },
+    ]
+    editor.commands.setContent(content)
+    expect(editor.getJSON()).toEqual(content)
+    const saved = editor.getMarkdown()
+    expect(saved).toContain('<h2>legacy heading</h2>')
+    expect(saved).toContain('<p>legacy paragraph</p>')
+    const reopened = mount(saved)
+    expect(reopened.getJSON().content?.[0].type).toBe('rawHtmlBlock')
+    expect(postProcessSerializedMarkdown(reopened.getMarkdown())).toBe(
+      postProcessSerializedMarkdown(saved)
+    )
+  })
+
+  it('preserves significant interior code whitespace in GFM cells', () => {
+    const editor = mount('| heading |\n| --- |\n| `one  two` |')
+    expect(expectPreserved(editor)).toContain('`one  two`')
+    expect(editor.getMarkdown()).not.toContain('<table')
+  })
+
+  it('normalizes pasted table headings and paragraphs while preserving inline marks and blank lines', () => {
+    const editor = mount('')
+    pasteHtml(
+      editor,
+      '<table><tr><th>heading</th></tr><tr><td><h2><strong>bold</strong></h2><p></p><p><em>italic</em> <code>one two</code></p></td></tr></table>'
+    )
+    const cell = editor.getJSON().content?.[0].content?.[1].content?.[0]
+    expect(cell?.content).toEqual([
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', marks: [{ type: 'bold' }], text: 'bold' },
+          { type: 'hardBreak' },
+          { type: 'hardBreak' },
+          { type: 'text', marks: [{ type: 'italic' }], text: 'italic' },
+          { type: 'text', text: ' ' },
+          { type: 'text', marks: [{ type: 'code' }], text: 'one two' },
+        ],
+      },
+    ])
+    expect(expectPreserved(editor)).not.toContain('<table')
+  })
+
+  it('pastes rich text blocks into an existing cell as inline content without changing surrounding text', () => {
+    const editor = mount(markdown)
+    selectText(editor, 'one', 1)
+    pasteHtml(editor, '<h2><strong>bold</strong></h2><p><em>italic</em></p>')
+    const cell = editor.getJSON().content?.[0].content?.[1].content?.[0]
+    expect(cell?.content).toHaveLength(1)
+    expect(cell?.content?.[0].type).toBe('paragraph')
+    expect(editor.state.selection.$from.parent.textContent).toBe('obolditalicne')
+    const saved = expectPreserved(editor)
+    expect(saved).toContain('o**bold**<br>*italic*ne')
+    expect(saved).not.toContain('<table')
+  })
+
+  it('leaves rich text blocks outside a table unchanged', () => {
+    const editor = mount('')
+    pasteHtml(editor, '<h2>heading</h2><p>paragraph</p>')
+    expect(editor.getJSON().content?.map((node) => node.type)).toEqual(['heading', 'paragraph'])
+    expectPreserved(editor)
+  })
+
+  it('normalizes native copied cells without rewriting the source document', () => {
+    const source = mount(markdown)
+    const sourceContent = source.getJSON()
+    const sourceCell = sourceContent.content?.[0].content?.[1].content?.[0]
+    expect(sourceCell).toBeDefined()
+    if (!sourceCell) return
+    sourceCell.content = [
+      { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'heading' }] },
+      { type: 'paragraph', content: [{ type: 'text', text: 'paragraph' }] },
+    ]
+    source.commands.setContent(sourceContent)
+    selectText(source, 'paragraph')
+    const sourceCellPosition = source.state.selection.$from.before(3)
+    source.view.dispatch(
+      source.state.tr.setSelection(CellSelection.create(source.state.doc, sourceCellPosition))
+    )
+    const clipboard = source.view.serializeForClipboard(source.state.selection.content())
+    const target = mount(markdown)
+    selectText(target, 'one')
+    pasteHtml(target, clipboard.dom.innerHTML)
+    expect(source.getJSON()).toEqual(sourceContent)
+    expect(expectPreserved(target)).toContain('heading<br>paragraph')
+  })
+
+  it.each([
+    ['nested table', '<table><tr><td>nested</td></tr></table>', '<table'],
+    ['image', '<img src="https://example.com/image.png" alt="image">', '<img'],
+    ['list', '<ul><li><p>nested item</p></li></ul>', '<ul'],
+  ])(
+    'preserves an unsupported pasted %s through the lossless HTML fallback',
+    (_label, block, tag) => {
+      const editor = mount('')
+      pasteHtml(
+        editor,
+        `<table><tr><th>heading</th></tr><tr><td><h2>keep heading</h2>${block}<p>keep paragraph</p></td></tr></table>`
+      )
+      const cell = editor.getJSON().content?.[0].content?.[1].content?.[0]
+      expect(cell?.content?.[0].type).toBe('heading')
+      const saved = postProcessSerializedMarkdown(editor.getMarkdown())
+      expect(saved).toContain('<h2>keep heading</h2>')
+      expect(saved).toContain('<p>keep paragraph</p>')
+      expect(saved).toContain(tag)
+      const reopened = mount(saved)
+      expect(reopened.getJSON().content?.[0].type).toBe('rawHtmlBlock')
+      expect(postProcessSerializedMarkdown(reopened.getMarkdown())).toBe(saved)
+    }
+  )
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-storage.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-storage.test.ts
@@ -187,8 +187,16 @@ describe('GFM table capabilities', () => {
     expect(editor.commands.toggleHeaderRow()).toBe(false)
     expect(editor.commands.toggleHeaderColumn()).toBe(false)
     expect(editor.commands.toggleHeaderCell()).toBe(false)
-    expect(editor.commands.mergeCells()).toBe(false)
     expect(editor.commands.setCellAttribute('colwidth', [240])).toBe(false)
+    const table = editor.state.doc.firstChild!
+    const firstCell = 2
+    const secondCell = firstCell + table.firstChild!.firstChild!.nodeSize
+    editor.view.dispatch(
+      editor.state.tr.setSelection(CellSelection.create(editor.state.doc, firstCell, secondCell))
+    )
+    expect(editor.state.selection).toBeInstanceOf(CellSelection)
+    expect(editor.can().mergeCells()).toBe(false)
+    expect(editor.commands.mergeCells()).toBe(false)
     expectPreserved(editor)
   })
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/index.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/index.ts
@@ -1,7 +1,17 @@
-export { MENTION_PLUGIN_KEY, Mention, type MentionStorage } from './mention'
-export { MentionChip } from './mention-chip'
-export { MarkdownMention } from './mention-node'
-export { SIM_LINK_SCHEME, simLinkPath, toSimHref } from './sim-link'
-export type { MentionItem, MentionKind } from './types'
-export { useEditorMentions } from './use-editor-mentions'
-export { useMarkdownMentions } from './use-markdown-mentions'
+export {
+  Mention,
+  type MentionStorage,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention'
+export { MentionChip } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-chip'
+export { MarkdownMention } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-node'
+export {
+  SIM_LINK_SCHEME,
+  simLinkPath,
+  toSimHref,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/sim-link'
+export type {
+  MentionItem,
+  MentionKind,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/types'
+export { useEditorMentions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/use-editor-mentions'
+export { useMarkdownMentions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/use-markdown-mentions'

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-list.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-list.test.tsx
@@ -11,10 +11,13 @@ import { File } from '@sim/emcn/icons'
 import { Editor } from '@tiptap/core'
 import { EditorContent, ReactRenderer } from '@tiptap/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMarkdownEditorExtensions } from '../editor-extensions'
-import { MentionList, type MentionListHandle } from './mention-list'
-import { createMentionStore } from './mention-store'
-import type { MentionItem } from './types'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+import {
+  MentionList,
+  type MentionListHandle,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-list'
+import { createMentionStore } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-store'
+import type { MentionItem } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/types'
 
 const items: MentionItem[] = [
   { kind: 'file', id: 'a', label: 'Alpha', group: 'Files', icon: File },
@@ -139,6 +142,35 @@ describe('MentionList keyboard nav', () => {
     })
     expect(handled).toBe(true)
     expect(command).toHaveBeenCalledWith(items[0])
+  })
+
+  it.each([
+    ['Enter', { shiftKey: true }],
+    ['Tab', { shiftKey: true }],
+    ['Enter', { ctrlKey: true }],
+    ['Tab', { ctrlKey: true }],
+    ['Enter', { metaKey: true }],
+    ['Tab', { altKey: true }],
+    ['ArrowDown', { shiftKey: true }],
+    ['ArrowUp', { metaKey: true }],
+    ['Enter', { isComposing: true }],
+    ['Enter', { keyCode: 229 }],
+  ])('does not consume %s with reserved modifiers or composition %j', (key, options) => {
+    const ref = createRef<MentionListHandle>()
+    const command = vi.fn()
+    const store = createMentionStore()
+    store.set(items)
+    act(() =>
+      root.render(
+        <MentionList ref={ref} query='' command={command} store={store} editor={editor} />
+      )
+    )
+
+    expect(
+      ref.current?.onKeyDown({ event: new KeyboardEvent('keydown', { key, ...options }) })
+    ).toBe(false)
+    expect(command).not.toHaveBeenCalled()
+    expect(container.querySelector('[aria-selected="true"]')?.textContent).toBe('Alpha')
   })
 
   it('exposes a working onKeyDown through ReactRenderer (the suggestion plugin path)', async () => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention.ts
@@ -1,13 +1,13 @@
 import { Extension } from '@tiptap/core'
-import { PluginKey } from '@tiptap/pm/state'
 import Suggestion from '@tiptap/suggestion'
-import { createSuggestionPopupRenderer } from '../menus/suggestion-popup'
-import { MentionList } from './mention-list'
-import { createMentionStore, type MentionStore } from './mention-store'
-import type { MentionItem } from './types'
-
-/** Distinct from the `/` slash command's key — two plugins can't share one key. Exported so the keymap can detect an open menu. */
-export const MENTION_PLUGIN_KEY = new PluginKey('mention')
+import { MentionList } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-list'
+import {
+  createMentionStore,
+  type MentionStore,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/mention-store'
+import type { MentionItem } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention/types'
+import { createSuggestionPopupRenderer } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-popup'
+import { MENTION_PLUGIN_KEY } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/suggestion-plugin-keys'
 
 /**
  * Per-editor storage for the `@` mention extension. The host component populates {@link store} with

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu.tsx
@@ -16,14 +16,26 @@ import {
   TextQuote,
   Unlink,
 } from '@sim/emcn/icons'
-import { PluginKey } from '@tiptap/pm/state'
+import {
+  PluginKey,
+  type SelectionBookmark,
+  TextSelection,
+  type Transaction,
+} from '@tiptap/pm/state'
 import type { Editor } from '@tiptap/react'
 import { useEditorState } from '@tiptap/react'
 import { BubbleMenu } from '@tiptap/react/menus'
-import { BUBBLE_MENU_CLASS } from './bubble-menu-chrome'
-import { applyLink, LinkUrlInput } from './link-editing'
-import { ToolbarButton, ToolbarDivider } from './toolbar-button'
-import { useBubbleMenuFloating } from './use-bubble-menu-floating'
+import { BUBBLE_MENU_CLASS } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu-chrome'
+import {
+  applyLink,
+  LinkUrlInput,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-editing'
+import {
+  ToolbarButton,
+  ToolbarDivider,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button'
+import { useBubbleMenuFloating } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-bubble-menu-floating'
+import { useEditorToolbar } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-editor-toolbar'
 
 /**
  * Whether the formatting toolbar may show for the given range: the editor is editable, the range
@@ -67,7 +79,7 @@ export function EditorBubbleMenu({
 }: EditorBubbleMenuProps) {
   const [linkValue, setLinkValue] = useState<string | null>(null)
   const linkInputRef = useRef<HTMLInputElement>(null)
-  const linkRangeRef = useRef<{ from: number; to: number } | null>(null)
+  const linkRangeRef = useRef<SelectionBookmark | null>(null)
   const isEditingLink = linkValue !== null
 
   const [bubbleMenuKey] = useState(() => new PluginKey('markdownBubbleMenu'))
@@ -76,6 +88,7 @@ export function EditorBubbleMenu({
   const active = useEditorState({
     editor,
     selector: ({ editor: e }) => ({
+      editable: e.isEditable,
       bold: e.isActive('bold'),
       italic: e.isActive('italic'),
       strike: e.isActive('strike'),
@@ -88,6 +101,12 @@ export function EditorBubbleMenu({
       orderedList: e.isActive('orderedList'),
       taskList: e.isActive('taskList'),
       blockquote: e.isActive('blockquote'),
+      canHeading1: e.can().toggleHeading({ level: 1 }),
+      canHeading2: e.can().toggleHeading({ level: 2 }),
+      canBulletList: e.can().toggleBulletList(),
+      canOrderedList: e.can().toggleOrderedList(),
+      canTaskList: e.can().toggleTaskList(),
+      canBlockquote: e.can().toggleBlockquote(),
     }),
   })
 
@@ -96,13 +115,31 @@ export function EditorBubbleMenu({
   }, [isEditingLink])
 
   useEffect(() => {
+    const mapLinkRange = ({
+      transaction,
+      appendedTransactions = [],
+    }: {
+      transaction: Transaction
+      appendedTransactions?: Transaction[]
+    }) => {
+      let bookmark = linkRangeRef.current
+      if (!bookmark) return
+      for (const change of [transaction, ...appendedTransactions])
+        bookmark = bookmark.map(change.mapping)
+      const selection = bookmark.resolve(editor.state.doc)
+      linkRangeRef.current =
+        selection instanceof TextSelection && !selection.empty ? bookmark : null
+      if (!linkRangeRef.current) setLinkValue(null)
+    }
     const exitOnCollapse = () => {
       const { from, to } = editor.state.selection
       if (from === to) setLinkValue(null)
     }
     editor.on('selectionUpdate', exitOnCollapse)
+    editor.on('transaction', mapLinkRange)
     return () => {
       editor.off('selectionUpdate', exitOnCollapse)
+      editor.off('transaction', mapLinkRange)
     }
   }, [editor])
 
@@ -137,9 +174,8 @@ export function EditorBubbleMenu({
   }, [editor, bubbleMenuKey])
 
   const openLinkEditor = () => {
-    if (editor.isActive('codeBlock') || editor.isActive('code')) return
-    const { from, to } = editor.state.selection
-    linkRangeRef.current = { from, to }
+    if (!editor.isEditable || editor.isActive('codeBlock') || editor.isActive('code')) return
+    linkRangeRef.current = editor.state.selection.getBookmark()
     setLinkValue(editor.getAttributes('link').href ?? '')
   }
 
@@ -147,12 +183,19 @@ export function EditorBubbleMenu({
     const dom = editor.view.dom
     const openLinkOnShortcut = (event: KeyboardEvent) => {
       if (!editor.isEditable) return
-      if (!(event.metaKey || event.ctrlKey) || event.isComposing) return
+      if (
+        !(event.metaKey || event.ctrlKey) ||
+        event.isComposing ||
+        event.keyCode === 229 ||
+        event.altKey ||
+        event.shiftKey
+      )
+        return
       if (event.key?.toLowerCase() !== 'k') return
       const { from, to } = editor.state.selection
       if (from === to || editor.isActive('codeBlock') || editor.isActive('code')) return
       event.preventDefault()
-      linkRangeRef.current = { from, to }
+      linkRangeRef.current = editor.state.selection.getBookmark()
       setLinkValue(editor.getAttributes('link').href ?? '')
     }
     dom.addEventListener('keydown', openLinkOnShortcut)
@@ -161,26 +204,32 @@ export function EditorBubbleMenu({
     }
   }, [editor])
 
-  // The captured range can outlive a programmatic doc change (image insert, content sync), so
-  // clamp it to the current document before re-selecting to avoid a "position out of range" throw.
-  const selectCapturedRange = (chain: ReturnType<Editor['chain']>) => {
-    const range = linkRangeRef.current
-    if (!range) return chain
-    const max = editor.state.doc.content.size
-    return chain.setTextSelection({ from: Math.min(range.from, max), to: Math.min(range.to, max) })
-  }
-
-  const commitLink = () => {
-    applyLink(selectCapturedRange(editor.chain().focus()), linkValue ?? '')
+  const commitCapturedLink = (href: string) => {
+    if (editor.isDestroyed || !editor.isEditable) return
+    const selection = linkRangeRef.current?.resolve(editor.state.doc)
+    if (selection instanceof TextSelection && !selection.empty) {
+      applyLink(
+        editor.chain().focus().setTextSelection({ from: selection.from, to: selection.to }),
+        href
+      )
+    }
+    linkRangeRef.current = null
     setLinkValue(null)
   }
-
-  const removeLink = () => {
-    applyLink(selectCapturedRange(editor.chain().focus()), '')
-    setLinkValue(null)
-  }
+  const commitLink = () => commitCapturedLink(linkValue ?? '')
+  const removeLink = () => commitCapturedLink('')
 
   const { resolveAnchor, appendTo } = useBubbleMenuFloating(editor, scrollContainerRef)
+  const canFocus = useCallback(
+    () => hasFormattableSelection(editor, editor.state.selection.from, editor.state.selection.to),
+    [editor]
+  )
+  const toolbar = useEditorToolbar({
+    editor,
+    pluginKey: bubbleMenuKey,
+    roving: !isEditingLink,
+    canFocus,
+  })
 
   const shouldShow = useCallback(
     ({ editor: e, from, to }: { editor: Editor; from: number; to: number }) => {
@@ -200,132 +249,134 @@ export function EditorBubbleMenu({
       pluginKey={bubbleMenuKey}
       getReferencedVirtualElement={resolveAnchor}
       appendTo={appendTo}
-      role='toolbar'
-      aria-label='Text formatting'
       updateDelay={0}
       shouldShow={shouldShow}
+      hidden={!active.editable}
       className={BUBBLE_MENU_CLASS}
     >
-      {isEditingLink ? (
-        <>
-          <LinkUrlInput
-            inputRef={linkInputRef}
-            value={linkValue ?? ''}
-            onChange={setLinkValue}
-            onCommit={commitLink}
-            onCancel={() => setLinkValue(null)}
-          />
-          {active.link && (
-            <ToolbarButton
-              icon={Unlink}
-              label='Remove link'
-              isActive={false}
-              onClick={removeLink}
+      <div
+        {...toolbar}
+        role={isEditingLink ? 'group' : 'toolbar'}
+        aria-label={isEditingLink ? 'Link editing' : 'Text formatting'}
+        className='flex items-center gap-0.5'
+      >
+        {isEditingLink ? (
+          <>
+            <LinkUrlInput
+              inputRef={linkInputRef}
+              value={linkValue ?? ''}
+              onChange={setLinkValue}
+              onCommit={commitLink}
+              onCancel={() => setLinkValue(null)}
             />
-          )}
-          <ToolbarButton icon={Check} label='Apply link' isActive={false} onClick={commitLink} />
-        </>
-      ) : (
-        <>
-          {onAddToChat && (
-            <>
-              <ToolbarButton
-                icon={Blimp}
-                label='Add to Chat'
-                isActive={false}
-                onClick={onAddToChat}
-              />
-              <ToolbarDivider />
-            </>
-          )}
-          <ToolbarButton
-            icon={Bold}
-            label='Bold'
-            shortcut='⌘B'
-            isActive={active.bold}
-            onClick={() => editor.chain().focus().toggleBold().run()}
-          />
-          <ToolbarButton
-            icon={Italic}
-            label='Italic'
-            shortcut='⌘I'
-            isActive={active.italic}
-            onClick={() => editor.chain().focus().toggleItalic().run()}
-          />
-          <ToolbarButton
-            icon={Strikethrough}
-            label='Strikethrough'
-            shortcut='⌘⇧S'
-            isActive={active.strike}
-            onClick={() => editor.chain().focus().toggleStrike().run()}
-          />
-          <ToolbarButton
-            icon={Highlighter}
-            label='Highlight'
-            shortcut='⌘⇧H'
-            isActive={active.highlight}
-            onClick={() => editor.chain().focus().toggleMark('highlight').run()}
-          />
-          <ToolbarButton
-            icon={Code}
-            label='Code'
-            shortcut='⌘E'
-            isActive={active.code}
-            onClick={() => editor.chain().focus().toggleCode().run()}
-          />
-          <ToolbarButton
-            icon={LinkIcon}
-            label='Link'
-            shortcut='⌘K'
-            isActive={active.link}
-            onClick={openLinkEditor}
-          />
-          <ToolbarDivider />
-          <ToolbarButton
-            icon={Heading1}
-            label='Heading 1'
-            shortcut='⌘⌥1'
-            isActive={active.heading1}
-            onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-          />
-          <ToolbarButton
-            icon={Heading2}
-            label='Heading 2'
-            shortcut='⌘⌥2'
-            isActive={active.heading2}
-            onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-          />
-          <ToolbarDivider />
-          <ToolbarButton
-            icon={List}
-            label='Bulleted list'
-            shortcut='⌘⇧8'
-            isActive={active.bulletList}
-            onClick={() => editor.chain().focus().toggleBulletList().run()}
-          />
-          <ToolbarButton
-            icon={ListOrdered}
-            label='Numbered list'
-            shortcut='⌘⇧7'
-            isActive={active.orderedList}
-            onClick={() => editor.chain().focus().toggleOrderedList().run()}
-          />
-          <ToolbarButton
-            icon={ListChecks}
-            label='Checklist'
-            shortcut='⌘⇧9'
-            isActive={active.taskList}
-            onClick={() => editor.chain().focus().toggleTaskList().run()}
-          />
-          <ToolbarButton
-            icon={TextQuote}
-            label='Quote'
-            shortcut='⌘⇧B'
-            isActive={active.blockquote}
-            onClick={() => editor.chain().focus().toggleBlockquote().run()}
-          />
-        </>
-      )}
+            {active.link && (
+              <ToolbarButton icon={Unlink} label='Remove link' onClick={removeLink} />
+            )}
+            <ToolbarButton icon={Check} label='Apply link' onClick={commitLink} />
+          </>
+        ) : (
+          <>
+            {onAddToChat && (
+              <>
+                <ToolbarButton icon={Blimp} label='Add to Chat' onClick={onAddToChat} />
+                <ToolbarDivider />
+              </>
+            )}
+            <ToolbarButton
+              icon={Bold}
+              label='Bold'
+              shortcut='⌘B'
+              isActive={active.bold}
+              onClick={() => editor.chain().focus().toggleBold().run()}
+            />
+            <ToolbarButton
+              icon={Italic}
+              label='Italic'
+              shortcut='⌘I'
+              isActive={active.italic}
+              onClick={() => editor.chain().focus().toggleItalic().run()}
+            />
+            <ToolbarButton
+              icon={Strikethrough}
+              label='Strikethrough'
+              shortcut='⌘⇧S'
+              isActive={active.strike}
+              onClick={() => editor.chain().focus().toggleStrike().run()}
+            />
+            <ToolbarButton
+              icon={Highlighter}
+              label='Highlight'
+              shortcut='⌘⇧H'
+              isActive={active.highlight}
+              onClick={() => editor.chain().focus().toggleMark('highlight').run()}
+            />
+            <ToolbarButton
+              icon={Code}
+              label='Code'
+              shortcut='⌘E'
+              isActive={active.code}
+              onClick={() => editor.chain().focus().toggleCode().run()}
+            />
+            <ToolbarButton
+              icon={LinkIcon}
+              label='Link'
+              shortcut='⌘K'
+              isActive={active.link}
+              onClick={openLinkEditor}
+            />
+            <ToolbarDivider />
+            <ToolbarButton
+              icon={Heading1}
+              label='Heading 1'
+              shortcut='⌘⌥1'
+              isActive={active.heading1}
+              disabled={!active.canHeading1}
+              onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+            />
+            <ToolbarButton
+              icon={Heading2}
+              label='Heading 2'
+              shortcut='⌘⌥2'
+              isActive={active.heading2}
+              disabled={!active.canHeading2}
+              onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+            />
+            <ToolbarDivider />
+            <ToolbarButton
+              icon={List}
+              label='Bulleted list'
+              shortcut='⌘⇧8'
+              isActive={active.bulletList}
+              disabled={!active.canBulletList}
+              onClick={() => editor.chain().focus().toggleBulletList().run()}
+            />
+            <ToolbarButton
+              icon={ListOrdered}
+              label='Numbered list'
+              shortcut='⌘⇧7'
+              isActive={active.orderedList}
+              disabled={!active.canOrderedList}
+              onClick={() => editor.chain().focus().toggleOrderedList().run()}
+            />
+            <ToolbarButton
+              icon={ListChecks}
+              label='Checklist'
+              shortcut='⌘⇧9'
+              isActive={active.taskList}
+              disabled={!active.canTaskList}
+              onClick={() => editor.chain().focus().toggleTaskList().run()}
+            />
+            <ToolbarButton
+              icon={TextQuote}
+              label='Quote'
+              shortcut='⌘⇧B'
+              isActive={active.blockquote}
+              disabled={!active.canBlockquote}
+              onClick={() => editor.chain().focus().toggleBlockquote().run()}
+            />
+          </>
+        )}
+      </div>
     </BubbleMenu>
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/editor-toolbar-integration.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/editor-toolbar-integration.test.tsx
@@ -1,0 +1,358 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { Tooltip } from '@sim/emcn'
+import { Editor } from '@tiptap/core'
+import { type EditorState, Plugin, type Transaction } from '@tiptap/pm/state'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { editorNormalForm } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+import { EditorBubbleMenu } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu'
+import { TableBubbleMenu } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu'
+
+let editor: Editor
+let root: Root
+let viewport: HTMLDivElement
+let host: HTMLDivElement
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+  viewport = document.createElement('div')
+  const editorHost = document.createElement('div')
+  host = document.createElement('div')
+  viewport.append(editorHost, host)
+  document.body.append(viewport)
+  editor = new Editor({
+    element: editorHost,
+    extensions: createMarkdownContentExtensions(),
+    content: editorNormalForm('format this\n\n| heading | value |\n| --- | --- |\n| one | two |'),
+    editorProps: { handleScrollToSelection: () => true },
+  })
+  vi.spyOn(editor.view, 'coordsAtPos').mockReturnValue({ top: 10, bottom: 30, left: 10, right: 50 })
+  root = createRoot(host)
+  act(() => {
+    root.render(
+      <Tooltip.Provider>
+        <EditorBubbleMenu editor={editor} scrollContainerRef={{ current: viewport }} />
+        <TableBubbleMenu editor={editor} scrollContainerRef={{ current: viewport }} />
+      </Tooltip.Provider>
+    )
+  })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  editor.destroy()
+  viewport.remove()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+function select(text: string, collapsed = false): void {
+  let from = -1
+  editor.state.doc.descendants((node, pos) => {
+    const index = node.isText ? (node.text?.indexOf(text) ?? -1) : -1
+    if (from < 0 && index >= 0) from = pos + index
+  })
+  expect(from).toBeGreaterThan(-1)
+  act(() => {
+    editor.commands.setTextSelection({ from, to: collapsed ? from : from + text.length })
+    editor.view.focus()
+  })
+}
+
+function key(
+  target: HTMLElement,
+  keyValue: string,
+  options: KeyboardEventInit = {}
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: keyValue,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  })
+  act(() => target.dispatchEvent(event))
+  return event
+}
+
+async function frame(): Promise<void> {
+  await act(async () => vi.advanceTimersToNextFrame())
+}
+
+function toolbar(name: string): HTMLElement {
+  const element = viewport.querySelector<HTMLElement>(`[role="toolbar"][aria-label="${name}"]`)
+  if (!element) throw new Error(`Missing real ${name} BubbleMenu`)
+  return element
+}
+
+function button(menu: HTMLElement, label: string): HTMLButtonElement {
+  const element = menu.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
+  if (!element) throw new Error(`Missing ${label} button`)
+  return element
+}
+
+function linkGroup(): HTMLElement {
+  const element = viewport.querySelector<HTMLElement>('[role="group"][aria-label="Link editing"]')
+  if (!element) throw new Error('Missing link-editing group')
+  return element
+}
+
+async function openLinkEditor(): Promise<HTMLInputElement> {
+  select('format')
+  key(editor.view.dom, 'F10', { altKey: true })
+  await frame()
+  act(() => button(toolbar('Text formatting'), 'Link').click())
+  const input = linkGroup().querySelector<HTMLInputElement>('input[aria-label="Link URL"]')
+  if (!input) throw new Error('Missing link URL field')
+  return input
+}
+
+function changeUrl(input: HTMLInputElement, value: string): void {
+  act(() => {
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+describe('real editor BubbleMenu keyboard integration', () => {
+  it('enters the formatting toolbar and returns with Escape without losing the selected text', async () => {
+    select('format')
+    const selection = editor.state.selection.toJSON()
+    expect(key(editor.view.dom, 'F10', { altKey: true }).defaultPrevented).toBe(true)
+    await frame()
+    const menu = toolbar('Text formatting')
+    expect(document.activeElement).toBe(button(menu, 'Bold'))
+    expect(editor.state.selection.toJSON()).toEqual(selection)
+    expect([...menu.querySelectorAll('button')].filter((item) => item.tabIndex === 0)).toHaveLength(
+      1
+    )
+    key(button(menu, 'Bold'), 'ArrowRight')
+    expect(document.activeElement).toBe(button(menu, 'Italic'))
+    key(button(menu, 'Italic'), 'Escape')
+    await frame()
+    expect(document.activeElement).toBe(editor.view.dom)
+    expect(editor.state.selection.toJSON()).toEqual(selection)
+    expect(viewport.contains(menu)).toBe(false)
+  })
+
+  it('applies a keyboard-reached formatting action to the original selection', async () => {
+    select('format')
+    const selection = editor.state.selection.toJSON()
+    key(editor.view.dom, 'F10', { altKey: true })
+    await frame()
+    act(() => button(toolbar('Text formatting'), 'Bold').click())
+    await frame()
+    expect(editor.getHTML()).toContain('<strong>format</strong> this')
+    expect(editor.state.selection.toJSON()).toEqual(selection)
+  })
+
+  it.each([
+    { text: 'format', collapsed: false, menuName: 'Text formatting', label: 'Bold' },
+    { text: 'one', collapsed: true, menuName: 'Table editing', label: 'Delete table' },
+  ])(
+    'hides $menuName and blocks a queued $label action when editability changes',
+    async ({ text, collapsed, menuName, label }) => {
+      select(text, collapsed)
+      key(editor.view.dom, 'F10', { altKey: true })
+      await frame()
+      const menu = toolbar(menuName)
+      const floating = menu.parentElement!
+      const action = button(menu, label)
+      const before = editor.getJSON()
+      expect(floating.hidden).toBe(false)
+      act(() => {
+        editor.setEditable(false)
+        action.click()
+      })
+      expect(editor.getJSON()).toEqual(before)
+      expect(floating.hidden).toBe(true)
+      expect(getComputedStyle(floating).display).toBe('none')
+      act(() => action.click())
+      expect(editor.getJSON()).toEqual(before)
+
+      act(() => editor.setEditable(true))
+      expect(floating.hidden).toBe(false)
+      act(() => action.click())
+      await frame()
+      expect(editor.getJSON()).not.toEqual(before)
+    }
+  )
+
+  it('does not focus a toolbar if editability changes before the Alt+F10 frame', async () => {
+    select('format')
+    key(editor.view.dom, 'F10', { altKey: true })
+    act(() => editor.setEditable(false))
+    await frame()
+    expect(document.activeElement?.closest('[role="toolbar"]')).toBeNull()
+  })
+
+  it('enters the table toolbar at a cell caret with non-toggle actions and preserves the caret', async () => {
+    select('one', true)
+    const selection = editor.state.selection.toJSON()
+    key(editor.view.dom, 'F10', { altKey: true })
+    await frame()
+    const menu = toolbar('Table editing')
+    expect(document.activeElement).toBe(button(menu, 'Insert row above'))
+    expect(button(menu, 'Insert row above').hasAttribute('aria-pressed')).toBe(false)
+    expect(editor.state.selection.toJSON()).toEqual(selection)
+    key(button(menu, 'Insert row above'), 'End')
+    expect(document.activeElement).toBe(button(menu, 'Delete table'))
+    key(button(menu, 'Delete table'), 'Escape')
+    await frame()
+    expect(document.activeElement).toBe(editor.view.dom)
+    expect(editor.state.selection.toJSON()).toEqual(selection)
+  })
+
+  it('disables unsupported table block controls and skips them during roving navigation', async () => {
+    select('one')
+    key(editor.view.dom, 'F10', { altKey: true })
+    await frame()
+    const menu = toolbar('Text formatting')
+    expect(document.activeElement).toBe(button(menu, 'Bold'))
+    for (const label of [
+      'Heading 1',
+      'Heading 2',
+      'Bulleted list',
+      'Numbered list',
+      'Checklist',
+      'Quote',
+    ]) {
+      expect(button(menu, label).disabled).toBe(true)
+    }
+    expect(button(menu, 'Bold').disabled).toBe(false)
+    key(button(menu, 'Bold'), 'End')
+    expect(document.activeElement).toBe(button(menu, 'Link'))
+    key(button(menu, 'Link'), 'ArrowRight')
+    expect(document.activeElement).toBe(button(menu, 'Bold'))
+  })
+
+  it('keeps native URL-field navigation and cancels the draft on Escape with the range retained', async () => {
+    select('format')
+    const selection = editor.state.selection.toJSON()
+    key(editor.view.dom, 'F10', { altKey: true })
+    await frame()
+    act(() => button(toolbar('Text formatting'), 'Link').click())
+    const input = viewport.querySelector<HTMLInputElement>('input[aria-label="Link URL"]')
+    expect(input).not.toBeNull()
+    if (!input) return
+    expect(document.activeElement).toBe(input)
+    expect(input.tabIndex).toBe(0)
+    expect(button(linkGroup(), 'Apply link').tabIndex).toBe(0)
+    for (const keyValue of ['ArrowLeft', 'ArrowRight', 'Home', 'End']) {
+      expect(key(input, keyValue).defaultPrevented).toBe(false)
+      expect(document.activeElement).toBe(input)
+    }
+    expect(key(input, 'Enter', { isComposing: true }).defaultPrevented).toBe(false)
+    expect(viewport.contains(input)).toBe(true)
+    key(input, 'Escape')
+    await frame()
+    expect(viewport.contains(input)).toBe(false)
+    expect(document.activeElement).toBe(editor.view.dom)
+    expect(editor.state.selection.toJSON()).toEqual(selection)
+    expect(editor.getHTML()).not.toContain('<a')
+  })
+
+  it('keeps URL input, remove, and apply actions in normal tab order for an existing link', async () => {
+    select('format')
+    act(() => editor.commands.setLink({ href: 'https://example.com/original' }))
+    const input = await openLinkEditor()
+    const group = linkGroup()
+    const remove = button(group, 'Remove link')
+    const apply = button(group, 'Apply link')
+    expect([input.tabIndex, remove.tabIndex, apply.tabIndex]).toEqual([0, 0, 0])
+    expect(key(input, 'Tab').defaultPrevented).toBe(false)
+    act(() => remove.focus())
+    expect([input.tabIndex, remove.tabIndex, apply.tabIndex]).toEqual([0, 0, 0])
+    expect(key(remove, 'ArrowRight').defaultPrevented).toBe(false)
+    expect(key(remove, 'Tab').defaultPrevented).toBe(false)
+  })
+
+  it('maps the captured link target through a prefix edit and an appended transaction', async () => {
+    const input = await openLinkEditor()
+    changeUrl(input, 'https://example.com/mapped')
+    const appendPrefix = vi.fn(
+      (transactions: readonly Transaction[], _oldState: EditorState, newState: EditorState) => {
+        if (!transactions.some((transaction) => transaction.getMeta('toolbar-prefix'))) return null
+        return newState.tr.insertText('appended ', 1)
+      }
+    )
+    editor.registerPlugin(new Plugin({ appendTransaction: appendPrefix }))
+    act(() =>
+      editor.view.dispatch(editor.state.tr.insertText('prefix ', 1).setMeta('toolbar-prefix', true))
+    )
+    expect(appendPrefix).toHaveBeenCalled()
+    expect(editor.state.doc.firstChild?.textContent).toBe('appended prefix format this')
+    expect(viewport.contains(input)).toBe(true)
+    act(() => button(linkGroup(), 'Apply link').click())
+    await frame()
+    const paragraph = editor.view.dom.querySelector('p')
+    expect(paragraph?.textContent).toBe('appended prefix format this')
+    const link = paragraph?.querySelector('a')
+    expect(link?.textContent).toBe('format')
+    expect(link?.getAttribute('href')).toBe('https://example.com/mapped')
+    expect(paragraph?.querySelectorAll('a')).toHaveLength(1)
+  })
+
+  it('preserves the link draft and maps its target through a temporary read-only interval', async () => {
+    const input = await openLinkEditor()
+    changeUrl(input, 'https://example.com/resumed')
+    const group = linkGroup()
+    const floating = group.parentElement!
+    const apply = button(group, 'Apply link')
+    const before = editor.getJSON()
+    act(() => {
+      editor.setEditable(false)
+      apply.click()
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    expect(editor.getJSON()).toEqual(before)
+    expect(floating.hidden).toBe(true)
+    expect(input.value).toBe('https://example.com/resumed')
+    act(() => editor.view.dispatch(editor.state.tr.insertText('prefix ', 1)))
+    act(() => editor.setEditable(true))
+    expect(floating.hidden).toBe(false)
+    expect(input.value).toBe('https://example.com/resumed')
+    act(() => apply.click())
+    await frame()
+    expect(editor.view.dom.querySelector('a')?.textContent).toBe('format')
+    expect(editor.view.dom.querySelector('a')?.getAttribute('href')).toBe(
+      'https://example.com/resumed'
+    )
+    expect(editor.state.doc.firstChild?.textContent).toBe('prefix format this')
+  })
+
+  it('cancels a captured link when its target is deleted and ignores a queued apply click', async () => {
+    const input = await openLinkEditor()
+    changeUrl(input, 'https://example.com/deleted')
+    const apply = button(linkGroup(), 'Apply link')
+    const { from, to } = editor.state.selection
+    act(() => editor.view.dispatch(editor.state.tr.delete(from, to)))
+    expect(viewport.contains(input)).toBe(false)
+    const afterDelete = editor.getJSON()
+    act(() => apply.click())
+    await frame()
+    expect(editor.getJSON()).toEqual(afterDelete)
+    expect(editor.view.dom.querySelector('a')).toBeNull()
+  })
+
+  it.each(['Apply link', 'Remove link'])(
+    'does not run a queued %s action after becoming read-only',
+    async (label) => {
+      select('format')
+      act(() => editor.commands.setLink({ href: 'https://example.com/original' }))
+      const input = await openLinkEditor()
+      changeUrl(input, 'https://example.com/replacement')
+      const action = button(linkGroup(), label)
+      const before = editor.getJSON()
+      act(() => editor.setEditable(false))
+      act(() => action.click())
+      await frame()
+      expect(editor.getJSON()).toEqual(before)
+      expect(editor.view.dom.querySelector('a')?.getAttribute('href')).toBe(
+        'https://example.com/original'
+      )
+    }
+  )
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-editing.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-editing.test.ts
@@ -1,6 +1,12 @@
+/** @vitest-environment jsdom */
+import { act, createElement, createRef } from 'react'
 import type { ChainedCommands } from '@tiptap/core'
+import { createRoot } from 'react-dom/client'
 import { describe, expect, it, vi } from 'vitest'
-import { applyLink } from './link-editing'
+import {
+  applyLink,
+  LinkUrlInput,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-editing'
 
 function chainSpy() {
   const calls: string[] = []
@@ -41,6 +47,50 @@ describe('applyLink', () => {
       const { chain, calls } = chainSpy()
       applyLink(chain, target)
       expect(calls).toEqual([])
+    }
+  })
+})
+
+describe('LinkUrlInput composition handling', () => {
+  it.each(['Enter', 'Escape'])('does not act on %s used by an IME', (key) => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root = createRoot(host)
+    const inputRef = createRef<HTMLInputElement>()
+    const onCommit = vi.fn()
+    const onCancel = vi.fn()
+    act(() =>
+      root.render(
+        createElement(LinkUrlInput, {
+          value: 'https://example.com',
+          onChange: vi.fn(),
+          onCommit,
+          onCancel,
+          inputRef,
+        })
+      )
+    )
+    try {
+      for (const options of [{ isComposing: true }, { isComposing: false, keyCode: 229 }]) {
+        const event = new KeyboardEvent('keydown', {
+          key,
+          bubbles: true,
+          cancelable: true,
+          ...options,
+        })
+        act(() => inputRef.current?.dispatchEvent(event))
+        expect(event.defaultPrevented).toBe(false)
+      }
+      expect(onCommit).not.toHaveBeenCalled()
+      expect(onCancel).not.toHaveBeenCalled()
+
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+      act(() => inputRef.current?.dispatchEvent(event))
+      expect(event.defaultPrevented).toBe(true)
+      expect(key === 'Enter' ? onCommit : onCancel).toHaveBeenCalledOnce()
+    } finally {
+      act(() => root.unmount())
+      host.remove()
     }
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-editing.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-editing.tsx
@@ -1,6 +1,6 @@
 import type { Ref } from 'react'
 import type { ChainedCommands } from '@tiptap/core'
-import { normalizeLinkHref } from '../markdown-fidelity'
+import { normalizeLinkHref } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
 
 /**
  * Applies a link to the chain's current selection: normalizes `rawHref`, expands to the full link
@@ -27,6 +27,7 @@ interface LinkUrlInputProps {
   onCommit: () => void
   onCancel: () => void
   inputRef: Ref<HTMLInputElement>
+  readOnly?: boolean
 }
 
 /**
@@ -34,7 +35,14 @@ interface LinkUrlInputProps {
  * cancels. Styled to sit flush in the 28px floating micro-toolbar (a `ChipInput` would impose its own
  * field chrome and break the bar), so this is a deliberate raw `<input>`.
  */
-export function LinkUrlInput({ value, onChange, onCommit, onCancel, inputRef }: LinkUrlInputProps) {
+export function LinkUrlInput({
+  value,
+  onChange,
+  onCommit,
+  onCancel,
+  inputRef,
+  readOnly = false,
+}: LinkUrlInputProps) {
   return (
     <input
       ref={inputRef}
@@ -42,9 +50,11 @@ export function LinkUrlInput({ value, onChange, onCommit, onCancel, inputRef }: 
       type='text'
       inputMode='url'
       value={value}
+      readOnly={readOnly}
       onChange={(event) => onChange(event.target.value)}
       onKeyDown={(event) => {
-        if (event.key === 'Enter') {
+        if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) return
+        if (event.key === 'Enter' && !readOnly) {
           event.preventDefault()
           onCommit()
         } else if (event.key === 'Escape') {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card.test.tsx
@@ -1,0 +1,247 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { computePosition } from '@floating-ui/dom'
+import { Tooltip } from '@sim/emcn'
+import { Editor } from '@tiptap/core'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+import { LinkHoverCard } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card'
+
+vi.mock('@floating-ui/dom', () => ({
+  autoUpdate: (_reference: HTMLElement, _floating: HTMLElement, update: () => void) => {
+    update()
+    return () => {}
+  },
+  computePosition: vi.fn(async () => ({ x: 10, y: 20 })),
+  flip: vi.fn(),
+  offset: vi.fn(),
+  shift: vi.fn(),
+}))
+
+describe('link hover card focus and draft lifecycle', () => {
+  let host: HTMLDivElement
+  let editorHost: HTMLDivElement
+  let root: Root
+  let editor: Editor
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    host = document.createElement('div')
+    editorHost = document.createElement('div')
+    document.body.append(host, editorHost)
+    root = createRoot(host)
+    editor = new Editor({
+      element: editorHost,
+      extensions: createMarkdownEditorExtensions({ placeholder: '' }),
+      content:
+        '<p><a href="https://example.com/first">first</a> and <a href="https://example.com/second">second</a></p>',
+    })
+    act(() =>
+      root.render(
+        <Tooltip.Provider>
+          <LinkHoverCard editor={editor} />
+        </Tooltip.Provider>
+      )
+    )
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    editor.destroy()
+    host.remove()
+    editorHost.remove()
+    vi.useRealTimers()
+  })
+
+  async function hover(): Promise<HTMLAnchorElement> {
+    const link = editor.view.dom.querySelector<HTMLAnchorElement>('a')
+    if (!link) throw new Error('Expected a rendered editor link')
+    await act(async () => {
+      link.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    })
+    expect(document.querySelector('[role="dialog"][aria-label="Link"]')).not.toBeNull()
+    return link
+  }
+
+  function button(label: string): HTMLButtonElement {
+    const element = document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
+    if (!element) throw new Error(`Missing ${label} button`)
+    return element
+  }
+
+  function input(): HTMLInputElement {
+    const element = document.querySelector<HTMLInputElement>('input[aria-label="Link URL"]')
+    if (!element) throw new Error('Missing link URL field')
+    return element
+  }
+
+  function editValue(value: string): void {
+    const field = input()
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(field, value)
+      field.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  it('keeps a focused draft through link/card mouse leave and hovering a different link', async () => {
+    const link = await hover()
+    act(() => link.dispatchEvent(new MouseEvent('mouseout', { bubbles: true })))
+    act(() => button('Edit link').click())
+    editValue('https://example.com/draft')
+    expect(document.activeElement).toBe(input())
+    const card = document.querySelector('[role="dialog"]')
+    act(() => {
+      card?.dispatchEvent(
+        new MouseEvent('mouseout', { bubbles: true, relatedTarget: document.body })
+      )
+      editor.view.dom
+        .querySelectorAll('a')[1]
+        .dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+      vi.advanceTimersByTime(200)
+    })
+    expect(input().value).toBe('https://example.com/draft')
+    expect(document.activeElement).toBe(input())
+    act(() => button('Apply link').click())
+    expect(editor.getHTML()).toContain('href="https://example.com/draft"')
+    expect(editor.getHTML()).toContain('href="https://example.com/second"')
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('does not reuse the previous anchor coordinates while a new link is being measured', async () => {
+    await hover()
+    const pending = Promise.withResolvers<Awaited<ReturnType<typeof computePosition>>>()
+    vi.mocked(computePosition).mockReturnValueOnce(pending.promise)
+    await act(async () => {
+      editor.view.dom
+        .querySelectorAll('a')[1]!
+        .dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    })
+    const card = document.querySelector<HTMLElement>('[role="dialog"][aria-label="Link"]')!
+    expect(card.style.opacity).toBe('0')
+    expect(card.style.pointerEvents).toBe('none')
+    await act(async () =>
+      pending.resolve({ x: 30, y: 40, placement: 'top', strategy: 'fixed', middlewareData: {} })
+    )
+    expect(card.style.opacity).toBe('1')
+    expect(card.style.transform).toBe('translate(30px, 40px)')
+  })
+
+  it('cancels without applying the draft when the user explicitly clicks outside', async () => {
+    await hover()
+    act(() => button('Edit link').click())
+    editValue('https://example.com/draft')
+    act(() => document.body.dispatchEvent(new Event('pointerdown', { bubbles: true })))
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+    expect(editor.getHTML()).toContain('href="https://example.com/first"')
+    expect(editor.getHTML()).not.toContain('/draft')
+  })
+
+  it('cancels on Escape but not on composition confirmation', async () => {
+    await hover()
+    act(() => button('Edit link').click())
+    editValue('https://example.com/draft')
+    act(() =>
+      input().dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', isComposing: true, bubbles: true })
+      )
+    )
+    expect(document.querySelector('input[aria-label="Link URL"]')).not.toBeNull()
+    act(() => input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })))
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+    expect(editor.getHTML()).not.toContain('/draft')
+  })
+
+  it('closes a nonfocused preview after the hover bridge delay', async () => {
+    const link = await hover()
+    act(() => link.dispatchEvent(new MouseEvent('mouseout', { bubbles: true })))
+    act(() => vi.advanceTimersByTime(119))
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+    act(() => vi.advanceTimersByTime(1))
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('keeps a keyboard-focused preview action open when the mouse leaves', async () => {
+    const link = await hover()
+    act(() => button('Copy link').focus())
+    act(() => {
+      link.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }))
+      vi.advanceTimersByTime(200)
+    })
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+    const external = document.createElement('button')
+    document.body.append(external)
+    act(() => external.focus())
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+    external.remove()
+  })
+
+  it('does not apply a stale draft after its target link has been removed', async () => {
+    await hover()
+    act(() => button('Edit link').click())
+    editValue('https://example.com/draft')
+    act(() => editor.commands.setContent('<p>replacement document</p>'))
+    act(() => button('Apply link').click())
+
+    expect(editor.getHTML()).toBe('<p>replacement document</p>')
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('does not mutate the document if editing permission changes during a draft', async () => {
+    await hover()
+    act(() => button('Edit link').click())
+    editValue('https://example.com/draft')
+    act(() => editor.setEditable(false))
+    act(() => button('Apply link').click())
+
+    expect(editor.getHTML()).not.toContain('/draft')
+    expect(editor.getHTML()).toContain('href="https://example.com/first"')
+  })
+
+  it('removes stale edit actions immediately and ignores a queued edit click while read-only', async () => {
+    await hover()
+    const edit = button('Edit link')
+    act(() => {
+      editor.setEditable(false)
+      edit.click()
+    })
+    expect(document.querySelector('button[aria-label="Edit link"]')).toBeNull()
+    expect(document.querySelector('button[aria-label="Remove link"]')).toBeNull()
+    expect(document.querySelector('input[aria-label="Link URL"]')).toBeNull()
+    expect(button('Copy link')).not.toBeNull()
+    act(() => editor.setEditable(true))
+    expect(button('Edit link')).not.toBeNull()
+  })
+
+  it('retains a focused link draft through a temporary read-only interval and resumes editing', async () => {
+    await hover()
+    act(() => button('Edit link').click())
+    editValue('https://example.com/resumed')
+    const field = input()
+    const before = editor.getJSON()
+    act(() => editor.setEditable(false))
+    expect(field.readOnly).toBe(true)
+    expect(button('Apply link').disabled).toBe(true)
+    act(() => field.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })))
+    expect(editor.getJSON()).toEqual(before)
+    expect(input()).toBe(field)
+    expect(field.value).toBe('https://example.com/resumed')
+    expect(document.activeElement).toBe(field)
+    act(() => editor.setEditable(true))
+    expect(field.readOnly).toBe(false)
+    expect(button('Apply link').disabled).toBe(false)
+    act(() => button('Apply link').click())
+    expect(editor.getHTML()).toContain('href="https://example.com/resumed"')
+  })
+
+  it('allows Escape to cancel a read-only link draft', async () => {
+    await hover()
+    act(() => button('Edit link').click())
+    editValue('https://example.com/cancelled')
+    const before = editor.getJSON()
+    act(() => editor.setEditable(false))
+    act(() => input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })))
+    expect(document.querySelector('input[aria-label="Link URL"]')).toBeNull()
+    expect(editor.getJSON()).toEqual(before)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card.tsx
@@ -3,11 +3,14 @@ import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/d
 import { useCopyToClipboard } from '@sim/emcn'
 import { Check, Duplicate, Pencil, Unlink } from '@sim/emcn/icons'
 import { getMarkRange } from '@tiptap/core'
-import type { Editor } from '@tiptap/react'
+import { type Editor, useEditorState } from '@tiptap/react'
 import { createPortal } from 'react-dom'
-import { normalizeLinkHref } from '../markdown-fidelity'
-import { applyLink, LinkUrlInput } from './link-editing'
-import { ToolbarButton } from './toolbar-button'
+import { normalizeLinkHref } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import {
+  applyLink,
+  LinkUrlInput,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-editing'
+import { ToolbarButton } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button'
 
 interface LinkHoverCardProps {
   editor: Editor
@@ -16,11 +19,11 @@ interface LinkHoverCardProps {
 interface LinkRange {
   from: number
   to: number
-  href: string
 }
 
-/** Resolves the document range and href of the link rendered by `el`, or null if it isn't a link. */
+/** Resolves a still-mounted link's current document range, including changes since it was hovered. */
 function resolveLinkRange(editor: Editor, el: HTMLElement): LinkRange | null {
+  if (!editor.view.dom.contains(el)) return null
   const { state } = editor.view
   const linkType = state.schema.marks.link
   if (!linkType) return null
@@ -30,8 +33,7 @@ function resolveLinkRange(editor: Editor, el: HTMLElement): LinkRange | null {
     getMarkRange(state.doc.resolve(pos), linkType) ??
     getMarkRange(state.doc.resolve(pos + 1), linkType)
   if (!range) return null
-  const href = el.getAttribute('href') ?? ''
-  return { from: range.from, to: range.to, href }
+  return { from: range.from, to: range.to }
 }
 
 /**
@@ -41,30 +43,38 @@ function resolveLinkRange(editor: Editor, el: HTMLElement): LinkRange | null {
  * close delay plus the card's own hover bridge let the pointer travel from the link into the card.
  */
 export function LinkHoverCard({ editor }: LinkHoverCardProps) {
+  const canEdit = useEditorState({ editor, selector: ({ editor: e }) => e.isEditable })
   const [activeLink, setActiveLink] = useState<HTMLElement | null>(null)
   const [draftHref, setDraftHref] = useState<string | null>(null)
-  const [position, setPosition] = useState<{ x: number; y: number } | null>(null)
+  const [measurement, setMeasurement] = useState<{
+    anchor: HTMLElement
+    x: number
+    y: number
+  } | null>(null)
+  const position = measurement?.anchor === activeLink ? measurement : null
   const isEditing = draftHref !== null
   const editInputRef = useRef<HTMLInputElement>(null)
   const floatingRef = useRef<HTMLDivElement>(null)
   const { copied, copy } = useCopyToClipboard()
   const hideTimerRef = useRef<number | undefined>(undefined)
 
-  // Keep the card anchored to the hovered link with Floating UI's DOM core (the same primitive the
-  // bubble menu positions through) — no React wrapper, so the harness/app share one React instance.
   useEffect(() => {
     const floating = floatingRef.current
-    if (!activeLink || !floating) {
-      setPosition(null)
-      return
-    }
-    return autoUpdate(activeLink, floating, () => {
+    if (!activeLink || !floating) return
+    let active = true
+    const cleanup = autoUpdate(activeLink, floating, () => {
       computePosition(activeLink, floating, {
         strategy: 'fixed',
         placement: 'top',
         middleware: [offset(8), flip({ padding: 8 }), shift({ padding: 8 })],
-      }).then(({ x, y }) => setPosition({ x, y }))
+      }).then(({ x, y }) => {
+        if (active) setMeasurement({ anchor: activeLink, x, y })
+      })
     })
+    return () => {
+      active = false
+      cleanup()
+    }
   }, [activeLink])
 
   const cancelHide = useCallback(() => window.clearTimeout(hideTimerRef.current), [])
@@ -75,17 +85,23 @@ export function LinkHoverCard({ editor }: LinkHoverCardProps) {
   }, [cancelHide])
   const scheduleHide = useCallback(() => {
     cancelHide()
+    if (isEditing) return
     hideTimerRef.current = window.setTimeout(() => {
+      if (floatingRef.current?.contains(document.activeElement)) return
       setActiveLink(null)
       setDraftHref(null)
     }, 120)
-  }, [cancelHide])
+  }, [cancelHide, isEditing])
 
   useEffect(() => {
     const dom = editor.view.dom
     const onOver = (event: Event) => {
-      // Don't compete with the selection toolbar while text is selected.
-      if (!editor.state.selection.empty) return
+      if (
+        isEditing ||
+        floatingRef.current?.contains(document.activeElement) ||
+        !editor.state.selection.empty
+      )
+        return
       const link = (event.target as HTMLElement | null)?.closest('a')
       if (link && dom.contains(link)) {
         cancelHide()
@@ -95,7 +111,6 @@ export function LinkHoverCard({ editor }: LinkHoverCardProps) {
     const onOut = (event: MouseEvent) => {
       const link = (event.target as HTMLElement | null)?.closest('a')
       if (!link) return
-      // Ignore moves that stay within the same link.
       if (link.contains(event.relatedTarget as Node | null)) return
       scheduleHide()
     }
@@ -106,7 +121,23 @@ export function LinkHoverCard({ editor }: LinkHoverCardProps) {
       dom.removeEventListener('mouseout', onOut)
       window.clearTimeout(hideTimerRef.current)
     }
-  }, [editor, cancelHide, scheduleHide])
+  }, [editor, cancelHide, scheduleHide, isEditing])
+
+  useEffect(() => {
+    if (!activeLink) return
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (
+        !(target instanceof Node) ||
+        activeLink.contains(target) ||
+        floatingRef.current?.contains(target)
+      )
+        return
+      dismiss()
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [activeLink, dismiss])
 
   useEffect(() => {
     if (isEditing) editInputRef.current?.focus()
@@ -116,17 +147,21 @@ export function LinkHoverCard({ editor }: LinkHoverCardProps) {
 
   const rawHref = activeLink.getAttribute('href') ?? ''
   const safeHref = normalizeLinkHref(rawHref)
-  const canEdit = editor.isEditable
-
-  const startEdit = () => setDraftHref(rawHref)
+  const startEdit = () => {
+    if (editor.isDestroyed || !editor.isEditable) return
+    cancelHide()
+    setDraftHref(rawHref)
+  }
 
   const commitEdit = () => {
+    if (editor.isDestroyed || !editor.isEditable) return
     const range = resolveLinkRange(editor, activeLink)
     if (range) applyLink(editor.chain().focus().setTextSelection(range), draftHref ?? '')
     dismiss()
   }
 
   const removeLink = () => {
+    if (editor.isDestroyed || !editor.isEditable) return
     const range = resolveLinkRange(editor, activeLink)
     if (range) applyLink(editor.chain().focus().setTextSelection(range), '')
     dismiss()
@@ -147,6 +182,10 @@ export function LinkHoverCard({ editor }: LinkHoverCardProps) {
       aria-label='Link'
       onMouseEnter={cancelHide}
       onMouseLeave={scheduleHide}
+      onFocus={cancelHide}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) dismiss()
+      }}
       className='z-[var(--z-popover)] flex items-center gap-0.5 rounded-lg border border-[var(--border)] bg-[var(--bg)] p-1 shadow-xs transition-opacity duration-150 ease-out'
     >
       {isEditing ? (
@@ -154,11 +193,15 @@ export function LinkHoverCard({ editor }: LinkHoverCardProps) {
           <LinkUrlInput
             inputRef={editInputRef}
             value={draftHref ?? ''}
+            readOnly={!canEdit}
             onChange={setDraftHref}
             onCommit={commitEdit}
-            onCancel={() => setDraftHref(null)}
+            onCancel={() => {
+              dismiss()
+              editor.commands.focus()
+            }}
           />
-          <ToolbarButton icon={Check} label='Apply link' onClick={commitEdit} />
+          <ToolbarButton icon={Check} label='Apply link' disabled={!canEdit} onClick={commitEdit} />
         </>
       ) : (
         <>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-list.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-list.test.tsx
@@ -1,0 +1,113 @@
+/** @vitest-environment jsdom */
+import { act, createRef } from 'react'
+import { Editor } from '@tiptap/core'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+import { SuggestionList } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-list'
+
+describe('suggestion list accessibility', () => {
+  let host: HTMLDivElement
+  let root: Root
+  let editors: Editor[]
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+    editors = [0, 1].map(
+      () =>
+        new Editor({
+          extensions: createMarkdownEditorExtensions({ placeholder: '' }),
+        })
+    )
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    for (const editor of editors) editor.destroy()
+    host.remove()
+  })
+
+  function menu(editor: Editor, command = vi.fn(), activeIndex = 0) {
+    return (
+      <SuggestionList
+        editor={editor}
+        containerRef={createRef<HTMLDivElement>()}
+        groups={[
+          {
+            group: 'Commands',
+            items: [
+              { item: 'First', index: 0 },
+              { item: 'Second', index: 1 },
+            ],
+          },
+        ]}
+        activeIndex={activeIndex}
+        setActiveIndex={vi.fn()}
+        command={command}
+        ariaLabel='Commands'
+        idPrefix='slash-command'
+        emptyLabel='No results'
+        itemKey={(item) => item}
+        renderItem={(item) => item}
+      />
+    )
+  }
+
+  it('uses unique IDs and editor-owned active-descendant references across instances', () => {
+    act(() =>
+      root.render(
+        <>
+          {menu(editors[0])}
+          {menu(editors[1], vi.fn(), 1)}
+        </>
+      )
+    )
+    const listboxes = Array.from(host.querySelectorAll('[role="listbox"]'))
+    const ids = Array.from(host.querySelectorAll('[id]'), (element) => element.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    editors.forEach((editor, index) => {
+      const activeId = editor.view.dom.getAttribute('aria-activedescendant') ?? ''
+      expect(editor.view.dom.getAttribute('aria-controls')).toBe(listboxes[index].id)
+      expect(listboxes[index].contains(document.getElementById(activeId))).toBe(true)
+      expect(document.getElementById(activeId)?.textContent).toBe(index === 0 ? 'First' : 'Second')
+    })
+  })
+
+  it('supports synthetic click activation without pointer-only handling or popup Tab stops', () => {
+    const command = vi.fn()
+    act(() => root.render(menu(editors[0], command)))
+    const option = host.querySelector<HTMLButtonElement>('[role="option"]')
+    expect(option).not.toBeNull()
+    const down = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    act(() => option?.dispatchEvent(down))
+    expect(down.defaultPrevented).toBe(true)
+    expect(command).not.toHaveBeenCalled()
+    act(() => option?.click())
+    expect(command).toHaveBeenCalledExactlyOnceWith('First')
+    expect(
+      Array.from(host.querySelectorAll<HTMLButtonElement>('[role="option"]')).every(
+        (element) => element.tabIndex === -1
+      )
+    ).toBe(true)
+  })
+
+  it('updates the active descendant and removes transient attributes when the menu closes', () => {
+    act(() => root.render(menu(editors[0])))
+    const listboxId = editors[0].view.dom.getAttribute('aria-controls')
+    act(() => root.render(menu(editors[0], vi.fn(), 1)))
+    const activeId = editors[0].view.dom.getAttribute('aria-activedescendant') ?? ''
+    expect(editors[0].view.dom.getAttribute('aria-controls')).toBe(listboxId)
+    expect(document.getElementById(activeId)?.textContent).toBe('Second')
+    act(() => root.render(null))
+    for (const name of [
+      'aria-controls',
+      'aria-activedescendant',
+      'aria-expanded',
+      'aria-haspopup',
+    ]) {
+      expect(editors[0].view.dom.hasAttribute(name)).toBe(false)
+    }
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-list.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-list.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, useEffect } from 'react'
+import { type ReactNode, type RefObject, useEffect, useId } from 'react'
 import { cn } from '@sim/emcn'
 import type { Editor } from '@tiptap/core'
 import {
@@ -6,7 +6,7 @@ import {
   SUGGESTION_ITEM_CLASS,
   SUGGESTION_SCROLL_CLASS,
   SUGGESTION_SURFACE_CLASS,
-} from './suggestion-menu-chrome'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-menu-chrome'
 
 /** A labeled run of items; `index` is each item's flat position, used for keyboard nav + scroll. */
 export interface SuggestionGroup<T> {
@@ -25,7 +25,7 @@ interface SuggestionListProps<T> {
   /** Inserts the chosen item (the suggestion plugin's `command`). */
   command: (item: T) => void
   ariaLabel: string
-  /** Prefix for each row's element id (`${idPrefix}-${index}`) and the listbox id. */
+  /** Human-readable prefix; an instance identifier keeps IDs unique across editors. */
   idPrefix: string
   /** Shown in place of the list when there are no groups (e.g. "No results" / "Loading…"). */
   emptyLabel: string
@@ -36,7 +36,7 @@ interface SuggestionListProps<T> {
 /**
  * The shared grouped-list shell for the `/` and `@` suggestion menus: the bordered surface, the empty
  * state, the `role="listbox"` → `role="group"` → option-button structure, and the active-row / hover /
- * mousedown-select wiring. Each menu computes its own `groups` and supplies `itemKey`/`renderItem`;
+ * click-selection wiring. Each menu computes its own `groups` and supplies `itemKey`/`renderItem`;
  * everything else (chrome, a11y, navigation hooks) lives here so the two menus stay identical.
  *
  * Accessibility: focus stays in the editor's contenteditable while the user arrows the menu, so the
@@ -57,9 +57,11 @@ export function SuggestionList<T>({
   itemKey,
   renderItem,
 }: SuggestionListProps<T>) {
-  const listboxId = `${idPrefix}-listbox`
+  const instanceId = useId()
+  const optionIdPrefix = `${idPrefix}-${instanceId}`
+  const listboxId = `${optionIdPrefix}-listbox`
   const hasOptions = groups.length > 0
-  const activeOptionId = hasOptions ? `${idPrefix}-${activeIndex}` : null
+  const activeOptionId = hasOptions ? `${optionIdPrefix}-${activeIndex}` : null
 
   useEffect(() => {
     const dom = editor.view.dom
@@ -112,7 +114,8 @@ export function SuggestionList<T>({
               key={itemKey(item)}
               type='button'
               role='option'
-              id={`${idPrefix}-${index}`}
+              id={`${optionIdPrefix}-${index}`}
+              tabIndex={-1}
               aria-selected={index === activeIndex}
               data-index={index}
               className={cn(
@@ -120,10 +123,8 @@ export function SuggestionList<T>({
                 index === activeIndex && 'bg-[var(--surface-active)]'
               )}
               onMouseEnter={() => setActiveIndex(index)}
-              onMouseDown={(event) => {
-                event.preventDefault()
-                command(item)
-              }}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => command(item)}
             >
               {renderItem(item)}
             </button>

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu.test.ts
@@ -9,7 +9,7 @@
  */
 import { Editor } from '@tiptap/core'
 import { afterEach, describe, expect, it } from 'vitest'
-import { createMarkdownContentExtensions } from '../extensions'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
 
 let editor: Editor | null = null
 afterEach(() => {
@@ -49,11 +49,11 @@ describe('table toolbar commands', () => {
     expect(md).toContain('| --- | --- |')
   })
 
-  it('inserts a row before the current row', () => {
+  it('keeps the required Markdown header first when inserting rows', () => {
     editor = mount('| a | b |\n| --- | --- |\n| 1 | 2 |')
     editor.commands.setTextSelection(firstCellPos(editor))
-    expect(editor.commands.addRowBefore()).toBe(true)
-    expect(editor.state.doc.firstChild?.childCount).toBe(3)
+    expect(editor.commands.addRowBefore()).toBe(false)
+    expect(editor.state.doc.firstChild?.childCount).toBe(2)
   })
 
   it('deletes the current row', () => {
@@ -94,12 +94,11 @@ describe('table toolbar commands', () => {
     expect(cols).toBe(2)
   })
 
-  it('toggles the header row', () => {
+  it('does not expose an unpersistable header-row toggle', () => {
     editor = mount('| a | b |\n| --- | --- |\n| 1 | 2 |')
     editor.commands.setTextSelection(firstCellPos(editor))
-    const before = editor.isActive('tableHeader')
-    expect(editor.commands.toggleHeaderRow()).toBe(true)
-    expect(editor.isActive('tableHeader')).toBe(!before)
+    expect(editor.commands.toggleHeaderRow()).toBe(false)
+    expect(editor.isActive('tableHeader')).toBe(true)
   })
 
   it('deletes the whole table', () => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu.tsx
@@ -1,21 +1,16 @@
-import { useState } from 'react'
-import {
-  ArrowDown,
-  ArrowLeft,
-  ArrowRight,
-  ArrowUp,
-  Columns3,
-  Rows3,
-  Table as TableIcon,
-  Trash,
-} from '@sim/emcn/icons'
+import { useCallback, useState } from 'react'
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Columns3, Rows3, Trash } from '@sim/emcn/icons'
 import { PluginKey } from '@tiptap/pm/state'
 import type { Editor } from '@tiptap/react'
 import { useEditorState } from '@tiptap/react'
 import { BubbleMenu } from '@tiptap/react/menus'
-import { BUBBLE_MENU_CLASS } from './bubble-menu-chrome'
-import { ToolbarButton, ToolbarDivider } from './toolbar-button'
-import { useBubbleMenuFloating } from './use-bubble-menu-floating'
+import { BUBBLE_MENU_CLASS } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu-chrome'
+import {
+  ToolbarButton,
+  ToolbarDivider,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button'
+import { useBubbleMenuFloating } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-bubble-menu-floating'
+import { useEditorToolbar } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-editor-toolbar'
 
 interface TableBubbleMenuProps {
   editor: Editor
@@ -28,9 +23,8 @@ const shouldShowTableMenu = ({ editor }: { editor: Editor }) =>
 
 /**
  * Floating toolbar shown whenever the selection is inside a table: row/column insert-before/after,
- * row/column delete, header-row toggle, and delete-table. `@tiptap/extension-table` already exposes
- * all of these as editor commands (`addRowBefore`, `addColumnAfter`, …) — this is UI only, no schema
- * or serializer change.
+ * row/column delete, and delete-table. The fixed header row is required by the Markdown storage
+ * format; capability checks omit operations that would remove it or insert a body row before it.
  */
 export function TableBubbleMenu({ editor, scrollContainerRef }: TableBubbleMenuProps) {
   const [menuKey] = useState(() => new PluginKey('markdownTableMenu'))
@@ -38,11 +32,26 @@ export function TableBubbleMenu({ editor, scrollContainerRef }: TableBubbleMenuP
   const active = useEditorState({
     editor,
     selector: ({ editor: e }) => ({
-      headerRow: e.isActive('tableHeader'),
+      editable: e.isEditable,
+      addRowBefore: e.can().addRowBefore(),
+      deleteRow: e.can().deleteRow(),
     }),
   })
 
   const { resolveAnchor, appendTo } = useBubbleMenuFloating(editor, scrollContainerRef)
+  const canFocus = useCallback(
+    () =>
+      editor.isActive('table') &&
+      editor.state.doc
+        .textBetween(editor.state.selection.from, editor.state.selection.to, ' ')
+        .trim().length === 0,
+    [editor]
+  )
+  const toolbar = useEditorToolbar({
+    editor,
+    pluginKey: menuKey,
+    canFocus,
+  })
 
   return (
     <BubbleMenu
@@ -50,62 +59,59 @@ export function TableBubbleMenu({ editor, scrollContainerRef }: TableBubbleMenuP
       pluginKey={menuKey}
       getReferencedVirtualElement={resolveAnchor}
       appendTo={appendTo}
-      role='toolbar'
-      aria-label='Table editing'
       updateDelay={0}
       shouldShow={shouldShowTableMenu}
+      hidden={!active.editable}
       className={BUBBLE_MENU_CLASS}
     >
-      <ToolbarButton
-        icon={ArrowUp}
-        label='Insert row above'
-        isActive={false}
-        onClick={() => editor.chain().focus().addRowBefore().run()}
-      />
-      <ToolbarButton
-        icon={ArrowDown}
-        label='Insert row below'
-        isActive={false}
-        onClick={() => editor.chain().focus().addRowAfter().run()}
-      />
-      <ToolbarButton
-        icon={Rows3}
-        label='Delete row'
-        isActive={false}
-        onClick={() => editor.chain().focus().deleteRow().run()}
-      />
-      <ToolbarDivider />
-      <ToolbarButton
-        icon={ArrowLeft}
-        label='Insert column left'
-        isActive={false}
-        onClick={() => editor.chain().focus().addColumnBefore().run()}
-      />
-      <ToolbarButton
-        icon={ArrowRight}
-        label='Insert column right'
-        isActive={false}
-        onClick={() => editor.chain().focus().addColumnAfter().run()}
-      />
-      <ToolbarButton
-        icon={Columns3}
-        label='Delete column'
-        isActive={false}
-        onClick={() => editor.chain().focus().deleteColumn().run()}
-      />
-      <ToolbarDivider />
-      <ToolbarButton
-        icon={TableIcon}
-        label='Toggle header row'
-        isActive={active.headerRow}
-        onClick={() => editor.chain().focus().toggleHeaderRow().run()}
-      />
-      <ToolbarButton
-        icon={Trash}
-        label='Delete table'
-        isActive={false}
-        onClick={() => editor.chain().focus().deleteTable().run()}
-      />
+      <div
+        {...toolbar}
+        role='toolbar'
+        aria-label='Table editing'
+        className='flex items-center gap-0.5'
+      >
+        {active.addRowBefore && (
+          <ToolbarButton
+            icon={ArrowUp}
+            label='Insert row above'
+            onClick={() => editor.chain().focus().addRowBefore().run()}
+          />
+        )}
+        <ToolbarButton
+          icon={ArrowDown}
+          label='Insert row below'
+          onClick={() => editor.chain().focus().addRowAfter().run()}
+        />
+        {active.deleteRow && (
+          <ToolbarButton
+            icon={Rows3}
+            label='Delete row'
+            onClick={() => editor.chain().focus().deleteRow().run()}
+          />
+        )}
+        <ToolbarDivider />
+        <ToolbarButton
+          icon={ArrowLeft}
+          label='Insert column left'
+          onClick={() => editor.chain().focus().addColumnBefore().run()}
+        />
+        <ToolbarButton
+          icon={ArrowRight}
+          label='Insert column right'
+          onClick={() => editor.chain().focus().addColumnAfter().run()}
+        />
+        <ToolbarButton
+          icon={Columns3}
+          label='Delete column'
+          onClick={() => editor.chain().focus().deleteColumn().run()}
+        />
+        <ToolbarDivider />
+        <ToolbarButton
+          icon={Trash}
+          label='Delete table'
+          onClick={() => editor.chain().focus().deleteTable().run()}
+        />
+      </div>
     </BubbleMenu>
   )
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, SVGProps } from 'react'
-import { cn, Tooltip } from '@sim/emcn'
+import { Button, cn, Tooltip } from '@sim/emcn'
 
 interface ToolbarButtonProps {
   /** Any SVG icon component, e.g. from `@sim/emcn/icons`. */
@@ -7,6 +7,7 @@ interface ToolbarButtonProps {
   label: string
   shortcut?: string
   isActive?: boolean
+  disabled?: boolean
   onClick: () => void
 }
 
@@ -15,27 +16,31 @@ export function ToolbarButton({
   icon: Icon,
   label,
   shortcut,
-  isActive = false,
+  isActive,
+  disabled,
   onClick,
 }: ToolbarButtonProps) {
   return (
     <Tooltip.Root>
       <Tooltip.Trigger asChild>
-        <button
+        <Button
           type='button'
+          variant='ghost'
+          size='icon'
           aria-label={label}
           aria-pressed={isActive}
+          disabled={disabled}
           onMouseDown={(event) => event.preventDefault()}
           onClick={onClick}
           className={cn(
-            'flex size-[28px] items-center justify-center rounded-md text-[var(--text-icon)] outline-hidden transition-colors focus-visible:bg-[var(--surface-hover)] [&_svg]:size-[14px]',
+            'size-[28px] focus-visible:bg-[var(--surface-hover)] [&_svg]:size-[14px]',
             isActive
               ? 'bg-[var(--surface-active)] text-[var(--text-body)]'
               : 'hover-hover:bg-[var(--surface-hover)]'
           )}
         >
           <Icon />
-        </button>
+        </Button>
       </Tooltip.Trigger>
       <Tooltip.Content>
         {shortcut ? <Tooltip.Shortcut keys={shortcut}>{label}</Tooltip.Shortcut> : label}
@@ -46,5 +51,5 @@ export function ToolbarButton({
 
 /** Thin vertical separator between groups of {@link ToolbarButton}s. */
 export function ToolbarDivider() {
-  return <div className='mx-0.5 h-[18px] w-px bg-[var(--border-1)]' />
+  return <div className='mx-0.5 h-[18px] w-px bg-[var(--border)]' />
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-editor-toolbar.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-editor-toolbar.test.tsx
@@ -1,0 +1,123 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { Tooltip } from '@sim/emcn'
+import { Bold, Check } from '@sim/emcn/icons'
+import { Editor } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { ToolbarButton } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button'
+import { useEditorToolbar } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-editor-toolbar'
+
+let editor: Editor
+let root: Root
+let host: HTMLDivElement
+let editorHost: HTMLDivElement
+const pluginKey = new PluginKey('testToolbar')
+const action = vi.fn()
+
+function Probe({ disabled = false, input = false }: { disabled?: boolean; input?: boolean }) {
+  const toolbar = useEditorToolbar({ editor, pluginKey, canFocus: () => true })
+  return (
+    <Tooltip.Provider>
+      <div {...toolbar} role='toolbar' aria-label='Formatting'>
+        <ToolbarButton
+          icon={Bold}
+          label='Bold'
+          isActive={false}
+          disabled={disabled}
+          onClick={action}
+        />
+        <ToolbarButton icon={Check} label='Apply' onClick={action} />
+        {input && <input aria-label='URL' />}
+      </div>
+    </Tooltip.Provider>
+  )
+}
+
+function buttons() {
+  return Array.from(host.querySelectorAll('button'))
+}
+function key(target: HTMLElement, key: string, extra: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...extra })
+  act(() => target.dispatchEvent(event))
+  return event
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+  host = document.createElement('div')
+  editorHost = document.createElement('div')
+  document.body.append(editorHost, host)
+  editor = new Editor({
+    element: editorHost,
+    extensions: createMarkdownContentExtensions(),
+    content: '<p>text</p>',
+    editorProps: { handleScrollToSelection: () => true },
+  })
+  root = createRoot(host)
+  act(() => root.render(<Probe />))
+})
+afterEach(() => {
+  act(() => root.unmount())
+  editor.destroy()
+  host.remove()
+  editorHost.remove()
+  vi.useRealTimers()
+})
+
+describe('editor toolbar keyboard interaction', () => {
+  it('has one tab stop, arrow navigation, wraparound, Home and End', () => {
+    const [first, second] = buttons()
+    expect(buttons().map((button) => button.tabIndex)).toEqual([0, -1])
+    act(() => first!.focus())
+    key(first!, 'ArrowRight')
+    expect(document.activeElement).toBe(second)
+    expect(buttons().map((button) => button.tabIndex)).toEqual([-1, 0])
+    key(second!, 'ArrowRight')
+    expect(document.activeElement).toBe(first)
+    key(first!, 'End')
+    expect(document.activeElement).toBe(second)
+    key(second!, 'Home')
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('moves the entry stop when its former button becomes disabled', () => {
+    act(() => root.render(<Probe disabled />))
+    expect(buttons()[1]!.tabIndex).toBe(0)
+    expect(buttons()[0]!.disabled).toBe(true)
+    expect(buttons()[0]!.getAttribute('aria-pressed')).toBe('false')
+    expect(buttons()[1]!.hasAttribute('aria-pressed')).toBe(false)
+  })
+
+  it('preserves modified and composing navigation and native URL editing', () => {
+    act(() => root.render(<Probe input />))
+    const first = buttons()[0]!
+    act(() => first.focus())
+    expect(key(first, 'ArrowRight', { ctrlKey: true }).defaultPrevented).toBe(false)
+    expect(key(first, 'ArrowRight', { isComposing: true }).defaultPrevented).toBe(false)
+    expect(document.activeElement).toBe(first)
+    const input = host.querySelector('input')!
+    act(() => input.focus())
+    expect(key(input, 'ArrowLeft').defaultPrevented).toBe(false)
+    expect(key(input, 'Home').defaultPrevented).toBe(false)
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('enters with Alt+F10 and returns to the document with Escape', async () => {
+    expect(key(editor.view.dom, 'F10', { altKey: true }).defaultPrevented).toBe(true)
+    await act(async () => vi.advanceTimersToNextFrame())
+    expect(document.activeElement).toBe(buttons()[0])
+    key(buttons()[0]!, 'Escape')
+    await act(async () => vi.advanceTimersToNextFrame())
+    expect(document.activeElement).toBe(editor.view.dom)
+  })
+
+  it('does not enter a toolbar when the document is read-only', () => {
+    editor.setEditable(false)
+    expect(key(editor.view.dom, 'F10', { altKey: true }).defaultPrevented).toBe(false)
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-editor-toolbar.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-editor-toolbar.ts
@@ -1,0 +1,137 @@
+import {
+  type FocusEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react'
+import type { PluginKey } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/react'
+
+interface EditorToolbarOptions {
+  editor: Editor
+  pluginKey: PluginKey
+  canFocus: () => boolean
+  /** URL editing uses ordinary form tab order so its native arrow keys do not trap action buttons. */
+  roving?: boolean
+}
+
+function controls(toolbar: HTMLElement): HTMLElement[] {
+  return Array.from(
+    toolbar.querySelectorAll<HTMLElement>('button:not(:disabled), input:not(:disabled)')
+  )
+}
+
+function makeTabStop(toolbar: HTMLElement, target: HTMLElement): void {
+  for (const control of controls(toolbar)) control.tabIndex = control === target ? 0 : -1
+}
+
+/** Shared roving focus for the editor's context toolbars; text inputs retain their native editing keys. */
+export function useEditorToolbar({
+  editor,
+  pluginKey,
+  canFocus,
+  roving = true,
+}: EditorToolbarOptions) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    const toolbar = ref.current
+    if (!toolbar) return
+    const items = controls(toolbar)
+    if (!roving) {
+      for (const item of items) item.tabIndex = 0
+      return
+    }
+    const target =
+      items.find((item) => item === document.activeElement) ??
+      items.find((item) => item.tabIndex === 0) ??
+      items[0]
+    if (target) makeTabStop(toolbar, target)
+  })
+
+  useEffect(() => {
+    let frame: number | undefined
+    const enterToolbar = (event: globalThis.KeyboardEvent) => {
+      if (
+        event.key !== 'F10' ||
+        !event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        event.isComposing ||
+        !editor.isEditable ||
+        !canFocus()
+      )
+        return
+      event.preventDefault()
+      editor.commands.setMeta(pluginKey, 'show')
+      editor.commands.setMeta(pluginKey, 'updatePosition')
+      frame = requestAnimationFrame(() => {
+        const toolbar = ref.current
+        if (!toolbar || editor.isDestroyed || !editor.isEditable || !canFocus()) return
+        const items = controls(toolbar)
+        const target = items.find((item) => item.tabIndex === 0) ?? items[0]
+        target?.focus()
+      })
+    }
+    const dom = editor.view.dom
+    dom.addEventListener('keydown', enterToolbar)
+    return () => {
+      dom.removeEventListener('keydown', enterToolbar)
+      if (frame !== undefined) cancelAnimationFrame(frame)
+    }
+  }, [editor, pluginKey, canFocus])
+
+  const onFocusCapture = (event: FocusEvent<HTMLDivElement>) => {
+    if (!roving) return
+    if (
+      event.target instanceof HTMLElement &&
+      controls(event.currentTarget).includes(event.target)
+    ) {
+      makeTabStop(event.currentTarget, event.target)
+    }
+  }
+
+  /** A permission/stream lock can precede React's render of the hidden toolbar. */
+  const onClickCapture = (event: MouseEvent<HTMLDivElement>) => {
+    if (editor.isDestroyed || !editor.isEditable) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+  }
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.nativeEvent.isComposing ||
+      event.nativeEvent.keyCode === 229 ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    )
+      return
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      editor.commands.focus()
+      editor.commands.setMeta(pluginKey, 'hide')
+      return
+    }
+    if (!roving || event.target instanceof HTMLInputElement) return
+    const items = controls(event.currentTarget)
+    const index = items.indexOf(event.target as HTMLElement)
+    if (index < 0 || items.length === 0) return
+    const direction = getComputedStyle(event.currentTarget).direction === 'rtl' ? -1 : 1
+    let next: number
+    if (event.key === 'Home') next = 0
+    else if (event.key === 'End') next = items.length - 1
+    else if (event.key === 'ArrowRight') next = (index + direction + items.length) % items.length
+    else if (event.key === 'ArrowLeft') next = (index - direction + items.length) % items.length
+    else return
+    event.preventDefault()
+    items[next]?.focus()
+  }
+
+  return { ref, onFocusCapture, onClickCapture, onKeyDown, 'aria-keyshortcuts': 'Alt+F10' }
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-suggestion-keyboard.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-suggestion-keyboard.test.tsx
@@ -1,0 +1,87 @@
+/** @vitest-environment jsdom */
+import { act, Suspense, startTransition, useLayoutEffect, useRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSuggestionKeyboard } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-suggestion-keyboard'
+
+describe('suggestion keyboard committed state', () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+    host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    ['items', 'Enter'],
+    ['items', 'Tab'],
+    ['callback', 'Enter'],
+    ['callback', 'Tab'],
+    ['activeIndex', 'Enter'],
+    ['activeIndex', 'Tab'],
+  ] as const)('uses committed %s when %s follows a suspended render', async (change, key) => {
+    const items = ['Visible first', 'Visible second']
+    const suspendedItems = ['Uncommitted first', 'Uncommitted second']
+    const onSelect = vi.fn()
+    const suspendedOnSelect = vi.fn()
+    const pending = new Promise<void>(() => {})
+    let attemptedSuspension = false
+    let committed!: ReturnType<typeof useSuggestionKeyboard<string>>
+
+    interface ProbeProps {
+      suspended: boolean
+    }
+
+    function Probe({ suspended }: ProbeProps) {
+      const containerRef = useRef<HTMLElement>(null)
+      const keyboard = useSuggestionKeyboard(
+        suspended && change === 'items' ? suspendedItems : items,
+        suspended && change === 'callback' ? suspendedOnSelect : onSelect,
+        containerRef
+      )
+      useLayoutEffect(() => {
+        committed = keyboard
+      })
+      if (suspended) {
+        attemptedSuspension = true
+        throw pending
+      }
+      return <div>{items[keyboard.activeIndex]}</div>
+    }
+
+    const view = (suspended: boolean) => (
+      <Suspense fallback={<div>Loading</div>}>
+        <Probe suspended={suspended} />
+      </Suspense>
+    )
+
+    await act(async () => root.render(view(false)))
+    const capturedHandler = committed.onKeyDown
+    await act(async () => committed.setActiveIndex(1))
+    expect(committed.onKeyDown).toBe(capturedHandler)
+
+    await act(async () => {
+      startTransition(() => {
+        if (change === 'activeIndex') committed.setActiveIndex(0)
+        root.render(view(true))
+      })
+    })
+    expect(attemptedSuspension).toBe(true)
+    expect(host.textContent).toBe('Visible second')
+    expect(committed.onKeyDown).toBe(capturedHandler)
+    act(() => {
+      expect(capturedHandler({ event: new KeyboardEvent('keydown', { key }) })).toBe(true)
+    })
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith('Visible second')
+    expect(suspendedOnSelect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-suggestion-keyboard.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/use-suggestion-keyboard.ts
@@ -4,6 +4,7 @@ import {
   type SetStateAction,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react'
@@ -47,9 +48,21 @@ export function useSuggestionKeyboard<T>(
   }, [activeIndex, containerRef])
 
   const latest = useRef({ items, activeIndex, onSelect })
-  latest.current = { items, activeIndex, onSelect }
+  useLayoutEffect(() => {
+    latest.current = { items, activeIndex, onSelect }
+  })
 
   const onKeyDown = useCallback(({ event }: { event: KeyboardEvent }) => {
+    if (
+      event.isComposing ||
+      event.keyCode === 229 ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return false
+    }
     const { items, activeIndex, onSelect } = latest.current
     if (items.length === 0) return false
     if (event.key === 'ArrowUp') {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/ordered-list.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/ordered-list.test.ts
@@ -1,0 +1,222 @@
+/** @vitest-environment jsdom */
+import { Editor, type JSONContent } from '@tiptap/core'
+import { OrderedList } from '@tiptap/extension-list'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import {
+  editorNormalForm,
+  parseMarkdownToDoc,
+  serializeMarkdownDocument,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+import { isRoundTripSafe } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety'
+
+const editors: Editor[] = []
+
+afterEach(() => {
+  editors.splice(0).forEach((editor) => editor.destroy())
+})
+
+function mount(content: string | JSONContent = '<p></p>', stock = false): Editor {
+  const extensions = createMarkdownContentExtensions().map((extension) =>
+    stock && extension.name === 'orderedList' ? OrderedList : extension
+  )
+  const editor = new Editor({ extensions, content })
+  editors.push(editor)
+  return editor
+}
+
+function starts(doc: JSONContent): number[] {
+  const result: number[] = []
+  const visit = (node: JSONContent): void => {
+    if (node.type === 'orderedList') result.push(node.attrs?.start ?? 1)
+    node.content?.forEach(visit)
+  }
+  visit(doc)
+  return result
+}
+
+const LIST_RUN =
+  '<ol><li><p><strong>first</strong></p></li></ol><ol start="7"><li><p>restart</p></li></ol><ol start="3"><li><p>another</p></li></ol>'
+
+describe('ordered-list Markdown boundaries', () => {
+  it.each([0, 9, 10, 123])('retains start %s and following item numbers', (start) => {
+    const editor = mount(`<ol start="${start}"><li><p>one</p></li><li><p>two</p></li></ol>`)
+    expect(editor.getMarkdown()).toContain(`${start}. one\n${start + 1}. two`)
+    editor.commands.setContent(editorNormalForm(editor.getMarkdown()))
+    expect(starts(editor.getJSON())).toEqual([start])
+  })
+
+  it.each(['a', 'A', 'i', 'I'])('retains stock %s list rendering and parsing', (type) => {
+    const html = `<ol type="${type}" start="3"><li><p>one</p></li><li><p>two</p></li></ol>`
+    const editor = mount(html)
+    const original = mount(html, true)
+    expect(editor.getMarkdown()).toBe(original.getMarkdown())
+    const markdown = original.getMarkdown()
+    editor.commands.setContent(markdown, { contentType: 'markdown' })
+    original.commands.setContent(markdown, { contentType: 'markdown' })
+    expect(editor.getJSON()).toEqual(original.getJSON())
+  })
+
+  it.each([
+    ['top-level', LIST_RUN],
+    ['nested', `<ul><li><p>parent</p>${LIST_RUN}</li></ul>`],
+    ['blockquote', `<blockquote>${LIST_RUN}</blockquote>`],
+  ])('preserves three adjacent %s lists across repeated saves', (_name, html) => {
+    const editor = mount(html)
+    editor.commands.setContent(editor.getJSON())
+    const original = editor.getJSON()
+    const markdown = editor.getMarkdown()
+    expect(starts(original)).toEqual([1, 7, 3])
+    expect(markdown).toContain('7) restart')
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      editor.commands.setContent(editorNormalForm(editor.getMarkdown()))
+      expect(editor.getJSON()).toEqual(original)
+      expect(editor.getMarkdown()).toBe(markdown)
+    }
+  })
+
+  it.each([
+    '1. first\n\n7) restart\n\n3. another',
+    '- parent\n  1. first\n  7) restart\n  3. another',
+    '1. outer\n  4. child\n  7) child restart\n2. other',
+    '> 1. first\n>\n> 7) restart\n>\n> 3. another',
+  ])('preserves delimiter boundaries on first parse: %s', (markdown) => {
+    const editor = mount()
+    editor.commands.setContent(markdown, { contentType: 'markdown' })
+    const original = editor.getJSON()
+    const expected = markdown.startsWith('1. outer') ? [1, 4, 7] : [1, 7, 3]
+    expect(starts(original)).toEqual(expected)
+    expect(starts(parseMarkdownToDoc(markdown))).toEqual(expected)
+    expect(starts(parseMarkdownToDoc(`${markdown}\n\n<!-- retained -->`))).toEqual(expected)
+    expect(serializeMarkdownDocument(serializeMarkdownDocument(markdown))).toBe(
+      serializeMarkdownDocument(markdown)
+    )
+  })
+
+  it.each([
+    '1. First\n  - sub bullet\n  - another\n  1. deep ordered\n  2. item\n2. Second',
+    '1. first\n\n  second paragraph in item one\n\n2. second item',
+    '1. outer\n  1. child\n    1. grandchild\n  2. another child\n2. other',
+    '4. outer\n  a. alphabetic child\n  b. another child\n5. other',
+  ])('retains stock first-parse semantics for legacy indentation: %s', (markdown) => {
+    const editor = mount()
+    const original = mount('<p></p>', true)
+    editor.commands.setContent(markdown, { contentType: 'markdown' })
+    original.commands.setContent(markdown, { contentType: 'markdown' })
+    expect(editor.getJSON()).toEqual(original.getJSON())
+  })
+
+  it('preserves an ordered restart when references require whole-document parsing', () => {
+    const markdown =
+      '1. [first](https://example.com)\n\n7) restart\n\nOutside [reference][ref].\n\n[ref]: https://example.com'
+    const original = parseMarkdownToDoc(markdown)
+    expect(starts(original)).toEqual([1, 7])
+    const editor = mount(editorNormalForm(markdown))
+    const normalized = editor.getJSON()
+    editor.commands.setContent(editorNormalForm(editor.getMarkdown()))
+    expect(editor.getJSON()).toEqual(normalized)
+    expect(editor.getMarkdown()).toContain('[first](https://example.com)')
+    expect(editor.getMarkdown()).toContain('[reference](https://example.com)')
+  })
+
+  it.each([
+    '1. [first][ref]',
+    '1. [ref]',
+    '1. [ref][]',
+    '1. **[first][ref]**',
+    '1. outer\n  1. [first][ref]',
+    '1. outer\n\n  [first][ref]',
+    '1. first\n\n7) [first][ref]',
+    'a. [first][ref]',
+    'iii. [first][ref]',
+  ])('resolves ordered reference links with whole-document context: %s', (body) => {
+    const markdown = `${body}\n\n[ref]: https://example.com "Title"`
+    const editor = mount(editorNormalForm(markdown))
+    const original = editor.getJSON()
+    let linkCount = 0
+    editor.state.doc.descendants((node) => {
+      linkCount += node.marks.filter(
+        (mark) => mark.type.name === 'link' && mark.attrs.href === 'https://example.com'
+      ).length
+    })
+    expect(linkCount).toBe(1)
+    expect(editor.getMarkdown()).toContain('(https://example.com "Title")')
+    editor.commands.setContent(editorNormalForm(editor.getMarkdown()))
+    expect(editor.getJSON()).toEqual(original)
+    expect(isRoundTripSafe(markdown)).toBe(true)
+  })
+
+  it('resolves reference images without changing escaped or code reference syntax', () => {
+    const markdown =
+      '1. ![photo][img] and \\[ref] and `[ref]`\n\nOutside [ref].\n\n[img]: https://example.com/photo.png\n[ref]: https://example.com'
+    const editor = mount(editorNormalForm(markdown))
+    const original = editor.getJSON()
+    let imageSource: string | undefined
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'image') imageSource = node.attrs.src
+    })
+    expect(imageSource).toBe('https://example.com/photo.png')
+    expect(editor.getMarkdown()).toContain('\\[ref\\] and `[ref]`')
+    editor.commands.setContent(editorNormalForm(editor.getMarkdown()))
+    expect(editor.getJSON()).toEqual(original)
+    expect(isRoundTripSafe(markdown)).toBe(true)
+  })
+
+  it.each([
+    ['blockquote', '1. outer\n\n  > [first][ref]', true],
+    ['table', '1. outer\n\n  | Header |\n  | --- |\n  | [first][ref] |', false],
+  ] as const)(
+    'preserves nested %s references and verifies edit eligibility',
+    (type, body, editable) => {
+      const markdown = `${body}\n\n[ref]: https://example.com "Title"`
+      const editor = mount(editorNormalForm(markdown))
+      const original = editor.getJSON()
+      let found = false
+      let linkCount = 0
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === type) found = true
+        linkCount += node.marks.filter(
+          (mark) => mark.type.name === 'link' && mark.attrs.href === 'https://example.com'
+        ).length
+      })
+      expect(found).toBe(true)
+      expect(linkCount).toBe(1)
+      expect(isRoundTripSafe(markdown)).toBe(editable)
+      if (!editable) {
+        const once = serializeMarkdownDocument(markdown)
+        expect(serializeMarkdownDocument(once)).not.toBe(once)
+        return
+      }
+      editor.commands.setContent(editorNormalForm(editor.getMarkdown()))
+      expect(editor.getJSON()).toEqual(original)
+    }
+  )
+
+  it('changes only item prefixes, not marker-shaped text inside multiline code', () => {
+    const editor = mount({
+      type: 'doc',
+      content: [
+        { type: 'orderedList', content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }] },
+        {
+          type: 'orderedList',
+          attrs: { start: 7 },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    { type: 'text', text: 'prefix\n9. literal', marks: [{ type: 'code' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    expect(editor.getMarkdown()).toContain('7) `prefix\n9. literal`')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/ordered-list.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/ordered-list.ts
@@ -1,0 +1,85 @@
+import type { JSONContent, MarkdownToken } from '@tiptap/core'
+import { OrderedList } from '@tiptap/extension-list'
+import {
+  joinListInputRules,
+  orderedListContinues,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-input-rules'
+import { excludeTableBlockInputRules } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table'
+
+/**
+ * CommonMark distinguishes adjacent ordered lists by their delimiter, not their starting number.
+ * Alternate delimiters within a sibling run to preserve explicit restarts without adding nodes.
+ * The weak map carries only renderer context between sibling callbacks; nothing enters the schema
+ * or persisted attributes, and repeated serialization recomputes each delimiter in document order.
+ */
+export function createJoiningOrderedList() {
+  const delimiters = new WeakMap<JSONContent, '.' | ')'>()
+  const parse = OrderedList.config.parseMarkdown
+
+  return OrderedList.extend({
+    addInputRules() {
+      return excludeTableBlockInputRules(
+        joinListInputRules(this.parent?.() ?? [], this.type, { compatible: orderedListContinues })
+      )
+    },
+    parseMarkdown: (token, helpers) => {
+      if (!token.ordered || !token.items?.length) return parse?.(token, helpers) ?? []
+
+      /**
+       * The upstream tokenizer retains each item's raw marker but ignores delimiter changes.
+       * Split its parsed item tokens, retaining its legacy indentation and nested-block behavior.
+       * Nested list tokens pass through this same parser via the stock list-item parser.
+       */
+      const groups: MarkdownToken[] = []
+      let delimiter: string | undefined
+      for (const item of token.items) {
+        const marker = /^[ \t]*(\d+)([.)])(?:[ \t]|$)/.exec(item.raw ?? '')
+        if (!marker) {
+          groups.length = 0
+          break
+        }
+        if (marker[2] !== delimiter) {
+          groups.push({ ...token, start: Number(marker[1]), items: [] })
+          delimiter = marker[2]
+        }
+        groups[groups.length - 1].items?.push(item)
+      }
+      if (groups.length > 1) return helpers.parseChildren(groups)
+
+      /**
+       * The custom tokenizer resolves item paragraphs before later reference definitions exist.
+       * At parse time the public helper uses the complete document's reference context.
+       */
+      const resolved = {
+        ...token,
+        items: token.items.map((item) => ({
+          ...item,
+          tokens: item.tokens?.map((child) =>
+            child.type === 'paragraph' && child.raw?.includes('[') && helpers.tokenizeInline
+              ? { ...child, tokens: helpers.tokenizeInline(child.raw) }
+              : child
+          ),
+        })),
+      }
+      const parsed = parse?.(resolved, helpers) ?? []
+      /** The stock parser's truthy default turns a valid zero start into one. */
+      if (groups[0]?.start === 0 && !Array.isArray(parsed) && 'type' in parsed) {
+        return { ...parsed, attrs: { ...parsed.attrs, start: 0 } }
+      }
+      return parsed
+    },
+    renderMarkdown: (node: JSONContent, helpers, context) => {
+      const previous = context.previousNode
+      const delimiter =
+        previous?.type === 'orderedList' && delimiters.get(previous) === '.' ? ')' : '.'
+      delimiters.set(node, delimiter)
+      const start = typeof node.attrs?.start === 'number' ? node.attrs.start : 1
+      return (node.content ?? [])
+        .map((item, index) => {
+          const rendered = helpers.renderChild?.(item, index) ?? helpers.renderChildren([item])
+          return rendered.replace(/^\d+\. /, `${start + index}${delimiter} `)
+        })
+        .join('\n')
+    },
+  })
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.test.ts
@@ -1,10 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
+
+import { PASTE_LIMITS, PASTE_RENDER_THRESHOLDS } from '@sim/utils/paste'
 import { Editor } from '@tiptap/core'
 import { TextSelection } from '@tiptap/pm/state'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { MarkdownPaste } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste'
 import {
   assessRawMarkdownPaste,
   createRichMarkdownPasteAdmission,
@@ -39,7 +42,123 @@ function runPaste(ed: Editor, text: string, html = ''): { handled: boolean; prev
   return { handled: false, prevented }
 }
 
+function dispatchPaste(ed: Editor, text: string) {
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      getData: (type: string) => (type === 'text/plain' ? text : ''),
+      files: [],
+      items: [],
+    },
+  })
+  ed.view.dom.dispatchEvent(event)
+}
+
 describe('rich Markdown paste admission', () => {
+  it('retains accepted literal text when appended autolink would exceed the limit', () => {
+    const onRejected = vi.fn()
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        MarkdownPaste,
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: 30,
+          maxResultCharacters: 30,
+          getCurrentText: () => editor?.getMarkdown() ?? '',
+          onRejected,
+        }),
+      ],
+      enablePasteRules: false,
+    })
+    dispatchPaste(editor, 'www.example.com ')
+    expect(editor.getMarkdown()).toBe('www.example.com ')
+    expect(editor.state.doc.firstChild?.firstChild?.marks).toEqual([])
+    expect(onRejected).toHaveBeenCalledExactlyOnceWith('formatting')
+
+    editor.view.dispatch(editor.state.tr.insertText('x'.repeat(31), 1))
+    expect(editor.state.doc.textContent).toContain('x'.repeat(31))
+    expect(onRejected).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears a rejected root paste before the next synchronous ordinary transaction', () => {
+    const onRejected = vi.fn()
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: 10,
+          getCurrentText: () => '',
+          onRejected,
+        }),
+      ],
+    })
+    editor.view.dispatch(editor.state.tr.insertText('x'.repeat(11)).setMeta('uiEvent', 'paste'))
+    expect(editor.state.doc.textContent).toBe('')
+    expect(onRejected).toHaveBeenCalledExactlyOnceWith('paste')
+    editor.view.dispatch(editor.state.tr.insertText('ordinary typing'))
+    expect(editor.state.doc.textContent).toBe('ordinary typing')
+    expect(onRejected).toHaveBeenCalledTimes(1)
+  })
+
+  it('admits autolink formatting when the final result still fits', () => {
+    const onRejected = vi.fn()
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        MarkdownPaste,
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: 100,
+          maxResultCharacters: 100,
+          getCurrentText: () => '',
+          onRejected,
+        }),
+      ],
+      enablePasteRules: false,
+    })
+    dispatchPaste(editor, 'https://example.com ')
+    expect(editor.getMarkdown()).toBe('[https://example.com](https://example.com) ')
+    expect(onRejected).not.toHaveBeenCalled()
+  })
+
+  it('rejects a canonical result that would reopen beyond the rich-editor character limit', () => {
+    const onRejected = vi.fn()
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: PASTE_LIMITS.RICH_MARKDOWN_BYTES,
+          getCurrentText: () => '',
+          onRejected,
+        }),
+      ],
+    })
+    editor.view.dispatch(
+      editor.state.tr
+        .insertText('a'.repeat(PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS + 1))
+        .setMeta('uiEvent', 'paste')
+    )
+    expect(editor.state.doc.textContent).toBe('')
+    expect(onRejected).toHaveBeenCalledOnce()
+  })
+
+  it('includes preserved frontmatter in the projected character budget', () => {
+    const onRejected = vi.fn()
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: 100,
+          maxResultCharacters: 10,
+          getCurrentText: () => '',
+          getFrontmatter: () => '---\nx\n---\n',
+          onRejected,
+        }),
+      ],
+    })
+    editor.view.dispatch(editor.state.tr.insertText('body').setMeta('uiEvent', 'paste'))
+    expect(editor.state.doc.textContent).toBe('')
+    expect(onRejected).toHaveBeenCalledOnce()
+  })
   it('rejects a raw-text append whose projected result exceeds the limit', () => {
     expect(
       assessRawMarkdownPaste(

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission.ts
@@ -1,17 +1,20 @@
 import {
   assessTextPaste,
   PASTE_LIMITS,
+  PASTE_RENDER_THRESHOLDS,
   type TextPasteAdmission,
   utf8ByteLength,
 } from '@sim/utils/paste'
 import { Extension } from '@tiptap/core'
-import { Plugin } from '@tiptap/pm/state'
+import { Plugin, type Transaction } from '@tiptap/pm/state'
 import { postProcessSerializedMarkdown } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
 
 export interface RichMarkdownPasteAdmissionOptions {
   maxResultBytes: number
+  maxResultCharacters?: number
   getCurrentText: () => string
-  onRejected: () => void
+  getFrontmatter?: () => string
+  onRejected: (reason?: 'paste' | 'formatting') => void
 }
 
 interface RawMarkdownPasteInput {
@@ -37,7 +40,9 @@ export function assessRawMarkdownPaste(
  */
 export function createRichMarkdownPasteAdmission({
   maxResultBytes,
+  maxResultCharacters = PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS,
   getCurrentText,
+  getFrontmatter = () => '',
   onRejected,
 }: RichMarkdownPasteAdmissionOptions): Extension {
   return Extension.create({
@@ -47,13 +52,27 @@ export function createRichMarkdownPasteAdmission({
     addProseMirrorPlugins() {
       const { editor } = this
       let pasteInProgress = false
+      let pasteRoot: Transaction | null = null
+      let formattingRejected = false
+
+      const finishPaste = () => {
+        pasteInProgress = false
+        pasteRoot = null
+        formattingRejected = false
+      }
 
       return [
         new Plugin({
+          /** View updates occur after the complete synchronous transaction/append pipeline. */
+          view: () => ({ update: finishPaste, destroy: finishPaste }),
           filterTransaction: (transaction) => {
             const isPaste = pasteInProgress || transaction.getMeta('uiEvent') === 'paste'
             if (!isPaste || !transaction.docChanged) return true
-            pasteInProgress = false
+            if (!pasteRoot) {
+              pasteRoot = transaction
+              pasteInProgress = true
+              queueMicrotask(finishPaste)
+            }
 
             if (!editor.markdown) {
               throw new Error('Rich Markdown paste admission requires the Markdown extension')
@@ -61,9 +80,22 @@ export function createRichMarkdownPasteAdmission({
             const projectedMarkdown = postProcessSerializedMarkdown(
               editor.markdown.serialize(transaction.doc.toJSON())
             )
-            if (utf8ByteLength(projectedMarkdown, maxResultBytes) <= maxResultBytes) return true
+            const frontmatter = getFrontmatter()
+            if (
+              frontmatter.length + projectedMarkdown.length <= maxResultCharacters &&
+              utf8ByteLength(frontmatter, maxResultBytes) +
+                utf8ByteLength(projectedMarkdown, maxResultBytes) <=
+                maxResultBytes
+            )
+              return true
 
-            onRejected()
+            if (transaction === pasteRoot) {
+              finishPaste()
+              onRejected('paste')
+            } else if (!formattingRejected) {
+              formattingRejected = true
+              onRejected('formatting')
+            }
             return false
           },
           props: {
@@ -75,7 +107,7 @@ export function createRichMarkdownPasteAdmission({
 
                 if (pastedHtml && utf8ByteLength(pastedHtml, maxResultBytes) > maxResultBytes) {
                   event.preventDefault()
-                  onRejected()
+                  onRejected('paste')
                   return true
                 }
 
@@ -97,16 +129,14 @@ export function createRichMarkdownPasteAdmission({
                     const projectedBytes = Math.max(0, currentBytes - replacedBytes) + pastedBytes
                     if (projectedBytes > maxResultBytes) {
                       event.preventDefault()
-                      onRejected()
+                      onRejected('paste')
                       return true
                     }
                   }
                 }
 
                 pasteInProgress = true
-                queueMicrotask(() => {
-                  pasteInProgress = false
-                })
+                queueMicrotask(finishPaste)
                 return false
               },
             },

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -1379,7 +1379,14 @@ export function LoadedRichMarkdownEditor({
             if (editor && anchor) removeImageUpload(editor, anchor)
             pendingImageAnchorRef.current = null
             input.value = ''
-            if (images.length > 0 && range !== null) void insertImagesRef.current(images, range)
+            if (images.length === 0) return
+            if (range === null) {
+              toast.info(
+                'The insertion location changed. Choose a new location and select the image again.'
+              )
+              return
+            }
+            void insertImagesRef.current(images, range)
           }}
         />
         {showPlaceholder && placeholderContent && (

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
-import { cn, toast } from '@sim/emcn'
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Chip, cn, toast } from '@sim/emcn'
 import { FILE_DOC_SEED, type JoinFileDocError } from '@sim/realtime-protocol/file-doc'
-import { formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
-import type { Extensions, JSONContent } from '@tiptap/core'
+import { PASTE_LIMITS, PASTE_RENDER_THRESHOLDS } from '@sim/utils/paste'
+import type { Extensions, JSONContent, Range } from '@tiptap/core'
 import { isChangeOrigin } from '@tiptap/extension-collaboration'
 import type { Editor } from '@tiptap/react'
 import { EditorContent, useEditor } from '@tiptap/react'
@@ -17,50 +17,64 @@ import {
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import { extractEmbeddedFileRef, extractImgSrcs } from '@/lib/uploads/utils/embedded-image-ref'
 import { FindBar } from '@/app/workspace/[workspaceId]/components'
+import { FileSaveConflict } from '@/app/workspace/[workspaceId]/files/components/file-viewer/file-save-conflict'
+import { PreviewLoadingFrame } from '@/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared'
+import {
+  announceAgentApplying,
+  clearAgentApplying,
+  isAgentStreamLeader,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/agent-stream-leader'
+import {
+  type AgentStreamSession,
+  applyAgentStreamFrame,
+  beginAgentStream,
+  endAgentStream,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/apply-streamed-markdown'
+import { nextCollabReadiness } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness'
+import { useFileDocCollaboration } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/use-file-doc-collaboration'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+import { useMarkdownFind } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/find'
+import { findHeadingPos } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/heading-anchors'
+import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
+import {
+  extractImageFiles,
+  findHostedImageAttrs,
+  shouldSkipFileUpload,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste'
+import {
+  beginImageUploads,
+  findImageUpload,
+  findImageUploadRange,
+  finishImageUpload,
+  removeImageUpload,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload'
+import {
+  applyFrontmatter,
+  normalizeLinkHref,
+  postProcessSerializedMarkdown,
+  splitFrontmatter,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import { parseMarkdownToDoc } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+import { isPlainTextPaste } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste'
+import { useEditorMentions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention'
+import { EditorBubbleMenu } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu'
+import { LinkHoverCard } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card'
+import { TableBubbleMenu } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/table-menu'
+import { normalizeMarkdownContent } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/normalize-content'
+import { isRoundTripSafe } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety'
+import { firstHeadingTitle } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/title-heading'
+import { TextEditor } from '@/app/workspace/[workspaceId]/files/components/file-viewer/text-editor'
+import { useEditableFileContent } from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content'
+import { useSelectionCopyBridge } from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-selection-copy-bridge'
 import { isUntitledName } from '@/app/workspace/[workspaceId]/files/untitled-title'
 import { useUploadWorkspaceFile } from '@/hooks/queries/workspace-files'
 import { useAddToChat } from '@/hooks/use-add-to-chat'
 import type { SaveStatus } from '@/hooks/use-autosave'
 import { useFileContentSource } from '@/hooks/use-file-content-source'
 import type { ChatContext } from '@/stores/panel'
-import { PreviewLoadingFrame } from '../preview-shared'
-import { useEditableFileContent } from '../use-editable-file-content'
-import { useSelectionCopyBridge } from '../use-selection-copy-bridge'
-import {
-  announceAgentApplying,
-  clearAgentApplying,
-  isAgentStreamLeader,
-} from './collaboration/agent-stream-leader'
-import {
-  type AgentStreamSession,
-  applyAgentStreamFrame,
-  beginAgentStream,
-  endAgentStream,
-} from './collaboration/apply-streamed-markdown'
-import { nextCollabReadiness } from './collaboration/readiness'
-import { useFileDocCollaboration } from './collaboration/use-file-doc-collaboration'
-import { createMarkdownEditorExtensions } from './editor-extensions'
-import { useMarkdownFind } from './find'
-import { findHeadingPos } from './heading-anchors'
-import { moveDraggedImageNode } from './image-drag-move'
-import { extractImageFiles, findHostedImageAttrs, shouldSkipFileUpload } from './image-paste'
-import {
-  applyFrontmatter,
-  normalizeLinkHref,
-  postProcessSerializedMarkdown,
-  splitFrontmatter,
-} from './markdown-fidelity'
-import { parseMarkdownToDoc } from './markdown-parse'
-import { useEditorMentions } from './mention'
-import { EditorBubbleMenu } from './menus/bubble-menu'
-import { LinkHoverCard } from './menus/link-hover-card'
-import { TableBubbleMenu } from './menus/table-menu'
-import { normalizeMarkdownContent } from './normalize-content'
-import { isRoundTripSafe } from './round-trip-safety'
-import { firstHeadingTitle } from './title-heading'
 import '@sim/emcn/components/code/code.css'
-import '../document-table.css'
-import './rich-markdown-editor.css'
+import '@/app/workspace/[workspaceId]/files/components/file-viewer/document-table.css'
+import '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.css'
 
 const PLACEHOLDER = "Write something, or press '/' for commands…"
 
@@ -76,9 +90,15 @@ const STREAM_REPARSE_THROTTLE_MS = 120
 /** Debounce before naming a still-untitled file after its leading heading, so it fires once typing settles. */
 const DERIVE_TITLE_DEBOUNCE_MS = 600
 
-function warnRichMarkdownPasteLimit() {
+function warnRichMarkdownPasteLimit(reason?: 'paste' | 'formatting') {
+  if (reason === 'formatting') {
+    toast.warning('Pasted text kept without automatic formatting', {
+      description: 'Adding that formatting would exceed the rich-text editing limit.',
+    })
+    return
+  }
   toast.warning('Paste is too large for rich-text editing', {
-    description: `Keep this document under ${formatPasteLimit(PASTE_LIMITS.RICH_MARKDOWN_BYTES)}, or import the content as a file and open it read-only.`,
+    description: `Rich-text editing supports up to ${PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS.toLocaleString()} characters. Use the source editor for larger documents.`,
   })
 }
 
@@ -115,7 +135,15 @@ function ReadOnlyPlaceholder({ content }: ReadOnlyPlaceholderProps) {
     immediatelyRender: true,
     shouldRerenderOnTransaction: false,
     content,
-    editorProps: { attributes: { class: 'rich-markdown-nodes rich-markdown-prose' } },
+    editorProps: {
+      attributes: {
+        class: 'rich-markdown-nodes rich-markdown-prose',
+        'aria-label': 'Document preview',
+        role: 'textbox',
+        'aria-multiline': 'true',
+        'aria-readonly': 'true',
+      },
+    },
   })
   return <EditorContent editor={editor} className={EDITOR_SURFACE_CLASS} />
 }
@@ -169,8 +197,26 @@ interface RichMarkdownEditorProps {
   enableFind?: boolean
 }
 
-/** Inline WYSIWYG markdown editor: agent output streams in read-only, then the same instance becomes editable on settle. */
-export const RichMarkdownEditor = memo(function RichMarkdownEditor({
+/** Source fallback unmounts the rich surface so only one editing engine owns the local draft. */
+export const RichMarkdownEditor = memo(function RichMarkdownEditor(props: RichMarkdownEditorProps) {
+  const [sourceFileId, setSourceFileId] = useState<string | null>(null)
+  if (sourceFileId === props.file.id)
+    return (
+      <TextEditor
+        {...props}
+        previewMode='editor'
+        disableStreamingAutoScroll={props.disableStreamingAutoScroll ?? false}
+      />
+    )
+  return <RichMarkdownSurface {...props} onEditSource={() => setSourceFileId(props.file.id)} />
+})
+
+interface RichMarkdownSurfaceProps extends RichMarkdownEditorProps {
+  onEditSource: () => void
+}
+
+/** Inline rich editor; agent output streams read-only before editing becomes available on settle. */
+function RichMarkdownSurface({
   file,
   workspaceId,
   canEdit,
@@ -189,7 +235,8 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
   collaborative = false,
   onDeriveTitleFromHeading,
   enableFind = false,
-}: RichMarkdownEditorProps) {
+  onEditSource,
+}: RichMarkdownSurfaceProps) {
   const { data: session, isPending: isSessionPending } = useSession()
   const userId = session?.user?.id ?? ''
   const userName = session?.user?.name?.trim() || 'Collaborator'
@@ -199,13 +246,13 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
    * autosaves the markdown). For a collaborative file it stays `false`: the realtime relay persists the
    * shared document to markdown server-side, so the client must never also autosave — a stale keystroke
    * saving over a server/copilot edit is exactly the clobber the server path closes. The child reports
-   * the right value up via `onCollabReadyChange`.
+   * the right value up via `onClientAutosaveChange`.
    *
    * Initialize from the `collaborative` prop (NOT unconditionally `true`): a collaborative file must
    * start with autosave OFF, or a save could fire in the window before the child mounts and reports —
    * re-clobbering exactly what this closes. The child turns it on for the non-collaborative fallback.
    */
-  const [collabReady, setCollabReady] = useState(!collaborative)
+  const [canClientAutosave, setCanClientAutosave] = useState(!collaborative)
 
   const {
     content,
@@ -214,6 +261,11 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
     isContentLoading,
     hasContentError,
     saveImmediately,
+    hasConflict,
+    isReloading,
+    reloadLatestContent,
+    downloadDraft,
+    acceptedBaselineContent,
   } = useEditableFileContent({
     file,
     workspaceId,
@@ -225,7 +277,7 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
     saveRef,
     discardRef,
     normalizeBaseline: normalizeMarkdownContent,
-    canAutosave: collabReady,
+    canAutosave: canClientAutosave,
   })
 
   // Wait for the session too: the child decides collaboration ONCE at mount from
@@ -243,35 +295,48 @@ export const RichMarkdownEditor = memo(function RichMarkdownEditor({
   }
 
   return (
-    <LoadedRichMarkdownEditor
-      key={previewContextKey ? `${file.id}:${previewContextKey}` : file.id}
-      file={file}
-      workspaceId={workspaceId}
-      content={content}
-      isStreaming={isStreamInteractionLocked}
-      canEdit={canEdit}
-      userId={userId}
-      userName={userName}
-      autoFocus={autoFocus}
-      streamIsIncremental={streamIsIncremental}
-      streamOperation={streamOperation}
-      disableStreamingAutoScroll={disableStreamingAutoScroll}
-      disableTagging={disableTagging}
-      collaborative={collaborative}
-      onChange={setDraftContent}
-      onSaveShortcut={saveImmediately}
-      onCollabReadyChange={setCollabReady}
-      onDeriveTitleFromHeading={onDeriveTitleFromHeading}
-      enableFind={enableFind}
-    />
+    <>
+      {hasConflict && (
+        <FileSaveConflict
+          isReloading={isReloading}
+          reloadLatestContent={reloadLatestContent}
+          downloadDraft={downloadDraft}
+        />
+      )}
+      <LoadedRichMarkdownEditor
+        key={previewContextKey ? `${file.id}:${previewContextKey}` : file.id}
+        file={file}
+        workspaceId={workspaceId}
+        content={content}
+        acceptedBaselineContent={acceptedBaselineContent}
+        isStreaming={isStreamInteractionLocked}
+        canEdit={canEdit}
+        userId={userId}
+        userName={userName}
+        autoFocus={autoFocus}
+        streamIsIncremental={streamIsIncremental}
+        streamOperation={streamOperation}
+        disableStreamingAutoScroll={disableStreamingAutoScroll}
+        disableTagging={disableTagging}
+        collaborative={collaborative}
+        onChange={setDraftContent}
+        onSaveShortcut={saveImmediately}
+        onClientAutosaveChange={setCanClientAutosave}
+        onDeriveTitleFromHeading={onDeriveTitleFromHeading}
+        enableFind={enableFind}
+        onEditSource={onEditSource}
+      />
+    </>
   )
-})
+}
 
 interface LoadedRichMarkdownEditorProps {
   file: WorkspaceFileRecord
   workspaceId: string
   /** The live content from the engine — grows as the agent streams, then settles to the saved doc. */
   content: string
+  /** Accepted external baseline, excluding local serialization echoes and own save acknowledgements. */
+  acceptedBaselineContent?: string
   /** True while agent output is streaming in: the editor renders it read-only and syncs each chunk. */
   isStreaming: boolean
   canEdit: boolean
@@ -289,12 +354,13 @@ interface LoadedRichMarkdownEditorProps {
   collaborative?: boolean
   onChange: (markdown: string) => void
   onSaveShortcut: () => Promise<void>
-  /** Reports whether the collaborative document is synced+seeded (autosave gate). */
-  onCollabReadyChange: (ready: boolean) => void
+  /** Reports client autosave eligibility; collaborative documents are persisted by the relay. */
+  onClientAutosaveChange: (canAutosave: boolean) => void
   /** See {@link RichMarkdownEditorProps.onDeriveTitleFromHeading}. */
   onDeriveTitleFromHeading?: (headingText: string) => void
   /** See {@link RichMarkdownEditorProps.enableFind}. */
   enableFind: boolean
+  onEditSource?: () => void
 }
 
 interface SettledContent {
@@ -302,7 +368,7 @@ interface SettledContent {
   verdict: boolean
 }
 
-/** Locks the round-trip verdict + frontmatter once; a round-trip-unsafe doc (raw HTML, footnotes, >256KB) opens read-only. */
+/** Assess an accepted source snapshot before rich editing can change its representation. */
 function lockSettled(content: string): SettledContent {
   return { frontmatter: splitFrontmatter(content).frontmatter, verdict: isRoundTripSafe(content) }
 }
@@ -312,6 +378,7 @@ export function LoadedRichMarkdownEditor({
   file,
   workspaceId,
   content,
+  acceptedBaselineContent,
   isStreaming,
   canEdit,
   userId,
@@ -324,36 +391,46 @@ export function LoadedRichMarkdownEditor({
   collaborative = false,
   onChange,
   onSaveShortcut,
-  onCollabReadyChange,
+  onClientAutosaveChange,
   onDeriveTitleFromHeading,
   enableFind,
+  onEditSource,
 }: LoadedRichMarkdownEditorProps) {
   /** Whether this editor mounted mid-stream — if so it starts empty and syncs streamed chunks until settle. */
-  const streamingAtMountRef = useRef(isStreaming)
+  const [streamingAtMount] = useState(isStreaming)
 
-  /** Verdict + frontmatter, locked once (at mount if settled, else on settle); null reads as read-only. */
-  const settledRef = useRef<SettledContent | null>(null)
-  if (!streamingAtMountRef.current && settledRef.current === null) {
-    settledRef.current = lockSettled(content)
-  }
+  /** Only accepted source snapshots and stream settlement change editing eligibility. */
+  const [settled, setSettled] = useState<SettledContent | null>(() =>
+    streamingAtMount ? null : lockSettled(content)
+  )
+  const [acceptedBaseline, setAcceptedBaseline] = useState(acceptedBaselineContent)
   /**
    * Collaboration is decided once at mount from synchronously-available inputs
-   * (`settledRef` is set just above) via `useState`-init, and never changes — TipTap
+   * via `useState`-init, and never changes — TipTap
    * fixes the extension set at editor creation, so it cannot turn on later. Enabled on a
    * `collaborative` surface (the Files page or the embedded chat file preview) for an editable,
    * round-trip-safe workspace document with a known user, as long as it is not ALREADY streaming at
-   * mount (`!streamingAtMountRef.current`). An agent stream that begins AFTER mount is applied as CRDT
+   * mount. An agent stream that begins AFTER mount is applied as CRDT
    * diffs into the live doc, so collaboration and streaming coexist (see the streaming effect below).
    */
   const [collaborationEnabled] = useState(
     () =>
       collaborative &&
       canEdit &&
-      !streamingAtMountRef.current &&
-      (settledRef.current?.verdict ?? false) &&
+      !streamingAtMount &&
+      (settled?.verdict ?? false) &&
       Boolean(userId) &&
       (file.storageContext ?? 'workspace') === 'workspace'
   )
+  if (
+    !collaborationEnabled &&
+    !isStreaming &&
+    acceptedBaselineContent !== undefined &&
+    acceptedBaselineContent !== acceptedBaseline
+  ) {
+    setAcceptedBaseline(acceptedBaselineContent)
+    setSettled(lockSettled(acceptedBaselineContent))
+  }
   /**
    * Whether the collaborative document is safe to edit + persist: synced and seeded.
    * Starts `false` for a collaborative document — so the editor is read-only and
@@ -361,8 +438,7 @@ export function LoadedRichMarkdownEditor({
    * empty, unsynced doc, which the seed would then discard) — and `true` for a local one.
    */
   const [collabReady, setCollabReady] = useState(!collaborationEnabled)
-  const isEditable =
-    canEdit && !isStreaming && (settledRef.current?.verdict ?? false) && collabReady
+  const isEditable = canEdit && !isStreaming && (settled?.verdict ?? false) && collabReady
 
   const collaboration = useFileDocCollaboration({
     fileId: file.id,
@@ -377,7 +453,7 @@ export function LoadedRichMarkdownEditor({
    * parsed markdown (chunked parse is linear vs the editor's ~O(n²) whole-body parse).
    */
   const [initialContent] = useState<JSONContent | string>(() =>
-    streamingAtMountRef.current || collaborationEnabled
+    streamingAtMount || collaborationEnabled
       ? ''
       : parseMarkdownToDoc(splitFrontmatter(content).body)
   )
@@ -396,7 +472,7 @@ export function LoadedRichMarkdownEditor({
    * rewrite holds the current content instead of collapsing to a partial result.
    */
   const lastSyncedBodyRef = useRef<string | null>(
-    streamingAtMountRef.current ? null : splitFrontmatter(content).body
+    streamingAtMount ? null : splitFrontmatter(content).body
   )
   /**
    * The body the AGENT last applied into the collaborative doc — a dedup guard for the collab streaming
@@ -407,23 +483,22 @@ export function LoadedRichMarkdownEditor({
    */
   const lastStreamedBodyRef = useRef<string | null>(null)
   const onChangeRef = useRef(onChange)
-  onChangeRef.current = onChange
   const onSaveShortcutRef = useRef(onSaveShortcut)
-  onSaveShortcutRef.current = onSaveShortcut
 
   /**
    * The frontmatter to re-attach to the body on save. For a collaborative doc it lives in the CRDT
    * (config map, seeded/updated server-side), so a server edit that changes it is reflected rather
-   * than reverted by this editor's stale open-time copy; falls back to the locked `settledRef` copy
+   * than reverted by this editor's stale open-time copy; falls back to the accepted source snapshot
    * before the seed lands and for non-collaborative documents.
    */
-  const resolveSaveFrontmatter = useCallback((): string => {
+  const resolveSaveFrontmatter = (): string => {
     const fromDoc = collaboration?.doc
       .getMap(FILE_DOC_SEED.configMap)
       .get(FILE_DOC_SEED.frontmatterKey)
     if (typeof fromDoc === 'string') return fromDoc
-    return settledRef.current?.frontmatter ?? ''
-  }, [collaboration])
+    return settled?.frontmatter ?? ''
+  }
+  const saveFrontmatterResolverRef = useRef(resolveSaveFrontmatter)
 
   /**
    * While the file is still unnamed, name it after its leading heading: `onDeriveTitleFromHeading` is
@@ -431,70 +506,66 @@ export function LoadedRichMarkdownEditor({
    * read the current name without re-subscribing. See {@link isUntitledName}.
    */
   const onDeriveTitleFromHeadingRef = useRef(onDeriveTitleFromHeading)
-  onDeriveTitleFromHeadingRef.current = onDeriveTitleFromHeading
   const fileNameRef = useRef(file.name)
-  fileNameRef.current = file.name
   const deriveTitleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   /**
    * Read in the RAF tick so an already-scheduled tick still sees the latest edit kind (it can change
    * between sessions within one turn, e.g. an append followed by a rewrite).
    */
   const streamIsIncrementalRef = useRef(streamIsIncremental)
-  streamIsIncrementalRef.current = streamIsIncremental
   const streamOperationRef = useRef(streamOperation)
-  streamOperationRef.current = streamOperation
   /** The live agent-stream shadow replica, held for the current stream and freed on settle/unmount. */
   const agentStreamSessionRef = useRef<AgentStreamSession | null>(null)
   /** True once this client has announced candidacy in the agent-stream election for the current stream. */
   const agentAnnouncedRef = useRef(false)
   const router = useRouter()
   const routerRef = useRef(router)
-  routerRef.current = router
 
   const containerRef = useRef<HTMLDivElement>(null)
   const uploadFile = useUploadWorkspaceFile()
   const editorInstanceRef = useRef<Editor | null>(null)
   const source = useFileContentSource()
   const resolveImageSrcRef = useRef(source.resolveImageSrc)
-  resolveImageSrcRef.current = source.resolveImageSrc
 
-  /**
-   * The `/Image` slash command opens this hidden picker; `pendingImagePosRef` holds the caret position
-   * captured when the command ran, so the upload inserts where `/Image` was typed.
-   */
+  /** The picker anchor maps through edits while the operating-system file dialog is open. */
   const imageInputRef = useRef<HTMLInputElement>(null)
-  const pendingImagePosRef = useRef<number | null>(null)
+  const pendingImageAnchorRef = useRef<string | null>(null)
 
   /**
-   * Upload then insert each image at `at` (paste caret / drop point), sequentially; held in a ref so
-   * handlers reach the latest. A persistent (`duration: 0`) progress toast shows per image during the
-   * upload and is dismissed once it settles, when the upload hook's own "Uploaded"/"Failed" toast takes over.
+   * Uploads are sequential; every position is anchored before awaiting so queued images also follow
+   * edits. Capture the editor instance, never a later file's editor, for completion and teardown.
    */
-  const insertImagesRef = useRef<(images: File[], at: number) => Promise<void>>(() =>
+  const insertImagesRef = useRef<(images: File[], range: Range) => Promise<void>>(() =>
     Promise.resolve()
   )
-  insertImagesRef.current = async (images, at) => {
-    let position = at
-    for (const image of images) {
+  const insertImages = async (images: File[], range: Range) => {
+    const editor = editorInstanceRef.current
+    if (!editor) return
+    const anchors = beginImageUploads(
+      editor,
+      range,
+      images.map((image) => image.name)
+    )
+    for (const [index, image] of images.entries()) {
+      if (editor.isDestroyed) break
+      if (!editor.isEditable) {
+        for (const pending of anchors) removeImageUpload(editor, pending)
+        break
+      }
+      const anchor = anchors[index]
+      if (!anchor || findImageUpload(editor, anchor) === null) continue
       const uploadingToastId = toast.info(`Uploading "${image.name}"…`, { duration: 0 })
       const result = await uploadFile
         .mutateAsync({ workspaceId, file: image, folderId: file.folderId ?? null })
         .catch(() => null)
       toast.dismiss(uploadingToastId)
-      const editor = editorInstanceRef.current
-      if (!result || !editor) continue
-      const safePosition = Math.min(position, editor.state.doc.content.size)
-      try {
-        editor
-          .chain()
-          .insertContentAt(safePosition, {
-            type: 'image',
-            attrs: { src: result.file.url, alt: image.name },
-          })
-          .run()
-        position = editor.state.selection.to
-      } catch {
-        position = editor.state.doc.content.size
+      if (result) {
+        const inserted = finishImageUpload(editor, anchor, result.file.url, image.name)
+        if (!inserted && !editor.isDestroyed) {
+          toast.info('The image was uploaded to the workspace but was not inserted.')
+        }
+      } else {
+        removeImageUpload(editor, anchor)
       }
     }
   }
@@ -509,16 +580,14 @@ export function LoadedRichMarkdownEditor({
    * than a re-derived guess. Returns `false` (falls through to a normal upload) if no match is found,
    * which is always correct, just occasionally a redundant upload — unlike blindly trusting the html.
    */
-  const cloneHostedImageRef = useRef<(imgSrcs: string[], at: number) => boolean>(() => false)
-  cloneHostedImageRef.current = (imgSrcs, at) => {
+  const cloneHostedImageRef = useRef<(imgSrcs: string[], range: Range) => boolean>(() => false)
+  const cloneHostedImage = (imgSrcs: string[], range: Range) => {
     const editor = editorInstanceRef.current
     if (!editor) return false
     const matchedAttrs = findHostedImageAttrs(editor.state.doc, imgSrcs, source.resolveImageSrc)
     if (!matchedAttrs) return false
-    const safePosition = Math.min(at, editor.state.doc.content.size)
     try {
-      editor.chain().insertContentAt(safePosition, { type: 'image', attrs: matchedAttrs }).run()
-      return true
+      return editor.chain().insertContentAt(range, { type: 'image', attrs: matchedAttrs }).run()
     } catch {
       return false
     }
@@ -541,7 +610,11 @@ export function LoadedRichMarkdownEditor({
           },
           pasteAdmission: {
             maxResultBytes: PASTE_LIMITS.RICH_MARKDOWN_BYTES,
-            getCurrentText: () => lastSyncedBodyRef.current ?? '',
+            getCurrentText: () => {
+              const editor = editorInstanceRef.current
+              return editor ? postProcessSerializedMarkdown(editor.getMarkdown()) : ''
+            },
+            getFrontmatter: () => saveFrontmatterResolverRef.current(),
             onRejected: warnRichMarkdownPasteLimit,
           },
         })
@@ -551,6 +624,7 @@ export function LoadedRichMarkdownEditor({
           pasteAdmission: {
             maxResultBytes: PASTE_LIMITS.RICH_MARKDOWN_BYTES,
             getCurrentText: () => lastSyncedBodyRef.current ?? '',
+            getFrontmatter: () => saveFrontmatterResolverRef.current(),
             onRejected: warnRichMarkdownPasteLimit,
           },
         })
@@ -560,19 +634,25 @@ export function LoadedRichMarkdownEditor({
     extensions,
     editable: isEditable,
     enablePasteRules: false,
-    autofocus: streamingAtMountRef.current ? false : autoFocus ? 'end' : false,
+    autofocus: streamingAtMount ? false : autoFocus ? 'end' : false,
     immediatelyRender: false,
     shouldRerenderOnTransaction: false,
     content: initialContent,
     editorProps: {
       attributes: {
         class: 'rich-markdown-nodes rich-markdown-prose',
+        'aria-label': `${file.name} document body`,
+        role: 'textbox',
+        'aria-multiline': 'true',
+        'aria-readonly': String(!isEditable),
         'data-owned-shortcuts': 'Mod+K',
         'data-paste-max-bytes': String(PASTE_LIMITS.RICH_MARKDOWN_BYTES),
         'data-paste-max-html-bytes': String(PASTE_LIMITS.RICH_MARKDOWN_BYTES),
         'data-paste-handles-images': 'true',
       },
       handleKeyDown: (_view, event) => {
+        if (event.isComposing || event.keyCode === 229 || event.shiftKey || event.altKey)
+          return false
         const isSaveShortcut = (event.metaKey || event.ctrlKey) && event.key?.toLowerCase() === 's'
         if (!isSaveShortcut) return false
         event.preventDefault()
@@ -624,13 +704,12 @@ export function LoadedRichMarkdownEditor({
        */
       handlePaste: (view, event) => {
         if (!view.editable) return false
+        const currentEditor = editorInstanceRef.current
+        if (currentEditor && isPlainTextPaste(currentEditor)) return false
         const images = extractImageFiles(event.clipboardData)
         const html = event.clipboardData?.getData('text/html') ?? ''
         if (shouldSkipFileUpload(images, html, (src) => extractEmbeddedFileRef(src) !== null)) {
-          const cloned = cloneHostedImageRef.current(
-            extractImgSrcs(html),
-            view.state.selection.from
-          )
+          const cloned = cloneHostedImageRef.current(extractImgSrcs(html), view.state.selection)
           if (cloned) {
             event.preventDefault()
             return true
@@ -638,7 +717,7 @@ export function LoadedRichMarkdownEditor({
         }
         if (images.length === 0) return false
         event.preventDefault()
-        void insertImagesRef.current(images, view.state.selection.from)
+        void insertImagesRef.current(images, view.state.selection)
         return true
       },
       /**
@@ -675,7 +754,8 @@ export function LoadedRichMarkdownEditor({
         if (images.length > 0) {
           event.preventDefault()
           const dropPos = view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos
-          void insertImagesRef.current(images, dropPos ?? view.state.selection.from)
+          const at = dropPos ?? view.state.selection.from
+          void insertImagesRef.current(images, { from: at, to: at })
           return true
         }
         if (event.dataTransfer?.files.length) {
@@ -686,9 +766,12 @@ export function LoadedRichMarkdownEditor({
       },
     },
     onUpdate: ({ editor, transaction }) => {
-      const md = postProcessSerializedMarkdown(editor.getMarkdown())
-      lastSyncedBodyRef.current = md
-      onChangeRef.current(applyFrontmatter(resolveSaveFrontmatter(), md))
+      /** The relay persists collaborative documents; a second Markdown projection has no consumer. */
+      if (!collaborationEnabled && transaction.docChanged) {
+        const md = postProcessSerializedMarkdown(editor.getMarkdown())
+        lastSyncedBodyRef.current = md
+        onChangeRef.current(applyFrontmatter(saveFrontmatterResolverRef.current(), md))
+      }
       // While the file is still untitled, name it after its leading heading once typing settles — but
       // only for the LOCAL user's own edits. `isChangeOrigin` is true for a remote Yjs change (a peer
       // typing); bail BEFORE touching the timer so a remote edit never cancels or reschedules the local
@@ -715,7 +798,6 @@ export function LoadedRichMarkdownEditor({
       }, DERIVE_TITLE_DEBOUNCE_MS)
     },
   })
-  editorInstanceRef.current = editor
 
   useEffect(
     () => () => {
@@ -729,7 +811,23 @@ export function LoadedRichMarkdownEditor({
    * runs once at seed time rather than every render.
    */
   const seedContentRef = useRef(content)
-  seedContentRef.current = content
+
+  /** The lifetime-stable editor and its async work consume only committed React inputs. */
+  useLayoutEffect(() => {
+    onChangeRef.current = onChange
+    onSaveShortcutRef.current = onSaveShortcut
+    saveFrontmatterResolverRef.current = resolveSaveFrontmatter
+    onDeriveTitleFromHeadingRef.current = onDeriveTitleFromHeading
+    fileNameRef.current = file.name
+    streamIsIncrementalRef.current = streamIsIncremental
+    streamOperationRef.current = streamOperation
+    routerRef.current = router
+    resolveImageSrcRef.current = source.resolveImageSrc
+    insertImagesRef.current = insertImages
+    cloneHostedImageRef.current = cloneHostedImage
+    editorInstanceRef.current = editor
+    seedContentRef.current = content
+  })
 
   /**
    * The collaborative document lifecycle. In one effect because the three concerns
@@ -768,7 +866,7 @@ export function LoadedRichMarkdownEditor({
       // markdown server-side (debounced + on last-disconnect), so the client must NOT also autosave —
       // a stale keystroke saving over a server/copilot edit is the clobber the server path closes.
       // Only the non-collaborative (solo) path client-autosaves.
-      onCollabReadyChange(collaboration ? false : ready)
+      onClientAutosaveChange(collaboration ? false : ready)
     }
     if (!collaboration) {
       setReady(true)
@@ -823,28 +921,9 @@ export function LoadedRichMarkdownEditor({
       report()
     }
 
-    // A server edit that changes ONLY the frontmatter (e.g. copilot) updates the config map but not
-    // the body fragment, so TipTap's `onUpdate` never fires and the autosave draft would keep the
-    // stale open-time frontmatter — an explicit save could then revert the live change. Re-attach the
-    // new frontmatter to the current body and push a fresh draft whenever it changes on its own.
-    let lastFrontmatter = config.get(FILE_DOC_SEED.frontmatterKey)
-    const syncFrontmatter = () => {
-      const current = config.get(FILE_DOC_SEED.frontmatterKey)
-      if (current === lastFrontmatter) return
-      lastFrontmatter = current
-      // Null body ref ⇒ no body has synced yet (e.g. this fired before the seed's own `onUpdate`);
-      // that path re-attaches the frontmatter itself, so there is nothing to do here.
-      if (lastSyncedBodyRef.current !== null) {
-        onChangeRef.current(
-          applyFrontmatter(typeof current === 'string' ? current : '', lastSyncedBodyRef.current)
-        )
-      }
-    }
-
     provider.on('synced', report)
     provider.on('join-error', onJoinError)
     config.observe(report)
-    config.observe(syncFrontmatter)
     report()
     if (provider.joinError) onJoinError(provider.joinError)
 
@@ -852,13 +931,12 @@ export function LoadedRichMarkdownEditor({
       provider.off('synced', report)
       provider.off('join-error', onJoinError)
       config.unobserve(report)
-      config.unobserve(syncFrontmatter)
       // Report NOT ready on teardown — the safe direction. If this effect ever re-runs while mounted
       // (a future dep change), briefly gating autosave off is harmless; reporting `true` here could
       // ungate it while the doc is unready.
-      onCollabReadyChange(false)
+      onClientAutosaveChange(false)
     }
-  }, [collaboration, editor, onCollabReadyChange, setCollabReady])
+  }, [collaboration, editor, onClientAutosaveChange, setCollabReady])
 
   /**
    * Owns editability for the collaborative lifecycle: `useEditor`'s `editable` is only the initial
@@ -891,18 +969,29 @@ export function LoadedRichMarkdownEditor({
    */
   useEffect(() => {
     if (!editor) return
+    const input = imageInputRef.current
+    const cancelImagePicker = () => {
+      const anchor = pendingImageAnchorRef.current
+      if (anchor) removeImageUpload(editor, anchor)
+      pendingImageAnchorRef.current = null
+    }
+    input?.addEventListener('cancel', cancelImagePicker)
     editor.storage.slashCommand.insertImage = (at: number) => {
-      pendingImagePosRef.current = at
+      const previous = pendingImageAnchorRef.current
+      if (previous) removeImageUpload(editor, previous)
+      pendingImageAnchorRef.current =
+        beginImageUploads(editor, { from: at, to: at }, [''])[0] ?? null
       imageInputRef.current?.click()
     }
     return () => {
+      input?.removeEventListener('cancel', cancelImagePicker)
       editor.storage.slashCommand.insertImage = null
     }
   }, [editor])
 
   useEditorMentions(editor, workspaceId, { navigable: true, disableTagging })
 
-  const wasStreamingRef = useRef(streamingAtMountRef.current)
+  const wasStreamingRef = useRef(streamingAtMount)
 
   const pendingStreamBodyRef = useRef<string | null>(null)
   const streamRafRef = useRef<number | null>(null)
@@ -1126,11 +1215,12 @@ export function LoadedRichMarkdownEditor({
       streamRafRef.current = null
     }
     /** Settle: re-lock the verdict + frontmatter on the freshly-settled content (every stream→settle, not just the first). */
-    const isInitialSettle = settledRef.current === null
+    const isInitialSettle = settled === null
     if (isInitialSettle || wasStreamingRef.current) {
       wasStreamingRef.current = false
-      settledRef.current = lockSettled(content)
-      const settledVerdict = settledRef.current.verdict
+      const nextSettled = lockSettled(content)
+      setSettled(nextSettled)
+      const settledVerdict = nextSettled.verdict
       const shouldFocus = isInitialSettle && autoFocus
       // A settle owes a selection collapse. Track it as a ref, not just inline in this microtask: if a
       // newer run bumps the token before this microtask fires, this settle's task is dropped — but the
@@ -1150,7 +1240,6 @@ export function LoadedRichMarkdownEditor({
       })
       return
     }
-    const settled = settledRef.current
     runOffRender(() => {
       syncEditorBody(splitFrontmatter(content).body)
       // Honor a collapse a superseded settle owed but never applied (its microtask was dropped when this
@@ -1164,6 +1253,9 @@ export function LoadedRichMarkdownEditor({
   }, [
     editor,
     content,
+    acceptedBaselineContent,
+    settled,
+    collaboration,
     isStreaming,
     canEdit,
     autoFocus,
@@ -1233,6 +1325,17 @@ export function LoadedRichMarkdownEditor({
     // The find bar is a sibling of the scroller, not a child: pinned inside `containerRef` it would
     // scroll away with the document the moment stepping moved the view.
     <div className='relative flex min-h-0 flex-1 flex-col'>
+      {canEdit && !isStreaming && settled?.verdict === false && onEditSource && (
+        <div
+          role='status'
+          className='flex items-center gap-2 border-[var(--border)] border-b px-4 py-2 text-[var(--text-muted)] text-small'
+        >
+          <p className='flex-1'>
+            This document needs source editing to preserve its content or handle its size.
+          </p>
+          <Chip onClick={onEditSource}>Edit source</Chip>
+        </div>
+      )}
       {find.isOpen && (
         <FindBar
           ariaLabel='Find in document'
@@ -1270,11 +1373,13 @@ export function LoadedRichMarkdownEditor({
           onChange={(event) => {
             const input = event.currentTarget
             const images = Array.from(input.files ?? []).filter((f) => f.type.startsWith('image/'))
-            const at =
-              pendingImagePosRef.current ?? editorInstanceRef.current?.state.selection.from ?? 0
-            pendingImagePosRef.current = null
+            const editor = editorInstanceRef.current
+            const anchor = pendingImageAnchorRef.current
+            const range = editor && anchor ? findImageUploadRange(editor, anchor) : null
+            if (editor && anchor) removeImageUpload(editor, anchor)
+            pendingImageAnchorRef.current = null
             input.value = ''
-            if (images.length > 0) void insertImagesRef.current(images, at)
+            if (images.length > 0 && range !== null) void insertImagesRef.current(images, range)
           }}
         />
         {showPlaceholder && placeholderContent && (

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.test.tsx
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { toast } from '@sim/emcn'
+import { PASTE_LIMITS, PASTE_RENDER_THRESHOLDS } from '@sim/utils/paste'
+import type { Editor } from '@tiptap/core'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RichMarkdownField } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field'
+
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention',
+  () => ({
+    useEditorMentions: vi.fn(),
+  })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu',
+  () => ({
+    EditorBubbleMenu: () => null,
+  })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card',
+  () => ({
+    LinkHoverCard: () => null,
+  })
+)
+
+let root: Root
+let container: HTMLDivElement
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+  vi.spyOn(toast, 'warning').mockReturnValue('paste-warning')
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+describe('shared field paste admission with real extensions', () => {
+  it.each([false, true])('counts preserved frontmatter (near limit=%s)', async (nearLimit) => {
+    const frontmatter = `---\ndescription: ${'f'.repeat(nearLimit ? 900 : 10)}\n---\n\n`
+    const body = 'x'.repeat(PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS - 1000)
+    const onChange = vi.fn()
+    await act(async () =>
+      root.render(<RichMarkdownField value={frontmatter + body} onChange={onChange} />)
+    )
+    const element = container.querySelector<HTMLElement & { editor: Editor }>('.tiptap')
+    expect(element).not.toBeNull()
+    const editor = element!.editor
+    await act(async () => editor.commands.setTextSelection(editor.state.doc.content.size - 1))
+    const before = editor.getJSON()
+    const event = new Event('paste', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'clipboardData', {
+      value: {
+        files: [],
+        items: [],
+        types: ['text/plain'],
+        getData: (type: string) => (type === 'text/plain' ? 'y'.repeat(100) : ''),
+      },
+    })
+    await act(async () => element!.dispatchEvent(event))
+    if (nearLimit) {
+      expect(editor.getJSON()).toEqual(before)
+      expect(onChange).not.toHaveBeenCalled()
+      expect(toast.warning).toHaveBeenCalledOnce()
+    } else {
+      expect(onChange).toHaveBeenCalledOnce()
+      expect(onChange.mock.lastCall?.[0]).toContain(frontmatter.trim())
+      expect(new TextEncoder().encode(onChange.mock.lastCall?.[0]).byteLength).toBeLessThanOrEqual(
+        PASTE_LIMITS.RICH_MARKDOWN_BYTES
+      )
+      expect(onChange.mock.lastCall?.[0].length).toBeLessThanOrEqual(
+        PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS
+      )
+      expect(editor.getText()).toBe(body + 'y'.repeat(100))
+      expect(toast.warning).not.toHaveBeenCalled()
+    }
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
@@ -217,6 +217,7 @@ function LoadedRichMarkdownField({
       pasteAdmission: {
         maxResultBytes: PASTE_LIMITS.RICH_MARKDOWN_BYTES,
         getCurrentText: () => lastSyncedBodyRef.current,
+        getFrontmatter: () => frontmatterRef.current,
         onRejected: warnRichMarkdownPasteLimit,
       },
     })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety.test.ts
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, expect, it } from 'vitest'
-import { isRoundTripSafe } from './round-trip-safety'
+import { normalizeMarkdownContent } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/normalize-content'
+import { isRoundTripSafe } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety'
 
 describe('isRoundTripSafe', () => {
   it('passes ordinary markdown and lossless normalizations', () => {
@@ -27,6 +28,55 @@ describe('isRoundTripSafe', () => {
 
   it('passes inline code without an interior backtick', () => {
     expect(isRoundTripSafe('use `npm install` here')).toBe(true)
+  })
+
+  it.each([
+    ['[![foo][image]](/dest)', '[image]: /url'],
+    ['[![foo][]](/dest)', '[foo]: /url'],
+    ['[![foo]](/dest)', '[foo]: /url'],
+    ['[![foo](/url)][link]', '[link]: /dest'],
+    ['[![foo][image]][link]', '[image]: /url\n[link]: /dest'],
+    ['[![foo][image]][link]', '[image]: /url "Image"\n[link]: /dest "Link"'],
+  ])('keeps %s in source mode when rich parsing loses its wrapping link', (body, definitions) => {
+    for (const prefix of ['', '- ', '1. ']) {
+      expect(isRoundTripSafe(`${prefix}${body}\n\n${definitions}`)).toBe(false)
+    }
+  })
+
+  it.each([
+    ['[foo][link]', '[link]: /dest'],
+    ['[foo][]', '[foo]: /dest'],
+    ['[foo]', '[foo]: /dest'],
+    ['![foo][link]', '[link]: /image'],
+  ])(
+    'keeps task references in source mode regardless of definition order: %s',
+    (body, definitions) => {
+      const tasks = `- [x] ${body}\n  - [ ] ${body}`
+      for (const source of [`${tasks}\n\n${definitions}`, `${definitions}\n\n${tasks}`]) {
+        expect(isRoundTripSafe(source)).toBe(false)
+        expect(normalizeMarkdownContent(source)).toBe(source)
+      }
+    }
+  )
+
+  it('does not count reference-looking code or escaped brackets as links', () => {
+    expect(isRoundTripSafe('- [ ] `[foo][link]`')).toBe(true)
+    expect(isRoundTripSafe('- [ ] \\[foo\\]\\[link\\]')).toBe(true)
+    expect(isRoundTripSafe('```md\n[![foo][image]](/dest)\n\n[image]: /url\n```')).toBe(true)
+  })
+
+  it('allows adjacent equal links to merge without treating the lower token count as data loss', () => {
+    expect(isRoundTripSafe('[a](/url)[b](/url)')).toBe(true)
+    expect(isRoundTripSafe('[a][link][b][link]\n\n[link]: /url')).toBe(true)
+    expect(isRoundTripSafe('- [ ] [a](/url)[b](/url)')).toBe(true)
+    expect(isRoundTripSafe('![a](/image)\n\n![b](/image)')).toBe(true)
+  })
+
+  it('does not let another link or image hide a lost wrapping link or duplicate table image', () => {
+    expect(isRoundTripSafe('[other](/dest)\n\n1. [![foo][image]](/dest)\n\n[image]: /url')).toBe(
+      false
+    )
+    expect(isRoundTripSafe('![kept](/image)\n\n| h |\n| --- |\n| <img src="/image"> |')).toBe(false)
   })
 
   it('passes a code block followed by other content (idempotent block separation)', () => {
@@ -84,12 +134,29 @@ describe('isRoundTripSafe', () => {
     expect(isRoundTripSafe('Use a<br>break or the pipe | operator.')).toBe(true)
   })
 
-  it('rejects <br> inside a table cell (flattened to a space)', () => {
-    expect(isRoundTripSafe('| a | b |\n| --- | --- |\n| one<br>two | x |')).toBe(false)
+  it('supports <br> inside a table cell without flattening its hard break', () => {
+    expect(isRoundTripSafe('| a | b |\n| --- | --- |\n| one<br>two | x |')).toBe(true)
   })
 
   it('allows <img> (a supported, resizable image node)', () => {
     expect(isRoundTripSafe('<img src="https://e.com/i.png" width="320">')).toBe(true)
+    expect(isRoundTripSafe('<img src="https://e.com/i.png">')).toBe(true)
+    expect(isRoundTripSafe('<img src="/image?a=1&amp;b=2">')).toBe(true)
+    expect(isRoundTripSafe("<img src='/image' width='40'>")).toBe(true)
+    expect(isRoundTripSafe('<img src=/image>')).toBe(true)
+  })
+
+  it.each([
+    '| <img src="/image.png"> |\n| --- |\n| body |',
+    '| header |\n| --- |\n| <img src="/image.png"> |',
+    '| header |\n| --- |\n| <IMG src="/image.png"> |',
+    '| header |\n| --- |\n| [<img src="/image.png">](/dest) |',
+  ])('refuses unsupported HTML images inside GFM tables: %s', (source) => {
+    expect(isRoundTripSafe(source)).toBe(false)
+  })
+
+  it('allows literal HTML image examples in table code spans', () => {
+    expect(isRoundTripSafe('| header |\n| --- |\n| `<img src="/image.png">` |')).toBe(true)
   })
 
   it('does not flag a fenced block that merely contains html or backticks', () => {
@@ -271,6 +338,7 @@ describe('editability gate — realistic documents stay editable', () => {
 
   it('frontmatter does not gate editability', () => {
     expect(isRoundTripSafe('---\ntitle: Hello\ntags: [a, b]\n---\n\n# Body\n\nText.')).toBe(true)
+    expect(isRoundTripSafe('---\ntitle: "[![foo][image]](/dest)"\n---\n\n# Body')).toBe(true)
   })
 })
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety.ts
@@ -1,27 +1,20 @@
-import { serializeMarkdownDocument } from './markdown-parse'
-
-/**
- * Above this size the file opens read-only. Parsing is chunked and linear now (see
- * {@link serializeMarkdownBody}), so this is no longer about parse cost — it guards ProseMirror's
- * whole-document-in-DOM rendering, which has no virtualization and gets sluggish to edit for very
- * large documents. 256KB sits past the p99 of real markdown files while keeping a giant outlier from
- * mounting thousands of editable DOM nodes.
- */
-const PROBE_SIZE_LIMIT = 256 * 1024
+import { PASTE_RENDER_THRESHOLDS } from '@sim/utils/paste'
+import { decodeHtmlEntities } from '@tiptap/core'
+import { Marked, type Token } from 'marked'
+import { extractImgSrcs } from '@/lib/uploads/utils/embedded-image-ref'
+import { splitFrontmatter } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import { serializeMarkdownDocument } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
 
 /**
  * Constructs the editor drops or mangles in a way that survives a second serialization
  * unchanged — so the idempotency probe below can't see the loss. Each must be matched directly.
- * (Linked images `[![alt](img)](href)` are handled by the image node and verified separately by
- * the link-count check in {@link isRoundTripSafe}, not here.)
+ * Image sources and their wrapping links are verified separately against the first serialization.
  *
  * Footnotes, HTML comments, and raw HTML tags (`<div>`, `<details>`, `<kbd>`, …) used to be listed
  * here — the schema had no node for any of them, so they were dropped or stripped (content kept,
  * structure lost). `./raw-markdown-snippet.ts` now holds each construct's exact source text and
  * re-emits it byte-for-byte, so none of them lose data on round-trip and none need a pattern below.
  *
- * - **`<br>` inside a table cell** — a GFM cell can't hold a real line break, so the serializer
- *   flattens `one<br>two` to `one two`. Matched on a table-shaped line (≥2 pipes) containing a `<br>`.
  * - **Hard break inside a heading** (trailing two spaces or a backslash) — the serializer splits
  *   the heading, ejecting the second line into a separate paragraph.
  * - **HTML entity** other than the lowercase canonical `&amp;`/`&lt;`/`&gt;` (e.g. `&copy;`, `&#39;`,
@@ -31,7 +24,6 @@ const PROBE_SIZE_LIMIT = 256 * 1024
  *   be treated as safe. A bare `&` with no matching `;`-terminated name is left alone (harmless churn).
  */
 const STABLE_LOSS_PATTERNS: ReadonlyArray<RegExp> = [
-  /^(?=(?:[^\n]*\|){2})[^\n]*<br\s*\/?>/im,
   /^#{1,6}\s.*(?: {2,}|\\)$/m,
   /&(?!(?:amp|lt|gt);)(?:#x?[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/,
 ]
@@ -49,17 +41,49 @@ function stripCode(content: string): string {
     .replace(/`+[^`\n]*`+/g, '')
 }
 
-/**
- * Linked images `[![alt](src)](href)`. The image node round-trips the common forms (clean URLs,
- * optional titles) via its `href` attribute, but an exotic one it can't tokenize falls back to the
- * stock parser, which drops the wrapping link — an invisible, stable loss. So instead of matching a
- * fixed pattern, {@link isRoundTripSafe} counts these before and after one serialization and rejects
- * if any disappeared.
- */
-const LINKED_IMAGE_PATTERN = /\[\s*!\[[^\]]*]\([^)]*\)\s*]\([^)]*\)/g
+const fidelityLexer = new Marked({ gfm: true })
 
-function linkedImageCount(content: string): number {
-  return content.match(LINKED_IMAGE_PATTERN)?.length ?? 0
+function imageSources(token: Token): string[] {
+  if (token.type === 'image') return [token.href]
+  return token.type === 'html' ? extractImgSrcs(token.raw) : []
+}
+
+/**
+ * Resolve reference syntax before comparing images and their wrapping links: a stable second
+ * serialization cannot reveal first-pass loss. Plain-text link counts are deliberately excluded:
+ * adjacent equal link marks can merge losslessly. Task references are conservatively source-only:
+ * their parser resolves definitions before a task but loses definitions appearing after it, so
+ * rearranging otherwise valid Markdown can silently remove a destination.
+ * Count HTML image sources too, allowing lossless HTML-to-Markdown conversion while catching images
+ * dropped from inline-only table cells. Frontmatter is stored separately, not interpreted as Markdown.
+ */
+function inspectMarkdownFidelity(content: string) {
+  const targets = new Map<string, number>()
+  let hasTaskReference = false
+  const add = (kind: 'image' | 'linkedImage', ...destinations: string[]) => {
+    const target = JSON.stringify([kind, ...destinations.map(decodeHtmlEntities)])
+    targets.set(target, (targets.get(target) ?? 0) + 1)
+  }
+  fidelityLexer.walkTokens(fidelityLexer.lexer(splitFrontmatter(content).body), (token) => {
+    for (const src of imageSources(token)) add('image', src)
+    if (token.type === 'link') {
+      fidelityLexer.walkTokens(token.tokens ?? [], (child) => {
+        for (const src of imageSources(child)) add('linkedImage', token.href, src)
+      })
+    }
+    if (token.type === 'list_item' && token.task) {
+      for (const child of token.tokens ?? []) {
+        if ((child.type === 'text' || child.type === 'paragraph') && child.tokens) {
+          fidelityLexer.walkTokens(child.tokens, (inline) => {
+            if ((inline.type === 'link' || inline.type === 'image') && inline.raw.endsWith(']')) {
+              hasTaskReference = true
+            }
+          })
+        }
+      }
+    }
+  })
+  return { targets, hasTaskReference }
 }
 
 /**
@@ -102,9 +126,9 @@ function hasOrphanReferenceDefinition(content: string): boolean {
 }
 
 /**
- * Whether `content` survives the editor's markdown round-trip without data loss or autosave
- * churn. The editor opens the content read-only when this is false, so the probe is deliberately
- * conservative: it rejects on any doubt rather than risk an edit silently corrupting a file.
+ * Whether `content` fits the rich editor's rendering budget and survives its Markdown round-trip
+ * without known data loss or autosave churn. A refusal keeps rich preview read-only and offers
+ * source editing; the character cap is a performance boundary, separate from fidelity checks.
  *
  * Two complementary checks: known stable-loss constructs are matched directly (the idempotency
  * probe is blind to them), and everything else must reach a fixpoint — `serializeMarkdownDocument(x)`
@@ -113,13 +137,18 @@ function hasOrphanReferenceDefinition(content: string): boolean {
  * pass and are allowed through; genuine churn (a blockquote wrapping a code fence keeps growing) is not.
  */
 export function isRoundTripSafe(content: string): boolean {
-  if (content.length > PROBE_SIZE_LIMIT) return false
+  if (content.length > PASTE_RENDER_THRESHOLDS.ENHANCED_TEXT_CHARACTERS) return false
   const stripped = stripCode(content)
   if (STABLE_LOSS_PATTERNS.some((pattern) => pattern.test(stripped))) return false
   if (hasOrphanReferenceDefinition(stripped)) return false
   try {
+    const source = inspectMarkdownFidelity(content)
+    if (source.hasTaskReference) return false
     const once = serializeMarkdownDocument(content)
-    if (linkedImageCount(stripped) !== linkedImageCount(stripCode(once))) return false
+    const serialized = inspectMarkdownFidelity(once)
+    for (const [target, count] of source.targets) {
+      if ((serialized.targets.get(target) ?? 0) < count) return false
+    }
     return serializeMarkdownDocument(once) === once
   } catch {
     return false

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/slash-command/slash-command.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/slash-command/slash-command.ts
@@ -1,23 +1,20 @@
 import { Extension } from '@tiptap/core'
-import { PluginKey } from '@tiptap/pm/state'
 import Suggestion from '@tiptap/suggestion'
-import { createSuggestionPopupRenderer } from '../menus/suggestion-popup'
+import { createSuggestionPopupRenderer } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/suggestion-popup'
 import {
   filterSlashCommands,
   type SlashCommandContext,
   type SlashCommandItem,
   type SlashCommandStorage,
-} from './commands'
-import { SlashCommandList } from './slash-command-list'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/slash-command/commands'
+import { SlashCommandList } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/slash-command/slash-command-list'
+import { SLASH_COMMAND_PLUGIN_KEY } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/suggestion-plugin-keys'
 
 declare module '@tiptap/core' {
   interface Storage {
     slashCommand: SlashCommandStorage
   }
 }
-
-/** Explicit key (distinct from the `@` mention's) so the keymap can detect an open menu. */
-export const SLASH_COMMAND_PLUGIN_KEY = new PluginKey('slashCommand')
 
 /**
  * Adds the `/` slash-command menu to the editor. Typing `/` at the start of a block — or after

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/suggestion-plugin-keys.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/suggestion-plugin-keys.ts
@@ -1,0 +1,7 @@
+import { PluginKey } from '@tiptap/pm/state'
+
+/** Shared suggestion identities let keyboard guards read activity without importing popup UI. */
+export const MENTION_PLUGIN_KEY = new PluginKey<{ active: boolean }>('mention')
+
+/** Slash commands have their own state and must never reuse the mention plugin's identity. */
+export const SLASH_COMMAND_PLUGIN_KEY = new PluginKey<{ active: boolean }>('slashCommand')

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table-serialization.node.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table-serialization.node.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment node
+ */
+import { getSchema, type JSONContent } from '@tiptap/core'
+import { prosemirrorJSONToYDoc } from '@tiptap/y-tiptap'
+import { describe, expect, it } from 'vitest'
+import { yDocToMarkdown } from '@/lib/collab-doc/converter'
+import { COLLAB_DOC_FIELD } from '@/lib/collab-doc/field'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import {
+  parseMarkdownToDoc,
+  serializeMarkdownDocument,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+
+describe('legacy table preservation through the server converter', () => {
+  it('keeps rich blocks, marks, spans, and widths as standard HTML in a Node environment', () => {
+    expect(typeof globalThis.window).toBe('undefined')
+    const document: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'table',
+          content: [
+            {
+              type: 'tableRow',
+              content: [
+                {
+                  type: 'tableHeader',
+                  attrs: { colspan: 2, colwidth: [120, 240] },
+                  content: [
+                    {
+                      type: 'heading',
+                      attrs: { level: 2 },
+                      content: [{ type: 'text', text: 'rich heading', marks: [{ type: 'bold' }] }],
+                    },
+                    { type: 'paragraph', content: [{ type: 'text', text: 'second block' }] },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableRow',
+              content: [
+                {
+                  type: 'tableCell',
+                  attrs: { rowspan: 2 },
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: 'a  b', marks: [{ type: 'code' }] }],
+                    },
+                  ],
+                },
+                {
+                  type: 'tableCell',
+                  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'peer text' }] }],
+                },
+              ],
+            },
+            {
+              type: 'tableRow',
+              content: [
+                {
+                  type: 'tableCell',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: '<script>literal</script>' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const shared = prosemirrorJSONToYDoc(
+      getSchema(createMarkdownContentExtensions()),
+      document,
+      COLLAB_DOC_FIELD
+    )
+    try {
+      const markdown = yDocToMarkdown(shared).trim()
+      expect(markdown).toContain('<table')
+      expect(markdown).toContain('colspan="2"')
+      expect(markdown).toContain('rowspan="2"')
+      expect(markdown).toContain('colwidth="120,240"')
+      expect(markdown).toContain('<h2><strong>rich heading</strong></h2>')
+      expect(markdown).toContain('<p>second block</p>')
+      expect(markdown).toContain('<code>a  b</code>')
+      expect(markdown).toContain('peer text')
+      expect(markdown).toContain('&lt;script&gt;literal&lt;/script&gt;')
+      expect(parseMarkdownToDoc(markdown).content?.[0].type).toBe('rawHtmlBlock')
+      expect(serializeMarkdownDocument(markdown).trim()).toBe(markdown)
+    } finally {
+      shared.destroy()
+    }
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table.ts
@@ -1,0 +1,241 @@
+import {
+  commands,
+  getHTMLFromFragment,
+  InputRule,
+  type JSONContent,
+  type MarkdownRendererHelpers,
+} from '@tiptap/core'
+import { Table } from '@tiptap/extension-table'
+import { Fragment, type Node as ProseMirrorNode, type Schema, Slice } from '@tiptap/pm/model'
+import { type EditorState, Plugin, type Transaction } from '@tiptap/pm/state'
+import { isInTable, selectedRect } from '@tiptap/pm/tables'
+
+/**
+ * Keep the established collaborative schema intact: older peers may already have block content in
+ * cells. Newly authored content is constrained at the command/input-rule boundary instead of having
+ * schema fitting silently discard existing shared content.
+ */
+export function selectionTouchesTable(state: EditorState): boolean {
+  if (isInTable(state)) return true
+  let found = false
+  state.doc.nodesBetween(state.selection.from, state.selection.to, (node) => {
+    if (node.type.name === 'table') found = true
+    return !found
+  })
+  return found
+}
+
+/** Prevent Markdown block-prefix autoformat inside a GFM cell without consuming the user's text. */
+export function excludeTableBlockInputRules(rules: InputRule[]): InputRule[] {
+  return rules.map(
+    (rule) =>
+      new InputRule({
+        find: rule.find,
+        undoable: rule.undoable,
+        handler: (props) => (selectionTouchesTable(props.state) ? null : rule.handler(props)),
+      })
+  )
+}
+
+/** New empty rows inherit the header's column alignment before they enter shared state. */
+function alignInsertedRow(tr: Transaction, tableStart: number, rowIndex: number): void {
+  const table = tr.doc.nodeAt(tableStart - 1)
+  if (!table?.firstChild || rowIndex >= table.childCount) return
+  let rowStart = tableStart
+  for (let index = 0; index < rowIndex; index++) rowStart += table.child(index).nodeSize
+  table.child(rowIndex).forEach((cell, offset, column) => {
+    const align = table.firstChild?.maybeChild(column)?.attrs.align ?? null
+    if (cell.attrs.align !== align) {
+      tr.setNodeMarkup(rowStart + 1 + offset, undefined, { ...cell.attrs, align })
+    }
+  })
+}
+
+/**
+ * Pasted text blocks adopt a cell's inline-only authoring contract. Preserve every inline node and
+ * mark, including empty lines. Unsupported blocks return null so nested tables, media, and other
+ * richer content retain their existing lossless HTML serialization instead of being flattened.
+ */
+function inlineCellParagraph(content: Fragment, schema: Schema): Fragment | null {
+  if (content.childCount === 0) return null
+  const inline: ProseMirrorNode[] = []
+  for (let index = 0; index < content.childCount; index++) {
+    const child = content.child(index)
+    if (child.type.name !== 'paragraph' && child.type.name !== 'heading') return null
+    if (index > 0) inline.push(schema.nodes.hardBreak.create())
+    child.content.forEach((node) => inline.push(node))
+  }
+  return Fragment.from(schema.nodes.paragraph.create(null, Fragment.fromArray(inline)))
+}
+
+/** Only clipboard cells are rewritten; legacy shared nodes are never normalized during editing. */
+function normalizePastedTableCells(content: Fragment, schema: Schema): Fragment {
+  const nodes: ProseMirrorNode[] = []
+  content.forEach((node) => {
+    const isCell = node.type.spec.tableRole === 'cell' || node.type.spec.tableRole === 'header_cell'
+    const normalized = isCell
+      ? inlineCellParagraph(node.content, schema)
+      : normalizePastedTableCells(node.content, schema)
+    nodes.push(normalized && !normalized.eq(node.content) ? node.copy(normalized) : node)
+  })
+  return Fragment.fromArray(nodes)
+}
+
+/**
+ * Tables expose only operations that GFM can persist: one fixed header row, rectangular body rows,
+ * inline cell content, and no merged cells or stored column widths. The header's text is editable;
+ * the structural row cannot be removed independently of the table.
+ */
+const MarkdownTable = Table.extend({
+  addProseMirrorPlugins() {
+    return [
+      ...(this.parent?.() ?? []),
+      new Plugin({
+        props: {
+          transformPasted: (slice, view) => {
+            const { schema } = view.state
+            const inline = isInTable(view.state) ? inlineCellParagraph(slice.content, schema) : null
+            if (inline) {
+              return new Slice(inline, Math.min(slice.openStart, 1), Math.min(slice.openEnd, 1))
+            }
+            return new Slice(
+              normalizePastedTableCells(slice.content, schema),
+              slice.openStart,
+              slice.openEnd
+            )
+          },
+        },
+      }),
+    ]
+  },
+  addCommands() {
+    const parent = this.parent?.()
+    return {
+      ...parent,
+      setNode: (type, attributes) => (props) =>
+        (!selectionTouchesTable(props.state) ||
+          (typeof type === 'string' ? type : type.name) === 'paragraph') &&
+        commands.setNode(type, attributes)(props),
+      toggleList:
+        (...args) =>
+        (props) =>
+          !selectionTouchesTable(props.state) && commands.toggleList(...args)(props),
+      wrapInList:
+        (...args) =>
+        (props) =>
+          !selectionTouchesTable(props.state) && commands.wrapInList(...args)(props),
+      wrapIn:
+        (...args) =>
+        (props) =>
+          !selectionTouchesTable(props.state) && commands.wrapIn(...args)(props),
+      insertTable: (options) => (props) =>
+        !selectionTouchesTable(props.state) &&
+        (parent?.insertTable?.({ ...options, withHeaderRow: true })(props) ?? false),
+      addRowBefore: () => (props) => {
+        if (!isInTable(props.state)) return false
+        const rect = selectedRect(props.state)
+        if (rect.top === 0 || !parent?.addRowBefore?.()(props)) return false
+        if (props.dispatch) alignInsertedRow(props.tr, rect.tableStart, rect.top)
+        return true
+      },
+      addRowAfter: () => (props) => {
+        if (!isInTable(props.state)) return false
+        const rect = selectedRect(props.state)
+        if (!parent?.addRowAfter?.()(props)) return false
+        if (props.dispatch) alignInsertedRow(props.tr, rect.tableStart, rect.bottom)
+        return true
+      },
+      deleteRow: () => (props) =>
+        isInTable(props.state) &&
+        selectedRect(props.state).top > 0 &&
+        (parent?.deleteRow?.()(props) ?? false),
+      toggleHeaderRow: () => () => false,
+      toggleHeaderColumn: () => () => false,
+      toggleHeaderCell: () => () => false,
+      mergeCells: () => () => false,
+      splitCell: () => () => false,
+      mergeOrSplit: () => () => false,
+      setCellAttribute: () => () => false,
+    }
+  },
+  addKeyboardShortcuts() {
+    return {
+      ...this.parent?.(),
+      Enter: () => this.editor.isActive('table') && this.editor.commands.setHardBreak(),
+    }
+  },
+})
+
+/** A GFM table has a single header, uniform columns, inline cell content, and column-level alignment. */
+function isGfmTable(node: JSONContent): boolean {
+  const rows = node.content ?? []
+  const header = rows[0]?.content ?? []
+  return (
+    header.length > 0 &&
+    rows.every(
+      (row, index) =>
+        row.content?.length === header.length &&
+        row.content.every(
+          (cell, column) =>
+            cell.type === (index === 0 ? 'tableHeader' : 'tableCell') &&
+            (cell.attrs?.colspan ?? 1) === 1 &&
+            (cell.attrs?.rowspan ?? 1) === 1 &&
+            cell.attrs?.colwidth == null &&
+            (cell.attrs?.align ?? null) === (header[column].attrs?.align ?? null) &&
+            cell.content?.length === 1 &&
+            cell.content[0].type === 'paragraph'
+        )
+    )
+  )
+}
+
+/**
+ * Render compatible cells without collapsing interior whitespace: spaces inside code spans are
+ * content, not table padding. Formatting padding is bounded so one wide cell cannot multiply its
+ * width across thousands of otherwise-small rows.
+ */
+function renderGfmTable(node: JSONContent, helpers: MarkdownRendererHelpers): string {
+  const rows = (node.content ?? []).map((row) =>
+    (row.content ?? []).map((cell) =>
+      helpers
+        .renderChildren(cell.content ?? [])
+        .replace(/\|/g, '\\|')
+        .replace(/\r?\n/g, '<br>')
+    )
+  )
+  const widths = rows[0].map(() => 3)
+  for (const row of rows) {
+    row.forEach((cell, column) => {
+      widths[column] = Math.min(80, Math.max(widths[column], cell.length))
+    })
+  }
+  const line = (cells: string[]) =>
+    `| ${cells.map((cell, column) => cell.padEnd(widths[column])).join(' | ')} |`
+  const separators = widths.map((width, column) => {
+    const align = node.content?.[0].content?.[column].attrs?.align
+    return `${align === 'left' || align === 'center' ? ':' : ''}${'-'.repeat(width)}${
+      align === 'right' || align === 'center' ? ':' : ''
+    }`
+  })
+  return [line(rows[0]), `| ${separators.join(' | ')} |`, ...rows.slice(1).map(line)].join('\n')
+}
+
+/**
+ * Standard HTML is the lossless fallback for legacy cells with rich blocks, spans, or widths that
+ * GFM cannot encode. It reopens through the existing raw-HTML node instead of silently losing those
+ * attributes. The native serializer uses this editor's schema and the DOM already provisioned by
+ * the client or the server collab converter; no additional DOM globals or parser are installed here.
+ */
+export function createMarkdownTable(): typeof MarkdownTable {
+  let schema: Schema | undefined
+  return MarkdownTable.extend({
+    onBeforeCreate() {
+      schema = this.editor.schema
+    },
+    renderMarkdown: (node: JSONContent, helpers: MarkdownRendererHelpers) => {
+      if (isGfmTable(node)) return renderGfmTable(node, helpers)
+      if (!schema) throw new Error('Table serialization requires an initialized editor schema')
+      return getHTMLFromFragment(Fragment.from(schema.nodeFromJSON(node)), schema)
+    },
+  })
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
@@ -322,20 +322,61 @@ describe('content-version ordering', () => {
     expect(next.conflict).toEqual(state.conflict)
   })
 
-  it('clears a fetch of its own save once the matching acknowledgement arrives', () => {
-    const state = {
-      ...ready('local trailing', 'original'),
-      savedVersion: version(1),
-      conflict: { version: version(2) },
+  it.each([
+    { fetchedVersion: undefined, savedVersion: version(2) },
+    { fetchedVersion: undefined, savedVersion: undefined },
+    { fetchedVersion: version(2), savedVersion: undefined },
+  ])(
+    'retains conflicts when acknowledgement ordering is unknown: %o',
+    ({ fetchedVersion, savedVersion }) => {
+      const conflicted = syncTextEditorContentState(
+        {
+          ...ready('local trailing', 'original'),
+          savedVersion: version(1),
+        },
+        {
+          canReconcileToFetchedContent: true,
+          fetchedContent: 'remote',
+          fetchedVersion,
+        }
+      )
+      expect(conflicted.conflict).toBeDefined()
+      const acknowledged = textEditorContentReducer(conflicted, {
+        type: 'save-success',
+        content: 'local saved',
+        version: savedVersion,
+      })
+      expect(acknowledged.conflict).toEqual(conflicted.conflict)
+      expect(acknowledged.content).toBe('local trailing')
+      expect(acknowledged.savedContent).toBe('local saved')
+      const reloaded = textEditorContentReducer(acknowledged, {
+        type: 'reload',
+        content: 'latest remote',
+        version: version(3),
+      })
+      expect(reloaded.conflict).toBeUndefined()
+      expect(reloaded.content).toBe('latest remote')
+      expect(reloaded.savedVersion).toBe(version(3))
     }
-    const next = textEditorContentReducer(state, {
-      type: 'save-success',
-      content: 'local saved',
-      version: version(2),
-    })
-    expect(next.content).toBe('local trailing')
-    expect(next.conflict).toBeUndefined()
-  })
+  )
+
+  it.each([2, 3])(
+    'clears a versioned conflict when acknowledgement version %i catches up',
+    (second) => {
+      const state = {
+        ...ready('local trailing', 'original'),
+        savedVersion: version(1),
+        conflict: { version: version(2) },
+      }
+      const next = textEditorContentReducer(state, {
+        type: 'save-success',
+        content: 'local saved',
+        version: version(second),
+      })
+      expect(next.content).toBe('local trailing')
+      expect(next.conflict).toBeUndefined()
+    }
+  )
 })
 
 describe('syncTextEditorContentState — streaming', () => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
@@ -158,7 +158,7 @@ describe('syncTextEditorContentState — static fetch updates', () => {
     })
     // Local edits take precedence — content should remain 'user edit'
     expect(next.content).toBe('user edit')
-    expect(next.conflict).toEqual({ content: 'v2', version: undefined })
+    expect(next.conflict).toEqual({ version: undefined })
     expect(next.phase).toBe('ready')
   })
 })
@@ -227,7 +227,6 @@ describe('content-version ordering', () => {
       savedVersion: version(2),
       conflict: { streamInterrupted: true },
     })
-    expect(next.conflict?.content).toBeUndefined()
     expect(next.conflict?.version).toBeUndefined()
   })
 
@@ -237,7 +236,7 @@ describe('content-version ordering', () => {
       const state = {
         ...ready('local draft', 'original'),
         savedVersion: version(2),
-        conflict: { content: 'newer remote', version: version(3) },
+        conflict: { version: version(3) },
       }
       const next = syncTextEditorContentState(state, {
         canReconcileToFetchedContent: true,
@@ -250,6 +249,52 @@ describe('content-version ordering', () => {
       expect(next.conflict).toEqual({ ...state.conflict, streamInterrupted: true })
     }
   )
+
+  it.each([false, true])(
+    'keeps conflict ordering across an unversioned fetch (streaming=%s)',
+    (streaming) => {
+      const original = {
+        ...ready('local draft', 'baseline'),
+        savedVersion: version(1),
+        conflict: { version: version(3) },
+      }
+      const options = { canReconcileToFetchedContent: true, fetchedContent: 'unknown remote' }
+      const unversioned = syncTextEditorContentState(original, {
+        ...options,
+        streamingContent: streaming ? 'agent output' : undefined,
+      })
+      expect(unversioned.conflict).toEqual({
+        version: version(3),
+        ...(streaming ? { streamInterrupted: true } : {}),
+      })
+      const stale = syncTextEditorContentState(unversioned, {
+        ...options,
+        fetchedVersion: version(2),
+      })
+      expect(stale).toBe(unversioned)
+      const acknowledged = textEditorContentReducer(stale, {
+        type: 'save-success',
+        content: 'local saved',
+        version: version(2),
+      })
+      expect(acknowledged.content).toBe('local draft')
+      expect(acknowledged.conflict).toEqual(unversioned.conflict)
+      const newer = syncTextEditorContentState(acknowledged, {
+        ...options,
+        fetchedVersion: version(4),
+      })
+      expect(newer.conflict?.version).toBe(version(4))
+    }
+  )
+
+  it('adopts a known version for a previously unversioned conflict', () => {
+    const original = { ...ready('draft', 'baseline'), conflict: {} }
+    const options = { canReconcileToFetchedContent: true, fetchedContent: 'remote' }
+    expect(syncTextEditorContentState(original, options)).toBe(original)
+    expect(
+      syncTextEditorContentState(original, { ...options, fetchedVersion: version(3) }).conflict
+    ).toEqual({ version: version(3) })
+  })
 
   it('never replaces a successfully saved baseline with an older in-flight fetch', () => {
     const state = { ...ready('saved'), savedVersion: version(2) }
@@ -265,7 +310,7 @@ describe('content-version ordering', () => {
     const state = {
       ...ready('local trailing', 'original'),
       savedVersion: version(1),
-      conflict: { content: 'remote', version: version(3) },
+      conflict: { version: version(3) },
     }
     const next = textEditorContentReducer(state, {
       type: 'save-success',
@@ -281,7 +326,7 @@ describe('content-version ordering', () => {
     const state = {
       ...ready('local trailing', 'original'),
       savedVersion: version(1),
-      conflict: { content: 'local saved', version: version(2) },
+      conflict: { version: version(2) },
     }
     const next = textEditorContentReducer(state, {
       type: 'save-success',

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.test.ts
@@ -7,7 +7,7 @@ import {
   syncTextEditorContentState,
   type TextEditorContentState,
   textEditorContentReducer,
-} from './text-editor-state'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state'
 
 function ready(content: string, savedContent = content): TextEditorContentState {
   return { phase: 'ready', content, savedContent, lastStreamedContent: null, hasBaseline: true }
@@ -158,7 +158,138 @@ describe('syncTextEditorContentState — static fetch updates', () => {
     })
     // Local edits take precedence — content should remain 'user edit'
     expect(next.content).toBe('user edit')
+    expect(next.conflict).toEqual({ content: 'v2', version: undefined })
     expect(next.phase).toBe('ready')
+  })
+})
+
+describe('content-version ordering', () => {
+  const version = (second: number) => `2026-09-03T20:00:0${second}.000Z`
+  it('accepts a new stream while the content query still contains the pre-save snapshot', () => {
+    let state = syncTextEditorContentState(INITIAL_TEXT_EDITOR_CONTENT_STATE, {
+      canReconcileToFetchedContent: true,
+      fetchedContent: 'original',
+      fetchedVersion: version(1),
+    })
+    state = textEditorContentReducer(state, { type: 'edit', content: 'saved local' })
+    state = textEditorContentReducer(state, {
+      type: 'save-success',
+      content: 'saved local',
+      version: version(2),
+    })
+    const staleSnapshot = {
+      canReconcileToFetchedContent: true,
+      fetchedContent: 'original',
+      fetchedVersion: version(1),
+    }
+
+    state = syncTextEditorContentState(state, {
+      ...staleSnapshot,
+      streamingContent: 'new agent output',
+    })
+    expect(state).toMatchObject({
+      phase: 'streaming',
+      content: 'new agent output',
+      savedContent: 'saved local',
+      savedVersion: version(2),
+      lastStreamedContent: 'new agent output',
+    })
+    state = syncTextEditorContentState(state, staleSnapshot)
+    expect(state.phase).toBe('reconciling')
+    expect(state.content).toBe('new agent output')
+    expect(state.savedVersion).toBe(version(2))
+    expect(syncTextEditorContentState(state, staleSnapshot)).toBe(state)
+
+    state = syncTextEditorContentState(state, {
+      canReconcileToFetchedContent: true,
+      fetchedContent: 'final agent output',
+      fetchedVersion: version(3),
+    })
+    expect(state).toMatchObject({
+      phase: 'ready',
+      content: 'final agent output',
+      savedContent: 'final agent output',
+      savedVersion: version(3),
+    })
+  })
+
+  it('preserves a trailing draft and records an incoming stream despite a stale fetch', () => {
+    const state = { ...ready('trailing draft', 'saved local'), savedVersion: version(2) }
+    const next = syncTextEditorContentState(state, {
+      canReconcileToFetchedContent: true,
+      fetchedContent: 'original',
+      fetchedVersion: version(1),
+      streamingContent: 'agent output',
+    })
+    expect(next).toMatchObject({
+      content: 'trailing draft',
+      savedContent: 'saved local',
+      savedVersion: version(2),
+      conflict: { streamInterrupted: true },
+    })
+    expect(next.conflict?.content).toBeUndefined()
+    expect(next.conflict?.version).toBeUndefined()
+  })
+
+  it.each([1, 2])(
+    'records streams without replacing a newer conflict with version %i',
+    (second) => {
+      const state = {
+        ...ready('local draft', 'original'),
+        savedVersion: version(2),
+        conflict: { content: 'newer remote', version: version(3) },
+      }
+      const next = syncTextEditorContentState(state, {
+        canReconcileToFetchedContent: true,
+        fetchedContent: 'stale remote',
+        fetchedVersion: version(second),
+        streamingContent: 'agent output',
+      })
+      expect(next.content).toBe('local draft')
+      expect(next.savedVersion).toBe(version(2))
+      expect(next.conflict).toEqual({ ...state.conflict, streamInterrupted: true })
+    }
+  )
+
+  it('never replaces a successfully saved baseline with an older in-flight fetch', () => {
+    const state = { ...ready('saved'), savedVersion: version(2) }
+    const next = syncTextEditorContentState(state, {
+      canReconcileToFetchedContent: true,
+      fetchedContent: 'stale',
+      fetchedVersion: version(1),
+    })
+    expect(next).toBe(state)
+  })
+
+  it('retains a later remote conflict when an earlier save response arrives', () => {
+    const state = {
+      ...ready('local trailing', 'original'),
+      savedVersion: version(1),
+      conflict: { content: 'remote', version: version(3) },
+    }
+    const next = textEditorContentReducer(state, {
+      type: 'save-success',
+      content: 'local saved',
+      version: version(2),
+    })
+    expect(next.savedVersion).toBe(version(2))
+    expect(next.content).toBe('local trailing')
+    expect(next.conflict).toEqual(state.conflict)
+  })
+
+  it('clears a fetch of its own save once the matching acknowledgement arrives', () => {
+    const state = {
+      ...ready('local trailing', 'original'),
+      savedVersion: version(1),
+      conflict: { content: 'local saved', version: version(2) },
+    }
+    const next = textEditorContentReducer(state, {
+      type: 'save-success',
+      content: 'local saved',
+      version: version(2),
+    })
+    expect(next.content).toBe('local trailing')
+    expect(next.conflict).toBeUndefined()
   })
 })
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.ts
@@ -15,8 +15,8 @@ export interface TextEditorContentState {
   /** Content-version token paired with the accepted immutable storage object. */
   savedVersion?: string
   acceptedBaselineContent?: string
-  /** A conflicting remote snapshot; missing content means the server reported a conflict first. */
-  conflict?: { content?: string; version?: string; streamInterrupted?: true }
+  /** Remote conflict metadata; the local draft remains in `content`. */
+  conflict?: { version?: string; streamInterrupted?: true }
 }
 
 export interface SyncTextEditorContentStateOptions {
@@ -208,9 +208,13 @@ export function syncTextEditorContentState(
       streamingContent !== undefined
         ? { ...state.conflict, streamInterrupted: true as const }
         : state.conflict
-    if (fetchedContent === undefined)
+    if (
+      fetchedContent === undefined ||
+      fetchedVersion === undefined ||
+      fetchedVersion === conflict.version
+    )
       return conflict === state.conflict ? state : { ...state, conflict }
-    return { ...state, conflict: { ...conflict, content: fetchedContent, version: fetchedVersion } }
+    return { ...state, conflict: { ...conflict, version: fetchedVersion } }
   }
 
   if (
@@ -222,7 +226,6 @@ export function syncTextEditorContentState(
     return {
       ...state,
       conflict: {
-        content: fetchedContent,
         version: fetchedVersion,
         ...(streamingContent !== undefined ? { streamInterrupted: true as const } : {}),
       },
@@ -298,7 +301,7 @@ export function textEditorContentReducer(
       return {
         ...state,
         content: action.content,
-        conflict: { content: state.savedContent, version: state.savedVersion },
+        conflict: { version: state.savedVersion },
       }
     case 'reload':
       return {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.ts
@@ -288,9 +288,10 @@ export function textEditorContentReducer(
         hasBaseline: true,
         savedVersion: action.version ?? state.savedVersion,
         conflict:
-          state.conflict?.streamInterrupted ||
-          (state.conflict?.version &&
-            action.version &&
+          state.conflict &&
+          (state.conflict.streamInterrupted ||
+            !state.conflict.version ||
+            !action.version ||
             Date.parse(state.conflict.version) > Date.parse(action.version))
             ? state.conflict
             : undefined,

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state.ts
@@ -12,18 +12,27 @@ export interface TextEditorContentState {
    * agent's write advancing past the baseline (which would finalize the editor to stale content).
    */
   hasBaseline: boolean
+  /** Content-version token paired with the accepted immutable storage object. */
+  savedVersion?: string
+  acceptedBaselineContent?: string
+  /** A conflicting remote snapshot; missing content means the server reported a conflict first. */
+  conflict?: { content?: string; version?: string; streamInterrupted?: true }
 }
 
 export interface SyncTextEditorContentStateOptions {
   canReconcileToFetchedContent: boolean
   fetchedContent?: string
   streamingContent?: string
+  fetchedVersion?: string
 }
 
 export type TextEditorContentAction =
   | ({ type: 'sync-external' } & SyncTextEditorContentStateOptions)
   | { type: 'edit'; content: string }
-  | { type: 'save-success'; content: string }
+  | { type: 'save-success'; content: string; version?: string }
+  | { type: 'save-conflict' }
+  | { type: 'restore-conflicting-draft'; content: string }
+  | { type: 'reload'; content: string; version: string }
 
 export const INITIAL_TEXT_EDITOR_CONTENT_STATE: TextEditorContentState = {
   phase: 'uninitialized',
@@ -103,7 +112,7 @@ function moveTextEditorContentStateToReconcile(
   }
 }
 
-export function syncTextEditorContentState(
+function syncUnversionedTextEditorContentState(
   state: TextEditorContentState,
   options: SyncTextEditorContentStateOptions
 ): TextEditorContentState {
@@ -179,6 +188,61 @@ export function syncTextEditorContentState(
   return state
 }
 
+/** Keeps local drafts and their original compare-and-swap token when remote bytes advance. */
+export function syncTextEditorContentState(
+  state: TextEditorContentState,
+  options: SyncTextEditorContentStateOptions
+): TextEditorContentState {
+  const isStaleSnapshot =
+    options.fetchedVersion &&
+    ((state.savedVersion && Date.parse(options.fetchedVersion) < Date.parse(state.savedVersion)) ||
+      (state.conflict?.version &&
+        Date.parse(options.fetchedVersion) < Date.parse(state.conflict.version)))
+  const currentOptions = isStaleSnapshot
+    ? { ...options, fetchedContent: undefined, fetchedVersion: undefined }
+    : options
+  const { fetchedContent, fetchedVersion, streamingContent } = currentOptions
+
+  if (state.conflict) {
+    const conflict =
+      streamingContent !== undefined
+        ? { ...state.conflict, streamInterrupted: true as const }
+        : state.conflict
+    if (fetchedContent === undefined)
+      return conflict === state.conflict ? state : { ...state, conflict }
+    return { ...state, conflict: { ...conflict, content: fetchedContent, version: fetchedVersion } }
+  }
+
+  if (
+    state.phase === 'ready' &&
+    state.content !== state.savedContent &&
+    (streamingContent !== undefined ||
+      (fetchedContent !== undefined && fetchedContent !== state.savedContent))
+  )
+    return {
+      ...state,
+      conflict: {
+        content: fetchedContent,
+        version: fetchedVersion,
+        ...(streamingContent !== undefined ? { streamInterrupted: true as const } : {}),
+      },
+    }
+
+  const next = syncUnversionedTextEditorContentState(state, currentOptions)
+  if (fetchedContent !== undefined && fetchedVersion && next.savedContent === fetchedContent) {
+    if (next.savedVersion === fetchedVersion && next.acceptedBaselineContent === fetchedContent)
+      return next
+    return { ...next, savedVersion: fetchedVersion, acceptedBaselineContent: fetchedContent }
+  }
+  return next === state
+    ? state
+    : {
+        ...next,
+        savedVersion: state.savedVersion,
+        acceptedBaselineContent: state.acceptedBaselineContent,
+      }
+}
+
 export function textEditorContentReducer(
   state: TextEditorContentState,
   action: TextEditorContentAction
@@ -195,6 +259,12 @@ export function textEditorContentReducer(
         content: action.content,
       }
     case 'save-success':
+      if (
+        action.version &&
+        state.savedVersion &&
+        Date.parse(action.version) < Date.parse(state.savedVersion)
+      )
+        return state
       // Advance only the saved baseline. Never roll `content` back to the saved snapshot: a
       // keystroke landing while the save was in flight makes `content` newer than `action.content`,
       // and overwriting it would silently drop that edit (and leave the doc looking clean so it's
@@ -202,7 +272,8 @@ export function textEditorContentReducer(
       if (
         state.phase === 'ready' &&
         state.savedContent === action.content &&
-        state.lastStreamedContent === null
+        state.lastStreamedContent === null &&
+        (!action.version || state.savedVersion === action.version)
       ) {
         return state
       }
@@ -212,6 +283,32 @@ export function textEditorContentReducer(
         savedContent: action.content,
         lastStreamedContent: null,
         hasBaseline: true,
+        savedVersion: action.version ?? state.savedVersion,
+        conflict:
+          state.conflict?.streamInterrupted ||
+          (state.conflict?.version &&
+            action.version &&
+            Date.parse(state.conflict.version) > Date.parse(action.version))
+            ? state.conflict
+            : undefined,
+      }
+    case 'save-conflict':
+      return state.conflict ? state : { ...state, conflict: {} }
+    case 'restore-conflicting-draft':
+      return {
+        ...state,
+        content: action.content,
+        conflict: { content: state.savedContent, version: state.savedVersion },
+      }
+    case 'reload':
+      return {
+        phase: 'ready',
+        content: action.content,
+        savedContent: action.content,
+        savedVersion: action.version,
+        acceptedBaselineContent: action.content,
+        hasBaseline: true,
+        lastStreamedContent: null,
       }
     default:
       return state

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-sync.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-sync.test.tsx
@@ -1,11 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-import { act, type ComponentProps } from 'react'
+import { act, type ComponentProps, Suspense } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
+import { SIM_PAGE_CONTENT_TYPE } from '@/lib/workspace-files/page-compile'
 import { TextEditor } from '@/app/workspace/[workspaceId]/files/components/file-viewer/text-editor'
+import { useFileViewerStore } from '@/stores/file-viewer/store'
 
 interface MockMonacoProps {
   onChange?: (value: string | undefined) => void
@@ -15,6 +17,7 @@ interface MockMonacoProps {
 
 const state = vi.hoisted(() => ({
   content: 'initial',
+  streaming: false,
   editorProps: null as MockMonacoProps | null,
 }))
 
@@ -33,7 +36,7 @@ vi.mock(
       setDraftContent: (content: string) => {
         state.content = content
       },
-      isStreamInteractionLocked: false,
+      isStreamInteractionLocked: state.streaming,
       isContentLoading: false,
       hasContentError: false,
       saveImmediately: vi.fn(),
@@ -47,6 +50,11 @@ vi.mock(
 )
 
 vi.mock('@/hooks/use-add-to-chat', () => ({ useAddToChat: () => vi.fn() }))
+
+vi.mock('@/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel', () => ({
+  resolvePreviewType: (_type: string, name: string) => (name.endsWith('.html') ? 'html' : null),
+  PreviewPanel: () => <div data-testid='preview' />,
+}))
 
 const file: WorkspaceFileRecord = {
   id: 'file-1',
@@ -82,6 +90,8 @@ function createEditor() {
     }),
     applyEdits,
     getFullModelRange: vi.fn(() => ({})),
+    getLineCount: vi.fn(() => 10),
+    getLineMaxColumn: vi.fn(() => 8),
   }
   const editor = {
     getModel: vi.fn(() => model),
@@ -89,6 +99,11 @@ function createEditor() {
     getSelection: vi.fn(() => null),
     onContextMenu: vi.fn(() => ({ dispose: vi.fn() })),
     onDidDispose: vi.fn(),
+    onDidScrollChange: vi.fn((_listener: () => void) => ({ dispose: vi.fn() })),
+    getScrollTop: vi.fn(() => 900),
+    getScrollHeight: vi.fn(() => 1000),
+    getLayoutInfo: vi.fn(() => ({ height: 100 })),
+    revealLine: vi.fn(),
   }
   const monaco = {
     KeyMod: { CtrlCmd: 1 },
@@ -107,12 +122,186 @@ function renderEditor(): { rerender: () => void; root: Root } {
   }
 }
 
+function renderSplitEditor(direction = 'ltr') {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  act(() => root.render(<TextEditor {...props} previewMode='split' />))
+  const separator = container.querySelector<HTMLDivElement>('[role="separator"]')!
+  const surface = container.querySelector<HTMLDivElement>('[data-find-tooltip-fix]')!
+  surface.style.direction = direction
+  const paneId = separator.getAttribute('aria-controls')!
+  const sourcePane = document.getElementById(paneId)!
+
+  return {
+    separator,
+    surface,
+    sourcePane,
+    key: (key: string, options: KeyboardEventInit = {}) => {
+      const event = new KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        cancelable: true,
+        ...options,
+      })
+      act(() => {
+        separator.dispatchEvent(event)
+      })
+      return event
+    },
+    unmount: () => {
+      act(() => root.unmount())
+      container.remove()
+    },
+  }
+}
+
 describe('TextEditor content synchronization', () => {
   beforeEach(() => {
     ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
     state.content = 'initial'
+    state.streaming = false
     state.editorProps = null
+    useFileViewerStore.getState().reset()
   })
+
+  it('shares page recognition with already mounted viewers and keeps it across remounts', () => {
+    const pageFile = { ...file, id: 'page-a', name: 'page.html', type: 'text/html' }
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const render = (recognized: boolean) =>
+      act(() =>
+        root.render(
+          <>
+            <TextEditor {...props} file={pageFile} />
+            {recognized && (
+              <TextEditor {...props} file={{ ...pageFile, type: SIM_PAGE_CONTENT_TYPE }} />
+            )}
+          </>
+        )
+      )
+
+    render(false)
+    expect(container.querySelectorAll('[data-testid="monaco-editor"]')).toHaveLength(1)
+    render(true)
+    expect(container.querySelectorAll('[data-testid="monaco-editor"]')).toHaveLength(0)
+    expect(container.querySelectorAll('[data-testid="preview"]')).toHaveLength(2)
+    act(() => root.unmount())
+
+    const remounted = createRoot(container)
+    act(() => remounted.render(<TextEditor {...props} file={pageFile} />))
+    expect(container.querySelector('[data-testid="monaco-editor"]')).toBeNull()
+    expect(container.querySelector('[data-testid="preview"]')).not.toBeNull()
+    act(() => remounted.unmount())
+  })
+
+  it('does not remember a page from a render that never commits', () => {
+    const pending = new Promise<void>(() => {})
+    function Suspend(): never {
+      throw pending
+    }
+    const root = createRoot(document.createElement('div'))
+    act(() =>
+      root.render(
+        <Suspense fallback={<div>Loading</div>}>
+          <TextEditor
+            {...props}
+            file={{ ...file, id: 'abandoned-page', type: SIM_PAGE_CONTENT_TYPE }}
+          />
+          <Suspend />
+        </Suspense>
+      )
+    )
+    expect(useFileViewerStore.getState().pageFileIds.has('abandoned-page')).toBe(false)
+    act(() => root.unmount())
+  })
+
+  it('exposes a focusable splitter with source-pane values and keyboard resizing', () => {
+    const view = renderSplitEditor()
+    try {
+      expect(view.separator.tabIndex).toBe(0)
+      expect(view.separator.getAttribute('aria-orientation')).toBe('vertical')
+      expect(view.separator.getAttribute('aria-valuemin')).toBe('20')
+      expect(view.separator.getAttribute('aria-valuemax')).toBe('80')
+      expect(view.separator.getAttribute('aria-valuenow')).toBe('50')
+      expect(
+        view.sourcePane.contains(document.querySelector('[data-testid="monaco-editor"]'))
+      ).toBe(true)
+      act(() => view.separator.focus())
+      expect(document.activeElement).toBe(view.separator)
+      expect(view.key('ArrowRight').defaultPrevented).toBe(true)
+      expect(view.sourcePane.style.width).toBe('55%')
+      expect(view.separator.getAttribute('aria-valuenow')).toBe('55')
+      expect(view.separator.getAttribute('aria-valuetext')).toBe('55% source, 45% preview')
+      view.key('ArrowLeft')
+      expect(view.sourcePane.style.width).toBe('50%')
+      expect(document.activeElement).toBe(view.separator)
+    } finally {
+      view.unmount()
+    }
+  })
+
+  it('uses Home and End and clamps arrow keys to the existing pointer bounds', () => {
+    const view = renderSplitEditor()
+    try {
+      view.key('Home')
+      view.key('ArrowLeft')
+      expect(view.sourcePane.style.width).toBe('20%')
+      expect(view.separator.getAttribute('aria-valuenow')).toBe('20')
+      view.key('End')
+      view.key('ArrowRight')
+      expect(view.sourcePane.style.width).toBe('80%')
+      expect(view.separator.getAttribute('aria-valuenow')).toBe('80')
+    } finally {
+      view.unmount()
+    }
+  })
+
+  it('does not consume unrelated, modified, or composing keys on the splitter', () => {
+    const view = renderSplitEditor()
+    try {
+      for (const key of ['Tab', 'ArrowUp', 'Enter', 'a']) {
+        expect(view.key(key).defaultPrevented).toBe(false)
+      }
+      for (const options of [
+        { ctrlKey: true },
+        { metaKey: true },
+        { altKey: true },
+        { shiftKey: true },
+        { isComposing: true },
+        { keyCode: 229 },
+      ]) {
+        expect(view.key('ArrowRight', options).defaultPrevented).toBe(false)
+      }
+      expect(view.sourcePane.style.width).toBe('50%')
+    } finally {
+      view.unmount()
+    }
+  })
+
+  it.each(['ltr', 'rtl'])(
+    'keeps keyboard and pointer movement aligned in %s layout',
+    (direction) => {
+      const view = renderSplitEditor(direction)
+      try {
+        view.key('ArrowRight')
+        expect(view.sourcePane.style.width).toBe(direction === 'rtl' ? '45%' : '55%')
+        view.key('ArrowLeft')
+        expect(view.sourcePane.style.width).toBe('50%')
+        vi.spyOn(view.surface, 'getBoundingClientRect').mockReturnValue(
+          new DOMRect(100, 0, 1000, 600)
+        )
+        act(() => view.separator.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })))
+        act(() => document.dispatchEvent(new MouseEvent('mousemove', { clientX: 800 })))
+        expect(view.sourcePane.style.width).toBe(direction === 'rtl' ? '30%' : '70%')
+        act(() => document.dispatchEvent(new MouseEvent('mousemove', { clientX: 0 })))
+        expect(view.sourcePane.style.width).toBe(direction === 'rtl' ? '80%' : '20%')
+        act(() => document.dispatchEvent(new MouseEvent('mouseup')))
+      } finally {
+        view.unmount()
+      }
+    }
+  )
 
   it('does not reread the complete Monaco model after a local edit', () => {
     const view = renderEditor()
@@ -134,6 +323,26 @@ describe('TextEditor content synchronization', () => {
     act(() => view.root.unmount())
   })
 
+  it('attaches scroll tracking when Monaco mounts after the streaming surface', () => {
+    state.streaming = true
+    const view = renderEditor()
+    const { editor, monaco } = createEditor()
+    act(() => state.editorProps?.onMount?.(editor, monaco))
+    expect(editor.onDidScrollChange).toHaveBeenCalledOnce()
+    state.content = 'initial append'
+    view.rerender()
+    expect(editor.revealLine).toHaveBeenCalled()
+    editor.revealLine.mockClear()
+    editor.getScrollTop.mockReturnValue(100)
+    act(() => editor.onDidScrollChange.mock.calls[0]![0]())
+    state.content = 'initial append next'
+    view.rerender()
+    expect(editor.revealLine).not.toHaveBeenCalled()
+    const listener = editor.onDidScrollChange.mock.results[0]!.value
+    act(() => view.root.unmount())
+    expect(listener.dispose).toHaveBeenCalledOnce()
+  })
+
   it('still reconciles an external update when the editor has no local changes', () => {
     const view = renderEditor()
     const { editor, monaco, getValue, applyEdits } = createEditor()
@@ -148,6 +357,19 @@ describe('TextEditor content synchronization', () => {
 
     expect(getValue).toHaveBeenCalledOnce()
     expect(applyEdits).toHaveBeenCalledWith([{ range: {}, text: 'server update' }])
+    act(() => view.root.unmount())
+  })
+
+  it('applies a deliberate conflict reload after the editor previously held a local draft', () => {
+    const view = renderEditor()
+    const { editor, monaco, model, applyEdits } = createEditor()
+    act(() => state.editorProps?.onMount?.(editor, monaco))
+    model.setValue('local draft')
+    act(() => state.editorProps?.onChange?.('local draft'))
+    view.rerender()
+    state.content = 'reloaded remote'
+    view.rerender()
+    expect(applyEdits).toHaveBeenCalledWith([{ range: {}, text: 'reloaded remote' }])
     act(() => view.root.unmount())
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/text-editor.tsx
@@ -3,8 +3,11 @@
 import {
   memo,
   type ClipboardEvent as ReactClipboardEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
   useEffect,
+  useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -21,18 +24,20 @@ import {
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import { getFileExtension } from '@/lib/uploads/utils/file-utils'
 import { isSimPageSource, SIM_PAGE_CONTENT_TYPE } from '@/lib/workspace-files/page-compile'
+import { EditorContextMenu } from '@/app/workspace/[workspaceId]/files/components/file-viewer/editor-context-menu'
+import { FileSaveConflict } from '@/app/workspace/[workspaceId]/files/components/file-viewer/file-save-conflict'
+import type { PreviewMode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/file-viewer'
+import {
+  PreviewPanel,
+  resolvePreviewType,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/preview-panel'
+import { PreviewLoadingFrame } from '@/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared'
 import { assessTextEditorPaste } from '@/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-paste'
+import { useEditableFileContent } from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content'
+import { useSelectionCopyBridge } from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-selection-copy-bridge'
 import { useAddToChat } from '@/hooks/use-add-to-chat'
+import { useFileViewerStore } from '@/stores/file-viewer/store'
 import type { ChatContext } from '@/stores/panel'
-import { EditorContextMenu } from './editor-context-menu'
-import type { PreviewMode } from './file-viewer'
-import { PreviewPanel, resolvePreviewType } from './preview-panel'
-import { PreviewLoadingFrame } from './preview-shared'
-import { useEditableFileContent } from './use-editable-file-content'
-import { useSelectionCopyBridge } from './use-selection-copy-bridge'
-
-/** File ids observed rendering as Sim pages this session (see the sticky lock). */
-const KNOWN_PAGE_FILE_IDS = new Set<string>()
 
 const TEXT_EDITOR_OPTIONS = {
   largeFileOptimizations: true,
@@ -267,6 +272,7 @@ const MonacoEditor = dynamic(
 const SPLIT_MIN_PCT = 20
 const SPLIT_MAX_PCT = 80
 const SPLIT_DEFAULT_PCT = 50
+const SPLIT_KEYBOARD_STEP_PCT = 5
 
 /**
  * Monaco's find-widget button hover tooltips render above the button by default. Because the find
@@ -422,12 +428,13 @@ export const TextEditor = memo(function TextEditor({
   const containerRef = useRef<HTMLDivElement>(null)
   const monacoEditorRef = useRef<Parameters<OnMount>[0] | null>(null)
   const lastEditorValueRef = useRef('')
-  const lastSyncedContentRef = useRef('')
   const hasAutoFocusedRef = useRef(false)
   const contentRef = useRef('')
   const textareaStuckRef = useRef(false)
   const suppressScrollListenerRef = useRef(false)
 
+  const [mountedEditor, setMountedEditor] = useState<Parameters<OnMount>[0] | null>(null)
+  const sourcePaneId = useId()
   const [splitPct, setSplitPct] = useState(SPLIT_DEFAULT_PCT)
   const [isResizing, setIsResizing] = useState(false)
   const [contextMenu, setContextMenu] = useState<{
@@ -478,6 +485,10 @@ export const TextEditor = memo(function TextEditor({
     isContentLoading,
     hasContentError,
     saveImmediately,
+    hasConflict,
+    isReloading,
+    reloadLatestContent,
+    downloadDraft,
   } = useEditableFileContent({
     file,
     workspaceId,
@@ -489,7 +500,9 @@ export const TextEditor = memo(function TextEditor({
     saveRef,
     discardRef,
   })
-  contentRef.current = content
+  useLayoutEffect(() => {
+    contentRef.current = content
+  }, [content])
 
   // Enable once content has loaded — the container (and Monaco) only mount after
   // the `isContentLoading` early return below, so the bridge must (re-)attach then.
@@ -505,42 +518,38 @@ export const TextEditor = memo(function TextEditor({
     const monacoValue = model.getValue()
     lastEditorValueRef.current = monacoValue
     if (monacoValue === content) return
-
-    if (isStreamInteractionLocked || monacoValue === lastSyncedContentRef.current) {
-      if (isStreamInteractionLocked) {
-        const scrollTop = editor.getScrollTop()
-        const scrollHeight = editor.getScrollHeight()
-        const { height } = editor.getLayoutInfo()
-        if (scrollHeight - scrollTop - height < 80) {
-          textareaStuckRef.current = true
-        }
+    if (isStreamInteractionLocked) {
+      const scrollTop = editor.getScrollTop()
+      const scrollHeight = editor.getScrollHeight()
+      const { height } = editor.getLayoutInfo()
+      if (scrollHeight - scrollTop - height < 80) {
+        textareaStuckRef.current = true
       }
-      suppressScrollListenerRef.current = true
-      if (content.startsWith(monacoValue) && monacoValue.length < content.length) {
-        const lastLine = model.getLineCount()
-        const lastCol = model.getLineMaxColumn(lastLine)
-        model.applyEdits([
-          {
-            range: {
-              startLineNumber: lastLine,
-              startColumn: lastCol,
-              endLineNumber: lastLine,
-              endColumn: lastCol,
-            },
-            text: content.slice(monacoValue.length),
-          },
-        ])
-      } else {
-        model.applyEdits([{ range: model.getFullModelRange(), text: content }])
-      }
-      suppressScrollListenerRef.current = false
-      lastEditorValueRef.current = content
-      lastSyncedContentRef.current = content
     }
+    suppressScrollListenerRef.current = true
+    if (content.startsWith(monacoValue) && monacoValue.length < content.length) {
+      const lastLine = model.getLineCount()
+      const lastCol = model.getLineMaxColumn(lastLine)
+      model.applyEdits([
+        {
+          range: {
+            startLineNumber: lastLine,
+            startColumn: lastCol,
+            endLineNumber: lastLine,
+            endColumn: lastCol,
+          },
+          text: content.slice(monacoValue.length),
+        },
+      ])
+    } else {
+      model.applyEdits([{ range: model.getFullModelRange(), text: content }])
+    }
+    suppressScrollListenerRef.current = false
+    lastEditorValueRef.current = content
   }, [content, isStreamInteractionLocked])
 
   useEffect(() => {
-    const editor = monacoEditorRef.current
+    const editor = mountedEditor
     if (!editor || !isStreamInteractionLocked || disableStreamingAutoScroll) {
       textareaStuckRef.current = false
       return
@@ -559,7 +568,7 @@ export const TextEditor = memo(function TextEditor({
     return () => {
       disposable.dispose()
     }
-  }, [isStreamInteractionLocked, disableStreamingAutoScroll])
+  }, [mountedEditor, isStreamInteractionLocked, disableStreamingAutoScroll])
 
   useEffect(() => {
     if (!isStreamInteractionLocked || !textareaStuckRef.current || disableStreamingAutoScroll)
@@ -579,7 +588,9 @@ export const TextEditor = memo(function TextEditor({
       const container = containerRef.current
       if (!container) return
       const rect = container.getBoundingClientRect()
-      const pct = ((e.clientX - rect.left) / rect.width) * 100
+      const isRtl = getComputedStyle(container).direction === 'rtl'
+      const sourceWidth = isRtl ? rect.right - e.clientX : e.clientX - rect.left
+      const pct = (sourceWidth / rect.width) * 100
       setSplitPct(Math.min(SPLIT_MAX_PCT, Math.max(SPLIT_MIN_PCT, pct)))
     }
 
@@ -598,8 +609,34 @@ export const TextEditor = memo(function TextEditor({
     }
   }, [isResizing])
 
+  const handleSplitKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey ||
+      event.nativeEvent.isComposing ||
+      event.keyCode === 229
+    ) {
+      return
+    }
+    const { key } = event
+    if (key !== 'ArrowLeft' && key !== 'ArrowRight' && key !== 'Home' && key !== 'End') return
+    event.preventDefault()
+    event.stopPropagation()
+    if (key === 'Home' || key === 'End') {
+      setSplitPct(key === 'Home' ? SPLIT_MIN_PCT : SPLIT_MAX_PCT)
+      return
+    }
+    const container = containerRef.current
+    const isRtl = container !== null && getComputedStyle(container).direction === 'rtl'
+    const delta = (key === 'ArrowLeft' ? -1 : 1) * (isRtl ? -1 : 1) * SPLIT_KEYBOARD_STEP_PCT
+    setSplitPct((current) => Math.min(SPLIT_MAX_PCT, Math.max(SPLIT_MIN_PCT, current + delta)))
+  }
+
   const handleEditorMount: OnMount = (editor, monaco) => {
     monacoEditorRef.current = editor
+    setMountedEditor(editor)
 
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
       saveImmediately()
@@ -611,7 +648,6 @@ export const TextEditor = memo(function TextEditor({
       if (model.getValue() !== currentContent) {
         model.setValue(currentContent)
       }
-      lastSyncedContentRef.current = currentContent
       lastEditorValueRef.current = currentContent
     }
 
@@ -703,12 +739,13 @@ export const TextEditor = memo(function TextEditor({
     (previewType === 'html' &&
       (isSimPageSource(content) ||
         (isStreaming && (trimmedContent === '' || trimmedContent.startsWith('-')))))
-  // Sticky per file: a PATCH stream carries only the replacement snippet,
-  // which is not frontmatter-shaped — without memory the lock would drop
-  // mid-edit and flash raw source. Once a file is known to be a page, it
-  // stays one for the session.
-  if (detectedSimPage) KNOWN_PAGE_FILE_IDS.add(file.id)
-  const isSimPageFile = detectedSimPage || KNOWN_PAGE_FILE_IDS.has(file.id)
+  const knownPage = useFileViewerStore((state) => state.pageFileIds.has(file.id))
+  const rememberPage = useFileViewerStore((state) => state.rememberPage)
+  /** Share only committed observations, before another viewer can paint partial page source. */
+  useLayoutEffect(() => {
+    if (detectedSimPage) rememberPage(file.id)
+  }, [detectedSimPage, file.id, rememberPage])
+  const isSimPageFile = detectedSimPage || knownPage
   const effectiveMode = isSimPageFile
     ? 'preview'
     : isStreaming && isIframeRendered
@@ -730,121 +767,144 @@ export const TextEditor = memo(function TextEditor({
   const closeContextMenu = () => setContextMenu(null)
 
   return (
-    <div ref={containerRef} data-find-tooltip-fix className='relative flex flex-1 overflow-hidden'>
-      <style>{FIND_TOOLTIP_FIX_CSS}</style>
-      {showEditor && (
-        <div
-          data-paste-max-bytes={PASTE_LIMITS.TEXT_EDITOR_BYTES}
-          data-paste-projects-text-result='true'
-          onPasteCapture={handleEditorPasteCapture}
-          style={showPreviewPane ? { width: `${splitPct}%`, flexShrink: 0 } : undefined}
-          className={cn(
-            'min-w-0',
-            !showPreviewPane && 'w-full',
-            isResizing && 'pointer-events-none'
-          )}
-        >
-          <MonacoEditor
-            key={file.id}
-            defaultValue={content}
-            language={monacoLanguage}
-            theme={monacoTheme}
-            options={editorOptions}
-            onChange={handleEditorChange}
-            onMount={handleEditorMount}
-            className='h-full'
-          />
-        </div>
+    <div className='flex min-h-0 flex-1 flex-col overflow-hidden'>
+      {hasConflict && (
+        <FileSaveConflict
+          isReloading={isReloading}
+          reloadLatestContent={reloadLatestContent}
+          downloadDraft={downloadDraft}
+        />
       )}
-      {showPreviewPane && (
-        <>
-          {showEditor && (
-            <div className='relative shrink-0'>
-              <div className='h-full w-px bg-[var(--border)]' />
-              <div
-                className='-left-[3px] absolute top-0 z-10 h-full w-[6px] cursor-col-resize'
-                onMouseDown={() => setIsResizing(true)}
-                role='separator'
-                aria-orientation='vertical'
-                aria-label='Resize split'
-              />
-              {isResizing && (
-                <div className='-translate-x-[0.5px] pointer-events-none absolute top-0 z-20 h-full w-[2px] bg-[var(--selection)]' />
-              )}
-            </div>
-          )}
+      <div
+        ref={containerRef}
+        data-find-tooltip-fix
+        className='relative flex flex-1 overflow-hidden'
+      >
+        <style>{FIND_TOOLTIP_FIX_CSS}</style>
+        {showEditor && (
           <div
+            id={sourcePaneId}
+            data-paste-max-bytes={PASTE_LIMITS.TEXT_EDITOR_BYTES}
+            data-paste-projects-text-result='true'
+            onPasteCapture={handleEditorPasteCapture}
+            style={showPreviewPane ? { width: `${splitPct}%`, flexShrink: 0 } : undefined}
             className={cn(
-              'flex min-w-0 flex-1 flex-col overflow-hidden',
+              'min-w-0',
+              !showPreviewPane && 'w-full',
               isResizing && 'pointer-events-none'
             )}
           >
-            <PreviewPanel
-              key={previewContextKey ? `${file.id}:${previewContextKey}` : file.id}
-              content={content}
-              mimeType={file.type}
-              filename={file.name}
-              workspaceId={workspaceId}
-              fileId={file.id}
-              fileKey={file.key}
-              isStreaming={isStreaming}
+            <MonacoEditor
+              key={file.id}
+              defaultValue={content}
+              language={monacoLanguage}
+              theme={monacoTheme}
+              options={editorOptions}
+              onChange={handleEditorChange}
+              onMount={handleEditorMount}
+              className='h-full'
             />
           </div>
-        </>
-      )}
-      {contextMenu && (
-        <EditorContextMenu
-          isOpen
-          position={contextMenu}
-          onClose={closeContextMenu}
-          hasSelection={contextMenu.hasSelection}
-          canEdit={!isEditorReadOnly}
-          onAddToChat={() => {
-            handleAddSelectionToChat()
-            closeContextMenu()
-          }}
-          onCut={() => {
-            monacoEditorRef.current?.focus()
-            monacoEditorRef.current?.trigger(
-              'contextmenu',
-              'editor.action.clipboardCutAction',
-              null
-            )
-            closeContextMenu()
-          }}
-          onCopy={() => {
-            monacoEditorRef.current?.focus()
-            monacoEditorRef.current?.trigger(
-              'contextmenu',
-              'editor.action.clipboardCopyAction',
-              null
-            )
-            closeContextMenu()
-          }}
-          onCopyAll={() => {
-            navigator.clipboard.writeText(monacoEditorRef.current?.getValue() ?? '').catch(() => {})
-            closeContextMenu()
-          }}
-          onPaste={() => {
-            monacoEditorRef.current?.focus()
-            monacoEditorRef.current?.trigger(
-              'contextmenu',
-              'editor.action.clipboardPasteAction',
-              null
-            )
-            closeContextMenu()
-          }}
-          onSelectAll={() => {
-            monacoEditorRef.current?.focus()
-            monacoEditorRef.current?.trigger('contextmenu', 'editor.action.selectAll', null)
-            closeContextMenu()
-          }}
-          onFind={() => {
-            monacoEditorRef.current?.getAction('actions.find')?.run()
-            closeContextMenu()
-          }}
-        />
-      )}
+        )}
+        {showPreviewPane && (
+          <>
+            {showEditor && (
+              <div className='relative shrink-0'>
+                <div className='h-full w-px bg-[var(--border)]' />
+                <div
+                  className='-left-[3px] absolute top-0 z-10 h-full w-[6px] cursor-col-resize focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--selection)]'
+                  onMouseDown={() => setIsResizing(true)}
+                  onKeyDown={handleSplitKeyDown}
+                  tabIndex={0}
+                  role='separator'
+                  aria-orientation='vertical'
+                  aria-label='Resize split'
+                  aria-controls={sourcePaneId}
+                  aria-valuemin={SPLIT_MIN_PCT}
+                  aria-valuemax={SPLIT_MAX_PCT}
+                  aria-valuenow={splitPct}
+                  aria-valuetext={`${Math.round(splitPct)}% source, ${Math.round(100 - splitPct)}% preview`}
+                />
+                {isResizing && (
+                  <div className='-translate-x-[0.5px] pointer-events-none absolute top-0 z-20 h-full w-[2px] bg-[var(--selection)]' />
+                )}
+              </div>
+            )}
+            <div
+              className={cn(
+                'flex min-w-0 flex-1 flex-col overflow-hidden',
+                isResizing && 'pointer-events-none'
+              )}
+            >
+              <PreviewPanel
+                key={previewContextKey ? `${file.id}:${previewContextKey}` : file.id}
+                content={content}
+                mimeType={file.type}
+                filename={file.name}
+                workspaceId={workspaceId}
+                fileId={file.id}
+                fileKey={file.key}
+                isStreaming={isStreaming}
+              />
+            </div>
+          </>
+        )}
+        {contextMenu && (
+          <EditorContextMenu
+            isOpen
+            position={contextMenu}
+            onClose={closeContextMenu}
+            hasSelection={contextMenu.hasSelection}
+            canEdit={!isEditorReadOnly}
+            onAddToChat={() => {
+              handleAddSelectionToChat()
+              closeContextMenu()
+            }}
+            onCut={() => {
+              monacoEditorRef.current?.focus()
+              monacoEditorRef.current?.trigger(
+                'contextmenu',
+                'editor.action.clipboardCutAction',
+                null
+              )
+              closeContextMenu()
+            }}
+            onCopy={() => {
+              monacoEditorRef.current?.focus()
+              monacoEditorRef.current?.trigger(
+                'contextmenu',
+                'editor.action.clipboardCopyAction',
+                null
+              )
+              closeContextMenu()
+            }}
+            onCopyAll={() => {
+              navigator.clipboard
+                .writeText(monacoEditorRef.current?.getValue() ?? '')
+                .catch(() => {})
+              closeContextMenu()
+            }}
+            onPaste={() => {
+              monacoEditorRef.current?.focus()
+              monacoEditorRef.current?.trigger(
+                'contextmenu',
+                'editor.action.clipboardPasteAction',
+                null
+              )
+              closeContextMenu()
+            }}
+            onSelectAll={() => {
+              monacoEditorRef.current?.focus()
+              monacoEditorRef.current?.trigger('contextmenu', 'editor.action.selectAll', null)
+              closeContextMenu()
+            }}
+            onFind={() => {
+              monacoEditorRef.current?.getAction('actions.find')?.run()
+              closeContextMenu()
+            }}
+          />
+        )}
+      </div>
     </div>
   )
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-conflicts.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-conflicts.test.tsx
@@ -340,6 +340,38 @@ describe('versioned solo-file editing', () => {
     )
   })
 
+  it('keeps an unversioned remote conflict paused after an in-flight save succeeds', async () => {
+    const pending = Promise.withResolvers<{ success: boolean; file: WorkspaceFileRecord }>()
+    mocks.save.mockReturnValueOnce(pending.promise)
+    await render()
+    await edit('local saved')
+    let saving: Promise<void> | undefined
+    act(() => {
+      saving = latest.saveImmediately()
+    })
+    await edit('local trailing')
+    file = { ...FILE, key: 'unknown-version', contentUpdatedAt: null }
+    mocks.query.content = 'remote'
+    await render()
+    expect(latest.hasConflict).toBe(true)
+    await act(async () => {
+      pending.resolve({ success: true, file: { ...FILE, contentUpdatedAt: new Date(V2) } })
+      await saving
+    })
+    expect(latest.hasConflict).toBe(true)
+    expect(latest.content).toBe('local trailing')
+    await advance()
+    await act(async () => latest.saveImmediately())
+    expect(mocks.save).toHaveBeenCalledTimes(1)
+    file = { ...FILE, key: 'immutable-v3', contentUpdatedAt: new Date(V3) }
+    mocks.reload.mockResolvedValueOnce({ content: 'latest remote', file })
+    await act(async () => latest.reloadLatestContent())
+    expect(latest.hasConflict).toBe(false)
+    await edit('resolved')
+    await act(async () => latest.saveImmediately())
+    expect(mocks.save).toHaveBeenLastCalledWith(expect.objectContaining({ expectedUpdatedAt: V3 }))
+  })
+
   it('uses the successful response token for trailing edits before the file-list refetch', async () => {
     const pending = Promise.withResolvers<{ success: boolean; file: WorkspaceFileRecord }>()
     mocks.save.mockReturnValueOnce(pending.promise)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-conflicts.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-conflicts.test.tsx
@@ -1,0 +1,475 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createRef, StrictMode, Suspense, startTransition, useLayoutEffect } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiClientError } from '@/lib/api/client/errors'
+import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
+import { useEditableFileContent } from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content'
+
+const mocks = vi.hoisted(() => ({
+  query: { content: 'original' as string | undefined },
+  save: vi.fn(),
+  reload: vi.fn(),
+  readDraft: vi.fn(),
+  writeDraft: vi.fn(),
+  deleteDraft: vi.fn(),
+}))
+vi.mock('@/hooks/queries/workspace-files', () => ({
+  useWorkspaceFileContent: () => ({ data: mocks.query.content, isLoading: false, error: null }),
+  useUpdateWorkspaceFileContent: () => ({ mutateAsync: mocks.save }),
+  useReloadWorkspaceFileContent: () => ({ mutateAsync: mocks.reload, isPending: false }),
+}))
+vi.mock('idb-keyval', () => ({
+  get: mocks.readDraft,
+  set: mocks.writeDraft,
+  del: mocks.deleteDraft,
+}))
+
+const V1 = '2026-09-03T20:00:00.000Z'
+const V2 = '2026-09-03T20:00:01.000Z'
+const V3 = '2026-09-03T20:00:02.000Z'
+const FILE: WorkspaceFileRecord = {
+  id: 'file-1',
+  workspaceId: 'workspace-1',
+  name: 'notes.txt',
+  type: 'text/plain',
+  key: 'immutable-v1',
+  path: '/file',
+  size: 8,
+  uploadedBy: 'user-1',
+  uploadedAt: new Date(V1),
+  updatedAt: new Date(V1),
+  contentUpdatedAt: new Date(V1),
+}
+let latest: ReturnType<typeof useEditableFileContent>
+let root: Root
+let container: HTMLDivElement
+let file = FILE
+let streamingContent: string | undefined
+let isAgentEditing = false
+const discardRef = createRef<(() => void) | null>()
+
+function Probe() {
+  latest = useEditableFileContent({
+    file,
+    workspaceId: FILE.workspaceId,
+    canEdit: true,
+    discardRef,
+    streamingContent,
+    isAgentEditing,
+  })
+  return null
+}
+async function render() {
+  await act(async () => root.render(<Probe />))
+}
+async function edit(content: string) {
+  await act(async () => latest.setDraftContent(content))
+}
+async function advance(ms = 2000) {
+  await act(async () => vi.advanceTimersByTimeAsync(ms))
+}
+
+interface TransitionProbeProps {
+  streamingContent?: string
+  isAgentEditing?: boolean
+}
+
+function TransitionProbe(options: TransitionProbeProps) {
+  const state = useEditableFileContent({
+    file,
+    workspaceId: FILE.workspaceId,
+    canEdit: true,
+    discardRef,
+    ...options,
+  })
+  useLayoutEffect(() => {
+    latest = state
+  })
+  return <div>{state.content}</div>
+}
+
+/** Suspend after the hook finishes its render-phase reconciliation, without committing the tree. */
+const pendingTransition = new Promise<void>(() => {})
+function SuspendTransition(): never {
+  throw pendingTransition
+}
+
+async function renderTransition(options: TransitionProbeProps = {}, suspend = false) {
+  const view = (
+    <Suspense fallback={<div>Loading</div>}>
+      <TransitionProbe {...options} />
+      {suspend && <SuspendTransition />}
+    </Suspense>
+  )
+  await act(async () => {
+    if (suspend) startTransition(() => root.render(view))
+    else root.render(view)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+  file = FILE
+  streamingContent = undefined
+  isAgentEditing = false
+  mocks.query.content = 'original'
+  mocks.readDraft.mockResolvedValue(undefined)
+  mocks.writeDraft.mockResolvedValue(undefined)
+  mocks.deleteDraft.mockResolvedValue(undefined)
+  mocks.save.mockResolvedValue({ success: true, file: { ...FILE, contentUpdatedAt: new Date(V2) } })
+  container = document.createElement('div')
+  root = createRoot(container)
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe('versioned solo-file editing', () => {
+  it('does not block a committed save when an abandoned render observes an agent stream', async () => {
+    await renderTransition()
+    await edit('committed local draft')
+    const committed = latest
+    await renderTransition(
+      { streamingContent: 'abandoned agent frame', isAgentEditing: true },
+      true
+    )
+    expect(container.textContent).toBe('committed local draft')
+    expect(latest.hasConflict).toBe(false)
+    await act(async () => committed.saveImmediately())
+    expect(mocks.save).toHaveBeenCalledWith(
+      expect.objectContaining({ content: 'committed local draft', expectedUpdatedAt: V1 })
+    )
+  })
+
+  it('keeps the committed agent reload lock when a suspended render removes it', async () => {
+    await renderTransition({ isAgentEditing: true })
+    const committed = latest
+    await renderTransition({}, true)
+    expect(latest.isStreamInteractionLocked).toBe(true)
+    await act(async () => {
+      await expect(committed.reloadLatestContent()).rejects.toThrow('Wait for the agent edit')
+    })
+    expect(mocks.reload).not.toHaveBeenCalled()
+  })
+
+  it('discards to the committed baseline after a suspended remote-baseline render', async () => {
+    await renderTransition()
+    await edit('local draft')
+    const committedDiscard = discardRef.current
+    file = { ...FILE, key: 'immutable-v2', contentUpdatedAt: new Date(V2) }
+    mocks.query.content = 'abandoned remote baseline'
+    await renderTransition({}, true)
+    expect(container.textContent).toBe('local draft')
+    file = FILE
+    mocks.query.content = 'original'
+    await act(async () => committedDiscard?.())
+    expect(latest.content).toBe('original')
+    expect(mocks.save).not.toHaveBeenCalled()
+  })
+
+  it('exports the visible committed content rather than a suspended stream snapshot', async () => {
+    const OriginalBlob = Blob
+    const createBlob = vi.fn(class extends OriginalBlob {})
+    const createObjectURL = vi.fn(() => 'blob:local-draft')
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    vi.stubGlobal('Blob', createBlob)
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL: vi.fn() })
+    try {
+      await renderTransition()
+      const committed = latest
+      await renderTransition({ streamingContent: 'abandoned agent frame' }, true)
+      expect(container.textContent).toBe('original')
+      act(() => committed.downloadDraft())
+      expect(createBlob).toHaveBeenCalledWith(['original'], {
+        type: 'text/plain;charset=utf-8',
+      })
+      expect(click).toHaveBeenCalledOnce()
+      await advance(0)
+    } finally {
+      click.mockRestore()
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('keeps a stream conflict and trailing draft when an earlier save finishes during the stream', async () => {
+    const pending = Promise.withResolvers<{ success: boolean; file: WorkspaceFileRecord }>()
+    mocks.save.mockReturnValueOnce(pending.promise)
+    await render()
+    await edit('first draft')
+    let saving: Promise<void> | undefined
+    act(() => {
+      saving = latest.saveImmediately()
+    })
+    await edit('trailing draft')
+    streamingContent = 'agent partial'
+    await render()
+    await act(async () => {
+      pending.resolve({ success: true, file: { ...FILE, contentUpdatedAt: new Date(V2) } })
+      await saving
+    })
+    expect(latest.content).toBe('trailing draft')
+    expect(latest.hasConflict).toBe(true)
+    expect(latest.isStreamInteractionLocked).toBe(true)
+    await act(async () => root.unmount())
+    root = createRoot(container)
+    expect(mocks.writeDraft).toHaveBeenCalledWith(expect.any(String), {
+      content: 'trailing draft',
+      savedContent: 'first draft',
+    })
+    expect(mocks.save).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists a dirty draft on unmount when the agent lock arrives before the first stream chunk', async () => {
+    await render()
+    await edit('local not yet persisted')
+    isAgentEditing = true
+    await render()
+    expect(latest.isStreamInteractionLocked).toBe(true)
+    await act(async () => root.unmount())
+    root = createRoot(container)
+    expect(mocks.writeDraft).toHaveBeenCalledWith(expect.any(String), {
+      content: 'local not yet persisted',
+      savedContent: 'original',
+    })
+    expect(mocks.save).not.toHaveBeenCalled()
+  })
+
+  it.each(['original', 'older server'])(
+    'recovers a draft through StrictMode effect replay (baseline=%s)',
+    async (savedContent) => {
+      mocks.readDraft.mockResolvedValue({ content: 'recovered local', savedContent })
+      await act(async () =>
+        root.render(
+          <StrictMode>
+            <Probe />
+          </StrictMode>
+        )
+      )
+      expect(latest.content).toBe('recovered local')
+      expect(latest.hasConflict).toBe(savedContent !== 'original')
+    }
+  )
+
+  it('preserves and persists a dirty local draft when an agent stream starts', async () => {
+    await render()
+    await edit('local unsaved')
+    streamingContent = 'agent partial'
+    await render()
+    expect(latest.content).toBe('local unsaved')
+    expect(latest.hasConflict).toBe(true)
+    expect(latest.isStreamInteractionLocked).toBe(true)
+    await advance()
+    expect(mocks.save).not.toHaveBeenCalled()
+    expect(mocks.writeDraft).toHaveBeenCalledWith(expect.any(String), {
+      content: 'local unsaved',
+      savedContent: 'original',
+    })
+    await act(async () => {
+      await expect(latest.reloadLatestContent()).rejects.toThrow('Wait for the agent edit')
+    })
+    expect(mocks.reload).not.toHaveBeenCalled()
+    file = { ...FILE, key: 'immutable-v2', contentUpdatedAt: new Date(V2) }
+    mocks.query.content = 'agent final'
+    streamingContent = undefined
+    await render()
+    expect(latest.content).toBe('local unsaved')
+    expect(latest.hasConflict).toBe(true)
+    expect(latest.isStreamInteractionLocked).toBe(false)
+    mocks.reload.mockResolvedValueOnce({ content: 'agent final', file })
+    await act(async () => latest.reloadLatestContent())
+    expect(latest.content).toBe('agent final')
+    expect(latest.hasConflict).toBe(false)
+  })
+
+  it('sends the original content version even when metadata advances before bytes arrive', async () => {
+    await render()
+    await edit('local')
+    file = { ...FILE, key: 'immutable-v2', contentUpdatedAt: new Date(V2) }
+    mocks.query.content = undefined
+    await render()
+    await act(async () => latest.saveImmediately())
+    expect(mocks.save).toHaveBeenCalledWith(
+      expect.objectContaining({ content: 'local', expectedUpdatedAt: V1 })
+    )
+  })
+
+  it('retains both versions and pauses saves when dirty content receives a remote update', async () => {
+    await render()
+    await edit('local')
+    file = { ...FILE, key: 'immutable-v2', contentUpdatedAt: new Date(V2) }
+    mocks.query.content = 'remote'
+    await render()
+    expect(latest.content).toBe('local')
+    expect(latest.hasConflict).toBe(true)
+    expect(latest.isDirty).toBe(true)
+    expect(latest.saveStatus).toBe('error')
+    await edit('local continuing')
+    await advance()
+    await act(async () => latest.saveImmediately())
+    expect(mocks.save).not.toHaveBeenCalled()
+    expect(mocks.writeDraft).toHaveBeenCalledWith(expect.any(String), {
+      content: 'local continuing',
+      savedContent: 'original',
+    })
+  })
+
+  it('does not retry a rejected CAS on typing, manual save, or unmount', async () => {
+    mocks.save.mockRejectedValue(
+      new ApiClientError({ status: 409, message: 'File changed', body: {} })
+    )
+    await render()
+    await edit('local')
+    await act(async () => latest.saveImmediately())
+    expect(latest.hasConflict).toBe(true)
+    await edit('local newer')
+    await advance(5000)
+    await act(async () => latest.saveImmediately())
+    await act(async () => root.unmount())
+    root = createRoot(container)
+    expect(mocks.save).toHaveBeenCalledTimes(1)
+    expect(mocks.writeDraft).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ content: 'local newer' })
+    )
+  })
+
+  it('uses the successful response token for trailing edits before the file-list refetch', async () => {
+    const pending = Promise.withResolvers<{ success: boolean; file: WorkspaceFileRecord }>()
+    mocks.save.mockReturnValueOnce(pending.promise)
+    await render()
+    await edit('first')
+    let saving: Promise<void> | undefined
+    act(() => {
+      saving = latest.saveImmediately()
+    })
+    await edit('second')
+    await act(async () => {
+      pending.resolve({ success: true, file: { ...FILE, contentUpdatedAt: new Date(V2) } })
+      await saving
+    })
+    await advance(700)
+    expect(mocks.save).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ content: 'second', expectedUpdatedAt: V2 })
+    )
+    expect(latest.content).toBe('second')
+  })
+
+  it('keeps a recovered local draft when its former baseline differs from the server', async () => {
+    mocks.readDraft.mockResolvedValue({ content: 'recovered local', savedContent: 'older server' })
+    await render()
+    expect(latest.content).toBe('recovered local')
+    expect(latest.hasConflict).toBe(true)
+    await advance()
+    expect(mocks.save).not.toHaveBeenCalled()
+    expect(mocks.deleteDraft).not.toHaveBeenCalled()
+  })
+
+  it('preserves the draft on reload failure, then accepts explicitly reloaded bytes and their token', async () => {
+    await render()
+    await edit('local')
+    file = { ...FILE, key: 'immutable-v2', contentUpdatedAt: new Date(V2) }
+    mocks.query.content = 'remote'
+    await render()
+    mocks.reload.mockRejectedValueOnce(new Error('offline'))
+    await act(async () => {
+      await expect(latest.reloadLatestContent()).rejects.toThrow('offline')
+    })
+    expect(latest.content).toBe('local')
+    expect(latest.hasConflict).toBe(true)
+    mocks.reload.mockResolvedValueOnce({
+      content: 'latest remote',
+      file: { ...FILE, key: 'immutable-v3', contentUpdatedAt: new Date(V3) },
+    })
+    await act(async () => latest.reloadLatestContent())
+    expect(latest.content).toBe('latest remote')
+    expect(latest.hasConflict).toBe(false)
+    expect(latest.isDirty).toBe(false)
+    expect(latest.acceptedBaselineContent).toBe('latest remote')
+    await edit('resolved')
+    await act(async () => latest.saveImmediately())
+    expect(mocks.save).toHaveBeenCalledWith(expect.objectContaining({ expectedUpdatedAt: V3 }))
+  })
+
+  it('does not undo a deliberate reload when an older save acknowledgement arrives afterward', async () => {
+    const pending = Promise.withResolvers<{ success: boolean; file: WorkspaceFileRecord }>()
+    mocks.save.mockReturnValueOnce(pending.promise)
+    await render()
+    await edit('local saved')
+    let saving: Promise<void> | undefined
+    act(() => {
+      saving = latest.saveImmediately()
+    })
+    file = { ...FILE, key: 'immutable-v3', contentUpdatedAt: new Date(V3) }
+    mocks.query.content = 'latest remote'
+    await render()
+    expect(latest.hasConflict).toBe(true)
+    mocks.reload.mockResolvedValueOnce({ content: 'latest remote', file })
+    await act(async () => latest.reloadLatestContent())
+    await act(async () => {
+      pending.resolve({ success: true, file: { ...FILE, contentUpdatedAt: new Date(V2) } })
+      await saving
+    })
+    await advance(5000)
+    expect(latest.content).toBe('latest remote')
+    expect(latest.isDirty).toBe(false)
+    expect(mocks.save).toHaveBeenCalledTimes(1)
+    await edit('resolved')
+    await act(async () => latest.saveImmediately())
+    expect(mocks.save).toHaveBeenLastCalledWith(expect.objectContaining({ expectedUpdatedAt: V3 }))
+  })
+
+  it('preserves edits made while a conflict reload is pending', async () => {
+    await render()
+    await edit('local')
+    file = { ...FILE, key: 'immutable-v2', contentUpdatedAt: new Date(V2) }
+    mocks.query.content = 'remote'
+    await render()
+    const pending = Promise.withResolvers<{ content: string; file: WorkspaceFileRecord }>()
+    mocks.reload.mockReturnValueOnce(pending.promise)
+    let reloading: Promise<void> | undefined
+    act(() => {
+      reloading = latest.reloadLatestContent()
+    })
+    await edit('local newer')
+    await act(async () => {
+      pending.resolve({ content: 'remote', file })
+      await expect(reloading).rejects.toThrow('Your draft changed')
+    })
+    expect(latest.content).toBe('local newer')
+    expect(latest.hasConflict).toBe(true)
+  })
+
+  it('does not re-enter conflict when a rejected older save arrives after explicit reload', async () => {
+    const pending = Promise.withResolvers<{ success: boolean; file: WorkspaceFileRecord }>()
+    mocks.save.mockReturnValueOnce(pending.promise)
+    await render()
+    await edit('local')
+    let saving: Promise<void> | undefined
+    act(() => {
+      saving = latest.saveImmediately()
+    })
+    file = { ...FILE, key: 'immutable-v3', contentUpdatedAt: new Date(V3) }
+    mocks.query.content = 'latest remote'
+    await render()
+    mocks.reload.mockResolvedValueOnce({ content: 'latest remote', file })
+    await act(async () => latest.reloadLatestContent())
+    await act(async () => {
+      pending.reject(new ApiClientError({ status: 409, message: 'File changed', body: {} }))
+      await saving
+    })
+    expect(latest.content).toBe('latest remote')
+    expect(latest.hasConflict).toBe(false)
+    expect(latest.isDirty).toBe(false)
+    await edit('resolved')
+    await act(async () => latest.saveImmediately())
+    expect(mocks.save).toHaveBeenLastCalledWith(expect.objectContaining({ expectedUpdatedAt: V3 }))
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@/hooks/queries/workspace-files', () => ({
     return { data: queryState.fetched, isLoading: queryState.fetched === undefined, error: null }
   },
   useUpdateWorkspaceFileContent: () => ({ mutateAsync: vi.fn(async () => ({ success: true })) }),
+  useReloadWorkspaceFileContent: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 
 vi.mock('idb-keyval', () => ({
@@ -46,7 +47,7 @@ import {
   RECONCILING_REFETCH_SLOW_INTERVAL_MS,
   RECONCILING_REFETCH_WINDOW_MS,
   useEditableFileContent,
-} from './use-editable-file-content'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content'
 
 const FILE = {
   id: 'f1',

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -1,20 +1,22 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react'
 import { toast } from '@sim/emcn'
+import { isApiClientError } from '@/lib/api/client/errors'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import { GENERATED_DOCUMENT_SOURCE_TYPES } from '@/lib/uploads/utils/file-utils'
 import {
+  INITIAL_TEXT_EDITOR_CONTENT_STATE,
+  type SyncTextEditorContentStateOptions,
+  textEditorContentReducer,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/text-editor-state'
+import {
+  useReloadWorkspaceFileContent,
   useUpdateWorkspaceFileContent,
   useWorkspaceFileContent,
 } from '@/hooks/queries/workspace-files'
 import { type SaveStatus, useAutosave } from '@/hooks/use-autosave'
 import { useSmoothText } from '@/hooks/use-smooth-text'
-import {
-  INITIAL_TEXT_EDITOR_CONTENT_STATE,
-  type SyncTextEditorContentStateOptions,
-  textEditorContentReducer,
-} from './text-editor-state'
 
 /**
  * Generated-document source files (`.pptx`/`.docx`/`.pdf`/`.xlsx` builders) whose
@@ -86,6 +88,11 @@ interface EditableFileContent {
   saveStatus: SaveStatus
   saveImmediately: () => Promise<void>
   isDirty: boolean
+  hasConflict: boolean
+  isReloading: boolean
+  reloadLatestContent: () => Promise<void>
+  downloadDraft: () => void
+  acceptedBaselineContent?: string
 }
 
 /**
@@ -95,15 +102,15 @@ interface EditableFileContent {
 function useFileContentState(options: SyncTextEditorContentStateOptions) {
   const [state, dispatch] = useReducer(textEditorContentReducer, INITIAL_TEXT_EDITOR_CONTENT_STATE)
 
-  const prevOptionsRef = useRef<SyncTextEditorContentStateOptions | null>(null)
-  const prev = prevOptionsRef.current
+  const [prev, setPrev] = useState<SyncTextEditorContentStateOptions | null>(null)
   if (
     prev === null ||
     prev.canReconcileToFetchedContent !== options.canReconcileToFetchedContent ||
     prev.fetchedContent !== options.fetchedContent ||
+    prev.fetchedVersion !== options.fetchedVersion ||
     prev.streamingContent !== options.streamingContent
   ) {
-    prevOptionsRef.current = options
+    setPrev(options)
     dispatch({ type: 'sync-external', ...options })
   }
 
@@ -111,9 +118,19 @@ function useFileContentState(options: SyncTextEditorContentStateOptions) {
     dispatch({ type: 'edit', content })
   }, [])
 
-  const markSavedContent = useCallback((content: string) => {
-    dispatch({ type: 'save-success', content })
+  const markSavedContent = useCallback((content: string, version?: string) => {
+    dispatch({ type: 'save-success', content, version })
   }, [])
+
+  const markConflict = useCallback(() => dispatch({ type: 'save-conflict' }), [])
+  const restoreConflictingDraft = useCallback(
+    (content: string) => dispatch({ type: 'restore-conflicting-draft', content }),
+    []
+  )
+  const acceptReload = useCallback(
+    (content: string, version: string) => dispatch({ type: 'reload', content, version }),
+    []
+  )
 
   return {
     content: state.content,
@@ -123,6 +140,12 @@ function useFileContentState(options: SyncTextEditorContentStateOptions) {
     isReconciling: state.phase === 'reconciling',
     setDraftContent,
     markSavedContent,
+    savedVersion: state.savedVersion,
+    hasConflict: Boolean(state.conflict),
+    acceptedBaselineContent: state.acceptedBaselineContent,
+    markConflict,
+    restoreConflictingDraft,
+    acceptReload,
   }
 }
 
@@ -147,8 +170,6 @@ export function useEditableFileContent({
 }: UseEditableFileContentOptions): EditableFileContent {
   const onDirtyChangeRef = useRef(onDirtyChange)
   const onSaveStatusChangeRef = useRef(onSaveStatusChange)
-  onDirtyChangeRef.current = onDirtyChange
-  onSaveStatusChangeRef.current = onSaveStatusChange
 
   /**
    * Mirrors the reducer's `reconciling` phase (assigned below the reducer hook; read here through a
@@ -189,27 +210,38 @@ export function useEditableFileContent({
     }
   )
 
-  /**
-   * Latches once this mount has ever streamed (agent edit). A mount that streams keeps the raw fetched
-   * value as its baseline for its whole life, so normalization can never perturb the stream-reconcile
-   * comparisons in {@link syncTextEditorContentState}. A pure at-rest open never latches and normalizes
-   * freely. Set during render (not an effect) so it is observed before the baseline is derived.
-   */
-  const everStreamedRef = useRef(false)
-  if (streamingContent !== undefined || isAgentEditing) everStreamedRef.current = true
-
-  // Re-derived only when the fetched content changes (never on a stream-flag flip), so the dirty
-  // baseline stays stable through a post-stream reconcile.
-  const baselineContent = useMemo(() => {
-    if (fetchedContent === undefined || !normalizeBaseline || everStreamedRef.current) {
-      return fetchedContent
-    }
-    return normalizeBaseline(fetchedContent)
-  }, [fetchedContent, normalizeBaseline])
+  /** A stream-only transition retains the accepted representation; subsequent fetched snapshots stay raw for reconciliation. */
+  const isStreamObserved = streamingContent !== undefined || Boolean(isAgentEditing)
+  const [baseline, setBaseline] = useState(() => ({
+    source: fetchedContent,
+    normalizer: normalizeBaseline,
+    everStreamed: isStreamObserved,
+    content:
+      fetchedContent !== undefined && normalizeBaseline && !isStreamObserved
+        ? normalizeBaseline(fetchedContent)
+        : fetchedContent,
+  }))
+  const everStreamed = baseline.everStreamed || isStreamObserved
+  const sourceChanged =
+    baseline.source !== fetchedContent || baseline.normalizer !== normalizeBaseline
+  if (sourceChanged || everStreamed !== baseline.everStreamed) {
+    setBaseline({
+      source: fetchedContent,
+      normalizer: normalizeBaseline,
+      everStreamed,
+      content: sourceChanged
+        ? fetchedContent !== undefined && normalizeBaseline && !everStreamed
+          ? normalizeBaseline(fetchedContent)
+          : fetchedContent
+        : baseline.content,
+    })
+  }
+  const baselineContent = baseline.content
+  const everStreamedRef = useRef(everStreamed)
 
   const updateContent = useUpdateWorkspaceFileContent()
+  const reloadContent = useReloadWorkspaceFileContent()
   const updateContentRef = useRef(updateContent)
-  updateContentRef.current = updateContent
 
   const {
     content,
@@ -219,15 +251,25 @@ export function useEditableFileContent({
     isReconciling,
     setDraftContent,
     markSavedContent,
+    savedVersion,
+    hasConflict,
+    acceptedBaselineContent,
+    markConflict,
+    restoreConflictingDraft,
+    acceptReload,
   } = useFileContentState({
     canReconcileToFetchedContent: file.key.length > 0,
     fetchedContent: baselineContent,
+    fetchedVersion:
+      fetchedContent !== undefined && file.contentUpdatedAt
+        ? new Date(file.contentUpdatedAt).toISOString()
+        : undefined,
     streamingContent,
   })
-  if (isReconciling && !isReconcilingRef.current) reconcilingSinceRef.current = Date.now()
-  isReconcilingRef.current = isReconciling
-
-  const isStreamInteractionLocked = isStreamPhaseLocked || Boolean(isAgentEditing)
+  const isAgentStreamActive = streamingContent !== undefined || Boolean(isAgentEditing)
+  const streamActiveRef = useRef(isAgentStreamActive)
+  const isStreamInteractionLocked =
+    isStreamPhaseLocked || Boolean(isAgentEditing) || (hasConflict && isAgentStreamActive)
 
   // Pace the streamed reveal for DISPLAY only. The reducer above keeps the true content so
   // reconciliation, dirty tracking, and saves are never thrown off by the paced prefix. Pacing is
@@ -239,31 +281,141 @@ export function useEditableFileContent({
   const displayContent = isStreamPhaseLocked ? pacedReveal : content
 
   const contentRef = useRef(content)
-  contentRef.current = content
+  const saveVersionRef = useRef(savedVersion)
+  const conflictRef = useRef(hasConflict)
+
+  /** Publish one committed draft/baseline to asynchronous saves, reloads, and query polling. */
+  useLayoutEffect(() => {
+    if (isReconciling && !isReconcilingRef.current) reconcilingSinceRef.current = Date.now()
+    isReconcilingRef.current = isReconciling
+    everStreamedRef.current = everStreamed
+    onDirtyChangeRef.current = onDirtyChange
+    onSaveStatusChangeRef.current = onSaveStatusChange
+    updateContentRef.current = updateContent
+    streamActiveRef.current = isAgentStreamActive
+    contentRef.current = content
+    saveVersionRef.current = savedVersion
+    conflictRef.current = hasConflict
+  })
 
   const onSave = useCallback(
     async (overrideContent?: string) => {
       const next = overrideContent ?? contentRef.current
-      await updateContentRef.current.mutateAsync({ workspaceId, fileId: file.id, content: next })
-      markSavedContent(next)
+      const expectedUpdatedAt = saveVersionRef.current
+      if (conflictRef.current) throw new Error('Reload the latest file before saving this draft')
+      if (!expectedUpdatedAt) {
+        conflictRef.current = true
+        markConflict()
+        throw new Error('The file version is unavailable; reload before saving')
+      }
+      try {
+        const result = await updateContentRef.current.mutateAsync({
+          workspaceId,
+          fileId: file.id,
+          content: next,
+          expectedUpdatedAt,
+        })
+        const version = result.file.contentUpdatedAt
+        if (!version) {
+          conflictRef.current = true
+          markConflict()
+          throw new Error('Saved file version is unavailable; reload before continuing')
+        }
+        const acknowledgedVersion = new Date(version).toISOString()
+        if (
+          !saveVersionRef.current ||
+          Date.parse(acknowledgedVersion) >= Date.parse(saveVersionRef.current)
+        ) {
+          saveVersionRef.current = acknowledgedVersion
+        }
+        markSavedContent(next, acknowledgedVersion)
+      } catch (error) {
+        if (
+          isApiClientError(error) &&
+          error.status === 409 &&
+          saveVersionRef.current === expectedUpdatedAt
+        ) {
+          conflictRef.current = true
+          markConflict()
+        }
+        throw error
+      }
     },
-    [workspaceId, file.id, markSavedContent]
+    [workspaceId, file.id, markSavedContent, markConflict]
   )
 
-  const autosaveEnabled = canEdit && isInitialized && !isStreamInteractionLocked && canAutosave
+  const autosaveEnabled =
+    canEdit &&
+    isInitialized &&
+    canAutosave &&
+    (!isStreamInteractionLocked ||
+      hasConflict ||
+      (!isStreamPhaseLocked && content !== savedContent))
 
-  const { saveStatus, saveImmediately, isDirty, discard } = useAutosave({
+  const {
+    saveStatus: autosaveStatus,
+    saveImmediately,
+    isDirty,
+    discard,
+  } = useAutosave({
     content,
     savedContent,
     onSave,
     enabled: autosaveEnabled,
+    pauseSaving: hasConflict || isStreamInteractionLocked,
     draftKey: autosaveEnabled ? `${workspaceId}:${file.id}` : undefined,
     onRestoreDraft: setDraftContent,
+    onRestoreConflictingDraft: restoreConflictingDraft,
     onDiscardCorrectionFailed: () =>
       toast.error(
         `Failed to discard "${file.name}" — the server may still have the discarded edit`
       ),
   })
+  const saveStatus = hasConflict ? 'error' : autosaveStatus
+
+  const reloadLatestContent = useCallback(async () => {
+    if (streamActiveRef.current)
+      throw new Error('Wait for the agent edit to finish before reloading')
+    const draftAtStart = contentRef.current
+    const result = await reloadContent.mutateAsync({
+      workspaceId,
+      fileId: file.id,
+      raw: GENERATED_SOURCE_FILE_TYPES.has(file.type),
+    })
+    if (streamActiveRef.current)
+      throw new Error('An agent edit started while reloading. Retry after it finishes.')
+    if (contentRef.current !== draftAtStart)
+      throw new Error('Your draft changed while reloading. Download it or retry reload.')
+    if (!result.file.contentUpdatedAt) throw new Error('The latest file version is unavailable')
+    const latestContent =
+      normalizeBaseline && !everStreamedRef.current
+        ? normalizeBaseline(result.content)
+        : result.content
+    discard({ correctInFlightSave: false })
+    const version = new Date(result.file.contentUpdatedAt).toISOString()
+    saveVersionRef.current = version
+    conflictRef.current = false
+    acceptReload(latestContent, version)
+  }, [
+    reloadContent.mutateAsync,
+    workspaceId,
+    file.id,
+    file.type,
+    normalizeBaseline,
+    discard,
+    acceptReload,
+  ])
+
+  const downloadDraft = useCallback(() => {
+    const url = URL.createObjectURL(
+      new Blob([contentRef.current], { type: 'text/plain;charset=utf-8' })
+    )
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `${file.name}.local-draft.txt`
+    anchor.click()
+    setTimeout(() => URL.revokeObjectURL(url), 0)
+  }, [file.name])
 
   // When the client can't autosave it isn't the durability owner: the collaborative editor holds
   // `canAutosave` permanently false because the relay persists the doc server-side (debounced + on
@@ -279,9 +431,9 @@ export function useEditableFileContent({
   useEffect(() => {
     onSaveStatusChangeRef.current?.(
       saveStatus,
-      saveStatus === 'error' ? saveImmediately : undefined
+      saveStatus === 'error' && !hasConflict ? saveImmediately : undefined
     )
-  }, [saveStatus, saveImmediately])
+  }, [saveStatus, saveImmediately, hasConflict])
 
   useEffect(() => {
     if (!saveRef) return
@@ -323,5 +475,10 @@ export function useEditableFileContent({
     saveStatus,
     saveImmediately,
     isDirty: isDirtyForCaller,
+    hasConflict,
+    isReloading: reloadContent.isPending,
+    reloadLatestContent,
+    downloadDraft,
+    acceptedBaselineContent,
   }
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/use-editable-file-content.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react'
 import { toast } from '@sim/emcn'
 import { isApiClientError } from '@/lib/api/client/errors'
+import { saveBlob } from '@/lib/uploads/client/download'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import { GENERATED_DOCUMENT_SOURCE_TYPES } from '@/lib/uploads/utils/file-utils'
 import {
@@ -407,14 +408,10 @@ export function useEditableFileContent({
   ])
 
   const downloadDraft = useCallback(() => {
-    const url = URL.createObjectURL(
-      new Blob([contentRef.current], { type: 'text/plain;charset=utf-8' })
+    saveBlob(
+      new Blob([contentRef.current], { type: 'text/plain;charset=utf-8' }),
+      `${file.name}.local-draft.txt`
     )
-    const anchor = document.createElement('a')
-    anchor.href = url
-    anchor.download = `${file.name}.local-draft.txt`
-    anchor.click()
-    setTimeout(() => URL.revokeObjectURL(url), 0)
   }, [file.name])
 
   // When the client can't autosave it isn't the durability owner: the collaborative editor holds

--- a/apps/sim/hooks/queries/workspace-files.test.tsx
+++ b/apps/sim/hooks/queries/workspace-files.test.tsx
@@ -12,9 +12,16 @@ import { sleep } from '@sim/utils/helpers'
 import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createWorkspaceFileContract } from '@/lib/api/contracts/workspace-files'
+import {
+  createWorkspaceFileContract,
+  listWorkspaceFilesContract,
+  updateWorkspaceFileContentContract,
+} from '@/lib/api/contracts/workspace-files'
+import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import {
   useCreateWorkspaceFile,
+  useReloadWorkspaceFileContent,
+  useUpdateWorkspaceFileContent,
   useWorkspaceFileContent,
   useWorkspaceFiles,
   type WorkspaceFileContentResult,
@@ -151,6 +158,246 @@ describe('useWorkspaceFileContent refetchInterval passthrough', () => {
     expect(fetchCount).toBe(settled)
     unmount()
   })
+})
+
+describe('useUpdateWorkspaceFileContent version precondition', () => {
+  it('forwards the original version without deriving it from a newer query cache', async () => {
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: 3 } } })
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    let mutation: ReturnType<typeof useUpdateWorkspaceFileContent> | undefined
+    function Probe() {
+      mutation = useUpdateWorkspaceFileContent()
+      return null
+    }
+    await act(async () =>
+      root.render(
+        <QueryClientProvider client={client}>
+          <Probe />
+        </QueryClientProvider>
+      )
+    )
+    const expectedUpdatedAt = '2026-09-03T20:00:00.000Z'
+    mockRequestJson.mockRejectedValueOnce(new Error('conflict'))
+    await act(async () => {
+      await expect(
+        mutation?.mutateAsync({
+          workspaceId: 'ws-1',
+          fileId: 'file-1',
+          content: 'draft',
+          expectedUpdatedAt,
+        })
+      ).rejects.toThrow('conflict')
+    })
+    expect(mockRequestJson).toHaveBeenCalledExactlyOnceWith(updateWorkspaceFileContentContract, {
+      params: { id: 'ws-1', fileId: 'file-1' },
+      body: { content: 'draft', expectedUpdatedAt },
+    })
+    act(() => root.unmount())
+    client.clear()
+  })
+})
+
+describe('useReloadWorkspaceFileContent', () => {
+  const file: WorkspaceFileRecord = {
+    id: 'file-1',
+    workspaceId: 'ws-1',
+    name: 'notes.md',
+    key: 'workspace/ws-1/immutable-new-notes.md',
+    path: '/notes.md',
+    size: 12,
+    type: 'text/markdown',
+    uploadedBy: 'user-1',
+    uploadedAt: new Date('2026-09-03T20:00:00.000Z'),
+    updatedAt: new Date('2026-09-03T20:00:01.000Z'),
+    contentUpdatedAt: new Date('2026-09-03T20:00:01.000Z'),
+  }
+  let client: QueryClient
+  let root: Root
+  let mutation: ReturnType<typeof useReloadWorkspaceFileContent>
+
+  beforeEach(() => {
+    client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+        mutations: { retry: 3 },
+      },
+    })
+    root = createRoot(document.createElement('div'))
+    mockRequestJson.mockResolvedValue({ success: true, files: [file] })
+    function Probe() {
+      mutation = useReloadWorkspaceFileContent()
+      return null
+    }
+    act(() => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <Probe />
+        </QueryClientProvider>
+      )
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    client.clear()
+  })
+
+  it.each([false, true])('forces matching fresh metadata and bytes for raw=%s', async (raw) => {
+    const oldFile = {
+      ...file,
+      key: 'workspace/ws-1/immutable-old-notes.md',
+      contentUpdatedAt: file.uploadedAt,
+    }
+    const contentKey = workspaceFilesKeys.content('ws-1', file.id, raw ? 'raw' : 'text', file.key)
+    client.setQueryData(workspaceFilesKeys.list('ws-1'), [oldFile])
+    client.setQueryData(contentKey, 'previously cached bytes')
+    const fetchMock = vi.fn(async () => new Response('fresh bytes', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await act(async () => {
+      await expect(
+        mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw })
+      ).resolves.toEqual({
+        file,
+        content: 'fresh bytes',
+      })
+    })
+
+    expect(mockRequestJson).toHaveBeenCalledExactlyOnceWith(listWorkspaceFilesContract, {
+      params: { id: 'ws-1' },
+      query: { scope: 'active' },
+      signal: expect.any(AbortSignal),
+    })
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(expect.any(String), {
+      signal: expect.any(AbortSignal),
+      cache: 'no-store',
+    })
+    const url = new URL(vi.mocked(fetch).mock.calls[0]?.[0] as string, 'http://localhost')
+    expect(url.pathname).toBe(`/api/files/serve/${encodeURIComponent(file.key)}`)
+    expect(url.searchParams.get('context')).toBe('workspace')
+    expect(url.searchParams.has('t')).toBe(true)
+    expect(url.searchParams.get('raw')).toBe(raw ? '1' : null)
+    expect(client.getQueryData(contentKey)).toBe('fresh bytes')
+    expect(client.getQueryData(workspaceFilesKeys.list('ws-1'))).toEqual([file])
+  })
+
+  it('cancels a pending metadata read before resolving the latest version', async () => {
+    const pending = Promise.withResolvers<{ success: boolean; files: WorkspaceFileRecord[] }>()
+    let oldSignal: AbortSignal | undefined
+    mockRequestJson.mockImplementationOnce(
+      (_contract: unknown, input: { signal?: AbortSignal }) => {
+        oldSignal = input.signal
+        return pending.promise
+      }
+    )
+    const previousRead = client
+      .fetchQuery({
+        queryKey: workspaceFilesKeys.list('ws-1'),
+        queryFn: ({ signal }) => mockRequestJson(listWorkspaceFilesContract, { signal }),
+      })
+      .then(
+        () => 'resolved',
+        () => 'cancelled'
+      )
+
+    await act(async () => {
+      await expect(
+        mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: false })
+      ).resolves.toEqual({
+        file,
+        content: '# content',
+      })
+    })
+
+    expect(oldSignal?.aborted).toBe(true)
+    expect(await previousRead).toBe('cancelled')
+    expect(mockRequestJson).toHaveBeenCalledTimes(2)
+    pending.resolve({ success: true, files: [] })
+    await pending.promise
+    expect(client.getQueryData(workspaceFilesKeys.list('ws-1'))).toEqual([file])
+  })
+
+  it('forwards cancellation to an in-flight byte read without accepting content', async () => {
+    const started = Promise.withResolvers<void>()
+    const pending = Promise.withResolvers<Response>()
+    let contentSignal: AbortSignal | null | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+        contentSignal = init?.signal
+        started.resolve()
+        return pending.promise
+      })
+    )
+    let outcome: Promise<string> | undefined
+    await act(async () => {
+      outcome = mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: true }).then(
+        () => 'resolved',
+        () => 'cancelled'
+      )
+      await started.promise
+      await client.cancelQueries({ queryKey: workspaceFilesKeys.contentFile('ws-1', file.id) })
+    })
+    expect(contentSignal?.aborted).toBe(true)
+    expect(await outcome).toBe('cancelled')
+    pending.resolve(new Response('late bytes', { status: 200 }))
+    await pending.promise
+    expect(
+      client.getQueryData(workspaceFilesKeys.content('ws-1', file.id, 'raw', file.key))
+    ).toBeUndefined()
+  })
+
+  it.each([
+    { files: [], error: 'File no longer exists' },
+    {
+      files: [{ ...file, contentUpdatedAt: null }],
+      error: 'The latest file version is unavailable',
+    },
+  ])('rejects unusable metadata: $error', async ({ files, error }) => {
+    mockRequestJson.mockResolvedValue({ success: true, files })
+    await act(async () => {
+      await expect(
+        mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: false })
+      ).rejects.toThrow(error)
+    })
+    expect(fetch).not.toHaveBeenCalled()
+    expect(mockRequestJson).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates metadata failure without reading bytes or retrying the operation', async () => {
+    mockRequestJson.mockRejectedValue(new Error('metadata offline'))
+    await act(async () => {
+      await expect(
+        mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: false })
+      ).rejects.toThrow('metadata offline')
+    })
+    expect(fetch).not.toHaveBeenCalled()
+    expect(mockRequestJson).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([404, 500])(
+    'propagates a %s byte failure without replacing cached bytes',
+    async (status) => {
+      const contentKey = workspaceFilesKeys.content('ws-1', file.id, 'text', file.key)
+      client.setQueryData(contentKey, 'cached bytes')
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response('unavailable', { status }))
+      )
+      await act(async () => {
+        await expect(
+          mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: false })
+        ).rejects.toThrow(
+          status === 404
+            ? 'File content is no longer at the requested storage key'
+            : 'Failed to fetch file content'
+        )
+      })
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(client.getQueryData(contentKey)).toBe('cached bytes')
+    }
+  )
 })
 
 /**

--- a/apps/sim/hooks/queries/workspace-files.test.tsx
+++ b/apps/sim/hooks/queries/workspace-files.test.tsx
@@ -161,7 +161,7 @@ describe('useWorkspaceFileContent refetchInterval passthrough', () => {
 })
 
 describe('useUpdateWorkspaceFileContent version precondition', () => {
-  it('forwards the original version without deriving it from a newer query cache', async () => {
+  it('forwards the supplied content version and disables mutation retries', async () => {
     const client = new QueryClient({ defaultOptions: { mutations: { retry: 3 } } })
     const container = document.createElement('div')
     const root = createRoot(container)
@@ -220,7 +220,7 @@ describe('useReloadWorkspaceFileContent', () => {
     client = new QueryClient({
       defaultOptions: {
         queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
-        mutations: { retry: 3 },
+        mutations: { retry: 3, retryDelay: 0 },
       },
     })
     root = createRoot(document.createElement('div'))
@@ -282,6 +282,80 @@ describe('useReloadWorkspaceFileContent', () => {
     expect(client.getQueryData(workspaceFilesKeys.list('ws-1'))).toEqual([file])
   })
 
+  it.each([false, true])(
+    'recovers matching bytes and version after key rotation (raw=%s)',
+    async (raw) => {
+      const nextFile = {
+        ...file,
+        key: 'workspace/ws-1/replacement.md',
+        contentUpdatedAt: new Date('2026-09-03T20:00:02.000Z'),
+      }
+      client.setDefaultOptions({
+        queries: { retry: 2, retryDelay: 0 },
+        mutations: { retryDelay: 0 },
+      })
+      mockRequestJson
+        .mockResolvedValueOnce({ success: true, files: [file] })
+        .mockResolvedValueOnce({ success: true, files: [nextFile] })
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response('gone', { status: 404 }))
+        .mockResolvedValueOnce(new Response('replacement bytes'))
+      vi.stubGlobal('fetch', fetchMock)
+      await act(async () => {
+        await expect(
+          mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw })
+        ).resolves.toEqual({ file: nextFile, content: 'replacement bytes' })
+      })
+      expect(mockRequestJson).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(
+        fetchMock.mock.calls.map(([url]) => new URL(url, 'http://localhost').pathname)
+      ).toEqual(
+        [file.key, nextFile.key].map((key) => `/api/files/serve/${encodeURIComponent(key)}`)
+      )
+      expect(
+        client.getQueryData(
+          workspaceFilesKeys.content('ws-1', file.id, raw ? 'raw' : 'text', nextFile.key)
+        )
+      ).toBe('replacement bytes')
+    }
+  )
+
+  it.each([
+    { files: [], error: 'File no longer exists' },
+    {
+      files: [{ ...file, contentUpdatedAt: null }],
+      error: 'The latest file version is unavailable',
+    },
+  ])('stops key recovery when metadata becomes unusable: $error', async ({ files, error }) => {
+    mockRequestJson
+      .mockResolvedValueOnce({ success: true, files: [file] })
+      .mockResolvedValueOnce({ success: true, files })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('gone', { status: 404 }))
+    )
+    await act(async () => {
+      await expect(
+        mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: false })
+      ).rejects.toThrow(error)
+    })
+    expect(mockRequestJson).toHaveBeenCalledTimes(2)
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('does not retry a transport failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    await act(async () => {
+      await expect(
+        mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: false })
+      ).rejects.toThrow('offline')
+    })
+    expect(mockRequestJson).toHaveBeenCalledOnce()
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
   it('cancels a pending metadata read before resolving the latest version', async () => {
     const pending = Promise.withResolvers<{ success: boolean; files: WorkspaceFileRecord[] }>()
     let oldSignal: AbortSignal | undefined
@@ -318,35 +392,42 @@ describe('useReloadWorkspaceFileContent', () => {
     expect(client.getQueryData(workspaceFilesKeys.list('ws-1'))).toEqual([file])
   })
 
-  it('forwards cancellation to an in-flight byte read without accepting content', async () => {
-    const started = Promise.withResolvers<void>()
-    const pending = Promise.withResolvers<Response>()
-    let contentSignal: AbortSignal | null | undefined
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
-        contentSignal = init?.signal
-        started.resolve()
-        return pending.promise
-      })
-    )
-    let outcome: Promise<string> | undefined
-    await act(async () => {
-      outcome = mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: true }).then(
-        () => 'resolved',
-        () => 'cancelled'
+  it.each([false, true])(
+    'forwards cancellation without accepting content (retry=%s)',
+    async (retry) => {
+      const started = Promise.withResolvers<void>()
+      const pending = Promise.withResolvers<Response>()
+      let contentSignal: AbortSignal | null | undefined
+      let attempt = 0
+      vi.stubGlobal(
+        'fetch',
+        vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+          if (retry && attempt++ === 0)
+            return Promise.resolve(new Response('gone', { status: 404 }))
+          contentSignal = init?.signal
+          started.resolve()
+          return pending.promise
+        })
       )
-      await started.promise
-      await client.cancelQueries({ queryKey: workspaceFilesKeys.contentFile('ws-1', file.id) })
-    })
-    expect(contentSignal?.aborted).toBe(true)
-    expect(await outcome).toBe('cancelled')
-    pending.resolve(new Response('late bytes', { status: 200 }))
-    await pending.promise
-    expect(
-      client.getQueryData(workspaceFilesKeys.content('ws-1', file.id, 'raw', file.key))
-    ).toBeUndefined()
-  })
+      let outcome: Promise<string> | undefined
+      await act(async () => {
+        outcome = mutation.mutateAsync({ workspaceId: 'ws-1', fileId: file.id, raw: true }).then(
+          () => 'resolved',
+          () => 'cancelled'
+        )
+        await started.promise
+        await client.cancelQueries({ queryKey: workspaceFilesKeys.contentFile('ws-1', file.id) })
+      })
+      expect(contentSignal?.aborted).toBe(true)
+      expect(await outcome).toBe('cancelled')
+      expect(mockRequestJson).toHaveBeenCalledTimes(retry ? 2 : 1)
+      pending.resolve(new Response('late bytes', { status: 200 }))
+      await pending.promise
+      expect(
+        client.getQueryData(workspaceFilesKeys.content('ws-1', file.id, 'raw', file.key))
+      ).toBeUndefined()
+    }
+  )
 
   it.each([
     { files: [], error: 'File no longer exists' },
@@ -394,7 +475,8 @@ describe('useReloadWorkspaceFileContent', () => {
             : 'Failed to fetch file content'
         )
       })
-      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(fetch).toHaveBeenCalledTimes(status === 404 ? 2 : 1)
+      expect(mockRequestJson).toHaveBeenCalledTimes(status === 404 ? 2 : 1)
       expect(client.getQueryData(contentKey)).toBe('cached bytes')
     }
   )

--- a/apps/sim/hooks/queries/workspace-files.ts
+++ b/apps/sim/hooks/queries/workspace-files.ts
@@ -19,6 +19,7 @@ import {
   listWorkspaceFilesContract,
   renameWorkspaceFileContract,
   restoreWorkspaceFileContract,
+  type UpdateWorkspaceFileContentBody,
   updateWorkspaceFileContentContract,
   updateWorkspaceFileDimensionsContract,
 } from '@/lib/api/contracts/workspace-files'
@@ -584,23 +585,23 @@ export function useCreateWorkspaceFile() {
 /**
  * Update workspace file content mutation
  */
-interface UpdateFileContentParams {
+interface UpdateFileContentParams extends UpdateWorkspaceFileContentBody {
   workspaceId: string
   fileId: string
-  content: string
-  encoding?: 'base64' | 'utf-8'
 }
 
 export function useUpdateWorkspaceFileContent() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ workspaceId, fileId, content, encoding }: UpdateFileContentParams) => {
+    retry: false,
+    mutationFn: async ({ workspaceId, fileId, ...body }: UpdateFileContentParams) => {
       return requestJson(updateWorkspaceFileContentContract, {
         params: { id: workspaceId, fileId },
-        body: encoding ? { content, encoding } : { content },
+        body,
       })
     },
+    /** A lost response may follow a committed write; reconcile bytes and versions even after transport errors. */
     onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: workspaceFilesKeys.contentFile(variables.workspaceId, variables.fileId),
@@ -613,6 +614,40 @@ export function useUpdateWorkspaceFileContent() {
     onError: (error) => {
       logger.error('Failed to update file content:', error)
     },
+  })
+}
+
+/** Reloads matching immutable bytes and their version before a user discards a conflicting draft. */
+export function useReloadWorkspaceFileContent() {
+  const queryClient = useQueryClient()
+  const source = useFileContentSource()
+  return useMutation({
+    mutationFn: async ({
+      workspaceId,
+      fileId,
+      raw,
+    }: {
+      workspaceId: string
+      fileId: string
+      raw: boolean
+    }) => {
+      await queryClient.cancelQueries({ queryKey: workspaceFilesKeys.workspaceLists(workspaceId) })
+      const files = await queryClient.fetchQuery({
+        ...getWorkspaceFilesQueryOptions(workspaceId),
+        staleTime: 0,
+      })
+      const file = files.find((record) => record.id === fileId)
+      if (!file) throw new Error('File no longer exists')
+      if (!file.contentUpdatedAt) throw new Error('The latest file version is unavailable')
+      const content = await queryClient.fetchQuery({
+        queryKey: workspaceFilesKeys.content(workspaceId, fileId, raw ? 'raw' : 'text', file.key),
+        queryFn: ({ signal }) =>
+          fetchWorkspaceFileContent(source.buildUrl(file.key, { raw, bust: true }), signal),
+        staleTime: 0,
+      })
+      return { file, content }
+    },
+    retry: false,
   })
 }
 

--- a/apps/sim/hooks/queries/workspace-files.ts
+++ b/apps/sim/hooks/queries/workspace-files.ts
@@ -644,10 +644,11 @@ export function useReloadWorkspaceFileContent() {
         queryFn: ({ signal }) =>
           fetchWorkspaceFileContent(source.buildUrl(file.key, { raw, bust: true }), signal),
         staleTime: 0,
+        retry: false,
       })
       return { file, content }
     },
-    retry: false,
+    retry: (failureCount, error) => failureCount < 1 && error instanceof StaleStorageKeyError,
   })
 }
 

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -28,6 +28,7 @@ interface ProbeProps {
   onSave: (overrideContent?: string) => Promise<void>
   delay?: number
   enabled?: boolean
+  pauseSaving?: boolean
   draftKey?: string
   onRestoreDraft?: (content: string) => void
   onDiscardCorrectionFailed?: () => void
@@ -1144,6 +1145,45 @@ describe('useAutosave', () => {
       expect(onSave).toHaveBeenCalledTimes(3)
       expect(onSave).toHaveBeenLastCalledWith()
     })
+
+    it.each([false, true])(
+      'retains and reports a paused discard correction (unmounted=%s)',
+      async (unmounted) => {
+        const pending = Promise.withResolvers<void>()
+        const onSave = vi
+          .fn<(content?: string) => Promise<void>>()
+          .mockReturnValueOnce(pending.promise)
+          .mockResolvedValue(undefined)
+        const onDiscardCorrectionFailed = vi.fn()
+        const { handle } = renderAutosave({
+          content: 'baseline',
+          savedContent: 'baseline',
+          onSave,
+          draftKey: 'paused-correction',
+          onDiscardCorrectionFailed,
+        })
+        handle.rerender({ content: 'discarded draft' })
+        await act(async () => vi.advanceTimersByTime(1500))
+        expect(onSave).toHaveBeenCalledOnce()
+        act(() => handle.discard())
+        handle.rerender({ content: 'baseline', pauseSaving: true })
+        if (unmounted) handle.unmount()
+        await act(async () => pending.resolve())
+        await flush()
+        expect(onSave).toHaveBeenCalledOnce()
+        expect(onDiscardCorrectionFailed).toHaveBeenCalledOnce()
+        if (!unmounted) {
+          expect(handle.status()).toBe('error')
+          handle.rerender({ pauseSaving: false })
+          expect(onSave).toHaveBeenCalledOnce()
+          await act(async () => handle.saveImmediately())
+          expect(onSave).toHaveBeenLastCalledWith('baseline')
+          expect(onSave).toHaveBeenCalledTimes(2)
+          expect(handle.status()).toBe('idle')
+          handle.unmount()
+        }
+      }
+    )
 
     it('does not lift discard suppression when only `enabled` toggles for the same document', async () => {
       const resolvers: Array<() => void> = []

--- a/apps/sim/hooks/use-autosave.test.tsx
+++ b/apps/sim/hooks/use-autosave.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { act } from 'react'
+import { act, Suspense, startTransition } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -92,8 +92,47 @@ async function flush() {
   })
 }
 
+/** Holds the committed UI while a transition renders a suspended draft. */
+function renderSuspendingAutosave(initial: ProbeProps) {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const pending = new Promise<void>(() => {})
+  let latest: ReturnType<typeof useAutosave> | null = null
+
+  function Probe({ suspend, ...options }: ProbeProps & { suspend: boolean }) {
+    const autosave = useAutosave(options)
+    if (suspend) throw pending
+    latest = autosave
+    return <div>{options.content}</div>
+  }
+
+  const render = async (options: ProbeProps, suspend = false) => {
+    const view = (
+      <Suspense fallback={<div>Loading</div>}>
+        <Probe {...options} suspend={suspend} />
+      </Suspense>
+    )
+    await act(async () => {
+      if (suspend) startTransition(() => root.render(view))
+      else root.render(view)
+    })
+  }
+
+  return {
+    container,
+    render,
+    mount: () => render(initial),
+    current: () => {
+      if (!latest) throw new Error('Autosave probe has not committed')
+      return latest
+    },
+    unmount: () => act(async () => root.unmount()),
+  }
+}
+
 describe('useAutosave', () => {
   beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
     vi.useFakeTimers()
     fakeDraftStore.clear()
   })
@@ -101,6 +140,85 @@ describe('useAutosave', () => {
     vi.runOnlyPendingTimers()
     vi.useRealTimers()
     vi.restoreAllMocks()
+  })
+
+  it('keeps saving and local recovery tied to the committed draft after a suspended render', async () => {
+    const committedSave = vi.fn(async () => {})
+    const abandonedSave = vi.fn(async () => {})
+    const options: ProbeProps = {
+      content: 'committed draft',
+      savedContent: 'baseline',
+      onSave: committedSave,
+      delay: 60_000,
+      draftKey: 'committed-file',
+    }
+    const view = renderSuspendingAutosave(options)
+    try {
+      await view.mount()
+      const committed = view.current()
+      await view.render({ ...options, content: 'abandoned draft', onSave: abandonedSave }, true)
+      expect(view.container.textContent).toBe('committed draft')
+
+      await act(async () => vi.advanceTimersByTime(400))
+      expect(fakeDraftStore.get('autosave-draft:committed-file')).toEqual({
+        content: 'committed draft',
+        savedContent: 'baseline',
+      })
+
+      await act(async () => committed.saveImmediately())
+      expect(committedSave).toHaveBeenCalledOnce()
+      expect(abandonedSave).not.toHaveBeenCalled()
+    } finally {
+      await view.unmount()
+    }
+  })
+
+  it('retains a failed discard correction when an abandoned render changes draft and file identity', async () => {
+    let resolveSave: (() => void) | undefined
+    const onSave = vi
+      .fn<(overrideContent?: string) => Promise<void>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve
+          })
+      )
+      .mockRejectedValueOnce(new Error('correction failed'))
+      .mockResolvedValue(undefined)
+    const options: ProbeProps = {
+      content: 'baseline',
+      savedContent: 'baseline',
+      onSave,
+      delay: 60_000,
+      draftKey: 'committed-file',
+    }
+    const view = renderSuspendingAutosave(options)
+    try {
+      await view.mount()
+      await view.render({ ...options, content: 'local draft' })
+      let pendingSave: Promise<void> | undefined
+      await act(async () => {
+        pendingSave = view.current().saveImmediately()
+      })
+      act(() => view.current().discard())
+      await view.render(options)
+      await act(async () => {
+        resolveSave?.()
+        await pendingSave
+      })
+      await flush()
+      expect(onSave).toHaveBeenCalledTimes(2)
+      expect(view.current().saveStatus).toBe('error')
+
+      const committed = view.current()
+      await view.render({ ...options, content: 'abandoned edit', draftKey: 'abandoned-file' }, true)
+      expect(view.container.textContent).toBe('baseline')
+      await act(async () => committed.saveImmediately())
+      expect(onSave).toHaveBeenCalledTimes(3)
+      expect(onSave).toHaveBeenLastCalledWith('baseline')
+    } finally {
+      await view.unmount()
+    }
   })
 
   it('debounces edits into a single save after the delay', async () => {

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -318,10 +318,11 @@ export function useAutosave({
   /** Pushes `target` (the reverted baseline) to the server. Used both by `discard()`'s initial correction and by `saveImmediately`'s retry of a correction that previously failed — content already equals `target` in both cases, so this bypasses `save()`'s dirty-check entirely rather than special-casing it there. */
   const runCorrection = useCallback(
     (target: string) => {
-      if (pauseSavingRef.current) return Promise.resolve()
       savingRef.current = true
-      const correctionRun = onSaveRef
-        .current(target)
+      const correction = pauseSavingRef.current
+        ? Promise.reject(new Error('Saving is paused; the discarded edit could not be reverted'))
+        : onSaveRef.current(target)
+      const correctionRun = correction
         .then(
           () => {
             failedCorrectionTargetRef.current = null

--- a/apps/sim/hooks/use-autosave.ts
+++ b/apps/sim/hooks/use-autosave.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createLogger } from '@sim/logger'
 import { del, get, set } from 'idb-keyval'
 
@@ -41,6 +41,8 @@ interface UseAutosaveOptions {
   onSave: (overrideContent?: string) => Promise<void>
   delay?: number
   enabled?: boolean
+  /** Suspends network writes without disabling local draft persistence or recovery. */
+  pauseSaving?: boolean
   /**
    * Uniquely identifies the document being edited (e.g. a file id). When set, the draft is
    * mirrored into IndexedDB on a short debounce, independent of the network save, and recovered
@@ -48,6 +50,8 @@ interface UseAutosaveOptions {
    */
   draftKey?: string
   onRestoreDraft?: (content: string) => void
+  /** Retains a recovered draft when its original server baseline is no longer current. */
+  onRestoreConflictingDraft?: (content: string) => void
   /** Called if `discard()`'s corrective save fails — the only way that failure can surface, since it happens after the component may already have unmounted. */
   onDiscardCorrectionFailed?: () => void
 }
@@ -57,7 +61,7 @@ interface UseAutosaveReturn {
   saveImmediately: () => Promise<void>
   isDirty: boolean
   /** Abandons the current draft: blocks any save/local-draft write not yet started, clears the local draft immediately, and corrects the server if a save already in flight lands afterward. */
-  discard: () => void
+  discard: (options?: { correctInFlightSave?: boolean }) => void
 }
 
 /**
@@ -71,8 +75,10 @@ export function useAutosave({
   onSave,
   delay = 1500,
   enabled = true,
+  pauseSaving = false,
   draftKey,
   onRestoreDraft,
+  onRestoreConflictingDraft,
   onDiscardCorrectionFailed,
 }: UseAutosaveOptions): UseAutosaveReturn {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
@@ -82,25 +88,20 @@ export function useAutosave({
   const displayTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const savingRef = useRef(false)
   const savingStartRef = useRef(0)
+  const saveGenerationRef = useRef(0)
   const inFlightRef = useRef<Promise<void> | null>(null)
   const unmountedRef = useRef(false)
   const onSaveRef = useRef(onSave)
-  onSaveRef.current = onSave
   const enabledRef = useRef(enabled)
-  enabledRef.current = enabled
-
+  const pauseSavingRef = useRef(pauseSaving)
   const savedContentRef = useRef(savedContent)
-  savedContentRef.current = savedContent
   const contentRef = useRef(content)
-  contentRef.current = content
 
   const effectiveDraftKey = enabled ? draftKey : undefined
   const draftKeyRef = useRef(effectiveDraftKey)
-  draftKeyRef.current = effectiveDraftKey
   const onRestoreDraftRef = useRef(onRestoreDraft)
-  onRestoreDraftRef.current = onRestoreDraft
+  const onRestoreConflictingDraftRef = useRef(onRestoreConflictingDraft)
   const onDiscardCorrectionFailedRef = useRef(onDiscardCorrectionFailed)
-  onDiscardCorrectionFailedRef.current = onDiscardCorrectionFailed
 
   const localDraftTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const lastPersistedContentRef = useRef<string | null>(null)
@@ -108,22 +109,31 @@ export function useAutosave({
   const discardedRef = useRef(false)
   const discardTargetRef = useRef<string | null>(null)
   const failedCorrectionTargetRef = useRef<string | null>(null)
-  // Keyed off the raw `draftKey`, not `effectiveDraftKey` — the latter also flips with `enabled`
-  // (e.g. a streaming lock toggling for the SAME document), which must not be mistaken for a
-  // hook instance being reused across documents (today's callers all remount per file instead).
+  /** Disabling autosave during a stream must not count as switching documents. */
   const documentKeyRef = useRef(draftKey)
-  const documentChanged = documentKeyRef.current !== draftKey
-  documentKeyRef.current = draftKey
-  if (documentChanged) {
-    discardedRef.current = false
-    failedCorrectionTargetRef.current = null
-  }
+
+  /** Timers, recovery, and explicit saves must never observe a suspended or abandoned render. */
+  useLayoutEffect(() => {
+    if (
+      documentKeyRef.current !== draftKey ||
+      (discardedRef.current && content !== discardTargetRef.current)
+    ) {
+      discardedRef.current = false
+      failedCorrectionTargetRef.current = null
+    }
+    documentKeyRef.current = draftKey
+    onSaveRef.current = onSave
+    enabledRef.current = enabled
+    pauseSavingRef.current = pauseSaving
+    savedContentRef.current = savedContent
+    contentRef.current = content
+    draftKeyRef.current = effectiveDraftKey
+    onRestoreDraftRef.current = onRestoreDraft
+    onRestoreConflictingDraftRef.current = onRestoreConflictingDraft
+    onDiscardCorrectionFailedRef.current = onDiscardCorrectionFailed
+  })
 
   const isDirty = content !== savedContent
-  if (discardedRef.current && content !== discardTargetRef.current) {
-    discardedRef.current = false
-    failedCorrectionTargetRef.current = null
-  }
 
   const persistLocalDraft = useCallback(() => {
     const key = draftKeyRef.current
@@ -158,12 +168,14 @@ export function useAutosave({
     if (
       discardedRef.current ||
       !enabledRef.current ||
+      pauseSavingRef.current ||
       savingRef.current ||
       contentRef.current === savedContentRef.current
     ) {
       return
     }
     savingRef.current = true
+    const generation = saveGenerationRef.current
     savingStartRef.current = Date.now()
     if (!unmountedRef.current) setSaveStatus('saving')
     const run = (async () => {
@@ -174,7 +186,10 @@ export function useAutosave({
         nextStatus = 'error'
       } finally {
         inFlightRef.current = null
-        if (unmountedRef.current) {
+        if (generation !== saveGenerationRef.current) {
+          savingRef.current = false
+          if (!unmountedRef.current && contentRef.current !== savedContentRef.current) save()
+        } else if (unmountedRef.current) {
           savingRef.current = false
         } else {
           const elapsed = Date.now() - savingStartRef.current
@@ -202,11 +217,11 @@ export function useAutosave({
   }, [])
 
   useEffect(() => {
-    if (!enabled || !isDirty || savingRef.current) return
+    if (!enabled || pauseSaving || !isDirty || savingRef.current) return
     clearTimeout(timerRef.current)
     timerRef.current = setTimeout(save, delay)
     return () => clearTimeout(timerRef.current)
-  }, [content, enabled, isDirty, delay, save])
+  }, [content, enabled, pauseSaving, isDirty, delay, save])
 
   useEffect(() => {
     // Reset on every (re)mount, not only set on unmount: React strict mode runs effects
@@ -223,6 +238,7 @@ export function useAutosave({
       if (
         discardedRef.current ||
         !enabledRef.current ||
+        pauseSavingRef.current ||
         contentRef.current === savedContentRef.current
       ) {
         return
@@ -232,7 +248,7 @@ export function useAutosave({
       // latest sequentially (last) prevents an out-of-order completion from clobbering it.
       void (async () => {
         await inFlightRef.current
-        if (!discardedRef.current) {
+        if (!discardedRef.current && !pauseSavingRef.current) {
           await onSaveRef.current().then(clearLocalDraft, () => {})
         }
       })()
@@ -270,14 +286,20 @@ export function useAutosave({
 
   useEffect(() => {
     if (!effectiveDraftKey || recoveredForKeyRef.current === effectiveDraftKey) return
-    recoveredForKeyRef.current = effectiveDraftKey
     let cancelled = false
     void enqueueDraftOp(effectiveDraftKey, () =>
       get<LocalDraft>(localDraftDbKey(effectiveDraftKey))
     )
       .then((draft) => {
-        if (cancelled || !draft) return
+        if (cancelled) return
+        recoveredForKeyRef.current = effectiveDraftKey
+        if (!draft) return
         if (draft.savedContent !== savedContentRef.current) {
+          if (onRestoreConflictingDraftRef.current) {
+            if (contentRef.current === savedContentRef.current)
+              onRestoreConflictingDraftRef.current(draft.content)
+            return
+          }
           clearLocalDraft()
           return
         }
@@ -296,6 +318,7 @@ export function useAutosave({
   /** Pushes `target` (the reverted baseline) to the server. Used both by `discard()`'s initial correction and by `saveImmediately`'s retry of a correction that previously failed — content already equals `target` in both cases, so this bypasses `save()`'s dirty-check entirely rather than special-casing it there. */
   const runCorrection = useCallback(
     (target: string) => {
+      if (pauseSavingRef.current) return Promise.resolve()
       savingRef.current = true
       const correctionRun = onSaveRef
         .current(target)
@@ -340,23 +363,35 @@ export function useAutosave({
     await save()
   }, [save, runCorrection])
 
-  const discard = useCallback(() => {
-    discardedRef.current = true
-    discardTargetRef.current = savedContentRef.current
-    failedCorrectionTargetRef.current = null
-    clearTimeout(timerRef.current)
-    clearTimeout(localDraftTimerRef.current)
-    clearLocalDraft()
-    const pendingSave = inFlightRef.current
-    if (!pendingSave) return
-    const target = discardTargetRef.current
-    const contentAtDiscard = contentRef.current
-    void pendingSave.then(() => {
-      const current = contentRef.current
-      if (inFlightRef.current || (current !== target && current !== contentAtDiscard)) return
-      runCorrection(target)
-    })
-  }, [clearLocalDraft, runCorrection])
+  const discard = useCallback(
+    (options?: { correctInFlightSave?: boolean }) => {
+      discardedRef.current = true
+      discardTargetRef.current = savedContentRef.current
+      failedCorrectionTargetRef.current = null
+      clearTimeout(timerRef.current)
+      clearTimeout(localDraftTimerRef.current)
+      clearLocalDraft()
+      const pendingSave = inFlightRef.current
+      if (options?.correctInFlightSave === false) {
+        saveGenerationRef.current += 1
+        clearTimeout(displayTimerRef.current)
+        clearTimeout(idleTimerRef.current)
+        if (!pendingSave) savingRef.current = false
+      }
+      if (!pendingSave || options?.correctInFlightSave === false) {
+        if (!unmountedRef.current) setSaveStatus('idle')
+        return
+      }
+      const target = discardTargetRef.current
+      const contentAtDiscard = contentRef.current
+      void pendingSave.then(() => {
+        const current = contentRef.current
+        if (inFlightRef.current || (current !== target && current !== contentAtDiscard)) return
+        runCorrection(target)
+      })
+    },
+    [clearLocalDraft, runCorrection]
+  )
 
   return { saveStatus, saveImmediately, isDirty, discard }
 }

--- a/apps/sim/lib/api/contracts/workspace-files.ts
+++ b/apps/sim/lib/api/contracts/workspace-files.ts
@@ -58,6 +58,8 @@ export const updateWorkspaceFileContentBodySchema = z
   .object({
     content: z.string().max(70_000_000, 'Content is too large'),
     encoding: z.enum(['base64', 'utf-8']).optional(),
+    /** The content-version timestamp returned with the bytes this edit was based on. */
+    expectedUpdatedAt: z.iso.datetime().optional(),
   })
   .superRefine(({ content, encoding }, ctx) => {
     if (encoding === 'base64' && !isCanonicalBase64(content)) {
@@ -95,6 +97,8 @@ export const createWorkspaceFileBodySchema = z
 
 export type CreateWorkspaceFileBody = z.input<typeof createWorkspaceFileBodySchema>
 
+export type UpdateWorkspaceFileContentBody = z.input<typeof updateWorkspaceFileContentBodySchema>
+
 /** No real image approaches this; the bound rejects absurd or hostile values on the backfill path. */
 const IMAGE_DIMENSION_MAX = 100_000
 
@@ -131,6 +135,8 @@ export const workspaceFileRecordSchema = z.object({
   deletedAt: z.coerce.date().nullable().optional(),
   uploadedAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
+  /** Advances only when file bytes change; metadata edits do not invalidate text drafts. */
+  contentUpdatedAt: z.coerce.date().nullable().optional(),
   storageContext: z.enum(['workspace', 'mothership']).optional(),
   share: shareRecordSchema.nullable().optional(),
 })

--- a/apps/sim/lib/workspace-files/queries.test.ts
+++ b/apps/sim/lib/workspace-files/queries.test.ts
@@ -29,8 +29,8 @@ const STORED_FILE = {
   folderId: null,
   uploadedAt: new Date('2026-01-01T00:00:00.000Z'),
   updatedAt: new Date('2026-01-02T00:00:00.000Z'),
-  /** Stored, but absent from `workspaceFileRecordSchema`. */
   contentUpdatedAt: new Date('2026-01-03T00:00:00.000Z'),
+  serverOnlyField: 'not part of the public contract',
 }
 
 describe('listWorkspaceFilesWithShares', () => {
@@ -48,7 +48,8 @@ describe('listWorkspaceFilesWithShares', () => {
   it('strips fields the response contract does not declare', async () => {
     const [file] = await listWorkspaceFilesWithShares('ws-1', 'active')
 
-    expect(file).not.toHaveProperty('contentUpdatedAt')
+    expect(file).not.toHaveProperty('serverOnlyField')
+    expect(file.contentUpdatedAt).toEqual(STORED_FILE.contentUpdatedAt)
     expect(file.id).toBe('file-1')
     expect(file.uploadedAt).toEqual(new Date('2026-01-01T00:00:00.000Z'))
   })

--- a/apps/sim/lib/workspace-files/queries.ts
+++ b/apps/sim/lib/workspace-files/queries.ts
@@ -10,9 +10,8 @@ import {
  * `GET /api/workspaces/[id]/files` response contract so the workspace layout's server seed
  * caches exactly the shape that route returns.
  *
- * Parsing through the route contract's response schema strips the server-only fields
- * `requestJson` strips on the client (`contentUpdatedAt`), so a prefetched entry is identical
- * to a client fetch rather than carrying a field that vanishes on the next refetch.
+ * The shared response schema keeps server-prefetched and client-fetched entries identical,
+ * including the content version used for conditional saves.
  *
  * Callers authorize the viewer against `workspaceId` first.
  *

--- a/apps/sim/stores/file-viewer/store.test.ts
+++ b/apps/sim/stores/file-viewer/store.test.ts
@@ -1,0 +1,27 @@
+/** @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFileViewerStore } from '@/stores/file-viewer/store'
+
+describe('file viewer session state', () => {
+  beforeEach(() => useFileViewerStore.getState().reset())
+
+  it('notifies subscribers only for newly recognized pages', () => {
+    const listener = vi.fn()
+    const unsubscribe = useFileViewerStore.subscribe(listener)
+    const { rememberPage } = useFileViewerStore.getState()
+    const previous = useFileViewerStore.getState().pageFileIds
+    rememberPage('page-a')
+    rememberPage('page-a')
+    expect(listener).toHaveBeenCalledOnce()
+    expect(previous.size).toBe(0)
+    expect(useFileViewerStore.getState().pageFileIds.has('page-a')).toBe(true)
+    expect(useFileViewerStore.getState().pageFileIds.has('page-b')).toBe(false)
+    unsubscribe()
+  })
+
+  it('clears recognition when the session is reset', () => {
+    useFileViewerStore.getState().rememberPage('page-a')
+    useFileViewerStore.getState().reset()
+    expect(useFileViewerStore.getState().pageFileIds.size).toBe(0)
+  })
+})

--- a/apps/sim/stores/file-viewer/store.test.ts
+++ b/apps/sim/stores/file-viewer/store.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useFileViewerStore } from '@/stores/file-viewer/store'
+import { resetRegisteredUserData } from '@/stores/user-data-reset-registry'
 
 describe('file viewer session state', () => {
   beforeEach(() => useFileViewerStore.getState().reset())
@@ -21,7 +22,7 @@ describe('file viewer session state', () => {
 
   it('clears recognition when the session is reset', () => {
     useFileViewerStore.getState().rememberPage('page-a')
-    useFileViewerStore.getState().reset()
+    resetRegisteredUserData()
     expect(useFileViewerStore.getState().pageFileIds.size).toBe(0)
   })
 })

--- a/apps/sim/stores/file-viewer/store.ts
+++ b/apps/sim/stores/file-viewer/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
+import { registerUserDataReset } from '@/stores/user-data-reset-registry'
 
 interface FileViewerState {
   /** Session-only recognition survives partial page streams and viewer remounts. */
@@ -22,3 +23,5 @@ export const useFileViewerStore = create<FileViewerState>()(
     { name: 'file-viewer-store' }
   )
 )
+
+registerUserDataReset('file-viewer', () => useFileViewerStore.getState().reset())

--- a/apps/sim/stores/file-viewer/store.ts
+++ b/apps/sim/stores/file-viewer/store.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+interface FileViewerState {
+  /** Session-only recognition survives partial page streams and viewer remounts. */
+  pageFileIds: ReadonlySet<string>
+  rememberPage: (fileId: string) => void
+  reset: () => void
+}
+
+export const useFileViewerStore = create<FileViewerState>()(
+  devtools(
+    (set) => ({
+      pageFileIds: new Set<string>(),
+      rememberPage: (fileId) =>
+        set((state) => {
+          if (state.pageFileIds.has(fileId)) return state
+          return { pageFileIds: new Set([...state.pageFileIds, fileId]) }
+        }),
+      reset: () => set({ pageFileIds: new Set<string>() }),
+    }),
+    { name: 'file-viewer-store' }
+  )
+)


### PR DESCRIPTION
## Summary

- Join a newly typed list item with a compatible neighboring list, preserving autoformat undo without bridging two pre-existing collaborative lists.
- Improve Markdown fidelity, GFM-persistable table editing, toolbar keyboard handling, paste admission and asynchronous image insertion.
- Preserve drafts across reload/streaming transitions; use version checks for stale saves and bounded recovery from rotated storage keys.
- Retain the existing empty-middle-list behavior. A collaborative list-exit redesign and dependency upgrades are intentionally excluded.

## Type of Change

- [x] Bug fix

## Testing

- 1,727 tests passed across 125 editor, collaboration, persistence and query suites.
- All workspace type checks, lint, 45 repository audits including strict API validation, and docs-manifest validation passed.
- Added 24 delayed-peer list cases across bullet, ordered and task lists, nested variants and both update orders; assert preserved content as well as convergence.
- Added regression coverage for paused discard corrections, conflict-version ordering, storage-key recovery, session reset, frontmatter-aware paste and invalidated image-picker feedback.
- Real two-peer image tests verify conservative anchor cancellation preserves intervening edits.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced in required checks
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
