### PR TITLE
feat(models): gate forced tool use by model capability

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/editor/components/sub-block/components/tool-input/tool-input.tsx
@@ -80,6 +80,7 @@ import { useCollaborativeWorkflow } from '@/hooks/use-collaborative-workflow'
 import { useOperationAccess } from '@/hooks/use-operation-access'
 import { usePermissionConfig } from '@/hooks/use-permission-config'
 import { useSettingsNavigation } from '@/hooks/use-settings-navigation'
+import { supportsForcedToolUse } from '@/providers/models'
 import { getProviderFromModel, supportsToolUsageControl } from '@/providers/utils'
 import type { ActiveSearchTarget } from '@/stores/panel/editor/store'
 import { useSubBlockStore } from '@/stores/workflows/subblock/store'
@@ -561,10 +562,11 @@ export const ToolInput = memo(function ToolInput({
     })
   }, [mcpTools, mcpServers])
 
-  const modelValue = useSubBlockStore.getState().getValue(blockId, 'model')
+  const modelValue = useSubBlockStore((state) => state.getValue(blockId, 'model'))
   const model = typeof modelValue === 'string' ? modelValue : ''
   const provider = model ? getProviderFromModel(model) : ''
   const supportsToolControl = provider ? supportsToolUsageControl(provider) : false
