### PR TITLE
fix(anthropic): keep enum and const as structured-output constraints

### DIFF
--- a/apps/sim/providers/anthropic/core.request.test.ts
+++ b/apps/sim/providers/anthropic/core.request.test.ts
@@ -305,7 +305,24 @@ describe('executeAnthropicProviderRequest forced tool use', () => {
 })
 
 describe('executeAnthropicProviderRequest native structured outputs', () => {
-  async function sendSchema(schema: Record<string, unknown>) {
+  /** The subset of the wire schema these assertions read back. */
+  interface WireSchemaNode {
+    type?: string | string[]
+    description?: string
+    format?: string
+    enum?: unknown[]
+    const?: unknown
+    minItems?: number
+    minimum?: number
+    additionalProperties?: boolean
+    required?: string[]
+    properties: Record<string, WireSchemaNode>
+    items: WireSchemaNode
+    anyOf: WireSchemaNode[]
+    $defs: Record<string, WireSchemaNode>
+  }
+
+  async function sendSchema(schema: Record<string, unknown>): Promise<WireSchemaNode> {
     const create = vi.fn().mockResolvedValue({
       id: 'msg-schema',
       type: 'message',
@@ -334,9 +351,9 @@ describe('executeAnthropicProviderRequest native structured outputs', () => {
     )
 
     const payload = create.mock.calls[0][0] as Anthropic.Messages.MessageCreateParams & {
-      output_config?: { format?: { type: string; schema: Record<string, any> } }
+      output_config?: { format?: { type: string; schema: WireSchemaNode } }
     }
-    return payload.output_config?.format?.schema as Record<string, any>
+    return payload.output_config?.format?.schema as WireSchemaNode
   }
 
   beforeEach(() => {
@@ -431,7 +448,7 @@ describe('executeAnthropicProviderRequest native structured outputs', () => {
     expect(wireSchema.properties.slug.format).toBeUndefined()
   })
 
-  it.each([
+  it.each<[string, Record<string, unknown>, 'enum' | 'const']>([
     ['object enum members', { type: 'object', enum: [{ a: 1 }, { a: 2 }] }, 'enum'],
     [
       'array enum members',

--- a/apps/sim/providers/anthropic/core.request.test.ts
+++ b/apps/sim/providers/anthropic/core.request.test.ts
@@ -303,3 +303,203 @@ describe('executeAnthropicProviderRequest forced tool use', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('rejects forced tool_choice'))
   })
 })
+
+describe('executeAnthropicProviderRequest native structured outputs', () => {
+  async function sendSchema(schema: Record<string, unknown>) {
+    const create = vi.fn().mockResolvedValue({
+      id: 'msg-schema',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [{ type: 'text', text: '{}' }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 2, output_tokens: 2 },
+    })
+
+    await executeAnthropicProviderRequest(
+      {
+        model: 'claude-sonnet-4-5',
+        apiKey: 'test-key',
+        maxTokens: 1024,
+        messages: [{ role: 'user', content: 'Extract' }],
+        responseFormat: { name: 'extract', schema },
+      },
+      {
+        providerId: 'anthropic',
+        providerLabel: 'Anthropic',
+        createClient: () => ({ messages: { create } }) as never,
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      }
+    )
+
+    const payload = create.mock.calls[0][0] as Anthropic.Messages.MessageCreateParams & {
+      output_config?: { format?: { type: string; schema: Record<string, any> } }
+    }
+    return payload.output_config?.format?.schema as Record<string, any>
+  }
+
+  beforeEach(() => {
+    mockExecuteTool.mockReset()
+  })
+
+  it('keeps enum and const as grammar constraints at every level', async () => {
+    const wireSchema = await sendSchema({
+      type: 'object',
+      additionalProperties: false,
+      required: ['kind', 'version', 'entities'],
+      properties: {
+        kind: { type: 'string', enum: ['person', 'org'] },
+        version: { type: 'string', const: 'v1' },
+        entities: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['role'],
+            properties: {
+              role: {
+                type: 'string',
+                description: 'Which role applies.',
+                enum: ['owner', 'viewer'],
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(wireSchema.properties.kind.enum).toEqual(['person', 'org'])
+    expect(wireSchema.properties.version.const).toBe('v1')
+    expect(wireSchema.properties.entities.items.properties.role.enum).toEqual(['owner', 'viewer'])
+  })
+
+  it('does not leave enum duplicated as description prose', async () => {
+    const wireSchema = await sendSchema({
+      type: 'object',
+      additionalProperties: false,
+      required: ['kind'],
+      properties: {
+        kind: { type: 'string', description: 'Which heading.', enum: ['goal', 'status'] },
+      },
+    })
+
+    expect(wireSchema.properties.kind.description).toBe('Which heading.')
+    expect(wireSchema.properties.kind.enum).toEqual(['goal', 'status'])
+  })
+
+  it('preserves enum inside $defs and anyOf branches', async () => {
+    const wireSchema = await sendSchema({
+      type: 'object',
+      additionalProperties: false,
+      required: ['status', 'choice'],
+      $defs: {
+        Status: { type: 'string', enum: ['open', 'closed'] },
+      },
+      properties: {
+        status: { $ref: '#/$defs/Status' },
+        choice: {
+          oneOf: [
+            { type: 'string', enum: ['a', 'b'] },
+            { type: 'string', const: 'c' },
+          ],
+        },
+      },
+    })
+
+    expect(wireSchema.$defs.Status.enum).toEqual(['open', 'closed'])
+    expect(wireSchema.properties.choice.anyOf[0].enum).toEqual(['a', 'b'])
+    expect(wireSchema.properties.choice.anyOf[1].const).toBe('c')
+  })
+
+  it('still sanitizes the constraints the API rejects', async () => {
+    const wireSchema = await sendSchema({
+      type: 'object',
+      required: ['tags', 'score', 'slug'],
+      properties: {
+        tags: { type: 'array', minItems: 5, items: { type: 'string', enum: ['x', 'y'] } },
+        score: { type: 'number', minimum: 1, maximum: 10 },
+        slug: { type: 'string', format: 'slug' },
+      },
+    })
+
+    expect(wireSchema.additionalProperties).toBe(false)
+    expect(wireSchema.properties.tags.minItems).toBeUndefined()
+    expect(wireSchema.properties.tags.items.enum).toEqual(['x', 'y'])
+    expect(wireSchema.properties.score.minimum).toBeUndefined()
+    expect(wireSchema.properties.score.description).toContain('minimum')
+    expect(wireSchema.properties.slug.format).toBeUndefined()
+  })
+
+  it.each([
+    ['object enum members', { type: 'object', enum: [{ a: 1 }, { a: 2 }] }, 'enum'],
+    [
+      'array enum members',
+      { type: 'array', items: { type: 'string' }, enum: [['a'], ['b']] },
+      'enum',
+    ],
+    ['enum containing null on a string node', { type: 'string', enum: ['a', null] }, 'enum'],
+    ['mixed-type enum on a string node', { type: 'string', enum: ['a', 1] }, 'enum'],
+    ['string enum on a number node', { type: 'number', enum: ['a', 'b'] }, 'enum'],
+    ['empty enum', { type: 'string', enum: [] }, 'enum'],
+    ['enum on a node with no declared type', { anyOf: [{ type: 'string' }], enum: ['a'] }, 'enum'],
+    ['const with an object value', { type: 'object', const: { a: 1 } }, 'const'],
+    [
+      'const with an array value',
+      { type: 'array', items: { type: 'string' }, const: ['a'] },
+      'const',
+    ],
+  ])(
+    'leaves %s demoted into description, exactly as the SDK transform does today',
+    async (_name, node, keyword) => {
+      const wireSchema = await sendSchema({
+        type: 'object',
+        additionalProperties: false,
+        required: ['field'],
+        properties: { field: node as Record<string, unknown> },
+      })
+
+      expect(wireSchema.properties.field[keyword]).toBeUndefined()
+      expect(wireSchema.properties.field.description).toContain(`${keyword}:`)
+    }
+  )
+
+  it('lifts the primitive const and enum shapes the API does grammar-check', async () => {
+    const wireSchema = await sendSchema({
+      type: 'object',
+      additionalProperties: false,
+      required: ['count', 'flag', 'rank', 'nothing', 'fixed', 'zero', 'off'],
+      properties: {
+        count: { type: 'number', enum: [1, 2, 3] },
+        flag: { type: 'boolean', enum: [true, false] },
+        rank: { type: 'integer', enum: [1, 2] },
+        nothing: { type: 'null', enum: [null] },
+        fixed: { type: 'string', const: 'v1' },
+        zero: { type: 'number', const: 0 },
+        off: { type: 'boolean', const: false },
+      },
+    })
+
+    expect(wireSchema.properties.count.enum).toEqual([1, 2, 3])
+    expect(wireSchema.properties.flag.enum).toEqual([true, false])
+    expect(wireSchema.properties.rank.enum).toEqual([1, 2])
+    expect(wireSchema.properties.nothing.enum).toEqual([null])
+    expect(wireSchema.properties.fixed.const).toBe('v1')
+    expect(wireSchema.properties.zero.const).toBe(0)
+    expect(wireSchema.properties.off.const).toBe(false)
+  })
+
+  it('does not mistake a property literally named enum for a keyword', async () => {
+    const wireSchema = await sendSchema({
+      type: 'object',
+      additionalProperties: false,
+      required: ['enum'],
+      properties: {
+        enum: { type: 'string', enum: ['left', 'right'] },
+      },
+    })
+
+    expect(wireSchema.properties.enum.type).toBe('string')
+    expect(wireSchema.properties.enum.enum).toEqual(['left', 'right'])
+  })
+})

--- a/apps/sim/providers/anthropic/core.request.test.ts
+++ b/apps/sim/providers/anthropic/core.request.test.ts
@@ -506,6 +506,23 @@ describe('executeAnthropicProviderRequest native structured outputs', () => {
     expect(wireSchema.properties.off.const).toBe(false)
   })
 
+  it("does not mutate the caller's schema, so parallel iterations reuse it safely", async () => {
+    const shared = {
+      type: 'object',
+      additionalProperties: false,
+      required: ['kind'],
+      properties: { kind: { type: 'string', enum: ['a', 'b'], description: 'd' } },
+    }
+    const before = JSON.stringify(shared)
+
+    const first = await sendSchema(shared)
+    const second = await sendSchema(shared)
+
+    expect(JSON.stringify(shared)).toBe(before)
+    expect(first.properties.kind.enum).toEqual(['a', 'b'])
+    expect(second.properties.kind.enum).toEqual(['a', 'b'])
+  })
+
   it('does not mistake a property literally named enum for a keyword', async () => {
     const wireSchema = await sendSchema({
       type: 'object',

--- a/apps/sim/providers/anthropic/core.ts
+++ b/apps/sim/providers/anthropic/core.ts
@@ -1,5 +1,4 @@
 import type Anthropic from '@anthropic-ai/sdk'
-import { transformJSONSchema } from '@anthropic-ai/sdk/lib/transform-json-schema'
 import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources/messages/messages'
 import type { Logger } from '@sim/logger'
 import { getErrorMessage, toError } from '@sim/utils/errors'
@@ -8,6 +7,7 @@ import type { IterationToolCall, NormalizedBlockOutput, StreamingExecution } fro
 import { MAX_TOOL_ITERATIONS } from '@/providers'
 import { convertAnthropicRequestHistory } from '@/providers/anthropic/request-history'
 import { createAnthropicStreamingToolLoopStream } from '@/providers/anthropic/streaming-tool-loop'
+import { buildAnthropicStructuredOutputSchema } from '@/providers/anthropic/structured-output-schema'
 import {
   addAnthropicUsage,
   buildAnthropicUsageCost,
@@ -333,7 +333,7 @@ export async function executeAnthropicProviderRequest(
     const schema = request.responseFormat.schema || request.responseFormat
 
     if (useNativeStructuredOutputs) {
-      const transformedSchema = transformJSONSchema(schema)
+      const transformedSchema = buildAnthropicStructuredOutputSchema(schema)
       payload.output_config = {
         ...payload.output_config,
         format: {

--- a/apps/sim/providers/anthropic/structured-output-schema.ts
+++ b/apps/sim/providers/anthropic/structured-output-schema.ts
@@ -1,0 +1,183 @@
+import { transformJSONSchema } from '@anthropic-ai/sdk/lib/transform-json-schema'
+
+type JsonSchemaNode = Record<string, unknown>
+
+/**
+ * Keywords Anthropic's structured-output grammar enforces but the SDK's
+ * `transformJSONSchema` does not recognise. The transform pops every keyword it
+ * knows and stringifies whatever is left into the node's `description`, so an
+ * `enum` or `const` left in place silently degrades from a grammar constraint
+ * into prose the model may ignore.
+ */
+const PRESERVED_KEYWORDS = ['enum', 'const'] as const
+
+/**
+ * The API grammar-checks only a narrow slice of `enum` and `const` and rejects
+ * the entire request for the rest, so a keyword outside that slice is left in
+ * place for the transform to demote into `description` — weakly enforced, but
+ * exactly today's behaviour. Lifting one would turn a working Agent block into a
+ * hard 400 on every run, which is strictly worse than the bug being fixed.
+ *
+ * Boundary confirmed against the live API: object or array members fail with
+ * "Schema type 'enum - complex' is not supported"; a member disagreeing with the
+ * node's declared `type` fails with "Enum value ... does not match declared
+ * type"; `[]` fails with "Enum must be non-empty". `const` accepts any primitive
+ * including `null` and is not checked against `type`, but rejects objects and
+ * arrays as "Schema type 'const - complex' is not supported".
+ */
+function isPrimitive(value: unknown): boolean {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
+}
+
+function matchesDeclaredType(value: unknown, type: unknown): boolean {
+  switch (type) {
+    case 'string':
+      return typeof value === 'string'
+    case 'number':
+    case 'integer':
+      return typeof value === 'number'
+    case 'boolean':
+      return typeof value === 'boolean'
+    case 'null':
+      return value === null
+    default:
+      return false
+  }
+}
+
+/**
+ * True when every member is a primitive matching the node's declared scalar
+ * type. An absent, composite, or non-scalar `type` yields false, so the keyword
+ * stays behind rather than being lifted onto a node the API would reject.
+ */
+function isLiftableEnum(value: unknown, type: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((member) => isPrimitive(member) && matchesDeclaredType(member, type))
+  )
+}
+
+/** A constraint lifted out of the source schema, addressed by its post-transform path. */
+interface PreservedConstraint {
+  /** Path into the transformed schema, expressed with the transform's own key names. */
+  path: (string | number)[]
+  keywords: JsonSchemaNode
+}
+
+function isSchemaNode(value: unknown): value is JsonSchemaNode {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Removes the preserved keywords from `node` and records them against the path
+ * the transform will place that node at.
+ *
+ * The traversal mirrors `transformJSONSchema` exactly: `$ref` short-circuits the
+ * whole node, `oneOf` is rewritten to `anyOf`, `allOf` is only visited when
+ * neither `anyOf` nor `oneOf` is present, and `properties`/`items` are visited
+ * on the declared `type`. Any divergence would re-attach a constraint to a node
+ * the transform did not emit, which the resolve step then drops.
+ */
+function extractPreservedKeywords(
+  node: JsonSchemaNode,
+  path: (string | number)[],
+  out: PreservedConstraint[]
+): void {
+  if (node.$ref !== undefined) return
+
+  if (isSchemaNode(node.$defs)) {
+    for (const [name, defSchema] of Object.entries(node.$defs)) {
+      if (isSchemaNode(defSchema)) {
+        extractPreservedKeywords(defSchema, [...path, '$defs', name], out)
+      }
+    }
+  }
+
+  const branches = Array.isArray(node.anyOf)
+    ? { key: 'anyOf', variants: node.anyOf }
+    : Array.isArray(node.oneOf)
+      ? { key: 'anyOf', variants: node.oneOf }
+      : Array.isArray(node.allOf)
+        ? { key: 'allOf', variants: node.allOf }
+        : null
+
+  if (branches) {
+    branches.variants.forEach((variant, index) => {
+      if (isSchemaNode(variant)) {
+        extractPreservedKeywords(variant, [...path, branches.key, index], out)
+      }
+    })
+  }
+
+  if (node.type === 'object') {
+    if (isSchemaNode(node.properties)) {
+      for (const [key, propSchema] of Object.entries(node.properties)) {
+        if (isSchemaNode(propSchema)) {
+          extractPreservedKeywords(propSchema, [...path, 'properties', key], out)
+        }
+      }
+    }
+  } else if (node.type === 'array' && isSchemaNode(node.items)) {
+    extractPreservedKeywords(node.items, [...path, 'items'], out)
+  }
+
+  const keywords: JsonSchemaNode = {}
+  for (const keyword of PRESERVED_KEYWORDS) {
+    if (!(keyword in node)) continue
+    const value = node[keyword]
+    const liftable = keyword === 'enum' ? isLiftableEnum(value, node.type) : isPrimitive(value)
+    if (!liftable) continue
+    keywords[keyword] = value
+    delete node[keyword]
+  }
+
+  if (Object.keys(keywords).length > 0) out.push({ path, keywords })
+}
+
+function resolvePath(root: JsonSchemaNode, path: (string | number)[]): JsonSchemaNode | null {
+  let current: unknown = root
+  for (const segment of path) {
+    if (typeof segment === 'number') {
+      if (!Array.isArray(current)) return null
+      current = current[segment]
+      continue
+    }
+    if (!isSchemaNode(current)) return null
+    current = current[segment]
+  }
+  return isSchemaNode(current) ? current : null
+}
+
+/**
+ * Sanitises a response-format schema for Anthropic's `output_config.format`.
+ *
+ * The SDK transform is load-bearing — the API rejects unknown string formats,
+ * numeric bounds, `minItems` above one, and a missing `additionalProperties` —
+ * so the schema still goes through it. The `enum` and `const` shapes the API
+ * actually grammar-checks are lifted out first and re-attached afterwards, which
+ * keeps them real constraints instead of description prose without weakening any
+ * of the transform's sanitising. Every other shape is left for the transform to
+ * demote, so no schema that works today starts failing.
+ */
+export function buildAnthropicStructuredOutputSchema(schema: unknown): JsonSchemaNode {
+  if (!isSchemaNode(schema)) return transformJSONSchema(schema as JsonSchemaNode)
+
+  const working = structuredClone(schema)
+  const preserved: PreservedConstraint[] = []
+  extractPreservedKeywords(working, [], preserved)
+
+  const transformed = transformJSONSchema(working) as JsonSchemaNode
+
+  for (const { path, keywords } of preserved) {
+    const target = resolvePath(transformed, path)
+    if (target) Object.assign(target, keywords)
+  }
+
+  return transformed
+}


### PR DESCRIPTION
## Summary
- `transformJSONSchema` from the Anthropic SDK has no branch for `enum` or `const`, so both were swept into the node's `description` as prose instead of staying real grammar constraints. Native structured outputs have been silently unenforced for them on every Anthropic and Azure Anthropic agent block.
- Lift `enum`/`const` out before the transform and re-attach them after, so all of the transform's sanitising (unknown string `format`, numeric bounds, `minItems > 1`, `additionalProperties`) is preserved verbatim.
- Only lift what the API grammar-checks: a non-empty `enum` of primitives all matching the node's declared type, and a primitive `const`. Everything else stays put and is demoted exactly as today — sending it would make the API reject the whole request, turning a working block into a hard 400.

## Type of Change
- [x] Bug fix

## Testing
Verified against the live Anthropic API on `claude-sonnet-5`:

- **Enforcement**: with a schema whose field is `enum: [...]` and a prompt explicitly instructing the model to emit an out-of-enum value, the old path returns the out-of-enum string and the new path returns a valid enum member. Same for number, integer, boolean and `const`.
- **No regressions**: 16 edge cases run through both the old and new code paths — object/array enum members, enum containing `null`, mixed-type enum, empty `enum`, enum disagreeing with the declared type, `const` with object/array values, plus the primitive shapes. All return 200 on both paths.
- Unit tests assert the wire payload's `output_config.format.schema` directly, and cover a property literally named `enum`, `$defs`, `oneOf`→`anyOf`, and both falsy `const` values (`0`, `false`).
- 1938/1938 tests in `providers/` pass; verified the new tests fail when the fix is reverted.
- `bun run lint`, `bun run check:audits` (45 audits), `docs-manifest:check` and `type-check` all clean.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)