### PR TITLE
fix(webhooks): requeue transient reservation refresh failures

### DIFF
--- a/apps/sim/background/webhook-execution.test.ts
+++ b/apps/sim/background/webhook-execution.test.ts
@@ -11,7 +11,10 @@ import {
   loggerMock,
   loggingSessionMock,
   loggingSessionMockFns,
+  redisConfigMockFns,
+  resetEnvFlagsMock,
   resetEnvironmentUtilsMock,
+  setEnvFlags,
 } from '@sim/testing'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -20,8 +23,6 @@ const {
   mockExecuteWorkflowCore,
   mockWasExecutionFinalizedByCore,
   mockExecuteWithIdempotency,
-  mockRefreshExecutionSlotExpiry,
-  mockReleaseExecutionSlot,
   mockLoadDeploymentVersionState,
   mockGetProviderHandler,
   mockSetResolvedSecretTraceRegistry,
@@ -35,8 +36,6 @@ const {
     mockExecuteWorkflowCore: vi.fn(),
     mockWasExecutionFinalizedByCore: vi.fn(),
     mockExecuteWithIdempotency: vi.fn(),
-    mockRefreshExecutionSlotExpiry: vi.fn().mockResolvedValue(true),
-    mockReleaseExecutionSlot: vi.fn(),
     mockGetProviderHandler: vi.fn(() => ({})),
     mockSetResolvedSecretTraceRegistry: vi.fn(),
     mockExecutionSnapshot: vi.fn(),
@@ -75,11 +74,6 @@ vi.mock('@/lib/workflows/executor/execution-core', () => ({
   wasExecutionFinalizedByCore: mockWasExecutionFinalizedByCore,
 }))
 
-vi.mock('@/lib/billing/calculations/usage-reservation', () => ({
-  refreshExecutionSlotExpiry: mockRefreshExecutionSlotExpiry,
-  releaseExecutionSlot: mockReleaseExecutionSlot,
-}))
-
 vi.mock('@/lib/core/idempotency', () => ({
   IdempotencyService: { createWebhookIdempotencyKey: vi.fn(() => 'idempotency-key') },
   webhookIdempotency: {
@@ -108,8 +102,8 @@ vi.mock('@/lib/core/execution-limits', () => ({
   capExecutionTimeoutMs: vi.fn((policyTimeoutMs, requestedTimeoutMs) =>
     requestedTimeoutMs === undefined ? policyTimeoutMs : requestedTimeoutMs
   ),
-  createTimeoutAbortController: vi.fn(() => ({
-    signal: new AbortController().signal,
+  createTimeoutAbortController: vi.fn((_timeoutMs: number, signal?: AbortSignal) => ({
+    signal: signal ?? new AbortController().signal,
     cleanup: vi.fn(),
     isTimedOut: () => false,
     timeoutMs: 120_000,
@@ -150,12 +144,19 @@ vi.mock('@/triggers', () => ({
   isTriggerValid: vi.fn(() => false),
 }))
 
+import * as usageReservation from '@/lib/billing/calculations/usage-reservation'
 import { isRetryableSetupError } from '@/lib/core/errors/retryable-infrastructure'
 import {
   executeWebhookJob,
   resolveWebhookExecutionProviderConfig,
   type WebhookExecutionPayload,
-} from './webhook-execution'
+} from '@/background/webhook-execution'
+
+const actualRefreshExecutionSlotExpiry = usageReservation.refreshExecutionSlotExpiry
+const mockRefreshExecutionSlotExpiry = vi.spyOn(usageReservation, 'refreshExecutionSlotExpiry')
+const mockReleaseExecutionSlot = vi.spyOn(usageReservation, 'releaseExecutionSlot')
+
+afterAll(resetEnvFlagsMock)
 
 const webhookExecutionLoggerCallIndex = loggerMock.createLogger.mock.calls.findIndex(
   ([name]) => name === 'TriggerWebhookExecution'
@@ -284,8 +285,10 @@ describe('executeWebhookJob fault vs error handling', () => {
         projectDiagnosticError: loggingSessionMockFns.mockProjectDiagnosticError,
       }
     })
+    mockRefreshExecutionSlotExpiry.mockReset().mockResolvedValue(true)
+    mockReleaseExecutionSlot.mockReset().mockResolvedValue(undefined)
     mockGetProviderHandler.mockReturnValue({})
-    mockEnqueue.mockResolvedValue('run_retry')
+    mockEnqueue.mockReset().mockResolvedValue('run_retry')
     mockExecuteWithIdempotency.mockImplementation(
       (_provider: string, _key: string, operation: () => Promise<unknown>) => operation()
     )
@@ -733,6 +736,126 @@ describe('executeWebhookJob fault vs error handling', () => {
     expect(loggingSessionMockFns.mockSafeCompleteWithError).not.toHaveBeenCalled()
   })
 
+  it('recovers from the uncoded Redis command timeout without running the first attempt', async () => {
+    setEnvFlags({ isHosted: true, isBillingEnabled: true })
+    const timeoutError = new Error('Command timed out')
+    const redisGet = vi.fn().mockRejectedValueOnce(timeoutError)
+    redisConfigMockFns.mockGetRedisClient.mockReturnValue({ get: redisGet })
+    mockRefreshExecutionSlotExpiry.mockImplementationOnce(actualRefreshExecutionSlotExpiry)
+
+    const result = await executeWebhookJob(payload)
+
+    expect(redisGet).toHaveBeenCalledWith('usage:reservation:execution-1')
+    expect(result).toMatchObject({ success: false, requeued: true })
+    expect(mockExecuteWithIdempotency).not.toHaveBeenCalled()
+    expect(mockExecuteWorkflowCore).not.toHaveBeenCalled()
+    expect(loggingSessionMockFns.mockSafeCompleteWithError).not.toHaveBeenCalled()
+    expect(mockReleaseExecutionSlot).toHaveBeenCalledExactlyOnceWith('execution-1')
+    expect(mockEnqueue).toHaveBeenCalledTimes(1)
+    expect(mockReleaseExecutionSlot.mock.invocationCallOrder[0]).toBeLessThan(
+      mockEnqueue.mock.invocationCallOrder[0]
+    )
+    const [jobType, retryPayload, options] = mockEnqueue.mock.calls[0]
+    expect(jobType).toBe('webhook-execution')
+    expect(retryPayload).toMatchObject({ ...payload, infraRetryCount: 1 })
+    expect(options.delayMs).toBeGreaterThan(0)
+    expect(options.delayMs).toBeLessThanOrEqual(300_000)
+
+    mockRefreshExecutionSlotExpiry.mockResolvedValueOnce(false)
+    mockExecuteWorkflowCore.mockResolvedValueOnce({
+      success: true,
+      status: 'completed',
+      output: {},
+      logs: [],
+    })
+
+    await expect(executeWebhookJob(retryPayload)).resolves.toMatchObject({ success: true })
+
+    expect(executionPreprocessingMockFns.mockPreprocessExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ executionId: 'execution-1', skipUsageLimits: false })
+    )
+    expect(mockExecuteWorkflowCore).toHaveBeenCalledTimes(1)
+    expect(mockEnqueue).toHaveBeenCalledTimes(1)
+  })
+
+  it('records a terminal refresh failure when the retry budget is exhausted', async () => {
+    const cause = new Error('Command timed out')
+    const error = new usageReservation.UsageReservationUnavailableError(
+      'Usage reservation refresh is temporarily unavailable. Please retry.',
+      cause
+    )
+    mockRefreshExecutionSlotExpiry.mockRejectedValueOnce(error)
+
+    await expect(executeWebhookJob({ ...payload, infraRetryCount: 5 })).rejects.toMatchObject({
+      name: 'RetryableSetupError',
+      cause: error,
+    })
+
+    expect(mockEnqueue).not.toHaveBeenCalled()
+    expect(mockExecuteWithIdempotency).not.toHaveBeenCalled()
+    expect(mockReleaseExecutionSlot).toHaveBeenCalledExactlyOnceWith('execution-1')
+    expect(loggingSessionMockFns.mockSafeStart).toHaveBeenCalledTimes(1)
+    expect(loggingSessionMockFns.mockSafeCompleteWithError).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ error: expect.objectContaining({ message: error.message }) })
+    )
+  })
+
+  it('records the original refresh failure when enqueueing its replacement fails', async () => {
+    const error = new usageReservation.UsageReservationUnavailableError(
+      'Usage reservation refresh is temporarily unavailable. Please retry.',
+      new Error('Command timed out')
+    )
+    mockRefreshExecutionSlotExpiry.mockRejectedValueOnce(error)
+    mockEnqueue.mockRejectedValueOnce(new Error('trigger api unavailable'))
+
+    await expect(executeWebhookJob(payload)).rejects.toMatchObject({ cause: error })
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(1)
+    expect(mockExecuteWorkflowCore).not.toHaveBeenCalled()
+    expect(loggingSessionMockFns.mockSafeCompleteWithError).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ error: expect.objectContaining({ message: error.message }) })
+    )
+  })
+
+  it('does not requeue a refresh failure when the attempt was cancelled', async () => {
+    const controller = new AbortController()
+    const error = new usageReservation.UsageReservationUnavailableError('Redis unavailable')
+    mockRefreshExecutionSlotExpiry.mockImplementationOnce(async () => {
+      controller.abort()
+      throw error
+    })
+
+    await expect(executeWebhookJob(payload, controller.signal)).rejects.toMatchObject({
+      cause: error,
+    })
+
+    expect(mockEnqueue).not.toHaveBeenCalled()
+    expect(mockExecuteWorkflowCore).not.toHaveBeenCalled()
+    expect(mockReleaseExecutionSlot).toHaveBeenCalledExactlyOnceWith('execution-1')
+    expect(loggingSessionMockFns.mockSafeCompleteWithError).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not requeue a non-transient refresh failure', async () => {
+    const error = new TypeError('Invalid Redis configuration')
+    mockRefreshExecutionSlotExpiry.mockRejectedValueOnce(error)
+
+    await expect(executeWebhookJob(payload)).rejects.toBe(error)
+
+    expect(mockReleaseExecutionSlot).toHaveBeenCalledExactlyOnceWith('execution-1')
+    expect(mockEnqueue).not.toHaveBeenCalled()
+    expect(mockExecuteWithIdempotency).not.toHaveBeenCalled()
+  })
+
+  it('does not treat an ambiguous idempotency claim timeout as a safe setup retry', async () => {
+    const error = new Error('Command timed out')
+    mockExecuteWithIdempotency.mockRejectedValueOnce(error)
+
+    await expect(executeWebhookJob(payload)).rejects.toBe(error)
+
+    expect(mockEnqueue).not.toHaveBeenCalled()
+    expect(mockExecuteWorkflowCore).not.toHaveBeenCalled()
+  })
+
   it('requeues on retryable infrastructure errors thrown by setup reads', async () => {
     dbChainMockFns.limit.mockRejectedValueOnce(
       Object.assign(new Error('write CONNECT_TIMEOUT'), { code: 'CONNECT_TIMEOUT' })
@@ -781,19 +904,23 @@ describe('executeWebhookJob fault vs error handling', () => {
     expect(mockEnqueue).not.toHaveBeenCalled()
   })
 
-  it('never reclassifies infrastructure errors after the workflow core started', async () => {
-    const infraError = Object.assign(new Error('Connection terminated unexpectedly'), {
+  it.each([
+    new Error('Command timed out'),
+    Object.assign(new Error('Connection terminated unexpectedly'), {
       code: 'CONNECTION_CLOSED',
-    })
-    mockExecuteWorkflowCore.mockRejectedValue(infraError)
-    mockWasExecutionFinalizedByCore.mockReturnValue(false)
+    }),
+  ])(
+    'never reclassifies infrastructure errors after the workflow core started: %s',
+    async (infraError) => {
+      mockExecuteWorkflowCore.mockRejectedValue(infraError)
+      mockWasExecutionFinalizedByCore.mockReturnValue(false)
 
-    await expect(executeWebhookJob(payload)).rejects.toBe(infraError)
+      await expect(executeWebhookJob(payload)).rejects.toBe(infraError)
 
-    expect(mockEnqueue).not.toHaveBeenCalled()
-    // Post-core failures keep recording the terminal row.
-    expect(loggingSessionMockFns.mockSafeCompleteWithError).toHaveBeenCalled()
-  })
+      expect(mockEnqueue).not.toHaveBeenCalled()
+      expect(loggingSessionMockFns.mockSafeCompleteWithError).toHaveBeenCalled()
+    }
+  )
 
   it('faults the run and restores the terminal log row when the requeue enqueue itself fails', async () => {
     executionPreprocessingMockFns.mockPreprocessExecution.mockResolvedValueOnce({

--- a/apps/sim/background/webhook-execution.ts
+++ b/apps/sim/background/webhook-execution.ts
@@ -434,11 +434,9 @@ async function requeueWebhookExecutionAfterSetupFailure(
 }
 
 /**
- * Restores the terminal failed execution-log row for a setup failure whose
- * replacement enqueue failed. Attempts headed for a requeue suppress their
- * failure row so the retry can reuse the execution id; once the requeue is
- * known to have failed, no retry will run, so the row must be written here or
- * the delivery faults without any execution record. Best-effort by design:
+ * Records a terminal setup failure when no replacement will run and setup
+ * either never reached preprocessing or suppressed its failure row for a retry.
+ * Best-effort by design:
  * the same infrastructure outage that broke setup may also break this write,
  * in which case the faulted run remains the only signal — matching how
  * preprocessing's own error logging degrades.
@@ -470,14 +468,11 @@ async function recordSetupFailureWithoutRequeue(
       skipCost: true,
     })
   } catch (loggingError) {
-    logger.error(
-      `[${correlation.requestId}] Failed to record webhook setup failure after requeue failure`,
-      {
-        workflowId: payload.workflowId,
-        executionId: correlation.executionId,
-        error: loggingError,
-      }
-    )
+    logger.error(`[${correlation.requestId}] Failed to record terminal webhook setup failure`, {
+      workflowId: payload.workflowId,
+      executionId: correlation.executionId,
+      error: loggingError,
+    })
   }
 }
 
@@ -536,16 +531,23 @@ export async function executeWebhookJob(
     ),
     externalAbortSignal
   )
+  let operationStarted = false
 
   try {
     const executionDeadlineAt = getExecutionDeadlineAt(timeoutController.signal)?.getTime()
-    const admissionCompleted =
-      executionDeadlineAt === undefined
-        ? true
-        : await refreshExecutionSlotExpiry(
-            executionId,
-            executionDeadlineAt + RESERVATION_TTL_BUFFER_MS
-          )
+    let admissionCompleted = true
+    if (executionDeadlineAt !== undefined) {
+      try {
+        admissionCompleted = await refreshExecutionSlotExpiry(
+          executionId,
+          executionDeadlineAt + RESERVATION_TTL_BUFFER_MS
+        )
+      } catch (error) {
+        if (!isRetryableInfrastructureError(error)) throw error
+        /** No idempotency claim or workflow block exists yet; only the usage lease was refreshed. */
+        throw new RetryableSetupError(toError(error).message, { cause: error })
+      }
+    }
     if (!admissionCompleted) {
       logger.warn('Queued webhook reservation expired; repeating usage admission', {
         workflowId: authenticatedPayload.workflowId,
@@ -569,7 +571,6 @@ export async function executeWebhookJob(
         authenticatedPayload.provider
       )
 
-      let operationStarted = false
       const runOperation = async () => {
         operationStarted = true
         return await executeWebhookJobInternal(
@@ -581,53 +582,53 @@ export async function executeWebhookJob(
         )
       }
 
-      try {
-        const result = await webhookIdempotency.executeWithIdempotency(
-          authenticatedPayload.provider,
-          idempotencyKey,
-          runOperation,
-          undefined,
-          {
-            inProgressExpiresAt:
-              executionDeadlineAt === undefined
-                ? Date.now() + WEBHOOK_IN_PROGRESS_LEASE_SECONDS * 1000
-                : executionDeadlineAt + RESERVATION_TTL_BUFFER_MS,
-          }
-        )
-        if (!operationStarted) {
-          await releaseExecutionSlot(executionId)
+      const result = await webhookIdempotency.executeWithIdempotency(
+        authenticatedPayload.provider,
+        idempotencyKey,
+        runOperation,
+        undefined,
+        {
+          inProgressExpiresAt:
+            executionDeadlineAt === undefined
+              ? Date.now() + WEBHOOK_IN_PROGRESS_LEASE_SECONDS * 1000
+              : executionDeadlineAt + RESERVATION_TTL_BUFFER_MS,
         }
-        return result
-      } catch (error) {
+      )
+      if (!operationStarted) {
         await releaseExecutionSlot(executionId)
-
-        /**
-         * A typed setup failure certifies no block ran and the idempotency
-         * claim was released, so requeueing the same delivery cannot double
-         * run it; the retry re-admits usage and re-claims from scratch. When
-         * the requeue enqueue itself fails, restore the terminal failure row
-         * the retry-bound attempt suppressed, then fall through to the throw
-         * so the run fails loudly rather than dropping the delivery silently.
-         */
-        if (isRetryableSetupError(error) && hasRemainingWebhookInfraRetry(authenticatedPayload)) {
-          if (
-            await requeueWebhookExecutionAfterSetupFailure(authenticatedPayload, correlation, error)
-          ) {
-            return {
-              success: false,
-              requeued: true,
-              workflowId: authenticatedPayload.workflowId,
-              executionId,
-              output: {},
-              executedAt: new Date().toISOString(),
-              provider: authenticatedPayload.provider,
-            }
-          }
-          await recordSetupFailureWithoutRequeue(authenticatedPayload, correlation, error)
-        }
-        throw error
       }
+      return result
     })
+  } catch (error) {
+    await releaseExecutionSlot(executionId)
+
+    /**
+     * Only typed setup failures certify that no block ran and any idempotency
+     * claim was released (or never acquired). The replacement re-admits usage
+     * and reclaims the same delivery; arbitrary execution errors must not replay.
+     */
+    if (isRetryableSetupError(error)) {
+      const hasRemainingRetry = hasRemainingWebhookInfraRetry(authenticatedPayload)
+      if (
+        hasRemainingRetry &&
+        !timeoutController.signal.aborted &&
+        (await requeueWebhookExecutionAfterSetupFailure(authenticatedPayload, correlation, error))
+      ) {
+        return {
+          success: false,
+          requeued: true,
+          workflowId: authenticatedPayload.workflowId,
+          executionId,
+          output: {},
+          executedAt: new Date().toISOString(),
+          provider: authenticatedPayload.provider,
+        }
+      }
+      if (!operationStarted || hasRemainingRetry) {
+        await recordSetupFailureWithoutRequeue(authenticatedPayload, correlation, error)
+      }
+    }
+    throw error
   } finally {
     timeoutController.cleanup()
   }

--- a/apps/sim/lib/billing/calculations/usage-reservation.test.ts
+++ b/apps/sim/lib/billing/calculations/usage-reservation.test.ts
@@ -339,12 +339,61 @@ describe('usage-reservation', () => {
   })
 
   describe('refreshExecutionSlotExpiry', () => {
-    it('rethrows the original error object rather than the diagnostic wrapper', async () => {
-      const original = Object.assign(new Error('Command timed out'), { code: 'ETIMEDOUT' })
+    it.each([
+      new Error('Command timed out'),
+      Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+    ])('classifies a Redis transport failure while preserving its cause: %s', async (original) => {
       getMock.mockRejectedValueOnce(original)
 
-      await expect(refreshExecutionSlotExpiry('exec-1', Date.now() + 60_000)).rejects.toBe(original)
+      await expect(refreshExecutionSlotExpiry('exec-1', Date.now() + 60_000)).rejects.toMatchObject(
+        {
+          name: 'UsageReservationUnavailableError',
+          code: 'SERVICE_OVERLOADED',
+          cause: original,
+        }
+      )
+      expect(evalMock).not.toHaveBeenCalled()
     })
+
+    it.each(['local', 'pointer'])('classifies a timeout extending the %s lease', async (stage) => {
+      evalMock.mockResolvedValueOnce(1).mockResolvedValueOnce(1)
+      await reserveExecutionSlot(memberParams)
+      const descriptor = String(evalMock.mock.calls[1][3])
+      vi.clearAllMocks()
+      getMock.mockResolvedValueOnce(descriptor)
+      if (stage === 'pointer') evalMock.mockResolvedValueOnce(1)
+      const original = new Error('Command timed out')
+      evalMock.mockRejectedValueOnce(original)
+
+      await expect(refreshExecutionSlotExpiry('exec-1', Date.now() + 60_000)).rejects.toMatchObject(
+        {
+          name: 'UsageReservationUnavailableError',
+          code: 'SERVICE_OVERLOADED',
+          cause: original,
+        }
+      )
+      expect(evalMock).toHaveBeenCalledTimes(stage === 'pointer' ? 2 : 1)
+    })
+
+    it.each([
+      new TypeError('invalid Redis command argument'),
+      Object.assign(new Error('NOAUTH Authentication required.'), { name: 'ReplyError' }),
+      Object.assign(
+        new Error('WRONGTYPE Operation against a key holding the wrong kind of value'),
+        {
+          name: 'ReplyError',
+        }
+      ),
+    ])(
+      'does not classify programming or server configuration failures as transient: %s',
+      async (original) => {
+        getMock.mockRejectedValueOnce(original)
+
+        await expect(refreshExecutionSlotExpiry('exec-1', Date.now() + 60_000)).rejects.toBe(
+          original
+        )
+      }
+    )
 
     it('refreshes only the locally owned slot and matching pointer', async () => {
       evalMock.mockResolvedValueOnce(1).mockResolvedValueOnce(1)

--- a/apps/sim/lib/billing/calculations/usage-reservation.ts
+++ b/apps/sim/lib/billing/calculations/usage-reservation.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/core/admission/transient-failure'
 import { isBillingEnabled, isHosted } from '@/lib/core/config/env-flags'
 import { describeRedisConnection, getRedisClient } from '@/lib/core/config/redis'
+import { isRetryableInfrastructureError } from '@/lib/core/errors/retryable-infrastructure'
 import { getExecutionReservationTtlMs } from '@/lib/core/execution-limits'
 
 const logger = createLogger('UsageReservation')
@@ -426,7 +427,7 @@ export type ReserveExecutionSlotResult =
     }
 
 /**
- * Records connection state alongside a failed slot operation.
+ * Records connection state and classifies transient Redis refresh failures.
  *
  * These three functions are the first Redis calls a queued workflow makes, so
  * when the connection is not usable they are where it surfaces — as an
@@ -449,6 +450,16 @@ async function withReservationDiagnostics<T>(
       error: toError(error).message,
       redis: describeRedisConnection(),
     })
+    /** ioredis commandTimeout rejects with an uncoded Error; match it only at the Redis boundary. */
+    if (
+      isRetryableInfrastructureError(error) ||
+      (error instanceof Error && error.name === 'Error' && error.message === 'Command timed out')
+    ) {
+      throw new UsageReservationUnavailableError(
+        'Usage reservation refresh is temporarily unavailable. Please retry.',
+        error
+      )
+    }
     throw error
   }
 }


### PR DESCRIPTION
## Summary

- Route transient reservation-refresh failures through the existing bounded webhook setup retry path.
- Preserve delivery identity, respect cancellation, and record terminal failures when no replacement can run.
- Keep post-start workflow failures and Redis timeout settings unchanged.

## Type of Change

- [x] Bug fix

## Testing

- 256 related tests passing, including an uncoded Redis timeout followed by a successful replacement attempt.
- Repository lint, all 45 audits, block registry, and docs manifest checks passed.
- App type check passed with incremental caching disabled.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
