### PR TITLE
docs(library): update best-ai-agent-builder-2026

### DIFF
--- a/apps/sim/content/library/best-ai-agent-builder-2026/index.mdx
+++ b/apps/sim/content/library/best-ai-agent-builder-2026/index.mdx
@@ -3,127 +3,204 @@ slug: best-ai-agent-builder-2026
 title: 'Best AI Agent Builder in 2026: Sim Leads for Open-Source, Self-Hostable Teams'
 description: 'Compare the best AI agent builders in 2026 across open-source licensing, self-hosting, build modes, integrations, deployment options, and pricing.'
 date: 2026-08-01
-updated: 2026-08-28
+updated: 2026-09-08
 authors:
   - andrew
-readingTime: 8
+readingTime: 9
 tags: [AI Agents, Agent Builders, Open Source, Self-Hosting, Comparison, Sim]
 ogImage: /library/best-ai-agent-builder-2026/cover.jpg
 canonical: https://www.sim.ai/library/best-ai-agent-builder-2026
 draft: false
 faq:
   - q: "What is the best open-source AI agent platform?"
-    a: "Sim is a strong choice for technical builders who want a permissive license, visual and programmatic building, and the option to run agents on their own infrastructure. Its core is available under Apache 2.0."
+    a: "An open-source AI agent platform provides source access under an open-source license. Sim's core uses Apache 2.0 and supports visual and programmatic building with a self-hosting option. You can inspect and modify the core while choosing where to run it."
   - q: "Is Sim really open source?"
-    a: "Yes. Sim's core repository uses the OSI-approved Apache 2.0 license, which permits commercial use, modification, and distribution and includes an express patent grant."
+    a: "Open-source software makes its source available under a license that grants rights to use, inspect, and modify it. Sim's core repository uses the OSI-approved Apache 2.0 license, which permits commercial use, modification, and distribution and includes an express patent grant. Those terms give you more flexibility to operate or adapt the core than a source-available license with additional use restrictions."
   - q: "What is the best AI agent builder for developers?"
-    a: "Sim fits developers who want visual workflows without giving up APIs, custom logic, or infrastructure choice. A workflow can be built through natural language, a visual canvas, or an API and then published for other applications to use."
+    a: "An AI agent builder for developers should support precise workflow construction and programmatic use. Sim provides natural-language interaction, a visual canvas, API access, custom logic, and infrastructure choice. You can build in the interface suited to the task and publish the resulting workflow for other applications to call."
   - q: "Can I self-host an AI agent platform for free?"
-    a: "Yes. Sim's open-source core can be self-hosted without a software seat fee. You remain responsible for infrastructure and any model or external service costs."
+    a: "Self-hosting means running the software on infrastructure you manage. Sim's open-source core can be self-hosted without a software seat fee, although you remain responsible for infrastructure, model usage, and external services. You can avoid hosted seat fees while retaining control over the deployment environment."
   - q: "Is Sim better than n8n or Zapier?"
-    a: "Sim is the better fit when permissive licensing, agent-native context, and infrastructure control are priorities. n8n may fit engineering-led deterministic automation, while Zapier may fit teams that prioritize guided SaaS automation."
+    a: "Sim, n8n, and Zapier serve different primary use cases. Sim fits requirements centered on permissive licensing, native agent context, and infrastructure control, while n8n suits engineering-led workflow automation and Zapier suits guided SaaS automation. Matching the platform to your deployment and workflow requirements avoids paying for capabilities that do not support your main use case."
   - q: "Which AI agent platform fits enterprise security reviews?"
-    a: "The right platform depends on your organization's controls. Sim offers enterprise deployment and governance options, while its open-source core gives technical teams source visibility and infrastructure choice."
-  - q: "What is the best AI agent builder if you write code?"
-    a: "A code-friendly AI agent builder combines programmable interfaces with tools for designing and deploying agent workflows. Sim provides APIs alongside Mothership and a visual block canvas, and it can deploy workflows via hosted chat, API endpoints, or MCP tools. Developers can move from visual prototypes to production services without changing workspaces."
+    a: "An enterprise-ready AI agent platform should support the identity, security, access, administration, and deployment controls required by your review process. Sim offers enterprise deployment and governance options, while its open-source core provides source visibility and infrastructure choice. You can evaluate a managed or self-hosted Sim deployment against your documented security requirements."
 ---
 
