### PR TITLE
feat(browser): add verified form filling and horizontal scroll

### DIFF
--- a/apps/desktop/e2e/browser-tools.spec.ts
+++ b/apps/desktop/e2e/browser-tools.spec.ts
@@ -189,6 +189,47 @@ test.describe('browser tools', () => {
     expect(await formState()).toMatchObject({ name: '', route: 'change route' })
   })
 
+  test('stops when a new popup exceeds the page summary limit', async () => {
+    const ref = await openForm()
+    await app.evaluate(async ({ webContents }, origin) => {
+      const page = webContents
+        .getAllWebContents()
+        .find((contents) => contents.getURL().startsWith(`${origin}/form`))
+      if (!page) throw new Error('Missing browser fixture')
+      await page.executeJavaScript(`
+        for (let index = 0; index < 10; index++) {
+          const toolbar = document.createElement('div')
+          toolbar.setAttribute('role', 'toolbar')
+          toolbar.textContent = 'Toolbar ' + index
+          document.body.append(toolbar)
+        }
+        document.getElementById('name').addEventListener('input', () => {
+          const popup = document.createElement('div')
+          popup.setAttribute('role', 'listbox')
+          popup.textContent = 'Suggestions'
+          document.body.append(popup)
+        }, { once: true })
+      `)
+    }, origin)
+
+    const fill = await execute('browser_fill_form', {
+      fields: [
+        { elementId: ref('Name'), kind: 'text', text: 'Example User' },
+        { elementId: ref('Plan'), kind: 'select', value: 'pro' },
+      ],
+    })
+    expect(fill.ok, fill.error).toBe(true)
+    expect(fill.result, JSON.stringify(fill.result)).toMatchObject({
+      completed: false,
+      completedCount: 1,
+      stoppedIndex: 0,
+      results: [{ verified: true, valuePreview: 'Example User' }],
+      doNotRetry: true,
+      error: expect.stringContaining('could not be fully verified'),
+    })
+    expect(await formState()).toMatchObject({ name: 'Example User', plan: 'basic' })
+  })
+
   test('refuses credential fields and leaves subsequent fields untouched', async () => {
     const ref = await openForm()
     const fill = await execute('browser_fill_form', {

--- a/apps/desktop/e2e/browser-tools.spec.ts
+++ b/apps/desktop/e2e/browser-tools.spec.ts
@@ -1,0 +1,203 @@
+import { mkdtempSync } from 'node:fs'
+import { createServer, type Server } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  type ElectronApplication,
+  _electron as electron,
+  expect,
+  type Page,
+  test,
+} from '@playwright/test'
+import type { BrowserToolName } from '@sim/browser-protocol'
+import type { SimDesktopApi } from '@sim/desktop-bridge'
+
+const DESKTOP_DIR = fileURLToPath(new URL('..', import.meta.url))
+const SCOPE = 'browser-tools-e2e'
+const FORM = `<!doctype html><html><head><title>Form fixture</title></head><body>
+  <label>Name <input id="name" autocomplete="off"></label>
+  <label>Plan <select id="plan" aria-label="Plan"><option value="basic">Basic</option><option value="pro">Pro</option></select></label>
+  <label>Updates <input id="updates" type="checkbox"></label>
+  <label>Password <input id="password" type="password"></label>
+  <label>Route <input id="route" oninput="history.pushState({}, '', '/form?changed=1')"></label>
+  <div id="horizontal" role="region" aria-label="Wide table" tabindex="0" style="width:280px;overflow-x:auto">
+    <div style="width:1600px;height:100px">Wide content</div>
+  </div>
+</body></html>`
+
+test.describe('browser tools', () => {
+  const calls = new Map<
+    string,
+    { chatId: string; toolName: BrowserToolName; args: Record<string, unknown> }
+  >()
+  let server: Server
+  let origin: string
+  let app: ElectronApplication
+  let window: Page
+  let callCount = 0
+
+  test.beforeAll(async () => {
+    server = createServer(async (request, response) => {
+      const path = new URL(request.url ?? '/', 'http://127.0.0.1').pathname
+      if (path === '/api/desktop/tool/authorize') {
+        let body = ''
+        for await (const chunk of request) body += chunk.toString()
+        const authorization = calls.get(JSON.parse(body).toolCallId)
+        response.writeHead(authorization ? 200 : 403, { 'Content-Type': 'application/json' })
+        response.end(JSON.stringify(authorization ?? {}))
+        return
+      }
+      response.writeHead(200, { 'Content-Type': 'text/html' })
+      response.end(
+        path === '/form'
+          ? FORM
+          : '<!doctype html><title>Sim fixture</title><h1>Browser tools fixture</h1>'
+      )
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (!address || typeof address === 'string') throw new Error('Missing fixture address')
+    origin = `http://127.0.0.1:${address.port}`
+  })
+
+  test.beforeEach(async () => {
+    app = await electron.launch({
+      args: ['.'],
+      cwd: DESKTOP_DIR,
+      env: {
+        ...process.env,
+        SIM_DESKTOP_ORIGIN: origin,
+        SIM_DESKTOP_USER_DATA: mkdtempSync(join(tmpdir(), 'sim-browser-tools-e2e-')),
+      },
+    })
+    window = await app.firstWindow()
+    await expect(window.getByRole('heading')).toHaveText('Browser tools fixture')
+    await window.evaluate(async (scope) => {
+      const api = (globalThis as typeof globalThis & { simDesktop: SimDesktopApi }).simDesktop
+      await api.browserAgent.activateScope(scope)
+      api.browserAgent.setPanelBounds(
+        { x: 0, y: 80, width: innerWidth, height: innerHeight - 80 },
+        null,
+        scope
+      )
+    }, SCOPE)
+  })
+
+  test.afterEach(async () => {
+    await app?.close()
+    calls.clear()
+  })
+
+  test.afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    )
+  })
+
+  async function execute(tool: BrowserToolName, args: Record<string, unknown>) {
+    const callId = `browser-fixture-${++callCount}`
+    calls.set(callId, { chatId: SCOPE, toolName: tool, args })
+    return window.evaluate(
+      async ({ callId, tool, args, scope }) => {
+        const api = (globalThis as typeof globalThis & { simDesktop: SimDesktopApi }).simDesktop
+        return api.browserAgent.executeTool(callId, tool, args, scope)
+      },
+      { callId, tool, args, scope: SCOPE }
+    )
+  }
+
+  async function openForm() {
+    const response = await execute('browser_open_url', { url: `${origin}/form` })
+    expect(response.ok, response.error).toBe(true)
+    const result = response.result as { snapshot: { outline: string } }
+    expect(result.snapshot.outline).toContain('Name')
+    return (name: string) => {
+      const line = result.snapshot.outline.split('\n').find((line) => line.includes(`"${name}"`))
+      const match = line?.match(/\[ref=(\d+)\]/)
+      if (!match) throw new Error(`No reference for ${name}: ${result.snapshot.outline}`)
+      return Number(match[1])
+    }
+  }
+
+  async function formState() {
+    return app.evaluate(async ({ webContents }, origin) => {
+      const page = webContents
+        .getAllWebContents()
+        .find((contents) => contents.getURL().startsWith(`${origin}/form`))
+      if (!page) throw new Error('Missing browser fixture')
+      return page.executeJavaScript(`({
+        name: document.getElementById('name').value,
+        plan: document.getElementById('plan').value,
+        updates: document.getElementById('updates').checked,
+        password: document.getElementById('password').value,
+        route: document.getElementById('route').value,
+        scrollLeft: document.getElementById('horizontal').scrollLeft
+      })`)
+    }, origin)
+  }
+
+  test('opens with references, fills in order, and scrolls a horizontal pane', async () => {
+    const ref = await openForm()
+    const fill = await execute('browser_fill_form', {
+      fields: [
+        { elementId: ref('Name'), kind: 'text', text: 'Example User' },
+        { elementId: ref('Plan'), kind: 'select', value: 'pro' },
+        { elementId: ref('Updates'), kind: 'checked', checked: true },
+      ],
+    })
+    expect(fill.ok, fill.error).toBe(true)
+    expect(fill.result, JSON.stringify(fill.result)).toMatchObject({
+      completed: true,
+      completedCount: 3,
+    })
+    expect(await formState()).toMatchObject({ name: 'Example User', plan: 'pro', updates: true })
+    const cleared = await execute('browser_fill_form', {
+      fields: [{ elementId: ref('Name'), kind: 'text', text: '' }],
+    })
+    expect(cleared.result, JSON.stringify(cleared.result)).toMatchObject({ completed: true })
+    expect(await formState()).toMatchObject({ name: '' })
+
+    const scroll = await execute('browser_scroll', {
+      direction: 'right',
+      amount: 240,
+      elementId: ref('Wide table'),
+    })
+    expect(scroll.ok, scroll.error).toBe(true)
+    expect(scroll.result).toMatchObject({ movedBy: 240 })
+    expect(Math.round((await formState()).scrollLeft)).toBe(240)
+    await execute('browser_scroll', {
+      direction: 'left',
+      amount: 240,
+      elementId: ref('Wide table'),
+    })
+    expect(await formState()).toMatchObject({ scrollLeft: 0 })
+  })
+
+  test('stops after a route change without writing the next field', async () => {
+    const ref = await openForm()
+    const fill = await execute('browser_fill_form', {
+      fields: [
+        { elementId: ref('Route'), kind: 'text', text: 'change route' },
+        { elementId: ref('Name'), kind: 'text', text: 'Must not be written' },
+      ],
+    })
+    expect(fill.result, JSON.stringify(fill.result)).toMatchObject({
+      completed: false,
+      doNotRetry: true,
+    })
+    expect(await formState()).toMatchObject({ name: '', route: 'change route' })
+  })
+
+  test('refuses credential fields and leaves subsequent fields untouched', async () => {
+    const ref = await openForm()
+    const fill = await execute('browser_fill_form', {
+      fields: [
+        { elementId: ref('Password'), kind: 'text', text: 'must-not-be-entered' },
+        { elementId: ref('Name'), kind: 'text', text: 'Must not be written' },
+      ],
+    })
+    expect(fill.result).toMatchObject({ completed: false, completedCount: 0 })
+    expect(await formState()).toMatchObject({ name: '', password: '' })
+  })
+})

--- a/apps/desktop/src/main/browser-agent/driver.test.ts
+++ b/apps/desktop/src/main/browser-agent/driver.test.ts
@@ -111,6 +111,64 @@ describe('executeTool', () => {
     expect(grant).toHaveBeenCalledTimes(navigations.length)
   })
 
+  it('keeps the 400ms hydration grace without rediscovering a completed load', async () => {
+    await driver.executeTool('chat-test', 'browser_open_tab', {})
+    const contents = session.requireTab().view.webContents
+    vi.useFakeTimers()
+    try {
+      let settled = false
+      const navigation = driver.executeTool('chat-test', 'browser_navigate', {
+        url: 'http://127.0.0.1/loaded',
+      })
+      void navigation.then(() => {
+        settled = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(contents.loadURL).toHaveBeenCalledWith('http://127.0.0.1/loaded')
+
+      await vi.advanceTimersByTimeAsync(399)
+      expect(settled).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(settled).toBe(true)
+      await expect(navigation).resolves.toMatchObject({ ok: true })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still waits for a replacement load after loadURL has resolved', async () => {
+    await driver.executeTool('chat-test', 'browser_open_tab', {})
+    const contents = session.requireTab().view.webContents
+    vi.mocked(contents.isLoading).mockReturnValue(true)
+    vi.useFakeTimers()
+    try {
+      let settled = false
+      const navigation = driver.executeTool('chat-test', 'browser_navigate', {
+        url: 'http://127.0.0.1/loading',
+      })
+      void navigation.then(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(500)
+      expect(settled).toBe(false)
+      vi.mocked(contents.isLoading).mockReturnValue(false)
+      for (const [event, listener] of vi.mocked(contents.on).mock.calls) {
+        if (String(event) === 'did-stop-loading') {
+          const onLoadComplete = listener as (...args: unknown[]) => void
+          onLoadComplete()
+        }
+      }
+      await vi.advanceTimersByTimeAsync(399)
+      expect(settled).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(settled).toBe(true)
+      await expect(navigation).resolves.toMatchObject({ ok: true })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('reports an aborted navigation when Chromium never leaves the current URL', async () => {
     vi.useFakeTimers()
     try {
@@ -2013,6 +2071,210 @@ describe('credential protection', () => {
       .mock.calls.filter(([called]) => called === method)
   }
 
+  async function openForm(
+    options: {
+      refuseAt?: number
+      retainValue?: boolean
+      afterWrite?: (index: number) => void
+      waitForWrite?: Promise<void>
+    } = {}
+  ) {
+    const contents = await openPage()
+    const values = ['', '']
+    const writes: number[] = []
+    const dialogs: string[] = []
+    let selectionReads = 0
+    vi.mocked(contents.executeJavaScript).mockImplementation(async (expression: string) => {
+      const encoded = expression.match(/\.apply\(null, (\[[^\n]*\])\)/)?.[1]
+      const args: unknown[] = encoded ? JSON.parse(encoded) : []
+      const index = Number(args[0]) - 1
+      if (isPageCall(expression, 'collectSnapshot'))
+        return {
+          url: 'https://example.com/login',
+          title: 'Form',
+          outline: '- combobox "First" [ref=1]\n- combobox "Second" [ref=2]',
+          truncated: false,
+          refIds: [1, 2],
+          refLineIndexes: { 1: 0, 2: 1 },
+          nextElementId: 3,
+        }
+      if (isPageCall(expression, 'readPageActionState'))
+        return {
+          url: contents.getURL(),
+          dialogs: [...dialogs],
+          popups: [],
+          observationTruncated: false,
+        }
+      if (isPageCall(expression, 'readFormFieldState')) {
+        if (index === options.refuseAt) return { error: 'password' }
+        return {
+          matchesRequested: values[index] === args[2],
+          valueLength: values[index].length,
+          valuePreview: values[index],
+          redacted: false,
+        }
+      }
+      if (isPageCall(expression, 'clickElement'))
+        return { dispatched: false, x: 24, y: 48, element: 'Select' }
+      if (isPageCall(expression, 'selectOptionInElement')) {
+        writes.push(index)
+        await options.waitForWrite
+        const requested = String(args[1])
+        if (options.retainValue !== false) values[index] = requested
+        options.afterWrite?.(index)
+        return { selected: requested, value: requested }
+      }
+      if (isPageCall(expression, 'readSelectElementState')) {
+        selectionReads++
+        return { selected: values[index], value: values[index] }
+      }
+      return undefined
+    })
+    const snapshot = await driver.executeTool('chat-test', 'browser_snapshot', {})
+    expect(snapshot, JSON.stringify(snapshot)).toMatchObject({ ok: true })
+    return { contents, values, writes, dialogs, selectionReads: () => selectionReads }
+  }
+
+  const formFields = [
+    { elementId: 1, kind: 'select', value: 'first' },
+    { elementId: 2, kind: 'select', value: 'second' },
+  ]
+
+  it('fills known form fields in order and verifies every final value', async () => {
+    const form = await openForm()
+    const result = await driver.executeTool('chat-test', 'browser_fill_form', {
+      fields: formFields,
+    })
+    expect(result.result, JSON.stringify(result)).toMatchObject({ completed: true })
+    expect(form.writes).toEqual([0, 1])
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        completed: true,
+        completedCount: 2,
+        results: [
+          { index: 0, verified: true, valuePreview: 'first' },
+          { index: 1, verified: true, valuePreview: 'second' },
+        ],
+      },
+    })
+  })
+
+  it.each([
+    { fields: [] },
+    {
+      fields: Array.from({ length: 9 }, (_, elementId) => ({ elementId, kind: 'text', text: 'x' })),
+    },
+    { fields: [formFields[0], { ...formFields[1], submit: true }] },
+    { fields: [formFields[0], formFields[0]] },
+    { fields: [{ elementId: 0, kind: 'text', text: 'x'.repeat(4097) }] },
+  ])('validates the entire bounded form payload before writing', async (params) => {
+    const form = await openForm()
+    expect(await driver.executeTool('chat-test', 'browser_fill_form', params)).toMatchObject({
+      ok: false,
+    })
+    expect(form.writes).toEqual([])
+  })
+
+  it('preflights later secret fields before changing earlier fields', async () => {
+    const form = await openForm({ refuseAt: 1 })
+    const result = await driver.executeTool('chat-test', 'browser_fill_form', {
+      fields: formFields,
+    })
+    expect(form.writes).toEqual([])
+    expect(result).toMatchObject({
+      ok: true,
+      result: { completed: false, completedCount: 0, stoppedIndex: 1 },
+    })
+  })
+
+  it('does not mistake dispatch or weak effects for a retained requested value', async () => {
+    const form = await openForm({ retainValue: false })
+    const result = await driver.executeTool('chat-test', 'browser_fill_form', {
+      fields: formFields,
+    })
+    expect(form.writes).toEqual([0])
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        completed: false,
+        completedCount: 0,
+        stoppedIndex: 0,
+        results: [{ verified: false }],
+        doNotRetry: true,
+      },
+    })
+  })
+
+  it('returns verified partial results and skips later fields when a dialog opens', async () => {
+    const form: Awaited<ReturnType<typeof openForm>> = await openForm({
+      afterWrite: () => form.dialogs.push('Confirm'),
+    })
+    const result = await driver.executeTool('chat-test', 'browser_fill_form', {
+      fields: formFields,
+    })
+    expect(form.writes).toEqual([0])
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        completed: false,
+        completedCount: 1,
+        results: [{ verified: true }],
+        doNotRetry: true,
+      },
+    })
+  })
+
+  it('stops before the next field after same-document navigation', async () => {
+    const form: Awaited<ReturnType<typeof openForm>> = await openForm({
+      afterWrite: () => vi.mocked(form.contents.getURL).mockReturnValue('https://example.com/next'),
+    })
+    const result = await driver.executeTool('chat-test', 'browser_fill_form', {
+      fields: formFields,
+    })
+    expect(form.writes).toEqual([0])
+    expect(result).toMatchObject({ ok: true, result: { completed: false, doNotRetry: true } })
+  })
+
+  it('detects a later field changing an earlier completed field', async () => {
+    const form: Awaited<ReturnType<typeof openForm>> = await openForm({
+      afterWrite: (index) => {
+        if (index === 1) form.values[0] = 'changed'
+      },
+    })
+    const result = await driver.executeTool('chat-test', 'browser_fill_form', {
+      fields: formFields,
+    })
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        completed: false,
+        stoppedIndex: 0,
+        results: [{ verified: false }, { verified: true }],
+      },
+    })
+  })
+
+  it('prevents later form writes after cancellation even if the pending page call resolves late', async () => {
+    let releaseWrite: () => void = () => {}
+    const waitForWrite = new Promise<void>((resolve) => {
+      releaseWrite = resolve
+    })
+    const form = await openForm({ waitForWrite })
+    const pending = driver.executeTool(
+      'chat-test',
+      'browser_fill_form',
+      { fields: formFields },
+      'cancel-form'
+    )
+    await vi.waitFor(() => expect(form.writes).toEqual([0]))
+    driver.cancelTool('chat-test', 'cancel-form')
+    expect(await pending).toMatchObject({ ok: false, error: expect.stringContaining('cancelled') })
+    releaseWrite()
+    await vi.waitFor(() => expect(form.selectionReads()).toBe(1))
+    expect(form.writes).toEqual([0])
+  })
+
   function mockScreenshotImage(size: { width: number; height: number } | null): void {
     vi.mocked(nativeImage.createFromBuffer).mockReturnValueOnce({
       isEmpty: vi.fn(() => size === null),
@@ -2199,6 +2461,35 @@ describe('credential protection', () => {
     })
     expect(cdpCalls(contents, 'Input.insertText')).toHaveLength(1)
   })
+
+  it('accepts empty text and sends it through native insertion to clear a field', async () => {
+    const contents = await openPage()
+    respondWith(contents, {
+      focusElementForTyping: { focused: true, kind: 'input', x: 24, y: 48 },
+      readActiveElementState: { activeElement: 'input', valueLength: 0, valuePreview: '' },
+      readPageActionState: {},
+    })
+
+    const result = await driver.executeTool('chat-test', 'browser_type', { elementId: 0, text: '' })
+
+    expect(result).toMatchObject({ ok: true, result: { dispatched: true, trusted: true } })
+    expect(cdpCalls(contents, 'Input.insertText')).toEqual([['Input.insertText', { text: '' }]])
+  })
+
+  it.each([{}, { text: undefined }, { text: null }, { text: 7 }, { text: false }])(
+    'rejects missing or nonstring text before native input',
+    async (params) => {
+      const contents = await openPage()
+      const result = await driver.executeTool('chat-test', 'browser_type', {
+        elementId: 0,
+        ...params,
+      })
+
+      expect(result).toMatchObject({ ok: false, error: expect.stringContaining('text') })
+      expect(cdpCalls(contents, 'Input.insertText')).toHaveLength(0)
+      expect(cdpCalls(contents, 'Input.dispatchKeyEvent')).toHaveLength(0)
+    }
+  )
 
   it('types through a focused combobox suggestions popup without pointer probing', async () => {
     const contents = await openPage()
@@ -2406,7 +2697,7 @@ describe('credential protection', () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error: 'Scroll direction must be "up" or "down".',
+      error: 'Scroll direction must be "up", "down", "left", or "right".',
     })
     expect(
       vi
@@ -2414,6 +2705,35 @@ describe('credential protection', () => {
         .mock.calls.some(([expression]) => isPageCall(String(expression), 'scrollPage'))
     ).toBe(false)
   })
+
+  it.each(['left', 'right'])(
+    'accepts browser_scroll %s and returns horizontal movement',
+    async (direction) => {
+      const contents = await openPage()
+      const movedBy = direction === 'left' ? -100 : 100
+      respondWith(contents, {
+        scrollPage: {
+          target: 'Table columns',
+          targetSource: 'viewport-center',
+          movedBy,
+          scrollLeft: 300,
+          scrollWidth: 1_000,
+          clientWidth: 200,
+          atLeft: false,
+          atRight: false,
+          atTop: true,
+          atBottom: true,
+        },
+      })
+
+      expect(
+        await driver.executeTool('chat-test', 'browser_scroll', { direction, amount: 100 })
+      ).toMatchObject({
+        ok: true,
+        result: { movedBy, scrollLeft: 300, atLeft: false, atRight: false },
+      })
+    }
+  )
 
   it('confirms a click when the requested target changes semantic state', async () => {
     const contents = await openPage()

--- a/apps/desktop/src/main/browser-agent/driver.ts
+++ b/apps/desktop/src/main/browser-agent/driver.ts
@@ -60,6 +60,7 @@ import {
   readActiveElementState,
   readCheckableElementState,
   readChildFrameElementState,
+  readFormFieldState,
   readPageActionState,
   readPageText,
   readSelectElementState,
@@ -83,6 +84,9 @@ const TAKEOVER_POLL_MS = 1_500
  * legitimate tool (browser_wait_for caps at 120s).
  */
 const DEFAULT_TOOL_WATCHDOG_MS = 20_000
+const MAX_FORM_FIELDS = 8
+const MAX_FORM_FIELD_TEXT = 4_096
+const MAX_FORM_TEXT = 16_384
 const WAIT_FOR_TOOL_WATCHDOG_GRACE_MS = 5_000
 /** Retained native tool calls: generous for normal serial use, finite under a wedged caller. */
 export const BROWSER_TOOL_ADMISSION_LIMITS = Object.freeze({
@@ -116,6 +120,73 @@ function isBrowserWaitElementState(value: string): value is BrowserWaitElementSt
 }
 
 type PageExecutionTarget = WebContents | WebFrameMain
+
+type FormField =
+  | { elementId: number; kind: 'text'; text: string }
+  | { elementId: number; kind: 'select'; value: string }
+  | { elementId: number; kind: 'checked'; checked: boolean }
+
+function parseFormFields(params: Record<string, unknown>): FormField[] {
+  if (Object.keys(params).some((key) => key !== 'fields')) {
+    throw new ToolError('Form filling accepts only fields; submitting is not supported.')
+  }
+  if (
+    !Array.isArray(params.fields) ||
+    params.fields.length === 0 ||
+    params.fields.length > MAX_FORM_FIELDS
+  ) {
+    throw new ToolError(`Form filling requires between 1 and ${MAX_FORM_FIELDS} fields.`)
+  }
+  const ids = new Set<number>()
+  let totalText = 0
+  return params.fields.map((field): FormField => {
+    if (
+      !isRecordLike(field) ||
+      typeof field.elementId !== 'number' ||
+      !Number.isSafeInteger(field.elementId) ||
+      field.elementId < 0 ||
+      ids.has(field.elementId)
+    ) {
+      throw new ToolError('Every form field requires a unique nonnegative integer elementId.')
+    }
+    ids.add(field.elementId)
+    const valueKey =
+      field.kind === 'text'
+        ? 'text'
+        : field.kind === 'select'
+          ? 'value'
+          : field.kind === 'checked'
+            ? 'checked'
+            : null
+    if (
+      !valueKey ||
+      Object.keys(field).some((key) => !['elementId', 'kind', valueKey].includes(key))
+    ) {
+      throw new ToolError(
+        'Each form field must specify text, select, or checked and only its matching value parameter.'
+      )
+    }
+    if (field.kind === 'checked' && typeof field.checked === 'boolean') {
+      return { elementId: field.elementId, kind: 'checked', checked: field.checked }
+    }
+    const value = field[valueKey]
+    if (
+      typeof value !== 'string' ||
+      value.length > MAX_FORM_FIELD_TEXT ||
+      field.kind === 'checked'
+    ) {
+      throw new ToolError(
+        `Text and selection values must be strings of at most ${MAX_FORM_FIELD_TEXT} characters; checked must be boolean.`
+      )
+    }
+    totalText += value.length
+    if (totalText > MAX_FORM_TEXT)
+      throw new ToolError(`Form field text cannot exceed ${MAX_FORM_TEXT} characters in total.`)
+    return field.kind === 'text'
+      ? { elementId: field.elementId, kind: 'text', text: value }
+      : { elementId: field.elementId, kind: 'select', value }
+  })
+}
 
 export type BrowserSessionPersistence = session.BrowserSessionPersistence
 
@@ -1303,8 +1374,10 @@ async function loadAgentCheckedUrlAndGetResult(
     throw new ToolError('The tab was closed before navigation could start.')
   }
   const beforeUrl = contents.getURL()
+  let loadCompleted = false
   try {
     await contents.loadURL(url)
+    loadCompleted = true
   } catch (error) {
     const candidate = error as { code?: unknown; errno?: unknown }
     const routineAbort =
@@ -1322,7 +1395,10 @@ async function loadAgentCheckedUrlAndGetResult(
       throw new ToolError(`The navigation was aborted (${getErrorMessage(error)}).`)
     }
   }
-  return await navigationResult(contents)
+  return await navigationResult(
+    contents,
+    loadCompleted && !contents.isLoading() ? Promise.resolve() : undefined
+  )
 }
 
 /**
@@ -3057,9 +3133,185 @@ async function executeToolInner(
       }
     }
 
+    case 'browser_fill_form': {
+      const fields = parseFormFields(params)
+      const contents = session.requireAutomationTab().view.webContents
+      const epoch = navigationEpoch(contents)
+      const url = contents.getURL()
+      const state = driverScopeState()
+      const tabIds = session
+        .getTabsState()
+        .tabs.map((tab) => tab.tabId)
+        .join(',')
+      const downloadIds = session
+        .getBrowserDownloadsState(session.getBrowserScopeId())
+        .downloads.map((download) => download.id)
+        .join(',')
+      const noticeCount = state.pendingNotices.length
+      const deadline = Math.min(executionDeadline ?? Number.POSITIVE_INFINITY, Date.now() + 18_000)
+      const results: Record<string, unknown>[] = []
+      let stoppedIndex = 0
+      let dispatchStarted = false
+      const readField = async (field: FormField) => {
+        const target = pageTargetForElement(contents, field.elementId)
+        if (target !== contents)
+          throw new ToolError(
+            'Form batches require top-page fields; use individual tools for framed fields.'
+          )
+        const readback = toRecord(
+          unwrapPageResult(
+            await execInPage(
+              contents,
+              readFormFieldState,
+              [
+                field.elementId,
+                field.kind,
+                field.kind === 'text'
+                  ? field.text
+                  : field.kind === 'select'
+                    ? field.value
+                    : field.checked,
+              ],
+              false,
+              deadline
+            )
+          )
+        )
+        if (typeof readback.error === 'string') throw new ToolError(readback.error)
+        if (typeof readback.matchesRequested !== 'boolean')
+          throw new ToolError('The form field could not be verified.')
+        return readback
+      }
+      const readBoundary = async () => {
+        const boundary = toRecord(
+          await execInPage(contents, readPageActionState, [], false, deadline)
+        )
+        if (
+          !Array.isArray(boundary.dialogs) ||
+          !Array.isArray(boundary.popups) ||
+          boundary.observationTruncated === true
+        ) {
+          throw new ToolError(
+            'The page state could not be fully verified for form filling. Use individual field tools.'
+          )
+        }
+        return JSON.stringify([boundary.url, boundary.dialogs, boundary.popups])
+      }
+      const assertBoundary = () => {
+        assertCurrentExecution()
+        if (Date.now() >= deadline) throw new ToolError('Form filling reached its time limit.')
+        assertActiveContents(contents, epoch)
+        if (
+          contents.getURL() !== url ||
+          session
+            .getTabsState()
+            .tabs.map((tab) => tab.tabId)
+            .join(',') !== tabIds ||
+          state.pendingNotices.length !== noticeCount ||
+          session
+            .getBrowserDownloadsState(session.getBrowserScopeId())
+            .downloads.map((download) => download.id)
+            .join(',') !== downloadIds
+        ) {
+          throw new ToolError(
+            'The page, tabs, dialogs, or downloads changed during form filling. Inspect the page before continuing.'
+          )
+        }
+      }
+      try {
+        assertBoundary()
+        const initialBoundary = await readBoundary()
+        for (const [index, field] of fields.entries()) {
+          stoppedIndex = index
+          await readField(field)
+          assertBoundary()
+        }
+        for (const [index, field] of fields.entries()) {
+          stoppedIndex = index
+          assertBoundary()
+          if ((await readBoundary()) !== initialBoundary)
+            throw new ToolError('A dialog, popup, or page transition interrupted form filling.')
+          const before = await readField(field)
+          assertBoundary()
+          if (before.matchesRequested !== true) {
+            dispatchStarted = true
+            await executeToolInner(
+              field.kind === 'text'
+                ? 'browser_type'
+                : field.kind === 'select'
+                  ? 'browser_select_option'
+                  : 'browser_set_checked',
+              field.kind === 'text'
+                ? { elementId: field.elementId, text: field.text }
+                : field.kind === 'select'
+                  ? { elementId: field.elementId, value: field.value }
+                  : { elementId: field.elementId, checked: field.checked },
+              assertBoundary,
+              deadline,
+              invocationEpoch
+            )
+          }
+          assertBoundary()
+          const readback = await readField(field)
+          results.push({
+            index,
+            elementId: field.elementId,
+            kind: field.kind,
+            verified: readback.matchesRequested === true,
+            ...omit(readback, ['matchesRequested', 'focused']),
+          })
+          if (readback.matchesRequested !== true)
+            throw new ToolError(
+              'The field did not retain the requested value. Inspect its readback before continuing.'
+            )
+          if (
+            field.kind === 'text' &&
+            before.matchesRequested !== true &&
+            readback.focused !== true
+          )
+            throw new ToolError(
+              'Focus moved away from the typed field. Inspect the page before continuing.'
+            )
+          if ((await readBoundary()) !== initialBoundary)
+            throw new ToolError('A dialog, popup, or page transition interrupted form filling.')
+          assertBoundary()
+        }
+        for (const [index, field] of fields.entries()) {
+          stoppedIndex = index
+          const readback = await readField(field)
+          results[index] = {
+            ...results[index],
+            verified: readback.matchesRequested === true,
+            ...omit(readback, ['matchesRequested', 'focused']),
+          }
+          assertBoundary()
+          if (readback.matchesRequested !== true)
+            throw new ToolError(
+              'A previously filled field changed. Inspect the partial result before continuing.'
+            )
+        }
+        if ((await readBoundary()) !== initialBoundary)
+          throw new ToolError('A dialog, popup, or page transition interrupted form filling.')
+        assertBoundary()
+        return { completed: true, completedCount: fields.length, results }
+      } catch (error) {
+        assertCurrentExecution()
+        return {
+          completed: false,
+          completedCount: results.filter((result) => result.verified === true).length,
+          stoppedIndex,
+          results,
+          error: getErrorMessage(error),
+          doNotRetry: dispatchStarted,
+          note: 'Earlier fields may already have taken effect. Inspect the readbacks and take a fresh snapshot before deciding which remaining fields to fill. Form filling is not atomic.',
+        }
+      }
+    }
+
     case 'browser_type': {
       const elementId = requireNum(params, 'elementId')
-      const text = requireStr(params, 'text')
+      const text = params.text
+      if (typeof text !== 'string') throw new ToolError('Missing required parameter "text"')
       const submit = params.submit === true
       const contents = session.requireAutomationTab().view.webContents
       const target = pageTargetForElement(contents, elementId)
@@ -3558,8 +3810,8 @@ async function executeToolInner(
 
     case 'browser_scroll': {
       const direction = requireStr(params, 'direction')
-      if (direction !== 'up' && direction !== 'down') {
-        throw new ToolError('Scroll direction must be "up" or "down".')
+      if (!['up', 'down', 'left', 'right'].includes(direction)) {
+        throw new ToolError('Scroll direction must be "up", "down", "left", or "right".')
       }
       const contents = session.requireAutomationTab().view.webContents
       const elementId = num(params, 'elementId')

--- a/apps/desktop/src/main/browser-agent/form-fields.test.ts
+++ b/apps/desktop/src/main/browser-agent/form-fields.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { readFormFieldState } from '@/main/browser-agent/page-functions'
+
+describe('readFormFieldState', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    window.__simAgentResolveElement = undefined
+    window.__simAgentElements = []
+  })
+
+  function register(markup: string): HTMLInputElement {
+    document.body.innerHTML = markup
+    const element = document.body.firstElementChild as HTMLInputElement
+    window.__simAgentElements = [element]
+    return element
+  }
+
+  it('compares the complete actual value even when previews and lengths match', () => {
+    const input = register('<input>')
+    input.value = `${'x'.repeat(120)}actual`
+    expect(readFormFieldState(0, 'text', `${'x'.repeat(120)}wanted`)).toMatchObject({
+      matchesRequested: false,
+      valueLength: 126,
+      valuePreview: 'x'.repeat(120),
+    })
+    expect(readFormFieldState(0, 'text', input.value)).toMatchObject({ matchesRequested: true })
+  })
+
+  it.each([
+    'type="password"',
+    'autocomplete="section-login current-password"',
+    'autocomplete="new-password"',
+  ])('refuses credentials without a value readback (%s)', (attributes) => {
+    register(`<input ${attributes} value="secret">`)
+    expect(readFormFieldState(0, 'text', 'secret')).toEqual({ error: 'password' })
+  })
+
+  it.each(['one-time-code', 'cc-number', 'cc-csc', 'cc-exp'])(
+    'verifies %s without previewing it',
+    (hint) => {
+      register(`<input autocomplete="${hint}" value="123456">`)
+      expect(readFormFieldState(0, 'text', '123456')).toMatchObject({
+        matchesRequested: true,
+        redacted: true,
+        valueLength: 6,
+        valuePreview: '',
+      })
+    }
+  )
+
+  it.each(['<input type="file">', '<div contenteditable="true">editor</div>'])(
+    'refuses nonordinary text fields',
+    (markup) => {
+      register(markup)
+      expect(readFormFieldState(0, 'text', '')).toEqual({
+        error: 'Form batches require ordinary text inputs or textareas.',
+      })
+    }
+  )
+
+  it('rejects a same-origin framed field', () => {
+    document.body.innerHTML = '<iframe></iframe>'
+    const inner = document.querySelector('iframe')?.contentDocument
+    if (!inner) throw new Error('Missing test frame')
+    inner.body.innerHTML = '<input>'
+    window.__simAgentElements = [inner.body.firstElementChild as Element]
+    expect(readFormFieldState(0, 'text', '')).toEqual({
+      error: 'Form batches require top-page fields.',
+    })
+  })
+
+  it('verifies native selection by the existing case-insensitive value or label match', () => {
+    register(
+      '<select><option value="us">United States</option><option value="ca">Canada</option></select>'
+    )
+    expect(readFormFieldState(0, 'select', 'UNITED STATES')).toMatchObject({
+      matchesRequested: true,
+      valuePreview: 'us',
+    })
+    expect(readFormFieldState(0, 'select', 'Canada')).toMatchObject({ matchesRequested: false })
+  })
+
+  it('rejects disabled options and multi-select controls', () => {
+    register('<select><option disabled value="us">United States</option></select>')
+    expect(readFormFieldState(0, 'select', 'us')).toMatchObject({ error: expect.any(String) })
+    register('<select multiple><option value="us">United States</option></select>')
+    expect(readFormFieldState(0, 'select', 'us')).toMatchObject({ error: expect.any(String) })
+  })
+
+  it('verifies native checkbox state while refusing direct radio unchecks', () => {
+    register('<input type="checkbox" checked>')
+    expect(readFormFieldState(0, 'checked', true)).toEqual({
+      matchesRequested: true,
+      checked: true,
+    })
+    register('<input type="radio" checked>')
+    expect(readFormFieldState(0, 'checked', false)).toMatchObject({ error: expect.any(String) })
+  })
+})

--- a/apps/desktop/src/main/browser-agent/page-functions.test.ts
+++ b/apps/desktop/src/main/browser-agent/page-functions.test.ts
@@ -1276,6 +1276,163 @@ describe('scrollPage', () => {
     return { scroller, child }
   }
 
+  function makeHorizontalScroller(
+    scrollLeft = 0,
+    rtl = false
+  ): {
+    scroller: HTMLDivElement
+    child: HTMLDivElement
+  } {
+    const { scroller, child } = makeScroller(300)
+    scroller.style.overflowX = 'auto'
+    scroller.style.direction = rtl ? 'rtl' : 'ltr'
+    Object.defineProperties(scroller, {
+      clientWidth: { configurable: true, value: 200 },
+      scrollWidth: { configurable: true, value: 1_000 },
+      scrollLeft: { configurable: true, writable: true, value: scrollLeft },
+    })
+    Object.defineProperty(scroller, 'scrollBy', {
+      configurable: true,
+      value: ({ left, top }: ScrollToOptions) => {
+        const extent = scroller.scrollWidth - scroller.clientWidth
+        const min = rtl ? -extent : 0
+        const max = rtl ? 0 : extent
+        scroller.scrollLeft = Math.max(min, Math.min(max, scroller.scrollLeft + (left || 0)))
+        scroller.scrollTop += top || 0
+      },
+    })
+    return { scroller, child }
+  }
+
+  it('scrolls a referenced horizontal region without changing its vertical position', () => {
+    const { scroller, child } = makeHorizontalScroller(100)
+    register(child)
+
+    expect(runSerialized(scrollPage, ['right', 125, 0])).toMatchObject({
+      target: 'Message history',
+      targetSource: 'element',
+      scrollLeft: 225,
+      scrollWidth: 1_000,
+      clientWidth: 200,
+      movedBy: 125,
+      atLeft: false,
+      atRight: false,
+      scrollTop: 300,
+      atTop: false,
+      atBottom: false,
+    })
+    expect(scroller.scrollTop).toBe(300)
+  })
+
+  it('uses viewport width for the default horizontal distance', () => {
+    const { scroller, child } = makeHorizontalScroller()
+    Object.defineProperty(scroller, 'scrollWidth', { configurable: true, value: 10_000 })
+    register(child)
+
+    expect(scrollPage('right', undefined, 0)).toMatchObject({
+      movedBy: Math.round(window.innerWidth * 0.85),
+    })
+  })
+
+  it('skips a vertical-only descendant when targeting a horizontal ancestor', () => {
+    const { scroller, child } = makeHorizontalScroller(200)
+    child.style.overflowY = 'auto'
+    Object.defineProperties(child, {
+      clientHeight: { configurable: true, value: 50 },
+      scrollHeight: { configurable: true, value: 500 },
+      scrollTop: { configurable: true, writable: true, value: 100 },
+    })
+    register(child)
+
+    expect(scrollPage('left', 75, 0)).toMatchObject({
+      target: 'Message history',
+      targetSource: 'element',
+      movedBy: -75,
+      scrollLeft: 125,
+    })
+    expect(scroller.scrollTop).toBe(300)
+    expect(child.scrollTop).toBe(100)
+  })
+
+  it('keeps a centered horizontal pane at its boundary instead of scrolling another pane', () => {
+    const { scroller, child } = makeHorizontalScroller(800)
+    const other = visible(document.createElement('div'))
+    other.style.overflowX = 'auto'
+    other.setAttribute('aria-label', 'Unrelated pane')
+    Object.defineProperties(other, {
+      clientWidth: { configurable: true, value: 200 },
+      scrollWidth: { configurable: true, value: 1_000 },
+    })
+    document.body.prepend(other)
+    Object.defineProperty(document, 'elementsFromPoint', {
+      configurable: true,
+      value: () => [child, scroller],
+    })
+
+    expect(scrollPage('right', 100)).toMatchObject({
+      target: 'Message history',
+      targetSource: 'viewport-center-boundary',
+      movedBy: 0,
+      atRight: true,
+    })
+    expect(other.scrollLeft).toBe(0)
+  })
+
+  it.each([
+    { direction: 'left', before: 0, after: -100, movedBy: -100, atLeft: false, atRight: false },
+    { direction: 'left', before: -750, after: -800, movedBy: -50, atLeft: true, atRight: false },
+    { direction: 'left', before: -800, after: -800, movedBy: 0, atLeft: true, atRight: false },
+    { direction: 'right', before: -50, after: 0, movedBy: 50, atLeft: false, atRight: true },
+    { direction: 'right', before: 0, after: 0, movedBy: 0, atLeft: false, atRight: true },
+  ])('scrolls RTL $direction from $before with physical boundaries', (test) => {
+    const { child } = makeHorizontalScroller(test.before, true)
+    register(child)
+
+    expect(scrollPage(test.direction, 100, 0)).toMatchObject({
+      scrollLeft: test.after,
+      movedBy: test.movedBy,
+      atLeft: test.atLeft,
+      atRight: test.atRight,
+    })
+  })
+
+  it('scrolls the document root containing an explicit same-origin iframe ref', () => {
+    document.body.innerHTML = '<iframe></iframe>'
+    const frame = visible(document.querySelector('iframe') as HTMLIFrameElement)
+    const frameDocument = frame.contentDocument as Document
+    const frameWindow = frame.contentWindow as Window
+    frameDocument.body.innerHTML = '<div>wide table</div>'
+    const child = visible(frameDocument.body.firstElementChild as HTMLDivElement)
+    const root = visible(frameDocument.documentElement)
+    Object.defineProperties(root, {
+      clientWidth: { configurable: true, value: 200 },
+      scrollWidth: { configurable: true, value: 1_000 },
+      scrollLeft: { configurable: true, writable: true, value: 0 },
+    })
+    Object.defineProperty(frameWindow, 'scrollX', { configurable: true, writable: true, value: 0 })
+    Object.defineProperty(frameWindow, 'scrollBy', {
+      configurable: true,
+      value: ({ left }: ScrollToOptions) => {
+        root.scrollLeft = Math.max(0, Math.min(800, root.scrollLeft + (left || 0)))
+        Object.defineProperty(frameWindow, 'scrollX', {
+          configurable: true,
+          value: root.scrollLeft,
+        })
+      },
+    })
+    register(child)
+
+    expect(scrollPage('right', 100, 0)).toMatchObject({
+      target: 'html',
+      targetSource: 'element',
+      scrollLeft: 100,
+      movedBy: 100,
+      atLeft: false,
+      atRight: false,
+      windowScrollX: 0,
+    })
+  })
+
   it('scrolls the movable internal container under the viewport center', () => {
     const { scroller, child } = makeScroller(600)
     Object.defineProperty(document, 'elementsFromPoint', {

--- a/apps/desktop/src/main/browser-agent/page-functions.test.ts
+++ b/apps/desktop/src/main/browser-agent/page-functions.test.ts
@@ -915,6 +915,43 @@ describe('collectSnapshot', () => {
     expect(after.popups).not.toEqual(before.popups)
   })
 
+  it.each([
+    { role: 'dialog', field: 'dialogs' },
+    { role: 'toolbar', field: 'popups' },
+  ] as const)(
+    'reports truncation when visible $field exceed the summary limit',
+    ({ role, field }) => {
+      for (let index = 0; index < 10; index++) {
+        const element = visible(document.createElement('div'))
+        element.setAttribute('role', role)
+        element.setAttribute('aria-label', `Existing ${index}`)
+        document.body.append(element)
+      }
+      const before = readPageActionState() as {
+        dialogs: string[]
+        popups: string[]
+        observationTruncated: boolean
+      }
+      expect(before[field]).toHaveLength(10)
+      expect(before.observationTruncated).toBe(false)
+
+      const additional = visible(document.createElement('div'))
+      additional.setAttribute('role', role === 'toolbar' ? 'listbox' : role)
+      additional.setAttribute('aria-label', 'New overlay')
+      document.body.append(additional)
+      expect(readPageActionState()).toMatchObject({
+        [field]: before[field],
+        observationTruncated: true,
+      })
+
+      additional.setAttribute('aria-hidden', 'true')
+      expect(readPageActionState()).toMatchObject({
+        [field]: before[field],
+        observationTruncated: false,
+      })
+    }
+  )
+
   it('reports a targeted control semantic disappearance after its panel closes', () => {
     document.body.innerHTML = `
       <aside aria-label="Thread panel"><button data-testid="close-thread">Close thread</button></aside>

--- a/apps/desktop/src/main/browser-agent/page-functions.ts
+++ b/apps/desktop/src/main/browser-agent/page-functions.ts
@@ -2208,6 +2208,7 @@ export function readPageActionState(
   const roots: ParentNode[] = observationRoot ? [observationRoot] : []
   const allElements: Element[] = []
   const stateNodeCap = 12_000
+  const overlayLimit = 10
   for (let index = 0; index < roots.length; index++) {
     for (const element of Array.from(roots[index].querySelectorAll('*'))) {
       if (allElements.length >= stateNodeCap) break
@@ -2296,48 +2297,46 @@ export function readPageActionState(
   const dialogs = allElements.filter((element) =>
     element.matches('dialog[open], [role="dialog"], [aria-modal="true"]')
   )
-  const visibleDialogLabels = dialogs
-    .filter((element) => {
-      const rect = element.getBoundingClientRect()
-      const view = element.ownerDocument.defaultView
-      if (!view || rect.width <= 0 || rect.height <= 0) return false
-      for (let current: Element | null = element; current; ) {
-        const style = view.getComputedStyle(current)
-        if (
-          style.display === 'none' ||
-          style.visibility === 'hidden' ||
-          Number.parseFloat(style.opacity || '1') <= 0.01 ||
-          current.hasAttribute('hidden') ||
-          current.getAttribute('aria-hidden') === 'true'
-        ) {
-          return false
-        }
-        if (current.parentElement) current = current.parentElement
-        else {
-          const root = current.getRootNode()
-          current = 'host' in root ? (root.host as Element) : null
-        }
+  const visibleDialogs = dialogs.filter((element) => {
+    const rect = element.getBoundingClientRect()
+    const view = element.ownerDocument.defaultView
+    if (!view || rect.width <= 0 || rect.height <= 0) return false
+    for (let current: Element | null = element; current; ) {
+      const style = view.getComputedStyle(current)
+      if (
+        style.display === 'none' ||
+        style.visibility === 'hidden' ||
+        Number.parseFloat(style.opacity || '1') <= 0.01 ||
+        current.hasAttribute('hidden') ||
+        current.getAttribute('aria-hidden') === 'true'
+      ) {
+        return false
       }
-      return (
-        rect.right > 0 &&
-        rect.bottom > 0 &&
-        rect.left < view.innerWidth &&
-        rect.top < view.innerHeight
-      )
-    })
-    .slice(0, 10)
-    .map((element) =>
-      (
-        element.getAttribute('aria-label') ||
-        (element as HTMLElement).innerText ||
-        element.textContent ||
-        ''
-      )
-        .replace(/\s+/g, ' ')
-        .trim()
-        .slice(0, 120)
-        .replace(/[\uD800-\uDBFF]$/, '')
+      if (current.parentElement) current = current.parentElement
+      else {
+        const root = current.getRootNode()
+        current = 'host' in root ? (root.host as Element) : null
+      }
+    }
+    return (
+      rect.right > 0 &&
+      rect.bottom > 0 &&
+      rect.left < view.innerWidth &&
+      rect.top < view.innerHeight
     )
+  })
+  const visibleDialogLabels = visibleDialogs.slice(0, overlayLimit).map((element) =>
+    (
+      element.getAttribute('aria-label') ||
+      (element as HTMLElement).innerText ||
+      element.textContent ||
+      ''
+    )
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 120)
+      .replace(/[\uD800-\uDBFF]$/, '')
+  )
 
   // Roles an app uses for something that APPEARS over the page. The first three
   // were the whole list, which missed the most common hover affordance there
@@ -2345,7 +2344,7 @@ export function readPageActionState(
   // with an aria-label). A hover that mounted one produced no popup change, no
   // target change, and so no observed effect at all — the agent concluded its
   // hover had failed and escalated to clicking pixels.
-  const visiblePopupLabels = allElements
+  const visiblePopups = allElements
     .filter((element) =>
       element.matches(
         '[role="tooltip"], [role="menu"], [role="listbox"], [role="toolbar"], [role="menubar"], [role="group"][aria-label], [popover]'
@@ -2367,20 +2366,19 @@ export function readPageActionState(
         rect.top < view.innerHeight
       )
     })
-    .slice(0, 10)
-    .map((element) =>
-      (
-        element.getAttribute('aria-label') ||
-        (element as HTMLElement).innerText ||
-        element.textContent ||
-        element.getAttribute('role') ||
-        ''
-      )
-        .replace(/\s+/g, ' ')
-        .trim()
-        .slice(0, 120)
-        .replace(/[\uD800-\uDBFF]$/, '')
+  const visiblePopupLabels = visiblePopups.slice(0, overlayLimit).map((element) =>
+    (
+      element.getAttribute('aria-label') ||
+      (element as HTMLElement).innerText ||
+      element.textContent ||
+      element.getAttribute('role') ||
+      ''
     )
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 120)
+      .replace(/[\uD800-\uDBFF]$/, '')
+  )
 
   const scrolledRegions = allElements
     .filter((element) => (element as HTMLElement).scrollTop !== 0)
@@ -2405,7 +2403,10 @@ export function readPageActionState(
     popups: visiblePopupLabels,
     scroll: [Math.round(observedWindow.scrollY), ...scrolledRegions],
     ...(targetState ? { targetState } : {}),
-    observationTruncated: allElements.length >= stateNodeCap,
+    observationTruncated:
+      allElements.length >= stateNodeCap ||
+      visibleDialogs.length > overlayLimit ||
+      visiblePopups.length > overlayLimit,
   }
 }
 

--- a/apps/desktop/src/main/browser-agent/page-functions.ts
+++ b/apps/desktop/src/main/browser-agent/page-functions.ts
@@ -2410,8 +2410,11 @@ export function readPageActionState(
 }
 
 export function scrollPage(direction: string, amount?: number, elementId?: number): unknown {
-  const distance = typeof amount === 'number' && amount > 0 ? amount : window.innerHeight * 0.85
-  const delta = direction === 'up' ? -distance : distance
+  const horizontal = direction === 'left' || direction === 'right'
+  const viewportSize = horizontal ? window.innerWidth : window.innerHeight
+  const distance = typeof amount === 'number' && amount > 0 ? amount : viewportSize * 0.85
+  const towardStart = direction === 'up' || direction === 'left'
+  const delta = towardStart ? -distance : distance
   const scrollingElement = (document.scrollingElement || document.documentElement) as HTMLElement
 
   const isVisible = (element: Element): boolean => {
@@ -2455,18 +2458,30 @@ export function scrollPage(direction: string, amount?: number, elementId?: numbe
   }
   const isScrollable = (element: Element): element is HTMLElement => {
     const html = element as HTMLElement
-    if (html.scrollHeight <= html.clientHeight + 1) return false
+    const scrollSize = horizontal ? html.scrollWidth : html.scrollHeight
+    const clientSize = horizontal ? html.clientWidth : html.clientHeight
+    if (scrollSize <= clientSize + 1) return false
     const ownerScroller =
       element.ownerDocument.scrollingElement || element.ownerDocument.documentElement
     if (element === ownerScroller) return true
     const view = element.ownerDocument.defaultView
     if (!view) return false
-    const overflow = view.getComputedStyle(element).overflowY
+    const style = view.getComputedStyle(element)
+    const overflow = horizontal ? style.overflowX : style.overflowY
     return overflow === 'auto' || overflow === 'scroll' || overflow === 'overlay'
   }
+  const horizontalBounds = (element: HTMLElement): { min: number; max: number } => {
+    const extent = Math.max(0, element.scrollWidth - element.clientWidth)
+    const rtl = element.ownerDocument.defaultView?.getComputedStyle(element).direction === 'rtl'
+    /** Chromium's RTL scrollLeft runs from a negative left edge to zero at the right edge. */
+    return rtl ? { min: -extent, max: 0 } : { min: 0, max: extent }
+  }
   const canMove = (element: HTMLElement): boolean => {
-    const max = Math.max(0, element.scrollHeight - element.clientHeight)
-    return direction === 'up' ? element.scrollTop > 1 : element.scrollTop < max - 1
+    const position = horizontal ? element.scrollLeft : element.scrollTop
+    const { min, max } = horizontal
+      ? horizontalBounds(element)
+      : { min: 0, max: Math.max(0, element.scrollHeight - element.clientHeight) }
+    return towardStart ? position > min + 1 : position < max - 1
   }
   const ancestors = (start: Element | null): HTMLElement[] => {
     const result: HTMLElement[] = []
@@ -2584,11 +2599,22 @@ export function scrollPage(direction: string, amount?: number, elementId?: numbe
   const targetWindow = targetDocument.defaultView
   const targetDocumentScroller = targetDocument.scrollingElement || targetDocument.documentElement
   const isDocumentScroller = target === targetDocumentScroller
-  const before = isDocumentScroller ? (targetWindow?.scrollY ?? target.scrollTop) : target.scrollTop
+  const position = (): number => {
+    if (horizontal) {
+      return isDocumentScroller ? (targetWindow?.scrollX ?? target.scrollLeft) : target.scrollLeft
+    }
+    return isDocumentScroller ? (targetWindow?.scrollY ?? target.scrollTop) : target.scrollTop
+  }
+  const before = position()
+  const scrollOptions: ScrollToOptions = horizontal
+    ? { left: delta, behavior: 'instant' }
+    : { top: delta, behavior: 'instant' }
   if (isDocumentScroller && targetWindow) {
-    targetWindow.scrollBy({ top: delta, behavior: 'instant' })
+    targetWindow.scrollBy(scrollOptions)
   } else if (typeof target.scrollBy === 'function') {
-    target.scrollBy({ top: delta, behavior: 'instant' })
+    target.scrollBy(scrollOptions)
+  } else if (horizontal) {
+    target.scrollLeft += delta
   } else {
     target.scrollTop += delta
   }
@@ -2601,6 +2627,7 @@ export function scrollPage(direction: string, amount?: number, elementId?: numbe
   const clientHeight = isDocumentScroller
     ? (targetWindow?.innerHeight ?? target.clientHeight)
     : target.clientHeight
+  const after = position()
   const label =
     target.getAttribute('aria-label') ||
     target.getAttribute('role') ||
@@ -2612,10 +2639,20 @@ export function scrollPage(direction: string, amount?: number, elementId?: numbe
     scrollTop: Math.round(scrollTop),
     scrollHeight: Math.round(scrollHeight),
     clientHeight: Math.round(clientHeight),
-    movedBy: Math.round(scrollTop - before),
+    movedBy: Math.round(after - before),
     atTop: scrollTop <= 1,
     atBottom: scrollTop + clientHeight >= scrollHeight - 2,
     windowScrollY: Math.round(window.scrollY),
+    ...(horizontal
+      ? {
+          scrollLeft: Math.round(after),
+          scrollWidth: Math.round(target.scrollWidth),
+          clientWidth: Math.round(target.clientWidth),
+          atLeft: after <= horizontalBounds(target).min + 1,
+          atRight: after >= horizontalBounds(target).max - 2,
+          windowScrollX: Math.round(window.scrollX),
+        }
+      : {}),
   }
 }
 
@@ -2656,6 +2693,106 @@ export function selectOptionInElement(id: number, value: string): unknown {
     selected: option.label.trim(),
     value: option.value,
     refRecovered: resolved?.recovered === true,
+  }
+}
+
+/** Reads and verifies an ordinary top-document form control without exposing secret values. */
+export function readFormFieldState(
+  id: number,
+  kind: 'text' | 'select' | 'checked',
+  expected: string | boolean
+): unknown {
+  const resolver = window.__simAgentResolveElement
+  const resolved = resolver?.(id)
+  const registered = resolver ? resolved?.element : (window.__simAgentElements || [])[id]
+  const element =
+    String(registered?.tagName || '').toUpperCase() === 'LABEL'
+      ? (registered as HTMLLabelElement).control
+      : registered
+  if (!element?.isConnected) return { error: 'stale' }
+  if (element.ownerDocument !== document) return { error: 'Form batches require top-page fields.' }
+  const tag = String(element.tagName || '').toUpperCase()
+  const input = element as HTMLInputElement
+  const type = tag === 'INPUT' ? String(input.type || 'text').toLowerCase() : ''
+  const hints = String(element.getAttribute('autocomplete') || '')
+    .toLowerCase()
+    .split(/\s+/)
+  if (
+    tag === 'INPUT' &&
+    (type === 'password' ||
+      hints.some((hint) => hint === 'current-password' || hint === 'new-password'))
+  )
+    return { error: 'password' }
+  if (element.matches(':disabled') || element.getAttribute('aria-disabled') === 'true') {
+    return { error: 'disabled' }
+  }
+  if (input.readOnly || element.getAttribute('aria-readonly') === 'true') {
+    return { error: 'readonly' }
+  }
+  if (kind === 'checked') {
+    if (tag !== 'INPUT' || !['checkbox', 'radio'].includes(type)) {
+      return { error: 'Form batches require native checkboxes or radio buttons.' }
+    }
+    if (type === 'radio' && expected === false)
+      return { error: 'Radio buttons cannot be unchecked directly.' }
+    return {
+      matchesRequested: !input.indeterminate && input.checked === expected,
+      checked: input.checked,
+    }
+  }
+  let value: string
+  let matchesRequested: boolean
+  if (kind === 'select') {
+    if (tag !== 'SELECT' || (element as HTMLSelectElement).multiple) {
+      return { error: 'Form batches require single-selection native dropdowns.' }
+    }
+    const select = element as HTMLSelectElement
+    const wanted = String(expected).trim().toLowerCase()
+    const option = Array.from(select.options).find(
+      (candidate) =>
+        candidate.value.trim().toLowerCase() === wanted ||
+        candidate.label.trim().toLowerCase() === wanted
+    )
+    if (
+      !option ||
+      option.disabled ||
+      (option.parentElement as HTMLOptGroupElement | null)?.disabled
+    ) {
+      return { error: 'The requested dropdown option is absent or disabled.' }
+    }
+    value = select.value
+    matchesRequested = value === option.value
+  } else {
+    if (
+      tag !== 'TEXTAREA' &&
+      (tag !== 'INPUT' || !['text', 'search', 'email', 'url', 'tel', 'number'].includes(type))
+    ) {
+      return { error: 'Form batches require ordinary text inputs or textareas.' }
+    }
+    value = input.value
+    matchesRequested = value === expected
+  }
+  const redacted =
+    tag === 'INPUT' &&
+    hints.some((hint) =>
+      ['one-time-code', 'cc-number', 'cc-csc', 'cc-exp', 'cc-exp-month', 'cc-exp-year'].includes(
+        hint
+      )
+    )
+  let active = document.activeElement
+  while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement
+  return {
+    matchesRequested,
+    focused: active === element,
+    valueLength: value.length,
+    valuePreview: redacted
+      ? ''
+      : value
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, 120)
+          .replace(/[\uD800-\uDBFF]$/, ''),
+    redacted,
   }
 }
 

--- a/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
@@ -15,6 +15,7 @@ export interface ToolCatalogEntry {
     | 'browser_close_tab'
     | 'browser_drag'
     | 'browser_extract'
+    | 'browser_fill_form'
     | 'browser_find'
     | 'browser_go_back'
     | 'browser_go_forward'
@@ -150,6 +151,7 @@ export interface ToolCatalogEntry {
     | 'browser_close_tab'
     | 'browser_drag'
     | 'browser_extract'
+    | 'browser_fill_form'
     | 'browser_find'
     | 'browser_go_back'
     | 'browser_go_forward'
@@ -811,6 +813,119 @@ export const BrowserExtract: ToolCatalogEntry = {
   clientExecutable: true,
 }
 
+export const BrowserFillForm: ToolCatalogEntry = {
+  id: 'browser_fill_form',
+  name: 'browser_fill_form',
+  route: 'client',
+  mode: 'async',
+  parameters: {
+    type: 'object',
+    properties: {
+      fields: {
+        type: 'array',
+        description:
+          "Ordered list of 1–8 fields with unique elementId refs from the current top page's latest snapshot. Supply exactly one matching value parameter per kind.",
+        items: {
+          type: 'object',
+          properties: {
+            checked: {
+              type: 'boolean',
+              description:
+                'Desired state for kind=checked. A radio can only be set true; native checkboxes may be true or false.',
+            },
+            elementId: {
+              type: 'number',
+              description:
+                "Nonnegative integer element ref from the current page's latest snapshot.",
+            },
+            kind: {
+              type: 'string',
+              description:
+                'text requires text; select requires value; checked requires checked. Do not supply parameters for another kind.',
+              enum: ['text', 'select', 'checked'],
+            },
+            text: {
+              type: 'string',
+              description:
+                'Replacement content for kind=text, including empty to clear. At most 4096 characters. Ordinary input or textarea only.',
+            },
+            value: {
+              type: 'string',
+              description:
+                'Option value or visible label for kind=select. At most 4096 characters. Native single-selection dropdown only.',
+            },
+          },
+          required: ['elementId', 'kind'],
+        },
+        maxItems: 8,
+      },
+    },
+    required: ['fields'],
+  },
+  resultSchema: {
+    type: 'object',
+    properties: {
+      completed: {
+        type: 'boolean',
+        description:
+          'True only when every requested field passed exact verification and the page boundary stayed unchanged.',
+      },
+      completedCount: {
+        type: 'number',
+        description:
+          'Number of field results whose latest readback matched the requested state. Inspect results for the individual indices.',
+      },
+      doNotRetry: {
+        type: 'boolean',
+        description:
+          'True when input dispatch began: inspect partial results and a fresh snapshot before deciding on remaining work; never blindly repeat the batch.',
+      },
+      error: {
+        type: 'string',
+        description: 'Reason filling stopped; preceding fields may already have taken effect.',
+      },
+      note: {
+        type: 'string',
+        description: 'Partial-outcome recovery guidance. Form filling is not atomic.',
+      },
+      notices: { type: 'array', items: { type: 'string' } },
+      results: {
+        type: 'array',
+        description:
+          'Ordered field readbacks. An interrupted write may have no result; absence is not proof that input had no effect.',
+        items: {
+          type: 'object',
+          properties: {
+            checked: { type: 'boolean' },
+            elementId: { type: 'number' },
+            index: { type: 'number' },
+            kind: { type: 'string', enum: ['text', 'select', 'checked'] },
+            redacted: { type: 'boolean' },
+            valueLength: { type: 'number' },
+            valuePreview: {
+              type: 'string',
+              description:
+                'Bounded normalized actual field preview, withheld for sensitive autocomplete fields; full-value equality is checked inside the page.',
+            },
+            verified: {
+              type: 'boolean',
+              description:
+                'Whether the full requested value or checked state matched at the latest successful probe, not merely whether input was dispatched.',
+            },
+          },
+          required: ['index', 'elementId', 'kind', 'verified'],
+        },
+      },
+      stoppedIndex: {
+        type: 'number',
+        description: 'Zero-based field index being processed or verified when filling stopped.',
+      },
+    },
+    required: ['completed', 'completedCount', 'results'],
+  },
+  clientExecutable: true,
+}
+
 export const BrowserFind: ToolCatalogEntry = {
   id: 'browser_find',
   name: 'browser_find',
@@ -1395,9 +1510,13 @@ export const BrowserScroll: ToolCatalogEntry = {
       amount: {
         type: 'number',
         description:
-          'Optional distance to scroll in pixels (default: 85% of the viewport height, so a little context carries over).',
+          'Optional distance to scroll in pixels (default: 85% of the viewport height for up/down or width for left/right, so a little context carries over).',
       },
-      direction: { type: 'string', description: 'Scroll direction.', enum: ['up', 'down'] },
+      direction: {
+        type: 'string',
+        description: 'Scroll direction.',
+        enum: ['up', 'down', 'left', 'right'],
+      },
       elementId: {
         type: 'number',
         description:
@@ -1413,14 +1532,29 @@ export const BrowserScroll: ToolCatalogEntry = {
         type: 'boolean',
         description: 'Whether the selected region is at its bottom boundary.',
       },
+      atLeft: {
+        type: 'boolean',
+        description:
+          'Whether the selected region is at its physical left boundary, included for left/right.',
+      },
+      atRight: {
+        type: 'boolean',
+        description:
+          'Whether the selected region is at its physical right boundary, included for left/right.',
+      },
       atTop: {
         type: 'boolean',
         description: 'Whether the selected region is at its top boundary.',
       },
       clientHeight: { type: 'number', description: 'Region viewport height.' },
+      clientWidth: {
+        type: 'number',
+        description: 'Region viewport width, included for left/right.',
+      },
       movedBy: {
         type: 'number',
-        description: 'Actual signed movement; zero means the target did not move.',
+        description:
+          'Actual signed movement on the requested axis: negative for up/left, positive for down/right; zero means the target did not move.',
       },
       notices: {
         type: 'array',
@@ -1429,16 +1563,29 @@ export const BrowserScroll: ToolCatalogEntry = {
         items: { type: 'string' },
       },
       scrollHeight: { type: 'number', description: 'Region content height.' },
-      scrollTop: { type: 'number', description: 'Resulting region scroll offset.' },
+      scrollLeft: {
+        type: 'number',
+        description:
+          'Resulting horizontal region scroll offset, included for left/right; may be negative in right-to-left regions.',
+      },
+      scrollTop: { type: 'number', description: 'Resulting vertical region scroll offset.' },
+      scrollWidth: {
+        type: 'number',
+        description: 'Region content width, included for left/right.',
+      },
       target: { type: 'string', description: 'Chosen scroll region label.' },
       targetSource: {
         type: 'string',
         description:
           'element, element-boundary, focus, focus-boundary, viewport-center, viewport-center-boundary, largest-visible, or page.',
       },
+      windowScrollX: {
+        type: 'number',
+        description: 'Top-page horizontal window scroll offset after a left/right region scroll.',
+      },
       windowScrollY: {
         type: 'number',
-        description: 'Top-page window scroll offset after the region scroll.',
+        description: 'Top-page vertical window scroll offset after the region scroll.',
       },
     },
     required: ['atTop', 'atBottom'],
@@ -7338,6 +7485,7 @@ export const TOOL_CATALOG: Record<string, ToolCatalogEntry> = {
   [BrowserCloseTab.id]: BrowserCloseTab,
   [BrowserDrag.id]: BrowserDrag,
   [BrowserExtract.id]: BrowserExtract,
+  [BrowserFillForm.id]: BrowserFillForm,
   [BrowserFind.id]: BrowserFind,
   [BrowserGoBack.id]: BrowserGoBack,
   [BrowserGoForward.id]: BrowserGoForward,

--- a/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-catalog-v1.ts
@@ -819,48 +819,71 @@ export const BrowserFillForm: ToolCatalogEntry = {
   route: 'client',
   mode: 'async',
   parameters: {
-    type: 'object',
+    additionalProperties: false,
     properties: {
       fields: {
-        type: 'array',
         description:
           "Ordered list of 1–8 fields with unique elementId refs from the current top page's latest snapshot. Supply exactly one matching value parameter per kind.",
         items: {
-          type: 'object',
+          oneOf: [
+            {
+              additionalProperties: false,
+              properties: { elementId: {}, kind: { enum: ['text'] }, text: {} },
+              required: ['text'],
+            },
+            {
+              additionalProperties: false,
+              properties: { elementId: {}, kind: { enum: ['select'] }, value: {} },
+              required: ['value'],
+            },
+            {
+              additionalProperties: false,
+              properties: { checked: {}, elementId: {}, kind: { enum: ['checked'] } },
+              required: ['checked'],
+            },
+          ],
           properties: {
             checked: {
-              type: 'boolean',
               description:
                 'Desired state for kind=checked. A radio can only be set true; native checkboxes may be true or false.',
+              type: 'boolean',
             },
             elementId: {
-              type: 'number',
               description:
                 "Nonnegative integer element ref from the current page's latest snapshot.",
+              maximum: 9007199254740991,
+              minimum: 0,
+              type: 'integer',
             },
             kind: {
-              type: 'string',
               description:
                 'text requires text; select requires value; checked requires checked. Do not supply parameters for another kind.',
               enum: ['text', 'select', 'checked'],
+              type: 'string',
             },
             text: {
-              type: 'string',
               description:
                 'Replacement content for kind=text, including empty to clear. At most 4096 characters. Ordinary input or textarea only.',
+              maxLength: 4096,
+              type: 'string',
             },
             value: {
-              type: 'string',
               description:
                 'Option value or visible label for kind=select. At most 4096 characters. Native single-selection dropdown only.',
+              maxLength: 4096,
+              type: 'string',
             },
           },
           required: ['elementId', 'kind'],
+          type: 'object',
         },
         maxItems: 8,
+        minItems: 1,
+        type: 'array',
       },
     },
     required: ['fields'],
+    type: 'object',
   },
   resultSchema: {
     type: 'object',

--- a/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
@@ -614,48 +614,89 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
   },
   browser_fill_form: {
     parameters: {
-      type: 'object',
+      additionalProperties: false,
       properties: {
         fields: {
-          type: 'array',
           description:
             "Ordered list of 1–8 fields with unique elementId refs from the current top page's latest snapshot. Supply exactly one matching value parameter per kind.",
           items: {
-            type: 'object',
+            oneOf: [
+              {
+                additionalProperties: false,
+                properties: {
+                  elementId: {},
+                  kind: {
+                    enum: ['text'],
+                  },
+                  text: {},
+                },
+                required: ['text'],
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  elementId: {},
+                  kind: {
+                    enum: ['select'],
+                  },
+                  value: {},
+                },
+                required: ['value'],
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  checked: {},
+                  elementId: {},
+                  kind: {
+                    enum: ['checked'],
+                  },
+                },
+                required: ['checked'],
+              },
+            ],
             properties: {
               checked: {
-                type: 'boolean',
                 description:
                   'Desired state for kind=checked. A radio can only be set true; native checkboxes may be true or false.',
+                type: 'boolean',
               },
               elementId: {
-                type: 'number',
                 description:
                   "Nonnegative integer element ref from the current page's latest snapshot.",
+                maximum: 9007199254740991,
+                minimum: 0,
+                type: 'integer',
               },
               kind: {
-                type: 'string',
                 description:
                   'text requires text; select requires value; checked requires checked. Do not supply parameters for another kind.',
                 enum: ['text', 'select', 'checked'],
+                type: 'string',
               },
               text: {
-                type: 'string',
                 description:
                   'Replacement content for kind=text, including empty to clear. At most 4096 characters. Ordinary input or textarea only.',
+                maxLength: 4096,
+                type: 'string',
               },
               value: {
-                type: 'string',
                 description:
                   'Option value or visible label for kind=select. At most 4096 characters. Native single-selection dropdown only.',
+                maxLength: 4096,
+                type: 'string',
               },
             },
             required: ['elementId', 'kind'],
+            type: 'object',
           },
           maxItems: 8,
+          minItems: 1,
+          type: 'array',
         },
       },
       required: ['fields'],
+      type: 'object',
     },
     resultSchema: {
       type: 'object',

--- a/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
+++ b/apps/sim/lib/copilot/generated/tool-schemas-v1.ts
@@ -612,6 +612,131 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
       },
     },
   },
+  browser_fill_form: {
+    parameters: {
+      type: 'object',
+      properties: {
+        fields: {
+          type: 'array',
+          description:
+            "Ordered list of 1–8 fields with unique elementId refs from the current top page's latest snapshot. Supply exactly one matching value parameter per kind.",
+          items: {
+            type: 'object',
+            properties: {
+              checked: {
+                type: 'boolean',
+                description:
+                  'Desired state for kind=checked. A radio can only be set true; native checkboxes may be true or false.',
+              },
+              elementId: {
+                type: 'number',
+                description:
+                  "Nonnegative integer element ref from the current page's latest snapshot.",
+              },
+              kind: {
+                type: 'string',
+                description:
+                  'text requires text; select requires value; checked requires checked. Do not supply parameters for another kind.',
+                enum: ['text', 'select', 'checked'],
+              },
+              text: {
+                type: 'string',
+                description:
+                  'Replacement content for kind=text, including empty to clear. At most 4096 characters. Ordinary input or textarea only.',
+              },
+              value: {
+                type: 'string',
+                description:
+                  'Option value or visible label for kind=select. At most 4096 characters. Native single-selection dropdown only.',
+              },
+            },
+            required: ['elementId', 'kind'],
+          },
+          maxItems: 8,
+        },
+      },
+      required: ['fields'],
+    },
+    resultSchema: {
+      type: 'object',
+      properties: {
+        completed: {
+          type: 'boolean',
+          description:
+            'True only when every requested field passed exact verification and the page boundary stayed unchanged.',
+        },
+        completedCount: {
+          type: 'number',
+          description:
+            'Number of field results whose latest readback matched the requested state. Inspect results for the individual indices.',
+        },
+        doNotRetry: {
+          type: 'boolean',
+          description:
+            'True when input dispatch began: inspect partial results and a fresh snapshot before deciding on remaining work; never blindly repeat the batch.',
+        },
+        error: {
+          type: 'string',
+          description: 'Reason filling stopped; preceding fields may already have taken effect.',
+        },
+        note: {
+          type: 'string',
+          description: 'Partial-outcome recovery guidance. Form filling is not atomic.',
+        },
+        notices: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        results: {
+          type: 'array',
+          description:
+            'Ordered field readbacks. An interrupted write may have no result; absence is not proof that input had no effect.',
+          items: {
+            type: 'object',
+            properties: {
+              checked: {
+                type: 'boolean',
+              },
+              elementId: {
+                type: 'number',
+              },
+              index: {
+                type: 'number',
+              },
+              kind: {
+                type: 'string',
+                enum: ['text', 'select', 'checked'],
+              },
+              redacted: {
+                type: 'boolean',
+              },
+              valueLength: {
+                type: 'number',
+              },
+              valuePreview: {
+                type: 'string',
+                description:
+                  'Bounded normalized actual field preview, withheld for sensitive autocomplete fields; full-value equality is checked inside the page.',
+              },
+              verified: {
+                type: 'boolean',
+                description:
+                  'Whether the full requested value or checked state matched at the latest successful probe, not merely whether input was dispatched.',
+              },
+            },
+            required: ['index', 'elementId', 'kind', 'verified'],
+          },
+        },
+        stoppedIndex: {
+          type: 'number',
+          description: 'Zero-based field index being processed or verified when filling stopped.',
+        },
+      },
+      required: ['completed', 'completedCount', 'results'],
+    },
+  },
   browser_find: {
     parameters: {
       type: 'object',
@@ -1277,12 +1402,12 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
         amount: {
           type: 'number',
           description:
-            'Optional distance to scroll in pixels (default: 85% of the viewport height, so a little context carries over).',
+            'Optional distance to scroll in pixels (default: 85% of the viewport height for up/down or width for left/right, so a little context carries over).',
         },
         direction: {
           type: 'string',
           description: 'Scroll direction.',
-          enum: ['up', 'down'],
+          enum: ['up', 'down', 'left', 'right'],
         },
         elementId: {
           type: 'number',
@@ -1299,6 +1424,16 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
           type: 'boolean',
           description: 'Whether the selected region is at its bottom boundary.',
         },
+        atLeft: {
+          type: 'boolean',
+          description:
+            'Whether the selected region is at its physical left boundary, included for left/right.',
+        },
+        atRight: {
+          type: 'boolean',
+          description:
+            'Whether the selected region is at its physical right boundary, included for left/right.',
+        },
         atTop: {
           type: 'boolean',
           description: 'Whether the selected region is at its top boundary.',
@@ -1307,9 +1442,14 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
           type: 'number',
           description: 'Region viewport height.',
         },
+        clientWidth: {
+          type: 'number',
+          description: 'Region viewport width, included for left/right.',
+        },
         movedBy: {
           type: 'number',
-          description: 'Actual signed movement; zero means the target did not move.',
+          description:
+            'Actual signed movement on the requested axis: negative for up/left, positive for down/right; zero means the target did not move.',
         },
         notices: {
           type: 'array',
@@ -1323,9 +1463,18 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
           type: 'number',
           description: 'Region content height.',
         },
+        scrollLeft: {
+          type: 'number',
+          description:
+            'Resulting horizontal region scroll offset, included for left/right; may be negative in right-to-left regions.',
+        },
         scrollTop: {
           type: 'number',
-          description: 'Resulting region scroll offset.',
+          description: 'Resulting vertical region scroll offset.',
+        },
+        scrollWidth: {
+          type: 'number',
+          description: 'Region content width, included for left/right.',
         },
         target: {
           type: 'string',
@@ -1336,9 +1485,13 @@ export const TOOL_RUNTIME_SCHEMAS: Record<string, ToolRuntimeSchemaEntry> = {
           description:
             'element, element-boundary, focus, focus-boundary, viewport-center, viewport-center-boundary, largest-visible, or page.',
         },
+        windowScrollX: {
+          type: 'number',
+          description: 'Top-page horizontal window scroll offset after a left/right region scroll.',
+        },
         windowScrollY: {
           type: 'number',
-          description: 'Top-page window scroll offset after the region scroll.',
+          description: 'Top-page vertical window scroll offset after the region scroll.',
         },
       },
       required: ['atTop', 'atBottom'],

--- a/apps/sim/lib/copilot/tools/client/browser-tool-execution.test.ts
+++ b/apps/sim/lib/copilot/tools/client/browser-tool-execution.test.ts
@@ -85,6 +85,31 @@ describe('executeBrowserToolOnClient', () => {
     vi.unstubAllGlobals()
   })
 
+  it('reports stopped form outcomes with partial readbacks and does not replay their writes', async () => {
+    const toolCallId = nextToolCallId()
+    const result = {
+      completed: false,
+      completedCount: 1,
+      stoppedIndex: 1,
+      results: [{ index: 0, elementId: 1, kind: 'text', verified: true, valuePreview: 'filled' }],
+      doNotRetry: true,
+      error: 'The next field disappeared',
+    }
+    mockExecuteBrowserTool.mockResolvedValue(result)
+    const params = { fields: [{ elementId: 1, kind: 'text', text: 'filled' }] }
+    executeBrowserToolOnClient(toolCallId, 'browser_fill_form', params, CHAT_SCOPE)
+    await flush()
+    expect(mockReportCompletion).toHaveBeenCalledWith(
+      toolCallId,
+      'error',
+      'Form filling stopped; inspect the partial result',
+      result
+    )
+    executeBrowserToolOnClient(toolCallId, 'browser_fill_form', params, CHAT_SCOPE)
+    await flush()
+    expect(mockExecuteBrowserTool).toHaveBeenCalledTimes(1)
+  })
+
   it('preserves every executed completion when a guard result arrives at retention capacity', async () => {
     const replayClaim = vi
       .spyOn(BrowserToolReplayLedger.prototype, 'claim')

--- a/apps/sim/lib/copilot/tools/client/browser-tool-execution.ts
+++ b/apps/sim/lib/copilot/tools/client/browser-tool-execution.ts
@@ -74,6 +74,7 @@ const OBSERVATION_ONLY_BROWSER_TOOLS = {
   browser_click: false,
   browser_click_at: false,
   browser_type: false,
+  browser_fill_form: false,
   browser_insert_text: false,
   browser_press_key: false,
   browser_scroll: false,
@@ -87,7 +88,7 @@ const OBSERVATION_ONLY_BROWSER_TOOLS = {
 
 const SESSION_CLOSED_MESSAGE =
   'The agent browser session is closed, so this browser tool cannot run. ' +
-  'Call browser_navigate or browser_open_tab to start a new session, or report the situation to the user. ' +
+  'Call browser_open_url, browser_navigate, or browser_open_tab to start a new session, or report the situation to the user. ' +
   'Do not retry other browser tools until a new session is open.'
 /** Tool events older than this are replays, not live instructions — never act on them. */
 const MAX_EVENT_AGE_MS = 120_000
@@ -983,10 +984,16 @@ async function doExecuteBrowserTool(
     }
     nativeActionPending = false
     if (cancelled) return
+    const formStopped =
+      toolName === 'browser_fill_form' && isRecordLike(result) && result.completed === false
     reportTerminalCompletion(
       {
-        status: ASYNC_TOOL_CONFIRMATION_STATUS.success,
-        message: 'Browser action completed',
+        status: formStopped
+          ? ASYNC_TOOL_CONFIRMATION_STATUS.error
+          : ASYNC_TOOL_CONFIRMATION_STATUS.success,
+        message: formStopped
+          ? 'Form filling stopped; inspect the partial result'
+          : 'Browser action completed',
         data: sanitizeResultForModel(toolName, result),
       },
       'Failed to report successful browser tool completion'

--- a/apps/sim/lib/copilot/tools/server/generated-schema.test.ts
+++ b/apps/sim/lib/copilot/tools/server/generated-schema.test.ts
@@ -5,6 +5,45 @@ import { describe, expect, it } from 'vitest'
 import { validateGeneratedToolPayload } from '@/lib/copilot/tools/server/generated-schema'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 
+describe('validateGeneratedToolPayload browser_fill_form parameters', () => {
+  it('accepts mixed fields, including empty text and false checked state', () => {
+    const payload = {
+      fields: [
+        { elementId: 0, kind: 'text', text: '' },
+        { elementId: 1, kind: 'select', value: 'pro' },
+        { elementId: 2, kind: 'checked', checked: false },
+      ],
+    }
+    expect(validateGeneratedToolPayload('browser_fill_form', 'parameters', payload)).toBe(payload)
+  })
+
+  it.each([
+    { fields: [] },
+    {
+      fields: Array.from({ length: 9 }, (_, elementId) => ({ elementId, kind: 'text', text: '' })),
+    },
+    { fields: [{ elementId: 1, kind: 'text' }] },
+    { fields: [{ elementId: 1, kind: 'select' }] },
+    { fields: [{ elementId: 1, kind: 'checked' }] },
+    { fields: [{ elementId: 1, kind: 'text', text: 'a', value: 'a' }] },
+    { fields: [{ elementId: 1, kind: 'select', value: 'a', checked: false }] },
+    { fields: [{ elementId: 1, kind: 'checked', checked: false, text: '' }] },
+    { fields: [{ elementId: 1, kind: 'checked', checked: 'false' }] },
+    { fields: [{ elementId: 1, kind: 'text', text: null }] },
+    { fields: [{ elementId: 1, kind: 'text', text: '', submit: true }] },
+    { fields: [{ elementId: -1, kind: 'text', text: '' }] },
+    { fields: [{ elementId: 1.5, kind: 'text', text: '' }] },
+    { fields: [{ elementId: Number.MAX_SAFE_INTEGER + 1, kind: 'text', text: '' }] },
+    { fields: [{ elementId: 1, kind: 'text', text: 'a'.repeat(4097) }] },
+    { fields: [{ elementId: 1, kind: 'select', value: 'a'.repeat(4097) }] },
+    { fields: [{ elementId: 1, kind: 'text', text: '' }], submit: true },
+  ])('rejects malformed form payload %# through the generated contract', (payload) => {
+    expect(() => validateGeneratedToolPayload('browser_fill_form', 'parameters', payload)).toThrow(
+      OrchestrationError
+    )
+  })
+})
+
 /**
  * The shapes below are what an agent actually sent when the catalog advertised
  * `updates` as a bare array: the provider-path sanitizer filled the missing

--- a/apps/sim/lib/copilot/tools/tool-display.test.ts
+++ b/apps/sim/lib/copilot/tools/tool-display.test.ts
@@ -763,6 +763,12 @@ describe('resource-naming titles', () => {
   })
 
   it('describes semantic browser controls without exposing element ids', () => {
+    expect(
+      getToolDisplayTitle('browser_fill_form', {
+        fields: [{ elementId: 42, kind: 'text', text: 'private form content' }],
+      })
+    ).toBe('Filling form')
+    expect(getToolCompletedTitle('Filling form')).toBe('Filled form')
     expect(getToolDisplayTitle('browser_find', { query: 'Submit order' })).toBe(
       'Finding "Submit order"'
     )

--- a/apps/sim/lib/copilot/tools/tool-display.ts
+++ b/apps/sim/lib/copilot/tools/tool-display.ts
@@ -635,6 +635,7 @@ const TOOL_TITLES: Record<string, string> = {
 
   browser_drag: 'Dragging element',
   browser_select_option: 'Selecting option',
+  browser_fill_form: 'Filling form',
   browser_set_checked: 'Updating control',
   browser_hover: 'Hovering element',
   browser_zoom: 'Changing page zoom',
@@ -1332,6 +1333,7 @@ const COMPLETED_VERB_REWRITES: Record<string, string> = {
   Extracting: 'Extracted',
   Fading: 'Faded',
   Finding: 'Found',
+  Filling: 'Filled',
   Gathering: 'Gathered',
   Generating: 'Generated',
   Going: 'Went',

--- a/packages/browser-protocol/src/index.ts
+++ b/packages/browser-protocol/src/index.ts
@@ -41,6 +41,7 @@ export const CURRENT_BROWSER_TOOL_NAMES = [
   'browser_click',
   'browser_click_at',
   'browser_type',
+  'browser_fill_form',
   'browser_insert_text',
   'browser_press_key',
   'browser_scroll',


### PR DESCRIPTION
## Summary
- Add sequential form filling for up to eight independent fields, with exact readbacks, stop-on-change handling, and replay-safe partial results.
- Report capped popup/dialog observations as incomplete so form batches stop instead of missing an overlay beyond the first ten entries.
- Add horizontal scrolling and physical RTL boundaries while preserving vertical behavior.
- Skip a redundant navigation completion check after a successful load and support empty-text clearing through the existing trusted typing path.
- Synchronize the canonical form schema and reuse the existing activity-title system. No new UI components, capability flags, or file-transfer permissions.

## Testing
- Desktop type check, 1,600 unit tests, and four real Electron scenarios passed, including a regression that fails on the previous implementation.
- 212 focused Sim execution, transport, display-title, and generated-schema tests passed.
- Lint, all 45 repository audits, API validation, generated catalog, and docs freshness passed.
- Companion Go vet and full test suites passed in both prompt modes.
- The full local web suite is not green: 41,849 tests passed; 82 failed and 16 suites could not load. Failures are outside this diff, including missing local dependencies and editor tests that passed in CI. The latest head, including the popup-truncation fix, passed all CI jobs: all web test shards, app build, desktop E2E, and packaged smoke.
- These are behavioral/regression checks, not an autonomous-agent performance benchmark.

## Companion PRs
- [ ] simstudioai/mothership#479

## Rollout
Coordinate desktop and Copilot releases before relying on the new tool or scroll directions. Older desktops reject unsupported operations. Form filling is not atomic: inspect partial results and fresh page state before continuing. Desktop preflight remains the runtime authority for client-executed browser tools.

## Checklist
- [x] Self-reviewed and followed project conventions
- [x] Focused regression tests added and passing
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)