### PR TITLE
improvement(docs): clarify Entra deprovisioning and validation

### DIFF
--- a/apps/docs/content/docs/platform/enterprise/scim/entra.mdx
+++ b/apps/docs/content/docs/platform/enterprise/scim/entra.mdx
@@ -82,10 +82,10 @@ Change the test user's display name in Entra and provision them again. Confirm t
 
 Remove the test user's app assignment, then run on-demand provisioning for that user again. Confirm that Sim deactivates the existing member. Reassign the user and provision again to verify reactivation of the same account. Assignment changes can take a few minutes to become available to provisioning.
 
-Sim deactivation suspends access while retaining organization membership, ownership, and the seat. See [deactivation behavior](/platform/enterprise/scim#what-it-does) before using unassignment for offboarding.
+Sim deactivation suspends access while retaining organization membership, ownership, and the seat. For users still managed by the provisioning job, soft deletion deactivates the Sim member and permanent deletion sends a SCIM `DELETE` that removes organization membership. Entra normally permanently deletes users 30 days after soft deletion, or sooner if an administrator purges them. After app unassignment, Entra stops managing the user and does not send a later directory deletion. See [Microsoft's deprovisioning lifecycle](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/how-provisioning-works#deprovisioning) and [Sim's deactivation behavior](/platform/enterprise/scim#what-it-does).
 
 <Callout type="info">
-  Disabled or deleted Entra users cannot be selected for on-demand provisioning. Use the scheduled provisioning cycle to verify those cases. See [Microsoft's on-demand limitations](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/provision-on-demand).
+  Disabled or deleted Entra users cannot be selected for on-demand provisioning. [Start automatic provisioning](#start-automatic-provisioning) and complete the initial cycle before testing those changes through a scheduled cycle. See [Microsoft's on-demand limitations](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/provision-on-demand).
 </Callout>
 
 ## Provision groups and map access
@@ -104,6 +104,8 @@ After the test succeeds, return to the provisioning **Overview** and select **St
 
 Keep the scope limited to assigned users and groups as you add more members. Use **Provision on demand** for a small test; use the regular cycle to verify directory account disablement and deletion.
 
+During a scheduled lifecycle test, leave the job running after changing the test user. **Restart provisioning** clears the change watermark and begins a new initial cycle; changing mappings or scoping filters also resets it. Wait for the incremental cycle and inspect that user's provisioning log before making further changes.
+
 ## Rotate the token
 
 Issue a replacement token in Sim while the current token remains active. In Entra, open the provisioning configuration's **Connectivity** page, replace **Secret token**, select **Test connection**, and save. Confirm a successful provisioning request before revoking the old token in Sim. Sim allows two active tokens so rotation can overlap.
@@ -116,6 +118,7 @@ Issue a replacement token in Sim while the current token remains active. In Entr
 | User is out of scope | Assign the user to this enterprise application and check the provisioning scope and scoping filters. Allow time for assignment changes to propagate. |
 | User creation fails | Verify the email domain in Sim, available seats, and whether the account belongs to another Sim organization. Review the mapped UPN and work email. |
 | Repeat provisioning reports **Skipped** | Inspect the reason. **RedundantExport** means the source and target already match. |
+| Directory disablement or deletion has not reached Sim | Check the user's scheduled provisioning log, the `IsSoftDeleted` mapping to `active`, enabled **Update** actions, and accidental deletion protection. Confirm **Skip out of scope deletions** is disabled. A successful connection test alone does not verify a lifecycle change. |
 | Group assignment is unavailable | Check your Entra license. The Free plan supports individual user assignment but requires an upgrade for group assignment and provisioning. |
 | Member has no workspace access | Provision the directory group and add a workspace mapping in Sim. User provisioning creates organization membership. |
 | Disabled member still uses a seat | Sim suspends access on deactivation. Removing organization membership is a separate offboarding action. |

--- a/apps/sim/ee/scim/TESTING.md
+++ b/apps/sim/ee/scim/TESTING.md
@@ -132,19 +132,20 @@ The run verified connection testing with a raw secret token, direct user
 assignment and creation with default mappings (including a minimal profile with
 no Mail or structured name attributes), structured-name and display-name
 updates, display-name precedence, repeated provisioning without duplicate
-accounts, unassignment deactivation, reactivation of the same account, an initial
-scheduled cycle, reconciliation, and overlapping token rotation. Entra continued
-to match the provisioned user after the old token was revoked; the old token
-returned 401 and the replacement returned 200. PostgreSQL checks confirmed stable
-SCIM and account IDs, retained membership on deactivation, and no implicit
-workspace grants.
+accounts, unassignment deactivation, reactivation of the same account, scheduled
+directory account disablement, reconciliation, and overlapping token rotation.
+Re-enabling the directory account and provisioning it on demand restored the same
+Sim account. Entra continued to match the provisioned user after the old token was
+revoked; the old token returned 401 and the replacement returned 200. PostgreSQL
+checks confirmed stable SCIM and account IDs, retained membership on deactivation,
+and no implicit workspace grants.
 
 The tenant used Entra ID Free. Live group provisioning and group access changes
 remain unverified because group assignment requires Premium. Directory account
-disablement and deletion also require a scheduled-cycle check; app unassignment
-was tested separately through on-demand provisioning. Synthetic users and a
-seeded verified domain were used, so this does not verify real DNS ownership,
-end-user SSO, or Microsoft gallery certification.
+deletion still requires a scheduled-cycle check. App unassignment was tested
+separately through on-demand provisioning. Synthetic users and a seeded verified
+domain were used, so this does not verify real DNS ownership, end-user SSO, or
+Microsoft gallery certification.
 
 ## Provider verification checklist
 

--- a/apps/sim/ee/scim/lib/application/users/deprovision-user.ts
+++ b/apps/sim/ee/scim/lib/application/users/deprovision-user.ts
@@ -30,10 +30,8 @@ export interface DeprovisionScimUserResult {
 /**
  * Removes a user from the organization at the directory's instruction.
  *
- * Okta never sends this — it deactivates instead — but Microsoft Entra does, 30
- * days after a hard delete, and OneLogin and JumpCloud can be configured to. The
- * Sim account itself survives: the person may hold access in another
- * organization later, and their audit history must remain attributable.
+ * The Sim account survives because the person may join another organization
+ * later and their audit history must remain attributable.
  *
  * Removal is the same primitive the settings UI uses. It ends the membership,
  * revokes sessions and personal keys, reassigns what the member owned, and


### PR DESCRIPTION
## Summary
- Clarify Entra soft deletion, permanent deletion, and scheduled lifecycle testing without resetting change tracking.
- Record live directory account disablement and reactivation checks; keep directory deletion and Premium group validation explicitly unverified.
- Remove inaccurate provider timing from the SCIM removal comment. Runtime behavior is unchanged.

## Type of Change
- [x] Documentation improvement

## Testing
59 focused SCIM tests passed. Lint, all 46 audits, generated-artifact checks, and the documentation production build passed. Verified the rendered guide and all three redacted screenshots in the browser. Live disablement and reactivation were checked against the provider logs and PostgreSQL state.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Existing focused tests passing; no behavioral change requires new tests
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
