### PR TITLE
feat(agent): validate structured outputs after generation with one retry

### DIFF
--- a/apps/docs/content/docs/workflows/blocks/agent.mdx
+++ b/apps/docs/content/docs/workflows/blocks/agent.mdx
@@ -72,6 +72,12 @@ Give the agent a JSON Schema to force structured output. The response is constra
 }
 ```
 
+The schema is checked after generation.
+A response that fails to parse as JSON, violates the schema (including constraints like `enum`, `minLength`, and number bounds), or was cut off at the output token limit counts as a failed generation.
+A block without tools retries once automatically; a block with tools is not retried, because its tools would run again.
+When no valid response remains, the block fails with the validation error instead of silently returning unstructured text.
+Set `"strict": false` in the response format to skip enforcement and accept whatever the model returns.
+
 ### Advanced
 
 Some settings live under advanced, or appear only for models that support them:

--- a/apps/sim/executor/handlers/agent/agent-handler.test.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.test.ts
@@ -148,6 +148,21 @@ vi.mock('@/lib/internal/custom-tools/read-available-by-id-or-title', () => ({
     mockReadAvailableCustomToolByIdOrTitleAsExecutor(...args),
 }))
 
+/**
+ * Provider response whose content satisfies a strict structured response
+ * format, for tests that exercise other behavior alongside a responseFormat.
+ */
+function structuredMockResponse(content: string) {
+  return {
+    content,
+    model: 'mock-model',
+    tokens: { input: 10, output: 20, total: 30 },
+    timing: { total: 100 },
+    toolCalls: [],
+    cost: undefined,
+  }
+}
+
 const mockGetAllBlocks = getAllBlocks as Mock
 const mockExecuteTool = executeTool as Mock
 const mockGetProviderFromModel = getProviderFromModel as Mock
@@ -1988,6 +2003,7 @@ describe('AgentBlockHandler', () => {
       mockContext.resolvedSecretTraceRegistry = new ResolvedSecretTraceRegistry([
         { name: 'UNUSED', plaintext: 'x', encryptedValue: 'encrypted-unused' },
       ])
+      mockExecuteProviderRequest.mockResolvedValueOnce(structuredMockResponse('{"answer":"ok"}'))
 
       await handler.execute(mockContext, mockBlock, {
         model: 'gpt-4o',
@@ -2014,6 +2030,7 @@ describe('AgentBlockHandler', () => {
       registry.recordResolvedAtInputPath('DESCRIPTION', 'classified', inputPath)
       registry.recordResolvedInputProjection(inputPath, 'classified', '{{DESCRIPTION}}')
       mockContext.resolvedSecretTraceRegistry = registry
+      mockExecuteProviderRequest.mockResolvedValueOnce(structuredMockResponse('{"answer":"ok"}'))
 
       await handler.execute(mockContext, mockBlock, {
         model: 'gpt-4o',
@@ -2051,6 +2068,7 @@ describe('AgentBlockHandler', () => {
         projectedResponseFormat
       )
       mockContext.resolvedSecretTraceRegistry = registry
+      mockExecuteProviderRequest.mockResolvedValueOnce(structuredMockResponse('{"answer":"ok"}'))
 
       await handler.execute(mockContext, mockBlock, {
         model: 'gpt-4o',
@@ -2177,6 +2195,7 @@ describe('AgentBlockHandler', () => {
       registry.recordResolvedAtInputPath('FORMAT_NAME', 'private-schema', inputPath)
       registry.recordResolvedInputProjection(inputPath, 'private-schema', '{{FORMAT_NAME}}')
       mockContext.resolvedSecretTraceRegistry = registry
+      mockExecuteProviderRequest.mockResolvedValueOnce(structuredMockResponse('{}'))
 
       await handler.execute(mockContext, mockBlock, {
         model: 'gpt-4o',
@@ -2298,6 +2317,7 @@ describe('AgentBlockHandler', () => {
         projectedResponseFormat
       )
       mockContext.resolvedSecretTraceRegistry = registry
+      mockExecuteProviderRequest.mockResolvedValueOnce(structuredMockResponse('{}'))
 
       await handler.execute(mockContext, mockBlock, {
         model: 'gpt-4o',
@@ -2352,6 +2372,7 @@ describe('AgentBlockHandler', () => {
         projectedResponseFormat
       )
       mockContext.resolvedSecretTraceRegistry = registry
+      mockExecuteProviderRequest.mockResolvedValueOnce(structuredMockResponse('{"answer":"ok"}'))
       const handlerInputs = {
         model: 'gpt-4o',
         userPrompt: 'Return an answer.',
@@ -2406,6 +2427,140 @@ describe('AgentBlockHandler', () => {
         providerTiming: { total: 100 },
         cost: undefined,
       })
+    })
+
+    it('retries once when a strict structured response fails to parse, then succeeds', async () => {
+      mockExecuteProviderRequest
+        .mockResolvedValueOnce(structuredMockResponse('{"result": "truncated mid'))
+        .mockResolvedValueOnce(structuredMockResponse('{"result": "ok"}'))
+
+      const result = await handler.execute(mockContext, mockBlock, {
+        model: 'gpt-4o',
+        userPrompt: 'Test context',
+        apiKey: 'test-api-key',
+        responseFormat: '{"type":"object","properties":{"result":{"type":"string"}}}',
+      })
+
+      expect(mockExecuteProviderRequest).toHaveBeenCalledTimes(2)
+      expect(result).toMatchObject({ result: 'ok' })
+      expect((result as Record<string, unknown>).tokens).toEqual({
+        input: 20,
+        output: 40,
+        total: 60,
+      })
+      expect(mockExecuteProviderRequest.mock.calls[0][1]).toEqual(
+        mockExecuteProviderRequest.mock.calls[1][1]
+      )
+    })
+
+    it('fails the block when the structured response fails validation twice', async () => {
+      mockExecuteProviderRequest
+        .mockResolvedValueOnce(structuredMockResponse('not json at all'))
+        .mockResolvedValueOnce(structuredMockResponse('still not json'))
+
+      await expect(
+        handler.execute(mockContext, mockBlock, {
+          model: 'gpt-4o',
+          userPrompt: 'Test context',
+          apiKey: 'test-api-key',
+          responseFormat: '{"type":"object","properties":{"result":{"type":"string"}}}',
+        })
+      ).rejects.toThrow('Agent structured output failed validation after a retry')
+      expect(mockExecuteProviderRequest).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects schema-violating output that parses as JSON', async () => {
+      mockExecuteProviderRequest
+        .mockResolvedValueOnce(structuredMockResponse('{"status":""}'))
+        .mockResolvedValueOnce(structuredMockResponse('{"status":"open"}'))
+
+      const result = await handler.execute(mockContext, mockBlock, {
+        model: 'gpt-4o',
+        userPrompt: 'Test context',
+        apiKey: 'test-api-key',
+        responseFormat:
+          '{"type":"object","properties":{"status":{"type":"string","enum":["open","closed"]}},"required":["status"]}',
+      })
+
+      expect(mockExecuteProviderRequest).toHaveBeenCalledTimes(2)
+      expect(result).toMatchObject({ status: 'open' })
+    })
+
+    it('keeps the lenient fallback when the response format sets strict false', async () => {
+      mockExecuteProviderRequest.mockResolvedValueOnce(structuredMockResponse('not json at all'))
+
+      const result = await handler.execute(mockContext, mockBlock, {
+        model: 'gpt-4o',
+        userPrompt: 'Test context',
+        apiKey: 'test-api-key',
+        responseFormat:
+          '{"name":"response_schema","schema":{"type":"object","properties":{"result":{"type":"string"}}},"strict":false}',
+      })
+
+      expect(mockExecuteProviderRequest).toHaveBeenCalledTimes(1)
+      expect(result).toMatchObject({
+        content: 'not json at all',
+        _responseFormatWarning: expect.stringContaining('did not adhere'),
+      })
+    })
+
+    it('fails without resampling when the request carries tools', async () => {
+      mockTransformBlockTool.mockReturnValue({
+        id: 'test_tool',
+        name: 'Test Tool',
+        description: 'A test tool',
+        parameters: { type: 'object', properties: {} },
+      })
+      mockExecuteProviderRequest.mockResolvedValueOnce(structuredMockResponse('not json at all'))
+
+      await expect(
+        handler.execute(mockContext, mockBlock, {
+          model: 'gpt-4o',
+          userPrompt: 'Test context',
+          apiKey: 'test-api-key',
+          responseFormat: '{"type":"object","properties":{"result":{"type":"string"}}}',
+          tools: [{ type: 'test_tool', title: 'Test Tool', params: {}, usageControl: 'auto' }],
+        })
+      ).rejects.toThrow('Agent structured output failed validation:')
+      expect(mockExecuteProviderRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails a structured response whose final model segment stopped at max_tokens', async () => {
+      const truncatedResponse = () => ({
+        content: '{"result": "parses but was cut short by the cap"}',
+        model: 'mock-model',
+        tokens: { input: 10, output: 20, total: 30 },
+        timing: {
+          startTime: 't0',
+          endTime: 't1',
+          duration: 10,
+          timeSegments: [
+            {
+              type: 'model',
+              name: 'final',
+              startTime: 0,
+              endTime: 1,
+              duration: 1,
+              finishReason: 'max_tokens',
+            },
+          ],
+        },
+        toolCalls: [],
+        cost: undefined,
+      })
+      mockExecuteProviderRequest
+        .mockResolvedValueOnce(truncatedResponse())
+        .mockResolvedValueOnce(truncatedResponse())
+
+      await expect(
+        handler.execute(mockContext, mockBlock, {
+          model: 'gpt-4o',
+          userPrompt: 'Test context',
+          apiKey: 'test-api-key',
+          responseFormat: '{"type":"object","properties":{"result":{"type":"string"}}}',
+        })
+      ).rejects.toThrow('output token limit')
+      expect(mockExecuteProviderRequest).toHaveBeenCalledTimes(2)
     })
 
     it('should handle invalid JSON in responseFormat gracefully', async () => {

--- a/apps/sim/executor/handlers/agent/agent-handler.ts
+++ b/apps/sim/executor/handlers/agent/agent-handler.ts
@@ -57,6 +57,12 @@ import {
   buildSkillsSystemPromptSection,
   resolveSkillMetadata,
 } from '@/executor/handlers/agent/skills-resolver'
+import {
+  mergeFailedStructuredAttempt,
+  STRUCTURED_OUTPUT_RETRIES,
+  shouldEnforceStructuredOutput,
+  validateStructuredOutput,
+} from '@/executor/handlers/agent/structured-output'
 import type {
   AgentInputs,
   Message,
@@ -94,7 +100,7 @@ import {
   registerProviderToolInputProvenance,
   registerProviderToolModelInputRegistry,
 } from '@/providers/tool-input-provenance'
-import type { ProviderToolConfig } from '@/providers/types'
+import type { ProviderResponse, ProviderToolConfig } from '@/providers/types'
 import { getProviderFromModel, transformBlockTool } from '@/providers/utils'
 import type { SerializedBlock } from '@/serializer/types'
 import { buildJsonSchemaParamShapes, decodeToolParams } from '@/tools/param-shape'
@@ -2585,6 +2591,14 @@ export class AgentBlockHandler implements BlockHandler {
     )
   }
 
+  /**
+   * Executes the provider request and, when a strict response format is
+   * configured, validates the completed output against it — truncation at
+   * the token limit, unparseable JSON, and schema violations all count as
+   * one failure condition. A failed attempt is resampled once (identical
+   * request, tool-free requests only); a second failure fails the block
+   * explicitly instead of silently falling back to the standard format.
+   */
   private async executeProviderRequest(
     ctx: ExecutionContext,
     providerRequest: any,
@@ -2612,58 +2626,114 @@ export class AgentBlockHandler implements BlockHandler {
 
       const { blockData, blockNameMapping } = collectBlockData(ctx)
 
-      const response = await executeProviderRequest(
-        providerId,
-        {
-          model,
-          systemPrompt:
-            'systemPrompt' in providerRequest ? providerRequest.systemPrompt : undefined,
-          context: 'context' in providerRequest ? providerRequest.context : undefined,
-          tools: providerRequest.tools,
-          temperature: providerRequest.temperature,
-          maxTokens: providerRequest.maxTokens,
-          apiKey: finalApiKey,
-          azureEndpoint: providerRequest.azureEndpoint,
-          azureApiVersion: providerRequest.azureApiVersion,
-          vertexProject: providerRequest.vertexProject,
-          vertexLocation: providerRequest.vertexLocation,
-          bedrockAccessKeyId: providerRequest.bedrockAccessKeyId,
-          bedrockSecretKey: providerRequest.bedrockSecretKey,
-          bedrockRegion: providerRequest.bedrockRegion,
-          responseFormat: providerRequest.responseFormat,
-          workflowId: providerRequest.workflowId,
-          workspaceId: ctx.workspaceId,
-          userId: ctx.userId,
-          stream: providerRequest.stream,
-          messages: 'messages' in providerRequest ? providerRequest.messages : undefined,
-          environmentVariables: normalizeStringRecord(ctx.environmentVariables),
-          workflowVariables: normalizeWorkflowVariables(ctx.workflowVariables),
-          blockData,
-          blockNameMapping,
-          isDeployedContext: ctx.isDeployedContext,
-          callChain: ctx.callChain,
-          billingAttribution: ctx.metadata.billingAttribution,
-          // Reaches tool `_context` via `prepareToolExecution`, so a tool that starts
-          // its own child execution (a custom block) correlates and cancels against
-          // this real run instead of minting a phantom id.
-          executionId: ctx.executionId,
-          reasoningEffort: providerRequest.reasoningEffort,
-          verbosity: providerRequest.verbosity,
-          thinkingLevel: providerRequest.thinkingLevel,
-          promptCaching: providerRequest.promptCaching,
-          // Stable per-block identity; providers use it to route cache lookups.
-          blockId: block.id,
-          previousInteractionId: providerRequest.previousInteractionId,
-          agentEvents: providerRequest.agentEvents,
-          abortSignal: ctx.abortSignal,
-        },
-        {
-          resolvedSecretTraceRegistry: modelRuntimeRegistry,
-          executionContext: ctx,
-        }
-      )
+      const request = {
+        model,
+        systemPrompt: 'systemPrompt' in providerRequest ? providerRequest.systemPrompt : undefined,
+        context: 'context' in providerRequest ? providerRequest.context : undefined,
+        tools: providerRequest.tools,
+        temperature: providerRequest.temperature,
+        maxTokens: providerRequest.maxTokens,
+        apiKey: finalApiKey,
+        azureEndpoint: providerRequest.azureEndpoint,
+        azureApiVersion: providerRequest.azureApiVersion,
+        vertexProject: providerRequest.vertexProject,
+        vertexLocation: providerRequest.vertexLocation,
+        bedrockAccessKeyId: providerRequest.bedrockAccessKeyId,
+        bedrockSecretKey: providerRequest.bedrockSecretKey,
+        bedrockRegion: providerRequest.bedrockRegion,
+        responseFormat: providerRequest.responseFormat,
+        workflowId: providerRequest.workflowId,
+        workspaceId: ctx.workspaceId,
+        userId: ctx.userId,
+        stream: providerRequest.stream,
+        messages: 'messages' in providerRequest ? providerRequest.messages : undefined,
+        environmentVariables: normalizeStringRecord(ctx.environmentVariables),
+        workflowVariables: normalizeWorkflowVariables(ctx.workflowVariables),
+        blockData,
+        blockNameMapping,
+        isDeployedContext: ctx.isDeployedContext,
+        callChain: ctx.callChain,
+        billingAttribution: ctx.metadata.billingAttribution,
+        // Reaches tool `_context` via `prepareToolExecution`, so a tool that starts
+        // its own child execution (a custom block) correlates and cancels against
+        // this real run instead of minting a phantom id.
+        executionId: ctx.executionId,
+        reasoningEffort: providerRequest.reasoningEffort,
+        verbosity: providerRequest.verbosity,
+        thinkingLevel: providerRequest.thinkingLevel,
+        promptCaching: providerRequest.promptCaching,
+        // Stable per-block identity; providers use it to route cache lookups.
+        blockId: block.id,
+        previousInteractionId: providerRequest.previousInteractionId,
+        agentEvents: providerRequest.agentEvents,
+        abortSignal: ctx.abortSignal,
+      }
+      const requestOptions = {
+        resolvedSecretTraceRegistry: modelRuntimeRegistry,
+        executionContext: ctx,
+      }
 
-      return this.processProviderResponse(response, block, responseFormat, ctx)
+      const enforceStructuredOutput = shouldEnforceStructuredOutput(responseFormat)
+      // Tools execute inside the provider call, so re-issuing a tool-carrying
+      // request would replay their side effects; those requests fail without
+      // the automatic resample.
+      const hasTools = Array.isArray(providerRequest.tools) && providerRequest.tools.length > 0
+      const retriesAllowed = enforceStructuredOutput && !hasTools ? STRUCTURED_OUTPUT_RETRIES : 0
+      let failedAttempt: ProviderResponse | undefined
+
+      for (let attempt = 0; ; attempt++) {
+        const response = await executeProviderRequest(providerId, request, requestOptions)
+
+        if (
+          !enforceStructuredOutput ||
+          this.isStreamingExecution(response) ||
+          response instanceof ReadableStream
+        ) {
+          return this.processProviderResponse(response, block, responseFormat, ctx)
+        }
+
+        const providerResponse = response as ProviderResponse
+        const verdict = validateStructuredOutput(providerResponse, responseFormat)
+        if (verdict.ok) {
+          if (failedAttempt) {
+            mergeFailedStructuredAttempt(providerResponse, failedAttempt)
+          }
+          return {
+            ...verdict.output,
+            ...this.createResponseMetadata(providerResponse),
+          }
+        }
+
+        const willRetry = attempt < retriesAllowed && ctx.abortSignal?.aborted !== true
+        logger.warn(
+          'Agent structured output failed validation',
+          projectAgentDiagnosticMetadata(
+            ctx,
+            {
+              reason: verdict.reason,
+              content: truncate(providerResponse.content, 200),
+              responseFormat,
+            },
+            {
+              contentLength:
+                typeof providerResponse.content === 'string'
+                  ? providerResponse.content.length
+                  : undefined,
+              attempt,
+              willRetry,
+            }
+          )
+        )
+
+        if (!willRetry) {
+          throw new Error(
+            `Agent structured output failed validation${
+              attempt > 0 ? ' after a retry' : ''
+            }: ${verdict.reason}`
+          )
+        }
+        failedAttempt = providerResponse
+      }
     } catch (error) {
       const errorRegistry = this.createErrorRegistry(providerErrorRegistry, modelRuntimeRegistry)
       ctx.errorResolvedSecretTraceRegistry = errorRegistry
@@ -2864,6 +2934,13 @@ export class AgentBlockHandler implements BlockHandler {
     return this.processStandardResponse(result)
   }
 
+  /**
+   * Lenient structured-response path, reached only when the response format
+   * opts out of enforcement with `"strict": false` (or for streaming
+   * responses, which have no complete content to validate). A parse failure
+   * falls back to the standard format with a warning instead of failing the
+   * block; the strict path lives in `executeProviderRequest`.
+   */
   private processStructuredResponse(
     result: any,
     responseFormat: any,

--- a/apps/sim/executor/handlers/agent/structured-output.test.ts
+++ b/apps/sim/executor/handlers/agent/structured-output.test.ts
@@ -1,0 +1,287 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  mergeFailedStructuredAttempt,
+  shouldEnforceStructuredOutput,
+  validateStructuredOutput,
+} from '@/executor/handlers/agent/structured-output'
+import type { ProviderResponse } from '@/providers/types'
+
+/**
+ * Mirrors the extraction-pipeline schema whose violations motivated this
+ * module: a required enum, a bounded importance score, and a non-empty text
+ * field — constraints that native structured output grammars demote to
+ * advisory prose and prompt-based models never had enforced at all.
+ */
+const OBSERVATION_FORMAT = {
+  name: 'response_schema',
+  schema: {
+    type: 'object',
+    properties: {
+      observations: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            type: { type: 'string', enum: ['fact', 'decision', 'question'] },
+            text: { type: 'string', minLength: 1 },
+            importance: { type: 'number', minimum: 1, maximum: 10 },
+          },
+          required: ['type', 'text', 'importance'],
+        },
+      },
+    },
+    required: ['observations'],
+  },
+  strict: true,
+}
+
+function makeResponse(overrides: Partial<ProviderResponse>): ProviderResponse {
+  return {
+    content: '',
+    model: 'mock-model',
+    tokens: { input: 10, output: 20, total: 30 },
+    ...overrides,
+  }
+}
+
+describe('shouldEnforceStructuredOutput', () => {
+  it('enforces when strict is true', () => {
+    expect(shouldEnforceStructuredOutput(OBSERVATION_FORMAT)).toBe(true)
+  })
+
+  it('enforces when strict is absent, matching the documented default', () => {
+    expect(shouldEnforceStructuredOutput({ name: 'x', schema: { type: 'object' } })).toBe(true)
+  })
+
+  it('does not enforce when strict is false', () => {
+    expect(shouldEnforceStructuredOutput({ ...OBSERVATION_FORMAT, strict: false })).toBe(false)
+  })
+
+  it('does not enforce without a response format', () => {
+    expect(shouldEnforceStructuredOutput(undefined)).toBe(false)
+    expect(shouldEnforceStructuredOutput('')).toBe(false)
+  })
+})
+
+describe('validateStructuredOutput', () => {
+  it('accepts a conforming response', () => {
+    const verdict = validateStructuredOutput(
+      makeResponse({
+        content: '{"observations":[{"type":"fact","text":"Staging is green.","importance":7}]}',
+      }),
+      OBSERVATION_FORMAT
+    )
+    expect(verdict).toEqual({
+      ok: true,
+      output: { observations: [{ type: 'fact', text: 'Staging is green.', importance: 7 }] },
+    })
+  })
+
+  it('rescues valid JSON wrapped in a Markdown code fence', () => {
+    const verdict = validateStructuredOutput(
+      makeResponse({
+        content: '```json\n{"observations":[{"type":"fact","text":"Fenced.","importance":3}]}\n```',
+      }),
+      OBSERVATION_FORMAT
+    )
+    expect(verdict.ok).toBe(true)
+  })
+
+  it('rejects unparseable content, as produced by truncated JSON', () => {
+    const verdict = validateStructuredOutput(
+      makeResponse({ content: '{"observations":[{"type":"fact","text":"cut of' }),
+      OBSERVATION_FORMAT
+    )
+    expect(verdict.ok).toBe(false)
+    if (verdict.ok) throw new Error('expected failure')
+    expect(verdict.reason).toContain('not valid JSON')
+  })
+
+  it('rejects empty content', () => {
+    const verdict = validateStructuredOutput(makeResponse({ content: '' }), OBSERVATION_FORMAT)
+    expect(verdict.ok).toBe(false)
+  })
+
+  it('rejects a hollow row violating the authored enum and bounds', () => {
+    const verdict = validateStructuredOutput(
+      makeResponse({
+        content: '{"observations":[{"type":"","text":"","importance":0}]}',
+      }),
+      OBSERVATION_FORMAT
+    )
+    expect(verdict.ok).toBe(false)
+    if (verdict.ok) throw new Error('expected failure')
+    expect(verdict.reason).toContain('violates the configured schema')
+    expect(verdict.reason).toContain('/observations/0/type')
+  })
+
+  it('rejects a JSON root that is not an object', () => {
+    const verdict = validateStructuredOutput(makeResponse({ content: '[1,2,3]' }), {
+      name: 'x',
+      strict: true,
+    })
+    expect(verdict.ok).toBe(false)
+    if (verdict.ok) throw new Error('expected failure')
+    expect(verdict.reason).toContain('not a JSON object')
+  })
+
+  it('rejects a response that stopped at the output token limit even when it parses', () => {
+    const verdict = validateStructuredOutput(
+      makeResponse({
+        content: '{"observations":[]}',
+        timing: {
+          startTime: 't0',
+          endTime: 't1',
+          duration: 5,
+          timeSegments: [
+            { type: 'model', name: 'first', startTime: 0, endTime: 1, duration: 1 },
+            {
+              type: 'model',
+              name: 'final',
+              startTime: 1,
+              endTime: 2,
+              duration: 1,
+              finishReason: 'MAX_TOKENS',
+            },
+          ],
+        },
+      }),
+      OBSERVATION_FORMAT
+    )
+    expect(verdict.ok).toBe(false)
+    if (verdict.ok) throw new Error('expected failure')
+    expect(verdict.reason).toContain('output token limit')
+  })
+
+  it('treats the OpenAI-family length finish reason as truncation', () => {
+    const verdict = validateStructuredOutput(
+      makeResponse({
+        content: '{"observations":[]}',
+        timing: {
+          startTime: 't0',
+          endTime: 't1',
+          duration: 5,
+          timeSegments: [
+            {
+              type: 'model',
+              name: 'final',
+              startTime: 0,
+              endTime: 1,
+              duration: 1,
+              finishReason: 'length',
+            },
+          ],
+        },
+      }),
+      OBSERVATION_FORMAT
+    )
+    expect(verdict.ok).toBe(false)
+  })
+
+  it('accepts a normal stop finish reason', () => {
+    const verdict = validateStructuredOutput(
+      makeResponse({
+        content: '{"observations":[]}',
+        timing: {
+          startTime: 't0',
+          endTime: 't1',
+          duration: 5,
+          timeSegments: [
+            {
+              type: 'model',
+              name: 'final',
+              startTime: 0,
+              endTime: 1,
+              duration: 1,
+              finishReason: 'end_turn',
+            },
+          ],
+        },
+      }),
+      OBSERVATION_FORMAT
+    )
+    expect(verdict.ok).toBe(true)
+  })
+
+  it('falls back to parse-only checks when the schema does not compile', () => {
+    const uncompilable = {
+      name: 'x',
+      schema: { type: 'object', properties: { a: { type: 'no-such-type' } } },
+      strict: true,
+    }
+    const verdict = validateStructuredOutput(
+      makeResponse({ content: '{"a":"anything"}' }),
+      uncompilable
+    )
+    expect(verdict.ok).toBe(true)
+  })
+
+  it('validates against a bare schema without the wrapper shape', () => {
+    const verdict = validateStructuredOutput(makeResponse({ content: '{"answer":2}' }), {
+      type: 'object',
+      properties: { answer: { type: 'string' } },
+      required: ['answer'],
+    })
+    expect(verdict.ok).toBe(false)
+  })
+})
+
+describe('mergeFailedStructuredAttempt', () => {
+  it('folds tokens, cost, and trace segments of the failed attempt into the response', () => {
+    const failedSegment = {
+      type: 'model',
+      name: 'failed',
+      startTime: 0,
+      endTime: 1,
+      duration: 1,
+    }
+    const finalSegment = { type: 'model', name: 'final', startTime: 2, endTime: 3, duration: 1 }
+    const pricing = { input: 1, output: 2, updatedAt: '2026-01-01' }
+    const response = makeResponse({
+      tokens: { input: 10, output: 20, total: 30 },
+      cost: { input: 0.1, output: 0.2, total: 0.3, pricing },
+      timing: {
+        startTime: 't1',
+        endTime: 't2',
+        duration: 50,
+        timeSegments: [finalSegment],
+      },
+    })
+    const failed = makeResponse({
+      tokens: { input: 5, output: 100, total: 105 },
+      cost: { input: 0.05, output: 1, total: 1.05, pricing },
+      timing: {
+        startTime: 't0',
+        endTime: 't1',
+        duration: 30,
+        timeSegments: [failedSegment],
+      },
+    })
+
+    mergeFailedStructuredAttempt(response, failed)
+
+    expect(response.tokens).toEqual({ input: 15, output: 120, total: 135 })
+    expect(response.cost?.input).toBeCloseTo(0.15)
+    expect(response.cost?.output).toBeCloseTo(1.2)
+    expect(response.cost?.total).toBeCloseTo(1.35)
+    expect(response.timing).toMatchObject({ startTime: 't0', duration: 80 })
+    expect(response.timing?.timeSegments).toEqual([failedSegment, finalSegment])
+  })
+
+  it('adopts the failed attempt cost when the final response has none', () => {
+    const pricing = { input: 1, output: 2, updatedAt: '2026-01-01' }
+    const response = makeResponse({ tokens: undefined })
+    const failed = makeResponse({
+      tokens: { input: 5, output: 6, total: 11 },
+      cost: { input: 0.05, output: 0.06, total: 0.11, pricing },
+    })
+
+    mergeFailedStructuredAttempt(response, failed)
+
+    expect(response.tokens).toEqual({ input: 5, output: 6, total: 11 })
+    expect(response.cost).toMatchObject({ total: 0.11 })
+  })
+})

--- a/apps/sim/executor/handlers/agent/structured-output.ts
+++ b/apps/sim/executor/handlers/agent/structured-output.ts
@@ -1,0 +1,234 @@
+import { createLogger } from '@sim/logger'
+import { getErrorMessage } from '@sim/utils/errors'
+import { truncate } from '@sim/utils/string'
+import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv'
+import { LRUCache } from 'lru-cache'
+import type { ProviderResponse } from '@/providers/types'
+
+const logger = createLogger('AgentStructuredOutput')
+
+/**
+ * How many times the provider call is re-issued after a structured output
+ * fails validation, before the block fails explicitly.
+ */
+export const STRUCTURED_OUTPUT_RETRIES = 1
+
+/**
+ * Finish reasons that mean the model hit its output token limit, across
+ * provider vocabularies: Anthropic/Bedrock report `max_tokens`, the OpenAI
+ * Chat Completions family reports `length`, Gemini reports `MAX_TOKENS`.
+ * Compared case-insensitively.
+ */
+const TRUNCATION_FINISH_REASONS = new Set(['max_tokens', 'length'])
+
+/**
+ * User-authored schemas are per-block and editable, so validators are cached
+ * by schema content rather than by a static name. `strict: false` tolerates
+ * unknown keywords in user-authored schemas instead of refusing to compile.
+ */
+const ajv = new Ajv({ allErrors: true, strict: false })
+const validatorCache = new LRUCache<string, ValidateFunction | false>({ max: 500 })
+
+export type StructuredOutputVerdict =
+  | { ok: true; output: Record<string, unknown> }
+  | { ok: false; reason: string }
+
+/**
+ * Whether the agent block should enforce its structured response format after
+ * generation. Enforcement follows the response format's own `strict` flag,
+ * which the block schema has always documented as defaulting to true —
+ * setting `"strict": false` in the response format keeps the legacy lenient
+ * fallback behavior.
+ */
+export function shouldEnforceStructuredOutput(responseFormat: unknown): boolean {
+  if (!responseFormat || typeof responseFormat !== 'object') return false
+  return (responseFormat as { strict?: unknown }).strict !== false
+}
+
+/**
+ * Validates a completed (non-streaming) provider response against the
+ * authored response format. One verdict covers the three failure modes that
+ * previously collapsed into silent success: truncation at the output token
+ * limit, unparseable JSON, and parseable JSON that violates the authored
+ * schema (including constraints like `enum` and `minLength` that native
+ * structured output grammars weaken to advisory prose).
+ */
+export function validateStructuredOutput(
+  response: ProviderResponse,
+  responseFormat: unknown
+): StructuredOutputVerdict {
+  const finishReason = lastModelFinishReason(response)
+  if (finishReason && TRUNCATION_FINISH_REASONS.has(finishReason.toLowerCase())) {
+    return {
+      ok: false,
+      reason: `the model stopped at its output token limit (finish reason "${finishReason}") before completing the structured response`,
+    }
+  }
+
+  const content = typeof response.content === 'string' ? response.content.trim() : ''
+  if (!content) {
+    return { ok: false, reason: 'the model returned empty content instead of structured JSON' }
+  }
+
+  const parsed = parseStructuredContent(content)
+  if (!parsed.ok) return parsed
+
+  const validator = getValidator(extractSchema(responseFormat))
+  if (validator && !validator(parsed.output)) {
+    return {
+      ok: false,
+      reason: `the response violates the configured schema: ${formatValidationErrors(validator.errors)}`,
+    }
+  }
+
+  return parsed
+}
+
+/**
+ * Folds a failed structured attempt's usage into the response that finally
+ * validated, so the block's reported tokens, cost, and trace segments reflect
+ * everything the run actually consumed. Mutates `response` in place, matching
+ * how routing cost is applied to block results.
+ */
+export function mergeFailedStructuredAttempt(
+  response: ProviderResponse,
+  failedAttempt: ProviderResponse
+): void {
+  if (failedAttempt.tokens) {
+    const merged = { ...(response.tokens ?? {}) }
+    for (const key of ['input', 'output', 'total', 'cacheRead', 'cacheWrite'] as const) {
+      const failedValue = failedAttempt.tokens[key]
+      if (failedValue === undefined) continue
+      merged[key] = (merged[key] ?? 0) + failedValue
+    }
+    response.tokens = merged
+  }
+
+  if (failedAttempt.cost) {
+    response.cost = response.cost
+      ? {
+          ...response.cost,
+          input: response.cost.input + failedAttempt.cost.input,
+          output: response.cost.output + failedAttempt.cost.output,
+          total: response.cost.total + failedAttempt.cost.total,
+        }
+      : { ...failedAttempt.cost }
+  }
+
+  if (failedAttempt.timing && response.timing) {
+    response.timing.startTime = failedAttempt.timing.startTime
+    response.timing.duration += failedAttempt.timing.duration
+    if (failedAttempt.timing.timeSegments?.length || response.timing.timeSegments?.length) {
+      response.timing.timeSegments = [
+        ...(failedAttempt.timing.timeSegments ?? []),
+        ...(response.timing.timeSegments ?? []),
+      ]
+    }
+  } else if (failedAttempt.timing && !response.timing) {
+    response.timing = failedAttempt.timing
+  }
+}
+
+/**
+ * Every provider's trace enricher records the finish reason on the model time
+ * segments it emits, so the final model segment carries the terminal finish
+ * reason without any per-provider wiring here.
+ */
+function lastModelFinishReason(response: ProviderResponse): string | undefined {
+  const segments = response.timing?.timeSegments
+  if (!Array.isArray(segments)) return undefined
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const segment = segments[i]
+    if (segment?.type === 'model') return segment.finishReason
+  }
+  return undefined
+}
+
+/**
+ * Parses model output as a JSON object, rescuing the common prompt-based
+ * failure of valid JSON wrapped in a Markdown code fence. Non-object roots
+ * are rejected because the block spreads the parsed fields into its output.
+ */
+function parseStructuredContent(content: string): StructuredOutputVerdict {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch (error) {
+    const unfenced = stripCodeFence(content)
+    if (unfenced === undefined) {
+      return {
+        ok: false,
+        reason: `the response is not valid JSON (${getErrorMessage(error, 'parse error')}; content began "${truncate(content, 120)}")`,
+      }
+    }
+    try {
+      parsed = JSON.parse(unfenced)
+    } catch (fencedError) {
+      return {
+        ok: false,
+        reason: `the response is not valid JSON (${getErrorMessage(fencedError, 'parse error')}; content began "${truncate(content, 120)}")`,
+      }
+    }
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, reason: 'the response parsed as JSON but is not a JSON object' }
+  }
+  return { ok: true, output: parsed as Record<string, unknown> }
+}
+
+function stripCodeFence(content: string): string | undefined {
+  const match = /^```[a-zA-Z]*\s*([\s\S]*?)\s*```$/.exec(content)
+  return match?.[1]
+}
+
+/**
+ * The provider layer sends `responseFormat.schema` when the wrapper shape is
+ * present and the whole value otherwise; validation mirrors that so the
+ * schema validated here is the schema the model was asked to follow.
+ */
+function extractSchema(responseFormat: unknown): object | undefined {
+  if (!responseFormat || typeof responseFormat !== 'object') return undefined
+  const wrapper = responseFormat as { schema?: unknown }
+  if (wrapper.schema && typeof wrapper.schema === 'object') return wrapper.schema
+  return responseFormat as object
+}
+
+/**
+ * Compiles (and caches) a validator for a user-authored schema. A schema ajv
+ * cannot compile downgrades enforcement to the parse-only checks rather than
+ * failing runs over an inexpressible schema.
+ */
+function getValidator(schema: object | undefined): ValidateFunction | undefined {
+  if (!schema) return undefined
+
+  let cacheKey: string
+  try {
+    cacheKey = JSON.stringify(schema)
+  } catch {
+    return undefined
+  }
+
+  const cached = validatorCache.get(cacheKey)
+  if (cached !== undefined) return cached === false ? undefined : cached
+
+  try {
+    const validator = ajv.compile(schema)
+    validatorCache.set(cacheKey, validator)
+    return validator
+  } catch (error) {
+    logger.warn('Response format schema failed to compile; falling back to JSON parse checks', {
+      error: getErrorMessage(error, 'compile error'),
+    })
+    validatorCache.set(cacheKey, false)
+    return undefined
+  }
+}
+
+function formatValidationErrors(errors: ErrorObject[] | null | undefined): string {
+  if (!errors || errors.length === 0) return 'unknown validation error'
+  return errors
+    .slice(0, 5)
+    .map((error) => `${error.instancePath || '/'} ${error.message || 'is invalid'}`.trim())
+    .join('; ')
+}


### PR DESCRIPTION
## Problem

The executor never validates agent-block structured output after generation. `processStructuredResponse` is a bare `JSON.parse(content.trim())`, and on parse failure it logs, attaches a `_responseFormatWarning` that nothing in the repo reads, and **returns success** via the standard-format fallback. Downstream blocks read the structured fields as `undefined`, indistinguishable from a legitimate empty answer.

Two enforcement gaps make this worse:

- **Native structured outputs are validated against a weakened schema.** For models with `nativeStructuredOutputs`, the Anthropic provider passes the schema through the SDK's `transformJSONSchema`, which strips `enum`, `const`, `minLength`/`maxLength`, `pattern`, numeric `minimum`/`maximum`, and `maxItems` out of the enforced grammar and pastes them into `description` as advisory prose. Outputs are grammar-valid but can violate the authored constraints.
- **Prompt-based models have zero enforcement** — the schema is system-prompt text only, and nothing checked the result.

Observed in production-shaped runs (~130 extraction workflows): enum-violating hollow rows emitted mid-degeneration, `importance: 0` against a prose-only "1 to 10" bound, and 128k `max_tokens` blowups whose truncated JSON failed parse and silently became success.

## Change

A new `executor/handlers/agent/structured-output.ts` validates every completed (non-streaming) structured response in the provider-request seam of the agent handler, treating three failure modes as one failure condition:

1. **Truncation** — the final model trace segment's `finishReason` is `max_tokens` / `length` / `MAX_TOKENS` (case-insensitive). Every provider's trace enricher already records this on the model time segments, so no per-provider wiring is needed.
2. **Unparseable JSON** — with a Markdown code-fence rescue before failing, since prompt-based models commonly fence otherwise-valid JSON.
3. **Schema violation** — ajv (already a dependency; `strict: false` so user-authored schemas with unknown keywords still compile) validates against the **authored** schema, restoring `enum`, `minLength`, and numeric bounds to enforced status on both native and prompt-based paths. A schema ajv cannot compile degrades to the parse-only checks rather than failing runs.

On failure: **one identical resample**, but only for requests without tools — tools execute inside the provider call, so a resample would replay their side effects. The failed attempt's tokens, cost, and trace segments are folded into the final result so the block's reported usage matches actual spend. A second failure (or the first, on a tool-carrying request) **fails the block explicitly** with the validation reason.

### Where the knob lives

No new settings. Enforcement follows the response format's existing `strict` flag, which the block's input schema has always documented as defaulting to `true` and which `parseResponseFormat` already normalizes onto every format — it was previously read by nothing. `"strict": false` keeps the exact legacy lenient fallback (including the `_responseFormatWarning`).

Deliberately **not model-conditional** at the surface: the UI's `model` value can be an unresolved `<block.output>` reference or `sim-auto` (resolved only at execution), so a model-conditional field cannot know the actual model — and prompt-based models need validation strictly more. Deliberately **not** the block-level `retry` machinery: that wraps the entire handler and would replay memory reads, MCP discovery, and tool calls.

Streaming responses are unchanged — there is no complete content to validate at this seam.

### Side benefit for schema authors

With post-generation validation in place, `minLength: 1`, `minimum`/`maximum`, and `maxItems` in response format schemas become meaningful for the first time on every model. (Also worth knowing: `format: "date"` is in the SDK's supported-formats set, so date fields get native grammar enforcement just by declaring it.)

## Testing

- New `structured-output.test.ts` (17 tests): fixtures modeled on the observed corruption — hollow enum-violating rows, truncated JSON, fenced JSON, `MAX_TOKENS`/`length` finish reasons, uncompilable schemas, bare-schema formats, usage merging.
- Handler-level tests: retry-then-succeed with token merging and identical resample request, fail-after-retry, schema-violation retry, `strict: false` legacy fallback, no-resample-with-tools, max_tokens tripwire.
- Six existing provenance tests updated to return schema-valid mock content (their `'Mocked response content'` default now correctly fails strict validation).
- `bun run type-check`, `bun run check:api-validation`, `bun run check:boundaries`, and the full agent-handler suite (115 tests) pass.

Docs: the agent block's Response Format section now describes enforcement, the retry, and the `strict: false` opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L7CosQfKB9SGCF8E9fLfY