### PR TITLE
fix(mcp): coordinate OAuth refresh without blocking tools

### DIFF
--- a/apps/sim/lib/credentials/application/discover-managed-mcp-tools.test.ts
+++ b/apps/sim/lib/credentials/application/discover-managed-mcp-tools.test.ts
@@ -121,7 +121,7 @@ describe('discoverManagedMcpToolsUseCase', () => {
     expect(mocks.discoverTools).toHaveBeenCalledWith(
       context.mcpServerId,
       context.workspaceId,
-      {},
+      { credentialId: context.credentialId, loadProvider: expect.any(Function) },
       signal,
       { requireComplete: true }
     )

--- a/apps/sim/lib/credentials/application/discover-managed-mcp-tools.ts
+++ b/apps/sim/lib/credentials/application/discover-managed-mcp-tools.ts
@@ -10,7 +10,6 @@ import {
   saveManagedMcpToolSnapshot,
 } from '@/lib/credentials/managed-mcp'
 import { loadManagedMcpAuthProvider } from '@/lib/mcp/application/managed-auth-provider'
-import { withMcpOauthRefreshLock } from '@/lib/mcp/oauth'
 import { mcpService } from '@/lib/mcp/service'
 
 export interface DiscoverManagedMcpToolsInput {
@@ -35,14 +34,15 @@ export const discoverManagedMcpToolsUseCase = defineAuthorizedWorkspaceUseCase({
   async execute({ input, context }) {
     input.signal?.throwIfAborted()
     const runtime = await loadManagedMcpRuntimeCredential(context.credentialId, context.workspaceId)
-    const tools = await withMcpOauthRefreshLock(runtime.credentialId, async () =>
-      mcpService.discoverManagedMcpTools(
-        runtime.mcpServerId,
-        runtime.workspaceId,
-        await loadManagedMcpAuthProvider(runtime.credentialId, runtime.workspaceId),
-        input.signal,
-        { requireComplete: true }
-      )
+    const tools = await mcpService.discoverManagedMcpTools(
+      runtime.mcpServerId,
+      runtime.workspaceId,
+      {
+        credentialId: runtime.credentialId,
+        loadProvider: () => loadManagedMcpAuthProvider(runtime.credentialId, runtime.workspaceId),
+      },
+      input.signal,
+      { requireComplete: true }
     )
     await saveManagedMcpToolSnapshot(
       runtime.credentialId,

--- a/apps/sim/lib/mcp/application/execute-managed-tool.test.ts
+++ b/apps/sim/lib/mcp/application/execute-managed-tool.test.ts
@@ -186,7 +186,7 @@ describe('executeManagedMcpToolUseCase', () => {
     expect(mocks.discoverTools).toHaveBeenCalledWith(
       context.mcpServerId,
       context.workspaceId,
-      {},
+      { credentialId: context.credentialId, loadProvider: expect.any(Function) },
       signal,
       { requireComplete: true }
     )

--- a/apps/sim/lib/mcp/application/execute-managed-tool.ts
+++ b/apps/sim/lib/mcp/application/execute-managed-tool.ts
@@ -17,7 +17,6 @@ import {
   validateToolArguments,
 } from '@/lib/mcp/application/execute-tool'
 import { loadManagedMcpAuthProvider } from '@/lib/mcp/application/managed-auth-provider'
-import { withMcpOauthRefreshLock } from '@/lib/mcp/oauth'
 import { mcpService } from '@/lib/mcp/service'
 import type { McpTool, McpToolCall, McpToolSchema } from '@/lib/mcp/types'
 
@@ -55,14 +54,15 @@ export const executeManagedMcpToolUseCase = defineAuthorizedWorkspaceUseCase({
   async execute({ input, context }): Promise<ExecuteMcpToolResult> {
     input.signal?.throwIfAborted()
     const runtime = await loadManagedMcpRuntimeCredential(context.credentialId, context.workspaceId)
-    const tools = await withMcpOauthRefreshLock(runtime.credentialId, async () =>
-      mcpService.discoverManagedMcpTools(
-        runtime.mcpServerId,
-        runtime.workspaceId,
-        await loadManagedMcpAuthProvider(runtime.credentialId, runtime.workspaceId),
-        input.signal,
-        { requireComplete: true }
-      )
+    const tools = await mcpService.discoverManagedMcpTools(
+      runtime.mcpServerId,
+      runtime.workspaceId,
+      {
+        credentialId: runtime.credentialId,
+        loadProvider: () => loadManagedMcpAuthProvider(runtime.credentialId, runtime.workspaceId),
+      },
+      input.signal,
+      { requireComplete: true }
     )
     await saveManagedMcpToolSnapshot(
       runtime.credentialId,

--- a/apps/sim/lib/mcp/client.test.ts
+++ b/apps/sim/lib/mcp/client.test.ts
@@ -71,8 +71,12 @@ vi.mock('@/lib/core/execution-limits', () => ({
 
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { getMaxExecutionTimeout } from '@/lib/core/execution-limits'
-import { McpClient } from './client'
-import type { McpClientOptions, McpServerConfig } from './types'
+import { McpClient } from '@/lib/mcp/client'
+import {
+  type McpClientOptions,
+  McpOauthAuthorizationRequiredError,
+  type McpServerConfig,
+} from '@/lib/mcp/types'
 
 function createConfig(): McpServerConfig {
   return {
@@ -92,6 +96,14 @@ describe('McpClient notification handler', () => {
     // clearAllMocks resets call history but not implementations; re-establish the
     // default so a per-test override can't bleed into later tests.
     vi.mocked(getMaxExecutionTimeout).mockReturnValue(30_000)
+  })
+
+  it('preserves authorization-required errors raised by a locked credential reload', async () => {
+    const error = new McpOauthAuthorizationRequiredError('server-1', 'Test Server')
+    mockSdkConnect.mockRejectedValueOnce(error)
+    const client = new McpClient({ config: createConfig() })
+    await expect(client.connect()).rejects.toBe(error)
+    expect(client.getStatus().lastError).toBeUndefined()
   })
 
   it('fires onToolsChanged when a notification arrives while connected', async () => {

--- a/apps/sim/lib/mcp/client.ts
+++ b/apps/sim/lib/mcp/client.ts
@@ -13,6 +13,7 @@ import { getErrorMessage } from '@sim/utils/errors'
 import { getMaxExecutionTimeout } from '@/lib/core/execution-limits'
 import { getMcpSafeErrorDiagnostics } from '@/lib/mcp/error-diagnostics'
 import { McpOauthRedirectRequired } from '@/lib/mcp/oauth'
+import { createCoordinatedMcpOauthFetch } from '@/lib/mcp/oauth/coordinated-fetch'
 import { createGuardedMcpFetch, createPinnedPrivateMcpFetch } from '@/lib/mcp/pinned-fetch'
 import {
   type McpClientOptions,
@@ -21,6 +22,7 @@ import {
   type McpConsentRequest,
   type McpConsentResponse,
   McpError,
+  McpOauthAuthorizationRequiredError,
   type McpSecurityPolicy,
   type McpServerConfig,
   type McpTool,
@@ -47,7 +49,10 @@ function classifyConnectionOutcome(
   error: unknown,
   authType: McpServerConfig['authType']
 ): ConnectionOutcome {
-  if (error instanceof McpOauthRedirectRequired) {
+  if (
+    error instanceof McpOauthRedirectRequired ||
+    error instanceof McpOauthAuthorizationRequiredError
+  ) {
     return 'authorization_required'
   }
   if (error instanceof UnauthorizedError) {
@@ -100,8 +105,15 @@ export class McpClient {
       throw new McpError('URL required for Streamable HTTP transport')
     }
 
-    if (this.config.authType === 'oauth' && this.authProvider == null) {
-      throw new McpError('OAuth MCP server requires an authProvider')
+    if (
+      this.config.authType === 'oauth' &&
+      this.authProvider == null &&
+      !options.oauthCredentials
+    ) {
+      throw new McpError('OAuth MCP server requires OAuth credentials')
+    }
+    if (options.oauthCredentials && this.authProvider) {
+      throw new McpError('OAuth MCP server must use one authentication strategy')
     }
     const useOauth = this.config.authType === 'oauth'
     // `resolvedIP` is null only when the hostname still carries an unresolved env-var
@@ -115,10 +127,18 @@ export class McpClient {
         : createGuardedMcpFetch(this.config.url)
       : undefined
     this.closeGuardedTransport = guarded?.close
+    const transportFetch =
+      useOauth && options.oauthCredentials
+        ? createCoordinatedMcpOauthFetch(options.oauthCredentials, {
+            serverUrl: this.config.url,
+            fetch: guarded?.fetch ?? fetch,
+            requestInit: { headers: this.config.headers },
+          })
+        : guarded?.fetch
     this.transport = new StreamableHTTPClientTransport(new URL(this.config.url), {
       authProvider: useOauth ? this.authProvider : undefined,
       requestInit: { headers: this.config.headers },
-      ...(guarded ? { fetch: guarded.fetch } : {}),
+      ...(transportFetch ? { fetch: transportFetch } : {}),
     })
 
     this.client = new Client(

--- a/apps/sim/lib/mcp/connection-manager.test.ts
+++ b/apps/sim/lib/mcp/connection-manager.test.ts
@@ -63,6 +63,7 @@ vi.mock('@/lib/mcp/oauth', () => ({
 }))
 
 import { McpConnectionManager } from '@/lib/mcp/connection-manager'
+import type { McpClientOptions } from '@/lib/mcp/types'
 
 beforeAll(() => {
   setEnvFlags({ isTest: false })
@@ -168,6 +169,11 @@ describe('McpConnectionManager', () => {
         userId: 'user-1',
         workspaceId: 'ws-1',
       })
+      const options: McpClientOptions = MockMcpClientConstructor.mock.calls[0][0]
+      expect(options.authProvider).toBeUndefined()
+      expect(options.oauthCredentials?.credentialId).toBe('server-oauth')
+      await options.oauthCredentials?.loadProvider()
+      expect(mockGetOrCreateOauthRow).toHaveBeenCalledTimes(2)
     })
 
     it('allows a new connect() after a previous one completes', async () => {

--- a/apps/sim/lib/mcp/connection-manager.ts
+++ b/apps/sim/lib/mcp/connection-manager.ts
@@ -16,12 +16,13 @@ import { isTest } from '@/lib/core/config/env-flags'
 import { McpClient } from '@/lib/mcp/client'
 import { getOrCreateOauthRow, loadPreregisteredClient, SimMcpOauthProvider } from '@/lib/mcp/oauth'
 import { mcpPubSub } from '@/lib/mcp/pubsub'
-import type {
-  ManagedConnectionState,
-  McpClientOptions,
-  McpServerConfig,
-  McpToolsChangedCallback,
-  ToolsChangedEvent,
+import {
+  type ManagedConnectionState,
+  type McpClientOptions,
+  McpOauthAuthorizationRequiredError,
+  type McpServerConfig,
+  type McpToolsChangedCallback,
+  type ToolsChangedEvent,
 } from '@/lib/mcp/types'
 
 const logger = createLogger('McpConnectionManager')
@@ -137,7 +138,7 @@ export class McpConnectionManager {
         this.handleToolsChanged(key)
       }
 
-      let authProvider: McpClientOptions['authProvider']
+      let oauthCredentials: McpClientOptions['oauthCredentials']
       if (config.authType === 'oauth') {
         const row = await getOrCreateOauthRow({
           mcpServerId: config.id,
@@ -150,8 +151,25 @@ export class McpConnectionManager {
           )
           return { supportsListChanged: false }
         }
-        const preregistered = await loadPreregisteredClient(config.id)
-        authProvider = new SimMcpOauthProvider({ row, preregistered })
+        oauthCredentials = {
+          credentialId: config.id,
+          initialProvider: new SimMcpOauthProvider({
+            row,
+            preregistered: await loadPreregisteredClient(config.id),
+          }),
+          loadProvider: async () => {
+            const current = await getOrCreateOauthRow({
+              mcpServerId: config.id,
+              userId,
+              workspaceId,
+            })
+            if (!current.tokens) {
+              throw new McpOauthAuthorizationRequiredError(config.id, config.name)
+            }
+            const preregistered = await loadPreregisteredClient(config.id)
+            return new SimMcpOauthProvider({ row: current, preregistered })
+          },
+        }
       }
 
       const client = new McpClient({
@@ -163,7 +181,7 @@ export class McpConnectionManager {
         },
         onToolsChanged,
         resolvedIP: resolvedIP ?? undefined,
-        authProvider,
+        oauthCredentials,
       })
 
       try {

--- a/apps/sim/lib/mcp/oauth/coordinated-fetch.test.ts
+++ b/apps/sim/lib/mcp/oauth/coordinated-fetch.test.ts
@@ -1,0 +1,475 @@
+/**
+ * @vitest-environment node
+ */
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { encryptionMock, redisConfigMockFns, resetRedisConfigMock } from '@sim/testing'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createCoordinatedMcpOauthFetch } from '@/lib/mcp/oauth/coordinated-fetch'
+import { withMcpOauthRefreshLock } from '@/lib/mcp/oauth/storage'
+
+vi.mock('@/lib/core/security/encryption', () => encryptionMock)
+
+const SERVER = 'https://mcp.example.com/mcp'
+const TOKEN_URL = 'https://auth.example.com/token'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+function createGrant() {
+  let persisted: OAuthTokens | undefined = {
+    access_token: 'access-0',
+    refresh_token: 'refresh-0',
+    token_type: 'Bearer',
+    scope: 'read',
+  }
+  let generation = 0
+  const save = vi.fn(async (tokens: OAuthTokens | undefined) => {
+    persisted = tokens
+  })
+  const redirect = vi.fn(async (_url: URL) => {
+    throw new Error('Reauthorization required')
+  })
+  const createProvider = (): OAuthClientProvider => {
+    let snapshot = persisted && { ...persisted }
+    return {
+      redirectUrl: 'https://sim.example.com/callback',
+      clientMetadata: { redirect_uris: ['https://sim.example.com/callback'] },
+      clientInformation: () => ({ client_id: 'test-client' }),
+      tokens: () => snapshot,
+      saveTokens: async (tokens) => {
+        await save(tokens)
+        snapshot = tokens
+      },
+      invalidateCredentials: async (scope) => {
+        if (scope === 'all' || scope === 'tokens') {
+          await save(undefined)
+          snapshot = undefined
+        }
+      },
+      redirectToAuthorization: redirect,
+      saveCodeVerifier: async () => {},
+      codeVerifier: () => 'verifier',
+      discoveryState: () => ({
+        authorizationServerUrl: new URL('https://auth.example.com'),
+        resourceMetadata: { resource: SERVER, authorization_servers: ['https://auth.example.com'] },
+        authorizationServerMetadata: {
+          issuer: 'https://auth.example.com',
+          authorization_endpoint: 'https://auth.example.com/authorize',
+          token_endpoint: TOKEN_URL,
+          response_types_supported: ['code'],
+          token_endpoint_auth_methods_supported: ['none'],
+          code_challenge_methods_supported: ['S256'],
+        },
+      }),
+    }
+  }
+  const loadProvider = vi.fn(async () => createProvider())
+  const tokenRequest = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+    const form = new URLSearchParams(String(init?.body))
+    if (form.get('refresh_token') !== `refresh-${generation}`) {
+      return Response.json({ error: 'invalid_grant' }, { status: 400 })
+    }
+    generation++
+    return Response.json({
+      access_token: `access-${generation}`,
+      refresh_token: `refresh-${generation}`,
+      token_type: 'Bearer',
+      scope: form.get('scope') ?? 'read',
+    })
+  })
+  return { loadProvider, tokenRequest, save, redirect, createProvider }
+}
+
+function rejection(status = 401, challenge = 'Bearer error="invalid_token"') {
+  return new Response(null, { status, headers: { 'www-authenticate': challenge } })
+}
+
+describe('coordinated MCP OAuth with the real SDK and refresh mutex', () => {
+  const clients: Client[] = []
+
+  beforeEach(() => {
+    resetRedisConfigMock()
+    vi.clearAllMocks()
+    redisConfigMockFns.mockAcquireLock.mockResolvedValue(true)
+    redisConfigMockFns.mockReleaseLock.mockResolvedValue(true)
+    redisConfigMockFns.mockExtendLock.mockResolvedValue(true)
+  })
+
+  afterEach(async () => {
+    await Promise.all(clients.splice(0).map((client) => client.close()))
+    resetRedisConfigMock()
+  })
+
+  async function connect(grant: ReturnType<typeof createGrant>, request: FetchLike) {
+    const client = new Client({ name: 'test', version: '1' }, { capabilities: {} })
+    clients.push(client)
+    const transport = new StreamableHTTPClientTransport(new URL(SERVER), {
+      fetch: createCoordinatedMcpOauthFetch(
+        {
+          credentialId: 'shared-grant',
+          loadProvider: grant.loadProvider,
+          initialProvider: grant.createProvider(),
+        },
+        {
+          serverUrl: SERVER,
+          fetch: async (url, init) => {
+            if (String(url) === TOKEN_URL) return grant.tokenRequest(url, init)
+            if (init?.method === 'GET') return new Response(null, { status: 405 })
+            const rpc = JSON.parse(String(init?.body))
+            if (rpc.method === 'initialize') {
+              return Response.json({
+                jsonrpc: '2.0',
+                id: rpc.id,
+                result: {
+                  protocolVersion: '2025-11-25',
+                  capabilities: { tools: {} },
+                  serverInfo: { name: 'fixture', version: '1' },
+                },
+              })
+            }
+            if (!('id' in rpc)) return new Response(null, { status: 202 })
+            return request(url, init)
+          },
+        }
+      ),
+    })
+    await client.connect(transport)
+    return client
+  }
+
+  it('allows two tool calls to run concurrently without acquiring the OAuth mutex', async () => {
+    const grant = createGrant()
+    const bothStarted = deferred()
+    const finish = deferred()
+    let started = 0
+    const request: FetchLike = async (_url, init) => {
+      if (++started === 2) bothStarted.resolve()
+      await finish.promise
+      const rpc = JSON.parse(String(init?.body))
+      return Response.json({ jsonrpc: '2.0', id: rpc.id, result: { content: [] } })
+    }
+    const first = await connect(grant, request)
+    const second = await connect(grant, request)
+    const calls = Promise.all([first.callTool({ name: 'slow' }), second.callTool({ name: 'slow' })])
+    try {
+      await bothStarted.promise
+      expect(redisConfigMockFns.mockAcquireLock).not.toHaveBeenCalled()
+      expect(grant.tokenRequest).not.toHaveBeenCalled()
+    } finally {
+      finish.resolve()
+      await calls
+    }
+  })
+
+  it.each([false, true])(
+    'refreshes once for concurrent 401s (shared client: %s)',
+    async (shared) => {
+      const grant = createGrant()
+      const request: FetchLike = async (_url, init) => {
+        if (new Headers(init?.headers).get('authorization') !== 'Bearer access-1')
+          return rejection()
+        const rpc = JSON.parse(String(init?.body))
+        return Response.json({ jsonrpc: '2.0', id: rpc.id, result: { content: [] } })
+      }
+      const first = await connect(grant, request)
+      const second = shared ? first : await connect(grant, request)
+      const results = await Promise.all([
+        first.callTool({ name: 'read' }),
+        second.callTool({ name: 'read' }),
+      ])
+      expect(results).toHaveLength(2)
+      expect(grant.tokenRequest).toHaveBeenCalledTimes(1)
+      expect(grant.save).toHaveBeenCalledTimes(1)
+      expect(redisConfigMockFns.mockReleaseLock).toHaveBeenCalledTimes(2)
+    }
+  )
+
+  it('reuses a concurrently refreshed token when the OAuth response omits optional scope', async () => {
+    const grant = createGrant()
+    grant.tokenRequest.mockResolvedValueOnce(
+      Response.json({
+        access_token: 'access-1',
+        refresh_token: 'refresh-1',
+        token_type: 'Bearer',
+      })
+    )
+    const request: FetchLike = async (_url, init) => {
+      if (new Headers(init?.headers).get('authorization') !== 'Bearer access-1') {
+        return rejection(401, 'Bearer error="invalid_token", scope="read"')
+      }
+      const rpc = JSON.parse(String(init?.body))
+      return Response.json({ jsonrpc: '2.0', id: rpc.id, result: { content: [] } })
+    }
+    const first = await connect(grant, request)
+    const second = await connect(grant, request)
+    await Promise.all([first.callTool({ name: 'read' }), second.callTool({ name: 'read' })])
+    expect(grant.tokenRequest).toHaveBeenCalledTimes(1)
+  })
+
+  function fetchFor(grant: ReturnType<typeof createGrant>, request: FetchLike) {
+    return createCoordinatedMcpOauthFetch(
+      {
+        credentialId: 'shared-grant',
+        loadProvider: grant.loadProvider,
+        initialProvider: grant.createProvider(),
+      },
+      {
+        serverUrl: SERVER,
+        fetch: (url, init) =>
+          String(url) === TOKEN_URL ? grant.tokenRequest(url, init) : request(url, init),
+      }
+    )
+  }
+
+  it('holds the mutex through token persistence and reuses the committed token', async () => {
+    const grant = createGrant()
+    const saving = deferred()
+    const finishSave = deferred()
+    const persist = grant.save.getMockImplementation()!
+    grant.save.mockImplementationOnce(async (tokens) => {
+      saving.resolve()
+      await finishSave.promise
+      await persist(tokens)
+    })
+    const rejected = deferred()
+    let requests = 0
+    const request: FetchLike = async (_url, init) => {
+      if (new Headers(init?.headers).get('authorization') === 'Bearer access-1') {
+        return new Response(null, { status: 202 })
+      }
+      if (++requests === 2) rejected.resolve()
+      return rejection()
+    }
+    const first = fetchFor(grant, request)
+    const second = fetchFor(grant, request)
+    const calls = Promise.all([first(SERVER), second(SERVER)])
+    try {
+      await Promise.all([saving.promise, rejected.promise])
+      expect(redisConfigMockFns.mockReleaseLock).not.toHaveBeenCalled()
+      expect(grant.loadProvider).toHaveBeenCalledTimes(1)
+    } finally {
+      finishSave.resolve()
+    }
+    expect((await calls).map((r) => r.status)).toEqual([202, 202])
+    expect(grant.tokenRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not block another credential while one credential refreshes', async () => {
+    const slowGrant = createGrant()
+    const otherGrant = createGrant()
+    const refreshing = deferred()
+    const finish = deferred()
+    const exchange = slowGrant.tokenRequest.getMockImplementation()!
+    slowGrant.tokenRequest.mockImplementationOnce(async (url, init) => {
+      refreshing.resolve()
+      await finish.promise
+      return exchange(url, init)
+    })
+    const request: FetchLike = async (_url, init) =>
+      new Headers(init?.headers).get('authorization') === 'Bearer access-1'
+        ? new Response(null, { status: 202 })
+        : rejection()
+    const slow = fetchFor(slowGrant, request)(SERVER)
+    try {
+      await refreshing.promise
+      const other = createCoordinatedMcpOauthFetch(
+        {
+          credentialId: 'other-grant',
+          loadProvider: otherGrant.loadProvider,
+          initialProvider: otherGrant.createProvider(),
+        },
+        {
+          serverUrl: SERVER,
+          fetch: (url, init) =>
+            String(url) === TOKEN_URL ? otherGrant.tokenRequest(url, init) : request(url, init),
+        }
+      )
+      expect((await other(SERVER)).status).toBe(202)
+      expect(slowGrant.save).not.toHaveBeenCalled()
+    } finally {
+      finish.resolve()
+      await slow
+    }
+  })
+
+  it('returns streaming responses without buffering or replaying their bodies', async () => {
+    const grant = createGrant()
+    const response = new Response(new ReadableStream(), {
+      headers: { 'content-type': 'text/event-stream' },
+    })
+    const request = vi.fn<FetchLike>().mockResolvedValue(response)
+    const received = await fetchFor(grant, request)(SERVER)
+    expect(received).toBe(response)
+    expect(received.bodyUsed).toBe(false)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(redisConfigMockFns.mockAcquireLock).not.toHaveBeenCalled()
+    await received.body?.cancel()
+  })
+
+  it('bounds retries even if the server keeps changing its scope challenge', async () => {
+    const grant = createGrant()
+    let scopes = 0
+    const request = vi.fn<FetchLike>(async () =>
+      rejection(403, `Bearer error="insufficient_scope", scope="scope-${++scopes}"`)
+    )
+    expect((await fetchFor(grant, request)(SERVER)).status).toBe(403)
+    expect(request).toHaveBeenCalledTimes(4)
+    expect(grant.tokenRequest).toHaveBeenCalledTimes(3)
+  })
+
+  it('coordinates authentication during initialization and GET stream reconnection too', async () => {
+    const grant = createGrant()
+    const request = vi.fn<FetchLike>(async (_url, init) =>
+      new Headers(init?.headers).get('authorization') === 'Bearer access-1'
+        ? new Response(null, { status: 202 })
+        : rejection()
+    )
+    const first = fetchFor(grant, request)
+    const second = fetchFor(grant, request)
+    const responses = await Promise.all([
+      first(SERVER, { method: 'POST', body: '{"method":"initialize"}' }),
+      second(SERVER, { method: 'GET', headers: { 'last-event-id': 'event-1' } }),
+    ])
+    expect(responses.map((r) => r.status)).toEqual([202, 202])
+    expect(grant.tokenRequest).toHaveBeenCalledTimes(1)
+    const retry = request.mock.calls.find(
+      ([, init]) =>
+        init?.method === 'GET' &&
+        new Headers(init.headers).get('authorization') === 'Bearer access-1'
+    )
+    expect(new Headers(retry?.[1]?.headers).get('last-event-id')).toBe('event-1')
+  })
+
+  it('does not replay an ordinary forbidden response or an uncertain network failure', async () => {
+    const grant = createGrant()
+    const request = vi.fn<FetchLike>().mockResolvedValueOnce(new Response(null, { status: 403 }))
+    const guarded = fetchFor(grant, request)
+    expect((await guarded(SERVER)).status).toBe(403)
+    request.mockRejectedValueOnce(new Error('connection reset'))
+    await expect(guarded(SERVER)).rejects.toThrow('connection reset')
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(grant.tokenRequest).not.toHaveBeenCalled()
+    expect(redisConfigMockFns.mockAcquireLock).not.toHaveBeenCalled()
+  })
+
+  it('stops after one authentication attempt if the server keeps rejecting the token', async () => {
+    const grant = createGrant()
+    const request = vi.fn<FetchLike>(async () => rejection())
+    expect((await fetchFor(grant, request)(SERVER)).status).toBe(401)
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(grant.tokenRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a scope challenge after recovering from an expired token', async () => {
+    const grant = createGrant()
+    const request = vi
+      .fn<FetchLike>()
+      .mockResolvedValueOnce(rejection())
+      .mockResolvedValueOnce(
+        rejection(403, 'Bearer error="insufficient_scope", scope="read write"')
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+    expect((await fetchFor(grant, request)(SERVER)).status).toBe(202)
+    expect(request).toHaveBeenCalledTimes(3)
+    expect(grant.tokenRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it('retains request headers and body when recovering from an insufficient-scope challenge', async () => {
+    const grant = createGrant()
+    const request = vi
+      .fn<FetchLike>()
+      .mockResolvedValueOnce(
+        rejection(403, 'Bearer error="insufficient_scope", scope="read write"')
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+    const body = '{"method":"tools/call","params":{"name":"write"}}'
+    const response = await fetchFor(grant, request)(SERVER, {
+      method: 'POST',
+      body,
+      headers: { 'mcp-session-id': 'session-1', 'x-sim-via': 'workflow-1' },
+    })
+    expect(response.status).toBe(202)
+    expect(request.mock.calls[1][1]?.body).toBe(body)
+    const headers = new Headers(request.mock.calls[1][1]?.headers)
+    expect(headers.get('mcp-session-id')).toBe('session-1')
+    expect(headers.get('x-sim-via')).toBe('workflow-1')
+  })
+
+  it('releases the lock and does not retry the tool if the versioned token save rejects', async () => {
+    const grant = createGrant()
+    grant.save.mockRejectedValueOnce(new Error('Credential grant changed'))
+    const request = vi.fn<FetchLike>(async () => rejection())
+    await expect(fetchFor(grant, request)(SERVER)).rejects.toThrow('Reauthorization required')
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(redisConfigMockFns.mockReleaseLock).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards the challenged scope when the SDK requires reauthorization', async () => {
+    const grant = createGrant()
+    grant.tokenRequest.mockResolvedValueOnce(
+      Response.json({ error: 'invalid_grant' }, { status: 400 })
+    )
+    const request = vi.fn<FetchLike>(async () =>
+      rejection(403, 'Bearer error="insufficient_scope", scope="read write"')
+    )
+    await expect(fetchFor(grant, request)(SERVER)).rejects.toThrow('Reauthorization required')
+    expect(grant.redirect.mock.calls[0][0].searchParams.get('scope')).toBe('read write')
+    expect(grant.save).toHaveBeenCalledWith(undefined)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(redisConfigMockFns.mockReleaseLock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not authenticate or retry after a grant is disabled before the locked reload', async () => {
+    const grant = createGrant()
+    grant.loadProvider.mockRejectedValueOnce(new Error('Grant disabled'))
+    const request = vi.fn<FetchLike>(async () => rejection())
+    await expect(fetchFor(grant, request)(SERVER)).rejects.toThrow('Grant disabled')
+    expect(grant.tokenRequest).not.toHaveBeenCalled()
+    expect(grant.save).not.toHaveBeenCalled()
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(redisConfigMockFns.mockReleaseLock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not attach the MCP bearer token to a different URL', async () => {
+    const grant = createGrant()
+    const request = vi.fn<FetchLike>(async () => new Response(null, { status: 200 }))
+    await fetchFor(grant, request)('https://other.example.com/metadata')
+    expect(grant.loadProvider).not.toHaveBeenCalled()
+    expect(new Headers(request.mock.calls[0][1]?.headers).has('authorization')).toBe(false)
+  })
+
+  it('does not refresh or retry a request cancelled while waiting for the lock', async () => {
+    const entered = deferred()
+    const finish = deferred()
+    const holder = withMcpOauthRefreshLock('shared-grant', async () => {
+      entered.resolve()
+      await finish.promise
+    })
+    await entered.promise
+    const rejected = deferred()
+    const grant = createGrant()
+    const request = vi.fn<FetchLike>(async () => {
+      rejected.resolve()
+      return rejection()
+    })
+    const abort = new AbortController()
+    const call = fetchFor(grant, request)(SERVER, { signal: abort.signal })
+    const outcome = expect(call).rejects.toThrow('cancelled')
+    await rejected.promise
+    abort.abort(new Error('cancelled'))
+    finish.resolve()
+    await holder
+    await outcome
+    expect(grant.tokenRequest).not.toHaveBeenCalled()
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/sim/lib/mcp/oauth/coordinated-fetch.ts
+++ b/apps/sim/lib/mcp/oauth/coordinated-fetch.ts
@@ -1,0 +1,89 @@
+import {
+  extractWWWAuthenticateParams,
+  type OAuthClientProvider,
+  UnauthorizedError,
+} from '@modelcontextprotocol/sdk/client/auth.js'
+import { createFetchWithInit, type FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { mcpAuthGuarded } from '@/lib/mcp/oauth/auth'
+import { withMcpOauthRefreshLock } from '@/lib/mcp/oauth/storage'
+
+export interface McpOauthCredentials {
+  /** Shared server ID for workspace OAuth, personal credential ID for managed OAuth. */
+  credentialId: string
+  /** Reloads the persisted grant; called again under the refresh lock after a challenge. */
+  loadProvider: () => Promise<OAuthClientProvider>
+}
+
+export interface McpOauthSession extends McpOauthCredentials {
+  /** Loaded before connecting so credential errors retain their application-level meaning. */
+  initialProvider: OAuthClientProvider
+}
+
+/**
+ * Coordinates the SDK's public OAuth flow across clients without locking MCP requests.
+ * The transport must omit authProvider so it cannot refresh outside this boundary.
+ * Only explicit authentication rejections are replayed. Allow a concurrent token
+ * update, authentication, and a scope upgrade, with at most three replays total.
+ */
+export function createCoordinatedMcpOauthFetch(
+  { credentialId, loadProvider, initialProvider }: McpOauthSession,
+  options: { serverUrl: string; fetch: FetchLike; requestInit?: RequestInit }
+): FetchLike {
+  const serverUrl = new URL(options.serverUrl)
+  const authFetch = createFetchWithInit(options.fetch, options.requestInit)
+  let currentProvider = initialProvider
+
+  return async (input, init) => {
+    if (new URL(input).href !== serverUrl.href) {
+      return options.fetch(input, init)
+    }
+
+    init?.signal?.throwIfAborted()
+    let provider = currentProvider
+    const authenticatedChallenges = new Set<string>()
+
+    for (let attempt = 0; ; attempt++) {
+      init?.signal?.throwIfAborted()
+      const tokens = await provider.tokens()
+      const headers = new Headers(init?.headers)
+      if (tokens && !headers.has('authorization')) {
+        headers.set('authorization', `Bearer ${tokens.access_token}`)
+      }
+      const response = await options.fetch(input, { ...init, headers })
+      if ((response.status !== 401 && response.status !== 403) || attempt === 3) {
+        return response
+      }
+      const challenge = extractWWWAuthenticateParams(response)
+      const needsAuth =
+        response.status === 401 ||
+        (response.status === 403 && challenge.error === 'insufficient_scope')
+      if (!needsAuth) return response
+      const challengeKey =
+        response.status === 401 ? '401' : `403:${response.headers.get('www-authenticate')}`
+      if (authenticatedChallenges.has(challengeKey)) return response
+
+      await response.body?.cancel()
+      await withMcpOauthRefreshLock(credentialId, async () => {
+        init?.signal?.throwIfAborted()
+        const current = await loadProvider()
+        const latestTokens = await current.tokens()
+        const refreshedElsewhere =
+          latestTokens && latestTokens.access_token !== tokens?.access_token
+
+        init?.signal?.throwIfAborted()
+        if (!refreshedElsewhere) {
+          const result = await mcpAuthGuarded(current, {
+            serverUrl,
+            resourceMetadataUrl: challenge.resourceMetadataUrl,
+            scope: challenge.scope,
+            fetchFn: authFetch,
+          })
+          if (result !== 'AUTHORIZED') throw new UnauthorizedError()
+          authenticatedChallenges.add(challengeKey)
+        }
+        provider = current
+        currentProvider = current
+      })
+    }
+  }
+}

--- a/apps/sim/lib/mcp/service-pool.test.ts
+++ b/apps/sim/lib/mcp/service-pool.test.ts
@@ -122,6 +122,7 @@ vi.mock('@/lib/mcp/storage', () => ({
   getMcpCacheType: () => 'memory',
 }))
 
+import { withMcpOauthRefreshLock } from '@/lib/mcp/oauth'
 import { mcpService } from '@/lib/mcp/service'
 
 describe('McpService connection reuse wiring', () => {
@@ -139,6 +140,55 @@ describe('McpService connection reuse wiring', () => {
 
   afterAll(() => {
     resetDbChainMock()
+  })
+
+  it('propagates initial managed credential errors before constructing a connection', async () => {
+    dbChainMockFns.limit.mockResolvedValue([{ ...SERVER_ROW, authType: 'oauth' }])
+    const error = new Error('Managed credential disabled')
+    await expect(
+      mcpService.executeManagedMcpTool({
+        connectionId: 'disabled-grant',
+        serverId: SERVER_ROW.id,
+        workspaceId: WORKSPACE_ID,
+        toolCall: { name: 'slow', arguments: {} },
+        loadAuthProvider: vi.fn().mockRejectedValue(error),
+      })
+    ).rejects.toBe(error)
+    expect(MockMcpClient).not.toHaveBeenCalled()
+  })
+
+  it('keeps managed tool execution outside the refresh mutex and passes a reloadable grant', async () => {
+    dbChainMockFns.limit.mockResolvedValue([{ ...SERVER_ROW, authType: 'oauth' }])
+    const initialProvider = {}
+    const loadAuthProvider = vi.fn().mockResolvedValue(initialProvider)
+    const signal = new AbortController().signal
+    await mcpService.executeManagedMcpTool({
+      connectionId: 'personal-grant',
+      serverId: SERVER_ROW.id,
+      workspaceId: WORKSPACE_ID,
+      toolCall: { name: 'slow', arguments: {} },
+      loadAuthProvider,
+      signal,
+      timeoutMs: 300_000,
+    })
+
+    expect(loadAuthProvider).toHaveBeenCalledTimes(1)
+    expect(withMcpOauthRefreshLock).not.toHaveBeenCalled()
+    expect(MockMcpClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oauthCredentials: {
+          credentialId: 'personal-grant',
+          loadProvider: loadAuthProvider,
+          initialProvider,
+        },
+      })
+    )
+    expect(mockCallTool).toHaveBeenCalledWith(
+      { name: 'slow', arguments: {} },
+      { signal, timeoutMs: 300_000 }
+    )
+    expect(mockAcquire).not.toHaveBeenCalled()
+    expect(mockDisconnect).toHaveBeenCalledTimes(1)
   })
 
   it('leases from the pool (keyed by server+workspace+user) and never disconnects on a hit', async () => {

--- a/apps/sim/lib/mcp/service.ts
+++ b/apps/sim/lib/mcp/service.ts
@@ -22,12 +22,8 @@ import {
   validateMcpDomain,
   validateMcpServerSsrf,
 } from '@/lib/mcp/domain-check'
-import {
-  getOrCreateOauthRow,
-  loadPreregisteredClient,
-  SimMcpOauthProvider,
-  withMcpOauthRefreshLock,
-} from '@/lib/mcp/oauth'
+import { getOrCreateOauthRow, loadPreregisteredClient, SimMcpOauthProvider } from '@/lib/mcp/oauth'
+import type { McpOauthCredentials } from '@/lib/mcp/oauth/coordinated-fetch'
 import { resolveMcpConfigEnvVars } from '@/lib/mcp/resolve-config'
 import {
   createMcpCacheAdapter,
@@ -431,12 +427,7 @@ class McpService {
     }
     const workspaceId = config.workspaceId
 
-    // Load the row inside the refresh lock so concurrent callers observe tokens
-    // written by a predecessor refresh, rather than a stale snapshot. Without
-    // this, the second caller's provider would hold a rotated-out refresh token
-    // and the SDK would trip `invalid_grant`. The lock is keyed on serverId
-    // since the row is per-server.
-    return withMcpOauthRefreshLock(config.id, async () => {
+    const loadProvider = async () => {
       const row = await getOrCreateOauthRow({
         mcpServerId: config.id,
         userId,
@@ -446,22 +437,26 @@ class McpService {
         throw new McpOauthAuthorizationRequiredError(config.id, config.name)
       }
       const preregistered = await loadPreregisteredClient(config.id)
-      const authProvider = new SimMcpOauthProvider({ row, preregistered })
-      const client = new McpClient({
-        config,
-        securityPolicy,
-        authProvider,
-        resolvedIP: resolvedIP ?? undefined,
-        resolvedSecretTraceProvenance,
-      })
-      await client.connect({ signal })
-      return client
+      return new SimMcpOauthProvider({ row, preregistered })
+    }
+    const client = new McpClient({
+      config,
+      securityPolicy,
+      oauthCredentials: {
+        credentialId: config.id,
+        loadProvider,
+        initialProvider: await loadProvider(),
+      },
+      resolvedIP: resolvedIP ?? undefined,
+      resolvedSecretTraceProvenance,
     })
+    await client.connect({ signal })
+    return client
   }
 
   private async createManagedOauthClient(
     config: McpServerConfig,
-    authProvider: OAuthClientProvider,
+    auth: OAuthClientProvider | McpOauthCredentials,
     signal?: AbortSignal
   ): Promise<McpClient> {
     if (config.authType !== 'oauth' || !config.url) {
@@ -484,7 +479,9 @@ class McpService {
         maxToolExecutionsPerHour: 1000,
         allowedOrigins: [new URL(config.url).origin],
       },
-      authProvider,
+      ...('loadProvider' in auth
+        ? { oauthCredentials: { ...auth, initialProvider: await auth.loadProvider() } }
+        : { authProvider: auth }),
       resolvedIP: resolvedIP ?? undefined,
     })
     await client.connect({ signal })
@@ -494,7 +491,7 @@ class McpService {
   async discoverManagedMcpTools(
     serverId: string,
     workspaceId: string,
-    authProvider: OAuthClientProvider,
+    auth: OAuthClientProvider | McpOauthCredentials,
     signal?: AbortSignal,
     options: { requireComplete?: boolean } = {}
   ): Promise<McpTool[]> {
@@ -502,7 +499,7 @@ class McpService {
     if (!config) throw new Error('Managed MCP server is unavailable')
     return this.withServerClient(
       { key: '', serverId, allowPool: false },
-      () => this.createManagedOauthClient(config, authProvider, signal),
+      () => this.createManagedOauthClient(config, auth, signal),
       (client) =>
         options.requireComplete
           ? client.listTools(signal, { requireComplete: true })
@@ -525,21 +522,19 @@ class McpService {
     const effectiveConfig = params.extraHeaders
       ? { ...config, headers: { ...config.headers, ...params.extraHeaders } }
       : config
-    return withMcpOauthRefreshLock(params.connectionId, () =>
-      this.withServerClient(
-        { key: '', serverId: params.serverId, allowPool: false },
-        async () =>
-          this.createManagedOauthClient(
-            effectiveConfig,
-            await params.loadAuthProvider(),
-            params.signal
-          ),
-        (client) =>
-          client.callTool(params.toolCall, {
-            signal: params.signal,
-            timeoutMs: params.timeoutMs,
-          })
-      )
+    return this.withServerClient(
+      { key: '', serverId: params.serverId, allowPool: false },
+      () =>
+        this.createManagedOauthClient(
+          effectiveConfig,
+          { credentialId: params.connectionId, loadProvider: params.loadAuthProvider },
+          params.signal
+        ),
+      (client) =>
+        client.callTool(params.toolCall, {
+          signal: params.signal,
+          timeoutMs: params.timeoutMs,
+        })
     )
   }
 

--- a/apps/sim/lib/mcp/types.ts
+++ b/apps/sim/lib/mcp/types.ts
@@ -4,7 +4,7 @@ import type { ResolvedSecretTraceProvenanceV1 } from '@/executor/utils/resolved-
 
 export type McpTransport = 'streamable-http'
 
-/** `oauth` uses the SDK's authProvider; `headers` is a static map; `none` is unauthenticated. */
+/** `oauth` uses an OAuth grant; `headers` is a static map; `none` is unauthenticated. */
 export type McpAuthType = 'none' | 'headers' | 'oauth'
 
 export interface McpServerStatusConfig {
@@ -203,12 +203,13 @@ export interface McpClientOptions {
    */
   resolvedIP?: string
   /**
-   * SDK-compatible OAuth client provider. When provided, the underlying
-   * StreamableHTTPClientTransport delegates token discovery, refresh, and
-   * 401 recovery to it. Should be supplied for `authType === 'oauth'`
-   * server configs.
+   * SDK provider for an enrollment whose grant has not been persisted yet.
+   * Persisted runtime grants must use oauthCredentials to coordinate refreshes.
+   * Supply exactly one of these for an OAuth server.
    */
   authProvider?: import('@modelcontextprotocol/sdk/client/auth.js').OAuthClientProvider
+  /** Runtime OAuth grants coordinate refreshes across clients using persisted credentials. */
+  oauthCredentials?: import('@/lib/mcp/oauth/coordinated-fetch').McpOauthSession
   /** Encrypted-only provenance for Secrets-tab references resolved into this connection. */
   resolvedSecretTraceProvenance?: ResolvedSecretTraceProvenanceV1
 }


### PR DESCRIPTION
## Summary
- allow concurrent MCP traffic while OAuth grants remain valid
- serialize rejected OAuth refreshes and reload persisted grants before refreshing

## Type of Change
- [x] Bug fix

## Testing
- 295 tests across 15 MCP, OAuth, execution, and cancellation suites
- `bun run lint`
- `bun run check:audits`
- `bun run docs-manifest:check`
- `bunx tsc --noEmit --incremental false`
- verified rotating-token refresh coordination across two Bun processes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
