### PR TITLE
chore(tooling): upgrade Bun to 1.4.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.14-alpine
+FROM oven/bun:1.4.1-alpine
 
 # Install necessary packages for development
 RUN apk add --no-cache \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -960,7 +960,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/docs-embeddings.yml
+++ b/.github/workflows/docs-embeddings.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       # Docker Compose and Kubernetes must run the same background jobs on the
       # same schedules; this fails the build if the two drift apart. The script

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/publish-sim-cli.yml
+++ b/.github/workflows/publish-sim-cli.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/publish-sim-setup.yml
+++ b/.github/workflows/publish-sim-setup.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node.js for npm publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -230,7 +230,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -303,7 +303,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.1
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "main": "dist/main.cjs",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "scripts": {

--- a/apps/realtime/package.json
+++ b/apps/realtime/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "scripts": {

--- a/apps/sim/lib/core/utils/fetch-deadline.ts
+++ b/apps/sim/lib/core/utils/fetch-deadline.ts
@@ -35,8 +35,9 @@ import { Agent, type Dispatcher } from 'undici'
  * disagree.
  *
  * Bun accepts only the boolean/zero form of `timeout`. Measured on Bun 1.3.14
- * against a server that withholds response headers, so the numbers below are
- * the real deadline rather than an inferred one:
+ * against a server that withholds response headers, with the numeric behavior
+ * rechecked on Bun 1.4.1, so the numbers below are the real deadline rather
+ * than an inferred one:
  *
  *   no option      -> THREW 300028ms (TimeoutError)   <- the 300s default
  *   timeout: false -> RESOLVED 310031ms               <- disarmed
@@ -56,10 +57,10 @@ import { Agent, type Dispatcher } from 'undici'
  *   dispatcher armed at 200ms            -> THREW 1011ms          <- honored
  *   dispatcher with 0/0 vs a 310s server -> RESOLVED 310016ms     <- disarmed
  *
- * `bun-types@1.3.14` does not declare `timeout` on `BunFetchRequestInit`, and
- * the DOM lib does not declare undici's `dispatcher`, even though each runtime
- * honors its respective option — the types lag the runtimes, which is why the
- * interface below is declared locally rather than imported.
+ * `bun-types@1.4.1` declares `timeout` on `BunFetchRequestInit`, but the shared
+ * DOM lib does not declare that Bun extension or undici's `dispatcher`. The
+ * interface below therefore stays local so this cross-runtime helper does not
+ * depend on either runtime's ambient types.
  */
 
 /**

--- a/apps/sim/package.json
+++ b/apps/sim/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=22.19.0"
   },
   "scripts": {

--- a/apps/sim/scripts/pi-sandbox-packages.ts
+++ b/apps/sim/scripts/pi-sandbox-packages.ts
@@ -14,7 +14,7 @@
  */
 
 /** Bun version mirrored from the root packageManager field. */
-export const PI_BUN_VERSION = '1.3.14'
+export const PI_BUN_VERSION = '1.4.1'
 
 /** Exact Pi version mirrored from the app dependencies and lockfile. */
 export const PI_PACKAGE_VERSION = '0.80.10'

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: runtime-only dependencies (inherited by the final image)
 # ========================================
-FROM oven/bun:1.3.14-slim AS base
+FROM oven/bun:1.4.1-slim AS base
 
 # Install Node.js 24 (Active LTS) and the runtime dependencies once in base.
 # Node runs only the isolated-vm sandbox worker (the app itself runs under Bun);

--- a/docker/db.Dockerfile
+++ b/docker/db.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.1-alpine AS base
 
 # ========================================
 # Dependencies Stage: Install Dependencies

--- a/docker/realtime.Dockerfile
+++ b/docker/realtime.Dockerfile
@@ -1,7 +1,7 @@
 # ========================================
 # Base Stage: Alpine Linux with Bun
 # ========================================
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.1-alpine AS base
 
 RUN apk add --no-cache libc6-compat curl
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simstudio",
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.1",
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/browser-protocol/package.json
+++ b/packages/browser-protocol/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/desktop-bridge/package.json
+++ b/packages/desktop-bridge/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/emcn/package.json
+++ b/packages/emcn/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/platform-authz/package.json
+++ b/packages/platform-authz/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/realtime-protocol/package.json
+++ b/packages/realtime-protocol/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/runtime-secrets/package.json
+++ b/packages/runtime-secrets/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/terminal-protocol/package.json
+++ b/packages/terminal-protocol/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/workflow-persistence/package.json
+++ b/packages/workflow-persistence/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/workflow-renderer/package.json
+++ b/packages/workflow-renderer/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {

--- a/packages/workflow-types/package.json
+++ b/packages/workflow-types/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "bun": ">=1.3.14",
+    "bun": ">=1.4.1",
     "node": ">=20.0.0"
   },
   "exports": {


### PR DESCRIPTION
## Summary
- upgrade Bun to 1.4.1 across package metadata, CI, containers, and sandbox configuration
- retain the existing lockfile after a frozen install and verify Bun-sensitive build and YAML paths

## Type of Change
- [x] Chore

## Testing
- bun install --frozen-lockfile
- bun run lint
- bun run check:audits
- bun run docs-manifest:check
- bun run type-check
- bun run test
- bun run images:check
- production Sim build and CLI bundle builds under Bun 1.4.1

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)