### PR TITLE
fix(settings): move authorized apps into General

### DIFF
--- a/apps/docs/content/docs/api-reference/authentication.mdx
+++ b/apps/docs/content/docs/api-reference/authentication.mdx
@@ -108,7 +108,7 @@ curl https://www.sim.ai/api/v2/workspaces \
 
 Scopes limit what an application may do; your current workspace membership and role still apply. Each endpoint documents its required scope. Some GET endpoints that perform external discovery require `api:write`, so HTTP method alone does not determine the permission.
 
-Manage grants in **Settings** → **Authorized apps**. Revoking an application signs out all of its logins. `sim logout` revokes the current CLI login and removes it from your machine. The Python and TypeScript SDKs currently use API keys; they do not manage OAuth sign-in or refresh tokens.
+Manage grants in **Settings** → **General** → **Authorized apps**. Revoking an application signs out all of its logins. `sim logout` revokes the current CLI login and removes it from your machine. The Python and TypeScript SDKs currently use API keys; they do not manage OAuth sign-in or refresh tokens.
 
 ## Security
 

--- a/apps/docs/content/docs/cli/authentication.mdx
+++ b/apps/docs/content/docs/cli/authentication.mdx
@@ -27,7 +27,7 @@ https://www.sim.ai/api/auth/oauth2/authorize?client_id=sim-cli&…
 Waiting for you to approve in the browser…
 
 ✓ Logged in. Login stored in /Users/you/.sim/credentials
