### PR TITLE
fix(executor): preserve disabled-branch execution and join readiness

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.test.tsx
@@ -16,6 +16,7 @@ const {
   mockEndScopedExecution,
   mockExecute,
   mockExecuteFromBlock,
+  mockFindStartBlock,
   mockFetch,
   mockHandleExecutionCancelledConsole,
   mockHandleExecutionErrorConsole,
@@ -101,6 +102,7 @@ const {
     mockEndScopedExecution: vi.fn(() => true),
     mockExecute: vi.fn(),
     mockExecuteFromBlock: vi.fn(),
+    mockFindStartBlock: vi.fn(() => ({ blockId: 'start' })),
     mockFetch: vi.fn(),
     mockHandleExecutionCancelledConsole: vi.fn(),
     mockHandleExecutionErrorConsole: vi.fn(),
@@ -180,7 +182,7 @@ vi.mock('@/lib/workflows/triggers/triggers', () => ({
     EXTERNAL_TRIGGER: 'external-trigger',
   },
   TriggerUtils: {
-    findStartBlock: () => ({ blockId: 'start' }),
+    findStartBlock: mockFindStartBlock,
     getTriggerValidationMessage: () => 'Missing trigger',
   },
 }))
@@ -1097,6 +1099,7 @@ describe('useWorkflowExecution attachment uploads', () => {
     }
     executionStoreState.getLastExecutionSnapshot.mockReturnValueOnce(sourceSnapshot)
     workflowStoreState.edges.push({ source: 'start', target: 'function-1' } as never)
+    workflowStoreState.edges.push({ source: 'function-1', target: 'disabledBranch' } as never)
     const currentBlocks = {
       ...workflowBlocks,
       'function-1': {
@@ -1105,6 +1108,18 @@ describe('useWorkflowExecution attachment uploads', () => {
         name: 'Function 1',
         enabled: true,
         subBlocks: { code: { value: 'return "current editor state"' } },
+      },
+      disabledBranch: {
+        id: 'disabledBranch',
+        type: 'slack',
+        name: 'Disabled Branch',
+        enabled: false,
+        subBlocks: {},
+      },
+      disabledTrigger: {
+        ...workflowBlocks.start,
+        id: 'disabledTrigger',
+        enabled: false,
       },
     }
     workflowStoreState.getWorkflowState.mockReturnValueOnce({
@@ -1147,10 +1162,23 @@ describe('useWorkflowExecution attachment uploads', () => {
         ...workflowBlocks.start,
         subBlocks: { inputFormat: { value: 'current-editor-state' } },
       },
+      disabledBranch: {
+        id: 'disabledBranch',
+        type: 'slack',
+        name: 'Disabled Branch',
+        enabled: false,
+        subBlocks: {},
+      },
+      disabledTrigger: {
+        ...workflowBlocks.start,
+        id: 'disabledTrigger',
+        enabled: false,
+      },
     }
+    const currentEdges = [{ source: 'start', target: 'disabledBranch' }]
     workflowStoreState.getWorkflowState.mockReturnValueOnce({
       blocks: currentBlocks,
-      edges: [],
+      edges: currentEdges,
       loops: {},
       parallels: {},
     })
@@ -1181,11 +1209,15 @@ describe('useWorkflowExecution attachment uploads', () => {
         isClientSession: true,
         workflowStateOverride: {
           blocks: currentBlocks,
-          edges: [],
+          edges: currentEdges,
           loops: {},
           parallels: {},
         },
       })
+    )
+    expect(mockResolveStartCandidates).toHaveBeenCalledWith(
+      { start: currentBlocks.start },
+      { execution: 'manual' }
     )
     expect(mockExecute.mock.calls[0]?.[0]).not.toHaveProperty('sourceSnapshot')
     expect(mockExecuteFromBlock).not.toHaveBeenCalled()
@@ -1276,4 +1308,103 @@ describe('useWorkflowExecution attachment uploads', () => {
 
     unmount()
   })
+})
+
+describe('useWorkflowExecution workflow state override', () => {
+  beforeEach(() => {
+    resetWorkflowExecutionTestState()
+    vi.stubGlobal('fetch', mockFetch)
+    const startCandidate = {
+      blockId: 'start',
+      block: workflowBlocks.start,
+      path: 'legacy-starter',
+    }
+    mockResolveStartCandidates.mockReturnValue([startCandidate])
+    mockSelectBestTrigger.mockReturnValue([startCandidate])
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each(['manual', 'chat', 'run-until'] as const)(
+    'keeps disabled blocks and edges in %s payloads while excluding disabled triggers',
+    async (triggerType) => {
+      const blocks = {
+        ...workflowBlocks,
+        condition1: {
+          id: 'condition1',
+          type: 'condition',
+          name: 'Check',
+          enabled: true,
+          subBlocks: {},
+        },
+        disabledBranch: {
+          id: 'disabledBranch',
+          type: 'slack',
+          name: 'Send Empty',
+          enabled: false,
+          subBlocks: {},
+        },
+        disabledTrigger: {
+          ...workflowBlocks.start,
+          id: 'disabledTrigger',
+          enabled: false,
+        },
+      }
+      const edges = [
+        {
+          id: 'edge-1',
+          source: 'condition1',
+          target: 'disabledBranch',
+          sourceHandle: 'condition-else1',
+        },
+      ]
+      workflowStoreState.getWorkflowState.mockReturnValueOnce({
+        blocks: { ...blocks, layout: { id: 'layout' } },
+        edges,
+        loops: {},
+        parallels: {},
+      })
+      const { result, unmount } = renderWorkflowExecutionHook()
+
+      await act(async () => {
+        if (triggerType === 'run-until') {
+          await result().handleRunUntilBlock('condition1', 'workflow-1')
+          return
+        }
+        const runResult = await result().handleRunWorkflow(
+          triggerType === 'chat'
+            ? {
+                input: 'go',
+                conversationId: 'conversation-1',
+              }
+            : undefined
+        )
+        await drainStream(runResult)
+      })
+
+      expect(mockExecute).toHaveBeenCalledTimes(1)
+      const { workflowStateOverride } = mockExecute.mock.calls[0][0]
+      const sentBlockIds = new Set(Object.keys(workflowStateOverride.blocks))
+
+      expect(workflowStateOverride.blocks).toEqual(blocks)
+      expect(workflowStateOverride.edges).toEqual(edges)
+      expect(sentBlockIds.has('disabledBranch')).toBe(true)
+      for (const edge of workflowStateOverride.edges) {
+        expect(sentBlockIds.has(edge.source)).toBe(true)
+        expect(sentBlockIds.has(edge.target)).toBe(true)
+      }
+      const enabledBlocks = { start: blocks.start, condition1: blocks.condition1 }
+      if (triggerType === 'chat') {
+        expect(mockFindStartBlock).toHaveBeenCalledWith(enabledBlocks, 'chat')
+      } else {
+        expect(mockResolveStartCandidates).toHaveBeenCalledWith(enabledBlocks, {
+          execution: 'manual',
+        })
+      }
+
+      unmount()
+    }
+  )
 })

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/hooks/use-workflow-execution.ts
@@ -1104,10 +1104,10 @@ export function useWorkflowExecution() {
     const workflowEdges = (executionWorkflowState?.edges ??
       latestWorkflowState.edges) as typeof currentWorkflow.edges
 
-    // Filter out blocks without type (these are layout-only blocks) and disabled blocks
+    /** Keep disabled targets available for routing; the DAG excludes them from execution. */
     const validBlocks = Object.entries(workflowBlocks).reduce(
       (acc, [blockId, block]) => {
-        if (block?.type && block.enabled !== false) {
+        if (block?.type) {
           acc[blockId] = block
         }
         return acc
@@ -1145,22 +1145,27 @@ export function useWorkflowExecution() {
       }
     })
 
-    // Filter out blocks without type and disabled blocks
     const filteredStates = Object.entries(mergedStates).reduce(
       (acc, [id, block]) => {
         if (!block || !block.type) {
           logger.warn(`Skipping block with undefined type: ${id}`, block)
           return acc
         }
-        // Skip disabled blocks to prevent them from being passed to executor
-        if (block.enabled === false) {
-          logger.warn(`Skipping disabled block: ${id}`)
-          return acc
-        }
         acc[id] = block
         return acc
       },
       {} as typeof mergedStates
+    )
+
+    /** Trigger resolution must never select a disabled trigger. */
+    const enabledStates = Object.entries(filteredStates).reduce(
+      (acc, [id, block]) => {
+        if (block.enabled !== false) {
+          acc[id] = block
+        }
+        return acc
+      },
+      {} as typeof filteredStates
     )
 
     // If this is a chat execution, get the selected outputs
@@ -1177,7 +1182,7 @@ export function useWorkflowExecution() {
 
     if (isExecutingFromChat) {
       // For chat execution, find the appropriate chat trigger
-      const startBlock = TriggerUtils.findStartBlock(filteredStates, 'chat')
+      const startBlock = TriggerUtils.findStartBlock(enabledStates, 'chat')
 
       if (!startBlock) {
         throw new WorkflowValidationError(
@@ -1191,7 +1196,7 @@ export function useWorkflowExecution() {
       startBlockId = startBlock.blockId
     } else {
       // Manual execution: detect and group triggers by paths
-      const candidates = resolveStartCandidates(filteredStates, {
+      const candidates = resolveStartCandidates(enabledStates, {
         execution: 'manual',
       })
 
@@ -1203,7 +1208,7 @@ export function useWorkflowExecution() {
           'Workflow Validation'
         )
         logger.error('No trigger blocks found for manual run', {
-          allBlockTypes: Object.values(filteredStates).map((b) => b.type),
+          allBlockTypes: Object.values(enabledStates).map((b) => b.type),
         })
         if (activeWorkflowId) finishOwnedExecution(activeWorkflowId, persistenceExecution)
         throw error
@@ -2034,15 +2039,15 @@ export function useWorkflowExecution() {
       const sourceExecutionId = isTriggerBlock ? undefined : effectiveSnapshot.sourceExecutionId
 
       const mergedStates = mergeSubblockState(latestWorkflowState.blocks, workflowId)
-      const executableStates = Object.entries(mergedStates).reduce(
+      const filteredStates = Object.entries(mergedStates).reduce(
         (states, [id, block]) => {
-          if (block?.type && block.enabled !== false) states[id] = block
+          if (block?.type) states[id] = block
           return states
         },
         {} as typeof mergedStates
       )
       const workflowStateOverride = workflowStateSchema.parse({
-        blocks: executableStates,
+        blocks: filteredStates,
         edges: workflowEdges,
         loops: latestWorkflowState.loops,
         parallels: latestWorkflowState.parallels,
@@ -2051,7 +2056,14 @@ export function useWorkflowExecution() {
       // Extract mock payload for trigger blocks
       let workflowInput: any
       if (isTriggerBlock) {
-        const candidates = resolveStartCandidates(executableStates, { execution: 'manual' })
+        const enabledStates = Object.entries(filteredStates).reduce(
+          (states, [id, block]) => {
+            if (block.enabled !== false) states[id] = block
+            return states
+          },
+          {} as typeof filteredStates
+        )
+        const candidates = resolveStartCandidates(enabledStates, { execution: 'manual' })
         const candidate = candidates.find((c) => c.blockId === blockId)
 
         if (candidate) {
@@ -2069,7 +2081,7 @@ export function useWorkflowExecution() {
           }
         } else {
           // Fallback: block is trigger by position but not classified as start candidate
-          const block = executableStates[blockId]
+          const block = enabledStates[blockId]
           if (block) {
             const blockConfig = getBlock(block.type)
             const hasTriggers = blockConfig?.triggers?.available?.length

--- a/apps/sim/executor/execution/edge-manager.test.ts
+++ b/apps/sim/executor/execution/edge-manager.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { EDGE } from '@/executor/constants'
-import type { DAG, DAGNode } from '@/executor/dag/builder'
+import { BlockType, EDGE } from '@/executor/constants'
+import { type DAG, DAGBuilder, type DAGNode } from '@/executor/dag/builder'
 import type { DAGEdge } from '@/executor/dag/types'
-import type { SerializedBlock } from '@/serializer/types'
-import { EdgeManager } from './edge-manager'
+import { EdgeManager } from '@/executor/execution/edge-manager'
+import type { NormalizedBlockOutput } from '@/executor/types'
+import {
+  buildBranchNodeId,
+  buildParallelSentinelEndId,
+  buildParallelSentinelStartId,
+  buildSentinelEndId,
+  buildSentinelStartId,
+} from '@/executor/utils/subflow-utils'
+import type { SerializedBlock, SerializedWorkflow } from '@/serializer/types'
 
 function createMockBlock(id: string): SerializedBlock {
   return {
@@ -45,6 +53,188 @@ function createMockDAG(nodes: Map<string, DAGNode>): DAG {
 }
 
 describe('EdgeManager', () => {
+  describe('Dead-end routing regressions', () => {
+    it.each(['loop', 'parallel'] as const)(
+      'keeps an independently activated join waiting until the enclosing %s exits',
+      (subflowType) => {
+        const workflow: SerializedWorkflow = {
+          version: '1',
+          blocks: [
+            { ...createMockBlock('trigger'), metadata: { id: BlockType.STARTER } },
+            {
+              ...createMockBlock('subflow'),
+              metadata: { id: subflowType === 'loop' ? BlockType.LOOP : BlockType.PARALLEL },
+            },
+            { ...createMockBlock('condition'), metadata: { id: BlockType.CONDITION } },
+            createMockBlock('skipped'),
+            createMockBlock('independent'),
+            createMockBlock('join'),
+          ],
+          connections: [
+            { source: 'trigger', target: 'subflow' },
+            { source: 'trigger', target: 'independent' },
+            {
+              source: 'subflow',
+              target: 'condition',
+              sourceHandle: subflowType === 'loop' ? 'loop-start-source' : 'parallel-start-source',
+            },
+            { source: 'condition', target: 'skipped', sourceHandle: 'condition-if' },
+            {
+              source: 'subflow',
+              target: 'join',
+              sourceHandle: subflowType === 'loop' ? 'loop-end-source' : 'parallel-end-source',
+            },
+            { source: 'independent', target: 'join' },
+          ],
+          loops:
+            subflowType === 'loop'
+              ? { subflow: { id: 'subflow', nodes: ['condition', 'skipped'], iterations: 2 } }
+              : {},
+          parallels:
+            subflowType === 'parallel'
+              ? {
+                  subflow: {
+                    id: 'subflow',
+                    nodes: ['condition', 'skipped'],
+                    count: 2,
+                    parallelType: 'count',
+                  },
+                }
+              : {},
+        }
+        const dag = new DAGBuilder().build(workflow, { triggerBlockId: 'trigger' })
+        const edgeManager = new EdgeManager(dag)
+        const sentinelStartId =
+          subflowType === 'loop'
+            ? buildSentinelStartId('subflow')
+            : buildParallelSentinelStartId('subflow')
+        const sentinelEndId =
+          subflowType === 'loop'
+            ? buildSentinelEndId('subflow')
+            : buildParallelSentinelEndId('subflow')
+        const conditionId = subflowType === 'loop' ? 'condition' : buildBranchNodeId('condition', 0)
+
+        edgeManager.processOutgoingEdges(dag.nodes.get('trigger')!, {})
+        expect(edgeManager.processOutgoingEdges(dag.nodes.get('independent')!, {})).toEqual([])
+        edgeManager.processOutgoingEdges(dag.nodes.get(sentinelStartId)!, { sentinelStart: true })
+
+        expect(
+          edgeManager.processOutgoingEdges(dag.nodes.get(conditionId)!, { selectedOption: 'else' })
+        ).toEqual([sentinelEndId])
+        expect(edgeManager.isNodeReady(dag.nodes.get('join')!)).toBe(false)
+
+        expect(
+          edgeManager.processOutgoingEdges(dag.nodes.get(sentinelEndId)!, {
+            selectedRoute: subflowType === 'loop' ? EDGE.LOOP_CONTINUE : EDGE.PARALLEL_CONTINUE,
+          })
+        ).toEqual([sentinelStartId])
+        expect(edgeManager.isNodeReady(dag.nodes.get('join')!)).toBe(false)
+
+        expect(
+          edgeManager.processOutgoingEdges(dag.nodes.get(sentinelEndId)!, {
+            selectedRoute: subflowType === 'loop' ? EDGE.LOOP_EXIT : EDGE.PARALLEL_EXIT,
+          })
+        ).toEqual(['join'])
+      }
+    )
+
+    it.each([
+      { handle: 'condition-else', output: { selectedOption: 'if' } },
+      { handle: 'router-other', output: { selectedRoute: 'selected' } },
+    ])('releases an activated join after cascading through $handle', ({ handle, output }) => {
+      const condition = createMockNode('decision', [{ target: 'skipped', sourceHandle: handle }])
+      const skipped = createMockNode('skipped', [{ target: 'join' }], ['decision'])
+      const independent = createMockNode('independent', [{ target: 'join' }])
+      const join = createMockNode('join', [], ['skipped', 'independent'])
+      const dag = createMockDAG(
+        new Map([
+          ['decision', condition],
+          ['skipped', skipped],
+          ['independent', independent],
+          ['join', join],
+        ])
+      )
+      const edgeManager = new EdgeManager(dag)
+
+      expect(edgeManager.processOutgoingEdges(independent, {})).toEqual([])
+      expect(edgeManager.processOutgoingEdges(condition, output as NormalizedBlockOutput)).toEqual([
+        'join',
+      ])
+      expect(edgeManager.hasActivatedEdge('skipped')).toBe(false)
+    })
+
+    it('releases an activated join when another branch remains executable', () => {
+      const decision = createMockNode('decision', [
+        { target: 'skipped', sourceHandle: 'condition-else' },
+        { target: 'selected', sourceHandle: 'condition-if' },
+      ])
+      const skipped = createMockNode('skipped', [{ target: 'join' }], ['decision'])
+      const selected = createMockNode('selected', [], ['decision'])
+      const independent = createMockNode('independent', [{ target: 'join' }])
+      const join = createMockNode('join', [], ['skipped', 'independent'])
+      const dag = createMockDAG(
+        new Map([
+          ['decision', decision],
+          ['skipped', skipped],
+          ['selected', selected],
+          ['independent', independent],
+          ['join', join],
+        ])
+      )
+      const edgeManager = new EdgeManager(dag)
+
+      expect(edgeManager.processOutgoingEdges(independent, {})).toEqual([])
+      expect(edgeManager.processOutgoingEdges(decision, { selectedOption: 'if' })).toEqual([
+        'selected',
+        'join',
+      ])
+    })
+
+    it.each(['loop', 'parallel'] as const)(
+      'releases an independently activated join when an entire downstream %s is skipped',
+      (subflowType) => {
+        const decision = createMockNode('decision', [
+          { target: 'subflow-start', sourceHandle: 'condition-if' },
+        ])
+        const start = createMockNode('subflow-start', [{ target: 'body' }], ['decision'])
+        const body = createMockNode('body', [{ target: 'subflow-end' }], ['subflow-start'])
+        const end = createMockNode(
+          'subflow-end',
+          [
+            {
+              target: 'subflow-start',
+              sourceHandle: subflowType === 'loop' ? EDGE.LOOP_CONTINUE : EDGE.PARALLEL_CONTINUE,
+            },
+            {
+              target: 'join',
+              sourceHandle: subflowType === 'loop' ? EDGE.LOOP_EXIT : EDGE.PARALLEL_EXIT,
+            },
+          ],
+          ['body']
+        )
+        end.metadata = {
+          isSentinel: true,
+          sentinelType: 'end',
+          subflowType,
+          subflowId: 'skipped-subflow',
+        }
+        const independent = createMockNode('independent', [{ target: 'join' }])
+        const join = createMockNode('join', [], ['subflow-end', 'independent'])
+        const edgeManager = new EdgeManager(
+          createMockDAG(
+            new Map([decision, start, body, end, independent, join].map((node) => [node.id, node]))
+          )
+        )
+
+        expect(edgeManager.processOutgoingEdges(independent, {})).toEqual([])
+        expect(edgeManager.processOutgoingEdges(decision, { selectedOption: 'else' })).toEqual([
+          'join',
+        ])
+        expect(edgeManager.hasActivatedEdge(start.id)).toBe(false)
+      }
+    )
+  })
+
   describe('Happy path - basic workflows', () => {
     it('should handle simple linear flow (A → B → C)', () => {
       const blockAId = 'block-a'

--- a/apps/sim/executor/execution/edge-manager.ts
+++ b/apps/sim/executor/execution/edge-manager.ts
@@ -72,10 +72,20 @@ export class EdgeManager {
 
     const isDeadEnd = activatedTargets.length === 0
     const isRoutedDeadEnd = isDeadEnd && !!(output.selectedOption || output.selectedRoute)
+    const isSubflowExit =
+      output.selectedRoute === EDGE.LOOP_EXIT || output.selectedRoute === EDGE.PARALLEL_EXIT
 
     for (const targetId of cascadeTargets) {
       if (!readyNodes.includes(targetId) && !activatedTargets.includes(targetId)) {
-        if (!isDeadEnd || !this.isTargetReady(targetId)) continue
+        if (!this.isTargetReady(targetId)) continue
+
+        /** A previously activated join can become ready several edges into a skipped branch. */
+        if (!isSubflowExit && this.nodesWithActivatedEdge.has(targetId)) {
+          readyNodes.push(targetId)
+          continue
+        }
+
+        if (!isDeadEnd) continue
 
         if (isRoutedDeadEnd) {
           // A condition/router deliberately selected a dead-end path.
@@ -92,7 +102,7 @@ export class EdgeManager {
       }
     }
 
-    if (output.selectedRoute !== EDGE.LOOP_EXIT && output.selectedRoute !== EDGE.PARALLEL_EXIT) {
+    if (!isSubflowExit) {
       for (const { target } of edgesToDeactivate) {
         if (
           !readyNodes.includes(target) &&
@@ -308,7 +318,8 @@ export class EdgeManager {
     targetId: string,
     sourceHandle?: string,
     cascadeTargets?: Set<string>,
-    isCascade = false
+    isCascade = false,
+    cascadeSourceId = sourceId
   ): void {
     const edgeKey = this.createEdgeKey(sourceId, targetId, sourceHandle)
     if (this.deactivatedEdges.has(edgeKey)) {
@@ -320,8 +331,21 @@ export class EdgeManager {
     const targetNode = this.dag.nodes.get(targetId)
     if (!targetNode) return
 
-    if (isCascade && this.isTerminalControlNode(targetId)) {
+    if (
+      isCascade &&
+      (this.isTerminalControlNode(targetId) || this.nodesWithActivatedEdge.has(targetId))
+    ) {
       cascadeTargets?.add(targetId)
+    }
+
+    /** The enclosing subflow must resolve its own exit before downstream joins become ready. */
+    const cascadeSourceNode = this.dag.nodes.get(cascadeSourceId)
+    if (
+      targetNode.metadata.sentinelType === 'end' &&
+      cascadeSourceNode &&
+      this.isEnclosingSentinel(cascadeSourceNode, targetId)
+    ) {
+      return
     }
 
     // Don't cascade if node has active incoming edges OR has received an activated edge
@@ -339,7 +363,8 @@ export class EdgeManager {
           outgoingEdge.target,
           outgoingEdge.sourceHandle,
           cascadeTargets,
-          true
+          true,
+          cascadeSourceId
         )
       }
     }

--- a/apps/sim/executor/handlers/condition/condition-handler.test.ts
+++ b/apps/sim/executor/handlers/condition/condition-handler.test.ts
@@ -5,8 +5,17 @@ import { loggerMock } from '@sim/testing'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NonRetryableExecutionError } from '@/lib/execution/non-retryable-error'
 import { BlockType } from '@/executor/constants'
+import { DAGBuilder } from '@/executor/dag/builder'
+import { EdgeManager } from '@/executor/execution/edge-manager'
 import { ConditionBlockHandler } from '@/executor/handlers/condition/condition-handler'
-import type { BlockState, ExecutionContext } from '@/executor/types'
+import type { BlockState, ExecutionContext, NormalizedBlockOutput } from '@/executor/types'
+import {
+  buildBranchNodeId,
+  buildParallelSentinelEndId,
+  buildParallelSentinelStartId,
+  buildSentinelEndId,
+  buildSentinelStartId,
+} from '@/executor/utils/subflow-utils'
 import type { SerializedBlock, SerializedWorkflow } from '@/serializer/types'
 
 vi.mock('@/tools', () => ({
@@ -457,6 +466,204 @@ describe('ConditionBlockHandler', () => {
 
     await expect(handler.execute(mockContext, mockBlock, inputs)).rejects.toThrow(
       `Target block ${mockTargetBlock1.id} not found`
+    )
+    expect(mockExecuteTool).toHaveBeenCalledOnce()
+    expect(mockContext.decisions.condition.has(mockBlock.id)).toBe(false)
+  })
+
+  it('preserves routing metadata when the target block is disabled', async () => {
+    mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+
+    const conditions = [{ id: 'cond1', title: 'if', value: 'true' }]
+    const inputs = { conditions: JSON.stringify(conditions) }
+
+    mockTargetBlock1.enabled = false
+
+    const result = await handler.execute(mockContext, mockBlock, inputs)
+
+    expect(result).toEqual({
+      value: 10,
+      text: 'hello',
+      conditionResult: true,
+      selectedOption: 'cond1',
+      selectedPath: {
+        blockId: mockTargetBlock1.id,
+        blockType: 'target',
+        blockTitle: 'Target Block 1',
+      },
+    })
+    expect(mockExecuteTool).toHaveBeenCalledOnce()
+    expect(mockContext.decisions.condition.get(mockBlock.id)).toBe('cond1')
+  })
+
+  describe('Dead-end routing through the DAG', () => {
+    const conditions = [
+      { id: 'cond1', title: 'if', value: 'true' },
+      { id: 'else1', title: 'else', value: '' },
+    ]
+
+    it('does not activate the else branch when the matching target is disabled', async () => {
+      mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+      mockTargetBlock1.enabled = false
+      const workflow: SerializedWorkflow = {
+        ...mockContext.workflow!,
+        version: '1',
+        loops: {},
+      }
+      const dag = new DAGBuilder().build(workflow, { triggerBlockId: mockSourceBlock.id })
+      const edgeManager = new EdgeManager(dag)
+
+      const output = await handler.execute(mockContext, mockBlock, {
+        conditions: JSON.stringify(conditions),
+      })
+      const readyNodes = edgeManager.processOutgoingEdges(
+        dag.nodes.get(mockBlock.id)!,
+        output as NormalizedBlockOutput
+      )
+
+      expect(dag.nodes.has(mockTargetBlock1.id)).toBe(false)
+      expect(readyNodes).toEqual([])
+      expect(edgeManager.hasActivatedEdge(mockTargetBlock2.id)).toBe(false)
+      expect(output).toMatchObject({
+        selectedOption: 'cond1',
+        selectedPath: { blockId: mockTargetBlock1.id },
+      })
+      expect(mockExecuteTool).toHaveBeenCalledOnce()
+    })
+
+    it('records a disabled else branch without evaluating an expression', async () => {
+      mockTargetBlock2.enabled = false
+
+      const output = await handler.execute(mockContext, mockBlock, {
+        conditions: JSON.stringify([conditions[1]]),
+      })
+
+      expect(output).toMatchObject({
+        conditionResult: true,
+        selectedOption: 'else1',
+        selectedPath: { blockId: mockTargetBlock2.id },
+      })
+      expect(mockContext.decisions.condition.get(mockBlock.id)).toBe('else1')
+      expect(mockExecuteTool).not.toHaveBeenCalled()
+    })
+
+    it.each(['loop', 'parallel'] as const)(
+      'completes the enclosing %s when the selected target is disabled',
+      async (subflowType) => {
+        mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+        mockTargetBlock1.enabled = false
+        const subflowId = 'enclosing-subflow'
+        const subflowBlock: SerializedBlock = {
+          ...mockSourceBlock,
+          id: subflowId,
+          metadata: { id: subflowType === 'loop' ? BlockType.LOOP : BlockType.PARALLEL },
+        }
+        const nodes = [mockBlock.id, mockTargetBlock1.id, mockTargetBlock2.id]
+        const workflow: SerializedWorkflow = {
+          version: '1',
+          blocks: [...mockContext.workflow!.blocks, subflowBlock],
+          connections: [
+            { source: mockSourceBlock.id, target: subflowId },
+            {
+              source: subflowId,
+              target: mockBlock.id,
+              sourceHandle: subflowType === 'loop' ? 'loop-start-source' : 'parallel-start-source',
+            },
+            ...mockContext.workflow!.connections.filter((edge) => edge.source === mockBlock.id),
+          ],
+          loops:
+            subflowType === 'loop' ? { [subflowId]: { id: subflowId, nodes, iterations: 2 } } : {},
+          parallels:
+            subflowType === 'parallel'
+              ? { [subflowId]: { id: subflowId, nodes, count: 2, parallelType: 'count' } }
+              : {},
+        }
+        mockContext.workflow = workflow
+        const dag = new DAGBuilder().build(workflow, { triggerBlockId: mockSourceBlock.id })
+        const edgeManager = new EdgeManager(dag)
+        const conditionNodeId =
+          subflowType === 'loop' ? mockBlock.id : buildBranchNodeId(mockBlock.id, 0)
+        const sentinelStartId =
+          subflowType === 'loop'
+            ? buildSentinelStartId(subflowId)
+            : buildParallelSentinelStartId(subflowId)
+        const sentinelEndId =
+          subflowType === 'loop'
+            ? buildSentinelEndId(subflowId)
+            : buildParallelSentinelEndId(subflowId)
+        const conditionNode = dag.nodes.get(conditionNodeId)!
+        mockContext.currentVirtualBlockId = conditionNodeId
+        edgeManager.processOutgoingEdges(dag.nodes.get(mockSourceBlock.id)!, {})
+        const readyAfterStart = edgeManager.processOutgoingEdges(
+          dag.nodes.get(sentinelStartId)!,
+          {}
+        )
+
+        const output = await handler.execute(mockContext, conditionNode.block, {
+          conditions: JSON.stringify(conditions),
+        })
+        const readyAfterCondition = edgeManager.processOutgoingEdges(
+          conditionNode,
+          output as NormalizedBlockOutput
+        )
+
+        expect(readyAfterStart).toContain(conditionNodeId)
+        expect(readyAfterCondition).toEqual([sentinelEndId])
+        expect(mockContext.decisions.condition.get(conditionNodeId)).toBe('cond1')
+        expect(output).toMatchObject({
+          selectedOption: 'cond1',
+          selectedPath: { blockId: mockTargetBlock1.id },
+        })
+      }
+    )
+
+    it.each(['before', 'after'] as const)(
+      'releases a join whose independent path completes %s the dead-end condition',
+      async (independentPathOrder) => {
+        mockExecuteTool.mockResolvedValueOnce(matchedAt(0))
+        mockTargetBlock1.enabled = false
+        const independentBlock: SerializedBlock = { ...mockSourceBlock, id: 'independent' }
+        const joinBlock: SerializedBlock = { ...mockTargetBlock2, id: 'join' }
+        const workflow: SerializedWorkflow = {
+          version: '1',
+          loops: {},
+          blocks: [...mockContext.workflow!.blocks, independentBlock, joinBlock],
+          connections: [
+            ...mockContext.workflow!.connections,
+            { source: mockSourceBlock.id, target: independentBlock.id },
+            { source: independentBlock.id, target: joinBlock.id },
+            { source: mockTargetBlock2.id, target: joinBlock.id },
+          ],
+        }
+        mockContext.workflow = workflow
+        const dag = new DAGBuilder().build(workflow, { triggerBlockId: mockSourceBlock.id })
+        const edgeManager = new EdgeManager(dag)
+        edgeManager.processOutgoingEdges(dag.nodes.get(mockSourceBlock.id)!, {})
+        const readyNodes: string[] = []
+        if (independentPathOrder === 'before') {
+          readyNodes.push(
+            ...edgeManager.processOutgoingEdges(dag.nodes.get(independentBlock.id)!, {})
+          )
+        }
+
+        const output = await handler.execute(mockContext, mockBlock, {
+          conditions: JSON.stringify(conditions),
+        })
+        readyNodes.push(
+          ...edgeManager.processOutgoingEdges(
+            dag.nodes.get(mockBlock.id)!,
+            output as NormalizedBlockOutput
+          )
+        )
+        if (independentPathOrder === 'after') {
+          readyNodes.push(
+            ...edgeManager.processOutgoingEdges(dag.nodes.get(independentBlock.id)!, {})
+          )
+        }
+
+        expect(readyNodes).toEqual([joinBlock.id])
+        expect(edgeManager.hasActivatedEdge(mockTargetBlock2.id)).toBe(false)
+      }
     )
   })
 

--- a/apps/sim/executor/handlers/router/router-handler.test.ts
+++ b/apps/sim/executor/handlers/router/router-handler.test.ts
@@ -438,14 +438,114 @@ describe('RouterBlockHandler', () => {
     expect(mockExecuteProviderRequest).not.toHaveBeenCalled()
   })
 
-  it('should throw error if target block is missing', async () => {
-    const inputs = { prompt: 'Test' }
-    mockContext.workflow!.blocks = [mockBlock, mockTargetBlock2]
+  it.each([true, false])(
+    'rejects a missing target before choosing another route when an enabled sibling exists: %s',
+    async (hasEnabledSibling) => {
+      mockContext.workflow!.blocks = hasEnabledSibling ? [mockBlock, mockTargetBlock2] : [mockBlock]
 
-    await expect(handler.execute(mockContext, mockBlock, inputs)).rejects.toThrow(
-      'Target block target-block-1 not found'
-    )
-    expect(mockExecuteProviderRequest).not.toHaveBeenCalled()
+      await expect(
+        handler.execute(mockContext, mockBlock, { prompt: 'Test', model: 'sim-auto' })
+      ).rejects.toThrow('Target block target-block-1 not found')
+      expect(mockGenerateRouterPrompt).not.toHaveBeenCalled()
+      expect(mockResolveAutoModel).not.toHaveBeenCalled()
+      expect(mockExecuteProviderRequest).not.toHaveBeenCalled()
+    }
+  )
+
+  it('keeps targets enabled by default for older serialized workflows', async () => {
+    Reflect.deleteProperty(mockTargetBlock1, 'enabled')
+
+    const result = await handler.execute(mockContext, mockBlock, { prompt: 'Test' })
+
+    expect(mockGenerateRouterPrompt).toHaveBeenCalledWith('Test', [
+      expect.objectContaining({ id: 'target-block-1' }),
+      expect.objectContaining({ id: 'target-block-2' }),
+    ])
+    expect(result).toMatchObject({ selectedRoute: 'target-block-1' })
+  })
+
+  it('preserves existing error-edge routing candidates and decisions', async () => {
+    mockContext.workflow!.connections = [
+      { source: mockBlock.id, target: mockTargetBlock1.id, sourceHandle: 'source-right' },
+      { source: mockBlock.id, target: mockTargetBlock2.id, sourceHandle: 'error' },
+    ]
+    mockExecuteProviderRequest.mockResolvedValueOnce({
+      content: 'target-block-2',
+      model: 'mock-model',
+    })
+
+    const result = await handler.execute(mockContext, mockBlock, { prompt: 'Test' })
+
+    expect(mockGenerateRouterPrompt).toHaveBeenCalledWith('Test', [
+      expect.objectContaining({ id: 'target-block-1' }),
+      expect.objectContaining({ id: 'target-block-2' }),
+    ])
+    expect(result).toMatchObject({
+      selectedRoute: 'target-block-2',
+      selectedPath: {
+        blockId: 'target-block-2',
+        blockType: 'target',
+        blockTitle: 'Option B',
+      },
+    })
+  })
+
+  it.each([true, false])(
+    'preserves a disabled routing decision when the other target enabled state is %s',
+    async (otherTargetEnabled) => {
+      mockTargetBlock1.enabled = false
+      mockTargetBlock2.enabled = otherTargetEnabled
+
+      const result = await handler.execute(mockContext, mockBlock, { prompt: 'Test' })
+
+      expect(mockGenerateRouterPrompt).toHaveBeenCalledWith('Test', [
+        expect.objectContaining({ id: 'target-block-1' }),
+        expect.objectContaining({ id: 'target-block-2' }),
+      ])
+      expect(result).toMatchObject({
+        selectedRoute: 'target-block-1',
+        selectedPath: {
+          blockId: 'target-block-1',
+          blockType: 'target',
+          blockTitle: 'Option A',
+        },
+      })
+      expect(result).not.toHaveProperty('error')
+      expect(mockExecuteProviderRequest).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('resolves sim-auto and preserves provider billing with existing routing candidates', async () => {
+    mockExecuteProviderRequest.mockResolvedValueOnce({
+      content: 'target-block-2',
+      model: 'fireworks/glm-5.2',
+      tokens: { input: 100, output: 20, total: 120 },
+      cost: { input: 0.001, output: 0.0005, total: 0.0015 },
+    })
+
+    const result = await handler.execute(mockContext, mockBlock, {
+      prompt: 'Choose the best option.',
+      model: 'sim-auto',
+    })
+
+    expect(mockResolveAutoModel).toHaveBeenCalledWith({
+      ctx: mockContext,
+      blockId: mockBlock.id,
+      signals: expect.objectContaining({
+        lastMessage: 'Choose the best option.',
+        hasResponseFormat: false,
+      }),
+      fallbackModel: 'claude-sonnet-5',
+    })
+    expect(providerRequestBody()).toMatchObject({
+      model: 'fireworks/glm-5.2',
+      systemPrompt: 'Sim auto system preamble\n\nGenerated System Prompt',
+    })
+    expect(result).toMatchObject({
+      model: 'sim-auto',
+      selectedRoute: 'target-block-2',
+      cost: { input: 0.001, output: 0.0005, routing: 0.002, total: 0.0035 },
+    })
   })
 
   it('should throw error if LLM response is not a valid target block ID', async () => {

--- a/apps/sim/serializer/index.test.ts
+++ b/apps/sim/serializer/index.test.ts
@@ -10,20 +10,45 @@
 
 import {
   createAgentWithToolsWorkflowState,
+  createBlock,
   createComplexWorkflowState,
   createConditionalWorkflowState,
   createInvalidSerializedWorkflow,
   createInvalidWorkflowState,
+  createLoopBlock,
   createLoopWorkflowState,
   createMinimalWorkflowState,
   createMissingMetadataWorkflow,
+  createParallelBlock,
 } from '@sim/testing/factories'
-import { blocksMock, toolsMetadataMock, toolsUtilsMock } from '@sim/testing/mocks'
+import {
+  blocksMock,
+  createMockGetBlock,
+  mockBlockConfigs,
+  toolsMetadataMock,
+  toolsUtilsMock,
+} from '@sim/testing/mocks'
 import { describe, expect, it, vi } from 'vitest'
+import { DAGBuilder } from '@/executor/dag/builder'
 import { Serializer } from '@/serializer/index'
 import type { SerializedWorkflow } from '@/serializer/types'
 
-vi.mock('@/blocks', () => blocksMock)
+vi.mock('@/blocks', () => ({
+  ...blocksMock,
+  getBlock: createMockGetBlock({
+    condition: {
+      ...mockBlockConfigs.condition,
+      subBlocks: [
+        ...mockBlockConfigs.condition.subBlocks,
+        { id: 'conditions', type: 'condition-input' },
+      ],
+    },
+    router_v2: {
+      ...mockBlockConfigs.condition,
+      subBlocks: [{ id: 'routes', type: 'router-input' }],
+    },
+  }),
+}))
 vi.mock('@/tools/utils', () => toolsUtilsMock)
 vi.mock('@/tools/metadata', () => toolsMetadataMock)
 
@@ -82,6 +107,148 @@ describe('Serializer', () => {
       expect(falsePathConnection).toBeDefined()
       expect(falsePathConnection?.target).toBe('agent2')
     })
+
+    it.concurrent.each(['agent1', 'condition1'])(
+      'should keep disabled block %s and its incoming and outgoing connections',
+      (disabledBlockId) => {
+        const { blocks, edges, loops } = createConditionalWorkflowState()
+        const serializer = new Serializer()
+
+        blocks[disabledBlockId].enabled = false
+
+        const serialized = serializer.serializeWorkflow(blocks, edges, loops)
+
+        expect(serialized.blocks.find((b) => b.id === disabledBlockId)?.enabled).toBe(false)
+        expect(serialized.connections).toEqual([
+          { source: 'starter', target: 'condition1' },
+          { source: 'condition1', target: 'agent1', sourceHandle: 'condition-true' },
+          { source: 'condition1', target: 'agent2', sourceHandle: 'condition-false' },
+        ])
+      }
+    )
+
+    it.concurrent('should preserve connections that reference a block that does not exist', () => {
+      const { blocks, edges, loops } = createConditionalWorkflowState()
+      const serializer = new Serializer()
+
+      const { agent1: _removed, ...remainingBlocks } = blocks
+
+      const serialized = serializer.serializeWorkflow(remainingBlocks, edges, loops)
+
+      expect(serialized.blocks.find((b) => b.id === 'agent1')).toBeUndefined()
+      expect(serialized.connections).toEqual([
+        { source: 'starter', target: 'condition1' },
+        { source: 'condition1', target: 'agent1', sourceHandle: 'condition-true' },
+        { source: 'condition1', target: 'agent2', sourceHandle: 'condition-false' },
+      ])
+    })
+
+    it.concurrent(
+      'should preserve connections from a missing source without changing valid edges',
+      () => {
+        const { blocks, edges, loops } = createMinimalWorkflowState()
+        edges.push({ id: 'dangling', source: 'missing', target: 'agent1' })
+
+        const serialized = new Serializer().serializeWorkflow(blocks, edges, loops)
+
+        expect(serialized.connections).toEqual([
+          { source: 'starter', target: 'agent1' },
+          { source: 'missing', target: 'agent1' },
+        ])
+        expect(edges).toHaveLength(2)
+        expect(Object.keys(blocks)).toEqual(['starter', 'agent1'])
+      }
+    )
+
+    it.concurrent.each([
+      { blockType: 'condition', configKey: 'conditions', handlePrefix: 'condition-' },
+      { blockType: 'router_v2', configKey: 'routes', handlePrefix: 'router-' },
+    ] as const)(
+      'should preserve inferred $blockType route handles when an earlier target is missing',
+      ({ blockType, configKey, handlePrefix }) => {
+        const { blocks } = createMinimalWorkflowState()
+        blocks.branch = createBlock({
+          id: 'branch',
+          type: blockType,
+          subBlocks: {
+            [configKey]: {
+              id: configKey,
+              type: blockType === 'condition' ? 'condition-input' : 'router-input',
+              value: JSON.stringify([
+                { id: 'first', title: 'if', value: 'true' },
+                { id: 'second', title: 'else', value: '' },
+              ]),
+            },
+          },
+        })
+        const edges = [
+          { id: 'entry', source: 'starter', target: 'branch' },
+          { id: 'first', source: 'branch', target: 'missing' },
+          { id: 'second', source: 'branch', target: 'agent1' },
+        ]
+
+        const serialized = new Serializer().serializeWorkflow(blocks, edges)
+        const dag = new DAGBuilder().build(serialized, { triggerBlockId: 'starter' })
+
+        expect(serialized.connections).toEqual([
+          { source: 'starter', target: 'branch' },
+          { source: 'branch', target: 'missing' },
+          { source: 'branch', target: 'agent1' },
+        ])
+        expect(Array.from(dag.nodes.get('branch')!.outgoingEdges.values())).toEqual([
+          expect.objectContaining({
+            target: 'agent1',
+            sourceHandle: `${handlePrefix}second`,
+          }),
+        ])
+        expect(edges[2]).not.toHaveProperty('sourceHandle')
+      }
+    )
+
+    it.concurrent.each(['loop', 'parallel'] as const)(
+      'should preserve connections to and from a %s container',
+      (containerType) => {
+        const { blocks } = createMinimalWorkflowState()
+        blocks.container =
+          containerType === 'loop'
+            ? createLoopBlock({ id: 'container' })
+            : createParallelBlock({ id: 'container' })
+        blocks.agent1.data = { parentId: 'container' }
+        const edges = [
+          { id: 'entry', source: 'starter', target: 'container' },
+          {
+            id: 'body',
+            source: 'container',
+            target: 'agent1',
+            sourceHandle: `${containerType}-start-source`,
+          },
+          {
+            id: 'end',
+            source: 'agent1',
+            target: 'container',
+            targetHandle: `${containerType}-end-target`,
+          },
+        ]
+
+        const serialized = new Serializer().serializeWorkflow(blocks, edges)
+
+        expect(serialized.connections).toEqual([
+          { source: 'starter', target: 'container' },
+          {
+            source: 'container',
+            target: 'agent1',
+            sourceHandle: `${containerType}-start-source`,
+          },
+          {
+            source: 'agent1',
+            target: 'container',
+            targetHandle: `${containerType}-end-target`,
+          },
+        ])
+        const containers = containerType === 'loop' ? serialized.loops : serialized.parallels
+        expect(containers?.container.nodes).toEqual(['agent1'])
+      }
+    )
 
     it.concurrent('should serialize a workflow with loops correctly', () => {
       const { blocks, edges, loops } = createLoopWorkflowState()

--- a/apps/sim/serializer/index.ts
+++ b/apps/sim/serializer/index.ts
@@ -194,6 +194,7 @@ export class Serializer {
     return {
       version: '1.0',
       blocks: serializedBlocks,
+      /** Legacy handleless branches infer route IDs from edge order, including missing targets. */
       connections: edges
         .filter((edge) => !droppedBlockIds.has(edge.source) && !droppedBlockIds.has(edge.target))
         .map((edge) => ({


### PR DESCRIPTION
## Summary
- Keep disabled block metadata in editor execution snapshots so condition and router edges resolve consistently. Disabled blocks remain excluded from execution and trigger selection.
- Release an independently activated join when a skipped branch removes its last dependency, while waiting for enclosing loops and parallel groups to exit.
- Ignore disabled source configuration during DAG route-handle inference so stale disabled condition/router data cannot block an unrelated active path.
- Add regression coverage for manual, chat, run-until, and run-from execution; disabled routing; both join completion orders; subflow boundaries; and legacy positional routes. Preserve existing route selection, output metadata, and missing-target errors.

## Type of Change
- [x] Bug fix

## Testing
- Final affected-suite run after the compatibility correction and staging merge: 6,509 passed, 51 skipped. Application type-check passed.
- The preceding local full application run passed 42,028 tests with 67 skipped. GitHub lint, all test shards, and the production build passed on the final commit.
- Counterfactual tests using staging's original editor and scheduler implementations failed 12 of 110 tests; the same 110 passed with the fix. Two additional disabled-metadata regressions failed before their correction and now pass.
- Repository lint and lint:check, all 45 audits (including API validation), block-registry validation, and docs-manifest check passed.
- Eight scoped cleanup passes found no additional issues. No database migrations or dependency changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
