### PR TITLE
feat(editor): replace canonical input toggle with icon switch

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/canonical-mode-toggle.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/canonical-mode-toggle.tsx
@@ -1,0 +1,28 @@
+import { IconSwitch } from '@sim/emcn'
+import { List } from '@sim/emcn/icons'
+import { VariableIcon } from '@/components/icons'
+import type { CanonicalMode } from '@/lib/workflows/subblocks/visibility'
+
+interface CanonicalModeToggleProps {
+  mode: CanonicalMode
+  disabled?: boolean
+  onToggle?: () => void
+}
+
+const MODE_OPTIONS = [
+  { value: 'basic', label: 'Selector', icon: List },
+  { value: 'advanced', label: 'Variable', icon: VariableIcon },
+] as const
+
+export function CanonicalModeToggle({ mode, disabled, onToggle }: CanonicalModeToggleProps) {
+  return (
+    <IconSwitch
+      options={MODE_OPTIONS}
+      value={mode}
+      onValueChange={() => onToggle?.()}
+      disabled={disabled}
+      showTooltips
+      aria-label='Input mode'
+    />
+  )
+}

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/index.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/index.ts
@@ -1,3 +1,4 @@
+export { CanonicalModeToggle } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/canonical-mode-toggle'
 export { CheckboxList } from './checkbox-list'
 export { Code } from './code'
 export { ComboBox } from './combobox'

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/sub-block.tsx
@@ -1,17 +1,11 @@
 import { type JSX, type MouseEvent, memo, useCallback, useMemo, useRef, useState } from 'react'
 import { Button, cn, Input, Label, Tooltip } from '@sim/emcn'
-import {
-  ArrowLeftRight,
-  ArrowUp,
-  Check,
-  Clipboard,
-  SquareArrowUpRight,
-  TriangleAlert,
-} from '@sim/emcn/icons'
+import { ArrowUp, Check, Clipboard, SquareArrowUpRight, TriangleAlert } from '@sim/emcn/icons'
 import { isEqual } from 'es-toolkit'
 import { useParams } from 'next/navigation'
 import type { FilterRule, SortRule } from '@/lib/table/query-builder/constants'
 import {
+  CanonicalModeToggle,
   CheckboxList,
   Code,
   ComboBox,
@@ -374,37 +368,11 @@ const renderLabel = (
           </Tooltip.Root>
         )}
         {showCanonicalToggle && (
-          <Tooltip.Root>
-            <Tooltip.Trigger asChild>
-              <button
-                type='button'
-                className='flex size-[12px] shrink-0 items-center justify-center bg-transparent p-0 disabled:cursor-not-allowed disabled:opacity-50'
-                onClick={canonicalToggle?.onToggle}
-                disabled={canonicalToggleDisabledResolved}
-                aria-label={
-                  canonicalToggle?.mode === 'advanced'
-                    ? 'Switch to selector'
-                    : 'Switch to manual ID'
-                }
-              >
-                <ArrowLeftRight
-                  className={cn(
-                    'h-[12px]! w-[12px]!',
-                    canonicalToggle?.mode === 'advanced'
-                      ? 'text-[var(--text-primary)]'
-                      : 'text-[var(--text-secondary)]'
-                  )}
-                />
-              </button>
-            </Tooltip.Trigger>
-            <Tooltip.Content side='top'>
-              <p>
-                {canonicalToggle?.mode === 'advanced'
-                  ? 'Switch to selector'
-                  : 'Switch to manual ID'}
-              </p>
-            </Tooltip.Content>
-          </Tooltip.Root>
+          <CanonicalModeToggle
+            mode={canonicalToggle?.mode ?? 'basic'}
+            onToggle={canonicalToggle?.onToggle}
+            disabled={canonicalToggleDisabledResolved}
+          />
         )}
       </div>
     </div>

