### PR TITLE
fix(knowledge): backfill legacy KB workspace ownership

### DIFF
--- a/apps/sim/hooks/queries/kb/knowledge.ts
+++ b/apps/sim/hooks/queries/kb/knowledge.ts
@@ -44,6 +44,7 @@ import {
   searchWorkspaceKnowledgeContract,
   type TagDefinitionData,
   type TagUsageData,
+  type UpdateKnowledgeBaseBody,
   type UpdateKnowledgeDocumentResponseData,
   updateKnowledgeBaseContract,
   updateKnowledgeChunkContract,
@@ -671,13 +672,7 @@ export function useCreateKnowledgeBase() {
 
 interface UpdateKnowledgeBaseParams {
   knowledgeBaseId: string
-  updates: {
-    name?: string
-    description?: string
-    workspaceId?: string | null
-    /** Moves the knowledge base between folders; `null` moves it to the workspace root. */
-    folderId?: string | null
-  }
+  updates: UpdateKnowledgeBaseBody
 }
 
 async function updateKnowledgeBase({

--- a/apps/sim/lib/api/contracts/knowledge/base.test.ts
+++ b/apps/sim/lib/api/contracts/knowledge/base.test.ts
@@ -6,10 +6,33 @@ import {
   chunkingStrategyOptionsSchema,
   createKnowledgeBaseBodySchema,
   knowledgeBaseDataSchema,
+  updateKnowledgeBaseBodySchema,
 } from '@/lib/api/contracts/knowledge/base'
 import { MAX_CHUNKING_SEPARATOR_LENGTH, MAX_CHUNKING_SEPARATORS } from '@/lib/chunkers/constants'
 
 const separators = (count: number) => Array.from({ length: count }, (_, i) => `@@sep${i}@@`)
+
+describe('knowledge base workspace ownership', () => {
+  it.each([undefined, null, ''])('rejects creation with workspaceId %s', (workspaceId) => {
+    expect(createKnowledgeBaseBodySchema.safeParse({ name: 'Docs', workspaceId }).success).toBe(
+      false
+    )
+  })
+
+  it.each([null, ''])('rejects detaching with workspaceId %s', (workspaceId) => {
+    expect(updateKnowledgeBaseBodySchema.safeParse({ workspaceId }).success).toBe(false)
+  })
+
+  it('allows a workspace move and moving a KB to the folder root', () => {
+    expect(
+      updateKnowledgeBaseBodySchema.parse({ workspaceId: 'workspace-2', folderId: null })
+    ).toEqual({ workspaceId: 'workspace-2', folderId: null })
+  })
+
+  it('leaves workspace ownership untouched when omitted from an update', () => {
+    expect(updateKnowledgeBaseBodySchema.parse({ name: 'Renamed' })).toEqual({ name: 'Renamed' })
+  })
+})
 
 describe('chunkingStrategyOptionsSchema.separators', () => {
   it('accepts a separator list at the bound', () => {

--- a/apps/sim/lib/api/contracts/knowledge/base.ts
+++ b/apps/sim/lib/api/contracts/knowledge/base.ts
@@ -148,7 +148,7 @@ export const createKnowledgeBaseBodySchema = z.object({
       `Description must be ${KNOWLEDGE_BASE_DESCRIPTION_MAX_LENGTH} characters or less`
     )
     .optional(),
-  workspaceId: z.string().min(1, 'Workspace ID is required'),
+  workspaceId: workspaceIdSchema,
   /**
    * Folder the knowledge base is created in, from the `knowledge_base` folder tree.
    * `null` (or omitted) creates it at the workspace root.
@@ -170,8 +170,10 @@ export const updateKnowledgeBaseBodySchema = createKnowledgeBaseBodySchema
      * explicit `null` moves it back to the workspace root.
      */
     folderId: z.string().min(1, 'Folder ID cannot be empty').nullable().optional(),
-    workspaceId: z.string().nullable().optional(),
+    workspaceId: workspaceIdSchema.optional(),
   })
+
+export type UpdateKnowledgeBaseBody = z.input<typeof updateKnowledgeBaseBodySchema>
 
 const knowledgeChunkingConfigSchema = z
   .object({

--- a/apps/sim/lib/knowledge/__integration__/search-index-policy.integration.ts
+++ b/apps/sim/lib/knowledge/__integration__/search-index-policy.integration.ts
@@ -274,11 +274,12 @@ describe('canonical search knowledge-base policy', () => {
       })
     ).rejects.toThrow('Only workspace admins')
     await expect(
+      /** @ts-expect-error Exercise a caller bypassing the HTTP contract. */
       updateKnowledgeBase(ids.knowledgeBaseId, { workspaceId: null }, 'fixture-detach', {
         assertedWorkspaceId: ids.workspaceId,
         actorUserId: ids.bobId,
       })
-    ).rejects.toThrow('The search index must stay in its workspace')
+    ).rejects.toThrow('Workspace ID is required')
     await expectIndexActive()
   })
 

--- a/apps/sim/lib/knowledge/__integration__/workspace-lifecycle.integration.ts
+++ b/apps/sim/lib/knowledge/__integration__/workspace-lifecycle.integration.ts
@@ -1,0 +1,176 @@
+/** Real PostgreSQL coverage for workspace deletion and knowledge base ownership. */
+import { db } from '@sim/db'
+import {
+  document,
+  knowledgeBase,
+  knowledgeConnector,
+  organization,
+  user,
+  workspace,
+} from '@sim/db/schema'
+import { generateId } from '@sim/utils/id'
+import { eq, inArray } from 'drizzle-orm'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/mcp/pubsub', () => ({ mcpPubSub: null }))
+vi.mock('@/lib/mcp/service', () => ({
+  mcpService: { clearCache: vi.fn().mockResolvedValue(undefined) },
+}))
+vi.mock('@/lib/workflows/lifecycle', () => ({
+  archiveWorkflowsForWorkspace: vi.fn().mockResolvedValue(0),
+}))
+
+import {
+  createKnowledgeAclFixtureIds,
+  seedKnowledgeAclFixture,
+} from '@/lib/knowledge/__integration__/seed-source-access-fixture'
+import {
+  createAuthorizedKnowledgeBase,
+  restoreKnowledgeBase,
+  updateKnowledgeBase,
+} from '@/lib/knowledge/service'
+import { archiveWorkspace } from '@/lib/workspaces/lifecycle'
+
+describe('workspace knowledge lifecycle in PostgreSQL', () => {
+  const fixtures: ReturnType<typeof createKnowledgeAclFixtureIds>[] = []
+
+  async function seed() {
+    const ids = createKnowledgeAclFixtureIds()
+    fixtures.push(ids)
+    await seedKnowledgeAclFixture(ids)
+    const documentId = generateId()
+    await db.insert(document).values({
+      id: documentId,
+      knowledgeBaseId: ids.knowledgeBaseId,
+      filename: 'fixture.txt',
+      fileUrl: 'data:text/plain,fixture',
+      fileSize: 7,
+      mimeType: 'text/plain',
+      processingStatus: 'completed',
+    })
+    return { ...ids, documentId }
+  }
+
+  afterEach(async () => {
+    for (const ids of fixtures.splice(0)) {
+      await db.delete(workspace).where(eq(workspace.id, ids.workspaceId))
+      await db.delete(organization).where(eq(organization.id, ids.organizationId))
+      await db.delete(user).where(inArray(user.id, [ids.aliceId, ids.bobId]))
+    }
+  })
+
+  it.each([false, true])(
+    'deletes child KBs when workspace was already archived: %s',
+    async (alreadyArchived) => {
+      const ids = await seed()
+      const other = await seed()
+      const previousArchive = new Date('2025-01-01T00:00:00.000Z')
+      if (alreadyArchived) {
+        await db
+          .update(workspace)
+          .set({ archivedAt: previousArchive })
+          .where(eq(workspace.id, ids.workspaceId))
+      }
+
+      expect(
+        await archiveWorkspace(ids.workspaceId, { requestId: 'lifecycle-fixture' })
+      ).toMatchObject({
+        archived: !alreadyArchived,
+      })
+
+      const [ws] = await db.select().from(workspace).where(eq(workspace.id, ids.workspaceId))
+      const [kb] = await db
+        .select()
+        .from(knowledgeBase)
+        .where(eq(knowledgeBase.id, ids.knowledgeBaseId))
+      const [doc] = await db.select().from(document).where(eq(document.id, ids.documentId))
+      const [connector] = await db
+        .select()
+        .from(knowledgeConnector)
+        .where(eq(knowledgeConnector.id, ids.connectorId))
+      expect(ws.archivedAt).toBeInstanceOf(Date)
+      expect(kb).toMatchObject({ workspaceId: ids.workspaceId, deletedAt: ws.archivedAt })
+      expect(doc).toMatchObject({ archivedAt: ws.archivedAt, deletedAt: null })
+      expect(connector).toMatchObject({ archivedAt: ws.archivedAt, status: 'paused' })
+      if (alreadyArchived) expect(ws.archivedAt).toEqual(previousArchive)
+
+      await expect(
+        restoreKnowledgeBase(ids.knowledgeBaseId, 'lifecycle-fixture')
+      ).rejects.toMatchObject({
+        code: 'conflict',
+        message: 'Cannot restore knowledge base into an archived workspace',
+      })
+      await archiveWorkspace(ids.workspaceId, { requestId: 'lifecycle-retry' })
+      const [unchanged] = await db
+        .select()
+        .from(knowledgeBase)
+        .where(eq(knowledgeBase.id, ids.knowledgeBaseId))
+      expect(unchanged.deletedAt).toEqual(kb.deletedAt)
+      const [otherKb] = await db
+        .select()
+        .from(knowledgeBase)
+        .where(eq(knowledgeBase.id, other.knowledgeBaseId))
+      expect(otherKb.deletedAt).toBeNull()
+      const [otherDoc] = await db.select().from(document).where(eq(document.id, other.documentId))
+      expect(otherDoc.archivedAt).toBeNull()
+    }
+  )
+
+  it('hard deletion cascades to KBs, documents, and connectors', async () => {
+    const ids = await seed()
+    await db.delete(workspace).where(eq(workspace.id, ids.workspaceId))
+
+    expect(
+      await db
+        .select({ id: knowledgeBase.id })
+        .from(knowledgeBase)
+        .where(eq(knowledgeBase.id, ids.knowledgeBaseId))
+    ).toEqual([])
+    expect(
+      await db.select({ id: document.id }).from(document).where(eq(document.id, ids.documentId))
+    ).toEqual([])
+    expect(
+      await db
+        .select({ id: knowledgeConnector.id })
+        .from(knowledgeConnector)
+        .where(eq(knowledgeConnector.id, ids.connectorId))
+    ).toEqual([])
+  })
+
+  it('refuses owner detachment without changing the KB or its documents', async () => {
+    const ids = await seed()
+    await expect(
+      /** @ts-expect-error Exercise a caller bypassing the HTTP contract. */
+      updateKnowledgeBase(ids.knowledgeBaseId, { workspaceId: null }, 'lifecycle-fixture', {
+        actorUserId: ids.aliceId,
+      })
+    ).rejects.toMatchObject({ code: 'validation' })
+    const [kb] = await db
+      .select()
+      .from(knowledgeBase)
+      .where(eq(knowledgeBase.id, ids.knowledgeBaseId))
+    expect(kb).toMatchObject({ workspaceId: ids.workspaceId, deletedAt: null })
+    const [doc] = await db.select().from(document).where(eq(document.id, ids.documentId))
+    expect(doc.archivedAt).toBeNull()
+  })
+
+  it('requires an owner for creation while allowing organization-owned indexes', async () => {
+    const ids = await seed()
+    const data = {
+      name: 'Organization search',
+      userId: ids.aliceId,
+      embeddingModel: 'text-embedding-3-small',
+      embeddingDimension: 1536 as const,
+      chunkingConfig: { maxSize: 1024, minSize: 1, overlap: 20 },
+      isSearchIndex: true,
+    }
+    await expect(createAuthorizedKnowledgeBase(data, 'lifecycle-fixture')).rejects.toThrow(
+      'Resource requires exactly one workspace or organization owner'
+    )
+    const kb = await createAuthorizedKnowledgeBase(
+      { ...data, organizationId: ids.organizationId },
+      'lifecycle-fixture'
+    )
+    expect(kb).toMatchObject({ workspaceId: null, organizationId: ids.organizationId })
+  })
+})

--- a/apps/sim/lib/knowledge/application/knowledge-bases.test.ts
+++ b/apps/sim/lib/knowledge/application/knowledge-bases.test.ts
@@ -517,6 +517,51 @@ describe('knowledge base application use cases', () => {
     )
   })
 
+  it.each([null, ''])('rejects detaching a KB even for its owner: %s', async (workspaceId) => {
+    await expect(
+      updateInternalKnowledgeBase.execute({
+        principal: { kind: 'session', userId: knowledgeBase.userId, sessionId: 'session-1' },
+        /** @ts-expect-error Exercise a runtime caller bypassing the HTTP contract. */
+        input: { knowledgeBaseId: knowledgeBase.id, workspaceId },
+      })
+    ).rejects.toMatchObject({ code: 'validation', message: 'Workspace ID is required' })
+    expect(mocks.performUpdate).not.toHaveBeenCalled()
+    expect(mocks.resolveWorkspace).not.toHaveBeenCalled()
+    expect(mocks.recordAudit).not.toHaveBeenCalled()
+  })
+
+  it('allows a legacy KB owner to move it into an authorized workspace', async () => {
+    mocks.getRecord.mockResolvedValueOnce({ ...knowledgeBase, workspaceId: null })
+
+    await updateInternalKnowledgeBase.execute({
+      principal: { kind: 'session', userId: knowledgeBase.userId, sessionId: 'session-1' },
+      input: { knowledgeBaseId: knowledgeBase.id, workspaceId: 'workspace-1' },
+    })
+
+    expect(mocks.resolveWorkspace).toHaveBeenCalledWith({ workspaceId: 'workspace-1' })
+    expect(mocks.resolvePermission).toHaveBeenCalledTimes(1)
+    expect(mocks.performUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: null,
+        updates: expect.objectContaining({ workspaceId: 'workspace-1' }),
+      })
+    )
+  })
+
+  it('allows metadata edits on a legacy KB without detaching another KB', async () => {
+    mocks.getRecord.mockResolvedValueOnce({ ...knowledgeBase, workspaceId: null })
+
+    await updateInternalKnowledgeBase.execute({
+      principal: { kind: 'session', userId: knowledgeBase.userId, sessionId: 'session-1' },
+      input: { knowledgeBaseId: knowledgeBase.id, name: 'Renamed' },
+    })
+
+    expect(mocks.performUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ updates: expect.objectContaining({ workspaceId: undefined }) })
+    )
+    expect(mocks.resolveWorkspace).not.toHaveBeenCalled()
+  })
+
   it('rejects a destination workspace before an internal move mutation', async () => {
     mocks.resolveWorkspace.mockResolvedValueOnce({ ...context, workspaceId: 'workspace-2' })
     mocks.resolvePermission.mockResolvedValueOnce('write').mockResolvedValueOnce(null)

--- a/apps/sim/lib/knowledge/application/knowledge-bases.ts
+++ b/apps/sim/lib/knowledge/application/knowledge-bases.ts
@@ -200,7 +200,7 @@ export interface ReadInternalKnowledgeBaseInput {
 export interface UpdateInternalKnowledgeBaseInput extends ReadInternalKnowledgeBaseInput {
   name?: string
   description?: string
-  workspaceId?: string | null
+  workspaceId?: string
   folderId?: string | null
   chunkingConfig?: ChunkingConfig
 }
@@ -777,20 +777,15 @@ export const updateInternalKnowledgeBase = {
     const knowledgeBase = await loadInternalActiveKnowledgeBase(input.knowledgeBaseId)
     await authorizeInternalKnowledgeBase(principal, knowledgeBase, knowledgeOperations.update)
 
+    if (input.workspaceId !== undefined && !input.workspaceId) {
+      throw new OrchestrationError('validation', 'Workspace ID is required')
+    }
+
     if (input.workspaceId !== undefined && input.workspaceId !== knowledgeBase.workspaceId) {
-      if (input.workspaceId === null) {
-        if (knowledgeBase.userId !== principal.userId) {
-          throw new OrchestrationError(
-            'forbidden',
-            'Only the knowledge base owner can remove it from a workspace'
-          )
-        }
-      } else {
-        const destination = await resolveKnowledgeWorkspaceContext({
-          workspaceId: input.workspaceId,
-        })
-        await authorizeWorkspaceOperation(principal, knowledgeOperations.update, destination)
-      }
+      const destination = await resolveKnowledgeWorkspaceContext({
+        workspaceId: input.workspaceId,
+      })
+      await authorizeWorkspaceOperation(principal, knowledgeOperations.update, destination)
     }
 
     const outcome = await performUpdateKnowledgeBase({

--- a/apps/sim/lib/knowledge/orchestration/knowledge-bases.ts
+++ b/apps/sim/lib/knowledge/orchestration/knowledge-bases.ts
@@ -128,7 +128,7 @@ export interface PerformUpdateKnowledgeBaseParams extends KnowledgeOperationCont
     name?: string
     description?: string
     /** Moves the knowledge base between workspaces; omitted leaves it in place. */
-    workspaceId?: string | null
+    workspaceId?: string
     folderId?: string | null
     chunkingConfig?: ChunkingConfig
   }

--- a/apps/sim/lib/knowledge/service.test.ts
+++ b/apps/sim/lib/knowledge/service.test.ts
@@ -313,25 +313,25 @@ describe('updateKnowledgeBase — workspace transfer authorization', () => {
     expect(permissionsMockFns.mockGetUserEntityPermissions).not.toHaveBeenCalled()
   })
 
-  it('rejects clearing workspaceId to null when actor is not the KB owner', async () => {
-    dbChainMockFns.limit.mockResolvedValue([{ workspaceId: 'ws-current', userId: 'owner' }])
+  it.each(['owner', 'other-user'])(
+    'rejects detaching a KB for %s before any writes',
+    async (actorUserId) => {
+      await expect(
+        /** @ts-expect-error Exercise runtime callers that bypass the HTTP contract. */
+        updateKnowledgeBase('kb-1', { workspaceId: null }, 'req-1', { actorUserId })
+      ).rejects.toMatchObject({ code: 'validation', message: 'Workspace ID is required' })
+      expect(dbChainMockFns.transaction).not.toHaveBeenCalled()
+      expect(dbChainMockFns.update).not.toHaveBeenCalled()
+      expect(mockApplyStorageUsageDeltasInTx).not.toHaveBeenCalled()
+      expect(mockResolveStorageBillingContext).not.toHaveBeenCalled()
+    }
+  )
 
+  it('rejects an empty destination before any writes', async () => {
     await expect(
-      updateKnowledgeBase('kb-1', { workspaceId: null }, 'req-1', { actorUserId: 'attacker' })
-    ).rejects.toMatchObject({
-      code: 'forbidden',
-      message: 'Only the knowledge base owner can remove it from a workspace',
-    })
-    expect(permissionsMockFns.mockGetUserEntityPermissions).not.toHaveBeenCalled()
-  })
-
-  it('allows the KB owner to clear workspaceId to null (gate passes; target permission not checked)', async () => {
-    dbChainMockFns.limit.mockResolvedValue([{ workspaceId: 'ws-current', userId: 'owner' }])
-
-    await expect(
-      updateKnowledgeBase('kb-1', { workspaceId: null }, 'req-1', { actorUserId: 'owner' })
-    ).resolves.toBeDefined()
-    expect(permissionsMockFns.mockGetUserEntityPermissions).not.toHaveBeenCalled()
+      updateKnowledgeBase('kb-1', { workspaceId: '' }, 'req-1', { actorUserId: 'owner' })
+    ).rejects.toMatchObject({ code: 'validation', message: 'Workspace ID is required' })
+    expect(dbChainMockFns.transaction).not.toHaveBeenCalled()
   })
 
   it('rejects transfer when actor has no permission on target workspace', async () => {
@@ -464,30 +464,6 @@ describe('updateKnowledgeBase — file ownership binding re-point on workspace c
     })
   })
 
-  it('moves billable bytes from a workspace payer to the owner personal counter', async () => {
-    dbChainMockFns.limit
-      .mockResolvedValueOnce([{ workspaceId: 'ws-current', userId: 'owner' }])
-      .mockResolvedValueOnce([{ workspaceId: 'ws-current', userId: 'owner' }])
-      .mockResolvedValueOnce([{ bytes: 321 }])
-      .mockResolvedValueOnce([])
-
-    await runIgnoringReadBack(
-      updateKnowledgeBase('kb-1', { workspaceId: null }, 'req-1', { actorUserId: 'owner' })
-    )
-
-    expect(mockEnsureUserStatsExists).toHaveBeenCalledWith('owner')
-    expect(mockApplyStorageUsageDeltasInTx).toHaveBeenCalledWith(expect.anything(), {
-      workspaceDeltas: [
-        {
-          context: expect.objectContaining({ workspaceId: 'ws-current' }),
-          deltaBytes: -321,
-        },
-      ],
-      legacyDeltas: [{ userId: 'owner', subscription: null, deltaBytes: 321 }],
-    })
-    expect(mockMaybeNotifyStorageLimitForBillingContext).not.toHaveBeenCalled()
-  })
-
   it('moves billable bytes from the owner personal counter to a workspace payer', async () => {
     dbChainMockFns.limit
       .mockResolvedValueOnce([{ workspaceId: null, userId: 'owner' }])
@@ -516,17 +492,6 @@ describe('updateKnowledgeBase — file ownership binding re-point on workspace c
       expect.objectContaining({ workspaceId: 'ws-target' }),
       421
     )
-  })
-
-  it('clears file ownership bindings when the KB is removed from its workspace', async () => {
-    dbChainMockFns.limit.mockResolvedValue([{ workspaceId: 'ws-current', userId: 'owner' }])
-
-    await runIgnoringReadBack(
-      updateKnowledgeBase('kb-1', { workspaceId: null }, 'req-1', { actorUserId: 'owner' })
-    )
-
-    expect(dbChainMockFns.update).toHaveBeenCalledTimes(2)
-    expect(dbChainMockFns.set).toHaveBeenCalledWith({ workspaceId: null })
   })
 
   it('does not re-point bindings when promoting a personal (null-workspace) KB into a workspace', async () => {

--- a/apps/sim/lib/knowledge/service.ts
+++ b/apps/sim/lib/knowledge/service.ts
@@ -112,13 +112,6 @@ type KnowledgeBaseStorageMove =
       destinationContext: StorageBillingContext
     }
   | {
-      kind: 'workspace-to-personal'
-      sourceContext: StorageBillingContext
-      sourceWorkspaceId: string
-      ownerSubscription: HighestPrioritySubscription | null
-      ownerUserId: string
-    }
-  | {
       kind: 'personal-to-workspace'
       sourceWorkspaceId: null
       destinationContext: StorageBillingContext
@@ -548,13 +541,17 @@ export async function updateKnowledgeBase(
   updates: {
     name?: string
     description?: string
-    workspaceId?: string | null
+    workspaceId?: string
     folderId?: string | null
     chunkingConfig?: ChunkingConfig
   },
   requestId: string,
   options?: { actorUserId?: string; assertedWorkspaceId?: string }
 ): Promise<KnowledgeBaseWithCounts> {
+  if (updates.workspaceId !== undefined && !updates.workspaceId) {
+    throw new OrchestrationError('validation', 'Workspace ID is required')
+  }
+
   const now = new Date()
   const updateData: Partial<typeof knowledgeBase.$inferInsert> = {
     updatedAt: now,
@@ -597,7 +594,7 @@ export async function updateKnowledgeBase(
    * below already reads the current row, and re-roots from there.
    */
   if (updates.folderId !== undefined) {
-    let effectiveWorkspaceId = updates.workspaceId
+    let effectiveWorkspaceId: string | null | undefined = updates.workspaceId
     if (effectiveWorkspaceId === undefined) {
       const [snapshot] = await db
         .select({ workspaceId: knowledgeBase.workspaceId })
@@ -649,7 +646,7 @@ export async function updateKnowledgeBase(
       throw new KnowledgeBaseNotFoundError(knowledgeBaseId)
     }
     const sourceWorkspaceId = kbSnapshot.workspaceId ?? null
-    const destinationWorkspaceId = updates.workspaceId ?? null
+    const destinationWorkspaceId = updates.workspaceId
 
     /**
      * Folders never cross workspaces, so a workspace move would leave the row pointing at a
@@ -678,19 +675,6 @@ export async function updateKnowledgeBase(
         sourceWorkspaceId,
         sourceContext,
         destinationContext,
-      }
-    } else if (sourceWorkspaceId && !destinationWorkspaceId) {
-      const [sourceContext, ownerSubscription] = await Promise.all([
-        resolveStorageBillingContext(sourceWorkspaceId),
-        getHighestPrioritySubscription(kbSnapshot.userId),
-        ensureUserStatsExists(kbSnapshot.userId),
-      ])
-      storageMove = {
-        kind: 'workspace-to-personal',
-        sourceWorkspaceId,
-        sourceContext,
-        ownerUserId: kbSnapshot.userId,
-        ownerSubscription,
       }
     } else if (!sourceWorkspaceId && destinationWorkspaceId) {
       const [destinationContext, ownerSubscription] = await Promise.all([
@@ -762,25 +746,17 @@ export async function updateKnowledgeBase(
       }
 
       if (updates.workspaceId !== undefined) {
-        const actorUserId = options?.actorUserId as string
         const currentWorkspaceId = currentKb.workspaceId ?? null
-        const targetWorkspaceId = updates.workspaceId ?? null
+        const targetWorkspaceId = updates.workspaceId
 
-        if (targetWorkspaceId !== currentWorkspaceId) {
-          if (!targetWorkspaceId) {
-            if (actorUserId !== currentKb.userId) {
-              throw new KnowledgeBasePermissionError(
-                'Only the knowledge base owner can remove it from a workspace'
-              )
-            }
-          } else if (
-            targetWorkspacePermission !== 'write' &&
-            targetWorkspacePermission !== 'admin'
-          ) {
-            throw new KnowledgeBasePermissionError(
-              'User does not have permission on the target workspace'
-            )
-          }
+        if (
+          targetWorkspaceId !== currentWorkspaceId &&
+          targetWorkspacePermission !== 'write' &&
+          targetWorkspacePermission !== 'admin'
+        ) {
+          throw new KnowledgeBasePermissionError(
+            'User does not have permission on the target workspace'
+          )
         }
       }
 
@@ -839,17 +815,6 @@ export async function updateKnowledgeBase(
             ],
             legacyDeltas: [],
           })
-        } else if (storageMove.kind === 'workspace-to-personal') {
-          transferUpdatedUsage = await applyStorageUsageDeltasInTx(tx, {
-            workspaceDeltas: [{ context: storageMove.sourceContext, deltaBytes: -billableBytes }],
-            legacyDeltas: [
-              {
-                userId: storageMove.ownerUserId,
-                subscription: storageMove.ownerSubscription,
-                deltaBytes: billableBytes,
-              },
-            ],
-          })
         } else {
           transferUpdatedUsage = await applyStorageUsageDeltasInTx(tx, {
             workspaceDeltas: [
@@ -889,7 +854,7 @@ export async function updateKnowledgeBase(
       // move. A null current workspace owns no bindings, so nothing is moved.
       if (updates.workspaceId !== undefined) {
         const currentWorkspaceId = currentKb.workspaceId ?? null
-        const targetWorkspaceId = updates.workspaceId ?? null
+        const targetWorkspaceId = updates.workspaceId
 
         if (currentWorkspaceId && targetWorkspaceId !== currentWorkspaceId) {
           await tx

--- a/apps/sim/lib/workspaces/lifecycle.test.ts
+++ b/apps/sim/lib/workspaces/lifecycle.test.ts
@@ -23,7 +23,7 @@ vi.mock('@/lib/workflows/lifecycle', () => ({
 
 vi.mock('@/lib/workspaces/permissions/utils', () => permissionsMock)
 
-import { archiveWorkspace } from './lifecycle'
+import { archiveWorkspace } from '@/lib/workspaces/lifecycle'
 
 function createUpdateChain() {
   return {
@@ -81,7 +81,7 @@ describe('workspace lifecycle', () => {
     expect(tx.delete).toHaveBeenCalledTimes(1)
   })
 
-  it('is idempotent for already archived workspaces', async () => {
+  it('retries child cleanup for already archived workspaces', async () => {
     mockGetWorkspaceWithOwner.mockResolvedValue({
       id: 'workspace-1',
       name: 'Workspace 1',
@@ -98,6 +98,6 @@ describe('workspace lifecycle', () => {
     expect(mockArchiveWorkflowsForWorkspace).toHaveBeenCalledWith('workspace-1', {
       requestId: 'req-1',
     })
-    expect(dbChainMockFns.transaction).not.toHaveBeenCalled()
+    expect(dbChainMockFns.transaction).toHaveBeenCalledOnce()
   })
 })

--- a/apps/sim/lib/workspaces/lifecycle.ts
+++ b/apps/sim/lib/workspaces/lifecycle.ts
@@ -35,12 +35,8 @@ export async function archiveWorkspace(
     return { archived: false }
   }
 
-  if (workspaceRecord.archivedAt) {
-    await archiveWorkflowsForWorkspace(workspaceId, options)
-    return { archived: false, workspaceName: workspaceRecord.name }
-  }
-
-  const now = new Date()
+  /** Retrying deletion also archives children left active by an older or incomplete deletion. */
+  const now = workspaceRecord.archivedAt ?? new Date()
   const workflowMcpServerIds = await db
     .select({ id: workflowMcpServer.id })
     .from(workflowMcpServer)
@@ -169,7 +165,7 @@ export async function archiveWorkspace(
   }
 
   return {
-    archived: true,
+    archived: !workspaceRecord.archivedAt,
     workspaceName: workspaceRecord.name,
   }
 }

--- a/packages/db/script-migrations-paused-billing-attribution.test.ts
+++ b/packages/db/script-migrations-paused-billing-attribution.test.ts
@@ -449,6 +449,7 @@ describe('script migration registry', () => {
       '0010_backfill_credential_group_resource_policies',
       '0011_remap_legacy_knowledge_connector_credentials',
       '0012_reconcile_oauth_provider_lifecycle',
+      '0013_backfill_legacy_knowledge_base_workspaces',
     ])
   })
 })

--- a/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.postgres.test.ts
+++ b/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.postgres.test.ts
@@ -1,0 +1,326 @@
+import {
+  backfillLegacyKnowledgeBaseWorkspaces,
+  createPostgresLegacyKnowledgeBaseWorkspaceStore,
+  selectLegacyKnowledgeBaseWorkspace,
+} from '@sim/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces'
+import { generateId } from '@sim/utils/id'
+import postgres, { type Sql } from 'postgres'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+const databaseUrl = process.env.KNOWLEDGE_ACL_TEST_DATABASE_URL
+const tables = [
+  'knowledge_base',
+  'document',
+  'workspace',
+  'workspace_files',
+  'permissions',
+  'settings',
+  'workflow',
+  'workflow_blocks',
+  'user_stats',
+  'organization',
+  'member',
+  'subscription',
+] as const
+
+/** Copies current table definitions into an isolated disposable schema; no public rows are touched. */
+describe.runIf(Boolean(databaseUrl))('legacy KB workspace backfill in PostgreSQL', () => {
+  let sql: Sql
+  let admin: Sql
+  const schemaName = `kb_backfill_${generateId().replaceAll('-', '')}`
+  let subject: ReturnType<typeof createPostgresLegacyKnowledgeBaseWorkspaceStore>
+
+  beforeAll(async () => {
+    const url = new URL(databaseUrl!)
+    if (
+      !['localhost', '127.0.0.1'].includes(url.hostname) ||
+      !url.pathname.startsWith('/sim_acl_test')
+    ) {
+      throw new Error('Backfill tests require a disposable local sim_acl_test database')
+    }
+    admin = postgres(url.toString(), { max: 1, onnotice: () => undefined })
+    await admin.unsafe(`CREATE SCHEMA "${schemaName}"`)
+    for (const table of tables) {
+      await admin.unsafe(
+        `CREATE TABLE "${schemaName}"."${table}" (LIKE public."${table}" INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES)`
+      )
+    }
+    sql = postgres(url.toString(), {
+      max: 2,
+      connection: { search_path: schemaName },
+      onnotice: () => undefined,
+    })
+    subject = createPostgresLegacyKnowledgeBaseWorkspaceStore(sql)
+  })
+
+  afterAll(async () => {
+    await sql?.end()
+    if (admin) {
+      await admin.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+      await admin.end()
+    }
+  })
+
+  beforeEach(async () => {
+    await sql.unsafe(`TRUNCATE ${tables.map((table) => `"${table}"`).join(', ')}`)
+  })
+
+  async function workspace(
+    id: string,
+    payer = 'owner',
+    role: 'write' | 'admin' | 'read' = 'admin'
+  ) {
+    await sql`INSERT INTO workspace (id, name, owner_id, billed_account_user_id) VALUES (${id}, ${id}, ${payer}, ${payer})`
+    await sql`INSERT INTO permissions (id, user_id, entity_type, entity_id, permission_type)
+      VALUES (${generateId()}, 'owner', 'workspace', ${id}, ${role})`
+  }
+
+  async function kb(id = 'kb', name = 'Docs', workspaceId: string | null = null) {
+    await sql`INSERT INTO knowledge_base (id, user_id, name, workspace_id) VALUES (${id}, 'owner', ${name}, ${workspaceId})`
+  }
+
+  async function document(
+    kbId: string,
+    size: number,
+    options: { archived?: boolean; deleted?: boolean; connector?: boolean; key?: string } = {}
+  ) {
+    await sql`INSERT INTO document (id, knowledge_base_id, filename, file_url, file_size, mime_type, archived_at, deleted_at, connector_id, storage_key)
+      VALUES (${generateId()}, ${kbId}, 'fixture.txt', 'data:text/plain,fixture', ${size}, 'text/plain',
+        ${options.archived ? new Date() : null}, ${options.deleted ? new Date() : null},
+        ${options.connector ? 'fixture-connector' : null}, ${options.key ?? null})`
+  }
+
+  async function workflow(workspaceId: string, runs: number, kbId?: string, enabled = true) {
+    const id = generateId()
+    await sql`INSERT INTO workflow (id, user_id, workspace_id, name, last_synced, created_at, updated_at, run_count, last_run_at)
+      VALUES (${id}, 'collaborator', ${workspaceId}, ${id}, now(), now(), now(), ${runs}, now())`
+    if (kbId) {
+      await sql`INSERT INTO workflow_blocks (id, workflow_id, type, name, position_x, position_y, enabled, sub_blocks)
+        VALUES (${generateId()}, ${id}, 'knowledge', 'Knowledge', 0, 0, ${enabled},
+          ${sql.json({ knowledgeBaseSelector: { value: kbId } })})`
+    }
+    return id
+  }
+
+  async function scopedKb(id = 'kb') {
+    const [row] = await sql`SELECT workspace_id, name FROM knowledge_base WHERE id = ${id}`
+    return row
+  }
+
+  async function userBytes(id: string) {
+    const [row] = await sql`SELECT storage_used_bytes FROM user_stats WHERE user_id = ${id}`
+    return Number(row?.storage_used_bytes ?? 0)
+  }
+
+  it('prefers a KB reference over unrelated runs and falls back to all authors’ workflow runs', async () => {
+    await workspace('referenced')
+    await workspace('busy')
+    await kb()
+    await kb('unreferenced', 'Unreferenced')
+    await workflow('referenced', 2, 'kb')
+    await workflow('busy', 1000)
+    expect(await selectLegacyKnowledgeBaseWorkspace(sql, 'kb')).toEqual({
+      workspace_id: 'referenced',
+      has_reference: true,
+    })
+    expect(await subject.moveCandidate('kb')).toBe('moved')
+    expect(await subject.moveCandidate('unreferenced')).toBe('moved')
+    expect((await scopedKb()).workspace_id).toBe('referenced')
+    expect((await scopedKb('unreferenced')).workspace_id).toBe('busy')
+  })
+
+  it('ignores disabled blocks, archived workflows, archived workspaces, and read-only memberships', async () => {
+    await workspace('valid')
+    await workspace('archived')
+    await workspace('read-only', 'owner', 'read')
+    await sql`UPDATE workspace SET archived_at = now() WHERE id = 'archived'`
+    await kb()
+    await workflow('read-only', 1000, 'kb')
+    await workflow('archived', 1000, 'kb')
+    const oldWorkflow = await workflow('valid', 1000, 'kb')
+    await sql`UPDATE workflow SET archived_at = now() WHERE id = ${oldWorkflow}`
+    await workflow('valid', 1, 'kb', false)
+    expect(await selectLegacyKnowledgeBaseWorkspace(sql, 'kb')).toEqual({
+      workspace_id: 'valid',
+      has_reference: false,
+    })
+  })
+
+  it('uses only the active selector and recognizes legacy array selections', async () => {
+    await workspace('target')
+    await kb()
+    const workflowId = await workflow('target', 1, 'kb')
+    await sql`UPDATE workflow_blocks SET sub_blocks = ${sql.json({
+      knowledgeBaseSelector: { value: 'other-kb' },
+      manualKnowledgeBaseId: { value: 'kb' },
+    })} WHERE workflow_id = ${workflowId}`
+    expect((await selectLegacyKnowledgeBaseWorkspace(sql, 'kb'))?.has_reference).toBe(false)
+    await sql`UPDATE workflow_blocks SET advanced_mode = true WHERE workflow_id = ${workflowId}`
+    expect((await selectLegacyKnowledgeBaseWorkspace(sql, 'kb'))?.has_reference).toBe(true)
+    await sql`UPDATE workflow_blocks SET advanced_mode = false,
+      sub_blocks = ${sql.json({ knowledgeBaseSelector: { value: ['kb', 'other-kb'] } })}
+      WHERE workflow_id = ${workflowId}`
+    expect((await selectLegacyKnowledgeBaseWorkspace(sql, 'kb'))?.has_reference).toBe(true)
+  })
+
+  it('uses recency before last selection when successful run counts tie', async () => {
+    await workspace('older')
+    await workspace('recent')
+    await kb()
+    const olderId = await workflow('older', 5)
+    await workflow('recent', 5)
+    await sql`UPDATE workflow SET last_run_at = '2025-01-01' WHERE id = ${olderId}`
+    expect((await selectLegacyKnowledgeBaseWorkspace(sql, 'kb'))?.workspace_id).toBe('recent')
+  })
+
+  it('skips owners without a writable workspace and never treats ownership as permission', async () => {
+    await workspace('owned')
+    await sql`DELETE FROM permissions`
+    await kb()
+    expect(await subject.moveCandidate('kb')).toBe('no_workspace')
+    expect((await scopedKb()).workspace_id).toBeNull()
+  })
+
+  it('allocates unique suffixes for existing names and multiple incoming names, including a taken suffix', async () => {
+    await workspace('target')
+    await kb('existing', 'Docs', 'target')
+    await kb('suffix', 'Docs (recovered kb)', 'target')
+    await kb()
+    await kb('kb2')
+    expect(await subject.moveCandidate('kb')).toBe('renamed')
+    expect(await subject.moveCandidate('kb2')).toBe('renamed')
+    expect((await scopedKb()).name).toBe('Docs (recovered kb-2)')
+    expect((await scopedKb('kb2')).name).toBe('Docs (recovered kb2)')
+    expect(await subject.moveCandidate('kb')).toBe('already_scoped')
+  })
+
+  it('keeps foreign file bindings untouched and skips the KB', async () => {
+    await workspace('target')
+    await kb()
+    await document('kb', 50, { key: 'foreign-key' })
+    await sql`INSERT INTO workspace_files (id, key, user_id, workspace_id, context, original_name, content_type, size_bytes)
+      VALUES ('file', 'foreign-key', 'other', 'other-workspace', 'knowledge-base', 'file.txt', 'text/plain', 50)`
+    expect(await subject.moveCandidate('kb')).toBe('file_conflict')
+    expect((await scopedKb()).workspace_id).toBeNull()
+    expect(
+      (await sql`SELECT workspace_id FROM workspace_files WHERE id = 'file'`)[0].workspace_id
+    ).toBe('other-workspace')
+  })
+
+  it('reconciles stale payer counters and retains remaining legacy and archived document bytes', async () => {
+    await workspace('destination', 'payer')
+    await workspace('source-workspace')
+    await sql`UPDATE workspace SET storage_used_bytes = 70 WHERE id = 'source-workspace'`
+    await kb()
+    await kb('remaining', 'Remaining')
+    await document('kb', 100)
+    await document('kb', 30, { archived: true })
+    await document('kb', 900, { deleted: true })
+    await document('kb', 900, { connector: true })
+    await document('remaining', 20)
+    await workflow('destination', 2, 'kb')
+    await sql`INSERT INTO user_stats (id, user_id, storage_used_bytes) VALUES ('stats', 'owner', 70)`
+    expect(await subject.moveCandidate('kb')).toBe('moved')
+    expect(await userBytes('owner')).toBe(90)
+    expect(await userBytes('payer')).toBe(130)
+    expect(
+      Number(
+        (await sql`SELECT storage_used_bytes FROM workspace WHERE id = 'destination'`)[0]
+          .storage_used_bytes
+      )
+    ).toBe(130)
+    expect(await subject.moveCandidate('kb')).toBe('already_scoped')
+    expect(await userBytes('payer')).toBe(130)
+  })
+
+  it('moves organization-billed legacy bytes without losing organization-owned documents', async () => {
+    await workspace('destination', 'payer')
+    await sql`INSERT INTO organization (id, name, slug) VALUES ('org', 'Org', 'org')`
+    await sql`INSERT INTO member (id, user_id, organization_id, role) VALUES ('member', 'owner', 'org', 'member')`
+    await sql`INSERT INTO subscription (id, reference_id, plan, status) VALUES ('sub', 'org', 'team_6000', 'active')`
+    await kb()
+    await kb('remaining', 'Remaining')
+    await kb('org-kb', 'Org docs')
+    await sql`UPDATE knowledge_base SET organization_id = 'org', is_search_index = true WHERE id = 'org-kb'`
+    await document('kb', 100)
+    await document('remaining', 20)
+    await document('org-kb', 30)
+    expect(await subject.moveCandidate('kb')).toBe('moved')
+    expect(await userBytes('payer')).toBe(100)
+    expect(
+      Number(
+        (await sql`SELECT storage_used_bytes FROM organization WHERE id = 'org'`)[0]
+          .storage_used_bytes
+      )
+    ).toBe(50)
+    expect(await subject.moveCandidate('org-kb')).toBe('already_scoped')
+  })
+
+  it('reconciles a destination organization without double-counting moved bytes', async () => {
+    await workspace('destination')
+    await sql`INSERT INTO organization (id, name, slug) VALUES ('org', 'Org', 'org')`
+    await sql`UPDATE workspace SET organization_id = 'org' WHERE id = 'destination'`
+    await kb()
+    await document('kb', 100)
+    expect(await subject.moveCandidate('kb')).toBe('moved')
+    expect(await userBytes('owner')).toBe(0)
+    expect(
+      Number(
+        (await sql`SELECT storage_used_bytes FROM organization WHERE id = 'org'`)[0]
+          .storage_used_bytes
+      )
+    ).toBe(100)
+  })
+
+  it('serializes concurrent moves with the same payer and colliding names', async () => {
+    await workspace('destination')
+    await kb('a')
+    await kb('b')
+    await document('a', 100)
+    await document('b', 200)
+    const outcomes = await Promise.all([subject.moveCandidate('a'), subject.moveCandidate('b')])
+    expect(outcomes.sort()).toEqual(['moved', 'renamed'])
+    const rows = await sql`SELECT name, workspace_id FROM knowledge_base ORDER BY id`
+    expect(new Set(rows.map((row) => row.name)).size).toBe(2)
+    expect(rows.every((row) => row.workspace_id === 'destination')).toBe(true)
+    expect(await userBytes('owner')).toBe(300)
+  })
+
+  it('rolls back scope, names, and accounting together on failure and resumes safely', async () => {
+    await workspace('destination')
+    await kb()
+    await document('kb', 100)
+    await sql`ALTER TABLE workspace ADD CONSTRAINT fixture_storage_limit CHECK (storage_used_bytes < 50)`
+    try {
+      await expect(subject.moveCandidate('kb')).rejects.toThrow()
+      expect((await scopedKb()).workspace_id).toBeNull()
+      expect(await userBytes('owner')).toBe(0)
+    } finally {
+      await sql`ALTER TABLE workspace DROP CONSTRAINT fixture_storage_limit`
+    }
+    expect(await subject.moveCandidate('kb')).toBe('moved')
+    expect(await userBytes('owner')).toBe(100)
+  })
+
+  it('pages past skipped rows and never moves deleted, already scoped, or organization-owned KBs', async () => {
+    await workspace('destination')
+    await kb('a-skip')
+    await sql`UPDATE knowledge_base SET user_id = 'no-access' WHERE id = 'a-skip'`
+    await kb('b-move')
+    await kb('c-deleted')
+    await sql`UPDATE knowledge_base SET deleted_at = now() WHERE id = 'c-deleted'`
+    await kb('d-scoped', 'Scoped', 'destination')
+    await kb('e-org', 'Org')
+    await sql`UPDATE knowledge_base SET organization_id = 'org' WHERE id = 'e-org'`
+    expect(await backfillLegacyKnowledgeBaseWorkspaces(subject, { batchSize: 1 })).toMatchObject({
+      moved: 1,
+      no_workspace: 1,
+    })
+    expect((await scopedKb('c-deleted')).workspace_id).toBeNull()
+    expect((await scopedKb('e-org')).workspace_id).toBeNull()
+    expect(await backfillLegacyKnowledgeBaseWorkspaces(subject)).toMatchObject({
+      moved: 0,
+      no_workspace: 1,
+    })
+  })
+})

--- a/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.postgres.test.ts
+++ b/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.postgres.test.ts
@@ -1,8 +1,10 @@
 import {
   backfillLegacyKnowledgeBaseWorkspaces,
   createPostgresLegacyKnowledgeBaseWorkspaceStore,
+  type LegacyKnowledgeBaseMoveOutcome,
   selectLegacyKnowledgeBaseWorkspace,
 } from '@sim/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces'
+import { sleep } from '@sim/utils/helpers'
 import { generateId } from '@sim/utils/id'
 import postgres, { type Sql } from 'postgres'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -285,6 +287,71 @@ describe.runIf(Boolean(databaseUrl))('legacy KB workspace backfill in PostgreSQL
     expect(rows.every((row) => row.workspace_id === 'destination')).toBe(true)
     expect(await userBytes('owner')).toBe(300)
   })
+
+  it('waits for an application-held workspace lock instead of aborting the migration', async () => {
+    await workspace('destination')
+    await kb()
+    await document('kb', 100)
+    let markWriterReady!: (pid: number) => void
+    const writerReady = new Promise<number>((resolve) => {
+      markWriterReady = resolve
+    })
+    let releaseWriter!: () => void
+    const writerReleased = new Promise<void>((resolve) => {
+      releaseWriter = resolve
+    })
+    const writer = sql.begin(async (tx) => {
+      await tx`SELECT id FROM workspace WHERE id = 'destination' FOR NO KEY UPDATE`
+      const [connection] = await tx<{ pid: number }[]>`SELECT pg_backend_pid() AS pid`
+      markWriterReady(connection.pid)
+      await writerReleased
+    })
+    let move: Promise<LegacyKnowledgeBaseMoveOutcome> | undefined
+    try {
+      const writerPid = await Promise.race([
+        writerReady,
+        writer.then(() => {
+          throw new Error('Workspace writer finished before the concurrency check')
+        }),
+      ])
+      let settled = false
+      move = subject.moveCandidate('kb')
+      void move.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+      let waiting = false
+      const deadline = Date.now() + 2_000
+      while (!settled && Date.now() < deadline) {
+        const [waiter] = await admin<{ waiting: boolean }[]>`
+          SELECT EXISTS (SELECT 1 FROM pg_stat_activity
+            WHERE ${writerPid} = ANY(pg_blocking_pids(pid)) AND wait_event_type = 'Lock') AS waiting
+        `
+        if (waiter.waiting) {
+          waiting = true
+          break
+        }
+        await sleep(1)
+      }
+      expect(waiting, 'The migration must wait for the workspace writer').toBe(true)
+      /** Real lock contention must outlast the former five-second timeout. */
+      await sleep(5_100)
+      expect(settled).toBe(false)
+      releaseWriter()
+      await writer
+      expect(await move).toBe('moved')
+      expect((await scopedKb()).workspace_id).toBe('destination')
+      expect(await userBytes('owner')).toBe(100)
+    } finally {
+      releaseWriter()
+      await writer
+      await move?.catch(() => undefined)
+    }
+  }, 15_000)
 
   it('rolls back scope, names, and accounting together on failure and resumes safely', async () => {
     await workspace('destination')

--- a/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.test.ts
+++ b/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.test.ts
@@ -1,0 +1,73 @@
+import {
+  backfillLegacyKnowledgeBaseWorkspaces,
+  type LegacyKnowledgeBaseWorkspaceStore,
+} from '@sim/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces'
+import { describe, expect, it, vi } from 'vitest'
+
+function store(pages: string[][]): LegacyKnowledgeBaseWorkspaceStore {
+  return {
+    listCandidateIds: vi.fn(async () => pages.shift() ?? []),
+    moveCandidate: vi.fn(async () => 'moved' as const),
+  }
+}
+
+describe('legacy KB workspace backfill paging', () => {
+  it('commits sequentially, advances past skipped rows, and keeps only one page', async () => {
+    const subject = store([['a', 'b'], ['c'], []])
+    vi.mocked(subject.moveCandidate)
+      .mockResolvedValueOnce('no_workspace')
+      .mockResolvedValueOnce('renamed')
+    expect(await backfillLegacyKnowledgeBaseWorkspaces(subject, { batchSize: 2 })).toMatchObject({
+      moved: 1,
+      renamed: 1,
+      no_workspace: 1,
+    })
+    expect(subject.listCandidateIds).toHaveBeenNthCalledWith(2, 'b', 2)
+    expect(subject.listCandidateIds).toHaveBeenNthCalledWith(3, 'c', 2)
+    expect(vi.mocked(subject.moveCandidate).mock.calls).toEqual([['a'], ['b'], ['c']])
+  })
+
+  it('treats database cursor ordering as opaque', async () => {
+    expect(await backfillLegacyKnowledgeBaseWorkspaces(store([['z'], ['A'], []]))).toMatchObject({
+      moved: 2,
+    })
+  })
+
+  it('rejects oversized, repeated, or duplicate pages', async () => {
+    await expect(
+      backfillLegacyKnowledgeBaseWorkspaces(store([['a', 'b']]), { batchSize: 1 })
+    ).rejects.toThrow('oversized')
+    await expect(backfillLegacyKnowledgeBaseWorkspaces(store([['a'], ['a']]))).rejects.toThrow(
+      'non-advancing'
+    )
+    await expect(backfillLegacyKnowledgeBaseWorkspaces(store([['a', 'a']]))).rejects.toThrow(
+      'non-advancing'
+    )
+  })
+
+  it('bounds total work and allows a retry to resume after committed moves', async () => {
+    const subject = store([['a'], ['b']])
+    await expect(
+      backfillLegacyKnowledgeBaseWorkspaces(subject, { batchSize: 1, maxBatches: 1 })
+    ).rejects.toThrow('rerun to resume')
+    expect(subject.moveCandidate).toHaveBeenCalledTimes(1)
+    expect(await backfillLegacyKnowledgeBaseWorkspaces(store([['b'], []]))).toMatchObject({
+      moved: 1,
+    })
+  })
+
+  it.each([0, -1, 251, 1.5])('rejects invalid batch size %s', async (batchSize) => {
+    await expect(backfillLegacyKnowledgeBaseWorkspaces(store([]), { batchSize })).rejects.toThrow(
+      'batch size'
+    )
+  })
+
+  it('propagates database failures without proceeding to the next KB', async () => {
+    const subject = store([['a', 'b']])
+    vi.mocked(subject.moveCandidate).mockRejectedValueOnce(new Error('database unavailable'))
+    await expect(backfillLegacyKnowledgeBaseWorkspaces(subject)).rejects.toThrow(
+      'database unavailable'
+    )
+    expect(subject.moveCandidate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.ts
+++ b/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.ts
@@ -1,0 +1,322 @@
+import type { ScriptMigration } from '@sim/db/script-migrations/types'
+import { createLogger } from '@sim/logger'
+import { getPostgresErrorCode } from '@sim/utils/errors'
+import { generateId } from '@sim/utils/id'
+import type { Fragment, Sql, TransactionSql } from 'postgres'
+
+const logger = createLogger('LegacyKnowledgeBaseWorkspaces')
+export const LEGACY_KB_WORKSPACE_BATCH_SIZE = 100
+const MAX_BATCH_SIZE = 250
+const MAX_BATCHES = 10_000
+const MAX_NAME_ATTEMPTS = 8
+
+type MigrationSql = Sql | TransactionSql
+export type LegacyKnowledgeBaseMoveOutcome =
+  | 'moved'
+  | 'renamed'
+  | 'already_scoped'
+  | 'no_workspace'
+  | 'file_conflict'
+
+export interface LegacyKnowledgeBaseWorkspaceStore {
+  listCandidateIds(afterId: string, limit: number): Promise<string[]>
+  moveCandidate(id: string): Promise<LegacyKnowledgeBaseMoveOutcome>
+}
+
+interface BackfillOptions {
+  batchSize?: number
+  maxBatches?: number
+}
+
+export type LegacyKnowledgeBaseWorkspaceSummary = Record<LegacyKnowledgeBaseMoveOutcome, number>
+
+/** Pages only ids; each KB, its name, and its storage accounting commit atomically. */
+export async function backfillLegacyKnowledgeBaseWorkspaces(
+  store: LegacyKnowledgeBaseWorkspaceStore,
+  options: BackfillOptions = {}
+): Promise<LegacyKnowledgeBaseWorkspaceSummary> {
+  const batchSize = options.batchSize ?? LEGACY_KB_WORKSPACE_BATCH_SIZE
+  const maxBatches = options.maxBatches ?? MAX_BATCHES
+  if (!Number.isInteger(batchSize) || batchSize < 1 || batchSize > MAX_BATCH_SIZE) {
+    throw new Error(`KB workspace backfill batch size must be between 1 and ${MAX_BATCH_SIZE}`)
+  }
+  if (!Number.isInteger(maxBatches) || maxBatches < 1 || maxBatches > MAX_BATCHES) {
+    throw new Error(`KB workspace backfill batch limit must be between 1 and ${MAX_BATCHES}`)
+  }
+  const result: LegacyKnowledgeBaseWorkspaceSummary = {
+    moved: 0,
+    renamed: 0,
+    already_scoped: 0,
+    no_workspace: 0,
+    file_conflict: 0,
+  }
+  let afterId = ''
+  for (let batch = 0; batch <= maxBatches; batch++) {
+    const ids = await store.listCandidateIds(afterId, batchSize)
+    if (ids.length === 0) return result
+    if (batch === maxBatches)
+      throw new Error('KB workspace backfill batch limit reached; rerun to resume')
+    if (ids.length > batchSize) throw new Error('KB workspace backfill returned an oversized page')
+    const lastId = ids.at(-1)
+    if (!lastId || lastId === afterId || new Set(ids).size !== ids.length) {
+      throw new Error('KB workspace backfill returned a non-advancing page')
+    }
+    for (const id of ids) result[await store.moveCandidate(id)]++
+    afterId = lastId
+  }
+  return result
+}
+
+/**
+ * Frozen migration equivalent of getHighestPrioritySubscription: entitled Enterprise > Team >
+ * Pro, organization before personal at the same tier. No application imports are available in
+ * the migrations image. The final id order makes multiple equivalent subscriptions deterministic.
+ */
+function legacyPayerId(sql: MigrationSql, userId: string | Fragment): Fragment {
+  return sql`coalesce((
+    SELECT s.reference_id FROM subscription s
+    WHERE s.status IN ('active', 'past_due')
+      AND (s.plan = 'enterprise' OR s.plan ~ '^(team|pro)(_|$)')
+      AND (s.reference_id = ${userId} OR EXISTS (
+        SELECT 1 FROM member m JOIN organization o ON o.id = m.organization_id
+        WHERE m.user_id = ${userId} AND o.id = s.reference_id
+      ))
+    ORDER BY CASE WHEN s.plan = 'enterprise' THEN 3 WHEN s.plan ~ '^team(_|$)' THEN 2 ELSE 1 END DESC,
+      (s.reference_id <> ${userId}) DESC, s.reference_id, s.id
+    LIMIT 1
+  ), ${userId})`
+}
+
+/**
+ * Read-only destination selection. Prefer enabled Knowledge blocks naming this KB; rank those
+ * workspaces by the referring workflows' successful runs. Otherwise use successful runs across
+ * all active workflows in the workspace, then recency, last selection, and stable creation/id order.
+ * The creator must still hold explicit write/admin access; ownership alone never grants admission.
+ */
+export async function selectLegacyKnowledgeBaseWorkspace(
+  sql: MigrationSql,
+  knowledgeBaseId: string
+) {
+  const [destination] = await sql<Array<{ workspace_id: string; has_reference: boolean }>>`
+    WITH kb AS MATERIALIZED (
+      SELECT id, user_id FROM knowledge_base
+      WHERE id = ${knowledgeBaseId} AND workspace_id IS NULL AND organization_id IS NULL
+        AND deleted_at IS NULL AND NOT is_search_index
+    ), candidates AS MATERIALIZED (
+      SELECT w.id, w.created_at, s.last_active_workspace_id = w.id AS last_selected
+      FROM kb
+      JOIN permissions p ON p.user_id = kb.user_id AND p.entity_type = 'workspace'
+        AND p.permission_type IN ('write', 'admin')
+      JOIN workspace w ON w.id = p.entity_id AND w.archived_at IS NULL
+      LEFT JOIN settings s ON s.user_id = kb.user_id
+    ), activity AS (
+      SELECT c.*, a.total_runs, a.last_run_at, a.referring_runs, a.referring_last_run_at, a.has_reference
+      FROM candidates c CROSS JOIN kb
+      CROSS JOIN LATERAL (
+        SELECT coalesce(sum(f.run_count), 0) AS total_runs, max(f.last_run_at) AS last_run_at,
+          coalesce(sum(f.run_count) FILTER (WHERE r.found), 0) AS referring_runs,
+          max(f.last_run_at) FILTER (WHERE r.found) AS referring_last_run_at,
+          coalesce(bool_or(r.found), false) AS has_reference
+        FROM workflow f
+        CROSS JOIN LATERAL (
+          SELECT EXISTS (
+            SELECT 1 FROM workflow_blocks b
+            CROSS JOIN LATERAL (
+              SELECT coalesce(nullif(CASE WHEN b.advanced_mode
+                THEN b.sub_blocks #> '{manualKnowledgeBaseId,value}'
+                ELSE b.sub_blocks #> '{knowledgeBaseSelector,value}' END, 'null'::jsonb),
+                b.sub_blocks #> '{knowledgeBaseId,value}') AS value
+            ) v
+            WHERE b.workflow_id = f.id AND b.type = 'knowledge' AND b.enabled
+              AND (v.value = to_jsonb(kb.id) OR v.value @> jsonb_build_array(kb.id))
+          ) AS found
+        ) r
+        WHERE f.workspace_id = c.id AND f.archived_at IS NULL
+      ) a
+    )
+    SELECT id AS workspace_id, has_reference FROM activity
+    ORDER BY has_reference DESC, referring_runs DESC, referring_last_run_at DESC NULLS LAST,
+      total_runs DESC, last_run_at DESC NULLS LAST, last_selected DESC NULLS LAST, created_at, id
+    LIMIT 1
+  `
+  return destination ?? null
+}
+
+/**
+ * Rebuild only the affected payer from workspace ledgers plus retained unscoped/organization KB
+ * documents. Legacy counters can already omit orphan bytes, so subtracting those bytes blindly
+ * would undercount unrelated storage. Archived but retained documents remain billable.
+ */
+async function reconcilePayer(tx: TransactionSql, kind: 'user' | 'organization', id: string) {
+  if (kind === 'user') {
+    await tx`
+      UPDATE user_stats SET storage_used_bytes =
+        coalesce((SELECT sum(storage_used_bytes) FROM workspace
+          WHERE organization_id IS NULL AND billed_account_user_id = ${id}), 0)
+        + coalesce((SELECT sum(d.file_size::bigint) FROM knowledge_base k
+          JOIN document d ON d.knowledge_base_id = k.id
+          WHERE k.user_id = ${id} AND k.workspace_id IS NULL AND k.organization_id IS NULL
+            AND d.connector_id IS NULL AND d.deleted_at IS NULL
+            AND ${legacyPayerId(tx, id)} = ${id}), 0)
+      WHERE user_id = ${id}
+    `
+  } else {
+    await tx`
+      UPDATE organization SET storage_used_bytes =
+        coalesce((SELECT sum(storage_used_bytes) FROM workspace WHERE organization_id = ${id}), 0)
+        + coalesce((SELECT sum(d.file_size::bigint) FROM knowledge_base k
+          JOIN document d ON d.knowledge_base_id = k.id
+          WHERE k.organization_id = ${id} AND d.connector_id IS NULL AND d.deleted_at IS NULL), 0)
+        + coalesce((SELECT sum(d.file_size::bigint) FROM knowledge_base k
+          JOIN document d ON d.knowledge_base_id = k.id
+          WHERE k.workspace_id IS NULL AND k.organization_id IS NULL
+            AND d.connector_id IS NULL AND d.deleted_at IS NULL
+            AND EXISTS (SELECT 1 FROM member m WHERE m.user_id = k.user_id AND m.organization_id = ${id})
+            AND ${legacyPayerId(tx, tx`k.user_id`)} = ${id}), 0)
+      WHERE id = ${id}
+    `
+  }
+}
+
+/** Uses the same KB → workspace → user payer → organization payer lock order as live moves. */
+async function moveKnowledgeBase(
+  tx: TransactionSql,
+  knowledgeBaseId: string
+): Promise<LegacyKnowledgeBaseMoveOutcome> {
+  await tx.unsafe("SET LOCAL lock_timeout = '5s'")
+  await tx.unsafe("SET LOCAL statement_timeout = '30s'")
+  const [kb] = await tx<Array<{ user_id: string }>>`
+    SELECT user_id FROM knowledge_base
+    WHERE id = ${knowledgeBaseId} AND workspace_id IS NULL AND organization_id IS NULL
+      AND deleted_at IS NULL AND NOT is_search_index
+    FOR UPDATE
+  `
+  if (!kb) return 'already_scoped'
+  const destination = await selectLegacyKnowledgeBaseWorkspace(tx, knowledgeBaseId)
+  if (!destination) return 'no_workspace'
+  const [target] = await tx<
+    Array<{ id: string; organization_id: string | null; billed_account_user_id: string }>
+  >`
+    SELECT w.id, w.organization_id, w.billed_account_user_id FROM workspace w
+    WHERE w.id = ${destination.workspace_id} AND w.archived_at IS NULL
+      AND EXISTS (SELECT 1 FROM permissions p WHERE p.user_id = ${kb.user_id}
+        AND p.entity_type = 'workspace' AND p.entity_id = w.id AND p.permission_type IN ('write', 'admin'))
+    FOR NO KEY UPDATE
+  `
+  if (!target) return 'no_workspace'
+  const [conflict] = await tx<Array<{ found: boolean }>>`
+    SELECT EXISTS (
+      SELECT 1 FROM document d JOIN workspace_files f ON f.key = d.storage_key
+      WHERE d.knowledge_base_id = ${knowledgeBaseId} AND f.deleted_at IS NULL
+        AND (f.context <> 'knowledge-base' OR f.workspace_id IS DISTINCT FROM ${target.id})
+    ) AS found
+  `
+  if (conflict?.found) return 'file_conflict'
+
+  const [source] = await tx<Array<{ id: string }>>`SELECT ${legacyPayerId(tx, kb.user_id)} AS id`
+  const sourceKind = source.id === kb.user_id ? 'user' : 'organization'
+  const targetKind = target.organization_id ? 'organization' : 'user'
+  const targetPayerId = target.organization_id ?? target.billed_account_user_id
+  const users = [
+    ...new Set([
+      ...(sourceKind === 'user' ? [source.id] : []),
+      ...(targetKind === 'user' ? [targetPayerId] : []),
+    ]),
+  ].sort()
+  const organizations = [
+    ...new Set([
+      ...(sourceKind === 'organization' ? [source.id] : []),
+      ...(targetKind === 'organization' ? [targetPayerId] : []),
+    ]),
+  ].sort()
+  for (const id of users) {
+    await tx`INSERT INTO user_stats (id, user_id) VALUES (${generateId()}, ${id}) ON CONFLICT (user_id) DO NOTHING`
+    await tx`SELECT user_id FROM user_stats WHERE user_id = ${id} FOR NO KEY UPDATE`
+  }
+  for (const id of organizations)
+    await tx`SELECT id FROM organization WHERE id = ${id} FOR NO KEY UPDATE`
+
+  const [invalid] = await tx<Array<{ found: boolean }>>`
+    SELECT EXISTS (
+      SELECT 1 FROM document d JOIN knowledge_base k ON k.id = d.knowledge_base_id
+      WHERE (k.id = ${knowledgeBaseId} OR k.workspace_id = ${target.id})
+        AND d.connector_id IS NULL AND d.deleted_at IS NULL AND (d.file_size IS NULL OR d.file_size < 0)
+      UNION ALL
+      SELECT 1 FROM workspace_files f WHERE f.workspace_id = ${target.id}
+        AND f.context = 'workspace' AND (f.size_bytes IS NULL OR f.size_bytes < 0)
+    ) AS found
+  `
+  if (invalid?.found) throw new Error('KB workspace backfill found invalid canonical storage sizes')
+
+  const [moved] = await tx<Array<{ renamed: boolean }>>`
+    WITH candidate_names AS (
+      SELECT k.name AS old_name, n.attempt,
+        CASE WHEN n.attempt = 0 THEN k.name
+          ELSE k.name || ' (recovered ' || k.id || CASE WHEN n.attempt = 1 THEN '' ELSE '-' || n.attempt::text END || ')'
+        END AS name
+      FROM knowledge_base k CROSS JOIN generate_series(0, ${MAX_NAME_ATTEMPTS}) n(attempt)
+      WHERE k.id = ${knowledgeBaseId}
+    ), chosen AS (
+      SELECT name, old_name FROM candidate_names c
+      WHERE NOT EXISTS (SELECT 1 FROM knowledge_base existing
+        WHERE existing.workspace_id = ${target.id} AND existing.name = c.name AND existing.deleted_at IS NULL)
+      ORDER BY attempt LIMIT 1
+    )
+    UPDATE knowledge_base k SET workspace_id = ${target.id}, folder_id = NULL, name = chosen.name, updated_at = now()
+    FROM chosen WHERE k.id = ${knowledgeBaseId} AND k.workspace_id IS NULL AND k.organization_id IS NULL
+      AND k.deleted_at IS NULL AND NOT k.is_search_index
+    RETURNING k.name <> chosen.old_name AS renamed
+  `
+  if (!moved) throw new Error('KB workspace backfill could not allocate a unique name')
+  await tx`
+    UPDATE workspace SET storage_used_bytes =
+      coalesce((SELECT sum(size_bytes) FROM workspace_files WHERE workspace_id = ${target.id} AND context = 'workspace'), 0)
+      + coalesce((SELECT sum(d.file_size::bigint) FROM document d JOIN knowledge_base k ON k.id = d.knowledge_base_id
+        WHERE k.workspace_id = ${target.id} AND d.connector_id IS NULL AND d.deleted_at IS NULL), 0)
+    WHERE id = ${target.id}
+  `
+  for (const id of users) await reconcilePayer(tx, 'user', id)
+  for (const id of organizations) await reconcilePayer(tx, 'organization', id)
+  return moved.renamed ? 'renamed' : 'moved'
+}
+
+export function createPostgresLegacyKnowledgeBaseWorkspaceStore(
+  sql: Sql
+): LegacyKnowledgeBaseWorkspaceStore {
+  return {
+    async listCandidateIds(afterId, limit) {
+      const rows = await sql<Array<{ id: string }>>`
+        SELECT id FROM knowledge_base WHERE id > ${afterId}
+          AND workspace_id IS NULL AND organization_id IS NULL AND deleted_at IS NULL AND NOT is_search_index
+        ORDER BY id LIMIT ${limit}
+      `
+      return rows.map((row) => row.id)
+    },
+    async moveCandidate(id) {
+      for (let attempt = 0; ; attempt++) {
+        try {
+          return await sql.begin((tx) => moveKnowledgeBase(tx, id))
+        } catch (error) {
+          if (getPostgresErrorCode(error) !== '23505' || attempt >= MAX_NAME_ATTEMPTS - 1)
+            throw error
+        }
+      }
+    },
+  }
+}
+
+export const backfillLegacyKnowledgeBaseWorkspacesMigration: ScriptMigration = {
+  name: '0013_backfill_legacy_knowledge_base_workspaces',
+  async up(sql) {
+    const result = await backfillLegacyKnowledgeBaseWorkspaces(
+      createPostgresLegacyKnowledgeBaseWorkspaceStore(sql)
+    )
+    logger.info('Legacy KB workspace backfill completed', result)
+    if (result.no_workspace || result.file_conflict) {
+      logger.warn(
+        'Some legacy KBs remain unassigned because their destination could not be established safely',
+        result
+      )
+    }
+  },
+}

--- a/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.ts
+++ b/packages/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces.ts
@@ -183,8 +183,6 @@ async function moveKnowledgeBase(
   tx: TransactionSql,
   knowledgeBaseId: string
 ): Promise<LegacyKnowledgeBaseMoveOutcome> {
-  await tx.unsafe("SET LOCAL lock_timeout = '5s'")
-  await tx.unsafe("SET LOCAL statement_timeout = '30s'")
   const [kb] = await tx<Array<{ user_id: string }>>`
     SELECT user_id FROM knowledge_base
     WHERE id = ${knowledgeBaseId} AND workspace_id IS NULL AND organization_id IS NULL

--- a/packages/db/script-migrations/index.ts
+++ b/packages/db/script-migrations/index.ts
@@ -1,4 +1,5 @@
 import { reconcileOAuthProviderLifecycleMigration } from '@sim/db/script-migrations/0012_reconcile_oauth_provider_lifecycle'
+import { backfillLegacyKnowledgeBaseWorkspacesMigration } from '@sim/db/script-migrations/0013_backfill_legacy_knowledge_base_workspaces'
 import type { Sql } from 'postgres'
 import { backfillTableOrderKeys } from './0001_backfill_table_order_keys'
 import { backfillPausedBillingAttribution } from './0002_backfill_paused_billing_attribution'
@@ -33,6 +34,7 @@ export const scriptMigrations: readonly ScriptMigration[] = [
   backfillCredentialGroupResourcePolicies,
   remapLegacyKnowledgeConnectorCredentialsMigration,
   reconcileOAuthProviderLifecycleMigration,
+  backfillLegacyKnowledgeBaseWorkspacesMigration,
 ]
 
 /**


### PR DESCRIPTION
## Summary

- Reject null or empty workspace updates so knowledge bases cannot be detached from their workspace. Preserve organization-owned search indexes.
- Register a resumable script migration for legacy unscoped KBs. Prefer workspaces whose enabled Knowledge blocks reference the KB, then workflow run counts and recency. Require creator write/admin access, suffix conflicting names, and reconcile affected storage accounting atomically.
- Preserve soft deletion when deleting a workspace: mark KBs deleted, archive documents, and pause connectors. Repeated deletion also cleans up children left active by an earlier deletion.

The migration leaves KBs without a writable destination or with conflicting file bindings unchanged and reports the skipped counts. It runs through the existing migration runner; no production migration was executed for this PR.

## Type of Change

- [x] Bug fix

## Testing

- 118 focused unit tests and 28 PostgreSQL integration tests passed, covering destination selection, name collisions, accounting, concurrent moves, rollback/resume, lock contention, and workspace deletion.
- App, database, and auth type checks passed.
- Repository lint, audit suite, block registry, and generated-artifact checks passed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
