### PR TITLE
fix(codeql): address validation findings

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table-serialization.node.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table-serialization.node.test.ts
@@ -97,4 +97,54 @@ describe('legacy table preservation through the server converter', () => {
       shared.destroy()
     }
   })
+
+  it('uses lossless HTML when a code span has a backslash immediately before a pipe', () => {
+    const document: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'table',
+          content: [
+            {
+              type: 'tableRow',
+              content: [
+                {
+                  type: 'tableHeader',
+                  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'value' }] }],
+                },
+              ],
+            },
+            {
+              type: 'tableRow',
+              content: [
+                {
+                  type: 'tableCell',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: '\\|', marks: [{ type: 'code' }] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const shared = prosemirrorJSONToYDoc(
+      getSchema(createMarkdownContentExtensions()),
+      document,
+      COLLAB_DOC_FIELD
+    )
+    try {
+      const markdown = yDocToMarkdown(shared).trim()
+      expect(markdown).toContain('<table')
+      expect(markdown).toContain('<code>\\|</code>')
+      expect(parseMarkdownToDoc(markdown).content?.[0].type).toBe('rawHtmlBlock')
+      expect(serializeMarkdownDocument(markdown).trim()).toBe(markdown)
+    } finally {
+      shared.destroy()
+    }
+  })
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/table.ts
@@ -166,6 +166,30 @@ const MarkdownTable = Table.extend({
   },
 })
 
+/** Whether a code span contains a pipe after an odd run of literal backslashes. */
+function hasAmbiguousCodePipe(value: string): boolean {
+  let backslashes = 0
+  for (const character of value) {
+    if (character === '\\') {
+      backslashes++
+      continue
+    }
+    if (character === '|' && backslashes % 2 === 1) return true
+    backslashes = 0
+  }
+  return false
+}
+
+/** Whether inline cell content can be represented without ambiguity in a GFM pipe table. */
+function isGfmCellContent(content: JSONContent[] | undefined): boolean {
+  return !(content ?? []).some(
+    (node) =>
+      node.type === 'text' &&
+      node.marks?.some((mark) => mark.type === 'code') &&
+      hasAmbiguousCodePipe(node.text ?? '')
+  )
+}
+
 /** A GFM table has a single header, uniform columns, inline cell content, and column-level alignment. */
 function isGfmTable(node: JSONContent): boolean {
   const rows = node.content ?? []
@@ -183,10 +207,18 @@ function isGfmTable(node: JSONContent): boolean {
             cell.attrs?.colwidth == null &&
             (cell.attrs?.align ?? null) === (header[column].attrs?.align ?? null) &&
             cell.content?.length === 1 &&
-            cell.content[0].type === 'paragraph'
+            cell.content[0].type === 'paragraph' &&
+            isGfmCellContent(cell.content[0].content)
         )
     )
   )
+}
+
+/** Escape pipes that belong to cell content while leaving the structural delimiters to the renderer. */
+function escapeGfmCellPipes(value: string): string {
+  const escaped: string[] = []
+  for (const character of value) escaped.push(character === '|' ? '\\|' : character)
+  return escaped.join('')
 }
 
 /**
@@ -197,10 +229,7 @@ function isGfmTable(node: JSONContent): boolean {
 function renderGfmTable(node: JSONContent, helpers: MarkdownRendererHelpers): string {
   const rows = (node.content ?? []).map((row) =>
     (row.content ?? []).map((cell) =>
-      helpers
-        .renderChildren(cell.content ?? [])
-        .replace(/\|/g, '\\|')
-        .replace(/\r?\n/g, '<br>')
+      escapeGfmCellPipes(helpers.renderChildren(cell.content ?? [])).replace(/\r?\n/g, '<br>')
     )
   )
   const widths = rows[0].map(() => 3)

--- a/apps/sim/lib/api/contracts/tools/aws/cloudtrail-shared.ts
+++ b/apps/sim/lib/api/contracts/tools/aws/cloudtrail-shared.ts
@@ -13,7 +13,7 @@ const TRAIL_NAME_MAX_LENGTH = 128
 const TRAIL_ARN_MAX_LENGTH = 256
 
 const TRAIL_NAME_OR_ARN_PATTERN =
-  /^(?:arn:aws[a-zA-Z0-9-]*:cloudtrail:[a-z0-9-]+:\d{12}:trail\/[\w.\-/]+|[a-zA-Z0-9](?:[._-]?[a-zA-Z0-9]+)+)$/
+  /^(?:arn:aws[a-zA-Z0-9-]*:cloudtrail:[a-z0-9-]+:\d{12}:trail\/[\w.\-/]+|[a-zA-Z0-9](?:[a-zA-Z0-9]|[._-][a-zA-Z0-9])+)$/
 
 /**
  * A trail name or a full trail ARN. The two branches carry different ceilings: a bare name

--- a/apps/sim/tools/cloudtrail/contract-validation.test.ts
+++ b/apps/sim/tools/cloudtrail/contract-validation.test.ts
@@ -28,6 +28,7 @@ const CONNECTION = {
 const QUERY_ID = 'abcdef01-2345-6789-abcd-ef0123456789'
 const LONGEST_VALID_NAME = 'a'.repeat(128)
 const TOO_LONG_NAME = 'a'.repeat(129)
+const LONG_INVALID_NAME = `${'a'.repeat(128)}!`
 const LONG_TRAIL_ARN = `arn:aws:cloudtrail:us-east-1:123456789012:trail/${'a'.repeat(100)}`
 
 describe('cloudtrail start query contract', () => {
@@ -100,6 +101,15 @@ describe('cloudtrail trail name bounds', () => {
     })
 
     expect(result.success).toBe(true)
+  })
+
+  it('rejects a long malformed trail name', () => {
+    const result = awsCloudtrailGetTrailStatusContract.body.safeParse({
+      ...CONNECTION,
+      name: LONG_INVALID_NAME,
+    })
+
+    expect(result.success).toBe(false)
   })
 
   it('accepts a trail ARN longer than 128 characters on get trail status', () => {


### PR DESCRIPTION
## Summary
- make CloudTrail trail-name validation linear-time
- preserve ambiguous escaped pipes in inline code with a lossless HTML table fallback

## Type of Change
- [x] Bug fix

## Testing
- focused Markdown round-trip and CloudTrail contract tests
- full lint, audit, generator, block-registry, and docs-manifest ship gates

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
