### PR TITLE
fix(composer): include Browser in the resource picker

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import {
   Button,
   cn,
@@ -22,6 +22,7 @@ import {
   BROWSER_SESSION_RESOURCE_ID,
   TERMINAL_SESSION_RESOURCE_ID,
 } from '@/lib/copilot/resources/types'
+import { subscribeDesktopPreferences } from '@/lib/desktop'
 import { isTerminalAvailable } from '@/lib/terminal/transport'
 import {
   type AvailableItem,
@@ -145,6 +146,16 @@ export function useAvailableResources(
 ): AvailableResources {
   const enabled = options?.enabled ?? true
   const excludeTypes = options?.excludeTypes
+  const browserAvailable = useSyncExternalStore(
+    subscribeDesktopPreferences,
+    isBrowserAgentAvailable,
+    () => false
+  )
+  const terminalAvailable = useSyncExternalStore(
+    subscribeDesktopPreferences,
+    isTerminalAvailable,
+    () => false
+  )
   // Destructured without `= []` defaults on purpose: a literal default allocates a
   // fresh array every render while `data` is undefined (exactly the disabled state),
   // which would bust the group memo below on every render. Undefined is stable.
@@ -292,7 +303,7 @@ export function useAvailableResources(
     ]
     // The live browser panel — desktop app only (needs the agent-browser
     // bridge). There is one top-level panel; repeated launches open inner tabs.
-    if (isBrowserAgentAvailable()) {
+    if (browserAvailable) {
       groups.push({
         type: 'browser' as const,
         items: [
@@ -305,7 +316,7 @@ export function useAvailableResources(
     }
     // The live terminal — desktop app only (needs the PTY bridge), and a
     // single top-level panel like the browser.
-    if (isTerminalAvailable()) {
+    if (terminalAvailable) {
       groups.push({
         type: 'terminal' as const,
         items: [
@@ -319,6 +330,8 @@ export function useAvailableResources(
     return groups.filter((g) => !excluded.has(g.type)).sort(byResourceMenuOrder)
   }, [
     enabled,
+    browserAvailable,
+    terminalAvailable,
     workflows,
     folders,
     fileFolders,

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { act, createRef } from 'react'
+import type { DesktopPreferences } from '@sim/desktop-bridge'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -51,6 +52,7 @@ import {
   BROWSER_SESSION_RESOURCE_ID,
   TERMINAL_SESSION_RESOURCE_ID,
 } from '@/lib/copilot/resources/types'
+import { setDesktopPreferencesSnapshot } from '@/lib/desktop'
 import {
   mapResourceToContext,
   type PlusMenuHandle,
@@ -59,6 +61,16 @@ import { PlusMenuDropdown } from '@/app/workspace/[workspaceId]/home/components/
 
 let root: Root
 let container: HTMLDivElement
+
+const PREFERENCES: DesktopPreferences = {
+  notificationsEnabled: true,
+  notificationSounds: true,
+  notificationsOnlyWhenUnfocused: true,
+  launchAtLogin: false,
+  autoDownloadUpdates: true,
+  browserEnabled: true,
+  terminalEnabled: true,
+}
 
 function openMenu(mention = false) {
   const ref = createRef<PlusMenuHandle>()
@@ -110,6 +122,7 @@ describe('PlusMenuDropdown desktop resources', () => {
     vi.clearAllMocks()
     fixtures.browserAvailable.mockReturnValue(true)
     fixtures.terminalAvailable.mockReturnValue(true)
+    setDesktopPreferencesSnapshot(PREFERENCES)
     Object.defineProperty(Element.prototype, 'scrollIntoView', {
       configurable: true,
       value: vi.fn(),
@@ -164,6 +177,19 @@ describe('PlusMenuDropdown desktop resources', () => {
       label: 'Browser',
     })
   })
+
+  it.each([false, true])(
+    'updates mounted desktop rows when preferences change in mention=%s mode',
+    (mention) => {
+      openMenu(mention)
+      expect(menuItems().map((item) => item.textContent)).toContain('Browser')
+
+      fixtures.browserAvailable.mockReturnValue(false)
+      act(() => setDesktopPreferencesSnapshot({ ...PREFERENCES, browserEnabled: false }))
+      expect(menuItems().map((item) => item.textContent)).not.toContain('Browser')
+      expect(menuItems().map((item) => item.textContent)).toContain('Terminal')
+    }
+  )
 
   it('finds Browser through plus-menu search and selects it with Enter', () => {
     const { onResourceSelect } = openMenu()

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fixtures = vi.hoisted(() => ({
+  browserAvailable: vi.fn(() => true),
+  terminalAvailable: vi.fn(() => true),
+  resources: { data: [{ id: 'resource-1', name: 'Example' }], isPending: false },
+  folders: { data: [], isPending: false },
+  tabs: [],
+  logs: {
+    data: {
+      pages: [{ logs: [{ id: 'log-1', createdAt: '2026-01-01T12:00:00Z', status: 'success' }] }],
+    },
+    isPending: false,
+  },
+}))
+
+vi.mock('@/lib/browser-agent/transport', () => ({
+  isBrowserAgentAvailable: fixtures.browserAvailable,
+}))
+vi.mock('@/lib/terminal/transport', () => ({
+  isTerminalAvailable: fixtures.terminalAvailable,
+}))
+vi.mock('@/hooks/queries/workflows', () => ({ useWorkflows: () => fixtures.resources }))
+vi.mock('@/hooks/queries/tables', () => ({ useTablesList: () => fixtures.resources }))
+vi.mock('@/hooks/queries/workspace-files', () => ({ useWorkspaceFiles: () => fixtures.resources }))
+vi.mock('@/hooks/queries/kb/knowledge', () => ({
+  useKnowledgeBasesQuery: () => fixtures.resources,
+}))
+vi.mock('@/hooks/queries/folders', () => ({ useFolders: () => fixtures.folders }))
+vi.mock('@/hooks/queries/workspace-file-folders', () => ({
+  useWorkspaceFileFolders: () => fixtures.folders,
+}))
+vi.mock('@/hooks/queries/mothership-chats', () => ({
+  useMothershipChats: () => fixtures.resources,
+}))
+vi.mock('@/hooks/queries/logs', () => ({ useLogsList: () => fixtures.logs }))
+vi.mock('@/blocks/integration-matcher', () => ({
+  listIntegrationsByPopularity: () => [
+    { blockType: 'example', name: 'Example integration', icon: () => null },
+  ],
+}))
+vi.mock('@/stores/browser-session/store', () => ({ useBrowserSessionStore: () => fixtures.tabs }))
+vi.mock('@/stores/copilot-terminal/store', () => ({ useCopilotTerminalStore: () => fixtures.tabs }))
+
+import {
+  BROWSER_SESSION_RESOURCE_ID,
+  TERMINAL_SESSION_RESOURCE_ID,
+} from '@/lib/copilot/resources/types'
+import {
+  mapResourceToContext,
+  type PlusMenuHandle,
+} from '@/app/workspace/[workspaceId]/home/components/user-input/components/constants'
+import { PlusMenuDropdown } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown'
+
+let root: Root
+let container: HTMLDivElement
+
+function openMenu(mention = false) {
+  const ref = createRef<PlusMenuHandle>()
+  const onResourceSelect = vi.fn()
+  act(() =>
+    root.render(
+      <PlusMenuDropdown
+        ref={ref}
+        workspaceId='workspace-1'
+        onResourceSelect={onResourceSelect}
+        onClose={vi.fn()}
+        textareaRef={createRef<HTMLTextAreaElement>()}
+        pendingCursorRef={{ current: null }}
+      />
+    )
+  )
+  act(() => ref.current?.open({ left: 0, top: 0 }, { mention }))
+  return { ref, onResourceSelect }
+}
+
+function menuItems(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).filter(
+    (item) => !item.closest('[hidden]')
+  )
+}
+
+function selectItem(name: string) {
+  const item = menuItems().find((item) => item.textContent === name)
+  if (!item) throw new Error(`Missing menu item: ${name}`)
+  act(() => item.click())
+}
+
+describe('PlusMenuDropdown desktop resources', () => {
+  const originalScrollIntoView = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    'scrollIntoView'
+  )
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    )
+    vi.clearAllMocks()
+    fixtures.browserAvailable.mockReturnValue(true)
+    fixtures.terminalAvailable.mockReturnValue(true)
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    if (originalScrollIntoView) {
+      Object.defineProperty(Element.prototype, 'scrollIntoView', originalScrollIntoView)
+    } else {
+      Reflect.deleteProperty(Element.prototype, 'scrollIntoView')
+    }
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps shared categories in the same order in browse and mention modes', () => {
+    const { ref } = openMenu()
+    const browseOrder = menuItems().map((item) => item.textContent)
+    expect(browseOrder).toEqual([
+      'Chats',
+      'Tables',
+      'Files',
+      'Knowledge Bases',
+      'Workflows',
+      'Logs',
+      'Browser',
+      'Terminal',
+    ])
+
+    act(() => ref.current?.open({ left: 0, top: 0 }, { mention: true }))
+    const headings = menuItems().map((item) => item.previousElementSibling?.textContent)
+    expect(headings).toEqual(['Integrations', ...browseOrder])
+  })
+
+  it.each([false, true])('selects the same whole Browser in mention=%s mode', (mention) => {
+    const { onResourceSelect } = openMenu(mention)
+    selectItem('Browser')
+
+    expect(onResourceSelect).toHaveBeenCalledExactlyOnceWith({
+      type: 'browser',
+      id: BROWSER_SESSION_RESOURCE_ID,
+      title: 'Browser',
+    })
+    expect(mapResourceToContext(onResourceSelect.mock.calls[0][0])).toEqual({
+      kind: 'browser_tab',
+      tabId: BROWSER_SESSION_RESOURCE_ID,
+      label: 'Browser',
+    })
+  })
+
+  it('finds Browser through plus-menu search and selects it with Enter', () => {
+    const { onResourceSelect } = openMenu()
+    const search = document.querySelector<HTMLInputElement>(
+      'input[placeholder="Search resources..."]'
+    )
+    const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+    if (!search || !valueSetter) throw new Error('Search input is unavailable')
+    act(() => {
+      valueSetter.call(search, 'browser')
+      search.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(menuItems().map((item) => item.textContent)).toEqual(['Browser'])
+    act(() => search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })))
+    expect(onResourceSelect).toHaveBeenCalledExactlyOnceWith({
+      type: 'browser',
+      id: BROWSER_SESSION_RESOURCE_ID,
+      title: 'Browser',
+    })
+  })
+
+  it.each([false, true])('keeps unavailable Browser hidden in mention=%s mode', (mention) => {
+    fixtures.browserAvailable.mockReturnValue(false)
+    const { onResourceSelect } = openMenu(mention)
+    expect(menuItems().some((item) => item.textContent === 'Browser')).toBe(false)
+    selectItem('Terminal')
+    expect(onResourceSelect).toHaveBeenCalledExactlyOnceWith({
+      type: 'terminal',
+      id: TERMINAL_SESSION_RESOURCE_ID,
+      title: 'Terminal',
+    })
+  })
+
+  it.each([false, true])('omits both desktop resources on web in mention=%s mode', (mention) => {
+    fixtures.browserAvailable.mockReturnValue(false)
+    fixtures.terminalAvailable.mockReturnValue(false)
+    openMenu(mention)
+    const names = menuItems().map((item) => item.textContent)
+    expect(names).not.toContain('Browser')
+    expect(names).not.toContain('Terminal')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -52,7 +52,6 @@ const MENTION_MAX_HEIGHT_CLASS = 'max-h-[min(280px,var(--radix-popper-available-
  * (`ADD_RESOURCE_EXCLUDED_TYPES` in `resource-tabs`).
  */
 const MENTION_ONLY_RESOURCE_TYPES = new Set<MothershipResourceType>(['integration'])
-const NON_ATTACHABLE_RESOURCE_TYPES = new Set<MothershipResourceType>(['browser'])
 const EMPTY_BROWSER_TABS = [] as const
 const EMPTY_TERMINAL_TABS = [] as const
 
@@ -121,17 +120,11 @@ export const PlusMenuDropdown = React.memo(
       setOpen(false)
     }, [])
 
-    // The `+` browse menu hides non-attachable and mention-only resource types.
-    // `@` mode exposes the full catalog and adds each live Browser/Terminal tab
-    // after its always-present whole-resource row.
     const visibleResources = useMemo(() => {
       if (isMention) {
         return withDesktopTabMentions(availableResources, browserTabs, terminalTabs)
       }
-      const attachable = availableResources.filter(
-        ({ type }) => !NON_ATTACHABLE_RESOURCE_TYPES.has(type)
-      )
-      return attachable.filter(({ type }) => !MENTION_ONLY_RESOURCE_TYPES.has(type))
+      return availableResources.filter(({ type }) => !MENTION_ONLY_RESOURCE_TYPES.has(type))
     }, [availableResources, browserTabs, isMention, terminalTabs])
 
     const treeSections = useResourceTreeSections({

--- a/apps/sim/lib/desktop/index.ts
+++ b/apps/sim/lib/desktop/index.ts
@@ -75,23 +75,30 @@ export function prefersInPlaceNavigation(): boolean {
  * reads availability synchronously while the shell only answers over async
  * IPC. An unread value uses the shell default (enabled).
  *
- * The cache is authoritative at call time, which is what tool execution and
- * capability reporting need. React trees that read it in a memo settle on the
- * next mount — flipping a switch happens on a settings route, so the chat view
- * has unmounted by then anyway.
+ * Synchronous callers read the cache at call time. React consumers subscribe
+ * to the same snapshot so asynchronous initialization and settings changes
+ * update mounted UI without keeping a second copy of the preferences.
  */
 let devicePreferences: DesktopPreferences | null = null
 let devicePreferencesLoad: Promise<void> | null = null
+const devicePreferencesListeners = new Set<() => void>()
 
 function loadDevicePreferences(): Promise<void> {
   devicePreferencesLoad ??=
     getDesktopBridge()
       ?.settings.getPreferences()
-      .then((preferences) => {
-        devicePreferences = preferences
-      })
+      .then(setDesktopPreferencesSnapshot)
       .catch(() => {}) ?? Promise.resolve()
   return devicePreferencesLoad
+}
+
+/** Subscribes React consumers to the shared desktop-preference snapshot. */
+export function subscribeDesktopPreferences(listener: () => void): () => void {
+  devicePreferencesListeners.add(listener)
+  void loadDevicePreferences()
+  return () => {
+    devicePreferencesListeners.delete(listener)
+  }
 }
 
 function isSurfaceSwitchedOn(key: 'browserEnabled' | 'terminalEnabled'): boolean {
@@ -106,6 +113,7 @@ function isSurfaceSwitchedOn(key: 'browserEnabled' | 'terminalEnabled'): boolean
 export function setDesktopPreferencesSnapshot(preferences: DesktopPreferences): void {
   devicePreferences = preferences
   devicePreferencesLoad = Promise.resolve()
+  for (const listener of devicePreferencesListeners) listener()
 }
 
 /** True when the agent browser is installed and switched on for this device. */

--- a/apps/sim/lib/desktop/preferences-loading.test.ts
+++ b/apps/sim/lib/desktop/preferences-loading.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment node
+ */
+import type { DesktopPreferences } from '@sim/desktop-bridge'
+import { afterEach, expect, it, vi } from 'vitest'
+import {
+  isBrowserAgentEnabled,
+  isTerminalEnabled,
+  setDesktopPreferencesSnapshot,
+  subscribeDesktopPreferences,
+} from '@/lib/desktop'
+
+afterEach(() => vi.unstubAllGlobals())
+
+it('publishes asynchronous startup preferences and later settings changes to subscribers', async () => {
+  const preferences: DesktopPreferences = {
+    notificationsEnabled: true,
+    notificationSounds: true,
+    notificationsOnlyWhenUnfocused: true,
+    launchAtLogin: false,
+    autoDownloadUpdates: true,
+    browserEnabled: false,
+    terminalEnabled: true,
+  }
+  const pending = Promise.withResolvers<DesktopPreferences>()
+  const getPreferences = vi.fn(() => pending.promise)
+  vi.stubGlobal('window', { simDesktop: { settings: { getPreferences } } })
+  const listener = vi.fn()
+  const unsubscribe = subscribeDesktopPreferences(listener)
+  const otherListener = vi.fn()
+  const unsubscribeOther = subscribeDesktopPreferences(otherListener)
+
+  try {
+    expect(getPreferences).toHaveBeenCalledOnce()
+    expect(isBrowserAgentEnabled()).toBe(true)
+    expect(isTerminalEnabled()).toBe(true)
+    expect(listener).not.toHaveBeenCalled()
+
+    pending.resolve(preferences)
+    await pending.promise
+    expect(listener).toHaveBeenCalledOnce()
+    expect(otherListener).toHaveBeenCalledOnce()
+    expect(isBrowserAgentEnabled()).toBe(false)
+    expect(isTerminalEnabled()).toBe(true)
+
+    unsubscribeOther()
+    const next = { ...preferences, browserEnabled: true }
+    setDesktopPreferencesSnapshot(next)
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(otherListener).toHaveBeenCalledOnce()
+    expect(isBrowserAgentEnabled()).toBe(true)
+    expect(getPreferences).toHaveBeenCalledOnce()
+  } finally {
+    unsubscribe()
+    unsubscribeOther()
+  }
+})


### PR DESCRIPTION
## Summary

- Show Browser in the composer’s `+` menu and search using the existing shared menu row and desktop availability check.
- Preserve the shared resource order across `+` and `@`, with integrations and individual desktop tabs remaining mention-only.
- Add regression coverage for ordering, Browser selection and context, search with Enter, and unavailable desktop resources.
- Keep mounted resource menus in sync when desktop preferences load or change, reusing the existing preference cache and preserving startup defaults.

## Type of Change

- [x] Bug fix

## Testing

- Component regression tests reproduce the missing Browser entry before the fix and pass after it.
- All 103 focused picker, resource-context, prompt-editor, and desktop utility tests pass, including asynchronous preference initialization and subscription cleanup.
- Repository lint, lint:check, all 45 audits, API boundary validation, block-registry checks, and docs-manifest check pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
