### PR TITLE
fix(search): gate every Sim Search surface on the flag that already refuses it

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/components/integration-tabs-header/integration-tabs-header.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/integration-tabs-header/integration-tabs-header.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockMemberAccessAvailable } = vi.hoisted(() => ({
+  mockMemberAccessAvailable: vi.fn(() => true),
+}))
+
+vi.mock('@/hooks/use-member-access', () => ({
+  useMemberAccessAvailable: () => mockMemberAccessAvailable(),
+}))
+
+import { IntegrationTabsHeader } from '@/app/workspace/[workspaceId]/components/integration-tabs-header/integration-tabs-header'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function mount(active: 'integrations' | 'skills' | 'search' = 'integrations') {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(<IntegrationTabsHeader active={active} workspaceId='workspace-1' />))
+}
+
+function tabs(): string[] {
+  return Array.from(container?.querySelectorAll('a') ?? []).map((node) => node.textContent ?? '')
+}
+
+beforeEach(() => {
+  mockMemberAccessAvailable.mockReturnValue(true)
+})
+
+afterEach(() => {
+  if (root) act(() => root?.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+describe('IntegrationTabsHeader', () => {
+  it('links every tab to its page in the routed workspace', () => {
+    mount()
+
+    expect(tabs()).toEqual(['Integrations', 'Skills', 'Search'])
+    expect(
+      Array.from(container?.querySelectorAll('a') ?? []).map((node) => node.getAttribute('href'))
+    ).toEqual([
+      '/workspace/workspace-1/integrations',
+      '/workspace/workspace-1/skills',
+      '/workspace/workspace-1/search',
+    ])
+  })
+
+  it('omits Search where per-member access is off, matching the page that 404s', () => {
+    mockMemberAccessAvailable.mockReturnValue(false)
+    mount()
+
+    expect(tabs()).toEqual(['Integrations', 'Skills'])
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/components/integration-tabs-header/integration-tabs-header.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/components/integration-tabs-header/integration-tabs-header.tsx
@@ -1,6 +1,9 @@
+'use client'
+
 import type { ReactNode } from 'react'
 import { ChipLink, cn } from '@sim/emcn'
 import { HEADER_ACTION_CLUSTER, PAGE_HEADER_BAR } from '@/components/page-header-bar'
+import { useMemberAccessAvailable } from '@/hooks/use-member-access'
 
 interface IntegrationTabsHeaderProps {
   active: 'integrations' | 'skills' | 'search'
@@ -17,6 +20,11 @@ interface IntegrationTabsHeaderProps {
  * because every page owns it equally; its former home made Skills reach across
  * into a sibling feature for its own chrome.
  *
+ * Search appears only where per-member access is on, matching the page it links
+ * to, which 404s otherwise. A client component so the three pages and their
+ * Suspense fallbacks all read that one judgement from the workspace host
+ * context rather than each resolving it again on the server.
+ *
  * The `gap-1` is explicit because chips carry no outer margin — the parent owns the
  * space between them.
  */
@@ -25,6 +33,8 @@ export function IntegrationTabsHeader({
   workspaceId,
   rightSlot,
 }: IntegrationTabsHeaderProps) {
+  const memberAccessAvailable = useMemberAccessAvailable()
+
   return (
     <div className={cn(PAGE_HEADER_BAR, 'gap-1')}>
       <ChipLink href={`/workspace/${workspaceId}/integrations`} active={active === 'integrations'}>
@@ -33,9 +43,11 @@ export function IntegrationTabsHeader({
       <ChipLink href={`/workspace/${workspaceId}/skills`} active={active === 'skills'}>
         Skills
       </ChipLink>
-      <ChipLink href={`/workspace/${workspaceId}/search`} active={active === 'search'}>
-        Search
-      </ChipLink>
+      {memberAccessAvailable && (
+        <ChipLink href={`/workspace/${workspaceId}/search`} active={active === 'search'}>
+          Search
+        </ChipLink>
+      )}
       {rightSlot && <div className={cn('ml-auto', HEADER_ACTION_CLUSTER)}>{rightSlot}</div>}
     </div>
   )

--- a/apps/sim/app/workspace/[workspaceId]/home/components/knowledge-search-results/knowledge-search-results.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/knowledge-search-results/knowledge-search-results.tsx
@@ -25,12 +25,12 @@ import {
   searchFilterParsers,
   UPDATED_WINDOWS,
 } from '@/app/workspace/[workspaceId]/home/search-params'
-import { useWorkspaceHostContext } from '@/app/workspace/[workspaceId]/providers/workspace-host-provider'
 import {
   useWorkspaceMemberConnectors,
   type WorkspaceMemberConnector,
 } from '@/hooks/queries/kb/connectors'
 import { useKnowledgeBasesQuery, useWorkspaceKnowledgeSearch } from '@/hooks/queries/kb/knowledge'
+import { useMemberAccessAvailable } from '@/hooks/use-member-access'
 
 const EMPTY_MEMBER_CONNECTORS: WorkspaceMemberConnector[] = []
 
@@ -185,13 +185,12 @@ export function KnowledgeSearchResults({
     isPlaceholderData,
     error,
   } = useWorkspaceKnowledgeSearch(workspaceId, knowledgeBaseIds, query)
-  const { features } = useWorkspaceHostContext()
   /**
    * Judged by the workspace, as the server judges it: with per-member access
    * off, member-scoped documents are hidden, so no source is indexing anything
    * the viewer will see, and the list is not worth asking for.
    */
-  const memberAccessAvailable = features?.knowledgeMemberAccess === true
+  const memberAccessAvailable = useMemberAccessAvailable()
   const { data: memberConnectorRows } = useWorkspaceMemberConnectors(workspaceId, {
     enabled: memberAccessAvailable,
   })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/knowledge-search-results/knowledge-search-results.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/knowledge-search-results/knowledge-search-results.tsx
@@ -186,9 +186,8 @@ export function KnowledgeSearchResults({
     error,
   } = useWorkspaceKnowledgeSearch(workspaceId, knowledgeBaseIds, query)
   /**
-   * Judged by the workspace, as the server judges it: with per-member access
-   * off, member-scoped documents are hidden, so no source is indexing anything
-   * the viewer will see, and the list is not worth asking for.
+   * With per-member access off, member-scoped documents are hidden, so the
+   * indexing list is not worth asking for.
    */
   const memberAccessAvailable = useMemberAccessAvailable()
   const { data: memberConnectorRows } = useWorkspaceMemberConnectors(workspaceId, {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/search-sources/search-sources.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/search-sources/search-sources.tsx
@@ -140,10 +140,7 @@ interface SearchSourcesProps {
  */
 export function SearchSources({ workspaceId }: SearchSourcesProps) {
   const { integrationAvailability } = usePermissionConfig()
-  /**
-   * Judged by the workspace, as the server judges it: with per-member access
-   * off, a connect is refused, so the chips say so instead of offering one.
-   */
+  /** With per-member access off, a connect is refused, so the chips say so instead. */
   const memberAccessAvailable = useMemberAccessAvailable()
   const { data: workspacePermissions } = useWorkspacePermissionsQuery(workspaceId)
   /** The first connect of a source turns it on for the workspace, which takes an admin. */

--- a/apps/sim/app/workspace/[workspaceId]/home/components/search-sources/search-sources.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/search-sources/search-sources.tsx
@@ -11,7 +11,6 @@ import {
   searchConnectorUnavailableReason,
 } from '@/lib/sim-search/connectors'
 import { SourceSetupModal } from '@/app/workspace/[workspaceId]/home/components/search-sources/source-setup-modal'
-import { useWorkspaceHostContext } from '@/app/workspace/[workspaceId]/providers/workspace-host-provider'
 import { BrandIcon } from '@/blocks/brand-icon'
 import {
   memberConnectorKeys,
@@ -19,6 +18,7 @@ import {
   type WorkspaceMemberConnector,
 } from '@/hooks/queries/kb/connectors'
 import { useWorkspacePermissionsQuery } from '@/hooks/queries/workspace'
+import { useMemberAccessAvailable } from '@/hooks/use-member-access'
 import { CONNECTABLE_MEMBERSHIPS, useMemberEnrollment } from '@/hooks/use-member-enrollment'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
 
@@ -140,12 +140,11 @@ interface SearchSourcesProps {
  */
 export function SearchSources({ workspaceId }: SearchSourcesProps) {
   const { integrationAvailability } = usePermissionConfig()
-  const { features } = useWorkspaceHostContext()
   /**
    * Judged by the workspace, as the server judges it: with per-member access
    * off, a connect is refused, so the chips say so instead of offering one.
    */
-  const memberAccessAvailable = features?.knowledgeMemberAccess === true
+  const memberAccessAvailable = useMemberAccessAvailable()
   const { data: workspacePermissions } = useWorkspacePermissionsQuery(workspaceId)
   /** The first connect of a source turns it on for the workspace, which takes an admin. */
   const canCreate = workspacePermissions?.viewer?.isAdmin ?? false

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/mode-switcher/mode-switcher.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/mode-switcher/mode-switcher.test.tsx
@@ -15,6 +15,8 @@ const mockUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>()
 vi.mock('next/navigation', () => ({
   useParams: () => ({ workspaceId: 'workspace-1' }),
 }))
+/** The switcher renders only where Search mode exists, so these tests are that workspace. */
+vi.mock('@/hooks/use-member-access', () => ({ useMemberAccessAvailable: () => true }))
 vi.mock('posthog-js/react', () => ({ usePostHog: () => null }))
 vi.mock('@/lib/posthog/client', () => ({ captureEvent: mockCaptureEvent }))
 

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.test.tsx
@@ -9,14 +9,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PromptEditorInstance } from '@/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor'
 import type { QueuedMessage } from '@/app/workspace/[workspaceId]/home/types'
 
-const { mockSubmit, mockResetTranscript } = vi.hoisted(() => ({
+const { mockSubmit, mockResetTranscript, mockMemberAccessAvailable } = vi.hoisted(() => ({
   mockSubmit: vi.fn(),
   mockResetTranscript: vi.fn(),
+  /** Search mode exists only where per-member access is on; these tests are that workspace. */
+  mockMemberAccessAvailable: vi.fn(() => true),
 }))
 
 vi.mock('next/navigation', () => ({ useParams: () => ({ workspaceId: 'workspace-1' }) }))
 vi.mock('posthog-js/react', () => ({ usePostHog: () => null }))
 vi.mock('@/lib/posthog/client', () => ({ captureEvent: vi.fn() }))
+vi.mock('@/hooks/use-member-access', () => ({
+  useMemberAccessAvailable: () => mockMemberAccessAvailable(),
+}))
 vi.mock('@/hooks/use-settings-navigation', () => ({
   useSettingsNavigation: () => ({ navigateToSettings: vi.fn() }),
 }))

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -190,11 +190,14 @@ export function Home({ chatId, userName, userId }: HomeProps) {
   /**
    * A link that carries a query but no mode opens in Search with the query in
    * the box; the composer follows the live query the same way (below), so the
-   * box and the results never show two different queries.
+   * box and the results never show two different queries. Where per-member
+   * access is off there is no Search to open into, so the query stays a plain
+   * Build draft rather than a mode write `useMothershipMode` would drop.
    */
   useEffect(() => {
+    if (!memberAccessAvailable) return
     if (searchQuery.trim() && composerMode === 'build') void setComposerMode('search')
-  }, [searchQuery, composerMode, setComposerMode])
+  }, [memberAccessAvailable, searchQuery, composerMode, setComposerMode])
   const hasCheckedLandingStorageRef = useRef(false)
   const initialViewInputRef = useRef<HTMLDivElement>(null)
   const initialViewUserInputRef = useRef<UserInputHandle>(null)
@@ -492,8 +495,13 @@ export function Home({ chatId, userName, userId }: HomeProps) {
        * Search lists documents, not a turn of the agent, and only a query can
        * be searched: attachments alone have nothing to search for. Assistant
        * makes the query a turn of the agent grounded in the sources.
+       *
+       * The override skips `useMothershipMode`, so the gate is applied again
+       * where the mode is consumed: both modes answer from the workspace's
+       * indexed sources, and neither is offered where those do not exist.
        */
-      const mode = modeOverride ?? composerMode
+      const requestedMode = modeOverride ?? composerMode
+      const mode = requestedMode !== 'build' && !memberAccessAvailable ? 'build' : requestedMode
       const answering = mode === 'assistant'
       if (mode === 'search') {
         /** A search sends nothing, so an edit in progress is released rather than left waiting. */
@@ -536,6 +544,7 @@ export function Home({ chatId, userName, userId }: HomeProps) {
       workspaceId,
       chatId,
       composerMode,
+      memberAccessAvailable,
       editingQueuedId,
       cancelQueueEdit,
       prepareResourceViewForAgentTurn,

--- a/apps/sim/app/workspace/[workspaceId]/home/home.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/home.tsx
@@ -68,6 +68,7 @@ import { useMarkMothershipChatRead } from '@/hooks/queries/mothership-chats'
 import { KNOWLEDGE_BASE_LIST_STALE_TIME, knowledgeKeys } from '@/hooks/queries/utils/knowledge-keys'
 import { useWorkflows } from '@/hooks/queries/workflows'
 import { getWorkspaceFilesQueryOptions, useWorkspaceFiles } from '@/hooks/queries/workspace-files'
+import { useMemberAccessAvailable } from '@/hooks/use-member-access'
 import { useOAuthReturnRouter } from '@/hooks/use-oauth-return'
 import type { ChatContext } from '@/stores/panel'
 import {
@@ -184,6 +185,7 @@ export function Home({ chatId, userName, userId }: HomeProps) {
     },
     [setSearchQueryParam, setSearchFilters]
   )
+  const memberAccessAvailable = useMemberAccessAvailable()
   const [composerMode, setComposerMode] = useMothershipMode()
   /**
    * A link that carries a query but no mode opens in Search with the query in
@@ -803,7 +805,7 @@ export function Home({ chatId, userName, userId }: HomeProps) {
                     defaultValue={initialPrompt || searchQuery}
                     draftScopeKey={draftScopeKey}
                     onSubmit={handleSubmit}
-                    canSearch
+                    canSearch={memberAccessAvailable}
                     clearOnSubmit={composerMode !== 'search'}
                     onCleared={clearSearch}
                     isSending={isSending}
@@ -835,7 +837,7 @@ export function Home({ chatId, userName, userId }: HomeProps) {
             isReconnecting={isReconnecting}
             isLoading={showChatSkeleton}
             onSubmit={handleSubmit}
-            canSearch
+            canSearch={memberAccessAvailable}
             clearOnSubmit={composerMode !== 'search'}
             onCleared={clearSearch}
             onStopGeneration={handleStopGeneration}

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { NuqsTestingAdapter, type UrlUpdateEvent } from 'nuqs/adapters/testing'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MothershipMode } from '@/app/workspace/[workspaceId]/home/search-params'
+
+const { mockMemberAccessAvailable } = vi.hoisted(() => ({
+  mockMemberAccessAvailable: vi.fn(() => true),
+}))
+const mockUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>()
+
+vi.mock('@/hooks/use-member-access', () => ({
+  useMemberAccessAvailable: () => mockMemberAccessAvailable(),
+}))
+
+import { useMothershipMode } from '@/app/workspace/[workspaceId]/home/hooks/use-mothership-mode'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+let current: ReturnType<typeof useMothershipMode> | null = null
+
+function Probe() {
+  current = useMothershipMode()
+  return null
+}
+
+function mount(searchParams = '') {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() =>
+    root?.render(
+      <NuqsTestingAdapter hasMemory searchParams={searchParams} onUrlUpdate={mockUrlUpdate}>
+        <Probe />
+      </NuqsTestingAdapter>
+    )
+  )
+}
+
+function mode(): MothershipMode {
+  if (!current) throw new Error('Probe did not render')
+  return current[0]
+}
+
+/** nuqs batches its URL write onto a timeout, so a write is read back after the tick. */
+async function setMode(next: MothershipMode) {
+  await act(async () => {
+    current?.[1](next)
+    await vi.advanceTimersByTimeAsync(1)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  mockMemberAccessAvailable.mockReturnValue(true)
+  mockUrlUpdate.mockClear()
+})
+
+afterEach(() => {
+  if (root) act(() => root?.unmount())
+  container?.remove()
+  root = null
+  container = null
+  current = null
+  vi.useRealTimers()
+})
+
+describe('useMothershipMode', () => {
+  it('defaults to Build and reads the mode the URL names', () => {
+    mount()
+    expect(mode()).toBe('build')
+
+    act(() => root?.unmount())
+    mount('?mode=search')
+    expect(mode()).toBe('search')
+  })
+
+  it('writes the chosen mode to the URL', async () => {
+    mount()
+    await setMode('search')
+
+    expect(mode()).toBe('search')
+    expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.get('mode')).toBe('search')
+  })
+
+  it('drops the query and its filters on every mode but Search', async () => {
+    mount('?mode=search&q=budget&source=upload&updated=7d')
+    await setMode('assistant')
+
+    expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.toString()).toBe('mode=assistant')
+  })
+
+  describe('without per-member access', () => {
+    beforeEach(() => {
+      mockMemberAccessAvailable.mockReturnValue(false)
+    })
+
+    it('reads Build from a link naming a mode the workspace does not have', () => {
+      mount('?mode=search')
+
+      expect(mode()).toBe('build')
+    })
+
+    it('writes no mode the workspace does not have', async () => {
+      mount()
+      await setMode('search')
+
+      expect(mode()).toBe('build')
+      expect(mockUrlUpdate).not.toHaveBeenCalled()
+    })
+
+    it('still returns to Build, so a stale link can be left', async () => {
+      mount('?mode=search&q=budget')
+      await setMode('build')
+
+      expect(mode()).toBe('build')
+      expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.toString()).toBe('')
+    })
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.test.tsx
@@ -69,29 +69,18 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
+/**
+ * The mode's ordinary read/write behavior is covered through the UI in
+ * `mode-switcher.test.tsx`; one write stands here as the control the
+ * per-member-access cases are read against.
+ */
 describe('useMothershipMode', () => {
-  it('defaults to Build and reads the mode the URL names', () => {
-    mount()
-    expect(mode()).toBe('build')
-
-    act(() => root?.unmount())
-    mount('?mode=search')
-    expect(mode()).toBe('search')
-  })
-
   it('writes the chosen mode to the URL', async () => {
     mount()
     await setMode('search')
 
     expect(mode()).toBe('search')
     expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.get('mode')).toBe('search')
-  })
-
-  it('drops the query and its filters on every mode but Search', async () => {
-    mount('?mode=search&q=budget&source=upload&updated=7d')
-    await setMode('assistant')
-
-    expect(mockUrlUpdate.mock.lastCall?.[0].searchParams.toString()).toBe('mode=assistant')
   })
 
   describe('without per-member access', () => {

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.ts
@@ -8,25 +8,36 @@ import {
   type MothershipMode,
   resourceUrlKeys,
 } from '@/app/workspace/[workspaceId]/home/search-params'
+import { useMemberAccessAvailable } from '@/hooks/use-member-access'
 
 /**
  * The composer's mode, read from and written to the URL's `mode` param so a
  * refresh, back, forward, or shared link lands in the same mode, as Glean's
  * separate Search and Assistant routes do. Build is the clean URL.
+ *
+ * Search and Assistant both answer from the workspace's indexed sources, so
+ * both exist only where per-member access is on. This is the one place that
+ * decides it: with the feature off the mode reads Build whatever the URL says
+ * — a stale link cannot strand the composer in a mode whose switcher is not
+ * rendered to leave it — and a write to either mode is dropped rather than
+ * putting a mode in the URL that the next read would contradict.
  */
 export function useMothershipMode() {
+  const memberAccessAvailable = useMemberAccessAvailable()
   const [{ mode }, setParams] = useQueryStates(composerModeParsers, resourceUrlKeys)
   const setMode = useCallback(
-    (next: MothershipMode) =>
-      setParams(
+    (next: MothershipMode) => {
+      if (next !== 'build' && !memberAccessAvailable) return
+      void setParams(
         {
           mode: next,
           ...(next === 'search' ? {} : { q: null, ...CLEARED_SEARCH_FILTERS }),
         },
         { history: 'replace', scroll: false }
-      ),
-    [setParams]
+      )
+    },
+    [memberAccessAvailable, setParams]
   )
 
-  return [mode, setMode] as const
+  return [memberAccessAvailable ? mode : 'build', setMode] as const
 }

--- a/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/hooks/use-mothership-mode.ts
@@ -16,19 +16,17 @@ import { useMemberAccessAvailable } from '@/hooks/use-member-access'
  * separate Search and Assistant routes do. Build is the clean URL.
  *
  * Search and Assistant both answer from the workspace's indexed sources, so
- * both exist only where per-member access is on. This is the one place that
- * decides it: with the feature off the mode reads Build whatever the URL says
- * — a stale link cannot strand the composer in a mode whose switcher is not
- * rendered to leave it — and a write to either mode is dropped rather than
- * putting a mode in the URL that the next read would contradict.
+ * both exist only where per-member access is on. With the feature off the mode
+ * reads Build whatever the URL says, and a write to either is dropped rather
+ * than leaving a mode in the URL that the next read would contradict.
  */
 export function useMothershipMode() {
   const memberAccessAvailable = useMemberAccessAvailable()
   const [{ mode }, setParams] = useQueryStates(composerModeParsers, resourceUrlKeys)
   const setMode = useCallback(
-    (next: MothershipMode) => {
+    async (next: MothershipMode) => {
       if (next !== 'build' && !memberAccessAvailable) return
-      void setParams(
+      await setParams(
         {
           mode: next,
           ...(next === 'search' ? {} : { q: null, ...CLEARED_SEARCH_FILTERS }),

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/add-connector-modal/add-connector-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/add-connector-modal/add-connector-modal.tsx
@@ -56,6 +56,7 @@ import type { ConnectorMeta } from '@/connectors/types'
 import { useCreateConnector } from '@/hooks/queries/kb/connectors'
 import { useOAuthCredentials } from '@/hooks/queries/oauth/oauth-credentials'
 import { useCredentialRefreshTriggers } from '@/hooks/use-credential-refresh-triggers'
+import { useMemberAccessAvailable } from '@/hooks/use-member-access'
 
 const CONNECTOR_ENTRIES = Object.entries(CONNECTOR_META_REGISTRY)
 
@@ -92,9 +93,9 @@ export function AddConnectorModal({
   const [searchTerm, setSearchTerm] = useState('')
 
   const { workspaceId } = useParams<{ workspaceId: string }>()
-  const { ownerBilling, features } = useWorkspaceHostContext()
+  const { ownerBilling } = useWorkspaceHostContext()
   const { canAdmin } = useUserPermissionsContext()
-  const memberAccessAvailable = features?.knowledgeMemberAccess === true
+  const memberAccessAvailable = useMemberAccessAvailable()
   const { mutate: createConnector, isPending: isCreating } = useCreateConnector()
 
   const hasMaxAccess = hasWorkspaceMaxConnectorAccess(ownerBilling)

--- a/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/edit-connector-modal/edit-connector-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/knowledge/[id]/components/edit-connector-modal/edit-connector-modal.tsx
@@ -55,6 +55,7 @@ import {
   useUpdateConnectorAccess,
 } from '@/hooks/queries/kb/connectors'
 import { useOAuthCredentials } from '@/hooks/queries/oauth/oauth-credentials'
+import { useMemberAccessAvailable } from '@/hooks/use-member-access'
 
 const logger = createLogger('EditConnectorModal')
 
@@ -232,7 +233,7 @@ export function EditConnectorModal({
     initialCanonicalModes,
   })
 
-  const { ownerBilling, features } = useWorkspaceHostContext()
+  const { ownerBilling } = useWorkspaceHostContext()
   const { canAdmin } = useUserPermissionsContext()
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const { mutate: updateConnector, isPending: isSavingSettings } = useUpdateConnector()
@@ -243,7 +244,7 @@ export function EditConnectorModal({
    * member keeps it where the flag has since been turned off, so an admin can
    * still bring it back to workspace mode; per-member cannot be re-chosen.
    */
-  const memberAccessAvailable = features?.knowledgeMemberAccess === true
+  const memberAccessAvailable = useMemberAccessAvailable()
   const showAccessField = memberAccessAvailable || connector.accessMode === 'members'
 
   const hasMaxAccess = hasWorkspaceMaxConnectorAccess(ownerBilling)

--- a/apps/sim/app/workspace/[workspaceId]/search/page.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/search/page.tsx
@@ -1,5 +1,8 @@
 import { Suspense } from 'react'
 import type { Metadata } from 'next'
+import { notFound, redirect } from 'next/navigation'
+import { getSession } from '@/lib/auth'
+import { getWorkspaceHostContextForViewer } from '@/lib/workspaces/host-context'
 import { IntegrationTabsHeader } from '@/app/workspace/[workspaceId]/components'
 import { Search } from '@/app/workspace/[workspaceId]/search/search'
 
@@ -8,13 +11,24 @@ export const metadata: Metadata = {
 }
 
 /**
- * Sim Search page entry. `Search` reads URL query params via nuqs (which uses
- * `useSearchParams` internally), so it must sit under a Suspense boundary. The
- * fallback renders the real page chrome (background + tab header) so a suspend
- * never shows a blank frame.
+ * Sim Search page entry, served only where per-member access is on: the whole
+ * surface is the feature, so with it off the route is not there to be typed,
+ * linked, or bookmarked into — the same judgement the tab header hides itself
+ * on. The host context is request-memoized, so this re-reads what the workspace
+ * layout already resolved.
+ *
+ * `Search` reads URL query params via nuqs (which uses `useSearchParams`
+ * internally), so it must sit under a Suspense boundary. The fallback renders
+ * the real page chrome (background + tab header) so a suspend never shows a
+ * blank frame.
  */
 export default async function SearchPage({ params }: { params: Promise<{ workspaceId: string }> }) {
+  const session = await getSession()
+  if (!session?.user) redirect('/login')
+
   const { workspaceId } = await params
+  const hostContext = await getWorkspaceHostContextForViewer(workspaceId, session.user.id)
+  if (!hostContext?.features?.knowledgeMemberAccess) notFound()
 
   return (
     <Suspense

--- a/apps/sim/app/workspace/[workspaceId]/search/search.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/search/search.test.tsx
@@ -15,7 +15,7 @@ vi.mock('next/navigation', () => ({
   useParams: () => ({ workspaceId: 'workspace-1' }),
 }))
 vi.mock('@/app/workspace/[workspaceId]/providers/workspace-host-provider', () => ({
-  useWorkspaceHostContext: () => ({ features: mockFeatures() }),
+  useOptionalWorkspaceHostContext: () => ({ features: mockFeatures() }),
 }))
 vi.mock('nuqs', () => ({
   useQueryState: () => ['', vi.fn()],

--- a/apps/sim/app/workspace/[workspaceId]/search/search.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/search/search.tsx
@@ -124,9 +124,8 @@ export function Search() {
   const workspaceId = (params?.workspaceId as string) || ''
   const { integrationAvailability } = usePermissionConfig()
   /**
-   * Judged by the workspace, as the server judges it: with per-member access
-   * off, every connect is refused, so the rows say so instead of offering
-   * one and the memberships are not fetched.
+   * With per-member access off, every connect is refused, so the rows say so
+   * and the memberships are not fetched.
    */
   const memberAccessAvailable = useMemberAccessAvailable()
   const { data: workspacePermissions } = useWorkspacePermissionsQuery(workspaceId)

--- a/apps/sim/app/workspace/[workspaceId]/search/search.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/search/search.tsx
@@ -18,7 +18,6 @@ import { SourceSetupModal } from '@/app/workspace/[workspaceId]/home/components/
 import { IntegrationSection } from '@/app/workspace/[workspaceId]/integrations/components/integration-section'
 import { IntegrationTile } from '@/app/workspace/[workspaceId]/integrations/components/integrations-showcase'
 import { useScrollRestoration } from '@/app/workspace/[workspaceId]/integrations/hooks/use-scroll-restoration'
-import { useWorkspaceHostContext } from '@/app/workspace/[workspaceId]/providers/workspace-host-provider'
 import { MemberConnectorsSection } from '@/app/workspace/[workspaceId]/search/components/member-connectors-section/member-connectors-section'
 import {
   connectorSearchParam,
@@ -33,6 +32,7 @@ import {
 } from '@/hooks/queries/kb/connectors'
 import { useWorkspacePermissionsQuery } from '@/hooks/queries/workspace'
 import { useDebouncedSearchSetter } from '@/hooks/use-debounced-search-setter'
+import { useMemberAccessAvailable } from '@/hooks/use-member-access'
 import {
   CONNECTABLE_MEMBERSHIPS,
   describeMembership,
@@ -123,13 +123,12 @@ export function Search() {
   const params = useParams()
   const workspaceId = (params?.workspaceId as string) || ''
   const { integrationAvailability } = usePermissionConfig()
-  const { features } = useWorkspaceHostContext()
   /**
    * Judged by the workspace, as the server judges it: with per-member access
    * off, every connect is refused, so the rows say so instead of offering
    * one and the memberships are not fetched.
    */
-  const memberAccessAvailable = features?.knowledgeMemberAccess === true
+  const memberAccessAvailable = useMemberAccessAvailable()
   const { data: workspacePermissions } = useWorkspacePermissionsQuery(workspaceId)
   /** The first connect of a source turns it on for the workspace, which takes an admin. */
   const canCreate = workspacePermissions?.viewer?.isAdmin ?? false

--- a/apps/sim/hooks/use-member-access.ts
+++ b/apps/sim/hooks/use-member-access.ts
@@ -3,13 +3,11 @@
 import { useOptionalWorkspaceHostContext } from '@/app/workspace/[workspaceId]/providers/workspace-host-provider'
 
 /**
- * Whether per-member knowledge access is on for the routed workspace, as the
- * server judged it: the `knowledge-member-access` flag and Credential Groups,
- * resolved once into the workspace host context.
+ * Whether per-member knowledge access is on for the routed workspace, as
+ * `isKnowledgeMemberAccessAvailable` judged it, resolved once into the
+ * workspace host context.
  *
- * The single client-side reading of that judgement, so every Sim Search
- * surface — the tab, the page, the composer's Search mode, the source rows,
- * and the connector modals — appears and behaves together, and none can drift
+ * The single client-side reading of that judgement, so no surface can drift
  * into offering a feature the server refuses. Outside a workspace route there
  * is no workspace to judge, so it reads false.
  */

--- a/apps/sim/hooks/use-member-access.ts
+++ b/apps/sim/hooks/use-member-access.ts
@@ -1,0 +1,18 @@
+'use client'
+
+import { useOptionalWorkspaceHostContext } from '@/app/workspace/[workspaceId]/providers/workspace-host-provider'
+
+/**
+ * Whether per-member knowledge access is on for the routed workspace, as the
+ * server judged it: the `knowledge-member-access` flag and Credential Groups,
+ * resolved once into the workspace host context.
+ *
+ * The single client-side reading of that judgement, so every Sim Search
+ * surface — the tab, the page, the composer's Search mode, the source rows,
+ * and the connector modals — appears and behaves together, and none can drift
+ * into offering a feature the server refuses. Outside a workspace route there
+ * is no workspace to judge, so it reads false.
+ */
+export function useMemberAccessAvailable(): boolean {
+  return useOptionalWorkspaceHostContext()?.features?.knowledgeMemberAccess === true
+}

--- a/apps/sim/lib/copilot/tools/server/knowledge/knowledge-base.test.ts
+++ b/apps/sim/lib/copilot/tools/server/knowledge/knowledge-base.test.ts
@@ -25,6 +25,7 @@ const {
   mockCreateKnowledgeConnector,
   mockCreateKnowledgeTag,
   mockListKnowledgeTags,
+  mockIsKnowledgeMemberAccessAvailable,
   knowledgeOperations,
 } = vi.hoisted(() => {
   const defineOperation = (id: string, minimumRole: 'read' | 'write') =>
@@ -58,6 +59,7 @@ const {
     mockCreateKnowledgeConnector: vi.fn(),
     mockCreateKnowledgeTag: vi.fn(),
     mockListKnowledgeTags: vi.fn(),
+    mockIsKnowledgeMemberAccessAvailable: vi.fn(),
     knowledgeOperations: {
       addWorkspaceFiles: defineOperation('knowledge.documents.add_workspace_files', 'write'),
       bulkDelete: defineOperation('knowledge.bulk_delete', 'write'),
@@ -98,6 +100,9 @@ vi.mock('@/lib/core/telemetry', () => ({
 }))
 vi.mock('@/lib/posthog/server', () => ({ captureServerEvent: mockCaptureServerEvent }))
 vi.mock('@/lib/knowledge/application/operations', () => ({ knowledgeOperations }))
+vi.mock('@/lib/knowledge/access/availability', () => ({
+  isKnowledgeMemberAccessAvailable: mockIsKnowledgeMemberAccessAvailable,
+}))
 vi.mock('@/lib/knowledge/application/add-workspace-files', () => ({
   addWorkspaceFilesToKnowledgeBase: {
     operation: knowledgeOperations.addWorkspaceFiles,
@@ -260,6 +265,7 @@ describe('manage_knowledge_base trusted application delegation', () => {
       ],
       failed: [],
     })
+    mockIsKnowledgeMemberAccessAvailable.mockResolvedValue(true)
     mockSearchKnowledge.mockResolvedValue({
       results: [],
       query: 'query',
@@ -405,6 +411,30 @@ describe('manage_knowledge_base trusted application delegation', () => {
       resultSecretRegistry: registry,
     })
     expect(mockReadKnowledgeBase).not.toHaveBeenCalled()
+  })
+
+  it('asks for citations where per-member access is on', async () => {
+    const result = await knowledgeBaseServerTool.execute(
+      { operation: 'query', args: { knowledgeBaseId: KNOWLEDGE_BASE.id, query: 'query' } },
+      { ...CONTEXT, resolvedSecretTraceRegistry: new ResolvedSecretTraceRegistry() }
+    )
+
+    expect(result.message).toContain('<source>')
+    expect(mockIsKnowledgeMemberAccessAvailable).toHaveBeenCalledWith({
+      workspaceId: 'workspace-paid',
+    })
+  })
+
+  it('asks for no citation where the workspace cannot render one', async () => {
+    mockIsKnowledgeMemberAccessAvailable.mockResolvedValue(false)
+
+    const result = await knowledgeBaseServerTool.execute(
+      { operation: 'query', args: { knowledgeBaseId: KNOWLEDGE_BASE.id, query: 'query' } },
+      { ...CONTEXT, resolvedSecretTraceRegistry: new ResolvedSecretTraceRegistry() }
+    )
+
+    expect(result).toMatchObject({ success: true })
+    expect(result.message).toBe('Found 0 result(s) for query "query".')
   })
 
   it('returns a safe model result for search infrastructure failures', async () => {

--- a/apps/sim/lib/copilot/tools/server/knowledge/knowledge-base.test.ts
+++ b/apps/sim/lib/copilot/tools/server/knowledge/knowledge-base.test.ts
@@ -437,6 +437,18 @@ describe('manage_knowledge_base trusted application delegation', () => {
     expect(result.message).toBe('Found 0 result(s) for query "query".')
   })
 
+  it('answers without citations when the eligibility lookup fails, rather than failing the query', async () => {
+    mockIsKnowledgeMemberAccessAvailable.mockRejectedValueOnce(new Error('billing unavailable'))
+
+    const result = await knowledgeBaseServerTool.execute(
+      { operation: 'query', args: { knowledgeBaseId: KNOWLEDGE_BASE.id, query: 'query' } },
+      { ...CONTEXT, resolvedSecretTraceRegistry: new ResolvedSecretTraceRegistry() }
+    )
+
+    expect(result).toMatchObject({ success: true })
+    expect(result.message).toBe('Found 0 result(s) for query "query".')
+  })
+
   it('returns a safe model result for search infrastructure failures', async () => {
     mockSearchKnowledge.mockRejectedValueOnce(new Error('database unavailable'))
 

--- a/apps/sim/lib/copilot/tools/server/knowledge/knowledge-base.ts
+++ b/apps/sim/lib/copilot/tools/server/knowledge/knowledge-base.ts
@@ -20,6 +20,7 @@ import {
 import { asOrchestrationError } from '@/lib/core/orchestration/types'
 import { PlatformEvents } from '@/lib/core/telemetry'
 import { getEffectiveDecryptedEnv } from '@/lib/environment/utils'
+import { isKnowledgeMemberAccessAvailable } from '@/lib/knowledge/access/availability'
 import { addWorkspaceFilesToKnowledgeBase } from '@/lib/knowledge/application/add-workspace-files'
 import { KnowledgeUsageLimitExceededError } from '@/lib/knowledge/application/billing'
 import {
@@ -64,6 +65,12 @@ const DEFAULT_QUERY_TOP_K = 5
  * How the model cites a knowledge result in its reply. The `<source>` tag is
  * what the chat renders as a link back to the document, so a result without
  * a source URL is quoted by name instead.
+ *
+ * Asked for only where per-member access is on. The chip and the sources strip
+ * that render the tag arrived with Sim Search, so a workspace without the
+ * feature must not be told to emit one: the gate belongs here, at the emission,
+ * because a client that merely declined to render the tag would leave the raw
+ * `<source>{...}</source>` JSON sitting in the visible reply.
  */
 const KNOWLEDGE_CITATION_INSTRUCTION =
   'Cite each result you use inline, right after the sentence it supports, as <source>{"url":"<sourceUrl>","title":"<documentName>","siteName":"<knowledgeBaseName>","connectorType":"<connectorType>","snippet":"<the sentence or two of content you relied on>","updatedAt":"<sourceModifiedAt>","author":"<author>"}</source> with every value JSON-escaped; leave out any optional field whose value is null or unknown, and omit the tag for a result whose sourceUrl is null and name the document instead.'
@@ -436,13 +443,16 @@ export const knowledgeBaseServerTool: BaseServerTool<KnowledgeBaseArgs, Knowledg
                 'Failed to query knowledge base: Knowledge result secret provenance is unavailable',
             }
           }
-          const searchResult = await executeCopilotKnowledgeUseCase(context, searchKnowledge, {
-            workspaceId,
-            knowledgeBaseIds: [args.knowledgeBaseId],
-            query: modelQuery,
-            topK,
-            resultSecretRegistry: context.resolvedSecretTraceRegistry,
-          })
+          const [searchResult, citable] = await Promise.all([
+            executeCopilotKnowledgeUseCase(context, searchKnowledge, {
+              workspaceId,
+              knowledgeBaseIds: [args.knowledgeBaseId],
+              query: modelQuery,
+              topK,
+              resultSecretRegistry: context.resolvedSecretTraceRegistry,
+            }),
+            isKnowledgeMemberAccessAvailable({ workspaceId }),
+          ])
           const results = searchResult.results
           const knowledgeBase = searchResult.knowledgeBases[0]
           if (!knowledgeBase)
@@ -455,9 +465,11 @@ export const knowledgeBaseServerTool: BaseServerTool<KnowledgeBaseArgs, Knowledg
             userId: context.userId,
           })
 
+          const foundMessage = `Found ${results.length} result(s) for query "${truncate(args.query, 50)}".`
+
           return {
             success: true,
-            message: `Found ${results.length} result(s) for query "${truncate(args.query, 50)}". ${KNOWLEDGE_CITATION_INSTRUCTION}`,
+            message: citable ? `${foundMessage} ${KNOWLEDGE_CITATION_INSTRUCTION}` : foundMessage,
             data: {
               knowledgeBaseId: args.knowledgeBaseId,
               knowledgeBaseName: knowledgeBase.name,

--- a/apps/sim/lib/copilot/tools/server/knowledge/knowledge-base.ts
+++ b/apps/sim/lib/copilot/tools/server/knowledge/knowledge-base.ts
@@ -451,7 +451,20 @@ export const knowledgeBaseServerTool: BaseServerTool<KnowledgeBaseArgs, Knowledg
               topK,
               resultSecretRegistry: context.resolvedSecretTraceRegistry,
             }),
-            isKnowledgeMemberAccessAvailable({ workspaceId }),
+            /**
+             * Whether to ask for a citation is a presentation choice, and it is
+             * answered by a billing-backed lookup that can reject. A rejection
+             * must not discard a search that succeeded, so it settles to "do not
+             * cite" — the same answer the feature being off gives — rather than
+             * failing the query.
+             */
+            isKnowledgeMemberAccessAvailable({ workspaceId }).catch((error) => {
+              logger.warn('Citation eligibility unavailable; answering without citations', {
+                workspaceId,
+                error: getErrorMessage(error),
+              })
+              return false
+            }),
           ])
           const results = searchResult.results
           const knowledgeBase = searchResult.knowledgeBases[0]

--- a/scripts/check-tool-registry-boundary.baseline.json
+++ b/scripts/check-tool-registry-boundary.baseline.json
@@ -374,16 +374,16 @@
       }
     },
     "app/workspace/[workspaceId]/search/page.tsx": {
-      "modules": 1260,
+      "modules": 1765,
       "gateways": {
-        "apps/sim/app/workspace/[workspaceId]/search/search.tsx": 1114,
-        "apps/sim/blocks/registry.ts": 957,
-        "apps/sim/triggers/index.ts": 524,
-        "apps/sim/triggers/registry.ts": 522,
-        "apps/sim/connectors/registry.ts": 66,
-        "apps/sim/blocks/blocks/credential-group.ts": 63,
-        "apps/sim/app/workspace/[workspaceId]/components/index.ts": 58,
-        "apps/sim/stores/workflows/registry/store.ts": 43
+        "apps/sim/triggers/index.ts": 487,
+        "apps/sim/triggers/registry.ts": 485,
+        "apps/sim/blocks/registry.ts": 412,
+        "apps/sim/lib/auth/index.ts": 404,
+        "apps/sim/lib/webhooks/providers/index.ts": 117,
+        "apps/sim/lib/webhooks/providers/registry.ts": 115,
+        "apps/sim/app/workspace/[workspaceId]/search/search.tsx": 112,
+        "apps/sim/connectors/registry.ts": 66
       }
     },
     "app/workspace/[workspaceId]/settings/[section]/error.tsx": {


### PR DESCRIPTION
## What's wrong

Sim Search shipped in #7385 "behind a feature flag". In production that flag is **off** — the AppConfig `feature-flags` document for `sim-production` has no `knowledge-member-access` entry at all, so it evaluates to `false` for everyone. (Staging has `{"enabled": true, "adminEnabled": true}`.)

The server honours that correctly: it refuses every per-member connect, hides member-scoped documents, and gates the connector engine. **The UI never asked.** The flag was wired to the actions and the data, never to the surfaces — so an unreleased feature has been visible to every production user, and the connect it offered failed with *"Per-member access is not available in this workspace"*, which reads like a plan limit rather than a feature that hasn't shipped.

What was rendering unconditionally:

| Surface | Where |
|---|---|
| **Search** tab beside Integrations and Skills | `integration-tabs-header.tsx` |
| `/workspace/[id]/search` + the whole Sim Search connector catalog | `search/page.tsx`, `search.tsx` |
| Composer **Search** and **Assistant** modes | `mode-switcher.tsx` over `MOTHERSHIP_MODES` |
| Source chips under the composer | `suggested-actions.tsx`, gated only on `mode !== 'build'` |
| Knowledge search results | `home.tsx`; `useWorkspaceKnowledgeSearch` fired regardless |
| **`<source>` citation chips and the sources strip** | `knowledge-base.ts` asked for them on *every* knowledge query, including plain Build turns |

That last row is the one worth reading twice: it needs no Search surface to reach. Any ordinary agent turn that searched a knowledge base instructed the model to emit `<source>` tags, and the chat rendered the citation chips and the "N sources" popover. Both the instruction and `collectMessageSources` trace to `0db625629d` (#7385); neither render site read the flag.

## What this does

One judgement, read everywhere.

- **`useMemberAccessAvailable`** (new) replaces five copies of `features?.knowledgeMemberAccess === true`. It reads the *optional* host context, so a missing provider, missing `features`, or an in-flight refetch all fail closed.
- **The Search tab** renders only where the page it links to is served.
- **`search/page.tsx`** authenticates and `notFound()`s when the feature is off, so the route can't be typed, linked, or bookmarked into. Same shape as `settings/[section]/page.tsx`; both `getSession` and `getWorkspaceHostContextForViewer` are `cache()`-wrapped, so it re-reads what the layout already resolved rather than repeating DB work.
- **`useMothershipMode`** coerces Search/Assistant to Build and drops writes to them, so a stale `?mode=search` link can't strand a composer whose switcher isn't rendered. `handleSubmit` re-applies it because `modeOverride` bypasses the hook entirely.
- **The citation instruction** is asked for only where per-member access is on. The gate is at the *emission*, not the renderer — a client that merely declined to render would leave raw `<source>{...}</source>` JSON in the visible reply.

## Deliberate calls

**The `memberAccessAvailable` guards on the member-connector queries stay**, though they're now unreachable through the gated entry points. `useWorkspaceMemberConnectors` sets `placeholderData: keepPreviousData`, so a *disabled* observer can still surface previously cached rows — the coercion to `EMPTY_MEMBER_CONNECTORS` is what stops rows from a flag-on render leaking into a flag-off one. Removing it would be a bug, not a simplification.

**A stale `?mode=search&q=…` is coerced, not stripped.** Clearing it would need a write-on-read effect, which `.claude/rules/sim-url-state.md` forbids; a dead param falls back and stays harmless, and the link self-heals when the flag flips on or the user opens it in an entitled workspace.

**`canSearch` stays a prop.** It encodes "this composer surface can answer with documents", which is a different question from "this workspace has the feature".

**The module-graph baseline** for `search/page.tsx` is re-recorded (1260 → 1765) for the session read the gate performs. Only that one entry changed. The +505 is entirely `@/lib/auth`, which the workspace layout already imports in the same render, so the incremental server cost is ~0 and none of it is client bundle — measured, the `'use client'` conversion of the tab header added **0 modules** to every other consumer of that barrel. The hard registry gate is untouched.

## Known gap, not fixed here

Assistant mode (`requestMode: 'ask'`) has no server-side refusal. The documents it grounds on are already scoped server-side, so no data leaks — what's ungated is the mode itself, and closing it means touching the copilot chat contract. Worth a follow-up rather than widening this PR.

## Testing

- New: `use-mothership-mode.test.tsx`, `integration-tabs-header.test.tsx`, and two citation-gate cases in `knowledge-base.test.ts`. Each new gate test was confirmed to go **red** when its gate is reverted.
- `bun run type-check` clean · 566 test files / 6560 tests pass · all 45 `bun run check:audits` green.
- Reviewed with `/simplify` and `/cleanup` (effects, state, memo, callback, React Query, emcn, url-state, comments — all eight passes clean or applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JmUGTitFeoQXVf9T3skEa
