### PR TITLE
chore(typescript): assert native TS7 per workspace and drop a dead install exemption

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,11 +3,6 @@ exact = true
 # Supply-chain gate: only install package versions published at least 7 days ago
 # (blocks freshly published, potentially compromised releases).
 minimumReleaseAge = 604800
-# @typescript/native-preview stays excluded permanently: it only publishes nightly
-# dev builds, so every version is structurally younger than any age gate.
-minimumReleaseAgeExcludes = [
-  "@typescript/native-preview",
-]
 
 [run]
 env = { NEXT_PUBLIC_APP_URL = "http://localhost:3000" }

--- a/scripts/check-native-typecheck.ts
+++ b/scripts/check-native-typecheck.ts
@@ -25,21 +25,40 @@ import { Glob } from 'bun'
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
-/** The `tsc` a bare invocation in `dir` would run: nearest `node_modules/.bin`, walking up. */
+/**
+ * The `tsc` a bare invocation in `dir` would run: nearest `node_modules/.bin`, walking up.
+ *
+ * The walk stops at the repository root even when nothing is found there. A machine that happens
+ * to have a TypeScript 7 above the checkout would otherwise satisfy every workspace and let the
+ * audit pass with `@typescript/native` deleted — the one thing it exists to catch.
+ */
 function resolveTsc(dir: string): string | null {
   let current = dir
   while (true) {
     const candidate = path.join(current, 'node_modules', '.bin', 'tsc')
     if (existsSync(candidate)) return candidate
+    if (current === ROOT) return null
     const parent = path.dirname(current)
-    if (parent === current || !current.startsWith(ROOT)) return null
+    if (parent === current) return null
     current = parent
   }
 }
 
+/** Read from the manifest rather than restating its globs, so a new workspace pattern is covered. */
+function workspacePatterns(): string[] {
+  const manifest = require(path.join(ROOT, 'package.json'))
+  const declared = Array.isArray(manifest.workspaces)
+    ? manifest.workspaces
+    : (manifest.workspaces?.packages ?? [])
+  if (declared.length === 0) throw new Error('Root package.json declares no workspaces')
+  return declared
+}
+
 const workspaceDirs = [
   '.',
-  ...[...new Glob('{apps,packages}/*/package.json').scanSync(ROOT)].map(path.dirname),
+  ...workspacePatterns().flatMap((pattern) =>
+    [...new Glob(`${pattern}/package.json`).scanSync(ROOT)].map(path.dirname)
+  ),
 ].sort()
 
 const failures: string[] = []

--- a/scripts/check-native-typecheck.ts
+++ b/scripts/check-native-typecheck.ts
@@ -1,29 +1,74 @@
 #!/usr/bin/env bun
 /**
- * Asserts that a bare `tsc` runs the native (Go) TypeScript 7 compiler.
+ * Asserts that every workspace's bare `tsc` runs the native (Go) TypeScript 7 compiler.
  *
- * `@typescript/typescript6` (needed for apps/sim's runtime TypeScript API) pulls in an alias of
- * `typescript@6` that declares its own `tsc` bin. Package managers pick bin winners by lexical
- * sort, not dependency depth, so it wins `node_modules/.bin/tsc` unless something sorts ahead —
- * which is the only job the root `@typescript/native` alias has. Nothing imports that alias, so
- * deleting it looks free and silently costs every `tsc` in the repo ~10x.
+ * `@typescript/typescript6` (needed for apps/sim's runtime TypeScript API, and for the audit
+ * scripts that read the stable compiler API) pulls in an alias of `typescript@6` that declares
+ * its own `tsc` bin. Package managers pick bin winners by lexical sort, not dependency depth, so
+ * it wins `node_modules/.bin/tsc` unless something sorts ahead — which is the only job the root
+ * `@typescript/native` alias has. Nothing imports that alias, so deleting it looks free and
+ * silently costs every `tsc` in the repo ~10x.
+ *
+ * Every workspace's `type-check` is a bare `tsc --noEmit`, which resolves through the nearest
+ * `node_modules/.bin` walking up from that package. They all reach the root bin today, but a
+ * workspace that installs anything shipping its own `tsc` would get a local one that shadows it —
+ * invisible to a root-only assertion, and slow in exactly the same silent way. So each workspace
+ * is resolved the way its own script would.
  *
  * @see https://github.com/microsoft/typescript-go/issues/4567
  */
 import { spawnSync } from 'node:child_process'
-import { localBin } from './local-bin'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Glob } from 'bun'
 
