### PR TITLE
test(file-editor): use canonical readiness import

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness.test.ts
@@ -2,7 +2,10 @@
  * @vitest-environment node
  */
 import { describe, expect, it } from 'vitest'
-import { type CollabReadinessInputs, isCollabReady } from './readiness'
+import {
+  type CollabReadinessInputs,
+  isCollabReady,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/readiness'
 
 /** An observation, with the healthy defaults filled in so each case states only what it exercises. */
 const at = (input: Partial<CollabReadinessInputs>): CollabReadinessInputs => ({


### PR DESCRIPTION
## Summary
- use the repository-standard absolute `@/` import in the collaboration readiness test
- close the final review finding from #7491 without changing runtime behavior

## Validation
- `bunx vitest run app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor` (58 files, 892 tests)
- `bun run type-check` (`apps/sim`)
- `bun run lint:check`
- `bun run check:audits` (45/45)