### PR TITLE
feat(comparisons): add answer-first lead, per-section H2s, and AEO copy fixes

### DIFF
--- a/apps/sim/app/(landing)/comparisons/[provider]/page.tsx
+++ b/apps/sim/app/(landing)/comparisons/[provider]/page.tsx
@@ -8,6 +8,7 @@ import { COMPARISON_SECTIONS, getFactGroup } from '@/app/(landing)/comparisons/c
 import { BrandIconTile, SimIconTile } from '@/app/(landing)/comparisons/components/brand-icon-tile'
 import { ComparisonCards } from '@/app/(landing)/comparisons/components/comparison-cards'
 import { ComparisonTable } from '@/app/(landing)/comparisons/components/comparison-table'
+import { ProseText } from '@/app/(landing)/comparisons/components/prose-text'
 import {
   ALL_COMPETITORS,
   buildBottomLine,
@@ -173,6 +174,11 @@ export default async function ComparisonProviderPage({
             >
               Sim vs {competitor.name}
             </h1>
+            {competitor.leadAnswer ? (
+              <p className='max-w-[720px] text-[var(--text-body)] text-sm leading-[150%] tracking-[0.02em] lg:text-base'>
+                <ProseText prose={competitor.leadAnswer} />
+              </p>
+            ) : null}
             <p className='max-w-[720px] text-[var(--text-muted)] text-sm leading-[150%] tracking-[0.02em] lg:text-base'>
               Sim is the open-source AI workspace where teams build, deploy, and manage AI agents
               visually, conversationally, or with code. Here is how Sim compares to{' '}
@@ -201,6 +207,22 @@ export default async function ComparisonProviderPage({
 
         <div className='mx-auto w-full max-w-[1446px]'>
           <div className='mx-12 border-[var(--border)] border-x max-sm:mx-5 max-lg:mx-8'>
+            {competitor.betterThanAnswer ? (
+              <>
+                <section aria-labelledby='better-than-heading' className='px-6 py-10'>
+                  <h2
+                    id='better-than-heading'
+                    className='mb-4 text-[20px] text-[var(--text-primary)] leading-[100%] tracking-[-0.02em] lg:text-[24px]'
+                  >
+                    Is Sim better than {competitor.name}?
+                  </h2>
+                  <p className='max-w-[720px] text-[var(--text-body)] text-small leading-[150%]'>
+                    <ProseText prose={competitor.betterThanAnswer} />
+                  </p>
+                </section>
+                <div className='h-px w-full bg-[var(--border)]' />
+              </>
+            ) : null}
             <div className='grid grid-cols-1 sm:grid-cols-2'>
               <section
                 aria-labelledby='what-is-sim-heading'
@@ -240,15 +262,44 @@ export default async function ComparisonProviderPage({
 
             <div className='h-px w-full bg-[var(--border)]' />
 
-            <section aria-labelledby='comparison-table-heading' className='px-6 py-10'>
+            <section aria-labelledby='comparison-table-heading' className='px-6 pt-10 pb-4'>
               <h2
                 id='comparison-table-heading'
                 className='mb-4 text-[20px] text-[var(--text-primary)] leading-[100%] tracking-[-0.02em] lg:text-[24px]'
               >
                 Sim vs {competitor.name}: feature-by-feature comparison
               </h2>
-              <ComparisonTable sim={simProfile} competitor={competitor} />
+              <p className='max-w-[720px] text-[var(--text-body)] text-small leading-[150%]'>
+                The sections below compare Sim and {competitor.name} across platform and deployment,
+                pricing, security and compliance, AI capabilities, integrations, observability, and
+                support.
+              </p>
             </section>
+
+            {COMPARISON_SECTIONS.map((section) => {
+              const sectionIntro = competitor.sectionIntros?.[section.group]
+
+              return (
+                <section
+                  key={section.group}
+                  aria-labelledby={`comparison-section-${section.group}-heading`}
+                  className='px-6 pb-10'
+                >
+                  <h2
+                    id={`comparison-section-${section.group}-heading`}
+                    className='mb-3 text-[18px] text-[var(--text-primary)] leading-snug tracking-[-0.01em]'
+                  >
+                    {section.title}
+                  </h2>
+                  {sectionIntro ? (
+                    <p className='mb-4 max-w-[720px] text-[var(--text-body)] text-small leading-[150%]'>
+                      <ProseText prose={sectionIntro} />
+                    </p>
+                  ) : null}
+                  <ComparisonTable sim={simProfile} competitor={competitor} section={section} />
+                </section>
+              )
+            })}
 
             <div className='h-px w-full bg-[var(--border)]' />
 

--- a/apps/sim/app/(landing)/comparisons/comparison-sections.ts
+++ b/apps/sim/app/(landing)/comparisons/comparison-sections.ts
@@ -55,7 +55,7 @@ function defineSection<G extends keyof ComparisonFacts>(section: {
 export const COMPARISON_SECTIONS: ComparisonSectionDef[] = [
   defineSection({
     group: 'platform',
-    title: 'Platform',
+    title: 'Platform & deployment',
     rows: [
       { key: 'builderType', label: 'Builder type' },
       { key: 'learningCurve', label: 'Learning curve' },

--- a/apps/sim/app/(landing)/comparisons/components/comparison-table/comparison-table.tsx
+++ b/apps/sim/app/(landing)/comparisons/components/comparison-table/comparison-table.tsx
@@ -1,13 +1,18 @@
 import type { ReactNode } from 'react'
 import { cn } from '@sim/emcn'
 import type { CompetitorProfile } from '@/lib/compare/data'
-import { COMPARISON_SECTIONS, getFactGroup } from '@/app/(landing)/comparisons/comparison-sections'
+import {
+  type ComparisonSectionDef,
+  getFactGroup,
+} from '@/app/(landing)/comparisons/comparison-sections'
 import { BrandIconTile, SimIconTile } from '@/app/(landing)/comparisons/components/brand-icon-tile'
 import { FactValue } from '@/app/(landing)/comparisons/components/fact-value'
 
 export interface ComparisonTableProps {
   sim: CompetitorProfile
   competitor: CompetitorProfile
+  /** The one fact group this table renders. The page gives each its own `h2`. */
+  section: ComparisonSectionDef
 }
 
 /**
@@ -78,12 +83,15 @@ function ColumnHeader({
  * text so crawlers and AI answer engines read the full comparison without
  * any client-side hydration.
  */
-export function ComparisonTable({ sim, competitor }: ComparisonTableProps) {
+export function ComparisonTable({ sim, competitor, section }: ComparisonTableProps) {
+  const simGroupFacts = getFactGroup(sim, section.group)
+  const competitorGroupFacts = getFactGroup(competitor, section.group)
+
   return (
     <div className='w-full overflow-x-auto rounded-xl border border-[var(--border-1)]'>
       <div
         role='table'
-        aria-label={`Sim vs ${competitor.name} feature comparison`}
+        aria-label={`Sim vs ${competitor.name}: ${section.title}`}
         className='grid grid-cols-1 lg:min-w-[560px] lg:grid-cols-[minmax(140px,max-content)_1fr_1fr]'
       >
         <div className='contents' role='row'>
@@ -119,86 +127,54 @@ export function ComparisonTable({ sim, competitor }: ComparisonTableProps) {
           />
         </div>
 
-        {COMPARISON_SECTIONS.map((section, sectionIdx) => {
-          const simGroupFacts = getFactGroup(sim, section.group)
-          const competitorGroupFacts = getFactGroup(competitor, section.group)
+        {section.rows.map((row, rowIdx) => {
+          const simFact = simGroupFacts[row.key]
+          const competitorFact = competitorGroupFacts[row.key]
+          const isNotLastRow = rowIdx < section.rows.length - 1
 
           return (
-            <div key={section.title} className='contents'>
-              <div className='contents' role='row'>
-                <div
-                  role='columnheader'
-                  className={cn(
-                    'border-[var(--border)] border-r bg-[var(--surface-1)] px-4 py-2',
-                    STICKY_LABEL_COL,
-                    'max-lg:border-r-0',
-                    sectionIdx > 0 && 'border-[var(--border-1)] border-t'
-                  )}
-                >
-                  <span className='font-medium text-[var(--text-primary)] text-small'>
-                    {section.title}
-                  </span>
-                </div>
-                <div
-                  role='presentation'
-                  className={cn(
-                    'col-span-2 bg-[var(--surface-1)] max-lg:hidden',
-                    sectionIdx > 0 && 'border-[var(--border-1)] border-t'
-                  )}
-                />
+            <div key={row.key} className='contents' role='row'>
+              <div
+                role='rowheader'
+                className={cn(
+                  'flex min-w-0 items-center border-[var(--border)] border-r bg-[var(--surface-1)] px-4 py-2.5',
+                  STICKY_LABEL_COL,
+                  MOBILE_STACK_LABEL,
+                  isNotLastRow && 'border-[var(--border-1)] border-b'
+                )}
+              >
+                <span className='text-[var(--text-body)] text-small max-lg:font-medium max-lg:text-[var(--text-primary)]'>
+                  {row.label}
+                </span>
               </div>
-
-              {section.rows.map((row, rowIdx) => {
-                const simFact = simGroupFacts[row.key]
-                const competitorFact = competitorGroupFacts[row.key]
-                const isNotLastRow = rowIdx < section.rows.length - 1
-
-                return (
-                  <div key={row.key} className='contents' role='row'>
-                    <div
-                      role='rowheader'
-                      className={cn(
-                        'flex min-w-0 items-center border-[var(--border)] border-r bg-[var(--surface-1)] px-4 py-2.5',
-                        STICKY_LABEL_COL,
-                        MOBILE_STACK_LABEL,
-                        isNotLastRow && 'border-[var(--border-1)] border-b'
-                      )}
-                    >
-                      <span className='text-[var(--text-body)] text-small max-lg:font-medium max-lg:text-[var(--text-primary)]'>
-                        {row.label}
-                      </span>
-                    </div>
-                    <div
-                      role='cell'
-                      className={cn(
-                        'flex min-w-0 items-center gap-1 border-[var(--border)] border-r bg-[var(--surface-2)] px-3 py-2.5',
-                        MOBILE_STACK_VALUE,
-                        'max-lg:border-b-0 max-lg:pt-1 max-lg:pb-1',
-                        isNotLastRow && 'border-[var(--border-1)] border-b'
-                      )}
-                    >
-                      <span className='font-medium text-[var(--text-muted)] text-caption lg:hidden'>
-                        {sim.name}
-                      </span>
-                      <FactValue fact={simFact} />
-                    </div>
-                    <div
-                      role='cell'
-                      className={cn(
-                        'flex min-w-0 items-center gap-1 bg-[var(--surface-2)] px-3 py-2.5',
-                        MOBILE_STACK_VALUE,
-                        'max-lg:pt-1 max-lg:pb-3',
-                        isNotLastRow && 'border-[var(--border-1)] border-b'
-                      )}
-                    >
-                      <span className='font-medium text-[var(--text-muted)] text-caption lg:hidden'>
-                        {competitor.name}
-                      </span>
-                      <FactValue fact={competitorFact} />
-                    </div>
-                  </div>
-                )
-              })}
+              <div
+                role='cell'
+                className={cn(
+                  'flex min-w-0 items-center gap-1 border-[var(--border)] border-r bg-[var(--surface-2)] px-3 py-2.5',
+                  MOBILE_STACK_VALUE,
+                  'max-lg:border-b-0 max-lg:pt-1 max-lg:pb-1',
+                  isNotLastRow && 'border-[var(--border-1)] border-b'
+                )}
+              >
+                <span className='font-medium text-[var(--text-muted)] text-caption lg:hidden'>
+                  {sim.name}
+                </span>
+                <FactValue fact={simFact} />
+              </div>
+              <div
+                role='cell'
+                className={cn(
+                  'flex min-w-0 items-center gap-1 bg-[var(--surface-2)] px-3 py-2.5',
+                  MOBILE_STACK_VALUE,
+                  'max-lg:pt-1 max-lg:pb-3',
+                  isNotLastRow && 'border-[var(--border-1)] border-b'
+                )}
+              >
+                <span className='font-medium text-[var(--text-muted)] text-caption lg:hidden'>
+                  {competitor.name}
+                </span>
+                <FactValue fact={competitorFact} />
+              </div>
             </div>
           )
         })}

--- a/apps/sim/app/(landing)/comparisons/components/prose-text/index.ts
+++ b/apps/sim/app/(landing)/comparisons/components/prose-text/index.ts
@@ -1,0 +1,2 @@
+export type { ProseTextProps } from './prose-text'
+export { ProseText } from './prose-text'

--- a/apps/sim/app/(landing)/comparisons/components/prose-text/prose-text.tsx
+++ b/apps/sim/app/(landing)/comparisons/components/prose-text/prose-text.tsx
@@ -1,0 +1,27 @@
+import { Fragment } from 'react'
+import type { Prose } from '@/lib/compare/data'
+import { ProseLink } from '@/app/(landing)/components/prose-page'
+
+export interface ProseTextProps {
+  prose: Prose
+}
+
+/**
+ * Renders a {@link Prose} run as plain text with inline links. Pure server
+ * component so answer engines read the full text without hydration.
+ */
+export function ProseText({ prose }: ProseTextProps) {
+  return (
+    <>
+      {prose.map((segment, index) =>
+        typeof segment === 'string' ? (
+          <Fragment key={index}>{segment}</Fragment>
+        ) : (
+          <ProseLink key={index} href={segment.href}>
+            {segment.text}
+          </ProseLink>
+        )
+      )}
+    </>
+  )
+}

--- a/apps/sim/lib/compare/data/competitors/dust.ts
+++ b/apps/sim/lib/compare/data/competitors/dust.ts
@@ -15,6 +15,35 @@ export const dustProfile: CompetitorProfile = {
   },
   oneLiner:
     'Dust is an enterprise AI agent platform where teams build no-code agents connected to company data and tools in a shared, multiplayer workspace, then deploy them to chat, Slack, and other surfaces.',
+  leadAnswer: [
+    'Dust is primarily an enterprise AI agent platform built for teams that want no-code agents connected to company data in a shared, multiplayer workspace. Sim is an open-source AI workspace built for teams that want to build, deploy, and manage agents visually, conversationally, or with code. Choose Dust when you want zero visual/flow layer and prefer building purely through forms, text, and templates guided by a conversational assistant. Sim is a stronger fit when you need a visual canvas, self-hosting, real-time multiplayer editing, or environment promotion across dev, QA, and prod.',
+  ],
+  betterThanAnswer: [
+    'Sim is the stronger fit when you need explicit control over how an agent is built, hosted, and promoted to production. Dust is the stronger fit when you want that control abstracted away, with agents assembled from forms, instructions, templates, and conversation inside a managed workspace. Choose on that axis: explicit workflow and deployment control, or a builder centered on forms and conversation.',
+  ],
+  sectionIntros: {
+    platform: [
+      'Sim offers a visual canvas, supported self-hosting, live canvas editing, and workspace promotion. Dust provides a hosted, form-based agent builder with shared conversations and Git-based configuration management.',
+    ],
+    pricing: [
+      'Sim charges for usage through credits and supports bring-your-own provider keys. Dust combines per-seat subscriptions with monthly AI credit allocations.',
+    ],
+    security: [
+      'Sim emphasizes self-hosting and configurable workspace controls, while Dust documents a broader set of managed-service compliance options. Enterprise features and deployment choices affect the exact controls available in each product.',
+    ],
+    aiCapabilities: [
+      'Sim provides explicit workflow controls for areas such as evaluation, approvals, iteration, and parallel execution. Dust centers these capabilities on conversational agents that choose among configured tools.',
+    ],
+    integrations: [
+      'Sim provides a larger workflow-oriented integration surface and supports custom code, SDKs, MCP publishing, and event triggers. Dust combines managed connections, APIs, triggers, and MCP-based tools around its conversational agent model.',
+    ],
+    observability: [
+      'Sim documents block-level traces, retries, alerts, data export, asynchronous runs, and execution limits. Dust documents workspace analytics and background triggers, but several run-level durability controls are not described publicly.',
+    ],
+    support: [
+      'Both products provide documentation and learning resources. Sim emphasizes its open-source community and an Enterprise dedicated-support option, while Dust also documents community forums and enterprise onboarding.',
+    ],
+  },
   standoutFeatures: [
     {
       title:

--- a/apps/sim/lib/compare/data/competitors/openai-agentkit.ts
+++ b/apps/sim/lib/compare/data/competitors/openai-agentkit.ts
@@ -31,11 +31,39 @@ export const openaiAgentkitProfile: CompetitorProfile = {
   },
   oneLiner:
     "OpenAI AgentKit bundled a visual Agent Builder, ChatKit embeddable chat UI, Connector Registry, Guardrails, and Evals for building agentic workflows on OpenAI's models. But OpenAI is winding down Agent Builder and Evals, with full shutdown November 30, 2026, in favor of the code-first Agents SDK or ChatGPT Workspace Agents.",
+  sectionIntros: {
+    platform: [
+      'Sim offers a visual builder, supported self-hosting, and promotion across environments. OpenAI Agent Builder is a hosted visual canvas that OpenAI is retiring, leaving the code-first Agents SDK as its successor.',
+    ],
+    pricing: [
+      { text: 'Sim combines a per-user subscription', href: '/pricing' },
+      ' with usage credits and bring-your-own-key exemptions, while OpenAI charges for model tokens and tools without a dedicated AgentKit plan. Estimate workflow volume, token consumption, and paid tool calls when comparing total cost.',
+    ],
+    security: [
+      'OpenAI publishes a broader certification portfolio, while Sim provides more direct infrastructure control through ',
+      { text: 'self-hosting', href: 'https://docs.sim.ai/platform/self-hosting' },
+      ' and configurable credential, retention, session, and audit policies.',
+    ],
+    aiCapabilities: [
+      'Sim provides visual and natural-language building across ',
+      { text: 'multiple model providers', href: 'https://docs.sim.ai/introduction' },
+      ". Agent Builder's visual selector is limited to OpenAI models and is being retired, although the separate Agents SDK can reach other providers through code-level adapters.",
+    ],
+    integrations: [
+      'Sim publishes integration and trigger counts for its first-party automation catalog, while OpenAI combines a smaller documented connector set with access to external MCP servers, which are third-party endpoints OpenAI does not review.',
+    ],
+    observability: [
+      'Both products provide run tracing, but their operational models differ. Sim includes visual workflow alerts and error branches, while several OpenAI retry, checkpoint, and recovery capabilities require developers to configure the Agents SDK in code.',
+    ],
+    support: [
+      'OpenAI documents 24/7 support and service commitments for qualifying enterprise offerings, while Sim lists dedicated Enterprise support without publishing response-time or uptime terms. Buyers who require contractual guarantees should confirm the exact coverage with each vendor.',
+    ],
+  },
   standoutFeatures: [
     {
       title: 'An official, open-source Agents SDK wired natively to its own models',
       description:
-        "The Agents SDK, openai-agents-python, is open source under the MIT license with over 27,500 GitHub stars and natively wired into OpenAI's own model lineup. It's the path OpenAI is steering AgentKit users toward as Agent Builder and Evals wind down (full shutdown November 30, 2026), and a team fully committed to an all-OpenAI, code-first stack gets that directly.",
+        "The Agents SDK, openai-agents-python, is open source under the MIT license with over 27,500 GitHub stars and natively wired into OpenAI's own model lineup. It's the path OpenAI is steering AgentKit users toward as Agent Builder and Evals wind down, and a team fully committed to an all-OpenAI, code-first stack gets that directly.",
       shortDescription: 'Open-source code-first framework, natively wired to OpenAI models.',
       source: {
         url: 'https://github.com/openai/openai-agents-python',
@@ -120,7 +148,7 @@ export const openaiAgentkitProfile: CompetitorProfile = {
         value:
           'Visual canvas (Agent Builder) for drag-and-drop multi-agent workflow construction, paired with a code-first alternative (Agents SDK, Python/TypeScript)',
         detail:
-          'Agent Builder was a visual, node-based canvas for creating and versioning multi-agent workflows with typed inputs/outputs and live-data preview. It is being deprecated (shutdown November 30, 2026) in favor of the code-first Agents SDK, making the long-term builder paradigm code-based rather than visual.',
+          'Agent Builder was a visual, node-based canvas for creating and versioning multi-agent workflows with typed inputs/outputs and live-data preview. It is being deprecated in favor of the code-first Agents SDK, making the long-term builder paradigm code-based rather than visual.',
         shortValue: 'Visual canvas, deprecated in favor of code-first SDK',
         confidence: 'verified',
         sources: [
@@ -213,7 +241,7 @@ export const openaiAgentkitProfile: CompetitorProfile = {
         value:
           'No dev/qa/prod-style environment promotion for full projects. Only single-workflow versioning and code export',
         detail:
-          "Agent Builder workflows export as code (Agents SDK, Python or TypeScript) or JSON templates, and templates can sync with a Git repo for reuse, but there's no built-in feature to clone a whole project and promote it between dev/qa/prod environments. Promoting environments means exporting to code and managing them yourself, which lines up with third-party reviews noting Agent Builder lacks production-grade deployment pipelines. Agent Builder is being deprecated, with full shutdown November 30, 2026, in favor of the code-first Agents SDK or ChatGPT Workspace Agents.",
+          "Agent Builder workflows export as code (Agents SDK, Python or TypeScript) or JSON templates, and templates can sync with a Git repo for reuse, but there's no built-in feature to clone a whole project and promote it between dev/qa/prod environments. Promoting environments means exporting to code and managing them yourself, which lines up with third-party reviews noting Agent Builder lacks production-grade deployment pipelines.",
         shortValue: 'No built-in dev/qa/prod promotion',
         confidence: 'estimated',
         sources: [
@@ -352,9 +380,9 @@ export const openaiAgentkitProfile: CompetitorProfile = {
       },
       customBlocks: {
         value:
-          "No: Agent Builder has no feature to publish a workflow as a named, encapsulated block that other org members can drop into their own separate workflows. Its full node palette (Start, Agent, Note, File search, Guardrails, MCP, If/else, While, Human approval, Transform, Set state) has no 'workflow as a block' node, and publishing only creates a versioned snapshot consumable via the API or embedded through ChatKit, not a reusable canvas block for teammates.",
+          'No: Agent Builder has no feature to publish a workflow as a named, encapsulated block that other org members can drop into their own separate workflows.',
         detail:
-          "Publishing a workflow in Agent Builder produces a versioned object callable via API or embeddable through ChatKit, but that is deploying one workflow as an endpoint, not turning it into a block that appears in other users' canvases with inputs auto-derived from its Start node and internals hidden. Team-level reuse in the documented deployment paths (templates, ChatKit, SDK code export) means copying a template, embedding a chat surface, or exporting code, none of which give other builders a live, encapsulated block that stays in sync with the source workflow's latest published version. Agent Builder itself is also being wound down, with full shutdown November 30, 2026.",
+          "Its node palette has no 'workflow as a block' node, and the documented reuse paths (templates, ChatKit, SDK code export) give teammates a copy or an endpoint, never a live encapsulated block that stays in sync with the source workflow's latest published version.",
         shortValue: 'No dedicated publish-as-reusable-block feature found',
         confidence: 'estimated',
         sources: [
@@ -451,7 +479,7 @@ export const openaiAgentkitProfile: CompetitorProfile = {
         value:
           'Yes: Evals (datasets, trace grading, automated prompt optimization) and a separate open-source Guardrails layer, but Evals is being deprecated alongside Agent Builder',
         detail:
-          'AgentKit shipped Datasets, Trace grading, and Automated prompt optimization under Evals, plus an open-source modular Guardrails safety layer (PII masking, jailbreak detection). Evals goes read-only October 31, 2026 and is fully shut down November 30, 2026, alongside Agent Builder.',
+          'AgentKit shipped Datasets, Trace grading, and Automated prompt optimization under Evals, plus an open-source modular Guardrails safety layer (PII masking, jailbreak detection). Evals is being retired alongside Agent Builder.',
         shortValue: 'Evals plus Guardrails (Evals sunsetting)',
         confidence: 'verified',
         sources: [
@@ -523,7 +551,7 @@ export const openaiAgentkitProfile: CompetitorProfile = {
       },
       agentSkills: {
         value:
-          "No: Agent Builder/AgentKit has no dedicated feature for defining a reusable, named prompt or knowledge snippet that multiple agents can share by reference. OpenAI's separate reusable-prompts feature is itself being phased out and is scheduled to shut down November 30, 2026, alongside Agent Builder. A distinct 'Agent Skills' concept exists only in the unrelated Codex product line, not in AgentKit.",
+          "No: Agent Builder/AgentKit has no dedicated feature for defining a reusable, named prompt or knowledge snippet that multiple agents can share by reference. A distinct 'Agent Skills' concept exists only in the unrelated Codex product line, not in AgentKit.",
         detail:
           'OpenAI recommends migrating reusable prompts to code-managed, versioned helper files instead, which is the opposite direction of a built-in skills feature.',
         shortValue: 'No dedicated cross-agent skill/snippet feature',
@@ -544,8 +572,7 @@ export const openaiAgentkitProfile: CompetitorProfile = {
       nativeChatDeployment: {
         value:
           'Yes: ChatKit is a native toolkit for embedding a publicly deployable, customizable chat-based agent surface (web widget) backed by a published Agent Builder workflow ID or the Agents SDK, distinct from just a form/API/webhook target.',
-        detail:
-          'ChatKit remains available even as Agent Builder itself is being wound down (shutdown November 30, 2026).',
+        detail: 'ChatKit remains available even as Agent Builder itself is being wound down.',
         shortValue: 'Yes, via ChatKit embeddable chat surface',
         confidence: 'verified',
         sources: [

--- a/apps/sim/lib/compare/data/index.ts
+++ b/apps/sim/lib/compare/data/index.ts
@@ -25,4 +25,6 @@ export type {
   CompetitorProfile,
   Fact,
   FactSource,
+  Prose,
+  ProseSegment,
 } from '@/lib/compare/data/types'

--- a/apps/sim/lib/compare/data/types.ts
+++ b/apps/sim/lib/compare/data/types.ts
@@ -173,6 +173,17 @@ export interface ComparisonFacts {
   }
 }
 
+/**
+ * One run of comparison prose, optionally hyperlinked. Kept as data (rather
+ * than markup or a markdown string) so the data layer stays UI-free while
+ * still expressing the in-sentence citation links that comparison intros
+ * need. A segment object renders `text` as a link to `href`.
+ */
+export type ProseSegment = string | { text: string; href: string }
+
+/** A paragraph of comparison prose, as an ordered run of {@link ProseSegment}s. */
+export type Prose = ProseSegment[]
+
 /** Brand icon + colors for a competitor, sourced from a brand-intelligence lookup rather than the vendor's own docs. */
 export interface CompetitorBrand {
   /** Icon component from @/components/icons rendering this competitor's logo. */
@@ -208,6 +219,24 @@ export interface CompetitorProfile {
   website: string
   /** One-sentence, neutral description of what the product is. */
   oneLiner: string
+  /**
+   * A 2-4 sentence direct answer to "which of these two should I pick", shown
+   * as the page's lead paragraph ahead of the generic intro. Written so an
+   * answer engine can quote it standalone: what each product is, then the
+   * condition under which each one wins.
+   */
+  leadAnswer?: Prose
+  /**
+   * Answer to the "Is Sim better than {name}?" section, phrased the way buyers
+   * ask the question of an AI model. Verdict first, then the condition that
+   * decides it. 3-5 sentences.
+   */
+  betterThanAnswer?: Prose
+  /**
+   * One-sentence lead-in per comparison-table section, stating what that
+   * section covers so the section is quotable without the rest of the page.
+   */
+  sectionIntros?: Partial<Record<keyof ComparisonFacts, Prose>>
   /**
    * Whether this competitor is, categorically, a visual workflow/automation
    * builder like Sim. Defaults to `true` when omitted. Set `false` for a


### PR DESCRIPTION
## Summary
- Comparison pages get three optional profile fields — a direct-answer lead paragraph, an "Is Sim better than {name}?" verdict, and per-section lead-ins. Every profile that doesn't set them renders exactly as before.
- The single feature table splits into one H2 + table per section, so each section is quotable on its own. `ComparisonTable` now takes one `section` instead of rendering all seven, and each table gets its own `aria-label`.
- Dust: adds the lead paragraph, the verdict section, and all seven section lead-ins.
- OpenAI AgentKit: adds section lead-ins with contextual links to pricing, docs, and self-hosting; drops the repeated "shutdown November 30, 2026" clause from the eight rows that restated it (the date stays in the intro and the shutdown limitation card); shortens the custom-blocks, agent-skills, and environment-promotion rows; states the built-in-vs-third-party-MCP distinction directly instead of announcing it.
- Inline links go through the existing `ProseLink` primitive, so external links get `rel="noopener noreferrer"` and internal ones stay crawlable Next `<Link>`s.

## Type of Change
- [x] Improvement (content + rendering)

## Testing
Tested manually against a local dev server: all 20 comparison pages return 200 with all 65 fact rows intact and seven per-section H2s; verified the new copy, the unique per-section `aria-label`s, and that `/pricing` renders as a Next `<Link>` while the docs links render hardened external anchors.

`bun run lint`, `bun run check:audits` (45 audits), `bun run docs-manifest:check`, `check-block-registry.ts`, and `bun run type-check` all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)