### PR TITLE
fix(file-editor): recover collaboration after reconnect

### DIFF
--- a/apps/realtime/src/handlers/file-doc.test.ts
+++ b/apps/realtime/src/handlers/file-doc.test.ts
@@ -233,12 +233,13 @@ describe('setupWorkspaceFileDocHandlers', () => {
     )
   })
 
-  it('rejects a payload missing the file id or client id before authorizing', async () => {
+  it('rejects a payload with a missing or out-of-range client id before authorizing', async () => {
     const { io } = createIo()
     const { socket, handlers } = setup('socket-1', io)
 
     await handlers[FILE_DOC_EVENTS.JOIN]({ fileId: '', clientId: 1 })
     await handlers[FILE_DOC_EVENTS.JOIN]({ fileId: 'file-1' })
+    await handlers[FILE_DOC_EVENTS.JOIN]({ fileId: 'file-1', clientId: 0x1_0000_0000 })
 
     expect(socket.emit).toHaveBeenCalledWith(
       FILE_DOC_EVENTS.JOIN_ERROR,

--- a/apps/realtime/src/handlers/file-doc.test.ts
+++ b/apps/realtime/src/handlers/file-doc.test.ts
@@ -545,6 +545,10 @@ describe('setupWorkspaceFileDocHandlers', () => {
 
     expect(socket.join).toHaveBeenCalledWith(ROOM_NAME)
     expect(joinSuccessFileId(socket)).toBe('file-1')
+    expect(socket.emit).toHaveBeenCalledWith(
+      FILE_DOC_EVENTS.JOIN_SUCCESS,
+      expect.objectContaining({ fileId: 'file-1', clientId: 1 })
+    )
 
     // A binary sync-step-1 message (type tag 0) is sent to kick off the handshake.
     const syncMessage = socket.emit.mock.calls.find(
@@ -843,7 +847,7 @@ describe('setupWorkspaceFileDocHandlers', () => {
     expect(mockFetchFileDocMerge).toHaveBeenCalledTimes(2)
   })
 
-  it('relays a document update to the rest of the room, excluding the sender', async () => {
+  it('relays a document update to every provider, including siblings on the sender socket', async () => {
     const { io, sent } = createIo()
     const a = setup('socket-a', io)
     const b = setup('socket-b', io)
@@ -860,7 +864,7 @@ describe('setupWorkspaceFileDocHandlers', () => {
 
     const relayed = sent.find((m) => m.event === FILE_DOC_EVENTS.MESSAGE)
     expect(relayed?.target).toBe(ROOM_NAME)
-    expect(relayed?.except).toBe('socket-a')
+    expect(relayed?.except).toBeUndefined()
     expect((relayed?.payload as Uint8Array)[0]).toBe(FILE_DOC_MESSAGE_TYPE.SYNC)
   })
 
@@ -957,6 +961,35 @@ describe('setupWorkspaceFileDocHandlers', () => {
     expect(relayedFor(501)).toBeDefined()
     // A client id this socket does NOT own is still dropped (ownership is not blanket-allowed).
     expect(relayedFor(999)).toBeUndefined()
+  })
+
+  it('accepts concurrent joins from co-mounted providers for the same file', async () => {
+    let resolveFirstAuth: (value: unknown) => void = () => {}
+    mockAuthorizeRoom.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirstAuth = resolve
+      })
+    )
+    const { io } = createIo()
+    const { socket, handlers } = setup('socket-a', io)
+
+    const first = handlers[FILE_DOC_EVENTS.JOIN]({ fileId: 'file-1', clientId: 500 })
+    await Promise.resolve()
+    const second = handlers[FILE_DOC_EVENTS.JOIN]({ fileId: 'file-1', clientId: 501 })
+    await second
+
+    resolveFirstAuth({
+      allowed: true,
+      status: 200,
+      workspaceId: 'ws-1',
+      workspacePermission: 'write',
+    })
+    await first
+
+    const acceptedClientIds = socket.emit.mock.calls
+      .filter(([event]) => event === FILE_DOC_EVENTS.JOIN_SUCCESS)
+      .map(([, payload]) => (payload as { clientId: number }).clientId)
+    expect(acceptedClientIds).toEqual(expect.arrayContaining([500, 501]))
   })
 
   it('preserves the existing caret when a rebind to a foreign client id is rejected', async () => {

--- a/apps/realtime/src/handlers/file-doc.ts
+++ b/apps/realtime/src/handlers/file-doc.ts
@@ -783,7 +783,7 @@ async function mergeMarkdownIntoRoom(
 /**
  * Get (or lazily create) the authoritative document for a room, wiring the two
  * relay handlers exactly once: document updates and awareness changes are
- * broadcast to the room, excluding the origin socket (it already applied them).
+ * broadcast to the room.
  */
 function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
   const name = roomName(ref)
@@ -821,18 +821,12 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
     const encoder = encoding.createEncoder()
     encoding.writeVarUint(encoder, FILE_DOC_MESSAGE_TYPE.SYNC)
     syncProtocol.writeUpdate(encoder, update)
-    // Fan out to THIS task's clients only (excluding the origin socket if local — a user edit OR an
-    // agent-streamed frame). Cross-task delivery rides the shared stream — every task's tailer applies +
-    // runs its own local fan-out.
-    // A client edit excludes its own sender socket (echo suppression). An agent frame broadcasts to the
-    // WHOLE room — no socket excluded — so a same-socket sibling provider (chat preview + Files editor)
-    // stays live mid-stream; the emitting provider no-ops on its own echo.
-    broadcastLocal(
-      io,
-      name,
-      encoding.toUint8Array(encoder),
-      origin === AGENT_SYNC_ORIGIN ? null : originSocketId(origin)
-    )
+    // Fan out to every client on THIS task, including the origin socket. One shared Socket.IO connection
+    // can host multiple providers for this file; excluding the whole socket would strand the sibling
+    // provider's distinct Y.Doc. Yjs updates are idempotent, and the originating provider applies its
+    // echo with the provider as transaction origin, so it does not send the update again. Cross-task
+    // delivery rides the shared stream, where every task's tailer runs its own local fan-out.
+    broadcastLocal(io, name, encoding.toUint8Array(encoder), null)
     // Share every locally-originated update to the stream so peers converge. Skip updates that already
     // came FROM the stream (REDIS_ORIGIN / REDIS_SNAPSHOT_ORIGIN / REDIS_AGENT_ORIGIN) and SEED_ORIGIN —
     // the seed is published EXPLICITLY and AWAITED under the seed lock (so it lands before the lock
@@ -898,12 +892,18 @@ function getOrCreateRoom(io: Server, ref: RoomRef): FileDocRoom {
 function emitJoinError(
   socket: AuthenticatedSocket,
   fileId: unknown,
+  clientId: unknown,
   error: string,
   code: string,
   retryable: boolean
 ) {
+  const normalizedClientId =
+    typeof clientId === 'number' && Number.isInteger(clientId) && clientId >= 0
+      ? clientId
+      : undefined
   socket.emit(FILE_DOC_EVENTS.JOIN_ERROR, {
     fileId: typeof fileId === 'string' ? fileId : '',
+    clientId: normalizedClientId,
     error,
     code,
     retryable,
@@ -1113,11 +1113,25 @@ export function setupWorkspaceFileDocHandlers(
       const userName = socket.userName
 
       if (!userId || !userName) {
-        emitJoinError(socket, fileId, 'Authentication required', 'AUTHENTICATION_REQUIRED', false)
+        emitJoinError(
+          socket,
+          fileId,
+          clientId,
+          'Authentication required',
+          'AUTHENTICATION_REQUIRED',
+          false
+        )
         return
       }
       if (!roomManager.isReady()) {
-        emitJoinError(socket, fileId, 'Realtime unavailable', 'ROOM_MANAGER_UNAVAILABLE', true)
+        emitJoinError(
+          socket,
+          fileId,
+          clientId,
+          'Realtime unavailable',
+          'ROOM_MANAGER_UNAVAILABLE',
+          true
+        )
         return
       }
       if (
@@ -1128,15 +1142,20 @@ export function setupWorkspaceFileDocHandlers(
         !Number.isInteger(clientId) ||
         clientId < 0
       ) {
-        emitJoinError(socket, fileId, 'Invalid join payload', 'INVALID_PAYLOAD', false)
+        emitJoinError(socket, fileId, clientId, 'Invalid join payload', 'INVALID_PAYLOAD', false)
         return
       }
 
-      // Claim this JOIN's generation before the async authorize below, and record the file the
-      // socket now intends to edit so a leave for it can cancel this join if it's still in-flight.
-      generation = (joinGeneration.get(socket.id) ?? 0) + 1
-      joinGeneration.set(socket.id, generation)
-      currentFileId = fileId
+      // A generation represents the socket's intended FILE, not an individual provider. Co-mounted
+      // providers for the same file must be allowed to join concurrently; switching files advances the
+      // generation so every in-flight join for the old file is cancelled together.
+      if (currentFileId !== fileId) {
+        generation = (joinGeneration.get(socket.id) ?? 0) + 1
+        joinGeneration.set(socket.id, generation)
+        currentFileId = fileId
+      } else {
+        generation = joinGeneration.get(socket.id) ?? 0
+      }
 
       const room = fileDocRoom(fileId)
       const name = roomName(room)
@@ -1153,7 +1172,7 @@ export function setupWorkspaceFileDocHandlers(
           accessDenied: 'Access denied to file',
         },
         emitError: ({ error, code, retryable }) =>
-          emitJoinError(socket, fileId, error, code, retryable),
+          emitJoinError(socket, fileId, clientId, error, code, retryable),
       })
       if (!authorized) return
 
@@ -1190,7 +1209,7 @@ export function setupWorkspaceFileDocHandlers(
           logger.warn(
             `User ${userId} lost write access to file ${fileId} before the join completed`
           )
-          emitJoinError(socket, fileId, 'Access denied to file', 'ACCESS_DENIED', false)
+          emitJoinError(socket, fileId, clientId, 'Access denied to file', 'ACCESS_DENIED', false)
           return
         }
 
@@ -1219,7 +1238,14 @@ export function setupWorkspaceFileDocHandlers(
           const owner = clientMap.get(clientId)
           if (owner === undefined) continue
           if (owner.userId !== userId) {
-            emitJoinError(socket, fileId, 'Client id already in use', 'CLIENT_ID_IN_USE', false)
+            emitJoinError(
+              socket,
+              fileId,
+              clientId,
+              'Client id already in use',
+              'CLIENT_ID_IN_USE',
+              false
+            )
             return
           }
           // Same user reclaiming its client id on a stale prior socket: evict just THAT clientID's
@@ -1268,7 +1294,11 @@ export function setupWorkspaceFileDocHandlers(
         // Name the document this room holds, so a client that still carries a DIFFERENT one (its room
         // outlived by a document rebuilt in its place) can refuse to merge instead of unioning two
         // documents into the file twice over. Read after readiness — before it, the room has no doc yet.
-        socket.emit(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId, docId: docIdOf(entry.doc) })
+        socket.emit(FILE_DOC_EVENTS.JOIN_SUCCESS, {
+          fileId,
+          clientId,
+          docId: docIdOf(entry.doc),
+        })
         // Server-authenticated roster → everyone in the room, including this joiner.
         broadcastFileDocPresence(io, name, entry)
 
@@ -1321,7 +1351,7 @@ export function setupWorkspaceFileDocHandlers(
         (generation !== undefined && joinGeneration.get(socket.id) !== generation)
       )
         return
-      emitJoinError(socket, fileId, 'Failed to join file document', 'JOIN_FAILED', true)
+      emitJoinError(socket, fileId, clientId, 'Failed to join file document', 'JOIN_FAILED', true)
     }
   })
 

--- a/apps/realtime/src/handlers/file-doc.ts
+++ b/apps/realtime/src/handlers/file-doc.ts
@@ -192,15 +192,19 @@ const fileDocRooms = new Map<string, FileDocRoom>()
 /** socketId → its current file-doc room name (a socket edits at most one doc). */
 const socketToRoomName = new Map<string, string>()
 /**
- * socketId → a monotonic join generation. A JOIN bumps it on arrival and, after
- * the async authorization, proceeds only if the generation is still its own — so
- * a newer JOIN (a fast document switch) or a disconnect (which drops the entry in
- * cleanup) that occurred during authorization aborts the now-stale JOIN. Without
- * this, an out-of-order authorize completion could bind the socket to the wrong
- * document, or a disconnect-during-authorize could register a dead socket and
- * leak its room.
+ * socketId → a monotonic file-intent generation. Switching files or leaving the
+ * intended file advances it; co-mounted providers joining the same file share it.
+ * After async authorization, a join proceeds only while its generation is current,
+ * preventing an out-of-order completion from binding the socket to the wrong file.
  */
 const joinGeneration = new Map<string, number>()
+const MAX_YJS_CLIENT_ID = 0xffff_ffff
+
+function isYjsClientId(value: unknown): value is number {
+  return (
+    typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= MAX_YJS_CLIENT_ID
+  )
+}
 
 interface AwarenessChange {
   added: number[]
@@ -227,10 +231,8 @@ function originSocketId(origin: unknown): string | null {
  * The transaction origin stamped on an agent-streamed frame (a {@link FILE_DOC_MESSAGE_TYPE.SYNC_NO_PERSIST}
  * apply). A non-string sentinel, so `originSocketId` returns `null` for it and the update never triggers
  * `edited`/`schedulePersist` (the copilot's final `edit_content` write is the durable persist). Unlike a
- * client edit, an agent frame is broadcast to the WHOLE room (its originating socket is NOT excluded), so a
- * second {@link FileDocProvider} on the same socket — e.g. the chat preview alongside the Files editor —
- * also receives the mid-stream ops. The emitting provider no-ops on its own echo (the ops are already
- * applied locally), so broadcasting back to the sender is harmless.
+ * client edit, it is marked so peers do not treat it as a durable user edit. The emitting provider no-ops
+ * on its own echo because the operations are already applied locally.
  */
 const AGENT_SYNC_ORIGIN = Symbol('file-doc-agent-sync')
 
@@ -897,10 +899,7 @@ function emitJoinError(
   code: string,
   retryable: boolean
 ) {
-  const normalizedClientId =
-    typeof clientId === 'number' && Number.isInteger(clientId) && clientId >= 0
-      ? clientId
-      : undefined
+  const normalizedClientId = isYjsClientId(clientId) ? clientId : undefined
   socket.emit(FILE_DOC_EVENTS.JOIN_ERROR, {
     fileId: typeof fileId === 'string' ? fileId : '',
     clientId: normalizedClientId,
@@ -1137,10 +1136,8 @@ export function setupWorkspaceFileDocHandlers(
       if (
         typeof fileId !== 'string' ||
         fileId.length === 0 ||
-        // A Yjs clientID is a uint32; reject NaN/Infinity/negative/non-integer so a malformed id
-        // can't become a bogus ownership key.
-        !Number.isInteger(clientId) ||
-        clientId < 0
+        // A Yjs clientID is a uint32; reject malformed values before they can become ownership keys.
+        !isYjsClientId(clientId)
       ) {
         emitJoinError(socket, fileId, clientId, 'Invalid join payload', 'INVALID_PAYLOAD', false)
         return

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-doc-provider.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-doc-provider.test.ts
@@ -572,7 +572,7 @@ describe('FileDocProvider', () => {
     // Two surfaces in one tab (Files editor + embedded chat panel) share one socket and both open the
     // same file. Tearing the first down must NOT strand the second — the server drops the socket from
     // the room on any LEAVE, so LEAVE may fire only when the last provider goes away.
-    const { socket, emit } = createSocket(true)
+    const { socket, emit, fire } = createSocket(true)
     const docA = new Y.Doc()
     const docB = new Y.Doc()
     const first = new FileDocProvider(
@@ -587,9 +587,20 @@ describe('FileDocProvider', () => {
       docB,
       new awarenessProtocol.Awareness(docB)
     )
+    fire(FILE_DOC_EVENTS.JOIN_SUCCESS, {
+      fileId: 'shared-file',
+      clientId: docA.clientID,
+    })
+    fire(FILE_DOC_EVENTS.JOIN_SUCCESS, {
+      fileId: 'shared-file',
+      clientId: docB.clientID,
+    })
     emit.mockClear()
 
     first.destroy()
+    expect(
+      emittedMessages(emit).some((message) => message[0] === FILE_DOC_MESSAGE_TYPE.AWARENESS)
+    ).toBe(true)
     expect(emit).not.toHaveBeenCalledWith(FILE_DOC_EVENTS.LEAVE, expect.anything())
 
     second.destroy()

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-doc-provider.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-doc-provider.test.ts
@@ -35,6 +35,8 @@ function createSocket(connected = true) {
     },
   }
   const fire = (event: string, ...args: unknown[]) => {
+    if (event === 'connect') socket.connected = true
+    if (event === 'disconnect') socket.connected = false
     for (const cb of listeners.get(event) ?? []) cb(...args)
   }
   return { socket: socket as unknown as Socket, emit, fire }
@@ -46,6 +48,14 @@ function createProvider(connected = true) {
   const awareness = new awarenessProtocol.Awareness(doc)
   const provider = new FileDocProvider(socket, 'file-1', doc, awareness)
   return { provider, doc, awareness, emit, fire }
+}
+
+function acceptJoin(
+  fire: (event: string, ...args: unknown[]) => void,
+  clientId: number,
+  docId?: string
+) {
+  fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1', clientId, docId })
 }
 
 /** Messages emitted to the server, decoded to their `{ type, bytes }`. */
@@ -77,10 +87,11 @@ describe('FileDocProvider', () => {
   })
 
   it('exchanges sync only after JOIN_SUCCESS', () => {
-    const { emit, fire } = createProvider(true)
+    const { doc, emit, fire } = createProvider(true)
     emit.mockClear()
+    expect(emittedMessages(emit)).toHaveLength(0)
 
-    fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1' })
+    acceptJoin(fire, doc.clientID)
 
     // A sync step 1 (type tag 0) is sent to exchange state with the server.
     const messages = emittedMessages(emit)
@@ -88,14 +99,90 @@ describe('FileDocProvider', () => {
     expect(messages[0][0]).toBe(FILE_DOC_MESSAGE_TYPE.SYNC)
   })
 
-  it('ignores a join ack for a different file', () => {
-    const { emit, fire } = createProvider(true)
+  it('ignores inbound sync until the current join is accepted', () => {
+    const { provider, doc, fire } = createProvider(true)
+    const serverDoc = new Y.Doc()
+    serverDoc.getText('default').insert(0, 'server content')
+    const encoder = encoding.createEncoder()
+    encoding.writeVarUint(encoder, FILE_DOC_MESSAGE_TYPE.SYNC)
+    syncProtocol.writeSyncStep2(encoder, serverDoc)
+    const frame = encoding.toUint8Array(encoder)
+
+    fire(FILE_DOC_EVENTS.MESSAGE, frame)
+
+    expect(provider.synced).toBe(false)
+    expect(doc.getText('default').toString()).toBe('')
+
+    acceptJoin(fire, doc.clientID)
+    fire(FILE_DOC_EVENTS.MESSAGE, frame)
+
+    expect(provider.synced).toBe(true)
+    expect(doc.getText('default').toString()).toBe('server content')
+  })
+
+  it('does not send local updates before the current join is accepted', () => {
+    const { doc, emit } = createProvider(true)
     emit.mockClear()
 
-    fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'other-file' })
+    doc.getText('default').insert(0, 'retained locally')
+
+    expect(emittedMessages(emit)).toHaveLength(0)
+    expect(doc.getText('default').toString()).toBe('retained locally')
+  })
+
+  it('does not send local awareness before the current join is accepted', () => {
+    const { awareness, emit } = createProvider(true)
+    emit.mockClear()
+
+    awareness.setLocalStateField('user', { name: 'Ada' })
+
+    expect(emittedMessages(emit)).toHaveLength(0)
+  })
+
+  it('ignores a join ack for a different file', () => {
+    const { doc, emit, fire } = createProvider(true)
+    emit.mockClear()
+
+    fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'other-file', clientId: doc.clientID })
 
     // No sync/awareness exchange starts for a file this provider does not own.
     expect(emittedMessages(emit)).toHaveLength(0)
+  })
+
+  it('scopes join acknowledgements to the matching provider on a shared socket', () => {
+    const { socket, fire } = createSocket(true)
+    const firstDoc = new Y.Doc()
+    const secondDoc = new Y.Doc()
+    const first = new FileDocProvider(
+      socket,
+      'file-1',
+      firstDoc,
+      new awarenessProtocol.Awareness(firstDoc)
+    )
+    const second = new FileDocProvider(
+      socket,
+      'file-1',
+      secondDoc,
+      new awarenessProtocol.Awareness(secondDoc)
+    )
+    const serverDoc = new Y.Doc()
+    const encoder = encoding.createEncoder()
+    encoding.writeVarUint(encoder, FILE_DOC_MESSAGE_TYPE.SYNC)
+    syncProtocol.writeSyncStep2(encoder, serverDoc)
+    const frame = encoding.toUint8Array(encoder)
+
+    acceptJoin(fire, firstDoc.clientID)
+    fire(FILE_DOC_EVENTS.MESSAGE, frame)
+
+    expect(first.synced).toBe(true)
+    expect(second.synced).toBe(false)
+
+    acceptJoin(fire, secondDoc.clientID)
+    fire(FILE_DOC_EVENTS.MESSAGE, frame)
+
+    expect(second.synced).toBe(true)
+    first.destroy()
+    second.destroy()
   })
 
   /**
@@ -111,7 +198,7 @@ describe('FileDocProvider', () => {
     provider.on('join-error', joinError)
     emit.mockClear()
 
-    fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1', docId: 'doc-rebuilt' })
+    acceptJoin(fire, doc.clientID, 'doc-rebuilt')
 
     expect(emittedMessages(emit)).toHaveLength(0)
     expect(provider.synced).toBe(false)
@@ -124,7 +211,7 @@ describe('FileDocProvider', () => {
     doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.docIdKey, 'doc-original')
     emit.mockClear()
 
-    fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1', docId: 'doc-original' })
+    acceptJoin(fire, doc.clientID, 'doc-original')
 
     expect(emittedMessages(emit).length).toBeGreaterThan(0)
   })
@@ -132,13 +219,13 @@ describe('FileDocProvider', () => {
   it('syncs when either side carries no identity (a fresh doc, or a room seeded before identities)', () => {
     const fresh = createProvider(true)
     fresh.emit.mockClear()
-    fresh.fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1', docId: 'doc-rebuilt' })
+    acceptJoin(fresh.fire, fresh.doc.clientID, 'doc-rebuilt')
     expect(emittedMessages(fresh.emit).length).toBeGreaterThan(0)
 
     const unnamedRoom = createProvider(true)
     unnamedRoom.doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.docIdKey, 'doc-original')
     unnamedRoom.emit.mockClear()
-    unnamedRoom.fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1' })
+    acceptJoin(unnamedRoom.fire, unnamedRoom.doc.clientID)
     expect(emittedMessages(unnamedRoom.emit).length).toBeGreaterThan(0)
   })
 
@@ -146,6 +233,7 @@ describe('FileDocProvider', () => {
     const { provider, doc, fire } = createProvider(true)
     const synced = vi.fn()
     provider.on('synced', synced)
+    acceptJoin(fire, doc.clientID)
 
     const serverDoc = new Y.Doc()
     serverDoc.getText('default').insert(0, 'hello world')
@@ -160,7 +248,8 @@ describe('FileDocProvider', () => {
   })
 
   it('sends local document edits to the server as sync updates', () => {
-    const { doc, emit } = createProvider(true)
+    const { doc, emit, fire } = createProvider(true)
+    acceptJoin(fire, doc.clientID)
     emit.mockClear()
 
     doc.getText('default').insert(0, 'x')
@@ -171,7 +260,8 @@ describe('FileDocProvider', () => {
   })
 
   it('tags agent-streamed edits as SYNC_NO_PERSIST so the relay skips the durable persist', () => {
-    const { doc, emit } = createProvider(true)
+    const { doc, emit, fire } = createProvider(true)
+    acceptJoin(fire, doc.clientID)
     emit.mockClear()
 
     // An agent-streamed frame is applied under AGENT_STREAM_ORIGIN; it must still reach the server (peers
@@ -184,8 +274,8 @@ describe('FileDocProvider', () => {
   })
 
   it('does not echo updates it applied from the server', () => {
-    const { provider, emit, fire } = createProvider(true)
-    fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1' })
+    const { provider, doc, emit, fire } = createProvider(true)
+    acceptJoin(fire, doc.clientID)
     emit.mockClear()
 
     const serverDoc = new Y.Doc()
@@ -201,7 +291,8 @@ describe('FileDocProvider', () => {
   })
 
   it('sends local awareness (cursor/selection) changes', () => {
-    const { awareness, emit } = createProvider(true)
+    const { awareness, doc, emit, fire } = createProvider(true)
+    acceptJoin(fire, doc.clientID)
     emit.mockClear()
 
     awareness.setLocalStateField('user', { name: 'Ada', color: '#f783ac' })
@@ -211,7 +302,7 @@ describe('FileDocProvider', () => {
   })
 
   it('reseeds a cleared awareness so a reused instance can publish again', () => {
-    const { socket, emit } = createSocket(true)
+    const { socket, emit, fire } = createSocket(true)
     const doc = new Y.Doc()
     const awareness = new awarenessProtocol.Awareness(doc)
     // Simulate a prior provider teardown having cleared the local state — after
@@ -224,6 +315,7 @@ describe('FileDocProvider', () => {
     new FileDocProvider(socket, 'file-1', doc, awareness)
     expect(awareness.getLocalState()).not.toBeNull()
 
+    acceptJoin(fire, doc.clientID)
     emit.mockClear()
     // The caret extension setting the user field must now actually publish.
     awareness.setLocalStateField('user', { name: 'Ada', color: '#f783ac' })
@@ -231,7 +323,8 @@ describe('FileDocProvider', () => {
   })
 
   it('does not forward awareness it applied from the server', () => {
-    const { emit, fire } = createProvider(true)
+    const { doc, emit, fire } = createProvider(true)
+    acceptJoin(fire, doc.clientID)
     emit.mockClear()
 
     const remoteDoc = new Y.Doc()
@@ -266,26 +359,87 @@ describe('FileDocProvider', () => {
     expect(provider.joinError).toEqual(error)
   })
 
-  it('still rejoins on reconnect after a retryable error', () => {
-    const { emit, fire } = createProvider(true)
-    fire(FILE_DOC_EVENTS.JOIN_ERROR, {
-      fileId: 'file-1',
-      error: 'Realtime unavailable',
-      code: 'ROOM_MANAGER_UNAVAILABLE',
-      retryable: true,
-    })
-    emit.mockClear()
-
-    fire('connect')
-
-    expect(emit).toHaveBeenCalledWith(
-      FILE_DOC_EVENTS.JOIN,
-      expect.objectContaining({ fileId: 'file-1' })
+  it('scopes join errors to the matching provider on a shared socket', () => {
+    const { socket, fire } = createSocket(true)
+    const firstDoc = new Y.Doc()
+    const secondDoc = new Y.Doc()
+    const first = new FileDocProvider(
+      socket,
+      'file-1',
+      firstDoc,
+      new awarenessProtocol.Awareness(firstDoc)
     )
+    const second = new FileDocProvider(
+      socket,
+      'file-1',
+      secondDoc,
+      new awarenessProtocol.Awareness(secondDoc)
+    )
+    const error = {
+      fileId: 'file-1',
+      clientId: firstDoc.clientID,
+      error: 'Access denied',
+      code: 'ACCESS_DENIED',
+      retryable: false,
+    }
+
+    fire(FILE_DOC_EVENTS.JOIN_ERROR, error)
+
+    expect(first.joinError).toEqual(error)
+    expect(second.joinError).toBeNull()
+    first.destroy()
+    second.destroy()
+  })
+
+  it('retries a retryable join error without waiting for another socket reconnect', () => {
+    vi.useFakeTimers()
+    try {
+      const { emit, fire } = createProvider(true)
+      emit.mockClear()
+
+      fire(FILE_DOC_EVENTS.JOIN_ERROR, {
+        fileId: 'file-1',
+        error: 'Realtime unavailable',
+        code: 'ROOM_MANAGER_UNAVAILABLE',
+        retryable: true,
+      })
+
+      expect(emit).not.toHaveBeenCalledWith(FILE_DOC_EVENTS.JOIN, expect.anything())
+      vi.advanceTimersByTime(1_000)
+      expect(emit).toHaveBeenCalledWith(
+        FILE_DOC_EVENTS.JOIN,
+        expect.objectContaining({ fileId: 'file-1' })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels a scheduled join retry after a successful join', () => {
+    vi.useFakeTimers()
+    try {
+      const { doc, emit, fire } = createProvider(true)
+      fire(FILE_DOC_EVENTS.JOIN_ERROR, {
+        fileId: 'file-1',
+        error: 'Realtime unavailable',
+        code: 'ROOM_MANAGER_UNAVAILABLE',
+        retryable: true,
+      })
+      vi.advanceTimersByTime(1_000)
+      acceptJoin(fire, doc.clientID)
+      emit.mockClear()
+
+      vi.advanceTimersByTime(10_000)
+
+      expect(emit).not.toHaveBeenCalledWith(FILE_DOC_EVENTS.JOIN, expect.anything())
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('resets synced and rejoins on a reconnect', () => {
-    const { provider, emit, fire } = createProvider(true)
+    const { provider, doc, emit, fire } = createProvider(true)
+    acceptJoin(fire, doc.clientID)
     // Become synced.
     const serverDoc = new Y.Doc()
     serverDoc.getText('default').insert(0, 'hi')
@@ -304,6 +458,101 @@ describe('FileDocProvider', () => {
       FILE_DOC_EVENTS.JOIN,
       expect.objectContaining({ fileId: 'file-1' })
     )
+  })
+
+  it('resets synced immediately when the socket disconnects', () => {
+    const { provider, doc, fire } = createProvider(true)
+    acceptJoin(fire, doc.clientID)
+    const synced = vi.fn()
+    provider.on('synced', synced)
+    const serverDoc = new Y.Doc()
+    const encoder = encoding.createEncoder()
+    encoding.writeVarUint(encoder, FILE_DOC_MESSAGE_TYPE.SYNC)
+    syncProtocol.writeSyncStep2(encoder, serverDoc)
+    fire(FILE_DOC_EVENTS.MESSAGE, encoding.toUint8Array(encoder))
+    expect(provider.synced).toBe(true)
+
+    const remoteDoc = new Y.Doc()
+    remoteDoc.clientID = 8888
+    const remoteAwareness = new awarenessProtocol.Awareness(remoteDoc)
+    remoteAwareness.setLocalStateField('user', { name: 'Remote' })
+    const awarenessEncoder = encoding.createEncoder()
+    encoding.writeVarUint(awarenessEncoder, FILE_DOC_MESSAGE_TYPE.AWARENESS)
+    encoding.writeVarUint8Array(
+      awarenessEncoder,
+      awarenessProtocol.encodeAwarenessUpdate(remoteAwareness, [remoteDoc.clientID])
+    )
+    fire(FILE_DOC_EVENTS.MESSAGE, encoding.toUint8Array(awarenessEncoder))
+    expect(provider.awareness.getStates().has(remoteDoc.clientID)).toBe(true)
+    synced.mockClear()
+
+    fire('disconnect', 'transport close')
+
+    expect(provider.synced).toBe(false)
+    expect(synced).toHaveBeenCalledWith(false)
+    expect(provider.awareness.getStates().has(remoteDoc.clientID)).toBe(false)
+  })
+
+  it('drops offline awareness emissions and republishes the latest state after rejoining', () => {
+    const { awareness, doc, emit, fire } = createProvider(true)
+    acceptJoin(fire, doc.clientID)
+    fire('disconnect', 'transport close')
+    emit.mockClear()
+
+    awareness.setLocalStateField('user', { name: 'Ada' })
+    awareness.setLocalStateField('selection', { anchor: 4, head: 4 })
+
+    expect(emittedMessages(emit)).toHaveLength(0)
+
+    fire('connect')
+    expect(emittedMessages(emit)).toHaveLength(0)
+    acceptJoin(fire, doc.clientID)
+
+    expect(
+      emittedMessages(emit).some((message) => message[0] === FILE_DOC_MESSAGE_TYPE.AWARENESS)
+    ).toBe(true)
+  })
+
+  it('cancels a scheduled join retry on disconnect', () => {
+    vi.useFakeTimers()
+    try {
+      const { emit, fire } = createProvider(true)
+      fire(FILE_DOC_EVENTS.JOIN_ERROR, {
+        fileId: 'file-1',
+        error: 'Realtime unavailable',
+        code: 'ROOM_MANAGER_UNAVAILABLE',
+        retryable: true,
+      })
+      fire('disconnect', 'transport close')
+      emit.mockClear()
+
+      vi.advanceTimersByTime(10_000)
+
+      expect(emit).not.toHaveBeenCalledWith(FILE_DOC_EVENTS.JOIN, expect.anything())
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels a scheduled join retry when destroyed', () => {
+    vi.useFakeTimers()
+    try {
+      const { provider, emit, fire } = createProvider(true)
+      fire(FILE_DOC_EVENTS.JOIN_ERROR, {
+        fileId: 'file-1',
+        error: 'Realtime unavailable',
+        code: 'ROOM_MANAGER_UNAVAILABLE',
+        retryable: true,
+      })
+      provider.destroy()
+      emit.mockClear()
+
+      vi.advanceTimersByTime(10_000)
+
+      expect(emit).not.toHaveBeenCalledWith(FILE_DOC_EVENTS.JOIN, expect.anything())
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('leaves the room and detaches on destroy', () => {
@@ -394,12 +643,12 @@ describe('FileDocProvider', () => {
   it('does not fire the fallback once the doc is synced AND seeded', () => {
     vi.useFakeTimers()
     try {
-      const { provider, fire } = createProvider(true)
+      const { provider, doc, fire } = createProvider(true)
       const onError = vi.fn()
       provider.on('join-error', onError)
 
       // The initial sync brings BOTH content and the server seed flag before the deadline.
-      fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1' })
+      acceptJoin(fire, doc.clientID)
       const remote = new Y.Doc()
       remote.getText('default').insert(0, 'hi')
       remote.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.flag, true)
@@ -419,13 +668,13 @@ describe('FileDocProvider', () => {
   it('fires the fallback when the doc synced but the server seed never landed', () => {
     vi.useFakeTimers()
     try {
-      const { provider, fire } = createProvider(true)
+      const { provider, doc, fire } = createProvider(true)
       const onError = vi.fn()
       provider.on('join-error', onError)
 
       // The socket syncs an empty doc, but the server-side seed never arrives (its build persistently
       // failed) — `synced` is true yet `initialContentLoaded` is never set.
-      fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1' })
+      acceptJoin(fire, doc.clientID)
       const remote = new Y.Doc()
       const encoder = encoding.createEncoder()
       encoding.writeVarUint(encoder, FILE_DOC_MESSAGE_TYPE.SYNC)
@@ -450,7 +699,7 @@ describe('FileDocProvider', () => {
     vi.useFakeTimers()
     try {
       const { provider, doc, fire } = createProvider(true)
-      fire(FILE_DOC_EVENTS.JOIN_SUCCESS, { fileId: 'file-1' })
+      acceptJoin(fire, doc.clientID)
 
       // Deadline lapses with no first sync → fatal fallback (editor falls back to a read-only seed).
       vi.advanceTimersByTime(12_000)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-doc-provider.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-doc-provider.ts
@@ -12,6 +12,7 @@ import {
   toFileDocBytes,
 } from '@sim/realtime-protocol/file-doc'
 import { ROOM_TYPES } from '@sim/realtime-protocol/rooms'
+import { backoffWithJitter } from '@sim/utils/retry'
 import * as decoding from 'lib0/decoding'
 import * as encoding from 'lib0/encoding'
 import { ObservableV2 } from 'lib0/observable'
@@ -45,6 +46,8 @@ interface FileDocProviderEvents {
  * relay's seed-fetch timeout — see `FILE_DOC_TIMEOUTS` and its ordering test.
  */
 const READINESS_DEADLINE_MS = FILE_DOC_TIMEOUTS.readinessDeadlineMs
+const JOIN_RETRY_BASE_MS = 500
+const JOIN_RETRY_MAX_MS = 5_000
 
 /**
  * Live-provider counts per file, per shared socket. Two surfaces in one tab (the Files editor and the
@@ -112,6 +115,10 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
   private fatal = false
   /** Deadline for reaching readiness (synced + seeded); fires the fallback if it is never reached. */
   private readinessTimer: ReturnType<typeof setTimeout> | null = null
+  private joinAccepted = false
+  private joinPending = false
+  private joinRetryAttempt = 0
+  private joinRetryTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(
     private readonly socket: Socket,
@@ -138,6 +145,7 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     socket.on(FILE_DOC_EVENTS.JOIN_ERROR, this.handleJoinError)
     socket.on(ROOM_ACCESS_REVOKED_EVENT, this.handleAccessRevoked)
     socket.on('connect', this.handleConnect)
+    socket.on('disconnect', this.handleDisconnect)
     doc.on('update', this.handleDocUpdate)
     awareness.on('update', this.handleAwarenessUpdate)
     // Watch the seed flag so reaching "seeded" (server seed applied) can clear the readiness deadline.
@@ -188,10 +196,34 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     }
   }
 
+  private clearJoinRetryTimer() {
+    if (this.joinRetryTimer !== null) {
+      clearTimeout(this.joinRetryTimer)
+      this.joinRetryTimer = null
+    }
+  }
+
   /** Join the room, binding our client id so the server only accepts awareness we own. */
   private join = () => {
-    if (this.fatal) return
+    if (this.fatal || this.disposed || !this.socket.connected || this.joinPending) return
+    this.joinPending = true
     this.socket.emit(FILE_DOC_EVENTS.JOIN, { fileId: this.fileId, clientId: this.doc.clientID })
+  }
+
+  private scheduleJoinRetry() {
+    this.clearJoinRetryTimer()
+    if (this.fatal || this.disposed || !this.socket.connected) return
+    this.joinRetryAttempt += 1
+    this.joinRetryTimer = setTimeout(
+      () => {
+        this.joinRetryTimer = null
+        this.join()
+      },
+      backoffWithJitter(this.joinRetryAttempt, null, {
+        baseMs: JOIN_RETRY_BASE_MS,
+        maxMs: JOIN_RETRY_MAX_MS,
+      })
+    )
   }
 
   /**
@@ -200,8 +232,30 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
    */
   private handleConnect = () => {
     if (this.fatal) return
+    this.clearJoinRetryTimer()
+    this.joinAccepted = false
+    this.joinPending = false
+    this.joinRetryAttempt = 0
     this.setSynced(false)
     this.join()
+  }
+
+  private handleDisconnect = () => {
+    this.clearJoinRetryTimer()
+    this.joinAccepted = false
+    this.joinPending = false
+    this.setSynced(false)
+
+    const remoteClientIds = [...this.awareness.getStates().keys()].filter(
+      (clientId) => clientId !== this.doc.clientID
+    )
+    if (remoteClientIds.length > 0) {
+      awarenessProtocol.removeAwarenessStates(
+        this.awareness,
+        remoteClientIds,
+        'provider-disconnect'
+      )
+    }
   }
 
   /**
@@ -217,7 +271,15 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
    * A reload binds a fresh document and recovers.
    */
   private handleJoinSuccess = (data: JoinFileDocSuccess) => {
-    if (data.fileId !== this.fileId) return
+    if (
+      data.fileId !== this.fileId ||
+      !this.joinPending ||
+      (data.clientId !== undefined && data.clientId !== this.doc.clientID)
+    )
+      return
+    this.joinPending = false
+    this.joinRetryAttempt = 0
+    this.clearJoinRetryTimer()
     const local = this.docId()
     if (local !== undefined && data.docId !== undefined && data.docId !== local) {
       this.failFatally(
@@ -226,6 +288,7 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
       )
       return
     }
+    this.joinAccepted = true
     this.sendSyncStep1()
     this.sendLocalAwareness()
   }
@@ -252,6 +315,9 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     this.fatal = true
     this.joinError = error
     this.clearReadinessTimer()
+    this.clearJoinRetryTimer()
+    this.joinAccepted = false
+    this.joinPending = false
     this.setSynced(false)
     this.emit('join-error', [error])
   }
@@ -262,11 +328,23 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
    * owner fall back to the non-collaborative view.
    */
   private handleJoinError = (data: JoinFileDocError) => {
-    if (data.fileId !== this.fileId) return
+    if (
+      data.fileId !== this.fileId ||
+      !this.joinPending ||
+      (data.clientId !== undefined && data.clientId !== this.doc.clientID)
+    )
+      return
+    this.joinAccepted = false
+    this.joinPending = false
     if (data.retryable === false) {
       this.fatal = true
       this.joinError = data
       this.clearReadinessTimer()
+      this.clearJoinRetryTimer()
+      this.setSynced(false)
+    } else {
+      this.setSynced(false)
+      this.scheduleJoinRetry()
     }
     this.emit('join-error', [data])
   }
@@ -291,7 +369,7 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     // duplicating content — and flip `synced` true, which un-gates autosave and would persist the
     // duplicate back to the real file. `fatal` guarding (re)join alone is not enough; it must also
     // stop applying sync here.
-    if (this.fatal) return
+    if (this.fatal || !this.joinAccepted) return
     const bytes = toFileDocBytes(data)
     if (!bytes) return
 
@@ -327,7 +405,7 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     // the stored content into the doc locally as its read-only fallback. Never relay those local
     // writes — the server never seeded this doc, so echoing them would push unseeded content to peers
     // (and each fallen-back client would do so, union-duplicating). A fatal client is fully local.
-    if (this.fatal) return
+    if (this.fatal || !this.joinAccepted || !this.socket.connected) return
     // Updates we applied from the server carry `this` as origin — don't echo them.
     if (origin === this) return
     // Agent-streamed frames must reach peers (so a collaborator sees the stream live) but must NOT be
@@ -352,7 +430,9 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     // removals for remote peers — forwarding either would be a frame for a client
     // id we don't own, which the server (correctly) rejects. Filter to our own id
     // so honest traffic never trips the ownership guard.
-    if (origin === this) return
+    // Socket.IO buffers emits while disconnected and flushes them before the reconnect callback can
+    // rejoin this room. Suppress those stale frames; the accepted join republishes the latest state.
+    if (origin === this || this.fatal || !this.joinAccepted || !this.socket.connected) return
     const localId = this.doc.clientID
     const changed = [...added, ...updated, ...removed].filter((id) => id === localId)
     if (changed.length === 0) return
@@ -404,6 +484,9 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     }
     this.disposed = true
     this.clearReadinessTimer()
+    this.clearJoinRetryTimer()
+    this.joinAccepted = false
+    this.joinPending = false
 
     awarenessProtocol.removeAwarenessStates(this.awareness, [this.doc.clientID], 'provider-destroy')
 
@@ -417,6 +500,7 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     this.socket.off(FILE_DOC_EVENTS.JOIN_ERROR, this.handleJoinError)
     this.socket.off(ROOM_ACCESS_REVOKED_EVENT, this.handleAccessRevoked)
     this.socket.off('connect', this.handleConnect)
+    this.socket.off('disconnect', this.handleDisconnect)
     this.doc.off('update', this.handleDocUpdate)
     this.doc.getMap(FILE_DOC_SEED.configMap).unobserve(this.handleConfigChange)
     this.awareness.off('update', this.handleAwarenessUpdate)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-doc-provider.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-doc-provider.ts
@@ -485,10 +485,12 @@ export class FileDocProvider extends ObservableV2<FileDocProviderEvents> {
     this.disposed = true
     this.clearReadinessTimer()
     this.clearJoinRetryTimer()
-    this.joinAccepted = false
     this.joinPending = false
 
+    // Publish our final awareness removal while this provider is still admitted. A co-mounted sibling
+    // keeps the socket in the room, so LEAVE cannot clear this provider's caret on its behalf.
     awarenessProtocol.removeAwarenessStates(this.awareness, [this.doc.clientID], 'provider-destroy')
+    this.joinAccepted = false
 
     // Only actually leave the room when this was the last provider for the file on the shared socket —
     // otherwise a sibling surface (e.g. the Files editor vs. the embedded chat panel) would be stranded.

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { type CollabReadinessInputs, nextCollabReadiness } from './readiness'
+import { type CollabReadinessInputs, isCollabReady } from './readiness'
 
 /** An observation, with the healthy defaults filled in so each case states only what it exercises. */
 const at = (input: Partial<CollabReadinessInputs>): CollabReadinessInputs => ({
@@ -13,112 +13,28 @@ const at = (input: Partial<CollabReadinessInputs>): CollabReadinessInputs => ({
   ...input,
 })
 
-/** Drive a sequence of observations through the latch, returning the readiness at each step. */
-function run(steps: Partial<CollabReadinessInputs>[]): boolean[] {
-  let syncedOnce = false
-  return steps.map((step) => {
-    const next = nextCollabReadiness(syncedOnce, at(step))
-    syncedOnce = next.syncedOnce
-    return next.ready
-  })
-}
-
-describe('nextCollabReadiness', () => {
+describe('isCollabReady', () => {
   it('is not ready before syncing or seeding', () => {
-    const { syncedOnce, ready } = nextCollabReadiness(
-      false,
-      at({
-        synced: false,
-        seeded: false,
-        offlineSeed: false,
-      })
-    )
-    expect(syncedOnce).toBe(false)
-    expect(ready).toBe(false)
+    expect(isCollabReady(at({ synced: false, seeded: false, offlineSeed: false }))).toBe(false)
   })
 
   it('is not ready when synced but not yet seeded', () => {
-    const { syncedOnce, ready } = nextCollabReadiness(
-      false,
-      at({
-        synced: true,
-        seeded: false,
-        offlineSeed: false,
-      })
-    )
-    expect(syncedOnce).toBe(true) // latched
-    expect(ready).toBe(false) // waits for the seed
+    expect(isCollabReady(at({ synced: true, seeded: false, offlineSeed: false }))).toBe(false)
   })
 
-  it('opens on the new-file flap sequence: synced true, then seed lands while synced flapped false', () => {
-    // The exact bug: `synced` and `seeded` are never true in the same observation. The latch must still
-    // open once BOTH have been seen across observations.
-    const readiness = run([
-      { synced: false, seeded: false, offlineSeed: false }, // joining
-      { synced: true, seeded: false, offlineSeed: false }, // initial (empty) sync
-      { synced: false, seeded: false, offlineSeed: false }, // synced flaps false on re-sync
-      { synced: false, seeded: true, offlineSeed: false }, // server seed lands (synced still false)
-    ])
-    expect(readiness).toEqual([false, false, false, true])
+  it('is ready only when the current session is synced and the server seed is present', () => {
+    expect(isCollabReady(at({ synced: true, seeded: true }))).toBe(true)
   })
 
-  it('opens even if the seed lands before we ever observed synced (server seed proves a sync)', () => {
-    // If the flap beat our first observation, the seed flag alone (not the offline fallback) proves a
-    // completed sync happened.
-    const { syncedOnce, ready } = nextCollabReadiness(
-      false,
-      at({
-        synced: false,
-        seeded: true,
-        offlineSeed: false,
-      })
-    )
-    expect(syncedOnce).toBe(true)
-    expect(ready).toBe(true)
+  it('closes readiness as soon as the current session loses sync', () => {
+    expect(isCollabReady(at({ synced: false, seeded: true }))).toBe(false)
   })
 
   it('stays read-only for an offline (local) seed that never reached the server', () => {
-    const readiness = run([
-      { synced: false, seeded: false, offlineSeed: false },
-      { synced: false, seeded: true, offlineSeed: true }, // offline fallback seeded locally
-    ])
-    expect(readiness).toEqual([false, false])
+    expect(isCollabReady(at({ synced: true, seeded: true, offlineSeed: true }))).toBe(false)
   })
 
-  it('never reverts once ready, even if synced later flaps false', () => {
-    const readiness = run([
-      { synced: true, seeded: true, offlineSeed: false }, // ready
-      { synced: false, seeded: true, offlineSeed: false }, // synced flaps — must stay ready
-    ])
-    expect(readiness).toEqual([true, true])
-  })
-  /**
-   * The reported bug. A brand-new file syncs EMPTY (latching `syncedOnce`), its server seed never
-   * lands, and the readiness deadline fires: the provider goes fatal and drops `synced` precisely so
-   * this gate closes. The offline fallback then seeds locally — and the sticky latch used to re-open
-   * the gate on that, handing back an editable editor bound to a document the provider had abandoned.
-   * Every keystroke was dropped (the provider ignores frames and never rejoins) and client autosave
-   * stayed off (collaboration is nominally on), so the edits vanished on reload with no error shown.
-   */
-  it('stays read-only after the readiness deadline goes fatal, even though a sync was latched', () => {
-    const readiness = run([
-      { synced: false },
-      { synced: true }, // initial EMPTY sync — latches syncedOnce
-      { synced: false, fatal: true }, // deadline: provider drops synced and gives up
-      { seeded: true, offlineSeed: true, fatal: true }, // fallback seeds locally
-    ])
-    expect(readiness).toEqual([false, false, false, false])
-  })
-
-  /**
-   * The same revocation on an ALREADY-ready doc: access is withdrawn mid-session, the provider goes
-   * fatal, and readiness must be taken back rather than left latched open.
-   */
   it('revokes readiness when a live document turns fatal', () => {
-    const readiness = run([
-      { synced: true, seeded: true }, // ready
-      { synced: false, seeded: true, fatal: true }, // access revoked mid-session
-    ])
-    expect(readiness).toEqual([true, false])
+    expect(isCollabReady(at({ synced: true, seeded: true, fatal: true }))).toBe(false)
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness.ts
@@ -1,22 +1,7 @@
-/**
- * Collaborative-readiness latch for the file editor.
- *
- * A file becomes "ready" (editable + agent streaming enabled) once its shared doc has both SYNCED and
- * SEEDED. The subtlety this latch solves: a brand-new file's provider reports `synced: true` on the
- * initial (empty) sync, then the SERVER pushes the seed and receiving that update flips `synced` back to
- * `false` — so `synced` and `seeded` are never `true` in the same observation. An un-latched
- * `synced && seeded` gate would therefore never open, and agent streaming would be dropped for the whole
- * run (the file only fills in on reload).
- *
- * The latch: `syncedOnce` is sticky — set the first time a completed sync is observed, and it never
- * reverts. A completed sync is proven by EITHER a live `synced`, OR the seed flag being present without
- * the offline fallback having set it (`offlineSeed`) — because a SERVER seed can only arrive after a
- * sync, whereas the offline fallback seeds locally without ever reaching the server and must stay
- * read-only. Once `syncedOnce` is set, a later `synced` flap can no longer re-gate the doc.
- */
+/** Inputs that determine whether the collaborative editor can currently accept writes. */
 
 export interface CollabReadinessInputs {
-  /** The provider's current `synced` flag (may flap false after the seed update). */
+  /** The provider's current-session synchronization state. */
   synced: boolean
   /** Whether the shared doc carries the seed flag. */
   seeded: boolean
@@ -30,24 +15,7 @@ export interface CollabReadinessInputs {
   fatal: boolean
 }
 
-/**
- * Pure transition for the readiness latch. `syncedOnce` is the sticky prior state — pass the returned
- * `syncedOnce` back in on the next call. `ready` is whether the doc is synced-and-seeded.
- *
- * `fatal` overrides the latch, and that override is the whole reason it is an input. The latch is
- * sticky on purpose, but stickiness must not outlive the document: a doc that syncs empty and never
- * receives its server seed trips the readiness deadline, and the provider answers by dropping `synced`
- * so this gate closes. The latch ignored that — `syncedOnce` was already set by the empty sync — so the
- * offline fallback's seed flag re-opened the gate and handed back an EDITABLE editor on a document the
- * provider had already abandoned. Nothing typed into it could persist: the provider drops every frame
- * and never rejoins, and the client's own autosave stays gated off because collaboration is nominally
- * on. The user types, sees no error, and loses the edits on reload. Revoking readiness on `fatal` is
- * what makes the fallback what it is documented to be — a READ-ONLY view of the stored content.
- */
-export function nextCollabReadiness(
-  syncedOnce: boolean,
-  input: CollabReadinessInputs
-): { syncedOnce: boolean; ready: boolean } {
-  const next = syncedOnce || input.synced || (input.seeded && !input.offlineSeed)
-  return { syncedOnce: next, ready: next && input.seeded && !input.fatal }
+/** A document is writable only while this connection has synced the server-seeded Yjs document. */
+export function isCollabReady(input: CollabReadinessInputs): boolean {
+  return input.synced && input.seeded && !input.offlineSeed && !input.fatal
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/use-file-doc-collaboration.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/use-file-doc-collaboration.ts
@@ -141,9 +141,12 @@ export function useFileDocCollaboration({
       }
       reportOthersRef.current([...byUser.values()])
     }
+    const handleDisconnect = () => reportOthersRef.current([])
     socket.on(FILE_DOC_EVENTS.PRESENCE, handlePresence)
+    socket.on('disconnect', handleDisconnect)
     return () => {
       socket.off(FILE_DOC_EVENTS.PRESENCE, handlePresence)
+      socket.off('disconnect', handleDisconnect)
       reportOthersRef.current([])
     }
   }, [enabled, socket, fileId])

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
@@ -1,10 +1,13 @@
 /** @vitest-environment jsdom */
 import { act, Suspense, startTransition } from 'react'
 import { toast } from '@sim/emcn'
+import { FILE_DOC_SEED, type JoinFileDocError } from '@sim/realtime-protocol/file-doc'
 import { PASTE_RENDER_THRESHOLDS } from '@sim/utils/paste'
 import { type Editor, Extension } from '@tiptap/core'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Awareness } from 'y-protocols/awareness'
+import * as Y from 'yjs'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
 import { ImageUploadPlaceholders } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload'
@@ -14,7 +17,10 @@ import {
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission'
 import { LoadedRichMarkdownEditor } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor'
 
-const { uploadFile } = vi.hoisted(() => ({ uploadFile: vi.fn() }))
+const { collaborationRef, uploadFile } = vi.hoisted(() => ({
+  collaborationRef: { current: null as unknown },
+  uploadFile: vi.fn(),
+}))
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
 vi.mock('@/lib/auth/auth-client', () => ({ useSession: () => ({ data: null, isPending: false }) }))
@@ -52,7 +58,7 @@ vi.mock(
 )
 vi.mock(
   '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/use-file-doc-collaboration',
-  () => ({ useFileDocCollaboration: () => null })
+  () => ({ useFileDocCollaboration: () => collaborationRef.current })
 )
 vi.mock(
   '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/find',
@@ -107,7 +113,38 @@ function SuspendAfterEditor({ active }: SuspendAfterEditorProps) {
   return null
 }
 
+class FakeFileDocProvider {
+  synced = false
+  joinError: JoinFileDocError | null = null
+  private readonly listeners = new Map<string, Set<(value: unknown) => void>>()
+
+  on(event: string, listener: (value: unknown) => void) {
+    let eventListeners = this.listeners.get(event)
+    if (!eventListeners) {
+      eventListeners = new Set()
+      this.listeners.set(event, eventListeners)
+    }
+    eventListeners.add(listener)
+  }
+
+  off(event: string, listener: (value: unknown) => void) {
+    this.listeners.get(event)?.delete(listener)
+  }
+
+  setSynced(synced: boolean) {
+    this.synced = synced
+    for (const listener of this.listeners.get('synced') ?? []) listener(synced)
+  }
+
+  fail(error: JoinFileDocError) {
+    this.joinError = error
+    this.synced = false
+    for (const listener of this.listeners.get('join-error') ?? []) listener(error)
+  }
+}
+
 interface RenderOptions {
+  collaborative?: boolean
   onChange?: typeof onChange
   onSaveShortcut?: typeof onSaveShortcut
   suspend?: boolean
@@ -132,6 +169,7 @@ async function render(
             canEdit={canEdit}
             userId='user-1'
             userName='User'
+            collaborative={options.collaborative}
             enableFind={false}
             onChange={options.onChange ?? onChange}
             onEditSource={onEditSource}
@@ -169,6 +207,7 @@ async function pasteImage(editor: Editor) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  collaborationRef.current = null
   vi.spyOn(toast, 'warning').mockReturnValue('test-toast')
   vi.spyOn(toast, 'info').mockReturnValue('uploading-toast')
   vi.spyOn(toast, 'dismiss').mockImplementation(() => {})
@@ -184,6 +223,99 @@ afterEach(async () => {
 })
 
 describe('loaded rich editor lifecycle', () => {
+  it('pauses editing while reconnecting and resumes after the document resyncs', async () => {
+    const provider = new FakeFileDocProvider()
+    const doc = new Y.Doc()
+    doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.flag, true)
+    collaborationRef.current = {
+      doc,
+      awareness: new Awareness(doc),
+      provider,
+      user: { name: 'User', color: '#000000', clientId: doc.clientID },
+    }
+    await render('body', 'body', true, { collaborative: true })
+
+    await act(async () => provider.setSynced(true))
+    const editor = getEditor()
+    expect(editor.isEditable).toBe(true)
+
+    await act(async () => editor.commands.insertContent('local change '))
+    await act(async () => provider.setSynced(false))
+
+    expect(editor.isEditable).toBe(false)
+    expect(editor.view.dom.getAttribute('aria-readonly')).toBe('true')
+    expect(editor.getText()).toContain('local change')
+    expect(container.textContent).toContain('Reconnecting…')
+    expect(editor.view.dom.closest('.hidden')).toBeNull()
+
+    await act(async () => provider.setSynced(true))
+
+    expect(editor.isEditable).toBe(true)
+    expect(editor.view.dom.getAttribute('aria-readonly')).toBe('false')
+    expect(container.textContent).not.toContain('Reconnecting…')
+  })
+
+  it('keeps the live document visible and read-only after a fatal collaboration error', async () => {
+    const provider = new FakeFileDocProvider()
+    const doc = new Y.Doc()
+    doc.getMap(FILE_DOC_SEED.configMap).set(FILE_DOC_SEED.flag, true)
+    collaborationRef.current = {
+      doc,
+      awareness: new Awareness(doc),
+      provider,
+      user: { name: 'User', color: '#000000', clientId: doc.clientID },
+    }
+    await render('stale opening snapshot', 'stale opening snapshot', true, { collaborative: true })
+
+    await act(async () => provider.setSynced(true))
+    const editor = getEditor()
+    await act(async () => editor.commands.insertContent('live local change'))
+
+    await act(async () =>
+      provider.fail({
+        fileId: 'file-1',
+        error: 'Access denied',
+        code: 'ACCESS_DENIED',
+        retryable: false,
+      })
+    )
+
+    expect(editor.isEditable).toBe(false)
+    expect(editor.view.dom.getAttribute('aria-readonly')).toBe('true')
+    expect(editor.getText()).toContain('live local change')
+    expect(editor.view.dom.closest('.hidden')).toBeNull()
+    expect(container.textContent).not.toContain('stale opening snapshot')
+    expect(container.textContent).not.toContain('Reconnecting…')
+  })
+
+  it('shows stored content read-only when collaboration fails before the first sync', async () => {
+    const provider = new FakeFileDocProvider()
+    const doc = new Y.Doc()
+    collaborationRef.current = {
+      doc,
+      awareness: new Awareness(doc),
+      provider,
+      user: { name: 'User', color: '#000000', clientId: doc.clientID },
+    }
+    await render('stored body', 'stored body', true, { collaborative: true })
+
+    await act(async () =>
+      provider.fail({
+        fileId: 'file-1',
+        error: 'Access denied',
+        code: 'ACCESS_DENIED',
+        retryable: false,
+      })
+    )
+
+    const editor = getEditor()
+    expect(editor.isEditable).toBe(false)
+    expect(editor.view.dom.getAttribute('aria-readonly')).toBe('true')
+    expect(editor.getText()).toContain('stored body')
+    expect(editor.view.dom.closest('.hidden')).toBeNull()
+    expect(container.textContent).not.toContain('Reconnecting…')
+  })
+
   it('explains a picker selection whose insertion anchor was invalidated', async () => {
     await render('before TARGET after')
     const editor = getEditor()

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -30,7 +30,7 @@ import {
   beginAgentStream,
   endAgentStream,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/apply-streamed-markdown'
-import { nextCollabReadiness } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness'
+import { isCollabReady } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness'
 import { useFileDocCollaboration } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/use-file-doc-collaboration'
 import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
 import { useMarkdownFind } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/find'
@@ -363,6 +363,8 @@ interface LoadedRichMarkdownEditorProps {
   onEditSource?: () => void
 }
 
+type CollaborationStatus = 'connecting' | 'ready' | 'reconnecting' | 'fatal'
+
 interface SettledContent {
   frontmatter: string
   verdict: boolean
@@ -437,7 +439,10 @@ export function LoadedRichMarkdownEditor({
    * autosave gated until the shared content has arrived (a user must not type into an
    * empty, unsynced doc, which the seed would then discard) — and `true` for a local one.
    */
-  const [collabReady, setCollabReady] = useState(!collaborationEnabled)
+  const [collabStatus, setCollabStatus] = useState<CollaborationStatus>(() =>
+    collaborationEnabled ? 'connecting' : 'ready'
+  )
+  const collabReady = collabStatus === 'ready'
   const isEditable = canEdit && !isStreaming && (settled?.verdict ?? false) && collabReady
 
   const collaboration = useFileDocCollaboration({
@@ -859,9 +864,13 @@ export function LoadedRichMarkdownEditor({
      * document that was already correct, and it opens mid-flight anyway whenever the updates arrive
      * more than a frame apart (which is what a remote Redis and a long room history produce).
      */
-    const setReady = (ready: boolean) => {
+    const setReady = (ready: boolean, fatal = false) => {
       // Child-local: gates editability (a user must never type into an unsynced/unseeded doc).
-      setCollabReady(ready)
+      setCollabStatus((previous) => {
+        if (fatal) return 'fatal'
+        if (ready) return 'ready'
+        return previous === 'ready' || previous === 'reconnecting' ? 'reconnecting' : 'connecting'
+      })
       // Parent: gates CLIENT autosave. In a collaborative session the relay persists the doc to
       // markdown server-side (debounced + on last-disconnect), so the client must NOT also autosave —
       // a stale keystroke saving over a server/copilot edit is the clobber the server path closes.
@@ -879,9 +888,6 @@ export function LoadedRichMarkdownEditor({
     }
     const config = doc.getMap(FILE_DOC_SEED.configMap)
 
-    // Readiness LATCHES so a post-seed `synced` flap can't re-gate a new file's agent stream — see
-    // {@link nextCollabReadiness} for the full rationale. `offlineSeed` marks a local (read-only) seed.
-    let syncedOnce = false
     let offlineSeed = false
 
     const seedFromLoaded = () => {
@@ -907,9 +913,7 @@ export function LoadedRichMarkdownEditor({
       // `joinError` is latched ONLY on the provider's fatal paths (non-retryable rejection, access
       // revocation, readiness deadline), so it is exactly "this document is abandoned".
       const fatal = provider.joinError !== null
-      const next = nextCollabReadiness(syncedOnce, { synced, seeded, offlineSeed, fatal })
-      syncedOnce = next.syncedOnce
-      setReady(next.ready)
+      setReady(isCollabReady({ synced, seeded, offlineSeed, fatal }), fatal)
     }
     /**
      * Re-report unconditionally, not just when the fallback seeds. A fatal that arrives on an ALREADY
@@ -936,7 +940,7 @@ export function LoadedRichMarkdownEditor({
       // ungate it while the doc is unready.
       onClientAutosaveChange(false)
     }
-  }, [collaboration, editor, onClientAutosaveChange, setCollabReady])
+  }, [collaboration, editor, onClientAutosaveChange])
 
   /**
    * Owns editability for the collaborative lifecycle: `useEditor`'s `editable` is only the initial
@@ -1307,11 +1311,9 @@ export function LoadedRichMarkdownEditor({
 
   useSelectionCopyBridge(containerRef, buildSelectionContext, workspaceId)
 
-  // Show the read-only placeholder (the already-fetched markdown) whenever a collaborative doc has not yet
-  // seeded — including during an agent stream that begins before the seed lands. Streamed diffs are held
-  // until `collabReady` (see the streaming effect), so before then the editor is empty; the placeholder
-  // shows the base content until the seed swaps it in, avoiding both a blank frame and a garbled merge.
-  const showPlaceholder = collaborationEnabled && !collabReady
+  /** Use the stored-content placeholder only while the live document is bootstrapping. */
+  const showPlaceholder = collaborationEnabled && collabStatus === 'connecting'
+  const showReconnecting = collaborationEnabled && collabStatus === 'reconnecting'
 
   /**
    * Find is off while the placeholder is up. The text on screen then belongs to the placeholder's own
@@ -1334,6 +1336,15 @@ export function LoadedRichMarkdownEditor({
             This document needs source editing to preserve its content or handle its size.
           </p>
           <Chip onClick={onEditSource}>Edit source</Chip>
+        </div>
+      )}
+      {showReconnecting && (
+        <div
+          role='status'
+          aria-live='polite'
+          className='border-[var(--border)] border-b px-4 py-2 text-[var(--text-muted)] text-small'
+        >
+          Reconnecting…
         </div>
       )}
       {find.isOpen && (

--- a/packages/realtime-protocol/src/file-doc.ts
+++ b/packages/realtime-protocol/src/file-doc.ts
@@ -139,6 +139,8 @@ export interface JoinFileDocPayload {
 /** Server → client acceptance of a {@link FILE_DOC_EVENTS.JOIN}. */
 export interface JoinFileDocSuccess {
   fileId: string
+  /** The provider whose join was accepted. Optional while older relays are still deployed. */
+  clientId?: number
   /**
    * The identity of the document this room holds ({@link FILE_DOC_SEED.docIdKey}), so a client can tell
    * "the room I left" from "a document built in its place" BEFORE it syncs. Absent for a room whose doc
@@ -151,6 +153,8 @@ export interface JoinFileDocSuccess {
 /** Server → client rejection of a {@link FILE_DOC_EVENTS.JOIN}. */
 export interface JoinFileDocError {
   fileId: string
+  /** The provider whose join failed. Optional when the payload did not contain a valid client id. */
+  clientId?: number
   error: string
   code: string
   retryable?: boolean


### PR DESCRIPTION
## Summary
- pause editing while a collaborative document reconnects while keeping the live draft visible
- retry transient room joins with bounded backoff and resume only after the current document re-syncs
- scope room join results per provider and keep co-mounted editors synchronized on a shared socket
- clear stale collaborator presence and suppress offline awareness frames until the room is rejoined

## Type of Change
- [x] Bug fix

## Testing
- [x] 891 rich-markdown editor tests
- [x] 288 realtime tests
- [x] affected TypeScript type checks
- [x] repository lint and 45 repository audits

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)