### PR TITLE
fix(models): make catalog feature selection explicit

### DIFF
--- a/apps/sim/app/(landing)/models/utils.test.ts
+++ b/apps/sim/app/(landing)/models/utils.test.ts
@@ -53,8 +53,19 @@ describe('model catalog capability facts', () => {
     expect(generalModel?.bestFor).toBeUndefined()
   })
 
-  it.concurrent('features the explicitly recommended OpenAI model first', () => {
-    expect(getProviderBySlug('openai')?.featuredModels[0]?.id).toBe('gpt-6-astra')
+  it.concurrent('uses explicit catalog features for flagship provider cards', () => {
+    expect(
+      ['anthropic', 'openai', 'google'].map((providerId) => {
+        const model = getProviderBySlug(providerId)?.featuredModels[0]
+        return { providerId, modelId: model?.id, featured: model?.featured }
+      })
+    ).toEqual([
+      { providerId: 'anthropic', modelId: 'claude-fable-5-1', featured: true },
+      { providerId: 'openai', modelId: 'gpt-6-astra', featured: true },
+      { providerId: 'google', modelId: 'gemini-3.8-flash', featured: true },
+    ])
+
+    expect(getProviderBySlug('anthropic')?.featuredModels[0]?.recommended).toBe(false)
   })
 
   it.concurrent('includes input-size tiers in structured pricing bounds', () => {

--- a/apps/sim/app/(landing)/models/utils.ts
+++ b/apps/sim/app/(landing)/models/utils.ts
@@ -120,6 +120,7 @@ export interface CatalogModel {
   contextWindow: number | null
   releaseDate: string | null
   deprecated: boolean
+  featured: boolean
   recommended: boolean
   pricing: PricingInfo
   capabilities: ModelCapabilities
@@ -441,6 +442,9 @@ function computeModelRelevanceScore(model: CatalogModel): number {
 }
 
 function compareModelsByRelevance(a: CatalogModel, b: CatalogModel): number {
+  const featuredDifference = Number(b.featured) - Number(a.featured)
+  if (featuredDifference !== 0) return featuredDifference
+
   const recommendationDifference = Number(b.recommended) - Number(a.recommended)
   if (recommendationDifference !== 0) return recommendationDifference
 
@@ -477,6 +481,7 @@ const rawProviders = Object.values(PROVIDER_DEFINITIONS).map((provider) => {
       contextWindow: model.contextWindow ?? null,
       releaseDate: model.releaseDate ?? null,
       deprecated: !!model.sunset,
+      featured: model.featured ?? false,
       recommended: model.recommended ?? false,
       pricing: model.pricing,
       capabilities: mergedCapabilities,

--- a/apps/sim/providers/models.test.ts
+++ b/apps/sim/providers/models.test.ts
@@ -50,6 +50,17 @@ describe('OpenAI provider definition', () => {
   })
 })
 
+describe('catalog featured model metadata', () => {
+  it('defines at most one active featured model per provider', () => {
+    for (const provider of Object.values(PROVIDER_DEFINITIONS)) {
+      const featuredModels = provider.models.filter((model) => model.featured)
+
+      expect(featuredModels.length).toBeLessThanOrEqual(1)
+      expect(featuredModels.every((model) => model.sunset === undefined)).toBe(true)
+    }
+  })
+})
+
 describe('Anthropic thinking stream visibility', () => {
   it('classifies visible Claude thinking as summarized rather than raw', () => {
     for (const providerId of ['anthropic', 'azure-anthropic'] as const) {

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -93,6 +93,8 @@ interface ModelDefinition {
   contextWindow?: number
   /** ISO date string (YYYY-MM-DD) when the model was first publicly released */
   releaseDate?: string
+  /** Promotes this model on public catalog surfaces, independently of workflow recommendations. */
+  featured?: boolean
   recommended?: boolean
   speedOptimized?: boolean
   /**
@@ -350,6 +352,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1050000,
         releaseDate: '2026-09-03',
+        featured: true,
         recommended: true,
       },
       // GPT-4.1 family
@@ -922,6 +925,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1000000,
         releaseDate: '2026-09-01',
+        featured: true,
       },
       {
         id: 'claude-fable-5',
@@ -1697,6 +1701,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
         },
         contextWindow: 1048576,
         releaseDate: '2026-09-02',
+        featured: true,
         recommended: true,
       },
       {


### PR DESCRIPTION
## Summary
- separate public catalog features from workflow model recommendations
- explicitly feature Claude Fable 5.1, GPT-6 Astra, and Gemini 3.8 Flash
- enforce one active featured model per provider and cover flagship selection with tests

## Type of Change
- [x] Bug fix

## Testing
- `bun test apps/sim/app/\(landing\)/models/utils.test.ts apps/sim/providers/models.test.ts`
- `bun run lint`
- `bun run type-check`
- `bun run check:audits`
- `bun run docs-manifest:check`
- `bun run apps/sim/scripts/check-block-registry.ts origin/staging`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)