-const result = spawnSync(localBin('tsc'), ['--version'], { encoding: 'utf8' })
-const reported = result.stdout?.trim() ?? ''
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
-if (!/^Version 7\./.test(reported)) {
-  const detail = reported || result.stderr?.trim() || `exit ${result.status}`
+/** The `tsc` a bare invocation in `dir` would run: nearest `node_modules/.bin`, walking up. */
+function resolveTsc(dir: string): string | null {
+  let current = dir
+  while (true) {
+    const candidate = path.join(current, 'node_modules', '.bin', 'tsc')
+    if (existsSync(candidate)) return candidate
+    const parent = path.dirname(current)
+    if (parent === current || !current.startsWith(ROOT)) return null
+    current = parent
+  }
+}
+
+const workspaceDirs = [
+  '.',
+  ...[...new Glob('{apps,packages}/*/package.json').scanSync(ROOT)].map(path.dirname),
+].sort()
+
+const failures: string[] = []
+
+for (const workspace of workspaceDirs) {
+  const tsc = resolveTsc(path.join(ROOT, workspace))
+  if (!tsc) {
+    failures.push(`${workspace}: no \`tsc\` resolvable from this package`)
+    continue
+  }
+  const result = spawnSync(tsc, ['--version'], { encoding: 'utf8' })
+  const reported = result.stdout?.trim() ?? ''
+  if (!/^Version 7\./.test(reported)) {
+    const detail = reported || result.stderr?.trim() || `exit ${result.status}`
+    failures.push(`${workspace}: ${path.relative(ROOT, tsc)} reports "${detail}"`)
+  }
+}
+
+if (failures.length > 0) {
   console.error(
-    `Native type-check audit failed: node_modules/.bin/tsc reports "${detail}", expected TypeScript 7.x.\n\n` +
+    `Native type-check audit failed — expected TypeScript 7.x everywhere:\n\n${failures
+      .map((failure) => `  ${failure}`)
+      .join('\n')}\n\n` +
       '  Check that `@typescript/native` is still in the root devDependencies, and that no newly\n' +
       '  added package sorts ahead of it while declaring a `tsc` bin.'
   )
   process.exit(1)
 }
 
-console.log(`Native type-check audit passed (bare \`tsc\` is ${reported}).`)
+console.log(
+  `Native type-check audit passed (bare \`tsc\` is TypeScript 7.x in ${workspaceDirs.length} workspaces).`
+)


### PR DESCRIPTION
## Summary
- Drop the dead `@typescript/native-preview` entry from the install age-gate allowlist
- Assert the native TypeScript 7 compiler in **every** workspace, not just the repo root

## The allowlist entry was dead
`bunfig.toml` excluded `@typescript/native-preview` from `minimumReleaseAge`, on the grounds that it only publishes nightly builds and so can never satisfy an age gate. That was true of the package, but the repo does not depend on it: the root uses `@typescript/native` (an alias of `typescript@^7.0.2`), and `native-preview` appears in no `package.json` and no `bun.lock` entry — the only two mentions in the entire repo were the exclude and its own comment.

An allowlist entry that names nothing still weakens the gate, because it is a standing exemption waiting for a package of that name to appear. Removed; `bun install --frozen-lockfile` still succeeds, which is what proves nothing was relying on it.

The gate itself, and its 7-day window, are unchanged.

## The guard only covered the root
`check:native-typecheck` exists because `@typescript/typescript6` pulls in an alias of `typescript@6` that ships its own `tsc` bin, and bin winners are picked by lexical sort rather than dependency depth — so a bare `tsc` silently drops to the ~10x slower JavaScript compiler unless `@typescript/native` sorts ahead of it.

It asserted that on `node_modules/.bin/tsc` alone. But every workspace's `type-check` is a bare `tsc --noEmit`, which resolves through the nearest `node_modules/.bin` walking up from that package. All 29 reach the root bin today, so the root-only assertion happened to be sufficient — but a workspace that installed anything shipping its own `tsc` would get a local bin that shadows the root one, in exactly the same silent way, and the audit would still pass.

The guard now resolves `tsc` per workspace the way each script would, and names the offending package and path when one disagrees. Verified by planting a stub reporting `Version 6.0.2` in `apps/sim/node_modules/.bin`: the previous guard passed, this one fails with `apps/sim: apps/sim/node_modules/.bin/tsc reports "Version 6.0.2"`.

## Why `@typescript/typescript6` stays
Worth recording, since removing it would dissolve the whole bin-shadowing problem. It cannot go: four audit scripts (`check-pending-drop-tables`, `check-sql-date-binding`, `check-tool-request-boundary`, `check-egress-boundary`) and `apps/sim`'s Function-block runtime read the stable compiler API — `createSourceFile`, `createScanner`, `forEachChild`, `SyntaxKind`.

`typescript@7` exposes no equivalent from its root entry point (that is `lib/version.cjs`); its compiler API lives entirely under `./unstable/*` subpaths. Moving five consumers — one of which transpiles user-supplied code in production — onto a surface the package itself labels unstable is not a trade worth making for a dependency cleanup.

## Type of Change
- [x] Chore (tooling)

## Testing
- `bun run check:native-typecheck` passes across 29 workspaces, and fails as intended against a planted shadowing bin.
- `bun install --frozen-lockfile` succeeds with the allowlist entry removed; `bun.lock` is unchanged.
- Full suite, `bun run check:audits`, `bunx turbo run type-check`, `bun run lint`, `bun run docs-manifest:check`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