--- a/packages/emcn/src/components/icon-switch/icon-switch.test.tsx
+++ b/packages/emcn/src/components/icon-switch/icon-switch.test.tsx
@@ -1,0 +1,112 @@
+/** @vitest-environment jsdom */
+import { act, useState } from 'react'
+import { IconSwitch } from '@sim/emcn'
+import { Code, List } from '@sim/emcn/icons'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const OPTIONS = [
+  { value: 'selector', label: 'Selector', icon: List },
+  { value: 'variable', label: 'Variable', icon: Code },
+] as const
+
+interface HarnessProps {
+  disabled?: boolean
+  showTooltips?: boolean
+  onValueChange: (value: string) => void
+}
+
+function Harness({ disabled, showTooltips, onValueChange }: HarnessProps) {
+  const [value, setValue] = useState('selector')
+  return (
+    <IconSwitch
+      options={OPTIONS}
+      value={value}
+      onValueChange={(nextValue) => {
+        setValue(nextValue)
+        onValueChange(nextValue)
+      }}
+      disabled={disabled}
+      showTooltips={showTooltips}
+      aria-label='Input mode'
+    />
+  )
+}
+
+let root: Root | null = null
+let container: HTMLDivElement
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container.remove()
+  root = null
+  vi.useRealTimers()
+})
+
+function mount(props: HarnessProps) {
+  act(() => root?.render(<Harness {...props} />))
+  return {
+    inputs: [...container.querySelectorAll('input')],
+    labels: [...container.querySelectorAll('label')],
+  }
+}
+
+describe('IconSwitch', () => {
+  it('selects either mode without toggling an already selected choice', () => {
+    const onValueChange = vi.fn()
+    const { inputs, labels } = mount({ onValueChange })
+
+    act(() => labels[1].click())
+    expect(inputs.map((input) => input.checked)).toEqual([false, true])
+    expect(onValueChange).toHaveBeenLastCalledWith('variable')
+
+    act(() => labels[1].click())
+    expect(onValueChange).toHaveBeenCalledTimes(1)
+
+    act(() => labels[0].click())
+    expect(inputs.map((input) => input.checked)).toEqual([true, false])
+    expect(onValueChange).toHaveBeenLastCalledWith('selector')
+  })
+
+  it('prevents selection changes while disabled', () => {
+    const onValueChange = vi.fn()
+    const { inputs, labels } = mount({ disabled: true, onValueChange })
+
+    act(() => labels[1].click())
+    expect(onValueChange).not.toHaveBeenCalled()
+    expect(inputs.every((input) => input.disabled)).toBe(true)
+    expect(inputs.map((input) => input.checked)).toEqual([true, false])
+  })
+
+  it('shows each option label in its hover tooltip', () => {
+    const { inputs } = mount({ showTooltips: true, onValueChange: vi.fn() })
+
+    for (const [index, option] of OPTIONS.entries()) {
+      act(() => {
+        inputs[index].dispatchEvent(
+          new MouseEvent('pointerover', { bubbles: true, clientX: 200, clientY: 200 })
+        )
+      })
+      expect(document.querySelector('[role="tooltip"]')?.textContent).toBe(option.label)
+      act(() => inputs[index].dispatchEvent(new MouseEvent('pointerout', { bubbles: true })))
+    }
+  })
+
+  it('shows a tooltip on keyboard focus without changing selection', () => {
+    const onValueChange = vi.fn()
+    const { inputs } = mount({ showTooltips: true, onValueChange })
+
+    act(() => inputs[1].focus())
+    expect(document.querySelector('[role="tooltip"]')?.textContent).toBe('Variable')
+    expect(onValueChange).not.toHaveBeenCalled()
+    expect(inputs.map((input) => input.checked)).toEqual([true, false])
+  })
+})

