### PR TITLE
docs(library): update best-ai-automation-tools-2026

### DIFF
--- a/apps/sim/content/library/best-ai-automation-tools-2026/index.mdx
+++ b/apps/sim/content/library/best-ai-automation-tools-2026/index.mdx
@@ -68,7 +68,7 @@ The comparison uses publicly described product capabilities and plan terms. Pric
 
 **Best for:** Technical buyers who want to control their agent infrastructure and build through natural-language instructions, a visual canvas, or code.
 
-[Sim](https://www.sim.ai/) supports [natural-language, visual, and programmatic building](https://docs.sim.ai/introduction) in one workspace. [Mothership](https://docs.sim.ai/mothership/tasks) can create and operate workflows, Tables, Files, knowledge bases, and recurring jobs through plain-language instructions. You can inspect and edit the same logic on a block-based canvas, then trigger or embed workflows through the API and SDK.
+[Sim](https://www.sim.ai/) supports [natural-language, visual, and programmatic building](https://docs.sim.ai/introduction) in one workspace. [Mothership](https://docs.sim.ai/chat/tasks) can create and operate workflows, Tables, Files, knowledge bases, and recurring jobs through plain-language instructions. You can inspect and edit the same logic on a block-based canvas, then trigger or embed workflows through the API and SDK.
 
 Sim releases its core under the [Apache 2.0 license](https://github.com/simstudioai/sim), which permits commercial use, modification, and distribution under its terms. You can use the managed cloud or [self-host through Docker or Kubernetes](https://docs.sim.ai/platform/self-hosting). The open-source core gives you control over deployment and modification, while the [Enterprise plan](https://www.sim.ai/pricing) adds governed self-hosting and organizational controls.
 
@@ -113,7 +113,9 @@ n8n works best when predictable workflows form the core requirement. Its [AI Age
 - Non-technical users may find n8n harder to operate than managed no-code products.
 - n8n uses a source-available [fair-code license](https://docs.n8n.io/privacy-and-security/sustainable-use-license). Sim uses Apache 2.0, which gives you broader rights to modify, redistribute, and build commercial products from the code.
 
-**Pricing:** n8n offers a [Community Edition without a software license fee](https://docs.n8n.io/deploy/host-n8n/community-edition-features) for self-hosting. [Cloud plans charge according to monthly workflow executions](https://n8n.io/pricing/), and enterprise pricing adds governance and support. Self-hosted deployments still carry infrastructure and maintenance costs. Read our guide to [n8n alternatives](https://www.sim.ai/library/n8n-alternatives) for a deeper comparison.
+### Pricing
+
+n8n offers a [Community Edition without a software license fee](https://docs.n8n.io/deploy/host-n8n/community-edition-features) for self-hosting. [Cloud plans charge according to monthly workflow executions](https://n8n.io/pricing/), and enterprise pricing adds governance and support. Self-hosted deployments still carry infrastructure and maintenance costs. Read our guide to [n8n alternatives](https://www.sim.ai/library/n8n-alternatives) for a deeper comparison.
 
 ## Zapier
 
@@ -123,19 +125,21 @@ Zapier supports app-to-app automation through an [extensive connector catalog](h
 
 Zapier provides a hosted automation builder based on [triggers and actions](https://help.zapier.com/hc/en-us/articles/8496288188429-Set-up-your-Zap-trigger). [Zapier Agents](https://zapier.com/agents) adds AI-driven task execution, but the agent product sits alongside Zapier's established workflow engine rather than serving as its foundation.
 
-**Pros**
+### Pros
 
 - Zapier's [extensive connector catalog](https://zapier.com/apps) supports a wide range of SaaS workflows.
 - The [hosted service](https://zapier.com/) handles deployment, maintenance, and infrastructure.
 - The familiar [no-code interface](https://zapier.com/how-it-works) works well for users without programming experience.
 
-**Cons**
+### Cons
 
 - [Task-based billing](https://zapier.com/pricing) can become costly when high-volume workflows contain several billable actions.
 - Complex branching and data transformations can feel constrained compared with more technical builders.
 - [Zapier Agents](https://zapier.com/agents) provides less control over agent infrastructure than an open-source, self-hostable platform.
 
-**Pricing:** Zapier [offers a free plan and paid tiers](https://zapier.com/pricing) based largely on task volume, features, and user access. Costs rise as workflows execute more billable actions, so buyers should estimate tasks per run before choosing a tier. Compare more options in our guide to the [best Zapier alternatives](https://www.sim.ai/library/best-zapier-alternatives).
+### Pricing
+
+Zapier [offers a free plan and paid tiers](https://zapier.com/pricing) based largely on task volume, features, and user access. Costs rise as workflows execute more billable actions, so buyers should estimate tasks per run before choosing a tier. Compare more options in our guide to the [best Zapier alternatives](https://www.sim.ai/library/best-zapier-alternatives).
 
 ## Make
 
@@ -145,20 +149,20 @@ Make's main strength is its mature scenario builder. [Routers split a workflow i
 
 Make also offers [AI Agents](https://www.make.com/en/ai-agents), but its scenario builder remains the primary focus in this comparison. Buyers seeking deep autonomous agent behavior may prefer an agent-native platform.
 
-**Pros**
+### Pros
 
 - The [visual canvas](https://www.make.com/en/product) shows each module, route, filter, and data mapping.
 - [Routers and iterators](https://help.make.com/router) support complex SaaS workflows.
 - The [managed service](https://www.make.com/en) removes infrastructure maintenance.
 
-**Cons**
+### Cons
 
 - Large scenarios can become difficult to scan and troubleshoot.
 - [Usage-based billing](https://www.make.com/en/pricing) can grow as scenarios process more steps.
 - Make's [product offering](https://www.make.com/en/product) does not include self-hosting or open-source deployment.
 - Buyers focused on agents should compare [Make's AI Agent controls](https://www.make.com/en/ai-agents) and deployment options with agent-native platforms.
 
-**Pricing**
+### Pricing
 
 Make [offers a free tier and paid plans based on usage credits](https://www.make.com/en/pricing), feature access, and execution capacity. Its pricing works well for predictable scenarios, but workflows with many modules can consume credits quickly.
 
@@ -170,19 +174,21 @@ Gumloop combines a [managed automation canvas](https://www.gumloop.com/) with re
 
 Gumloop partially overlaps with Sim because both support visual AI workflows. Gumloop is positioned for buyers who want a managed no-code service, while Sim is the better fit when self-hosting, Apache 2.0 licensing, or multiple builder modes matter.
 
-**Pros**
+### Pros
 
 - The [managed canvas](https://www.gumloop.com/) removes server maintenance and deployment work.
 - [Go-to-market templates](https://www.gumloop.com/templates) shorten setup for common research and enrichment workflows.
 - [Hosted MCP support](https://www.gumloop.com/mcp) reduces the work required to connect compatible services.
 
-**Cons**
+### Cons
 
 - Gumloop's [product offering](https://www.gumloop.com/) does not provide the same open-source ownership or self-hosting options as Sim.
 - [Credit-based usage](https://www.gumloop.com/pricing) can make costs harder to forecast when workflows process uneven volumes.
 - Technical builders have less infrastructure control than they get with open-source platforms.
 
-**Pricing:** Gumloop uses [managed subscription plans with usage credits](https://www.gumloop.com/pricing). Your cost depends on plan limits and workflow consumption, so estimate expected run volume before choosing a tier.
+### Pricing
+
+Gumloop uses [managed subscription plans with usage credits](https://www.gumloop.com/pricing). Your cost depends on plan limits and workflow consumption, so estimate expected run volume before choosing a tier.
 
 ## How the top picks compare
 

--- a/apps/sim/content/library/best-ai-automation-tools-2026/index.mdx
+++ b/apps/sim/content/library/best-ai-automation-tools-2026/index.mdx
@@ -3,7 +3,7 @@ slug: best-ai-automation-tools-2026
 title: 'Best AI Automation Tools in 2026'
 description: 'Compare the best AI automation tools in 2026, including Sim, n8n, Zapier, Make, and Gumloop, across agent depth, hosting, integrations, and pricing.'
 date: 2026-08-01
-updated: 2026-08-01
+updated: 2026-09-08
 authors:
   - andrew
 readingTime: 10
@@ -13,64 +13,50 @@ canonical: https://www.sim.ai/library/best-ai-automation-tools-2026
 draft: false
 faq:
   - q: "What is the difference between AI automation and AI agent platforms?"
-    a: "AI automation follows predefined workflows, while AI agent platforms let models reason, choose tools, and act within defined controls. Sim combines deterministic workflow logic with agent reasoning in one visual graph."
+    a: "AI automation tools run predefined workflows and may include model-powered steps. AI agent platforms let models reason, select tools, and act within defined controls. Sim combines deterministic workflow logic with agent reasoning in one visual graph."
   - q: "Is there a free or open-source option?"
-    a: "Yes. Sim offers both a free cloud plan and an Apache 2.0 open-source core. You can test the managed product or inspect, modify, and run the core software on your own infrastructure."
+    a: "Open-source tools let you inspect, modify, and host their core software. Sim offers a $0 Free plan and an Apache 2.0 core. You can test the cloud product or run the software on your own infrastructure."
   - q: "Which tool is cheapest at scale?"
-    a: "The answer depends on workload shape. Compare execution volume, model costs, seats, infrastructure, and maintenance instead of relying only on an entry-level subscription price."
+    a: "No product is consistently cheapest across every usage pattern because vendors charge by different units. Sim cloud plans use credits, while self-hosting Sim shifts spending toward infrastructure and model providers. Compare the cost of seats, executions or tasks, model usage, and infrastructure at your expected volume."
+  - q: "Can these tools be self-hosted?"
+    a: "Self-hosting runs automation software on infrastructure you control. Sim and n8n support self-hosting, while Zapier, Make, and Gumloop primarily provide managed cloud products. Self-hosting gives you more control over deployment, but you must manage infrastructure, maintenance, and related costs."
   - q: "How should I choose a tool for my first project?"
-    a: "Test your preferred tool with a small production-shaped pilot that includes realistic data, failure handling, volume, and governance requirements."
-  - q: "What is the best open-source Zapier alternative?"
-    a: "Sim is a strong open-source Zapier alternative for teams that want agent-native workflows, self-hosting, and a permissive Apache 2.0 license."
-  - q: "What is the difference between Sim and Gumloop?"
-    a: "Sim prioritizes infrastructure ownership and multiple builder modes, while Gumloop prioritizes a managed no-code AI experience."
+    a: "Your first tool should match the workflow's complexity and your preferred builder. Choose Zapier or Gumloop for managed simplicity, Make for visual branching, n8n for technical automation, or Sim for agent-native workflows and infrastructure ownership. Test the leading option with a limited pilot that uses realistic data, integrations, and execution volume."
 ---
-
-*Last updated: August 2026*
 
 ## TL;DR
 
 The top AI automation tools in 2026 are Sim, n8n, Zapier, Make, and Gumloop.
 
 - **Sim** offers [Apache 2.0 licensing and self-hosting](https://github.com/simstudioai/sim) for technical buyers who want to own their agent infrastructure.
-- **n8n** provides a [visual, code-extensible execution engine](https://docs.n8n.io/code/) for technical buyers running high-volume, deterministic workflows.
-- **Zapier** offers a [large app catalog](https://zapier.com/apps) for buyers who want simple SaaS automation without managing infrastructure.
-- **Make** provides a [visual scenario canvas](https://www.make.com/en/product) for buyers building complex workflows with branching logic.
-- **Gumloop** offers a [managed visual builder](https://www.gumloop.com/) for non-technical operations and go-to-market buyers.
+- **n8n** provides a [visual, code-extensible execution engine](https://docs.n8n.io/build/code-in-n8n/using-the-code-node) for technical buyers running high-volume, deterministic workflows.
+- **Zapier** offers an [extensive app catalog](https://zapier.com/apps) for buyers who want simple SaaS automation without managing infrastructure.
+- **Make** provides a [mature visual canvas](https://www.make.com/en/product) for buyers building complex workflows with branching logic.
+- **Gumloop** offers a [managed builder](https://www.gumloop.com/) for non-technical operations and go-to-market buyers.
 
-[Start building with Sim](https://sim.ai) if you want an open-source platform that supports natural language, visual workflows, and code. For a more agent-focused comparison, read our guide to the [best AI agent builders in 2026](https://www.sim.ai/library/best-ai-agent-builder-2026).
-
-## Quick answer
-
-- **Best overall AI automation tool:** Sim
-- **Best for high-volume deterministic automation:** n8n
-- **Best AI automation tool for app catalog breadth:** Zapier
-- **Best AI automation tool for visual branching:** Make
-- **Best managed no-code AI automation tool:** Gumloop
+Consider [building with Sim](https://sim.ai) if you want an open-source platform that supports natural-language instructions, visual workflows, and code. You can also compare the [best AI agent builders in 2026](https://www.sim.ai/library/best-ai-agent-builder-2026).
 
 ## What counts as an AI automation tool in 2026
 
 AI automation tools connect triggers, business software, data, and AI models to complete work with limited manual input. The category includes deterministic workflow platforms that follow predefined rules and agent-native platforms that let models interpret context, choose actions, and use tools within defined controls.
 
-Platforms with AI bolted onto automation usually treat a model as one step inside a conventional workflow. For example, a model might summarize an email before fixed rules route it. Agent-native platforms make model reasoning part of the workflow structure, often alongside knowledge retrieval, tool selection, memory, and human approval. Our guide to [AI agent orchestration frameworks](https://www.sim.ai/library/ai-agent-orchestration-frameworks-explained) explains how those parts work together.
+Platforms with AI bolted onto automation usually treat a model as one step inside a conventional workflow. For example, a model might summarize an email before fixed rules route it. Agent-native platforms make model reasoning part of the workflow structure, often alongside knowledge retrieval, tool selection, memory, and human approval.
 
-A general-purpose roundup must evaluate both approaches because buyers often begin without a single job in mind. Sales and support automations may use the same underlying platform, but their templates reveal little about hosting, model choice, deployment options, or builder flexibility. Those platform-level traits determine whether a tool can support several use cases as your needs change.
+A general-purpose comparison should evaluate both approaches because one platform may need to support several kinds of automation. Templates for sales or support reveal little about hosting, model choice, deployment options, or builder flexibility. Those product capabilities indicate whether you can adapt the platform to additional use cases. Our guide to [AI agent orchestration frameworks](https://www.sim.ai/library/ai-agent-orchestration-frameworks-explained) explains how these components work together.
 
-## Why trust this ranking
+## How we ranked the tools
 
-We rank each tool by buyer-relevant capability rather than market visibility or marketing polish. The ranking weighs how each product lets you build and whether agent reasoning shapes its core or appears as an added feature.
+We rank each tool by six product characteristics: builder model, agent depth, deployment surfaces, model flexibility, hosting and license terms, and pricing model. We give greater weight to agent capabilities and infrastructure control because this roundup focuses on AI automation rather than conventional app-to-app workflows.
 
-We also compare deployment options and model choice. Hosting and license terms reveal how much infrastructure you can control, while pricing models show how costs may scale. The comparison table applies these criteria consistently across every product.
-
-**Author and methodology:** Andrew Caslow at Sim evaluated these platforms hands-on and reviewed vendor documentation for product capabilities, integrations, licensing, deployment, and pricing. Facts and prices were rechecked in August 2026.
+The comparison uses publicly described product capabilities and plan terms. Pricing can change, so confirm current limits and usage rules with each vendor before buying.
 
 ## What to look for in an AI automation tool
 
-**Builder model.** The builder model determines whether you create workflows through natural language, a visual canvas, code, or a combination. Choose an approach that matches how you build and maintain automation.
+**Builder model.** A tool may let you create workflows through natural-language instructions, a visual canvas, code, or a combination. Choose an approach that matches how you build and maintain automation.
 
 **Agent depth.** Agent-native platforms give models control over reasoning, tool selection, context, and multi-step decisions. Conventional automation platforms usually add AI as one step within a predefined flow.
 
-**Deployment surfaces.** Deployment options determine whether a workflow can run on schedules and events or serve as an API, chat interface, or tool for another AI system.
+**Deployment surfaces.** Check whether you can run a workflow on a schedule or event and publish it as an API, chat interface, or tool for another AI system.
 
 **Model flexibility.** Model options affect provider choice, cost, and data control. Check whether the tool supports multiple providers, your own API keys, and local models.
 
@@ -80,165 +66,149 @@ We also compare deployment options and model choice. Hosting and license terms r
 
 ## Sim
 
-### Best for
+**Best for:** Technical buyers who want to control their agent infrastructure and build through natural-language instructions, a visual canvas, or code.
 
-Technical teams and builders who want to own their agent infrastructure and use multiple build modes.
+[Sim](https://www.sim.ai/) supports [natural-language, visual, and programmatic building](https://docs.sim.ai/introduction) in one workspace. [Mothership](https://docs.sim.ai/mothership/tasks) can create and operate workflows, Tables, Files, knowledge bases, and recurring jobs through plain-language instructions. You can inspect and edit the same logic on a block-based canvas, then trigger or embed workflows through the API and SDK.
 
-[Sim](https://www.sim.ai/) supports natural-language, visual, and programmatic building in one workspace. [Mothership](https://docs.sim.ai/mothership) can create and operate workflows, Tables, Files, knowledge bases, and recurring jobs through plain-language instructions. You can inspect and edit the same logic on a block-based canvas, then trigger or embed workflows through APIs and SDKs.
+Sim releases its core under the [Apache 2.0 license](https://github.com/simstudioai/sim), which permits commercial use, modification, and distribution under its terms. You can use the managed cloud or [self-host through Docker or Kubernetes](https://docs.sim.ai/platform/self-hosting). The open-source core gives you control over deployment and modification, while the [Enterprise plan](https://www.sim.ai/pricing) adds governed self-hosting and organizational controls.
 
-Sim releases its core under the permissive [Apache 2.0 license](https://github.com/simstudioai/sim/blob/main/LICENSE). You can use the managed cloud or follow the repository's self-hosting options. The open-source core gives you control over deployment and modification, while the [Enterprise plan](https://www.sim.ai/pricing) adds organizational controls and support.
-
-Sim combines the resources needed to maintain production agents within one workspace. Tables store structured records, Files hold working context, and knowledge bases retrieve relevant document content during execution. Workflows can connect to [Sim's integration catalog](https://www.sim.ai/integrations), use [models from multiple providers](https://www.sim.ai/models), and expose execution logs for inspecting runs.
+Sim keeps agent data, retrieved documents, and execution records in the same workspace as workflow logic. Tables store structured records, Files hold working context, and knowledge bases retrieve relevant document content during execution. Workflows can use Sim's integration and model catalogs. [Block-level logs record inputs, outputs, errors, latency, token use, and cost](https://docs.sim.ai/logs-debugging/logging).
 
 ### Pros
 
-- Three build modes let you describe workflows to Mothership, edit them visually, or work through APIs and SDKs.
-- Apache 2.0 licensing permits inspection, modification, and self-hosting without fair-code commercial restrictions.
-- Workflows can deploy as APIs, hosted chat experiences, or MCP tools.
-- Hosted models, eligible provider keys, and local model connections provide flexibility over model infrastructure.
+- [Three build modes](https://docs.sim.ai/introduction) let you describe workflows to Mothership, edit them visually, or work through APIs and SDKs.
+- [Apache 2.0 licensing](https://github.com/simstudioai/sim) permits inspection, modification, and self-hosting without fair-code commercial restrictions.
+- You can [deploy workflows as REST APIs, hosted chat experiences, or MCP tools](https://docs.sim.ai/workflows/deployment).
+- You can use hosted models, supported provider API keys, or [local model connections](https://docs.sim.ai/platform/self-hosting/troubleshooting).
 - Native Tables, Files, knowledge bases, and execution logs reduce the need for separate storage, retrieval, and monitoring products.
 
 ### Cons
 
 - Technical users will get more value than buyers seeking simple, prebuilt app-to-app recipes.
-- Credit-based billing requires you to account for workflow runs, model use, and tool use.
-- Advanced governance and dedicated support require an Enterprise plan.
+- [Credit-based billing](https://docs.sim.ai/platform/costs) requires you to account for workflow runs, model use, and tool use.
+- [Access control, SSO, SOC 2 compliance, governed self-hosting, and dedicated support](https://www.sim.ai/pricing) require an Enterprise plan.
 
 ### Pricing
 
-Sim offers a Free plan, paid individual plans, and custom Enterprise pricing. Usage follows a credit model, and eligible providers support bring-your-own-key billing. See the current [Sim pricing plans](https://www.sim.ai/pricing) for prices, included credits, and plan limits.
+Sim offers [Free at $0, Pro at $25 per user per month, Max at $100 per user per month, and custom Enterprise pricing](https://www.sim.ai/pricing). Usage follows a credit model, and eligible providers support bring-your-own-key billing. See the current [Sim pricing plans](https://www.sim.ai/pricing) for included credits and plan limits.
 
 ## n8n
 
-### Best for
+**Best for:** Technical buyers running deterministic automations that need code extensibility, self-hosting, and an established node ecosystem.
 
-Technical teams running high-volume deterministic automations that need code extensibility, self-hosting, and a mature node ecosystem.
+n8n's main strength is its technical depth. You can combine visual workflows with [JavaScript or Python](https://docs.n8n.io/build/code-in-n8n/using-the-code-node), build [custom nodes](https://docs.n8n.io/integrations/community-nodes/building-community-nodes), and control execution infrastructure. When you [self-host n8n](https://docs.n8n.io/deploy/host-n8n), you can keep workflow logic and credentials in infrastructure you control.
 
-n8n's main strength is its technical depth. You can combine visual workflows with [JavaScript or Python](https://docs.n8n.io/code/code-node/), build [custom nodes](https://docs.n8n.io/integrations/creating-nodes/), and control execution infrastructure through [self-hosting](https://docs.n8n.io/hosting/). Its [live integrations directory](https://n8n.io/integrations/) provides a broad connector ecosystem. A technical team can use n8n to process multi-step jobs while keeping application logic and credentials inside its own environment.
-
-n8n works best when predictable workflows form the core requirement. Its [AI workflow documentation](https://docs.n8n.io/advanced-ai/) covers models, tools, and agent patterns, while the node-based execution engine remains the platform's foundation.
+n8n works best when predictable workflows form the core requirement. Its [AI Agent node supports models and tools](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent), but the deterministic execution engine remains the platform's foundation.
 
 ### Pros
 
-- [Self-hosting](https://docs.n8n.io/hosting/) gives you direct control over data, credentials, scaling, and runtime configuration.
-- [Code nodes and custom nodes](https://docs.n8n.io/code/) support logic that prebuilt connectors cannot cover.
-- [Execution-based cloud pricing](https://n8n.io/pricing/) can suit complex workflows because plans meter workflow executions rather than every individual step.
-- The [n8n integrations directory](https://n8n.io/integrations/) offers connectors and templates across a mature ecosystem.
+- [Self-hosting](https://docs.n8n.io/deploy/host-n8n) gives you direct control over data, credentials, scaling, and runtime configuration.
+- [Code nodes](https://docs.n8n.io/build/code-in-n8n/using-the-code-node) and custom nodes support logic that prebuilt connectors cannot cover.
+- [Execution-based pricing](https://n8n.io/pricing/) can suit complex workflows because each full workflow run counts as one execution rather than charging for every step.
+- A [mature node ecosystem](https://n8n.io/integrations/) covers a broad range of databases, APIs, and business applications.
 
 ### Cons
 
 - Self-hosting requires you to manage deployment, upgrades, security, and capacity.
 - Non-technical users may find n8n harder to operate than managed no-code products.
-- n8n uses the source-available [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license/), a fair-code license rather than an OSI-approved open-source license. Sim uses Apache 2.0, which gives you broader rights to modify, redistribute, and build commercial products from the code.
+- n8n uses a source-available [fair-code license](https://docs.n8n.io/privacy-and-security/sustainable-use-license). Sim uses Apache 2.0, which gives you broader rights to modify, redistribute, and build commercial products from the code.
 
-### Pricing
-
-n8n offers a Community Edition for eligible self-hosting under its [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license/). [Cloud plans](https://n8n.io/pricing/) charge according to monthly workflow executions, and enterprise pricing adds governance and support. Self-hosted deployments still carry infrastructure and maintenance costs. See [n8n alternatives](https://www.sim.ai/library/n8n-alternatives) for a deeper comparison of the tradeoffs.
+**Pricing:** n8n offers a [Community Edition without a software license fee](https://docs.n8n.io/deploy/host-n8n/community-edition-features) for self-hosting. [Cloud plans charge according to monthly workflow executions](https://n8n.io/pricing/), and enterprise pricing adds governance and support. Self-hosted deployments still carry infrastructure and maintenance costs. Read our guide to [n8n alternatives](https://www.sim.ai/library/n8n-alternatives) for a deeper comparison.
 
 ## Zapier
 
-### Best for
+**Best for:** Buyers who want an extensive app catalog and familiar no-code automation without managing infrastructure.
 
-Teams that want a large app catalog and familiar no-code automation without managing infrastructure.
+Zapier supports app-to-app automation through an [extensive connector catalog](https://zapier.com/apps). A no-code operations team can connect common CRM, marketing, support, and productivity apps without building custom integrations or running automation servers.
 
-Zapier's main strength comes from its [connector breadth](https://zapier.com/apps). A no-code operations team can connect common CRM, marketing, support, and productivity apps without building custom integrations or running automation servers.
+Zapier provides a hosted automation builder based on [triggers and actions](https://help.zapier.com/hc/en-us/articles/8496288188429-Set-up-your-Zap-trigger). [Zapier Agents](https://zapier.com/agents) adds AI-driven task execution, but the agent product sits alongside Zapier's established workflow engine rather than serving as its foundation.
 
-Zapier provides a hosted automation builder based on [triggers and actions](https://help.zapier.com/hc/en-us/articles/8496288188429-Set-up-your-Zap-trigger). [Zapier Agents](https://zapier.com/agents) adds AI-driven task execution alongside Zapier's established workflow engine.
+**Pros**
 
-### Pros
-
-- Zapier's [app catalog](https://zapier.com/apps) supports a wide range of SaaS workflows.
+- Zapier's [extensive connector catalog](https://zapier.com/apps) supports a wide range of SaaS workflows.
 - The [hosted service](https://zapier.com/) handles deployment, maintenance, and infrastructure.
-- Its [no-code workflow editor](https://zapier.com/how-it-works) works well for users without programming experience.
+- The familiar [no-code interface](https://zapier.com/how-it-works) works well for users without programming experience.
 
-### Cons
+**Cons**
 
 - [Task-based billing](https://zapier.com/pricing) can become costly when high-volume workflows contain several billable actions.
 - Complex branching and data transformations can feel constrained compared with more technical builders.
-- [Zapier Agents](https://zapier.com/agents) provides less infrastructure control than an open-source, self-hostable platform.
+- [Zapier Agents](https://zapier.com/agents) provides less control over agent infrastructure than an open-source, self-hostable platform.
 
-### Pricing
-
-Zapier offers a free plan and [paid tiers](https://zapier.com/pricing) based on task volume, features, and user access. Costs rise as workflows execute more billable actions, so buyers should estimate tasks per run before choosing a tier. Our review of the [best Zapier alternatives](https://www.sim.ai/library/best-zapier-alternatives) compares other pricing and deployment models.
+**Pricing:** Zapier [offers a free plan and paid tiers](https://zapier.com/pricing) based largely on task volume, features, and user access. Costs rise as workflows execute more billable actions, so buyers should estimate tasks per run before choosing a tier. Compare more options in our guide to the [best Zapier alternatives](https://www.sim.ai/library/best-zapier-alternatives).
 
 ## Make
 
-### Best for
+**Best for:** Buyers who need visual SaaS automation with branching logic and limited coding.
 
-Teams that build SaaS-to-SaaS automations on a visual canvas and need branching logic without writing much code.
+Make's main strength is its mature scenario builder. [Routers split a workflow into conditional paths](https://help.make.com/router), while [iterators process items within collections](https://help.make.com/iterator). The canvas makes complex data movement easier to inspect, which helps when you connect systems such as a CRM, billing platform, and support desk.
 
-Make's main strength is its [visual scenario builder and app catalog](https://www.make.com/en/integrations). [Routers](https://help.make.com/router) split a workflow into conditional paths, while [iterators](https://help.make.com/iterator) process items within collections. The canvas makes complex data movement easier to inspect, which helps when you connect systems such as a CRM, billing platform, and support desk.
+Make also offers [AI Agents](https://www.make.com/en/ai-agents), but its scenario builder remains the primary focus in this comparison. Buyers seeking deep autonomous agent behavior may prefer an agent-native platform.
 
-Make also offers [AI Agents](https://www.make.com/en/ai-agents), but buyers should evaluate those features separately from its established scenario automation. Buyers seeking deep autonomous agent behavior may prefer an agent-native platform.
-
-### Pros
+**Pros**
 
 - The [visual canvas](https://www.make.com/en/product) shows each module, route, filter, and data mapping.
-- [Routers and iterators](https://help.make.com/router) support complex SaaS workflows across Make's [app catalog](https://www.make.com/en/integrations).
-- The [managed platform](https://www.make.com/en) removes infrastructure maintenance.
+- [Routers and iterators](https://help.make.com/router) support complex SaaS workflows.
+- The [managed service](https://www.make.com/en) removes infrastructure maintenance.
 
-### Cons
+**Cons**
 
 - Large scenarios can become difficult to scan and troubleshoot.
-- [Credit-based billing](https://www.make.com/en/pricing) can grow as scenarios process more modules or use AI features.
-- Make is a managed product and does not advertise a self-hosted, open-source deployment option on its [product page](https://www.make.com/en/product).
-- Make's [AI Agents](https://www.make.com/en/ai-agents) are a distinct feature surface from its deterministic scenario tools.
+- [Usage-based billing](https://www.make.com/en/pricing) can grow as scenarios process more steps.
+- Make's [product offering](https://www.make.com/en/product) does not include self-hosting or open-source deployment.
+- Buyers focused on agents should compare [Make's AI Agent controls](https://www.make.com/en/ai-agents) and deployment options with agent-native platforms.
 
-### Pricing
+**Pricing**
 
-Make offers a free tier and [paid plans based on credits](https://www.make.com/en/pricing), feature access, and execution capacity. Make's [credits documentation](https://help.make.com/credits) explains how module actions and AI features consume credits, so workflows with many modules can use credits quickly.
+Make [offers a free tier and paid plans based on usage credits](https://www.make.com/en/pricing), feature access, and execution capacity. Its pricing works well for predictable scenarios, but workflows with many modules can consume credits quickly.
 
 ## Gumloop
 
-### Best for
+**Best for:** Non-technical operations and go-to-market buyers who want a managed visual builder.
 
-Non-technical operations and go-to-market teams that want a polished visual builder without managing infrastructure.
+Gumloop combines a [managed automation canvas](https://www.gumloop.com/) with ready-made go-to-market templates. [Hosted Model Context Protocol connections](https://www.gumloop.com/mcp) let workflows access compatible tools and data sources without requiring you to run the connection layer. A revenue operations team could use it to research accounts, enrich records, and route qualified leads through one hosted service.
 
-Gumloop combines a [managed automation canvas](https://www.gumloop.com/) with templates for common business workflows. Its [MCP integrations](https://www.gumloop.com/mcp) let workflows connect to compatible tools and data sources through a hosted product. A revenue operations team could use it to research accounts, enrich records, and route qualified leads through one service.
+Gumloop partially overlaps with Sim because both support visual AI workflows. Gumloop is positioned for buyers who want a managed no-code service, while Sim is the better fit when self-hosting, Apache 2.0 licensing, or multiple builder modes matter.
 
-### Pros
+**Pros**
 
 - The [managed canvas](https://www.gumloop.com/) removes server maintenance and deployment work.
-- Gumloop's [templates](https://www.gumloop.com/templates) shorten setup for common research and enrichment workflows.
-- [Hosted MCP integrations](https://www.gumloop.com/mcp) reduce the work required to connect compatible services.
+- [Go-to-market templates](https://www.gumloop.com/templates) shorten setup for common research and enrichment workflows.
+- [Hosted MCP support](https://www.gumloop.com/mcp) reduces the work required to connect compatible services.
 
-### Cons
+**Cons**
 
-- Gumloop does not advertise the same open-source ownership or self-hosting options as Sim on its [product site](https://www.gumloop.com/).
+- Gumloop's [product offering](https://www.gumloop.com/) does not provide the same open-source ownership or self-hosting options as Sim.
 - [Credit-based usage](https://www.gumloop.com/pricing) can make costs harder to forecast when workflows process uneven volumes.
 - Technical builders have less infrastructure control than they get with open-source platforms.
 
-### Pricing
-
-Gumloop's [official pricing page](https://www.gumloop.com/pricing) lists its current plans, included credits, usage charges, and Enterprise option. Credit consumption varies by workload, so buyers should model representative runs rather than compare only subscription prices. See our guide to the [best Gumloop alternatives](https://www.sim.ai/library/best-gumloop-alternatives-in-2026) for more options.
+**Pricing:** Gumloop uses [managed subscription plans with usage credits](https://www.gumloop.com/pricing). Your cost depends on plan limits and workflow consumption, so estimate expected run volume before choosing a tier.
 
 ## How the top picks compare
 
-The table uses ✅ for strong support, 🟡 for partial or narrower support, and ❌ for no meaningful option. Product capabilities and pricing models should always be checked against the linked vendor pages before purchase.
+The table uses ✅ for broad native support, 🟡 for narrower or add-on support, and ❌ when the product does not offer the capability described.
 
 | Product | Builder model | Agent depth | Deployment surfaces | Model flexibility | Hosting and license | Pricing model |
 | --- | --- | --- | --- | --- | --- | --- |
-| **Sim** | ✅ Language, canvas, and code | ✅ Agent-native reasoning and context | ✅ API, chat, and MCP | ✅ Multiple providers, BYOK, and local options | ✅ [Apache 2.0](https://github.com/simstudioai/sim/blob/main/LICENSE), cloud or self-hosted | 🟡 [Seats plus usage credits](https://www.sim.ai/pricing) |
-| **n8n** | ✅ [Visual nodes and code](https://docs.n8n.io/code/) | 🟡 [Agent nodes inside automation](https://docs.n8n.io/advanced-ai/) | 🟡 [Workflows and webhooks](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/) | ✅ [Multiple provider integrations](https://n8n.io/integrations/categories/ai/) | 🟡 [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license/), cloud or self-hosted | ✅ [Execution-based](https://n8n.io/pricing/) |
-| **Zapier** | 🟡 [No-code Zaps and Agents](https://zapier.com/agents) | 🟡 [Agents alongside automation](https://zapier.com/agents) | 🟡 [Cloud workflows and Agents](https://zapier.com/agents) | 🟡 [Managed AI options](https://zapier.com/ai) | ❌ [Proprietary cloud service](https://zapier.com/) | 🟡 [Task-based](https://zapier.com/pricing) |
-| **Make** | ✅ [Visual scenarios](https://www.make.com/en/product) | 🟡 [AI Agents](https://www.make.com/en/ai-agents) | 🟡 [Scenarios and webhooks](https://help.make.com/webhooks) | 🟡 [Provider integrations](https://www.make.com/en/integrations) | ❌ [Managed cloud product](https://www.make.com/en/product) | 🟡 [Credit-based](https://www.make.com/en/pricing) |
-| **Gumloop** | 🟡 [Managed visual canvas](https://www.gumloop.com/) | ✅ [AI-first workflows](https://www.gumloop.com/) | 🟡 [Hosted workflows and MCP](https://www.gumloop.com/mcp) | 🟡 [Managed model options](https://www.gumloop.com/) | ❌ [Managed product](https://www.gumloop.com/) | 🟡 [Credit-based](https://www.gumloop.com/pricing) |
+| **Sim** | ✅ [Language, canvas, and code](https://docs.sim.ai/introduction) | ✅ Agent-native reasoning and context | ✅ [API, chat, and MCP](https://docs.sim.ai/workflows/deployment) | ✅ Multiple providers, BYOK, and local options | ✅ [Apache 2.0, cloud or self-hosted](https://github.com/simstudioai/sim) | 🟡 [Seats plus usage credits](https://www.sim.ai/pricing) |
+| **n8n** | ✅ [Visual nodes and code](https://docs.n8n.io/build/code-in-n8n/using-the-code-node) | 🟡 [Agent nodes inside automation](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent) | 🟡 [Workflows and webhooks](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook) | ✅ [Configurable LLM components](https://docs.n8n.io/build/integrate-ai/langchain-in-n8n) | 🟡 [Fair-code, cloud or self-hosted](https://docs.n8n.io/privacy-and-security/sustainable-use-license) | ✅ [Execution-based](https://n8n.io/pricing/) |
+| **Zapier** | 🟡 [No-code Zaps and Agents](https://zapier.com/agents) | 🟡 [Agents layered onto automation](https://zapier.com/agents) | 🟡 Cloud workflows and Agents | 🟡 Managed provider choices | ❌ [Proprietary cloud](https://zapier.com/) | 🟡 [Task-based](https://zapier.com/pricing) |
+| **Make** | ✅ [Mature visual scenarios](https://www.make.com/en/product) | 🟡 [AI Agent blocks](https://www.make.com/en/ai-agents) | 🟡 Scenarios and webhooks | 🟡 Provider integrations | ❌ [Proprietary cloud](https://www.make.com/en/product) | ✅ [Credit-based](https://www.make.com/en/pricing) |
+| **Gumloop** | 🟡 [Managed visual canvas](https://www.gumloop.com/) | 🟡 AI-oriented workflows | 🟡 [Hosted workflows and MCP](https://www.gumloop.com/mcp) | 🟡 Managed model options | ❌ [Proprietary cloud](https://www.gumloop.com/) | 🟡 [Credit-based](https://www.gumloop.com/pricing) |
 
 ## Which tool fits your situation
 
-- **Solo developer or technical builder.** Choose Sim for agent-heavy projects that may move between natural language, a visual canvas, and code. Choose [n8n](https://docs.n8n.io/code/) when deterministic automation and code extensibility take priority.
-- **Ops or no-code team.** Choose [Zapier](https://zapier.com/apps) for straightforward SaaS automation and connector breadth. Choose [Gumloop](https://www.gumloop.com/) when you need a managed visual builder for AI-driven operations or GTM workflows.
-- **Enterprise needing governance.** Choose [Sim Enterprise](https://www.sim.ai/pricing) when your agent program requires organizational controls, deployment options, and execution visibility. [Zapier](https://zapier.com/enterprise) remains a simpler choice for standardized app-to-app automation without infrastructure management.
-- **Team wanting to self-host or own infrastructure.** Choose [Sim](https://sim.ai) when you want agent-native workflows under an [Apache 2.0 license](https://github.com/simstudioai/sim). Choose [n8n](https://docs.n8n.io/hosting/) when mature deterministic automation matters more than a permissive open-source license.
+- **Solo developer or technical builder.** Choose Sim for agent-heavy projects that may move between natural language, a visual canvas, and code. Choose n8n when deterministic automation and code extensibility take priority.
+- **Operations or no-code buyer.** Choose Zapier for straightforward SaaS automation and an extensive connector catalog. Choose Gumloop when you need a managed visual builder for AI-driven operations or GTM workflows.
+- **Enterprise buyer needing governance.** Consider [Sim Enterprise](https://www.sim.ai/pricing) when your agent program requires access controls, SSO, governed deployment, and block-level execution records. Zapier remains the simpler choice for standardized app-to-app automation without infrastructure management.
+- **Buyer wanting to self-host or control infrastructure.** Choose [Sim](https://sim.ai) when you want agent-native workflows under an [Apache 2.0 license](https://github.com/simstudioai/sim). Choose [n8n](https://docs.n8n.io/deploy/host-n8n) when mature deterministic automation matters more than a permissive open-source license.
 
 ## Why Sim leads this list
 
-Sim leads this general ranking because it gives technical buyers several ways to build while preserving control over their infrastructure. [Mothership](https://docs.sim.ai/mothership) creates and modifies workspace resources through natural language, while the visual canvas exposes workflow logic for inspection. APIs and SDKs support custom code when a prototype needs deeper integration.
+Sim leads this general ranking because it gives technical buyers several ways to build while preserving control over their infrastructure. [Mothership creates and modifies workspace resources through natural language](https://docs.sim.ai/introduction), while the visual canvas exposes workflow logic for inspection. APIs and SDKs support custom code when a prototype needs deeper integration.
 
-Sim's [Apache 2.0 core](https://github.com/simstudioai/sim) permits self-hosting without the commercial restrictions of fair-code licenses. You can use the managed cloud during early development, then operate the core on your own infrastructure. [Enterprise plans](https://www.sim.ai/pricing) add governance options when organizational requirements expand.
+Sim's [Apache 2.0 core](https://github.com/simstudioai/sim) permits self-hosting without the commercial restrictions of fair-code licenses. You can use the managed cloud during early development, then [operate the core on your own infrastructure](https://docs.sim.ai/platform/self-hosting). [Enterprise plans](https://www.sim.ai/pricing) add governed self-hosting and access controls when organizational requirements expand.
 
-The Sim workspace also keeps workflows connected to data, files, knowledge, integrations, and execution logs. Workflows can move into production as APIs or hosted chat experiences, and MCP provides another deployment option. You can inspect runs without adding a separate monitoring product.
+The Sim workspace keeps workflow logic alongside Tables, Files, knowledge bases, integrations, and execution logs. You can [deploy versioned workflows as APIs, hosted chat experiences, or MCP tools](https://docs.sim.ai/workflows/deployment). You can inspect each run and its actual cost without adding a separate monitoring product.
 
-Gumloop is the closest product analog in this ranking because [both support visual AI workflows](https://www.gumloop.com/). Gumloop provides a managed no-code experience for buyers who do not want infrastructure responsibility. Sim gives technical buyers more control through self-hosting, an Apache 2.0 license, and natural-language, visual, and programmatic builder modes.
-
-[Start building with Sim](https://sim.ai) or review the [open-source repository on GitHub](https://github.com/simstudioai/sim).
+Explore [Sim](https://sim.ai) or review the [open-source Sim repository](https://github.com/simstudioai/sim) on GitHub.


### PR DESCRIPTION
Content update to `apps/sim/content/library/best-ai-automation-tools-2026`: Full replacement: replace the entire body of the existing post with the supplied replacement article, and regenerate the frontmatter accordingly (keep the original `date`, set `updated` to today, recompute readingTime, keep authors: andrew). Move the article's FAQ section into the frontmatter `faq` array with ALL 5 entries verbatim as plain text (strip markdown links), and remove the `## FAQs` heading from the body. Keep slug, ogImage, and canonical as-is. Do not change the title, so do not regenerate the cover.

- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)