### PR TITLE
improvement(editor-toolbar): align toolbar visual weight

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu.tsx
@@ -278,7 +278,12 @@ export function EditorBubbleMenu({
           <>
             {onAddToChat && (
               <>
-                <ToolbarButton icon={Blimp} label='Add to Chat' onClick={onAddToChat} />
+                <ToolbarButton
+                  icon={Blimp}
+                  iconSize='compact'
+                  label='Add to Chat'
+                  onClick={onAddToChat}
+                />
                 <ToolbarDivider />
               </>
             )}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button.test.tsx
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+import { act, type ReactNode } from 'react'
+import { Tooltip } from '@sim/emcn'
+import { Blimp, Bold } from '@sim/emcn/icons'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ToolbarButton } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button'
+
+describe('ToolbarButton', () => {
+  const rendered: Array<{ host: HTMLDivElement; root: Root }> = []
+
+  afterEach(() => {
+    for (const { host, root } of rendered) {
+      act(() => root.unmount())
+      host.remove()
+    }
+    rendered.length = 0
+  })
+
+  function renderButton(button: ReactNode): HTMLDivElement {
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root = createRoot(host)
+    act(() => root.render(<Tooltip.Provider>{button}</Tooltip.Provider>))
+    rendered.push({ host, root })
+    return host
+  }
+
+  it('uses the canonical active button treatment for selected formatting', () => {
+    const host = renderButton(<ToolbarButton icon={Bold} label='Bold' isActive onClick={vi.fn()} />)
+    const button = host.querySelector('button[aria-label="Bold"]')
+
+    expect(button?.className).toContain('bg-[var(--surface-5)]')
+    expect(button?.className).toContain('border-[var(--border-1)]')
+    expect(button?.className).toContain('text-[var(--text-primary)]')
+  })
+
+  it('supports a compact glyph without reducing the button hit target', () => {
+    const host = renderButton(
+      <ToolbarButton icon={Blimp} iconSize='compact' label='Add to Chat' onClick={vi.fn()} />
+    )
+
+    const button = host.querySelector('button[aria-label="Add to Chat"]')
+    expect(button?.className).toContain('size-[28px]')
+    expect(button?.querySelector('svg')?.className.baseVal).toContain('size-[12px]')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/toolbar-button.tsx
@@ -4,6 +4,8 @@ import { Button, cn, Tooltip } from '@sim/emcn'
 interface ToolbarButtonProps {
   /** Any SVG icon component, e.g. from `@sim/emcn/icons`. */
   icon: ComponentType<SVGProps<SVGSVGElement>>
+  /** Reduces optically dense filled glyphs while keeping the standard button hit target. */
+  iconSize?: 'default' | 'compact'
   label: string
   shortcut?: string
   isActive?: boolean
@@ -14,6 +16,7 @@ interface ToolbarButtonProps {
 /** A single icon button for the editor's floating toolbars (bubble menu, link hover card). */
 export function ToolbarButton({
   icon: Icon,
+  iconSize = 'default',
   label,
   shortcut,
   isActive,
@@ -25,7 +28,7 @@ export function ToolbarButton({
       <Tooltip.Trigger asChild>
         <Button
           type='button'
-          variant='ghost'
+          variant={isActive ? 'active' : 'ghost'}
           size='icon'
           aria-label={label}
           aria-pressed={isActive}
@@ -33,13 +36,11 @@ export function ToolbarButton({
           onMouseDown={(event) => event.preventDefault()}
           onClick={onClick}
           className={cn(
-            'size-[28px] focus-visible:bg-[var(--surface-hover)] [&_svg]:size-[14px]',
-            isActive
-              ? 'bg-[var(--surface-active)] text-[var(--text-body)]'
-              : 'hover-hover:bg-[var(--surface-hover)]'
+            'size-[28px] focus-visible:bg-[var(--surface-hover)]',
+            !isActive && 'hover-hover:bg-[var(--surface-hover)]'
           )}
         >
-          <Icon />
+          <Icon className={iconSize === 'compact' ? 'size-[12px]' : 'size-[14px]'} />
         </Button>
       </Tooltip.Trigger>
       <Tooltip.Content>


### PR DESCRIPTION
## Summary
- Use the canonical active button treatment for selected editor formatting
- Optically balance the filled Add to Chat glyph without changing the toolbar hit target
- Cover selected and compact icon presentation with focused component tests

## Type of Change
- [x] Improvement

## Testing
- 21 focused editor toolbar tests passed
- App type-check passed
- Lint and all 45 repository audits passed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)