--- a/packages/emcn/src/components/icon-switch/icon-switch.tsx
+++ b/packages/emcn/src/components/icon-switch/icon-switch.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { type ComponentType, useId } from 'react'
+import { cn, Tooltip } from '@sim/emcn'
+
+export interface IconSwitchOption<T extends string = string> {
+  value: T
+  label: string
+  icon: ComponentType<{ className?: string }>
+}
+
+export interface IconSwitchProps<T extends string = string> {
+  options: readonly [IconSwitchOption<T>, IconSwitchOption<T>]
+  value: T
+  onValueChange: (value: T) => void
+  disabled?: boolean
+  showTooltips?: boolean
+  'aria-label': string
+  className?: string
+}
+
+/**
+ * Two square icon choices inside a compact frame. Native radios provide mutually
+ * exclusive selection and keyboard navigation; optional tooltips use each label.
+ *
+ * @example
+ * <IconSwitch options={modes} value={mode} onValueChange={setMode} aria-label="Input mode" />
+ */
+export function IconSwitch<T extends string>({
+  options,
+  value,
+  onValueChange,
+  disabled = false,
+  showTooltips = false,
+  'aria-label': ariaLabel,
+  className,
+}: IconSwitchProps<T>) {
+  const groupName = useId()
+
+  return (
+    <div
+      role='radiogroup'
+      aria-label={ariaLabel}
+      className={cn(
+        'inline-flex w-fit shrink-0 items-center gap-0.5 rounded-[5px] border border-[var(--border)] bg-[var(--surface-3)] p-0.5',
+        disabled && 'opacity-50',
+        className
+      )}
+    >
+      {options.map((option) => {
+        const Icon = option.icon
+        const selected = option.value === value
+        const optionId = `${groupName}-${option.value}`
+        const input = (
+          <input
+            id={optionId}
+            type='radio'
+            name={groupName}
+            value={option.value}
+            checked={selected}
+            onChange={() => onValueChange(option.value)}
+            disabled={disabled}
+            aria-label={option.label}
+            className='peer m-0 size-5 cursor-pointer appearance-none rounded-[3px] bg-transparent transition-colors checked:bg-[var(--surface-active)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--text-icon)] disabled:cursor-not-allowed'
+          />
+        )
+
+        return (
+          <label
+            key={option.value}
+            htmlFor={optionId}
+            className={cn('relative flex', disabled ? 'cursor-not-allowed' : 'cursor-pointer')}
+          >
+            {showTooltips ? (
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>{input}</Tooltip.Trigger>
+                <Tooltip.Content side='top'>{option.label}</Tooltip.Content>
+              </Tooltip.Root>
+            ) : (
+              input
+            )}
+            <Icon
+              aria-hidden='true'
+              className={cn(
+                '-translate-x-1/2 -translate-y-1/2 pointer-events-none absolute top-1/2 left-1/2 size-[14px] transition-colors',
+                selected
+                  ? 'text-[var(--text-primary)]'
+                  : 'text-[var(--text-muted)] peer-hover:text-[var(--text-secondary)]'
+              )}
+            />
+          </label>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/emcn/src/components/icon-switch/icon-switch.tsx
+++ b/packages/emcn/src/components/icon-switch/icon-switch.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { type ComponentType, useId } from 'react'
-import { cn, Tooltip } from '@sim/emcn'
+import { cn } from '../../lib/cn'
+import { Tooltip } from '../tooltip/tooltip'
 
 export interface IconSwitchOption<T extends string = string> {
   value: T

--- a/packages/emcn/src/components/index.ts
+++ b/packages/emcn/src/components/index.ts
@@ -132,6 +132,7 @@ export {
 } from './dropdown-menu/dropdown-menu'
 export { Expandable, ExpandableContent } from './expandable/expandable'
 export { DashedDividerLine, FieldDivider } from './field-divider/field-divider'
+export { IconSwitch, type IconSwitchOption, type IconSwitchProps } from './icon-switch/icon-switch'
 export { Info } from './info/info'
 export {
   InfoCard,


### PR DESCRIPTION
## Summary

- Replace the canonical input mode arrow with explicit Selector and Variable icon choices across subblocks and nested tool parameters.
- Use a shared, keyboard-accessible icon switch with optional tooltips, disabled states, and a transparent unselected background.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- IconSwitch tests: 4 passed.
- App TypeScript check passed.
- Scoped Biome check and API validation audit passed.
- Verified selection, hover tooltips, cursor, and nested field rendering in Chrome.
- Review focus: selection behavior, disabled states, keyboard access, and consistent rendering across canonical inputs.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
Before:
<img width="308" height="88" alt="Screenshot 2026-09-05 at 3 22 26 PM" src="https://github.com/user-attachments/assets/a1cd202e-def9-4099-8d54-fc88b99990d3" />

After:
<img width="315" height="103" alt="Screenshot 2026-09-05 at 3 22 03 PM" src="https://github.com/user-attachments/assets/15e19c97-8047-441b-b8f1-1a9abad00bd8" />