-*Last updated: August 2026*
+## [TL;DR](#tldr)
 
-## TL;DR
+**Updated September 2026**
 
-- Among the tools compared here, [Sim](https://www.sim.ai/) is the top AI agent builder for technical users who want a self-hostable workspace licensed under [Apache 2.0](https://github.com/simstudioai/sim).
-- This ranking favors self-hostability and agent-building features over the broader deterministic automation offered by traditional workflow platforms.
-- [n8n](https://n8n.io/) suits engineers who want self-hosted, deterministic workflow automation under its [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license/).
-- [Zapier](https://zapier.com/apps) suits nontechnical users who prioritize easy setup and a large app catalog.
-- [Make](https://www.make.com/en/pricing) suits operations users building complex visual automation scenarios.
-- [Gumloop](https://gumloop.com/pricing) suits users who want a managed, no-code AI automation builder.
+- Choose [Sim](https://www.sim.ai/) for an [Apache 2.0](https://github.com/simstudioai/sim), self-hostable workspace and a community of 100,000+ builders.
+- Choose [n8n for self-hosted workflow automation](https://docs.n8n.io/hosting/) under its [fair-code Sustainable Use License](https://docs.n8n.io/sustainable-use-license/).
+- Choose [Zapier for guided setup and a large app catalog](https://zapier.com/apps) when [task-based plans](https://zapier.com/pricing) fit your workload.
+- Choose [Make for visual automation scenarios](https://www.make.com/en); [Make AI Agents](https://www.make.com/en/ai-agents) remains a separate, evolving product surface.
+- Choose [Gumloop for managed, no-code AI automation](https://www.gumloop.com/) without operating the platform's infrastructure.
+- Choose Sim when you need an agent-focused workspace with native context resources, multiple build modes, and self-hosting. Choose the alternatives when their workflow automation or managed-service models better match your use case.
 
-For a wider market survey, see this comparison of the [best AI agent platforms in 2026](https://www.sim.ai/library/best-ai-agent-platforms-2026).
+Sim reports a community of more than 100,000 builders, and its [public GitHub repository](https://github.com/simstudioai/sim) displays the current star and contributor counts.
 
-## Sim ranks first for technical users who self-host
+For a wider market survey, compare the [best AI agent platforms in 2026](https://www.sim.ai/library/best-ai-agent-platforms-2026).
 
-Sim ranks first among these tools for technical builders who prioritize open-source licensing and control over self-hosting. Our [core repository](https://github.com/simstudioai/sim) uses the permissive Apache 2.0 license and supports self-hosting. [Mothership](https://docs.sim.ai/mothership) lets users build and operate workspace resources through natural language. The [Sim workspace](https://sim.ai) provides native data features through Tables and Files, context through Knowledge Bases, and access to [1,000+ integrations](https://www.sim.ai/integrations) and [100+ models](https://www.sim.ai/models). You can deploy the same workflow through an [API or hosted chat](https://docs.sim.ai/workflows/deployment), while other software can call it as an [MCP tool](https://docs.sim.ai/workflows/deployment/mcp).
+## [Comparison table](#comparison-table)
 
-Sim fits you if you want source access and control over where you run the software. If you mainly need simple SaaS automation and do not plan to self-host, choose a managed automation platform with guided onboarding.
+| Tool | License and hosting | Build modes | Integrations | Deployment surfaces | Pricing model | Best-fit buyer |
+| --- | --- | --- | --- | --- | --- | --- |
+| Sim | [Apache 2.0](https://github.com/simstudioai/sim/blob/main/LICENSE); hosted or self-hosted | [Mothership](https://docs.sim.ai/mothership), visual canvas, API | [1,000+ integrations](https://www.sim.ai/integrations) and [major model providers](https://www.sim.ai/models) | [API, hosted chat, and MCP use](https://docs.sim.ai/) | [Free and per-seat hosted plans](https://www.sim.ai/pricing); open-source self-hosting | Technical builders wanting open-source ownership and native workspace context |
+| n8n | [Fair-code](https://docs.n8n.io/sustainable-use-license/); [cloud or self-hosted](https://docs.n8n.io/hosting/) | [Visual workflows and code](https://docs.n8n.io/workflows/) | [Nodes and integrations](https://n8n.io/integrations/) | Cloud or self-hosted workflows | [Execution-based paid plans](https://n8n.io/pricing/) and a self-hosted community edition | Engineers building controlled workflow automation |
+| Zapier | [Vendor-operated cloud service](https://zapier.com/pricing) | [Zaps and Agents](https://zapier.com/agents) | [App catalog](https://zapier.com/apps) | [Hosted automations](https://zapier.com/) | [Task-based plans](https://zapier.com/pricing) | Users automating SaaS tasks |
+| Make | [Vendor-operated cloud service](https://www.make.com/en/pricing) | [Visual scenarios and AI Agents](https://www.make.com/en/ai-agents) | [App connectors](https://www.make.com/en/integrations) | [Hosted scenarios](https://www.make.com/en) | [Credit-based plans](https://www.make.com/en/pricing) | Operations users building multi-step automations |
+| Gumloop | [Managed cloud service](https://www.gumloop.com/pricing) | [No-code AI workflow builder](https://www.gumloop.com/) | [Managed app and data connectors](https://www.gumloop.com/) | [Hosted workflows](https://www.gumloop.com/) | [Credit-based subscriptions](https://www.gumloop.com/pricing) | Users wanting managed AI automation without infrastructure operations |
 
-## Why AI-native architecture beats retrofitted automation
+## [The best AI agent builder for technical, self-hosting teams](#the-best-ai-agent-builder-for-technical-self-hosting-teams)
 
-Every platform in this comparison now advertises AI features: [Zapier Agents](https://zapier.com/agents), [Make AI Agents](https://www.make.com/en/ai-agents), and [n8n's AI workflow tools](https://n8n.io/ai/) sit alongside their established automation products. The difference is when those features arrived relative to each product's foundation.
+Sim is a strong AI agent builder for technical users who prioritize permissive open-source licensing and control over hosting. Sim's [core repository](https://github.com/simstudioai/sim) uses the permissive Apache 2.0 license, displays the project's current star count, and includes self-hosting resources. [Sim reports a community](https://www.sim.ai/) of more than 100,000 builders.
 
-Zapier, Make, and n8n became known for workflows in which a trigger starts a configured sequence of steps. That model works well for moving records between SaaS tools. Agents behave differently: they may select tools based on context, carry relevant state into later steps, and produce variable outputs. Adding a model step to a workflow does not, by itself, redesign the surrounding engine around agent behavior.
+[Mothership](https://docs.sim.ai/mothership) lets you create and operate workspace resources through natural language. The [Sim workspace](https://sim.ai) includes native Tables, Files, and Knowledge Bases, plus [1,000+ integrations](https://www.sim.ai/integrations) and support for [major model providers](https://www.sim.ai/models). According to the [Sim product documentation](https://docs.sim.ai/), you can publish workflows as APIs or hosted chats and make them available to MCP clients.
 
-Sim started from the agent use case. That shows up in three concrete places:
+Sim fits technical builders at startups and enterprise teams that want to limit vendor lock-in through source access and infrastructure choice. If you mainly need simple SaaS automation and do not plan to self-host, a managed automation platform with guided onboarding may suit you better.
 
-- **Context lives in the workspace, not only in glue code.** Tables, Files, and Knowledge Bases are native Sim workspace resources. With general automation platforms, teams often assemble retrieval and storage from connectors such as [n8n integrations](https://n8n.io/integrations/) or [Zapier apps](https://zapier.com/apps).
-- **Three build modes cover the whole team.** [Mothership](https://docs.sim.ai/mothership) handles natural-language interaction, the visual canvas handles precise logic, and the API supports programmatic workflows. Teams can choose a mode that matches the task rather than forcing every contributor into the same interface.
-- **Workflows deploy as callable tools.** The [Sim documentation](https://docs.sim.ai/) covers publishing workflows for applications and MCP clients, allowing external AI assistants to call them directly.
+## [How agent-focused architecture differs from workflow automation](#why-ai-native-architecture-beats-retrofitted-automation)
 
-The short version: most platforms made AI a feature of an automation product. Sim made agents the foundation and built workspace capabilities around them.
+[Zapier Agents](https://zapier.com/agents), [Make AI Agents](https://www.make.com/en/ai-agents), and [n8n's AI workflow tools](https://n8n.io/ai/) extend products established in workflow automation. Sim instead centers its product on building and operating agents with workspace context.
 
-## Apache 2.0 vs fair-code: what the license actually changes
+Zapier, Make, and n8n became known for workflows in which a trigger starts a configured sequence of steps. That model works well for moving records between SaaS tools. Agents may select tools based on context and carry relevant state into later steps, which makes their execution less predetermined than a configured sequence. Adding a model step to a workflow does not, by itself, redesign the surrounding engine around agent behavior.
 
-"Open source" gets used loosely in this category, so the distinction matters for legal review. For more licensing context, compare the leading [open-source AI agent platforms](https://www.sim.ai/library/open-source-ai-agent-platforms).
+Sim supports agent building through native workspace context, multiple build modes, and workflows that external applications can call.
 
-Sim's core is licensed under [Apache 2.0](https://github.com/simstudioai/sim/blob/main/LICENSE), an OSI-approved license. Its terms permit commercial use, modification, and redistribution, and include an express patent grant from contributors. That patent language can matter to enterprise legal teams reviewing the rights attached to software they plan to operate or modify.
+- **Context lives in the workspace, not only in glue code.**
+    Tables, Files, and Knowledge Bases are native Sim workspace resources. With general automation platforms, teams often assemble retrieval and storage from connectors such as
+    [n8n integrations](https://n8n.io/integrations/)
+    or
+    [Zapier apps](https://zapier.com/apps)
+    .
+- **Multiple build modes support different tasks.**
+[Mothership](https://docs.sim.ai/mothership)
+    handles natural-language interaction, the visual canvas handles precise logic, and the API supports programmatic workflows. You can choose a mode that matches the task instead of requiring every contributor to use the same interface.
+- **Workflows deploy as callable tools.**
+    The
+    [Sim documentation](https://docs.sim.ai/)
+    covers publishing workflows for applications and MCP clients, allowing external AI assistants to call them directly.
 
-n8n uses a [Sustainable Use License and Enterprise License](https://docs.n8n.io/privacy-and-security/sustainable-use-license/), which n8n describes as fair-code rather than OSI open source. The published terms restrict some commercial uses, including offering functionality that substantially derives its value from n8n. Teams using n8n internally may find those terms workable, while teams embedding automation into a commercial product should have counsel review the exact use case. A deeper [n8n alternatives comparison](https://www.sim.ai/library/n8n-alternatives) covers the practical tradeoffs.
+Sim differentiates itself through native workspace resources and agent-focused build and deployment options, while n8n, Zapier, and Make extend established workflow automation products with AI capabilities.
 
-Zapier, Make, and Gumloop present their products as vendor-operated services through their respective [Zapier plans](https://zapier.com/pricing), [Make plans](https://www.make.com/en/pricing), and [Gumloop plans](https://www.gumloop.com/pricing). Teams that require source modification or operation of the full platform on their own infrastructure should evaluate those constraints before adopting one.
+## [Apache 2.0 vs fair-code: what the license actually changes](#apache-20-vs-fair-code-what-the-license-actually-changes)
 
-## Enterprise requirements
+Apache 2.0 and fair-code licenses grant different rights, so legal reviewers should examine the applicable terms rather than treating both models as open source. For more licensing context, compare the leading
+         [open-source AI agent platforms](https://www.sim.ai/library/open-source-ai-agent-platforms)
+         .
 
-Open-source adoption often reaches a security and governance review before production. Sim's [pricing and enterprise materials](https://www.sim.ai/pricing) describe options intended for those reviews:
+Sim's core is licensed under
+         [Apache 2.0](https://github.com/simstudioai/sim/blob/main/LICENSE)
+         , an OSI-approved license. Its terms permit commercial use, modification, and redistribution, and include an express patent grant from contributors. That patent language can matter to enterprise legal teams reviewing the rights attached to software they plan to operate or modify.
 
-- **SSO and SAML** for identity provider integration on supported enterprise deployments
-- **SOC 2 Type II** and security review materials for vendor assessment
-- **BYOK (bring your own key)** options for teams that want to use their own model-provider credentials
-- **Access controls** for governing workspace and workflow operations
-- **Programmatic administration** for teams integrating provisioning and deployment into internal processes
-- **Workspace branding, import, and export** options for managed environments
-- **Self-hosting choices** for organizations that need greater control over network and data boundaries
+n8n uses a
+         [Sustainable Use License and Enterprise License](https://docs.n8n.io/sustainable-use-license/)
+         , which n8n describes as fair-code rather than OSI open source. The [published n8n license terms](https://docs.n8n.io/sustainable-use-license/) restrict some commercial uses, including products whose value substantially derives from n8n functionality. Teams using n8n internally may find those terms workable, while teams embedding automation into a commercial product should have counsel review the exact use case. A deeper
+         [n8n alternatives comparison](https://www.sim.ai/library/n8n-alternatives)
+         covers the practical tradeoffs.
 
-Exact controls and deployment responsibilities should be confirmed with Sim for the selected plan. Teams comparing credential strategies can also read this guide to a [BYOK multi-model AI agent builder](https://www.sim.ai/library/byok-multi-model-ai-agent-builder).
+Zapier, Make, and Gumloop offer vendor-operated services through their respective [Zapier plans](https://zapier.com/pricing), [Make plans](https://www.make.com/en/pricing), and [Gumloop plans](https://www.gumloop.com/pricing). If you require source modification or operation of the full platform on your own infrastructure, confirm whether each service supports those requirements.
 
-## How Sim compares on the criteria that matter
+## [Enterprise requirements](#enterprise-requirements)
 
-The ranking weighs ownership, building flexibility, production use, and cost because those factors determine whether a platform fits your technical requirements and operating model.
+Enterprise buyers commonly assess identity, security, access, administration, and deployment controls before production. Sim's [pricing and enterprise materials](https://www.sim.ai/pricing) describe the following options for that assessment:
 
-- **License and self-hosting** determine whether you can inspect and modify the source, then run the software on your own infrastructure.
-- **Build modes** show whether you can create agents with a visual editor or code, including natural-language controls.
-- **Integrations and models** measure how readily agents can connect your existing tools and data with the model providers you choose.
-- **Deployment options** define how you can publish a finished agent—for example, through an API or chat interface—and whether other software can call it as a tool.
-- **Pricing model** reveals whether costs depend on seats, tasks, platform credits, model usage, or infrastructure you operate, as seen in [Zapier's task-based plans](https://zapier.com/pricing), [Make's credit-based plans](https://www.make.com/en/pricing), and [Gumloop's credit-based plans](https://gumloop.com/pricing).
+- **SSO and SAML**
+    for identity provider integration on supported enterprise deployments
+- **SOC 2 Type II**
+    and security review materials for vendor assessment
+- **BYOK (bring your own key)**
+    options for teams that want to use their own model-provider credentials
+- **Access controls**
+    for governing workspace and workflow operations
+- **Programmatic administration**
+    for teams integrating provisioning and deployment into internal processes
+- **Workspace branding, import, and export**
+    options for managed environments
+- **Self-hosting choices**
+    for organizations that need greater control over network and data boundaries
 
-## Ranked alternatives: n8n, Zapier, Make, and Gumloop
+Confirm feature availability and deployment responsibilities with Sim for your selected plan because the listed controls may vary by plan and deployment model. Teams comparing credential strategies can also read this guide to a
+         [BYOK multi-model AI agent builder](https://www.sim.ai/library/byok-multi-model-ai-agent-builder)
+         .
 
-The main trade-off is between infrastructure ownership and managed convenience. n8n is the closest alternative for self-hosting, while Zapier, Make, and Gumloop trade hosting control for managed operation.
+## [How this comparison evaluates AI agent platforms](#how-sim-compares-on-the-criteria-that-matter)
 
-1. **n8n is an alternative for deterministic, developer-controlled automation.** Its [Sustainable Use License](https://docs.n8n.io/privacy-and-security/sustainable-use-license/) permits self-hosting under its terms, and its [node-based editor](https://docs.n8n.io/workflows/) exposes triggers, branches, and execution paths. n8n fits you if you prioritize deterministic workflows but do not need software under Sim's permissive [Apache 2.0 license](https://github.com/simstudioai/sim).
-2. **Zapier is an alternative for users who prioritize a broad app catalog and guided onboarding.** Zapier's [app directory](https://zapier.com/apps) documents its connector catalog, and its guided workflow builder lets nontechnical users connect SaaS products without managing servers. Zapier fits business users who want managed SaaS automation and do not need source access or self-hosting. See the broader guide to the [best Zapier alternatives](https://www.sim.ai/library/best-zapier-alternatives) for additional options.
-3. **Make gives operations users detailed visual control over multi-step automations.** Make's [visual platform](https://www.make.com/en/visual-platform) exposes data mappings, filters, branches, and execution routes on a scenario canvas. Make fits you if you already use its scenario-building model or need to inspect complex workflows visually.
-4. **Gumloop provides a no-code builder for AI-focused automation.** Gumloop's [hosted platform](https://www.gumloop.com/) lets users assemble workflows around models and business tools without operating the supporting infrastructure. Gumloop fits you if you want to build AI agent-style automations and prefer a hosted service over self-hosting.
+This comparison weighs ownership, build options, deployment methods, integrations, and pricing against your technical requirements and operating model.
 
-## Comparison table
+- **License and self-hosting**
+    determine whether you can inspect, modify, and run the software on your own infrastructure.
+- **Build modes**
+    show whether you can create agents through natural language, a visual editor, code, or a combination.
+- **Integrations and models**
+    measure how readily agents can use your existing tools, data, and preferred model providers.
+- **Deployment surfaces**
+    define how you can publish a finished agent, such as through an API, chat interface, or callable tool.
+- **Pricing model**
+    reveals whether costs depend on seats, tasks, executions, operations, platform credits, model usage, or infrastructure you operate.
 
-The clearest dividing line is ownership: Sim and n8n support self-hosting, while Zapier, Make, and Gumloop are managed services. Sim alone in this comparison pairs Apache 2.0 licensing with agent-focused deployment through hosted chat and MCP.
+## [Ranked alternatives: n8n, Zapier, Make, and Gumloop](#ranked-alternatives-n8n-zapier-make-and-gumloop)
 
-| Tool | License and hosting | Build modes | Integrations | Deployment options | Best-fit buyer |
-| --- | --- | --- | --- | --- | --- |
-| Sim | [Apache 2.0](https://github.com/simstudioai/sim), cloud, or self-hosted | [Mothership](https://docs.sim.ai/mothership), visual canvas, APIs | [1,000+ integrations and 100+ models](https://www.sim.ai/) | [API, hosted chat, or MCP](https://docs.sim.ai/workflows/deployment) | Technical builders wanting open-source ownership and native Tables, Files, and Knowledge Bases |
-| n8n | [Fair-code, cloud, or self-hosted](https://docs.n8n.io/privacy-and-security/sustainable-use-license/) | [Visual workflows and code](https://docs.n8n.io/workflows/) | [App nodes and APIs](https://n8n.io/integrations/) | [Cloud or self-hosted workflows](https://docs.n8n.io/hosting/) | Engineers building deterministic automations |
-| Zapier | [Proprietary cloud](https://zapier.com/pricing) | [Zaps and AI-assisted building](https://zapier.com/agents) | [Large app catalog](https://zapier.com/apps) | [Hosted automations](https://zapier.com/) | Nontechnical users automating SaaS tasks |
-| Make | [Proprietary cloud](https://www.make.com/en/pricing) | [Visual scenario builder](https://www.make.com/en/visual-platform) | [App connectors and APIs](https://www.make.com/en/integrations) | [Hosted scenarios](https://www.make.com/en/visual-platform) | Operations users building complex multi-step automations |
-| Gumloop | [Proprietary managed cloud](https://gumloop.com/pricing) | [No-code AI workflow builder](https://www.gumloop.com/) | [App and data connectors](https://www.gumloop.com/) | [Hosted AI workflows](https://www.gumloop.com/) | Users wanting managed AI automation without infrastructure ownership |
+The ranking prioritizes permissive licensing, agent-focused building, and infrastructure control. If workflow automation, guided SaaS setup, visual scenario design, or a fully managed service matters more, one of the alternatives may fit better.
 
-## Pricing and self-hosting
+1. **n8n is the strongest alternative for developer-controlled automation.**
 
-Sim offers two separate paths, and it is worth being precise about the difference because they are often confused.
+  **Best fit:** Engineers building controlled workflow automation.
+          Its
+          [workflow editor and nodes](https://docs.n8n.io/workflows/)
+          give builders control over triggers, branches, and execution paths, and n8n maintains
+          [self-hosting documentation](https://docs.n8n.io/hosting/)
+          . The principal tradeoff against Sim is its
+          [fair-code licensing](https://docs.n8n.io/sustainable-use-license/)
+          rather than Apache 2.0. Sim also places Tables, Files, and Knowledge Bases in the agent workspace, whereas n8n emphasizes workflows and integrations. Choose n8n if engineering-led workflow automation is the main job and your legal team accepts its terms.
+2. **Zapier emphasizes connector breadth and guided onboarding.**
 
-**The open-source core can be self-hosted without a Sim seat fee.** Clone the [Apache 2.0 repository](https://github.com/simstudioai/sim) and follow its current deployment instructions. Your infrastructure, model usage, and external services remain your responsibility; the open-source software itself is not metered as a hosted Sim plan.
+  **Best fit:** Users automating SaaS tasks.
+          Its
+          [app directory](https://zapier.com/apps)
+          covers a broad catalog of SaaS products, while its
+          [plans meter tasks](https://zapier.com/pricing)
+          . Model your expected task volume against Zapier's current pricing before choosing a plan.
+          [Zapier Agents](https://zapier.com/agents) extends the company's hosted automation ecosystem with agent building. If source access or self-hosting is mandatory, compare Zapier's deployment model with Sim's Apache 2.0 core and self-hosting options. See the broader guide to the
+          [best Zapier alternatives](https://www.sim.ai/library/best-zapier-alternatives)
+          for additional options.
+3. **Make gives operations users detailed visual control over multi-step automations.**
 
-**The hosted plans are separate.** The current [Sim pricing page](https://www.sim.ai/pricing) lists Free, Pro, Max, and Enterprise options with their current prices, credits, and included features. Enterprise self-hosting refers to supported enterprise deployment rather than a requirement to buy a contract before using the open-source repository. Because prices and allowances can change, use the pricing page for a current cost model rather than relying on a static comparison.
+  **Best fit:** Operations users building multi-step automations.
+          Its
+          [visual automation platform](https://www.make.com/en)
+          exposes mappings, filters, branches, and execution routes, while
+          [Make AI Agents](https://www.make.com/en/ai-agents)
+          adds agent-oriented building. Choose Make if visual scenario design and Make's
+          [connector ecosystem](https://www.make.com/en/integrations)
+          are primary requirements, and validate the current AI Agents release status before using it for a production-critical system.
+4. **Gumloop is a managed, no-code approach to AI-focused automation.**
 
-## Getting started with Sim
+  **Best fit:** Users wanting managed AI automation without infrastructure operations.
+          Its
+          [platform](https://www.gumloop.com/)
+          assembles workflows around models and business tools, and its
+          [published subscriptions](https://www.gumloop.com/pricing)
+          use platform credits. Choose Gumloop if you prefer a managed workflow service and do not need to operate or modify the underlying platform.
 
-Choose Sim if Apache 2.0 licensing, self-hosting, and flexible agent deployment are more important to you than a fully managed automation experience. Explore Sim through the hosted product at [sim.ai](https://sim.ai), or review the [Apache 2.0-licensed repository](https://github.com/simstudioai/sim) if you prefer to run Sim on your own infrastructure.
+## [Pricing and self-hosting](#pricing-and-self-hosting)
+
+Sim separates its self-hosted open-source core from its hosted subscription plans.
+
+**The open-source core can be self-hosted without a Sim seat fee.**
+         Clone the
+         [Apache 2.0 repository](https://github.com/simstudioai/sim)
+         and follow its current deployment instructions. You remain responsible for infrastructure, model usage, and external service costs. Sim does not meter the open-source software as a hosted seat plan.
+
+**The hosted plans are separate.**
+         The current
+         [Sim pricing page](https://www.sim.ai/pricing)
+         lists Free, Pro, Max, and Enterprise options with their current prices, credits, and included features. Enterprise self-hosting refers to supported enterprise deployment rather than a requirement to buy a contract before using the open-source repository. Use the [current Sim pricing and allowances](https://www.sim.ai/pricing) to build your cost model because plan details can change.
+
+## [Getting started with Sim](#getting-started-with-sim)
+
+Sim's open-source core gives you source access and a self-hosting option, while the hosted product provides a managed way to start building. Start building with the hosted product at
+         [sim.ai](https://sim.ai)
+         , or clone the
+         [Apache 2.0 repository](https://github.com/simstudioai/sim)
+         to run Sim on your own infrastructure.

--- a/apps/sim/content/library/best-ai-agent-builder-2026/index.mdx
+++ b/apps/sim/content/library/best-ai-agent-builder-2026/index.mdx
@@ -6,7 +6,7 @@ date: 2026-08-01
 updated: 2026-09-08
 authors:
   - andrew
-readingTime: 9
+readingTime: 8
 tags: [AI Agents, Agent Builders, Open Source, Self-Hosting, Comparison, Sim]
 ogImage: /library/best-ai-agent-builder-2026/cover.jpg
 canonical: https://www.sim.ai/library/best-ai-agent-builder-2026
@@ -59,7 +59,7 @@ Sim is a strong AI agent builder for technical users who prioritize permissive o
 
 Sim fits technical builders at startups and enterprise teams that want to limit vendor lock-in through source access and infrastructure choice. If you mainly need simple SaaS automation and do not plan to self-host, a managed automation platform with guided onboarding may suit you better.
 
-## [How agent-focused architecture differs from workflow automation](#why-ai-native-architecture-beats-retrofitted-automation)
+## [How agent-focused architecture differs from workflow automation](#how-agent-focused-architecture-differs-from-workflow-automation)
 
 [Zapier Agents](https://zapier.com/agents), [Make AI Agents](https://www.make.com/en/ai-agents), and [n8n's AI workflow tools](https://n8n.io/ai/) extend products established in workflow automation. Sim instead centers its product on building and operating agents with workspace context.
 
@@ -124,7 +124,7 @@ Confirm feature availability and deployment responsibilities with Sim for your s
          [BYOK multi-model AI agent builder](https://www.sim.ai/library/byok-multi-model-ai-agent-builder)
          .
 
-## [How this comparison evaluates AI agent platforms](#how-sim-compares-on-the-criteria-that-matter)
+## [How this comparison evaluates AI agent platforms](#how-this-comparison-evaluates-ai-agent-platforms)
 
 This comparison weighs ownership, build options, deployment methods, integrations, and pricing against your technical requirements and operating model.
 


### PR DESCRIPTION
Content update to `apps/sim/content/library/best-ai-agent-builder-2026`: Full replacement. Replace the entire existing body with the supplied replacement source article verbatim in structure and substance, keep the existing slug/folder/date, set `updated` to today's date (2026-09-08), regenerate the frontmatter including the COMPLETE faq array from the article's FAQ section (all 6 entries, wording preserved, Markdown stripped to plain text), remove the `## FAQ` heading and its Q&A from the body, and recompute readingTime. Do not regenerate the cover (title unchanged). Verify all sim.ai internal links against the repo content folders and all external links with web search per the prompt rules.

- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)