### PR TITLE
feat(analytics): fire the Google Ads demo-booked conversion on Cal.com booking success

### DIFF
--- a/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.test.tsx
+++ b/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.test.tsx
@@ -5,21 +5,30 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockCal, mockCalComponent, mockConsent, mockGetCalApi, mockTrackGoogleEvent } = vi.hoisted(
-  () => ({
-    mockCal: vi.fn(),
-    mockCalComponent: vi.fn(() => null),
-    mockConsent: { marketing: true, measurement: true },
-    mockGetCalApi: vi.fn(),
-    mockTrackGoogleEvent: vi.fn(),
-  })
-)
+const {
+  mockCal,
+  mockCalComponent,
+  mockConsent,
+  mockGetCalApi,
+  mockTrackGoogleAdsConversion,
+  mockTrackGoogleEvent,
+} = vi.hoisted(() => ({
+  mockCal: vi.fn(),
+  mockCalComponent: vi.fn(() => null),
+  mockConsent: { marketing: true, measurement: true },
+  mockGetCalApi: vi.fn(),
+  mockTrackGoogleAdsConversion: vi.fn(),
+  mockTrackGoogleEvent: vi.fn(),
+}))
 
 vi.mock('@calcom/embed-react', () => ({
   default: mockCalComponent,
   getCalApi: mockGetCalApi,
 }))
