### PR TITLE
fix(security): guard two OOXML paths that reached JSZip without a zip-bomb check

### DIFF
--- a/apps/sim/lib/copilot/tools/server/files/doc-asset-extract.test.ts
+++ b/apps/sim/lib/copilot/tools/server/files/doc-asset-extract.test.ts
@@ -4,6 +4,7 @@
 import JSZip from 'jszip'
 import { describe, expect, it } from 'vitest'
 import { extractDocAssets } from '@/lib/copilot/tools/server/files/doc-asset-extract'
+import { MAX_OOXML_CENTRAL_DIRECTORY_RECORDS, ZipBombError } from '@/lib/file-parsers/ooxml-limits'
 
 const THEME_XML = `<?xml version="1.0"?>
 <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office">
@@ -141,6 +142,21 @@ describe('extractDocAssets', () => {
     })
     expect(slide.texts[1].bold).toBeUndefined()
     expect(slide.texts.some((t) => t.text.includes('grouped'))).toBe(false)
+  })
+
+  it('refuses an archive the OOXML guard rejects', async () => {
+    // Every media entry is inflated into a retained Buffer with no cap of its
+    // own, so the guard is the only thing bounding this. Tripping its
+    // record-count ceiling asserts the call site is guarded without building a
+    // multi-megabyte fixture; the size ceilings are covered in zip-guard.test.ts.
+    const zip = new JSZip()
+    for (let index = 0; index <= MAX_OOXML_CENTRAL_DIRECTORY_RECORDS; index++) {
+      zip.file(`ppt/media/image${index}.png`, PNG_BYTES)
+    }
+
+    await expect(
+      extractDocAssets(await zip.generateAsync({ type: 'nodebuffer' }), 'pptx')
+    ).rejects.toThrow(ZipBombError)
   })
 
   it('tolerates a package with no theme or media', async () => {

--- a/apps/sim/lib/copilot/tools/server/files/doc-asset-extract.ts
+++ b/apps/sim/lib/copilot/tools/server/files/doc-asset-extract.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip'
+import { assertOoxmlArchiveWithinLimits } from '@/lib/file-parsers/zip-guard'
 
 /**
  * Pulls the reusable design material out of an OOXML document (.pptx/.docx):
@@ -370,6 +371,11 @@ export async function extractDocAssets(
   binary: Buffer,
   format: 'pptx' | 'docx'
 ): Promise<ExtractedDocAssets> {
+  // The media loop below inflates every entry into a retained Buffer, so an
+  // attacker-supplied archive has to be bounded from its central directory first —
+  // the same guard `extractDocumentStyle` and the document parsers already apply.
+  assertOoxmlArchiveWithinLimits(binary)
+
   const zip = await JSZip.loadAsync(binary)
   const prefix = format === 'pptx' ? 'ppt' : 'word'
 

--- a/apps/sim/lib/microsoft-word/document.server.test.ts
+++ b/apps/sim/lib/microsoft-word/document.server.test.ts
@@ -4,6 +4,7 @@
 import { Document, Header, Packer, Paragraph, TextRun } from 'docx'
 import JSZip from 'jszip'
 import { describe, expect, it } from 'vitest'
+import { MAX_OOXML_CENTRAL_DIRECTORY_RECORDS, ZipBombError } from '@/lib/file-parsers/ooxml-limits'
 import {
   appendParagraphsToDocx,
   buildDocxFromContent,
@@ -197,6 +198,21 @@ describe('extractDocxText', () => {
     const blank = await buildDocxFromContent('')
 
     await expect(extractDocxText(blank)).resolves.toBe('')
+  })
+
+  it('refuses an archive the OOXML guard rejects rather than rescuing it', async () => {
+    // The rescue re-opens the buffer with JSZip and reads `word/document.xml`
+    // into a string with no size cap, and the parser rejecting the archive is
+    // exactly what routes it there. The body stays empty so the rescue would
+    // otherwise succeed — reporting the archive as an empty document.
+    const zip = await JSZip.loadAsync(await buildDocxFromContent(''))
+    for (let index = 0; index <= MAX_OOXML_CENTRAL_DIRECTORY_RECORDS; index++) {
+      zip.file(`word/embeddings/pad${index}.bin`, '')
+    }
+
+    await expect(extractDocxText(await zip.generateAsync({ type: 'nodebuffer' }))).rejects.toThrow(
+      ZipBombError
+    )
   })
 
   it('still fails on an archive that is not a Word package', async () => {

--- a/apps/sim/lib/microsoft-word/document.server.ts
+++ b/apps/sim/lib/microsoft-word/document.server.ts
@@ -249,6 +249,12 @@ export async function extractDocxText(buffer: Buffer): Promise<string> {
 
 /** Whether the buffer is a valid Word package whose body holds no text. */
 async function isEmptyWordPackage(buffer: Buffer): Promise<boolean> {
+  // Reached with the untrusted buffer the parser just rejected — including when it
+  // rejected it as a zip bomb. Without this the rescue reads `word/document.xml`
+  // into a string with no size cap, making the guard the trigger for the expansion
+  // it prevents. Kept outside the catch so the rejection propagates.
+  assertOoxmlArchiveWithinLimits(buffer)
+
   try {
     const zip = await JSZip.loadAsync(buffer)
     const part = zip.file(DOCUMENT_PART_PATH)


### PR DESCRIPTION
## Summary
- `extractDocxText` rescues a parse failure by re-reading the package as a possibly-empty document. That rescue handed the buffer to JSZip with no size guard, and a zip bomb's rejection is exactly what routes it there — so the guard was the trigger for reading `word/document.xml` into a string uncapped. Now guarded like every other JSZip call site in the file, placed outside the catch so the rejection propagates instead of being read as "not empty".
- `extractDocAssets` handed an attacker-supplied `.pptx`/`.docx` straight to JSZip and inflated every `*/media/*` entry into a retained Buffer. The only ceiling was on the **compressed** source, which DEFLATE's ~1000:1 ratio makes meaningless. Now applies the same shared guard the document parsers and `extractDocumentStyle` already apply.

**No new limits are introduced.** Both call sites use the existing shared ceilings in `ooxml-limits.ts`, so a file rejected here is one Sim's text-extraction path (`/api/v2/files/<id>/text`) already rejects today — this removes an inconsistency rather than adding a restriction.

The Word path provably has zero new rejection surface: `isEmptyWordPackage` is module-private and reached only after `DocxParser.parseBuffer` ran the identical guard on the identical buffer, so the new call can only throw where the parser already threw.

## Type of Change
- [x] Bug fix

## Testing
- Two regression tests, each verified to fail without its fix and pass with it.
- Full `apps/sim` suite: 3,030 files / 41,965 tests passing.
- `bun run lint`, `bun run type-check`, `bun run check:audits` (45 audits), `docs-manifest:check`, and the block-registry audit all pass.

## Notes
Follow-up worth considering (deliberately not in this PR): an audit rule asserting that server-side OOXML consumers call `assertOoxmlArchiveWithinLimits`. The invariant spans four decompression libraries (mammoth, SheetJS, officeparser, JSZip), so it can't be expressed as a wrapper — a lint-style check is the right shape, but it's ~150 lines of tooling that doesn't belong on a two-line security fix.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