+  const supportsForce = supportsForcedToolUse(model)
 
   const {
     filterBlocks,
@@ -1710,12 +1712,16 @@ export const ToolInput = memo(function ToolInput({
                         </PopoverItem>
                         <PopoverItem
                           active={tool.usageControl === 'force'}
+                          disabled={!supportsForce}
                           onClick={() => {
                             handleUsageControlChange(toolIndex, 'force')
                             setUsageControlPopoverIndex(null)
                           }}
                         >
-                          Force <span className='text-[var(--text-tertiary)]'>(always use)</span>
+                          Force{' '}
+                          <span className='text-[var(--text-tertiary)]'>
+                            {supportsForce ? '(always use)' : '(not supported by model)'}
+                          </span>
                         </PopoverItem>
                         <PopoverItem
                           active={tool.usageControl === 'none'}

--- a/apps/sim/providers/anthropic/core.request.test.ts
+++ b/apps/sim/providers/anthropic/core.request.test.ts
@@ -296,8 +296,13 @@ describe('executeAnthropicProviderRequest forced tool use', () => {
     expect(payload.tool_choice).toEqual({ type: 'tool', name: 'publish' })
   })
 
-  it('drops forced tool_choice on Claude Fable 5.1 because the API rejects it', async () => {
-    const { payload, warn } = await runWithForcedTool('claude-fable-5-1')
+  it.each([
+    'claude-fable-5-1',
+    'claude-fable-5-1-20260901',
+    'azure-anthropic/claude-fable-5-1',
+    'claude-mythos-5-1',
+  ])('drops forced tool_choice on %s because the API rejects it', async (model) => {
+    const { payload, warn } = await runWithForcedTool(model)
     expect(payload.tools?.map((tool) => tool.name)).toEqual(['publish'])
     expect(payload).not.toHaveProperty('tool_choice')
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('rejects forced tool_choice'))

--- a/apps/sim/providers/anthropic/core.request.test.ts
+++ b/apps/sim/providers/anthropic/core.request.test.ts
@@ -296,13 +296,8 @@ describe('executeAnthropicProviderRequest forced tool use', () => {
     expect(payload.tool_choice).toEqual({ type: 'tool', name: 'publish' })
   })
 
-  it.each([
-    'claude-fable-5-1',
-    'claude-fable-5-1-20260901',
-    'azure-anthropic/claude-fable-5-1',
-    'claude-mythos-5-1',
-  ])('drops forced tool_choice on %s because the API rejects it', async (model) => {
-    const { payload, warn } = await runWithForcedTool(model)
+  it('drops forced tool_choice when the catalog model disables Force', async () => {
+    const { payload, warn } = await runWithForcedTool('claude-fable-5-1')
     expect(payload.tools?.map((tool) => tool.name)).toEqual(['publish'])
     expect(payload).not.toHaveProperty('tool_choice')
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('rejects forced tool_choice'))

--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -21,6 +21,7 @@ import {
 import {
   getMaxOutputTokensForModel,
   getThinkingCapability,
+  supportsForcedToolUse,
   supportsNativeStructuredOutputs,
   supportsTemperature,
 } from '@/providers/models'
@@ -153,17 +154,6 @@ function supportsAdaptiveThinking(modelId: string): boolean {
     normalizedModel.includes('sonnet-4-6') ||
     normalizedModel.includes('sonnet-4.6')
   )
-}
-
-/**
- * Claude Fable 5.1 and Claude Mythos 5.1 reject forced tool use: a `tool_choice` of
- * type `tool` or `any` returns a 400 (`tool_choice: type "tool" and "any" are not
- * supported for this model.`). Thinking is always on for these models, so a forced
- * call would skip it. The request is sent with the default `auto` instead.
- */
-function rejectsForcedToolChoice(modelId: string): boolean {
-  const normalizedModel = modelId.toLowerCase()
-  return normalizedModel.includes('fable-5-1') || normalizedModel.includes('mythos-5-1')
 }
 
 /**
@@ -428,7 +418,7 @@ export async function executeAnthropicProviderRequest(
     } else if (toolChoice === 'none') {
       payload.tool_choice = { type: 'none' }
     } else if (toolChoice !== 'auto') {
-      if (rejectsForcedToolChoice(request.model)) {
+      if (!supportsForcedToolUse(request.model)) {
         logger.warn(
           `Model ${modelId} rejects forced tool_choice; sending tool "${toolChoice.name}" with tool_choice auto`
         )

--- a/apps/sim/providers/models.test.ts
+++ b/apps/sim/providers/models.test.ts
@@ -16,7 +16,6 @@ import {
   PROVIDER_DEFINITIONS,
   supportsForcedToolUse,
   updateFireworksModels,
-  updateOpenRouterModels,
 } from '@/providers/models'
 import { supportsPromptCaching } from '@/providers/utils'
 
@@ -65,57 +64,14 @@ describe('catalog featured model metadata', () => {
 })
 
 describe('forced tool use capability', () => {
-  it('keeps Auto and None support when a model disables Force', () => {
-    expect(getModelCapabilities('claude-fable-5-1')).toMatchObject({
-      toolUsageControl: true,
-      forcedToolUse: false,
-    })
-  })
-
-  it.each([
-    'claude-fable-5-1',
-    'CLAUDE-FABLE-5-1-20260901',
-    'azure-anthropic/claude-fable-5-1',
-    'azure-anthropic/claude-fable-5-1-20260901',
-    'bedrock/anthropic.claude-fable-5-1-v1:0',
-    'claude-mythos-5-1',
-    'claude-mythos-5-1-20260901',
-  ])('disables forced tool use for %s', (model) => {
-    expect(getModelCapabilities(model)).toMatchObject({
-      toolUsageControl: true,
-      forcedToolUse: false,
-    })
-    expect(supportsForcedToolUse(model)).toBe(false)
-  })
-
-  it('adds only known alias capabilities to provider defaults', () => {
-    expect(getModelCapabilities('claude-mythos-5-1')).toEqual({
-      ...PROVIDER_DEFINITIONS.anthropic.capabilities,
-      forcedToolUse: false,
-    })
-  })
-
-  it('inherits alias capabilities for dynamic models and respects explicit overrides', () => {
-    const originalModels = PROVIDER_DEFINITIONS.openrouter.models
-    const modelId = 'anthropic/claude-fable-5-1'
-    try {
-      updateOpenRouterModels([modelId])
-      expect(getModelCapabilities(modelId)?.forcedToolUse).toBe(false)
-      expect(supportsForcedToolUse(modelId)).toBe(false)
-
-      PROVIDER_DEFINITIONS.openrouter.models[0].capabilities.forcedToolUse = true
-      expect(getModelCapabilities(modelId)?.forcedToolUse).toBe(true)
-      expect(supportsForcedToolUse(modelId)).toBe(true)
-    } finally {
-      PROVIDER_DEFINITIONS.openrouter.models = originalModels
-    }
-  })
-
-  it.each(['claude-fable-5-10', 'claude-mythos-5-10', 'claude-not-fable-5-1'])(
-    'does not apply alias restrictions to unrelated model %s',
+  it.each(['claude-fable-5-1', 'CLAUDE-FABLE-5-1'])(
+    'disables Force while keeping Auto and None support for %s',
     (model) => {
-      expect(getModelCapabilities(model)).toEqual(PROVIDER_DEFINITIONS.anthropic.capabilities)
-      expect(supportsForcedToolUse(model)).toBe(true)
+      expect(getModelCapabilities(model)).toMatchObject({
+        toolUsageControl: true,
+        forcedToolUse: false,
+      })
+      expect(supportsForcedToolUse(model)).toBe(false)
     }
   )
 

--- a/apps/sim/providers/models.test.ts
+++ b/apps/sim/providers/models.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 import {
   getBaseModelProviders,
   getHostedModels,
+  getModelCapabilities,
   getModelPricing,
   getModelsWithPromptCaching,
   getPromptCachingMinimumTokens,
@@ -13,6 +14,7 @@ import {
   isModelDeprecated,
   orderModelIdsByReleaseDate,
   PROVIDER_DEFINITIONS,
+  supportsForcedToolUse,
   updateFireworksModels,
 } from '@/providers/models'
 import { supportsPromptCaching } from '@/providers/utils'
@@ -58,6 +60,35 @@ describe('catalog featured model metadata', () => {
       expect(featuredModels.length).toBeLessThanOrEqual(1)
       expect(featuredModels.every((model) => model.sunset === undefined)).toBe(true)
     }
+  })
+})
+
+describe('forced tool use capability', () => {
+  it('keeps Auto and None support when a model disables Force', () => {
+    expect(getModelCapabilities('claude-fable-5-1')).toMatchObject({
+      toolUsageControl: true,
+      forcedToolUse: false,
+    })
+  })
+
+  it.each([
+    'claude-fable-5-1',
+    'CLAUDE-FABLE-5-1-20260901',
+    'azure-anthropic/claude-fable-5-1',
+    'claude-mythos-5-1',
+  ])('disables forced tool use for %s', (model) => {
+    expect(supportsForcedToolUse(model)).toBe(false)
+  })
+
+  it.each(['claude-sonnet-5', 'claude-fable-5', 'claude-opus-5', 'gpt-5.5'])(
+    'inherits provider tool-control support for %s',
+    (model) => {
+      expect(supportsForcedToolUse(model)).toBe(true)
+    }
+  )
+
+  it('does not enable Force for an unknown model without tool-control capabilities', () => {
+    expect(supportsForcedToolUse('unknown-model')).toBe(false)
   })
 })
 

--- a/apps/sim/providers/models.test.ts
+++ b/apps/sim/providers/models.test.ts
@@ -16,6 +16,7 @@ import {
   PROVIDER_DEFINITIONS,
   supportsForcedToolUse,
   updateFireworksModels,
+  updateOpenRouterModels,
 } from '@/providers/models'
 import { supportsPromptCaching } from '@/providers/utils'
 
@@ -75,10 +76,48 @@ describe('forced tool use capability', () => {
     'claude-fable-5-1',
     'CLAUDE-FABLE-5-1-20260901',
     'azure-anthropic/claude-fable-5-1',
+    'azure-anthropic/claude-fable-5-1-20260901',
+    'bedrock/anthropic.claude-fable-5-1-v1:0',
     'claude-mythos-5-1',
+    'claude-mythos-5-1-20260901',
   ])('disables forced tool use for %s', (model) => {
+    expect(getModelCapabilities(model)).toMatchObject({
+      toolUsageControl: true,
+      forcedToolUse: false,
+    })
     expect(supportsForcedToolUse(model)).toBe(false)
   })
+
+  it('adds only known alias capabilities to provider defaults', () => {
+    expect(getModelCapabilities('claude-mythos-5-1')).toEqual({
+      ...PROVIDER_DEFINITIONS.anthropic.capabilities,
+      forcedToolUse: false,
+    })
+  })
+
+  it('inherits alias capabilities for dynamic models and respects explicit overrides', () => {
+    const originalModels = PROVIDER_DEFINITIONS.openrouter.models
+    const modelId = 'anthropic/claude-fable-5-1'
+    try {
+      updateOpenRouterModels([modelId])
+      expect(getModelCapabilities(modelId)?.forcedToolUse).toBe(false)
+      expect(supportsForcedToolUse(modelId)).toBe(false)
+
+      PROVIDER_DEFINITIONS.openrouter.models[0].capabilities.forcedToolUse = true
+      expect(getModelCapabilities(modelId)?.forcedToolUse).toBe(true)
+      expect(supportsForcedToolUse(modelId)).toBe(true)
+    } finally {
+      PROVIDER_DEFINITIONS.openrouter.models = originalModels
+    }
+  })
+
+  it.each(['claude-fable-5-10', 'claude-mythos-5-10', 'claude-not-fable-5-1'])(
+    'does not apply alias restrictions to unrelated model %s',
+    (model) => {
+      expect(getModelCapabilities(model)).toEqual(PROVIDER_DEFINITIONS.anthropic.capabilities)
+      expect(supportsForcedToolUse(model)).toBe(true)
+    }
+  )
 
   it.each(['claude-sonnet-5', 'claude-fable-5', 'claude-opus-5', 'gpt-5.5'])(
     'inherits provider tool-control support for %s',
@@ -88,6 +127,7 @@ describe('forced tool use capability', () => {
   )
 
   it('does not enable Force for an unknown model without tool-control capabilities', () => {
+    expect(getModelCapabilities('unknown-model')).toBeNull()
     expect(supportsForcedToolUse('unknown-model')).toBe(false)
   })
 })

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -166,6 +166,16 @@ export function getProviderFileAttachment(providerId: string): ProviderFileAttac
   return PROVIDER_DEFINITIONS[providerId]?.fileAttachment ?? DEFAULT_FILE_ATTACHMENT
 }
 
+const CLAUDE_5_1_TOOL_CAPABILITIES = { forcedToolUse: false } as const satisfies ModelCapabilities
+
+/** Known capabilities for model aliases; explicit catalog capabilities take precedence. */
+const MODEL_CAPABILITY_FALLBACKS = [
+  {
+    pattern: /(?:^|[/.])claude-(?:fable|mythos)-5-1(?:$|[-:])/,
+    capabilities: CLAUDE_5_1_TOOL_CAPABILITIES,
+  },
+] satisfies { pattern: RegExp; capabilities: ModelCapabilities }[]
+
 export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   fireworks: {
     id: 'fireworks',
@@ -916,7 +926,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
           updatedAt: '2026-09-04',
         },
         capabilities: {
-          forcedToolUse: false,
+          ...CLAUDE_5_1_TOOL_CAPABILITIES,
           nativeStructuredOutputs: true,
           maxOutputTokens: 128000,
           promptCaching: { minimumCacheableTokens: 512 },
@@ -4387,10 +4397,19 @@ export function getModelPricing(modelId: string): ModelPricing | null {
 }
 
 export function getModelCapabilities(modelId: string): ModelCapabilities | null {
+  const normalizedModel = modelId.toLowerCase()
+  const fallbackCapabilities = MODEL_CAPABILITY_FALLBACKS.find(({ pattern }) =>
+    pattern.test(normalizedModel)
+  )?.capabilities
+
   for (const provider of Object.values(PROVIDER_DEFINITIONS)) {
-    const model = provider.models.find((m) => m.id.toLowerCase() === modelId.toLowerCase())
+    const model = provider.models.find((m) => m.id.toLowerCase() === normalizedModel)
     if (model) {
-      const capabilities: ModelCapabilities = { ...provider.capabilities, ...model.capabilities }
+      const capabilities: ModelCapabilities = {
+        ...provider.capabilities,
+        ...fallbackCapabilities,
+        ...model.capabilities,
+      }
       return capabilities
     }
   }
@@ -4398,14 +4417,16 @@ export function getModelCapabilities(modelId: string): ModelCapabilities | null 
   for (const provider of Object.values(PROVIDER_DEFINITIONS)) {
     if (provider.modelPatterns) {
       for (const pattern of provider.modelPatterns) {
-        if (pattern.test(modelId.toLowerCase())) {
-          return provider.capabilities || null
+        if (pattern.test(normalizedModel)) {
+          return fallbackCapabilities
+            ? { ...provider.capabilities, ...fallbackCapabilities }
+            : provider.capabilities || null
         }
       }
     }
   }
 
-  return null
+  return fallbackCapabilities || null
 }
 
 export function getModelsWithTemperatureSupport(): string[] {
@@ -4484,18 +4505,10 @@ export function supportsToolUsageControl(providerId: string): boolean {
   return getProvidersWithToolUsageControl().includes(providerId)
 }
 
-/** Whether the model accepts forced tool choice, including uncataloged Claude aliases. */
+/** Whether the model accepts forced tool choice. */
 export function supportsForcedToolUse(modelId: string): boolean {
   const capabilities = getModelCapabilities(modelId)
-  if (capabilities?.forcedToolUse !== undefined) return capabilities.forcedToolUse
-
-  /** Preserve the restriction for date-suffixed and reseller IDs outside the catalog. */
-  const normalizedModel = modelId.toLowerCase()
-  if (normalizedModel.includes('fable-5-1') || normalizedModel.includes('mythos-5-1')) {
-    return false
-  }
-
-  return capabilities?.toolUsageControl ?? false
+  return capabilities?.forcedToolUse ?? capabilities?.toolUsageControl ?? false
 }
 
 export function updateOllamaModels(models: string[]): void {

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -166,16 +166,6 @@ export function getProviderFileAttachment(providerId: string): ProviderFileAttac
   return PROVIDER_DEFINITIONS[providerId]?.fileAttachment ?? DEFAULT_FILE_ATTACHMENT
 }
 
-const CLAUDE_5_1_TOOL_CAPABILITIES = { forcedToolUse: false } as const satisfies ModelCapabilities
-
-/** Known capabilities for model aliases; explicit catalog capabilities take precedence. */
-const MODEL_CAPABILITY_FALLBACKS = [
-  {
-    pattern: /(?:^|[/.])claude-(?:fable|mythos)-5-1(?:$|[-:])/,
-    capabilities: CLAUDE_5_1_TOOL_CAPABILITIES,
-  },
-] satisfies { pattern: RegExp; capabilities: ModelCapabilities }[]
-
 export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
   fireworks: {
     id: 'fireworks',
@@ -926,7 +916,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
           updatedAt: '2026-09-04',
         },
         capabilities: {
-          ...CLAUDE_5_1_TOOL_CAPABILITIES,
+          forcedToolUse: false,
           nativeStructuredOutputs: true,
           maxOutputTokens: 128000,
           promptCaching: { minimumCacheableTokens: 512 },
@@ -4397,19 +4387,10 @@ export function getModelPricing(modelId: string): ModelPricing | null {
 }
 
 export function getModelCapabilities(modelId: string): ModelCapabilities | null {
-  const normalizedModel = modelId.toLowerCase()
-  const fallbackCapabilities = MODEL_CAPABILITY_FALLBACKS.find(({ pattern }) =>
-    pattern.test(normalizedModel)
-  )?.capabilities
-
   for (const provider of Object.values(PROVIDER_DEFINITIONS)) {
-    const model = provider.models.find((m) => m.id.toLowerCase() === normalizedModel)
+    const model = provider.models.find((m) => m.id.toLowerCase() === modelId.toLowerCase())
     if (model) {
-      const capabilities: ModelCapabilities = {
-        ...provider.capabilities,
-        ...fallbackCapabilities,
-        ...model.capabilities,
-      }
+      const capabilities: ModelCapabilities = { ...provider.capabilities, ...model.capabilities }
       return capabilities
     }
   }
@@ -4417,16 +4398,14 @@ export function getModelCapabilities(modelId: string): ModelCapabilities | null 
   for (const provider of Object.values(PROVIDER_DEFINITIONS)) {
     if (provider.modelPatterns) {
       for (const pattern of provider.modelPatterns) {
-        if (pattern.test(normalizedModel)) {
-          return fallbackCapabilities
-            ? { ...provider.capabilities, ...fallbackCapabilities }
-            : provider.capabilities || null
+        if (pattern.test(modelId.toLowerCase())) {
+          return provider.capabilities || null
         }
       }
     }
   }
 
-  return fallbackCapabilities || null
+  return null
 }
 
 export function getModelsWithTemperatureSupport(): string[] {

--- a/apps/sim/providers/models.ts
+++ b/apps/sim/providers/models.ts
@@ -45,6 +45,8 @@ export interface ModelCapabilities {
     max: number
   }
   toolUsageControl?: boolean
+  /** Whether tools can be forced. Defaults to toolUsageControl when omitted. */
+  forcedToolUse?: boolean
   computerUse?: boolean
   nativeStructuredOutputs?: boolean
   /** Maximum supported output tokens for this model */
@@ -914,6 +916,7 @@ export const PROVIDER_DEFINITIONS: Record<string, ProviderDefinition> = {
           updatedAt: '2026-09-04',
         },
         capabilities: {
+          forcedToolUse: false,
           nativeStructuredOutputs: true,
           maxOutputTokens: 128000,
           promptCaching: { minimumCacheableTokens: 512 },
@@ -4479,6 +4482,20 @@ export function getMaxTemperature(modelId: string): number | undefined {
 
 export function supportsToolUsageControl(providerId: string): boolean {
   return getProvidersWithToolUsageControl().includes(providerId)
+}
+
+/** Whether the model accepts forced tool choice, including uncataloged Claude aliases. */
+export function supportsForcedToolUse(modelId: string): boolean {
+  const capabilities = getModelCapabilities(modelId)
+  if (capabilities?.forcedToolUse !== undefined) return capabilities.forcedToolUse
+
+  /** Preserve the restriction for date-suffixed and reseller IDs outside the catalog. */
+  const normalizedModel = modelId.toLowerCase()
+  if (normalizedModel.includes('fable-5-1') || normalizedModel.includes('mythos-5-1')) {
+    return false
+  }
+
+  return capabilities?.toolUsageControl ?? false
 }
 
 export function updateOllamaModels(models: string[]): void {


### PR DESCRIPTION
## Summary

Disable Force in the agent tool picker for catalog models that reject forced tool calls. Declare `forcedToolUse: false` directly on `claude-fable-5-1` and share the capability check between the picker and the Anthropic request builder. Existing Force configurations for that model fall back to Auto at execution, and the picker updates immediately when the selected model changes.

Model capabilities use the existing catalog lookup. Unlisted model IDs inherit provider defaults without special alias matching.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing

- Model capability and Anthropic request tests: 57 passed.
- App TypeScript check passed.
- Scoped lint and API validation audit passed.
- Review focus: catalog capability overrides, the Auto fallback for Fable 5.1, and picker updates when switching models.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos

Not attached.