-vi.mock('@/lib/analytics/google', () => ({ trackGoogleEvent: mockTrackGoogleEvent }))
+vi.mock('@/lib/analytics/google', () => ({
+  trackGoogleAdsConversion: mockTrackGoogleAdsConversion,
+  trackGoogleEvent: mockTrackGoogleEvent,
+}))
 vi.mock('@/lib/consent/scripts', () => ({ X_DEMO_BOOKED_EVENT_ID: 'demo-booked' }))
 vi.mock('@/lib/consent/tracking-consent', () => ({
   useTrackingConsent: () => mockConsent,
@@ -35,6 +44,18 @@ const LEAD = {
   name: 'Ada Lovelace',
   email: 'ada@example.com',
   notes: 'Company: Analytical Engines\nTopic: Demo',
+}
+
+interface BookingRegistration {
+  action: string
+  callback: () => void
+}
+
+/** The listener the scheduler registered with the Cal.com embed, if any. */
+function bookingRegistration(): BookingRegistration | undefined {
+  return mockCal.mock.calls.find(([method]) => method === 'on')?.[1] as
+    | BookingRegistration
+    | undefined
 }
 
 describe('DemoScheduler', () => {
@@ -101,9 +122,7 @@ describe('DemoScheduler', () => {
       await Promise.resolve()
     })
 
-    const registration = mockCal.mock.calls.find(([method]) => method === 'on')?.[1] as
-      | { action: string; callback: () => void }
-      | undefined
+    const registration = bookingRegistration()
     expect(registration?.action).toBe('bookingSuccessfulV2')
 
     registration?.callback()
@@ -112,6 +131,7 @@ describe('DemoScheduler', () => {
       form_name: 'sim_demo',
       booking_status: 'scheduled',
     })
+    expect(mockTrackGoogleAdsConversion).toHaveBeenCalledWith('demo_booked')
     expect(trackXEvent).toHaveBeenCalledWith('event', 'demo-booked', {})
 
     await act(async () => {
@@ -123,6 +143,23 @@ describe('DemoScheduler', () => {
       callback: registration?.callback,
     })
     root = createRoot(container)
+  })
+
+  it('sends measurement analytics but no ad conversion without marketing consent', async () => {
+    mockConsent.marketing = false
+    const trackXEvent = vi.fn()
+    window.twq = trackXEvent
+
+    await act(async () => {
+      root.render(<DemoScheduler lead={LEAD} />)
+      await Promise.resolve()
+    })
+
+    bookingRegistration()?.callback()
+
+    expect(mockTrackGoogleEvent).toHaveBeenCalledOnce()
+    expect(mockTrackGoogleAdsConversion).not.toHaveBeenCalled()
+    expect(trackXEvent).not.toHaveBeenCalled()
   })
 
   it('does not register booking analytics without measurement or marketing consent', async () => {
@@ -138,7 +175,7 @@ describe('DemoScheduler', () => {
       hideEventTypeDetails: true,
       styles: { branding: { brandColor: '#6f3dfa' } },
     })
-    expect(mockCal.mock.calls.some(([method]) => method === 'on')).toBe(false)
+    expect(bookingRegistration()).toBeUndefined()
   })
 
   it('preloads the configured booker only once', async () => {

--- a/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.tsx
+++ b/apps/sim/app/(landing)/demo/components/demo-scheduler/demo-scheduler.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import Cal, { getCalApi } from '@calcom/embed-react'
-import { trackGoogleEvent } from '@/lib/analytics/google'
+import { trackGoogleAdsConversion, trackGoogleEvent } from '@/lib/analytics/google'
 import { X_DEMO_BOOKED_EVENT_ID } from '@/lib/consent/scripts'
 import { useTrackingConsent } from '@/lib/consent/tracking-consent'
 import type { DemoLead } from '@/app/(landing)/demo/components/demo-form'
@@ -102,7 +102,10 @@ export function DemoScheduler({ lead }: DemoSchedulerProps) {
           booking_status: 'scheduled',
         })
       }
-      if (marketing) window.twq?.('event', X_DEMO_BOOKED_EVENT_ID, {})
+      if (marketing) {
+        trackGoogleAdsConversion('demo_booked')
+        window.twq?.('event', X_DEMO_BOOKED_EVENT_ID, {})
+      }
     }
     const api = getCalApi({ namespace: CAL_NAMESPACE, embedJsUrl: CAL_EMBED.embedJsUrl })
     api

--- a/apps/sim/lib/analytics/google.test.ts
+++ b/apps/sim/lib/analytics/google.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { trackGoogleAdsConversion } from '@/lib/analytics/google'
+import { GOOGLE_ADS_ID } from '@/lib/consent/scripts'
+
+afterEach(() => {
+  window.gtag = undefined
+})
+
+describe('trackGoogleAdsConversion', () => {
+  it('addresses the conversion to the Ads tag and its registered label', () => {
+    const gtag = vi.fn()
+    window.gtag = gtag
+
+    trackGoogleAdsConversion('demo_booked')
+
+    expect(gtag).toHaveBeenCalledWith('event', 'conversion', {
+      send_to: `${GOOGLE_ADS_ID}/Xt8wCK7b1e4cEL_Zk99C`,
+    })
+  })
+
+  it('is a no-op when the Google tag has not loaded', () => {
+    expect(() => trackGoogleAdsConversion('demo_booked')).not.toThrow()
+  })
+})

--- a/apps/sim/lib/analytics/google.ts
+++ b/apps/sim/lib/analytics/google.ts
@@ -1,4 +1,11 @@
-import { GOOGLE_ANALYTICS_ID } from '@/lib/consent/scripts'
+import { GOOGLE_ADS_ID, GOOGLE_ANALYTICS_ID } from '@/lib/consent/scripts'
+
+/** Conversion labels registered in Google Ads, keyed by the action they measure. */
+const GOOGLE_ADS_CONVERSION_LABELS = {
+  demo_booked: 'Xt8wCK7b1e4cEL_Zk99C',
+} as const
+
+export type GoogleAdsConversion = keyof typeof GOOGLE_ADS_CONVERSION_LABELS
 
 interface GoogleAnalyticsEventMap {
   sign_up: { method: string }
@@ -15,6 +22,17 @@ export function trackGoogleEvent<E extends keyof GoogleAnalyticsEventMap>(
   parameters: GoogleAnalyticsEventMap[E]
 ): void {
   window.gtag?.('event', name, parameters)
+}
+
+/**
+ * Records a Google Ads conversion, addressed as `<tag id>/<conversion label>`.
+ * Call only after the caller has verified marketing consent: without it Consent
+ * Mode keeps `ad_storage` denied and the hit could not be attributed to a click.
+ */
+export function trackGoogleAdsConversion(conversion: GoogleAdsConversion): void {
+  window.gtag?.('event', 'conversion', {
+    send_to: `${GOOGLE_ADS_ID}/${GOOGLE_ADS_CONVERSION_LABELS[conversion]}`,
+  })
 }
 
 export function trackGooglePageView(path: string): void {


### PR DESCRIPTION
## Summary
- Fire the Google Ads demo-booked conversion from the Cal.com `bookingSuccessfulV2` callback on /demo, so it counts only after Cal.com confirms a booking and never on page visit, embed open, or button click
- Gate it on marketing consent alongside the existing X pixel event; Consent Mode already maps `ad_storage` to that category, so an analytics-only visitor sends nothing attributable
- Add a typed `trackGoogleAdsConversion` helper keyed on a closed set of conversion actions, mirroring the existing GA4 event map, with the label registered beside it
- Tests cover the send_to composition, the fire path, and the declined-marketing path

## Type of Change
- [x] New feature

## Testing
Lint, type-check, `check:audits`, and `docs-manifest:check` pass. Vitest: scheduler, consent-script, and analytics helper suites pass (13 tests).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