-  Renews itself; revoke it any time in Settings → Authorized apps, or with: sim logout
+  Renews itself; revoke it any time in Settings → General → Authorized apps, or with: sim logout
   No default workspace. Set one with: sim configure --set-workspace <id>
 ```
 
@@ -151,7 +151,7 @@ For an OAuth login, `sim logout` revokes that login's complete token family
 before removing it from disk, including access tokens issued before earlier
 rotations. Other machines that ran their own `sim login` remain signed in. To
 cut off every independent login for the client, revoke the grant under
-**Settings → Authorized apps**.
+**Settings → General → Authorized apps**.
 
 A workspace profile that shares authentication cannot remove the shared login.
 Remove only that local profile with `sim logout --all --profile <name>`, or log

--- a/apps/docs/content/docs/platform/self-hosting/authentication.mdx
+++ b/apps/docs/content/docs/platform/self-hosting/authentication.mdx
@@ -122,7 +122,7 @@ requires a real Better Auth user session.
 Access tokens are opaque and last an hour; refresh tokens rotate on every use.
 Each login has a fixed thirty-day lifetime that refreshing does not extend.
 Token validation checks current grants, so revoking a grant under
-**Settings → Authorized apps** stops the app on its very next request. These
+**Settings → General → Authorized apps** stops the app on its very next request. These
 settings remain available for reviewing and revoking existing grants while the
 provider is off, and scheduled OAuth token cleanup continues.
 

--- a/apps/sim/app/account/settings/[section]/page.test.tsx
+++ b/apps/sim/app/account/settings/[section]/page.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetSession, mockPrefetch } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockPrefetch: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND')
+  },
+  redirect: (href: string) => {
+    throw new Error(`NEXT_REDIRECT:${href}`)
+  },
+}))
+vi.mock('@/lib/auth', () => ({ getSession: mockGetSession }))
+vi.mock('@/lib/core/config/env-flags', () => ({ isBillingEnabled: true }))
+vi.mock('@/lib/permissions/super-user', () => ({ isPlatformAdmin: vi.fn() }))
+vi.mock('@/app/_shell/providers/get-query-client', () => ({ getQueryClient: vi.fn() }))
+vi.mock('@/components/settings/prefetch-standalone-general', () => ({
+  prefetchStandaloneGeneral: mockPrefetch,
+}))
+vi.mock('@/components/settings/account-settings-renderer', () => ({
+  AccountSettingsRenderer: () => null,
+}))
+
+import AccountSettingsSectionPage from '@/app/account/settings/[section]/page'
+
+const pageProps = (section: string) => ({ params: Promise.resolve({ section }) })
+
+describe('account settings legacy links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({ user: { id: 'viewer-a' } })
+  })
+
+  it('redirects Authorized apps bookmarks to the General subview', async () => {
+    await expect(AccountSettingsSectionPage(pageProps('authorized-apps'))).rejects.toThrow(
+      'NEXT_REDIRECT:/account/settings/general?view=authorized-apps'
+    )
+    expect(mockPrefetch).not.toHaveBeenCalled()
+  })
+
+  it('authenticates before following the legacy bookmark', async () => {
+    mockGetSession.mockResolvedValue(null)
+
+    await expect(AccountSettingsSectionPage(pageProps('authorized-apps'))).rejects.toThrow(
+      'NEXT_REDIRECT:/login'
+    )
+  })
+
+  it('still rejects unknown sections', async () => {
+    await expect(AccountSettingsSectionPage(pageProps('unknown'))).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+})

--- a/apps/sim/app/account/settings/[section]/page.tsx
+++ b/apps/sim/app/account/settings/[section]/page.tsx
@@ -41,6 +41,9 @@ export default async function AccountSettingsSectionPage({
   if (!session?.user) redirect('/login')
 
   const { section } = await params
+  if (section === 'authorized-apps') {
+    redirect(`${getAccountSettingsHref('general')}?view=authorized-apps`)
+  }
   const parsed = parseSettingsPathSection({
     path: section,
     items: ACCOUNT_SETTINGS_ITEMS,

--- a/apps/sim/app/workspace/[workspaceId]/settings/[section]/layout.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/[section]/layout.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND')
+  },
+  redirect: (href: string) => {
+    throw new Error(`NEXT_REDIRECT:${href}`)
+  },
+}))
+vi.mock(
+  '@/app/workspace/[workspaceId]/settings/components/settings-header/settings-header',
+  () => ({
+    SettingsHeaderProvider: () => null,
+    SettingsHeaderShell: () => null,
+  })
+)
+
+import SettingsSectionLayout from '@/app/workspace/[workspaceId]/settings/[section]/layout'
+
+const layoutProps = (section: string) => ({
+  children: null,
+  params: Promise.resolve({ workspaceId: 'workspace-a', section }),
+})
+
+describe('workspace settings legacy links', () => {
+  it.each(['privacy', 'authorized-apps'])(
+    'redirects %s before rendering the shell',
+    async (view) => {
+      await expect(SettingsSectionLayout(layoutProps(view))).rejects.toThrow(
+        `NEXT_REDIRECT:/workspace/workspace-a/settings/general?view=${view}`
+      )
+    }
+  )
+
+  it('still rejects unknown sections', async () => {
+    await expect(SettingsSectionLayout(layoutProps('unknown'))).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/settings/[section]/layout.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/[section]/layout.tsx
@@ -6,14 +6,15 @@ import {
 import { resolveSettingsSection } from '@/app/workspace/[workspaceId]/settings/navigation'
 
 /**
- * Sections that were promoted out of settings into their own workspace routes. Kept as
- * segment-level rewrites so old links and bookmarks still land somewhere sensible.
+ * Legacy settings sections kept as redirects so old links and bookmarks still work.
  */
 const TOP_LEVEL_REDIRECTS: Readonly<Record<string, (workspaceId: string) => string>> = {
   integrations: (workspaceId) => `/workspace/${workspaceId}/integrations`,
   skills: (workspaceId) => `/workspace/${workspaceId}/skills`,
   /** Cookie preferences moved into General. */
   privacy: (workspaceId) => `/workspace/${workspaceId}/settings/general?view=privacy`,
+  'authorized-apps': (workspaceId) =>
+    `/workspace/${workspaceId}/settings/general?view=authorized-apps`,
 }
 
 /**

--- a/apps/sim/app/workspace/[workspaceId]/settings/[section]/settings.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/[section]/settings.tsx
@@ -25,11 +25,6 @@ const ApiKeys = dynamic(() =>
 const BYOK = dynamic(() =>
   import('@/app/workspace/[workspaceId]/settings/components/byok/byok').then((m) => m.BYOK)
 )
-const AuthorizedApps = dynamic(() =>
-  import('@/app/workspace/[workspaceId]/settings/components/authorized-apps/authorized-apps').then(
-    (m) => m.AuthorizedApps
-  )
-)
 const Forks = dynamic(() => import('@/ee/workspace-forking/components/forks').then((m) => m.Forks))
 const Secrets = dynamic(() =>
   import('@/app/workspace/[workspaceId]/settings/components/secrets/secrets').then((m) => m.Secrets)
@@ -189,7 +184,6 @@ export function SettingsPage({ section }: SettingsPageProps) {
         />
       )}
       {effectiveSection === 'apikeys' && <ApiKeys scope='combined' />}
-      {effectiveSection === 'authorized-apps' && <AuthorizedApps />}
       {billingEnabled && effectiveSection === 'billing' && (
         <Billing
           scope={organizationId ? 'organization' : 'account'}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/authorized-apps/authorized-apps.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/authorized-apps/authorized-apps.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Chip, ChipConfirmModal, toast } from '@sim/emcn'
+import { ArrowLeft } from '@sim/emcn/icons'
 import { getErrorMessage } from '@sim/utils/errors'
 import { formatDate } from '@sim/utils/formatting'
 import { summarizeOAuthAccess } from '@/lib/auth/oauth-provider'
@@ -18,12 +19,16 @@ import {
 import { useSettingsSearch } from '@/app/workspace/[workspaceId]/settings/components/use-settings-search'
 import { useAuthorizedApps, useRevokeAuthorizedApp } from '@/hooks/queries/oauth-provider'
 
+interface AuthorizedAppsProps {
+  onBack: () => void
+}
+
 /**
  * The apps this account has authorized through Sim's OAuth provider. Revoking
  * one withdraws its consent and kills every token it holds, so the next
  * request it makes fails and the next sign-in asks again.
  */
-export function AuthorizedApps() {
+export function AuthorizedApps({ onBack }: AuthorizedAppsProps) {
   const [searchTerm, setSearchTerm] = useSettingsSearch()
   const apps = useAuthorizedApps(searchTerm.trim())
   const revoke = useRevokeAuthorizedApp()
@@ -46,6 +51,16 @@ export function AuthorizedApps() {
   return (
     <>
       <SettingsPanel
+        back={{
+          text: 'General',
+          icon: ArrowLeft,
+          onSelect: () => {
+            setSearchTerm('')
+            onBack()
+          },
+        }}
+        title='Authorized apps'
+        description='Review and revoke apps that can act on your account.'
         search={{
           value: searchTerm,
           onChange: setSearchTerm,

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, type ReactNode, Suspense } from 'react'
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ANONYMOUS_USER_ID } from '@/lib/auth/constants'
+
+const { mockUseSession, mockUseAuthorizedApps, mockUrlUpdate } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockUseAuthorizedApps: vi.fn(),
+  mockUrlUpdate: vi.fn(),
+}))
+
+vi.mock('next/dynamic', () => ({
+  default: () => AuthorizedApps,
+}))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/account/settings/general',
+}))
+vi.mock('@/lib/auth/auth-client', () => ({ useSession: mockUseSession, signOut: vi.fn() }))
+vi.mock('@/lib/core/config/deployment-shape', () => ({
+  useDeploymentShape: () => ({ hosted: false }),
+}))
+vi.mock('@/ee/whitelabeling', () => ({ useBrandConfig: () => ({ logoUrl: '/logo.png' }) }))
+vi.mock('@/stores', () => ({ clearUserData: vi.fn() }))
+vi.mock('@/hooks/queries/general-settings', () => ({
+  useGeneralSettings: () => ({ data: {}, isLoading: false }),
+  useUpdateGeneralSetting: () => ({ mutateAsync: vi.fn() }),
+}))
+vi.mock('@/hooks/queries/user-profile', () => ({
+  useUserProfile: () => ({
+    data: { name: 'Test user', email: 'user@example.com' },
+    isLoading: false,
+  }),
+  useUpdateUserProfile: () => ({ mutateAsync: vi.fn() }),
+  useResetPassword: () => ({ mutateAsync: vi.fn() }),
+}))
+vi.mock('@/hooks/queries/oauth-provider', () => ({
+  useAuthorizedApps: mockUseAuthorizedApps,
+  useRevokeAuthorizedApp: () => ({ mutate: vi.fn() }),
+}))
+vi.mock('@/app/workspace/[workspaceId]/settings/hooks/use-profile-picture-upload', () => ({
+  useProfilePictureUpload: () => ({
+    fileInputRef: { current: null },
+    handleThumbnailClick: vi.fn(),
+    handleFileChange: vi.fn(),
+  }),
+}))
+vi.mock(
+  '@/app/workspace/[workspaceId]/settings/components/general/components/delete-account-modal',
+  () => ({
+    DeleteAccountModal: () => null,
+  })
+)
+vi.mock(
+  '@/app/workspace/[workspaceId]/settings/components/general/components/privacy-view',
+  () => ({
+    PrivacyView: () => null,
+  })
+)
+vi.mock('@/app/workspace/[workspaceId]/settings/components/settings-panel', () => ({
+  SettingsPanel: ({
+    children,
+    title,
+    back,
+    search,
+  }: {
+    children: ReactNode
+    title?: string
+    back?: { onSelect: () => void; text: string }
+    search?: { value: string; onChange: (value: string) => void; placeholder: string }
+  }) => (
+    <>
+      {back && (
+        <button type='button' onClick={back.onSelect}>
+          {back.text}
+        </button>
+      )}
+      {title && <h1>{title}</h1>}
+      {search && (
+        <input
+          aria-label={search.placeholder}
+          value={search.value}
+          onChange={(event) => search.onChange(event.target.value)}
+        />
+      )}
+      {children}
+    </>
+  ),
+}))
+
+import { AuthorizedApps } from '@/app/workspace/[workspaceId]/settings/components/authorized-apps/authorized-apps'
+import { General } from '@/app/workspace/[workspaceId]/settings/components/general/general'
+
+let root: Root
+let container: HTMLDivElement
+
+async function renderGeneral(searchParams = '') {
+  await act(async () => {
+    root.render(
+      <NuqsTestingAdapter hasMemory searchParams={searchParams} onUrlUpdate={mockUrlUpdate}>
+        <Suspense fallback={null}>
+          <General />
+        </Suspense>
+      </NuqsTestingAdapter>
+    )
+  })
+}
+
+describe('General authorized apps subview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    mockUseSession.mockReturnValue({ data: { user: { id: 'viewer-a' } } })
+    mockUseAuthorizedApps.mockReturnValue({ data: { pages: [{ apps: [] }] }, isPending: false })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('opens the full management view from Account without loading grants beforehand', async () => {
+    await renderGeneral('?keep=value')
+    expect(mockUseAuthorizedApps).not.toHaveBeenCalled()
+
+    const label = [...container.querySelectorAll('label')].find(
+      (node) => node.textContent === 'Authorized apps'
+    )!
+    await act(async () => label.parentElement!.querySelector('button')!.click())
+
+    expect(container.querySelector('h1')?.textContent).toBe('Authorized apps')
+    expect(container.querySelector('input[aria-label="Search authorized apps..."]')).not.toBeNull()
+    expect(container.textContent).toContain('No apps have access to your account')
+    await vi.waitFor(() => expect(mockUrlUpdate).toHaveBeenCalled())
+    const update = mockUrlUpdate.mock.calls.at(-1)![0]
+    expect(update.searchParams.get('view')).toBe('authorized-apps')
+    expect(update.searchParams.get('keep')).toBe('value')
+    expect(update.options.history).toBe('push')
+  })
+
+  it('opens a direct link and clears its search on Back without adding history', async () => {
+    await renderGeneral('?view=authorized-apps&search=old&keep=value')
+    expect(container.querySelector('h1')?.textContent).toBe('Authorized apps')
+    expect(mockUseAuthorizedApps).toHaveBeenCalledWith('old')
+
+    const back = [...container.querySelectorAll('button')].find(
+      (node) => node.textContent === 'General'
+    )!
+    await act(async () => back.click())
+
+    expect(container.querySelector('h1')).toBeNull()
+    await vi.waitFor(() => expect(mockUrlUpdate).toHaveBeenCalled())
+    const update = mockUrlUpdate.mock.calls.at(-1)![0]
+    expect(update.searchParams.has('view')).toBe(false)
+    expect(update.searchParams.has('search')).toBe(false)
+    expect(update.searchParams.get('keep')).toBe('value')
+    expect(update.options.history).toBe('replace')
+  })
+
+  it('keeps account grants unavailable when authentication is disabled', async () => {
+    mockUseSession.mockReturnValue({ data: { user: { id: ANONYMOUS_USER_ID } } })
+    await renderGeneral('?view=authorized-apps')
+
+    expect(container.textContent).not.toContain('Authorized apps')
+    expect(mockUseAuthorizedApps).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/general/general.tsx
@@ -19,6 +19,7 @@ import {
 } from '@sim/emcn'
 import { Camera, Check, CircleInfo, Pencil } from '@sim/emcn/icons'
 import { createLogger } from '@sim/logger'
+import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useQueryState } from 'nuqs'
@@ -49,6 +50,12 @@ import {
   useUserProfile,
 } from '@/hooks/queries/user-profile'
 import { clearUserData } from '@/stores'
+
+const AuthorizedApps = dynamic(() =>
+  import('@/app/workspace/[workspaceId]/settings/components/authorized-apps/authorized-apps').then(
+    (module) => module.AuthorizedApps
+  )
+)
 
 const logger = createLogger('General')
 
@@ -273,7 +280,11 @@ export function General() {
   const imageUrl = profilePictureUrl || profile?.image || brandConfig.logoUrl
 
   if (view === 'privacy') {
-    return <PrivacyView onBack={() => setView(null)} />
+    return <PrivacyView onBack={() => setView(null, { history: 'replace' })} />
+  }
+
+  if (view === 'authorized-apps' && !isAuthDisabled) {
+    return <AuthorizedApps onBack={() => setView(null, { history: 'replace' })} />
   }
 
   const actions: SettingsAction[] = [
@@ -596,9 +607,15 @@ export function General() {
 
         {!isAuthDisabled && (
           <SettingsSection label='Account'>
-            <div className='flex items-center justify-between'>
-              <Label>Delete account</Label>
-              <Chip onClick={() => setShowDeleteAccountModal(true)}>Delete</Chip>
+            <div className='flex flex-col gap-4'>
+              <div className='flex items-center justify-between'>
+                <Label>Authorized apps</Label>
+                <Chip onClick={() => setView('authorized-apps')}>Manage</Chip>
+              </div>
+              <div className='flex items-center justify-between'>
+                <Label>Delete account</Label>
+                <Chip onClick={() => setShowDeleteAccountModal(true)}>Delete</Chip>
+              </div>
             </div>
           </SettingsSection>
         )}

--- a/apps/sim/app/workspace/[workspaceId]/settings/components/general/search-params.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/general/search-params.ts
@@ -1,13 +1,12 @@
 import { parseAsStringLiteral } from 'nuqs/server'
 
 /**
- * The sub-view open inside General. Only `privacy` exists today; the literal
- * parser means an unknown value from an old link falls back to General rather
- * than rendering an empty detail pane.
+ * General's sub-view. Unknown values fall back to General rather than rendering
+ * an empty detail pane.
  */
 export const generalViewParam = {
   key: 'view',
-  parser: parseAsStringLiteral(['privacy'] as const),
+  parser: parseAsStringLiteral(['privacy', 'authorized-apps'] as const),
 } as const
 
 /** Opening the sub-view is a destination — Back should return to General. */

--- a/apps/sim/app/workspace/[workspaceId]/settings/navigation.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/settings/navigation.test.ts
@@ -37,7 +37,6 @@ describe('unified settings navigation', () => {
       { id: 'custom-tools', label: 'Custom tools', section: 'workspace' },
       { id: 'mcp', label: 'MCP tools', section: 'workspace' },
       { id: 'apikeys', label: 'Sim API keys', section: 'workspace' },
-      { id: 'authorized-apps', label: 'Authorized apps', section: 'account' },
       { id: 'workflow-mcp-servers', label: 'MCP servers', section: 'workspace' },
       { id: 'byok', label: 'BYOK', section: 'workspace' },
       { id: 'sandboxes', label: 'Sandboxes', section: 'workspace' },
@@ -68,7 +67,6 @@ describe('unified settings navigation', () => {
       'desktop',
       'browser',
       'terminal',
-      'authorized-apps',
     ])
     expect(idsForSection('workspace')).toEqual([
       'teammates',

--- a/apps/sim/components/settings/account-settings-renderer.tsx
+++ b/apps/sim/components/settings/account-settings-renderer.tsx
@@ -17,11 +17,6 @@ const ApiKeys = dynamic(() =>
     (module) => module.ApiKeys
   )
 )
-const AuthorizedApps = dynamic(() =>
-  import('@/app/workspace/[workspaceId]/settings/components/authorized-apps/authorized-apps').then(
-    (module) => module.AuthorizedApps
-  )
-)
 const Admin = dynamic(() =>
   import('@/app/workspace/[workspaceId]/settings/components/admin/admin').then(
     (module) => module.Admin
@@ -47,7 +42,6 @@ export function AccountSettingsRenderer({ section }: AccountSettingsRendererProp
   if (section === 'general') return <General />
   if (section === 'billing') return <Billing scope='account' />
   if (section === 'api-keys') return <ApiKeys scope='personal' />
-  if (section === 'authorized-apps') return <AuthorizedApps />
   if (section === 'admin') return <Admin />
   return <Mothership />
 }

--- a/apps/sim/components/settings/navigation.test.ts
+++ b/apps/sim/components/settings/navigation.test.ts
@@ -110,7 +110,6 @@ describe('settings navigation boundaries', () => {
       'custom-tools',
       'mcp',
       'apikeys',
-      'authorized-apps',
       'workflow-mcp-servers',
       'byok',
       'sandboxes',
@@ -130,7 +129,6 @@ describe('settings navigation boundaries', () => {
       'general',
       'billing',
       'api-keys',
-      'authorized-apps',
       'admin',
       'mothership',
     ])

--- a/apps/sim/components/settings/navigation.ts
+++ b/apps/sim/components/settings/navigation.ts
@@ -3,7 +3,6 @@ import {
   ChartColumn,
   ClipboardList,
   Clock,
-  Connections,
   Credit,
   Database,
   Globe,
@@ -34,13 +33,7 @@ import type { DeploymentFeatures, DeploymentShape } from '@/lib/api/contracts/wo
 
 export type SettingsPlane = 'account' | 'selfhost' | 'workspace'
 
-export type AccountSettingsSection =
-  | 'general'
-  | 'billing'
-  | 'api-keys'
-  | 'authorized-apps'
-  | 'admin'
-  | 'mothership'
+export type AccountSettingsSection = 'general' | 'billing' | 'api-keys' | 'admin' | 'mothership'
 
 /**
  * Settings a self-hoster needs from the managed service: their profile, what
@@ -102,7 +95,6 @@ export type UnifiedSettingsSection =
   | 'custom-blocks'
   | 'audit-logs'
   | 'apikeys'
-  | 'authorized-apps'
   | 'byok'
   | 'billing'
   | 'teammates'
@@ -588,24 +580,6 @@ export const SETTINGS_SECTION_REGISTRY: readonly SettingsSectionRegistryEntry[] 
         description: 'Manage workspace API keys and personal-key policy.',
         group: 'system',
         order: 7,
-      },
-    },
-  },
-  {
-    label: 'Authorized apps',
-    icon: Connections,
-    unified: {
-      id: 'authorized-apps',
-      description: 'Review and revoke apps that can act on your account.',
-      group: 'account',
-      order: 4,
-    },
-    planes: {
-      account: {
-        id: 'authorized-apps',
-        description: 'Review and revoke apps that can act on your account.',
-        group: 'developer',
-        order: 3,
       },
     },
   },

--- a/packages/sim-cli/README.md
+++ b/packages/sim-cli/README.md
@@ -36,7 +36,7 @@ sim login
 The CLI opens Sim in your browser, asks you to approve the requested access,
 and receives the one-time authorization code on a loopback callback. It stores
 a short-lived OAuth login that renews automatically and can be revoked under
-**Settings → Authorized apps**. Choose a default workspace afterward with
+**Settings → General → Authorized apps**. Choose a default workspace afterward with
 `sim configure --set-workspace <id>`.
 
 Use `sim login --no-browser` to print the OAuth URL without opening it. The

--- a/packages/sim-cli/src/auth/oauth-flow.ts
+++ b/packages/sim-cli/src/auth/oauth-flow.ts
@@ -17,7 +17,7 @@ import { USER_AGENT } from '../version'
  * the life of one login.
  *
  * The result is a short-lived access token and a rotating refresh token, both
- * revocable from Settings → Authorized apps, instead of the permanent API key
+ * revocable from Settings → General → Authorized apps, instead of the permanent API key
  * the pairing-code handoff in `device-flow.ts` mints. That handoff remains the
  * path for a terminal whose browser cannot reach it (SSH, containers).
  */

--- a/packages/sim-cli/src/auth/refresh.ts
+++ b/packages/sim-cli/src/auth/refresh.ts
@@ -26,7 +26,7 @@ const REFRESH_TIMEOUT_MS = 10 * 1000
  * and containing a copied token remains the authorization server's job.
  *
  * `invalid_grant` means the server no longer honours the refresh token — it
- * was revoked from Settings → Authorized apps, expired, or was already rotated
+ * was revoked from Settings → General → Authorized apps, expired, or was already rotated
  * by a process this one could not see — and the remedy is logout followed by a
  * new login.
  */

--- a/packages/sim-cli/src/commands/auth.ts
+++ b/packages/sim-cli/src/commands/auth.ts
@@ -501,7 +501,7 @@ async function loginWithOAuth(
     } catch (revocationError) {
       console.log(
         chalk.yellow(
-          `Could not revoke the uncommitted login (${safeOneLine(getErrorMessage(revocationError))}). Revoke Sim CLI in Settings → Authorized apps.`
+          `Could not revoke the uncommitted login (${safeOneLine(getErrorMessage(revocationError))}). Revoke Sim CLI in Settings → General → Authorized apps.`
         )
       )
     }
@@ -518,7 +518,7 @@ async function loginWithOAuth(
   console.log(
     chalk.dim(
       grantsWriteAccess(tokens.scope)
-        ? '  Renews itself; revoke it any time in Settings → Authorized apps, or with: sim logout'
+        ? '  Renews itself; revoke it any time in Settings → General → Authorized apps, or with: sim logout'
         : '  Read-only login — commands that change anything will be refused.'
     )
   )
@@ -708,7 +708,7 @@ async function loginWithHandoff(
 
 /**
  * Revokes the complete server-side token family before forgetting it locally.
- * Settings → Authorized apps is broader: it revokes every independent login
+ * Settings → General → Authorized apps is broader: it revokes every independent login
  * for the client. An unreachable server must not stop someone clearing their
  * machine, but it is said out loud so nobody assumes revocation succeeded.
  */
@@ -739,7 +739,7 @@ async function revokeStoredOAuth(credential: StoredOAuthCredential): Promise<voi
   } catch (error) {
     console.log(
       chalk.yellow(
-        `  Could not revoke the login on ${displayEndpoint} (${safeOneLine(getErrorMessage(error))}). Revoke it in Settings → Authorized apps.`
+        `  Could not revoke the login on ${displayEndpoint} (${safeOneLine(getErrorMessage(error))}). Revoke it in Settings → General → Authorized apps.`
       )
     )
   }


### PR DESCRIPTION
## Summary

- Move Authorized apps into General settings with a Manage action and Back navigation, preserving search, pagination, and revocation.
- Redirect existing Authorized apps settings links and update CLI and documentation guidance.

## Type of Change

- [x] Bug fix

## Testing

63 focused consent, OAuth hook, navigation, and redirect tests passed. CLI suite: 924 passed, 3 skipped. Full repository lint, all 46 audits, the block registry check, and docs-manifest validation passed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
