### PR TITLE
improvement(ci): measure where the layer-cache disk actually goes

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -163,6 +163,36 @@ runs:
           echo "::warning::Layer cache prune failed; this sticky disk is unbounded for this run"
         fi
 
+        # Why this block exists: the cap above is enforced against `buildctl du`,
+        # and on the busiest disk that number no longer describes the disk. The
+        # app image's amd64 sticky disk reports 224.9 GB while du inside the same
+        # job reads 65.87 GB, so the prune correctly does nothing — it is already
+        # under a 100 GB cap by its own accounting — and the disk keeps growing.
+        # The same Dockerfile's arm64 disk, which builds far less often, reads
+        # 88.04 GB against an 86.4 GB disk: no gap at all. So the divergence
+        # tracks build frequency, not image content.
+        #
+        # The mount log ("Filesystem free space after mount") says the filesystem
+        # really is holding those bytes, so this is not a thin-provisioned volume
+        # failing to release freed blocks — there are real files here that du's
+        # total does not cover. The candidates are the `RUN --mount=type=cache`
+        # dirs (apt, bun, npm, next, turbo), which are a different record class
+        # from the layer cache `--keep-storage` trims.
+        #
+        # These three readings separate those cases: df is the filesystem's own
+        # view, the record-type summary shows whether du even accounts for cache
+        # mounts, and the directory walk locates the bytes if it does not. All are
+        # best-effort and bounded — this step must never be able to fail a deploy,
+        # which is why every command is guarded and the walk has a timeout.
+        echo "--- cache accounting (diagnostic) ---"
+        df -h /var/lib/buildkit 2>/dev/null || true
+        echo "du by record type:"
+        sudo buildctl --addr "$addr" du --verbose 2>/dev/null \
+          | awk '/^Type:/ { t=$2 } /^Size:/ { s[t] += $2 } END { for (k in s) printf "  %-24s %10.2f GB\n", k, s[k]/1e9 }' \
+          | sort -k2 -rn || true
+        echo "largest directories under /var/lib/buildkit:"
+        sudo timeout 120 du -xh -d1 /var/lib/buildkit 2>/dev/null | sort -rh | head -8 || true
+
     - name: Set up Docker Buildx
       if: inputs.provider != '' && inputs.provider != 'blacksmith'
       uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4


### PR DESCRIPTION
## The problem

The layer-cache cap is enforced against `buildctl du`, and on the busiest disk that number no longer describes the disk.

From a single real job (app image, amd64):

```
before prune -> Total: 65.87GB
after prune  -> Total: 65.87GB  (keep-storage 102400 MB)
```

The prune is behaving **correctly** — 65.87 GB is already under the 100 GB cap, so there is nothing to trim. Meanwhile that sticky disk reports **224.9 GB**.

The control is the same Dockerfile on the other architecture:

| disk | `buildctl du` | actual disk | gap |
|---|---|---|---|
| `app.Dockerfile/linux-amd64` | 65.87 GB | ~241 GB | **3.7×** |
| `app.Dockerfile/linux-arm64` | 88.04 GB | ~93 GB | ~1× |

Same image, same 100 GB cap, both disks created 2026-08-29. The only difference is build frequency — amd64 builds on every push to `main` *and* `staging`, arm64 only on `main`. So the divergence tracks **write churn, not image content**.

## Why this is a diagnostic and not a fix

Two causes fit the symptom, and they need opposite fixes:

1. **Thin-provisioned volume not releasing freed blocks.** Sticky disks are Ceph block volumes cloned and committed per job, so a filesystem that deletes files without `discard` would grow monotonically. Fix would be `fstrim`.
2. **Real files `du`'s total does not cover.** The `RUN --mount=type=cache` dirs (apt ×2, bun, npm, next, turbo) are a different record class from the layer cache `--keep-storage` trims. Fix would be bounding or dropping specific mounts.

One log line argues against (1) — `Filesystem free space after mount: 527497363456 bytes (491.27 GiB)` implies the filesystem really is holding those bytes — but that is a single indirect reading, not proof, and shipping `fstrim` or deleting a cache mount on it would be guessing.

So this adds the three readings that separate the cases:

- **`df`** — the filesystem's own view, versus buildkit's.
- **`buildctl du --verbose` summarised by record type** — whether cache mounts are accounted for at all.
- **a bounded `du -x -d1` walk** — where the bytes actually live, if they are not.

One or two builds of output settles it, and the follow-up fix is then evidenced rather than assumed.

## Safety

Composite steps run under `bash -e -o pipefail`, where a failing command inside an assignment or pipeline aborts the step and fails the build — the bug that broke a real app image build in #7252. Every command here is guarded, and the directory walk is bounded by `timeout 120`.

Verified rather than assumed: the block was run under `bash --noprofile --norc -e -o pipefail` with **every command failing** (no buildkitd, no `/var/lib/buildkit` locally). It reaches the end and exits 0. Shellcheck clean.

This step already could not fail a deploy by design — that property is preserved.

## Type of Change
- [x] Improvement

## Testing
Executed the block under the exact composite-step shell flags with all commands failing (exit 0, reached end marker). Shellcheck clean. No behaviour change to the prune itself — this is additive output after the existing before/after readings.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
