### PR TITLE
fix(auth): move OAuth account controls below consent actions

### DIFF
--- a/apps/sim/app/(auth)/oauth/consent/consent-view.test.tsx
+++ b/apps/sim/app/(auth)/oauth/consent/consent-view.test.tsx
@@ -68,10 +68,13 @@ describe('OAuth consent view', () => {
     vi.useRealTimers()
   })
 
-  it('shows the registered app, account and destination with one row per distinct capability', () => {
+  it('shows the account below the decisions without a CLI destination sentence', () => {
     expect(container.querySelector('h1')?.textContent).toBe('Authorize Sim CLI')
     expect(container.textContent).toContain('Continuing as test@example.com.')
-    expect(container.textContent).toContain('Returns to this computer.')
+    expect(container.textContent).not.toContain('Returns to this computer.')
+    expect(
+      Array.from(container.querySelectorAll('button')).map((element) => element.textContent)
+    ).toEqual(['Allow', 'Deny', 'Use another account'])
     expect(container.querySelectorAll('li')).toHaveLength(2)
     expect(button('Allow').disabled).toBe(false)
     expect(button('Deny').disabled).toBe(false)

--- a/apps/sim/app/(auth)/oauth/consent/consent-view.tsx
+++ b/apps/sim/app/(auth)/oauth/consent/consent-view.tsx
@@ -152,12 +152,6 @@ export function OAuthConsentView({
             ))}
           </ul>
         )}
-        <p className='break-words text-center text-[var(--text-muted)] text-caption'>
-          Continuing as {email}.{' '}
-          <AuthTextLink onClick={changeAccount} disabled={isPending}>
-            {switchAccount.isPending ? 'Signing out…' : 'Use another account'}
-          </AuthTextLink>
-        </p>
         <AuthSubmitButton
           type='button'
           loading={consent.isPending && consent.variables === true}
@@ -177,7 +171,7 @@ export function OAuthConsentView({
         >
           {consent.isPending && consent.variables === false ? 'Declining…' : 'Deny'}
         </Chip>
-        {destination && (
+        {!isCli && destination && (
           <p className='break-words text-center text-[var(--text-muted)] text-caption'>
             Returns to {destination}.
           </p>
@@ -192,6 +186,12 @@ export function OAuthConsentView({
             </AuthFormMessage>
           </div>
         )}
+        <p className='break-words text-center text-[var(--text-muted)] text-caption'>
+          Continuing as {email}.{' '}
+          <AuthTextLink onClick={changeAccount} disabled={isPending}>
+            {switchAccount.isPending ? 'Signing out…' : 'Use another account'}
+          </AuthTextLink>
+        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Move the account and switch-account controls below the consent actions.
- Remove the Sim CLI destination sentence while preserving destination visibility for other clients.

## Type of Change

- [x] Bug fix

## Testing

All 12 consent and OAuth hook tests passed. Full repository lint, all 46 audits, the block registry check, and docs-manifest validation passed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
