### PR TITLE
fix(copilot): resolve folder mentions across resource families

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/mothership-view/components/add-resource-dropdown/add-resource-dropdown.tsx
@@ -75,10 +75,8 @@ interface AvailableItemsByType {
 }
 
 /**
- * Folder hierarchies that exist purely to structure the browse menus. Unlike
- * workflow (`folder`) and workspace-file (`filefolder`) folders these are not
- * attachable resources, so they stay out of `groups` — which also feeds the
- * flat search results, where a non-attachable row would be a dead end.
+ * Table and knowledge-base folder hierarchies. Chat also offers these as folder
+ * mentions, while the resource tab picker uses them only for navigation.
  */
 interface StructureFolders {
   table: AvailableItem[]
@@ -97,6 +95,8 @@ interface AvailableResources {
 }
 
 interface UseAvailableResourcesOptions {
+  /** Chat can attach every folder family, so these lists also gate mention hydration. */
+  includeFolderMentions?: boolean
   /**
    * Skips the underlying list queries and the group construction they feed
    * while `false`, returning a stable empty result. Menus pass their own open
@@ -171,16 +171,17 @@ export function useAvailableResources(
     { enabled }
   )
   const { data: folders, isPending: foldersPending } = useFolders(workspaceId, { enabled })
-  // Folder lists exist only to shape their family's submenu, so they skip the
-  // fetch entirely when that family is excluded.
-  const { data: tableFolders } = useFolders(workspaceId, {
+  const { data: tableFolders, isPending: tableFoldersPending } = useFolders(workspaceId, {
     enabled: enabled && !excludeTypes?.includes('table'),
     resourceType: 'table',
   })
-  const { data: knowledgeBaseFolders } = useFolders(workspaceId, {
-    enabled: enabled && !excludeTypes?.includes('knowledgebase'),
-    resourceType: 'knowledge_base',
-  })
+  const { data: knowledgeBaseFolders, isPending: knowledgeBaseFoldersPending } = useFolders(
+    workspaceId,
+    {
+      enabled: enabled && !excludeTypes?.includes('knowledgebase'),
+      resourceType: 'knowledge_base',
+    }
+  )
   const { data: fileFolders, isPending: fileFoldersPending } = useWorkspaceFileFolders(
     workspaceId,
     'active',
@@ -199,10 +200,8 @@ export function useAvailableResources(
    * settles to "not hydrating" — an errored query must not block the caller
    * forever.
    *
-   * Only the lists feeding `groups` count. The table and knowledge-base folder
-   * lists shape submenus but never add candidates, so gating on them would
-   * swallow an `@`-mention Enter behind two round-trips that cannot change the
-   * answer.
+   * Chat includes table and knowledge-base folders as candidates. Its Enter
+   * handling must wait for those lists too, or an unresolved mention can submit.
    */
   const isHydrating =
     enabled &&
@@ -211,6 +210,9 @@ export function useAvailableResources(
       filesPending ||
       knowledgeBasesPending ||
       foldersPending ||
+      (options?.includeFolderMentions &&
+        ((!excludeTypes?.includes('table') && tableFoldersPending) ||
+          (!excludeTypes?.includes('knowledgebase') && knowledgeBaseFoldersPending))) ||
       fileFoldersPending ||
       tasksPending ||
       logsPending)
@@ -371,9 +373,7 @@ interface ResourceFolderTreeItemsProps {
   /** Resource type of the leaf items. */
   type: MothershipResourceType
   /**
-   * Set when the folder is itself an attachable resource (workspace files): the
-   * folder is then offered as the first entry of its own submenu. Omitted for
-   * folders that only provide structure (workflows, tables, knowledge bases).
+   * Offers the folder itself as the first entry of its submenu when selectable.
    */
   folderType?: MothershipResourceType
   onSelect: (resource: MothershipResource) => void
@@ -429,10 +429,6 @@ export function ResourceFolderTreeItems({
 interface FolderedSectionSpec {
   /** Leaf resource type — also supplies the submenu's label and icon. */
   type: MothershipResourceType
-  /**
-   * Where this family's folders come from: another entry in `groups` when the
-   * folders are attachable resources, or `structureFolders` when they are not.
-   */
   folders:
     | { kind: 'group'; type: MothershipResourceType }
     | { kind: 'structure'; key: keyof StructureFolders }
@@ -483,22 +479,25 @@ export interface ResourceTreeSection {
 export function useResourceTreeSections({
   groups,
   structureFolders,
-}: Pick<AvailableResources, 'groups' | 'structureFolders'>): ResourceTreeSection[] {
+  selectFolders = false,
+}: Pick<AvailableResources, 'groups' | 'structureFolders'> & {
+  selectFolders?: boolean
+}): ResourceTreeSection[] {
   return useMemo(() => {
     const itemsOf = (type: MothershipResourceType) =>
       groups.find((group) => group.type === type)?.items ?? []
     return FOLDERED_SECTION_SPECS.map((spec) => ({
       type: spec.type,
-      folderType: spec.folderType,
+      folderType: spec.folderType ?? (selectFolders ? 'folder' : undefined),
       nodes: buildResourceFolderTree(
         itemsOf(spec.type),
         spec.folders.kind === 'group'
           ? itemsOf(spec.folders.type)
           : structureFolders[spec.folders.key],
-        { orderBySortOrder: spec.orderBySortOrder, pruneEmpty: !spec.folderType }
+        { orderBySortOrder: spec.orderBySortOrder, pruneEmpty: !selectFolders && !spec.folderType }
       ),
     })).filter((section) => section.nodes.length > 0)
-  }, [groups, structureFolders])
+  }, [groups, structureFolders, selectFolders])
 }
 
 interface ResourceMenuSectionsProps {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.test.tsx
@@ -10,7 +10,18 @@ const fixtures = vi.hoisted(() => ({
   browserAvailable: vi.fn(() => true),
   terminalAvailable: vi.fn(() => true),
   resources: { data: [{ id: 'resource-1', name: 'Example' }], isPending: false },
-  folders: { data: [], isPending: false },
+  folders: {
+    data: [] as { id: string; name: string; parentId: string | null }[],
+    isPending: false,
+  },
+  tableFolders: {
+    data: [] as { id: string; name: string; parentId: string | null }[],
+    isPending: false,
+  },
+  knowledgeFolders: {
+    data: [] as { id: string; name: string; parentId: string | null }[],
+    isPending: false,
+  },
   tabs: [],
   logs: {
     data: {
@@ -32,7 +43,14 @@ vi.mock('@/hooks/queries/workspace-files', () => ({ useWorkspaceFiles: () => fix
 vi.mock('@/hooks/queries/kb/knowledge', () => ({
   useKnowledgeBasesQuery: () => fixtures.resources,
 }))
-vi.mock('@/hooks/queries/folders', () => ({ useFolders: () => fixtures.folders }))
+vi.mock('@/hooks/queries/folders', () => ({
+  useFolders: (_workspaceId: string, options?: { resourceType?: string }) =>
+    options?.resourceType === 'table'
+      ? fixtures.tableFolders
+      : options?.resourceType === 'knowledge_base'
+        ? fixtures.knowledgeFolders
+        : fixtures.folders,
+}))
 vi.mock('@/hooks/queries/workspace-file-folders', () => ({
   useWorkspaceFileFolders: () => fixtures.folders,
 }))
@@ -72,7 +90,7 @@ const PREFERENCES: DesktopPreferences = {
   terminalEnabled: true,
 }
 
-function openMenu(mention = false) {
+function openMenu(mention = false, mentionQuery?: string) {
   const ref = createRef<PlusMenuHandle>()
   const onResourceSelect = vi.fn()
   act(() =>
@@ -80,6 +98,7 @@ function openMenu(mention = false) {
       <PlusMenuDropdown
         ref={ref}
         workspaceId='workspace-1'
+        mentionQuery={mentionQuery}
         onResourceSelect={onResourceSelect}
         onClose={vi.fn()}
         textareaRef={createRef<HTMLTextAreaElement>()}
@@ -120,6 +139,11 @@ describe('PlusMenuDropdown desktop resources', () => {
       }
     )
     vi.clearAllMocks()
+    fixtures.resources.data = [{ id: 'resource-1', name: 'Example' }]
+    for (const folders of [fixtures.folders, fixtures.tableFolders, fixtures.knowledgeFolders]) {
+      folders.data = []
+      folders.isPending = false
+    }
     fixtures.browserAvailable.mockReturnValue(true)
     fixtures.terminalAvailable.mockReturnValue(true)
     setDesktopPreferencesSnapshot(PREFERENCES)
@@ -230,5 +254,43 @@ describe('PlusMenuDropdown desktop resources', () => {
     const names = menuItems().map((item) => item.textContent)
     expect(names).not.toContain('Browser')
     expect(names).not.toContain('Terminal')
+  })
+
+  it.each(['tableFolders', 'knowledgeFolders'] as const)(
+    'selects an empty %s folder by @ mention and preserves its ID',
+    (family) => {
+      fixtures[family].data = [{ id: 'folder-1', name: 'Planning', parentId: null }]
+      const { ref, onResourceSelect } = openMenu(true, 'Planning')
+      act(() => {
+        expect(ref.current?.selectActive()).toBe('selected')
+      })
+      expect(mapResourceToContext(onResourceSelect.mock.calls[0][0])).toEqual({
+        kind: 'folder',
+        folderId: 'folder-1',
+        label: 'Planning',
+      })
+    }
+  )
+
+  it.each(['tableFolders', 'knowledgeFolders'] as const)(
+    'waits for %s hydration before submitting an unresolved mention',
+    (family) => {
+      fixtures[family].isPending = true
+      const { ref, onResourceSelect } = openMenu(true, 'Planning')
+      expect(ref.current?.selectActive()).toBe('hydrating')
+      expect(onResourceSelect).not.toHaveBeenCalled()
+    }
+  )
+
+  it('keeps empty table and knowledge folder families in the attachment browse menu', () => {
+    fixtures.resources.data = []
+    fixtures.tableFolders.data = [{ id: 'table-folder', name: 'Table Planning', parentId: null }]
+    fixtures.knowledgeFolders.data = [
+      { id: 'kb-folder', name: 'Knowledge Planning', parentId: null },
+    ]
+    openMenu()
+    expect(menuItems().map((item) => item.textContent)).toEqual(
+      expect.arrayContaining(['Tables', 'Knowledge Bases'])
+    )
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/plus-menu-dropdown.tsx
@@ -25,6 +25,7 @@ import {
   buildMentionPreview,
   resourceMentionMatches,
   withDesktopTabMentions,
+  withFolderMentions,
 } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items'
 import type {
   MothershipResource,
@@ -103,6 +104,7 @@ export const PlusMenuDropdown = React.memo(
       isHydrating,
     } = useAvailableResources(workspaceId, {
       enabled: open || !!warm,
+      includeFolderMentions: true,
     })
 
     const doOpen = useCallback(
@@ -121,15 +123,17 @@ export const PlusMenuDropdown = React.memo(
     }, [])
 
     const visibleResources = useMemo(() => {
+      const resources = withFolderMentions(availableResources, structureFolders)
       if (isMention) {
-        return withDesktopTabMentions(availableResources, browserTabs, terminalTabs)
+        return withDesktopTabMentions(resources, browserTabs, terminalTabs)
       }
-      return availableResources.filter(({ type }) => !MENTION_ONLY_RESOURCE_TYPES.has(type))
-    }, [availableResources, browserTabs, isMention, terminalTabs])
+      return resources.filter(({ type }) => !MENTION_ONLY_RESOURCE_TYPES.has(type))
+    }, [availableResources, structureFolders, browserTabs, isMention, terminalTabs])
 
     const treeSections = useResourceTreeSections({
-      groups: visibleResources,
+      groups: availableResources,
       structureFolders,
+      selectFolders: true,
     })
 
     const filteredItems = useMemo(() => {

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.test.ts
@@ -9,6 +9,7 @@ import {
   buildMentionPreview,
   resourceMentionMatches,
   withDesktopTabMentions,
+  withFolderMentions,
 } from '@/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items'
 
 const groups = [
@@ -170,5 +171,33 @@ describe('byResourceMenuOrder', () => {
     ].sort(byResourceMenuOrder)
 
     expect(ordered.map((group) => group.type)).toEqual(['task', 'workflow', 'log', 'browser'])
+  })
+})
+
+describe('folder mentions', () => {
+  it('includes nested and empty table and knowledge folders without changing the browse groups', () => {
+    const source = [
+      { type: 'folder' as const, items: [{ id: 'workflow-folder', name: 'Planning' }] },
+    ]
+    const result = withFolderMentions(source, {
+      table: [{ id: 'table-folder', name: 'Planning', parentId: 'parent' }],
+      knowledgebase: [{ id: 'kb-folder', name: 'Planning', parentId: null }],
+    })
+    expect(source[0].items).toHaveLength(1)
+    expect(result[0].items.map((item) => item.id)).toEqual([
+      'workflow-folder',
+      'table-folder',
+      'kb-folder',
+    ])
+    expect(
+      result[0].items
+        .filter((item) => resourceMentionMatches(item, 'table folders'))
+        .map((item) => item.id)
+    ).toEqual(['table-folder'])
+    expect(
+      result[0].items
+        .filter((item) => resourceMentionMatches(item, 'knowledge base folders'))
+        .map((item) => item.id)
+    ).toEqual(['kb-folder'])
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/plus-menu-dropdown/resource-mention-items.ts
@@ -13,6 +13,28 @@ export interface ResourceMentionGroup {
   items: AvailableItem[]
 }
 
+/** Adds table and knowledge-base folders as stable folder-ID chat mentions. */
+export function withFolderMentions(
+  groups: readonly ResourceMentionGroup[],
+  folders: { table: AvailableItem[]; knowledgebase: AvailableItem[] }
+): ResourceMentionGroup[] {
+  return groups.map((group) =>
+    group.type === 'folder'
+      ? {
+          ...group,
+          items: [
+            ...group.items,
+            ...folders.table.map((item) => ({ ...item, mentionFamily: 'Table folders' })),
+            ...folders.knowledgebase.map((item) => ({
+              ...item,
+              mentionFamily: 'Knowledge base folders',
+            })),
+          ],
+        }
+      : group
+  )
+}
+
 export type ResourceMentionLevel = 'resource' | 'tab'
 
 /** A family query such as "browser" keeps that resource's live tabs visible. */

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.test.tsx
@@ -430,3 +430,54 @@ describe('usePromptEditor context insertion', () => {
     unmount()
   })
 })
+
+describe('folder resource mention identity', () => {
+  it('retains distinct folder IDs and labels when inserting a batch', () => {
+    const { result, unmount } = renderPromptEditor({ workspaceId: 'ws-1' })
+    try {
+      act(() =>
+        result().insertResources([
+          { type: 'folder', id: 'workflow-folder', title: 'Planning' },
+          { type: 'folder', id: 'table-folder', title: 'Planning' },
+          { type: 'folder', id: 'knowledge-folder', title: 'Planning' },
+          { type: 'filefolder', id: 'file-folder', title: 'Planning' },
+          { type: 'folder', id: 'table-folder', title: 'Planning' },
+        ])
+      )
+      expect(result().contexts).toEqual([
+        { kind: 'folder', folderId: 'workflow-folder', label: 'Planning' },
+        { kind: 'folder', folderId: 'table-folder', label: 'Planning (2)' },
+        { kind: 'folder', folderId: 'knowledge-folder', label: 'Planning (3)' },
+        { kind: 'filefolder', fileFolderId: 'file-folder', label: 'Planning (4)' },
+      ])
+      expect(result().value).toBe(
+        '@Planning @Planning (2) @Planning (3) @Planning (4) @Planning (2) '
+      )
+    } finally {
+      unmount()
+    }
+  })
+
+  it('keeps same-named folders as separate chips and reuses the label for a repeated ID', () => {
+    const { result, unmount } = renderPromptEditor({ workspaceId: 'ws-1' })
+    try {
+      act(() =>
+        result().insertResource({ type: 'folder', id: 'workflow-folder', title: 'Planning' })
+      )
+      act(() => result().insertResource({ type: 'folder', id: 'table-folder', title: 'Planning' }))
+      act(() =>
+        result().insertResource({ type: 'folder', id: 'knowledge-folder', title: 'Planning' })
+      )
+      act(() => result().insertResource({ type: 'folder', id: 'table-folder', title: 'Planning' }))
+      expect(result().contexts).toEqual([
+        { kind: 'folder', folderId: 'workflow-folder', label: 'Planning' },
+        { kind: 'folder', folderId: 'table-folder', label: 'Planning (2)' },
+        { kind: 'folder', folderId: 'knowledge-folder', label: 'Planning (3)' },
+      ])
+      expect(result().value).toContain('@Planning (2)')
+      expect(result().value).toContain('@Planning (3)')
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/components/prompt-editor/use-prompt-editor.ts
@@ -27,11 +27,13 @@ import {
   useMentionTokens,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks'
 import {
+  areContextsEqual,
   escapeRegex,
   filterContextsPresentInMessage,
   prepareContextForInsert,
   restoreSkillTriggerText,
   SKILL_CHIP_TRIGGER,
+  uniqueContextLabel,
 } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/utils'
 import { type McpServer, useMcpToolServers } from '@/hooks/queries/mcp'
 import { type SkillDefinition, useSkills } from '@/hooks/queries/skills'
@@ -423,7 +425,14 @@ export function usePromptEditor({
   }, [textareaRef])
 
   const insertResource = useCallback(
-    (resource: MothershipResource) => {
+    (resource: MothershipResource, selected = contextManagementRef.current.selectedContexts) => {
+      const candidate = mapResourceToContext(resource)
+      const context =
+        candidate.kind === 'folder' || candidate.kind === 'filefolder'
+          ? (selected.find(
+              (current) => current.kind === candidate.kind && areContextsEqual(current, candidate)
+            ) ?? { ...candidate, label: uniqueContextLabel(candidate.label, selected) })
+          : candidate
       const textarea = textareaRef.current
       if (textarea) {
         const currentValue = valueRef.current
@@ -438,12 +447,12 @@ export function usePromptEditor({
           after = currentValue.slice(range.end)
           const needsSpaceBefore =
             range.start > 0 && !/\s/.test(currentValue.charAt(range.start - 1))
-          insertText = `${needsSpaceBefore ? ' ' : ''}@${resource.title} `
+          insertText = `${needsSpaceBefore ? ' ' : ''}@${context.label} `
           newPos = before.length + insertText.length
         } else {
           const insertAt = atInsertPosRef.current ?? textarea.selectionStart ?? currentValue.length
           const needsSpaceBefore = insertAt > 0 && !/\s/.test(currentValue.charAt(insertAt - 1))
-          insertText = `${needsSpaceBefore ? ' ' : ''}@${resource.title} `
+          insertText = `${needsSpaceBefore ? ' ' : ''}@${context.label} `
           before = currentValue.slice(0, insertAt)
           after = currentValue.slice(insertAt)
           newPos = before.length + insertText.length
@@ -459,8 +468,8 @@ export function usePromptEditor({
         setValueState(newValue)
       }
 
-      const context = mapResourceToContext(resource)
       addContextNotified(context)
+      return context
     },
     [textareaRef, addContextNotified]
   )
@@ -471,8 +480,10 @@ export function usePromptEditor({
    */
   const insertResources = useCallback(
     (resources: MothershipResource[]) => {
+      let selected = contextManagementRef.current.selectedContexts
       for (const resource of resources) {
-        insertResource(resource)
+        const context = insertResource(resource, selected)
+        selected = [...selected, context]
       }
       atInsertPosRef.current = null
     },

--- a/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/utils.ts
+++ b/apps/sim/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/utils.ts
@@ -222,6 +222,10 @@ export function areContextsEqual(c: ChatContext, context: ChatContext): boolean 
       const ctx = context as FileContext
       return c.fileId === ctx.fileId
     }
+    case 'folder':
+      return context.kind === 'folder' && c.folderId === context.folderId
+    case 'filefolder':
+      return context.kind === 'filefolder' && c.fileFolderId === context.fileFolderId
     // Selection kinds scope to part of a resource, so equality is the selected
     // range — not the file/table — or re-selecting a different passage of an
     // already-referenced file would be swallowed as a duplicate.
@@ -325,9 +329,8 @@ export function isContextAlreadySelected(
  * collision would silently drop the second context. The ordinal keeps both
  * chips alive and stays readable in the input, unlike an opaque hash.
  *
- * Only meaningful for programmatically inserted contexts; menu-driven picks
- * name a distinct resource and dedupe correctly via
- * {@link isContextAlreadySelected}.
+ * Also used by folder menu picks, where separate resource families or parent
+ * folders may contain folders with the same name.
  */
 export function uniqueContextLabel(label: string, selectedContexts: ChatContext[]): string {
   const taken = new Set(selectedContexts.map((c) => c.label))

--- a/apps/sim/lib/copilot/auth/table-delegation.test.ts
+++ b/apps/sim/lib/copilot/auth/table-delegation.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest'
+import { createCopilotChatTablePrincipal } from '@/lib/copilot/auth/table-delegation'
+import { tableDelegationPolicy } from '@/lib/table/application/authorization'
+
+describe('chat table delegation', () => {
+  it('satisfies the table read policy only for the mentioned table', () => {
+    const principal = createCopilotChatTablePrincipal(
+      { userId: 'user-1', workspaceId: 'workspace-1', chatId: 'chat-1' },
+      'table-1'
+    )
+    const context = {
+      workspaceId: 'workspace-1',
+      workspaceOrganizationId: null,
+      allowPersonalApiKeys: true,
+      billedAccountUserId: 'billing-owner',
+    }
+    expect(principal).toMatchObject({
+      subjectUserId: 'user-1',
+      audience: tableDelegationPolicy.audience,
+      resourceScope: { tableId: 'table-1', chatId: 'chat-1' },
+    })
+    expect(tableDelegationPolicy.isWithinScope(principal, { ...context, tableId: 'table-1' })).toBe(
+      true
+    )
+    expect(tableDelegationPolicy.isWithinScope(principal, { ...context, tableId: 'table-2' })).toBe(
+      false
+    )
+    expect(tableDelegationPolicy.isWithinScope(principal, context)).toBe(false)
+  })
+})

--- a/apps/sim/lib/copilot/auth/table-delegation.ts
+++ b/apps/sim/lib/copilot/auth/table-delegation.ts
@@ -1,7 +1,27 @@
 import { messageForCopilotApplicationError } from '@/lib/copilot/application/error'
-import type { CopilotExecutionContext } from '@/lib/copilot/auth/application-delegation'
+import {
+  COPILOT_APPLICATION_DELEGATION_TTL_MS,
+  type CopilotExecutionContext,
+  createTrustedCopilotPrincipal,
+} from '@/lib/copilot/auth/application-delegation'
+import { tableDelegationPolicy } from '@/lib/table/application/authorization'
 
 export type CopilotTableDelegationContext = CopilotExecutionContext
+
+/** Creates the trusted Table principal used while resolving Copilot chat context. */
+export function createCopilotChatTablePrincipal(
+  context: { userId: string; workspaceId: string; chatId?: string },
+  tableId: string
+) {
+  return createTrustedCopilotPrincipal(
+    { ...context, delegationId: `copilot-chat:${context.chatId ?? context.workspaceId}` },
+    {
+      audience: tableDelegationPolicy.audience,
+      ttlMs: COPILOT_APPLICATION_DELEGATION_TTL_MS,
+      resourceScope: { tableId },
+    }
+  )
+}
 
 export function messageForCopilotTableError(
   error: unknown,

--- a/apps/sim/lib/copilot/chat/folder-context.ts
+++ b/apps/sim/lib/copilot/chat/folder-context.ts
@@ -1,0 +1,123 @@
+import { createLogger } from '@sim/logger'
+import {
+  COPILOT_APPLICATION_DELEGATION_TTL_MS,
+  createTrustedCopilotPrincipal,
+} from '@/lib/copilot/auth/application-delegation'
+import { createCopilotChatFilePrincipal } from '@/lib/copilot/auth/file-delegation'
+import { buildVfsFolderPathMap, encodeVfsPathSegments } from '@/lib/copilot/vfs/path-utils'
+import { knowledgeDelegationPolicy } from '@/lib/knowledge/application/authorization'
+import { listKnowledgeFolders } from '@/lib/knowledge/application/folders'
+import { tableDelegationPolicy } from '@/lib/table/application/authorization'
+import { listTableFoldersUseCase } from '@/lib/table/application/folders'
+import { workflowDelegationPolicy } from '@/lib/workflows/application/authorization'
+import { listWorkflowFolders } from '@/lib/workflows/application/workflow-folders'
+import { resolveWorkspaceFileFolderPathOperation } from '@/lib/workspace-files/application/workspace-file-folders'
+import { parseWorkspaceFileFolderDisplayPath } from '@/lib/workspace-files/folder-display-path'
+
+const logger = createLogger('ChatFolderContext')
+
+const FOLDER_DOMAINS = {
+  workflow: { root: 'workflows', policy: workflowDelegationPolicy },
+  table: { root: 'tables', policy: tableDelegationPolicy },
+  knowledge_base: { root: 'knowledgebases', policy: knowledgeDelegationPolicy },
+} as const
+
+type FolderDomain = keyof typeof FOLDER_DOMAINS
+
+/**
+ * Resolves chat folder IDs through each domain's authorized, active-folder query.
+ * The cache belongs to one request: repeated mentions share reads, but later turns
+ * recheck access and pick up moves, renames, and deletions. Generic folder chips
+ * retain their stable ID across clipboard and persisted-chat round trips.
+ */
+export function createChatFolderResolver(userId: string, workspaceId: string, chatId?: string) {
+  const paths = new Map<FolderDomain, Promise<Map<string, string>>>()
+  const filePaths = new Map<string, Promise<string | null>>()
+
+  async function loadPaths(domain: FolderDomain): Promise<Map<string, string>> {
+    const principal = createTrustedCopilotPrincipal(
+      { userId, workspaceId, chatId, delegationId: `copilot-chat:${chatId ?? workspaceId}` },
+      {
+        audience: FOLDER_DOMAINS[domain].policy.audience,
+        ttlMs: COPILOT_APPLICATION_DELEGATION_TTL_MS,
+      }
+    )
+    const input = { workspaceId, sortBy: 'name', sortOrder: 'asc' } as const
+    const { folders } = await (() => {
+      switch (domain) {
+        case 'workflow':
+          return listWorkflowFolders.execute({ principal, input })
+        case 'table':
+          return listTableFoldersUseCase.execute({ principal, input })
+        case 'knowledge_base':
+          return listKnowledgeFolders.execute({ principal, input })
+      }
+    })()
+    return buildVfsFolderPathMap(
+      folders.map((folder) => ({
+        folderId: folder.id,
+        folderName: folder.name,
+        parentId: folder.parentId,
+      }))
+    )
+  }
+
+  async function folderPath(folderId: string, domain: FolderDomain): Promise<string | null> {
+    let pending = paths.get(domain)
+    if (!pending) {
+      pending = loadPaths(domain)
+      paths.set(domain, pending)
+    }
+    return (await pending).get(folderId) ?? null
+  }
+
+  async function folderPointer(folderId: string, fileFolder = false): Promise<string | null> {
+    if (fileFolder) {
+      let pending = filePaths.get(folderId)
+      if (!pending) {
+        pending = resolveWorkspaceFileFolderPathOperation
+          .execute({
+            principal: createCopilotChatFilePrincipal({ userId, workspaceId, chatId }),
+            input: { workspaceId, folderId },
+          })
+          .then(({ path }) =>
+            path
+              ? `files/${encodeVfsPathSegments(parseWorkspaceFileFolderDisplayPath(path))}`
+              : null
+          )
+          .catch((error) => {
+            logger.warn('Could not resolve chat file folder', { workspaceId, folderId, error })
+            return null
+          })
+        filePaths.set(folderId, pending)
+      }
+      return pending
+    }
+    const domains: FolderDomain[] = ['workflow', 'table', 'knowledge_base']
+    const results = await Promise.allSettled(
+      domains.map(async (domain) => {
+        const path = await folderPath(folderId, domain)
+        return path ? `${FOLDER_DOMAINS[domain].root}/${path}` : null
+      })
+    )
+    for (const [index, result] of results.entries()) {
+      if (result.status === 'rejected') {
+        logger.warn('Could not resolve chat folder domain', {
+          domain: domains[index],
+          workspaceId,
+          error: result.reason,
+        })
+      }
+    }
+    return (
+      results.find(
+        (result): result is PromiseFulfilledResult<string> =>
+          result.status === 'fulfilled' && typeof result.value === 'string'
+      )?.value ?? null
+    )
+  }
+
+  return { folderPath, folderPointer }
+}
+
+export type ChatFolderResolver = ReturnType<typeof createChatFolderResolver>

--- a/apps/sim/lib/copilot/chat/process-contents.test.ts
+++ b/apps/sim/lib/copilot/chat/process-contents.test.ts
@@ -24,6 +24,11 @@ const {
   getTableById,
   getRowsByIds,
   readKnowledgeBase,
+  readTableUseCase,
+  listWorkflowFolders,
+  listTableFolders,
+  listKnowledgeFolders,
+  resolveFileFolderPath,
   getBlockVisibilityForCopilot,
   isIntegrationDeploymentAvailable,
   searchDocsExecute,
@@ -38,6 +43,23 @@ const {
   getTableById: vi.fn(),
   getRowsByIds: vi.fn(),
   readKnowledgeBase: vi.fn(),
+  readTableUseCase: vi.fn(),
+  listWorkflowFolders: vi.fn(
+    async (): Promise<{ folders: { id: string; name: string; parentId: string | null }[] }> => ({
+      folders: [],
+    })
+  ),
+  listTableFolders: vi.fn(
+    async (): Promise<{ folders: { id: string; name: string; parentId: string | null }[] }> => ({
+      folders: [],
+    })
+  ),
+  listKnowledgeFolders: vi.fn(
+    async (): Promise<{ folders: { id: string; name: string; parentId: string | null }[] }> => ({
+      folders: [],
+    })
+  ),
+  resolveFileFolderPath: vi.fn(async (): Promise<{ path: string | null }> => ({ path: null })),
   getBlockVisibilityForCopilot: vi.fn(async () => null),
   isIntegrationDeploymentAvailable: vi.fn(() => true),
   searchDocsExecute: vi.fn(),
@@ -60,6 +82,21 @@ vi.mock('@/lib/table/rows/service', () => ({ getRowsByIds }))
 vi.mock('@/lib/knowledge/application/knowledge-bases', () => ({
   readKnowledgeBase: { execute: readKnowledgeBase },
 }))
+vi.mock('@/lib/table/application/tables', () => ({
+  readTableUseCase: { execute: readTableUseCase },
+}))
+vi.mock('@/lib/workflows/application/workflow-folders', () => ({
+  listWorkflowFolders: { execute: listWorkflowFolders },
+}))
+vi.mock('@/lib/table/application/folders', () => ({
+  listTableFoldersUseCase: { execute: listTableFolders },
+}))
+vi.mock('@/lib/knowledge/application/folders', () => ({
+  listKnowledgeFolders: { execute: listKnowledgeFolders },
+}))
+vi.mock('@/lib/workspace-files/application/workspace-file-folders', () => ({
+  resolveWorkspaceFileFolderPathOperation: { execute: resolveFileFolderPath },
+}))
 vi.mock('@/lib/copilot/tools/server/docs/search-docs', () => ({
   searchDocsServerTool: { execute: searchDocsExecute },
 }))
@@ -69,13 +106,17 @@ vi.mock('@/lib/copilot/tools/server/docs/search-docs', () => ({
  * controllable row data, which the stable `dbChainMockFns.limit` provides.
  */
 
-import { processContextsServer } from './process-contents'
+import {
+  processContextsServer,
+  resolveActiveResourceContext,
+} from '@/lib/copilot/chat/process-contents'
 
 describe('processContextsServer - knowledge contexts', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     readKnowledgeBase.mockResolvedValue({
       knowledgeBase: { id: 'knowledge-1', name: 'Product docs' },
+      folderPath: '/',
     })
   })
 
@@ -1057,5 +1098,199 @@ describe('processContextsServer - table_selection contexts', () => {
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toContain(huge)
+  })
+})
+
+describe('folder and foldered-resource chat pointers', () => {
+  const nestedFolders = [
+    { id: 'parent', name: 'Finance/Legal', parentId: null },
+    { id: 'child', name: 'Q4 100%', parentId: 'parent' },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resolveFileFolderPath.mockResolvedValue({ path: null })
+    for (const list of [listWorkflowFolders, listTableFolders, listKnowledgeFolders]) {
+      list.mockResolvedValue({ folders: [] })
+    }
+  })
+
+  it.each([
+    ['workflow', 'workflows', listWorkflowFolders],
+    ['table', 'tables', listTableFolders],
+    ['knowledge', 'knowledgebases', listKnowledgeFolders],
+  ] as const)(
+    'resolves nested %s folders identically for mentions and active resources',
+    async (_kind, root, list) => {
+      list.mockResolvedValue({ folders: nestedFolders })
+      const context: ChatContext = { kind: 'folder', folderId: 'child', label: 'Chosen folder' }
+      const [mention] = await processContextsServer(
+        [context],
+        'user-1',
+        'inspect',
+        'ws-1',
+        'chat-1'
+      )
+      const active = await resolveActiveResourceContext(
+        context.kind,
+        'child',
+        'ws-1',
+        'user-1',
+        'chat-1'
+      )
+      const path = `${root}/Finance%2FLegal/Q4%20100%25`
+      expect(mention).toMatchObject({ type: context.kind, tag: '@Chosen folder', path })
+      expect(mention.content).toBe('')
+      expect(active).toMatchObject({ type: 'folder', tag: '@active_resource', path })
+      expect(list).toHaveBeenCalledWith({
+        principal: expect.objectContaining({
+          kind: 'delegated',
+          serviceId: 'copilot',
+          subjectUserId: 'user-1',
+          workspaceId: 'ws-1',
+          resourceScope: { chatId: 'chat-1' },
+        }),
+        input: expect.objectContaining({ workspaceId: 'ws-1' }),
+      })
+    }
+  )
+
+  it('resolves file-folder mentions and active resources through the authorized path query', async () => {
+    resolveFileFolderPath.mockResolvedValue({ path: 'Finance\\/Legal/Q4 100%' })
+    const [result] = await processContextsServer(
+      [{ kind: 'filefolder', fileFolderId: 'child', label: 'Chosen folder' }],
+      'user-1',
+      '',
+      'ws-1',
+      'chat-1'
+    )
+    const active = await resolveActiveResourceContext(
+      'filefolder',
+      'child',
+      'ws-1',
+      'user-1',
+      'chat-1'
+    )
+    expect(result.path).toBe('files/Finance%2FLegal/Q4%20100%25')
+    expect(result.content).toBe('')
+    expect(active).toMatchObject({
+      type: 'filefolder',
+      tag: '@active_resource',
+      path: result.path,
+    })
+    expect(resolveFileFolderPath).toHaveBeenCalledWith({
+      principal: expect.objectContaining({
+        subjectUserId: 'user-1',
+        workspaceId: 'ws-1',
+        audience: 'sim:workspace-files',
+        resourceScope: { chatId: 'chat-1' },
+      }),
+      input: { workspaceId: 'ws-1', folderId: 'child' },
+    })
+  })
+
+  it('shares folder reads within a turn and re-resolves moves on the next turn', async () => {
+    listTableFolders.mockResolvedValue({ folders: nestedFolders })
+    const contexts: ChatContext[] = [
+      { kind: 'folder', folderId: 'parent', label: 'Parent' },
+      { kind: 'folder', folderId: 'child', label: 'Child' },
+    ]
+    await processContextsServer(contexts, 'user-1', '', 'ws-1')
+    expect(listTableFolders).toHaveBeenCalledTimes(1)
+    listTableFolders.mockResolvedValue({
+      folders: [{ id: 'child', name: 'Moved', parentId: null }],
+    })
+    const [result] = await processContextsServer([contexts[1]], 'user-1', '', 'ws-1')
+    expect(result.path).toBe('tables/Moved')
+    expect(listTableFolders).toHaveBeenCalledTimes(2)
+  })
+
+  it('can resolve an allowed folder when another resource family is forbidden', async () => {
+    listWorkflowFolders.mockRejectedValueOnce(new DelegatedWorkspaceAuthorizationError())
+    listTableFolders.mockResolvedValue({ folders: nestedFolders })
+    const [result] = await processContextsServer(
+      [{ kind: 'folder', folderId: 'child', label: 'Child' }],
+      'user-1',
+      '',
+      'ws-1'
+    )
+    expect(result.path).toBe('tables/Finance%2FLegal/Q4%20100%25')
+  })
+
+  it.each(['missing', 'deleted', 'other-workspace'])(
+    'reports an unresolved %s folder without substituting by name',
+    async (id) => {
+      listTableFolders.mockResolvedValue({ folders: nestedFolders })
+      const [result] = await processContextsServer(
+        [{ kind: 'folder', folderId: id, label: 'Q4 100%' }],
+        'user-1',
+        '',
+        'ws-1'
+      )
+      expect(result.path).toBeUndefined()
+      expect(result.content).toContain('could not be resolved')
+    }
+  )
+
+  it('conceals denied file-folder paths and infrastructure details', async () => {
+    resolveFileFolderPath.mockRejectedValueOnce(new Error('private database host'))
+    const [result] = await processContextsServer(
+      [{ kind: 'filefolder', fileFolderId: 'child', label: 'Child' }],
+      'user-1',
+      '',
+      'ws-1'
+    )
+    expect(result.path).toBeUndefined()
+    expect(result.content).not.toContain('private database host')
+  })
+
+  it.each(['table', 'knowledge'] as const)(
+    'keeps the canonical folder path for a %s mention and active resource',
+    async (kind) => {
+      const folderPath = '/Finance%2FLegal/Q4%20100%25'
+      readTableUseCase.mockResolvedValue({
+        table: { id: 'resource', name: 'Same name' },
+        folderPath,
+      })
+      readKnowledgeBase.mockResolvedValue({
+        knowledgeBase: { id: 'resource', name: 'Same name' },
+        folderPath,
+      })
+      const context: ChatContext =
+        kind === 'table'
+          ? { kind, tableId: 'resource', label: 'Resource' }
+          : { kind, knowledgeId: 'resource', label: 'Resource' }
+      const [result] = await processContextsServer([context], 'user-1', '', 'ws-1')
+      const active = await resolveActiveResourceContext(
+        kind === 'knowledge' ? 'knowledgebase' : kind,
+        'resource',
+        'ws-1',
+        'user-1'
+      )
+      const root = kind === 'table' ? 'tables' : 'knowledgebases'
+      expect(result.path).toBe(`${root}/Finance%2FLegal/Q4%20100%25/Same%20name/meta.json`)
+      expect(active?.path).toBe(result.path)
+    }
+  )
+
+  it('conceals unauthorized table mentions through the application query', async () => {
+    readTableUseCase.mockRejectedValueOnce(new DelegatedWorkspaceAuthorizationError())
+    await expect(
+      processContextsServer(
+        [{ kind: 'table', tableId: 'hidden', label: 'Hidden' }],
+        'user-1',
+        '',
+        'ws-1'
+      )
+    ).resolves.toEqual([])
+    expect(readTableUseCase).toHaveBeenCalledWith({
+      principal: expect.objectContaining({
+        audience: 'sim:tables',
+        subjectUserId: 'user-1',
+        workspaceId: 'ws-1',
+        resourceScope: { tableId: 'hidden' },
+      }),
+      input: { tableId: 'hidden', workspaceId: 'ws-1' },
+    })
   })
 })

--- a/apps/sim/lib/copilot/chat/process-contents.ts
+++ b/apps/sim/lib/copilot/chat/process-contents.ts
@@ -7,7 +7,12 @@ import {
 import { eq } from 'drizzle-orm'
 import { createCopilotChatKnowledgePrincipal } from '@/lib/copilot/application/execute-knowledge-use-case'
 import { createCopilotChatFilePrincipal } from '@/lib/copilot/auth/file-delegation'
+import { createCopilotChatTablePrincipal } from '@/lib/copilot/auth/table-delegation'
 import { getBlockVisibilityForCopilot } from '@/lib/copilot/block-visibility'
+import {
+  type ChatFolderResolver,
+  createChatFolderResolver,
+} from '@/lib/copilot/chat/folder-context'
 import {
   MAX_TABLE_SELECTION_CONTENT_LENGTH,
   safeBrowserSelectionUrl,
@@ -30,6 +35,7 @@ import {
 } from '@/lib/copilot/vfs/path-utils'
 import { EnvCapabilityConfigurationError } from '@/lib/core/config/env-capabilities'
 import { getAllowedIntegrationsFromEnv } from '@/lib/core/config/env-flags'
+import { parseFolderPath } from '@/lib/folders/paths'
 import { isIntegrationDeploymentAvailableForVisibility } from '@/lib/integrations/availability.server'
 import { readKnowledgeBase } from '@/lib/knowledge/application/knowledge-bases'
 import {
@@ -47,15 +53,14 @@ import {
   intersectIntegrationAllowlists,
   resolveAccessControlBlockType,
 } from '@/lib/permission-groups/integration-allowlist'
+import { readTableUseCase } from '@/lib/table/application/tables'
 import { getColumnId } from '@/lib/table/column-keys'
 import { getRowsByIds } from '@/lib/table/rows/service'
 import { getTableById } from '@/lib/table/service'
 import type { ColumnDefinition } from '@/lib/table/types'
-import { getWorkspaceFileFolderPath } from '@/lib/uploads/contexts/workspace/workspace-file-folder-manager'
 import { getSkillById } from '@/lib/workflows/skills/operations'
 import { listFolders } from '@/lib/workflows/utils'
 import { readWorkspaceFileMetadata } from '@/lib/workspace-files/application/read-workspace-file-metadata'
-import { parseWorkspaceFileFolderDisplayPath } from '@/lib/workspace-files/folder-display-path'
 import { escapeRegExp } from '@/executor/constants'
 import type { ResolvedSecretTraceRegistry } from '@/executor/utils/resolved-secret-trace-registry'
 import type { BrowserTextSelection, ChatContext, TerminalTextSelection } from '@/stores/panel'
@@ -137,6 +142,9 @@ export async function processContextsServer(
   resolvedSecretTraceRegistry?: ResolvedSecretTraceRegistry
 ): Promise<AgentContext[]> {
   if (!Array.isArray(contexts) || contexts.length === 0) return []
+  const folderResolver = currentWorkspaceId
+    ? createChatFolderResolver(userId, currentWorkspaceId, chatId)
+    : undefined
   const tasks = contexts.map(async (ctx) => {
     try {
       if (ctx.kind === 'skill' && ctx.skillId && currentWorkspaceId) {
@@ -256,7 +264,7 @@ export async function processContextsServer(
         )
       }
       if (ctx.kind === 'table' && ctx.tableId && currentWorkspaceId) {
-        const result = await resolveTableResource(ctx.tableId, currentWorkspaceId)
+        const result = await resolveTableResource(ctx.tableId, currentWorkspaceId, userId, chatId)
         if (!result) return null
         return {
           type: 'table',
@@ -299,27 +307,20 @@ export async function processContextsServer(
           currentWorkspaceId,
           ctx.rowIds,
           ctx.columnIds,
-          ctx.label
+          ctx.label,
+          folderResolver
         )
       }
-      if (ctx.kind === 'folder' && 'folderId' in ctx && ctx.folderId && currentWorkspaceId) {
-        const result = await resolveFolderResource(ctx.folderId, currentWorkspaceId)
-        if (!result) return null
+      if ((ctx.kind === 'folder' || ctx.kind === 'filefolder') && folderResolver) {
+        const folderId = ctx.kind === 'folder' ? ctx.folderId : ctx.fileFolderId
+        const path = await folderResolver.folderPointer(folderId, ctx.kind === 'filefolder')
         return {
-          type: 'folder',
+          type: ctx.kind,
           tag: ctx.label ? `@${ctx.label}` : '@',
-          content: result.content,
-          path: result.path,
-        }
-      }
-      if (ctx.kind === 'filefolder' && ctx.fileFolderId && currentWorkspaceId) {
-        const result = await resolveFileFolderResource(ctx.fileFolderId, currentWorkspaceId)
-        if (!result) return null
-        return {
-          type: 'filefolder',
-          tag: ctx.label ? `@${ctx.label}` : '@',
-          content: result.content,
-          path: result.path,
+          content: path
+            ? ''
+            : 'The attached folder could not be resolved in this workspace. Do not guess its contents or substitute a similarly named folder.',
+          ...(path ? { path } : {}),
         }
       }
       if (ctx.kind === 'docs') {
@@ -580,7 +581,7 @@ async function processKnowledgeFromDb(
       workspaceId: currentWorkspaceId,
       chatId,
     })
-    const { knowledgeBase: kb } = await readKnowledgeBase.execute({
+    const { knowledgeBase: kb, folderPath } = await readKnowledgeBase.execute({
       principal,
       input: {
         knowledgeBaseId,
@@ -592,7 +593,7 @@ async function processKnowledgeFromDb(
       type: 'knowledge',
       tag,
       content: '',
-      path: `${canonicalKnowledgeBaseVfsDir(kb.name)}/meta.json`,
+      path: `${canonicalKnowledgeBaseVfsDir(kb.name, encodeVfsPathSegments(parseFolderPath(folderPath)))}/meta.json`,
     }
   } catch (error) {
     logger.error('Error processing knowledge context (db)', { knowledgeBaseId, error })
@@ -871,16 +872,18 @@ export async function resolveActiveResourceContext(
         }
       }
       case 'table': {
-        return await resolveTableResource(resourceId, workspaceId)
+        return await resolveTableResource(resourceId, workspaceId, userId, chatId)
       }
       case 'file': {
         return await resolveFileResource(resourceId, workspaceId, userId, chatId)
       }
-      case 'folder': {
-        return await resolveFolderResource(resourceId, workspaceId)
-      }
+      case 'folder':
       case 'filefolder': {
-        return await resolveFileFolderResource(resourceId, workspaceId)
+        const path = await createChatFolderResolver(userId, workspaceId, chatId).folderPointer(
+          resourceId,
+          resourceType === 'filefolder'
+        )
+        return path ? { type: resourceType, tag: '@active_resource', content: '', path } : null
       }
       default:
         return null
@@ -892,16 +895,19 @@ export async function resolveActiveResourceContext(
 }
 async function resolveTableResource(
   tableId: string,
-  workspaceId: string
+  workspaceId: string,
+  userId: string,
+  chatId?: string
 ): Promise<AgentContext | null> {
-  const table = await getTableById(tableId)
-  if (!table) return null
-  if (table.workspaceId !== workspaceId) return null
+  const { table, folderPath } = await readTableUseCase.execute({
+    principal: createCopilotChatTablePrincipal({ userId, workspaceId, chatId }, tableId),
+    input: { tableId, workspaceId },
+  })
   return {
     type: 'active_resource',
     tag: '@active_resource',
     content: '',
-    path: canonicalTableVfsPath(table.name),
+    path: canonicalTableVfsPath(table.name, encodeVfsPathSegments(parseFolderPath(folderPath))),
   }
 }
 
@@ -1008,10 +1014,16 @@ async function resolveTableSelectionResource(
   workspaceId: string,
   rowIds: string[],
   columnIds: string[] | undefined,
-  label: string
+  label: string,
+  folderResolver?: ChatFolderResolver
 ): Promise<AgentContext | null> {
   const table = await getTableById(tableId)
   if (!table || table.workspaceId !== workspaceId) return null
+
+  const folderPath = table.folderId
+    ? await folderResolver?.folderPath(table.folderId, 'table')
+    : null
+  if (table.folderId && !folderPath) return null
 
   const rows = await getRowsByIds(tableId, rowIds, workspaceId)
   if (rows.length === 0) return null
@@ -1069,40 +1081,6 @@ async function resolveTableSelectionResource(
     type: 'table_selection',
     tag: label ? `@${label}` : '@',
     content,
-    path: canonicalTableVfsPath(table.name),
-  }
-}
-
-async function resolveFileFolderResource(
-  folderId: string,
-  workspaceId: string
-): Promise<AgentContext | null> {
-  try {
-    const rawPath = await getWorkspaceFileFolderPath(workspaceId, folderId)
-    if (!rawPath) return null
-    const encoded = encodeVfsPathSegments(parseWorkspaceFileFolderDisplayPath(rawPath))
-    return {
-      type: 'active_resource',
-      tag: '@active_resource',
-      content: '',
-      path: `files/${encoded}`,
-    }
-  } catch (error) {
-    logger.error('Failed to resolve file folder resource', { folderId, error })
-    return null
-  }
-}
-
-async function resolveFolderResource(
-  folderId: string,
-  workspaceId: string
-): Promise<AgentContext | null> {
-  const folderPath = await resolveWorkflowFolderPath(workspaceId, folderId)
-  if (!folderPath) return null
-  return {
-    type: 'active_resource',
-    tag: '@active_resource',
-    content: '',
-    path: `workflows/${folderPath}`,
+    path: canonicalTableVfsPath(table.name, folderPath),
   }
 }

--- a/apps/sim/lib/copilot/vfs/path-utils.test.ts
+++ b/apps/sim/lib/copilot/vfs/path-utils.test.ts
@@ -59,6 +59,16 @@ describe('canonical resource VFS paths', () => {
     ).toBe('workflows/My%20Folder/Sub%20Folder/My%20Flow')
   })
 
+  it('preserves encoded nested folders in table and knowledge-base pointers', () => {
+    const folderPath = 'Finance%2FLegal/Q4%20100%25'
+    expect(canonicalTableVfsPath('Same name', folderPath)).toBe(
+      'tables/Finance%2FLegal/Q4%20100%25/Same%20name/meta.json'
+    )
+    expect(canonicalKnowledgeBaseVfsDir('Same name', folderPath)).toBe(
+      'knowledgebases/Finance%2FLegal/Q4%20100%25/Same%20name'
+    )
+  })
+
   it('builds table, knowledge base, and block pointers', () => {
     expect(canonicalTableVfsPath('Sales Data')).toBe('tables/Sales%20Data/meta.json')
     expect(canonicalKnowledgeBaseVfsDir('Docs — KB')).toBe('knowledgebases/Docs%20%E2%80%94%20KB')

--- a/apps/sim/lib/copilot/vfs/path-utils.ts
+++ b/apps/sim/lib/copilot/vfs/path-utils.ts
@@ -99,14 +99,14 @@ export function canonicalWorkflowVfsDir(parts: {
   return parts.folderPath ? `workflows/${parts.folderPath}/${safeName}` : `workflows/${safeName}`
 }
 
-/** Canonical VFS path for a table's metadata file (`tables/{name}/meta.json`). */
-export function canonicalTableVfsPath(name: string): string {
-  return `tables/${encodeVfsSegment(name)}/meta.json`
+/** Canonical table metadata path; folderPath is already encoded per segment. */
+export function canonicalTableVfsPath(name: string, folderPath?: string | null): string {
+  return `tables/${folderPath ? `${folderPath}/` : ''}${encodeVfsSegment(name)}/meta.json`
 }
 
-/** Canonical VFS directory for a knowledge base (`knowledgebases/{name}`). */
-export function canonicalKnowledgeBaseVfsDir(name: string): string {
-  return `knowledgebases/${encodeVfsSegment(name)}`
+/** Canonical knowledge-base directory; folderPath is already encoded per segment. */
+export function canonicalKnowledgeBaseVfsDir(name: string, folderPath?: string | null): string {
+  return `knowledgebases/${folderPath ? `${folderPath}/` : ''}${encodeVfsSegment(name)}`
 }
 
 /** Canonical VFS path for a block catalog entry (`components/blocks/{type}.json`). */

--- a/apps/sim/lib/knowledge/application/folders.test.ts
+++ b/apps/sim/lib/knowledge/application/folders.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTrustedCopilotPrincipal } from '@/lib/copilot/auth/application-delegation'
 
 const mocks = vi.hoisted(() => ({
   resolveWorkspace: vi.fn(),
@@ -117,6 +118,41 @@ describe('knowledge folder application use cases', () => {
     )
     expect(result.folders[0]).toMatchObject({ id: 'folder-1', path: '/Docs' })
   })
+
+  it('allows a current workspace reader to resolve folders through Copilot', async () => {
+    mocks.resolvePermission.mockResolvedValue('read')
+    const result = await listKnowledgeFolders.execute({
+      principal: createTrustedCopilotPrincipal(
+        { userId: 'user-1', workspaceId: 'workspace-1', delegationId: 'chat-1' },
+        { audience: 'sim:knowledge', ttlMs: 60_000 }
+      ),
+      input: { workspaceId: 'workspace-1' },
+    })
+    expect(result.folders).toEqual([{ ...folder, path: '/Docs' }])
+    expect(mocks.recordAudit).not.toHaveBeenCalled()
+  })
+
+  it.each(['revoked', 'other-workspace'])(
+    'rejects %s Copilot access before listing folders',
+    async (reason) => {
+      if (reason === 'revoked') mocks.resolvePermission.mockResolvedValue(null)
+      await expect(
+        listKnowledgeFolders.execute({
+          principal: createTrustedCopilotPrincipal(
+            {
+              userId: 'user-1',
+              workspaceId: reason === 'other-workspace' ? 'workspace-2' : 'workspace-1',
+              delegationId: 'chat-1',
+            },
+            { audience: 'sim:knowledge', ttlMs: 60_000 }
+          ),
+          input: { workspaceId: 'workspace-1' },
+        })
+      ).rejects.toThrow()
+      expect(mocks.loadIndex).not.toHaveBeenCalled()
+      expect(mocks.listRows).not.toHaveBeenCalled()
+    }
+  )
 
   /**
    * `parentPath` is a filter, so a path naming no active folder narrows the

--- a/apps/sim/lib/knowledge/application/operations.test.ts
+++ b/apps/sim/lib/knowledge/application/operations.test.ts
@@ -212,14 +212,24 @@ describe('knowledge operation registry', () => {
     ).toBe(true)
   })
 
-  it('allows delegated callers only on semantic knowledge and document operations', () => {
+  it('allows Copilot folder discovery without delegating folder mutations or upload completion', () => {
     expect(knowledgeOperations.list.principalKinds).toContain('delegated')
     expect(knowledgeOperations.search.principalKinds).toContain('delegated')
     expect(knowledgeOperations.uploadDocument.principalKinds).toContain('delegated')
     expect(knowledgeOperations.updateDocument.principalKinds).toContain('delegated')
     expect(knowledgeOperations.updateTag.principalKinds).toContain('delegated')
     expect(knowledgeOperations.syncConnector.principalKinds).toContain('delegated')
-    expect(knowledgeOperations.listFolders.principalKinds).not.toContain('delegated')
+    expect(knowledgeOperations.listFolders.principalKinds).toContain('delegated')
+    expect(knowledgeOperations.listFolders.delegatedServices).toEqual(['copilot'])
+    expect(knowledgeOperations.listFolders.minimumRole).toBe('read')
+    for (const operation of [
+      knowledgeOperations.createFolder,
+      knowledgeOperations.relocateFolder,
+      knowledgeOperations.deleteFolder,
+    ]) {
+      expect(operation.principalKinds).not.toContain('delegated')
+      expect(operation.delegatedServices).toBeUndefined()
+    }
     expect(knowledgeOperations.uploadComplete.principalKinds).not.toContain('delegated')
     expect(knowledgeOperations.list.delegatedServices).toEqual(['copilot'])
     expect(knowledgeOperations.search.delegatedServices).toEqual(['copilot', 'executor'])

--- a/apps/sim/lib/knowledge/application/operations.ts
+++ b/apps/sim/lib/knowledge/application/operations.ts
@@ -15,12 +15,19 @@ export type ScopedKnowledgeOperation<O extends WorkspaceOperation = WorkspaceOpe
   readonly organizationOperation: OrganizationOperation
 }
 
+interface KnowledgeOperationOptions {
+  organizationDelegation?: 'deny'
+}
+
 /** Binds organization policy to the same semantic operation declared for workspace access. */
 function defineKnowledgeOperation<const O extends WorkspaceOperation>(
-  operation: O
+  operation: O,
+  options?: KnowledgeOperationOptions
 ): ScopedKnowledgeOperation<O> {
   const supportsOrganizationDelegation =
-    operation.minimumRole === 'read' && operation.delegatedServices?.includes('copilot')
+    options?.organizationDelegation !== 'deny' &&
+    operation.minimumRole === 'read' &&
+    operation.delegatedServices?.includes('copilot')
   const organizationOperation = defineOrganizationOperation({
     id: operation.id,
     capability: operation.capability,
@@ -258,7 +265,9 @@ export const knowledgeOperations = {
       workspaceApiKey: 'allow',
       capability: 'knowledge.use',
       ...ALL_PRINCIPAL_POLICY,
-    })
+    }),
+    /** Folder mentions resolve workspace folders; organization delegation stays disabled. */
+    { organizationDelegation: 'deny' }
   ),
   createFolder: defineKnowledgeOperation(
     defineWorkspaceOperation({

--- a/apps/sim/lib/knowledge/application/operations.ts
+++ b/apps/sim/lib/knowledge/application/operations.ts
@@ -257,7 +257,7 @@ export const knowledgeOperations = {
       minimumRole: 'read',
       workspaceApiKey: 'allow',
       capability: 'knowledge.use',
-      principalKinds: HTTP_PRINCIPAL_KINDS,
+      ...ALL_PRINCIPAL_POLICY,
     })
   ),
   createFolder: defineKnowledgeOperation(

--- a/apps/sim/lib/workspace-files/application/workspace-file-folders.test.ts
+++ b/apps/sim/lib/workspace-files/application/workspace-file-folders.test.ts
@@ -13,6 +13,7 @@ const {
   mockDeleteByPath,
   mockEnsure,
   mockList,
+  mockGetFolderPath,
   mockRelocate,
   mockRestore,
   mockAudit,
@@ -27,6 +28,7 @@ const {
   mockDeleteByPath: vi.fn(),
   mockEnsure: vi.fn(),
   mockList: vi.fn(),
+  mockGetFolderPath: vi.fn(),
   mockRelocate: vi.fn(),
   mockRestore: vi.fn(),
   mockAudit: vi.fn(),
@@ -40,6 +42,7 @@ vi.mock('@/lib/uploads/contexts/workspace', () => ({
   deleteWorkspaceFileFolderByPath: mockDeleteByPath,
   ensureWorkspaceFileFolderPath: mockEnsure,
   listWorkspaceFileFolders: mockList,
+  getWorkspaceFileFolderPath: mockGetFolderPath,
   loadWorkspaceFileOperationContext: mockLoadContext,
   relocateWorkspaceFileFolderByPath: mockRelocate,
   restoreWorkspaceFileFolder: mockRestore,
@@ -61,12 +64,14 @@ vi.mock('@sim/audit', () => ({
 }))
 vi.mock('@/lib/realtime/notify', () => ({ notifyWorkspaceFilesChanged: mockNotify }))
 
+import { createCopilotChatFilePrincipal } from '@/lib/copilot/auth/file-delegation'
 import { OrchestrationError } from '@/lib/core/orchestration/types'
 import {
   createWorkspaceFileFolderOperation,
   deleteWorkspaceFileFolderOperation,
   ensureWorkspaceFileFolderPathOperation,
   listWorkspaceFileFoldersOperation,
+  resolveWorkspaceFileFolderPathOperation,
   restoreWorkspaceFileFolderOperation,
   updateWorkspaceFileFolderOperation,
 } from '@/lib/workspace-files/application/workspace-file-folders'
@@ -102,6 +107,36 @@ describe('workspace file folder operations', () => {
     })
     mockAssertItems.mockResolvedValue(undefined)
     mockArchive.mockResolvedValue({ files: 0, folders: 1, fileIds: [], folderIds: ['folder-1'] })
+  })
+
+  it('resolves a Copilot folder pointer after authorization without listing every folder', async () => {
+    mockGetFolderPath.mockImplementation(async () => {
+      events.push('read-path')
+      return 'Reports/Quarterly'
+    })
+    const result = await resolveWorkspaceFileFolderPathOperation.execute({
+      principal: createCopilotChatFilePrincipal({
+        userId: 'user-1',
+        workspaceId: 'ws-1',
+        chatId: 'chat-1',
+      }),
+      input: { workspaceId: 'ws-1', folderId: 'folder-1' },
+    })
+    expect(result.path).toBe('Reports/Quarterly')
+    expect(events.indexOf('authorize')).toBeLessThan(events.indexOf('read-path'))
+    expect(mockGetFolderPath).toHaveBeenCalledWith('ws-1', 'folder-1')
+    expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it('refuses a folder pointer after the Copilot user loses workspace access', async () => {
+    mockResolvePermission.mockResolvedValue(null)
+    await expect(
+      resolveWorkspaceFileFolderPathOperation.execute({
+        principal: createCopilotChatFilePrincipal({ userId: 'user-1', workspaceId: 'ws-1' }),
+        input: { workspaceId: 'ws-1', folderId: 'folder-1' },
+      })
+    ).rejects.toThrow()
+    expect(mockGetFolderPath).not.toHaveBeenCalled()
   })
 
   const LEAF = {

--- a/apps/sim/lib/workspace-files/application/workspace-file-folders.ts
+++ b/apps/sim/lib/workspace-files/application/workspace-file-folders.ts
@@ -13,6 +13,7 @@ import {
   createWorkspaceFileFolderAtPath,
   deleteWorkspaceFileFolderByPath,
   ensureWorkspaceFileFolderPath,
+  getWorkspaceFileFolderPath,
   listWorkspaceFileFolders,
   loadWorkspaceFileOperationContext,
   relocateWorkspaceFileFolderByPath,
@@ -358,6 +359,16 @@ export const listWorkspaceFileFoldersOperation = defineAuthorizedWorkspaceFileUs
   operation: fileOperations.listFolders,
   resolveContext: (args: { input: ListWorkspaceFileFoldersInput }) => resolveFolderContext(args),
   execute: executeListWorkspaceFileFolders,
+})
+
+/** Resolves one active folder under the folder-list policy without loading the entire tree. */
+export const resolveWorkspaceFileFolderPathOperation = defineAuthorizedWorkspaceFileUseCase({
+  operation: fileOperations.listFolders,
+  resolveContext: (args: { input: { workspaceId: string; folderId: string } }) =>
+    resolveFolderContext(args),
+  async execute({ input, context }) {
+    return { path: await getWorkspaceFileFolderPath(context.workspaceId, input.folderId) }
+  },
 })
 
 export const createWorkspaceFileFolderOperation = defineAuthorizedWorkspaceFileUseCase({


### PR DESCRIPTION
## Summary
- Make table, knowledge-base, workflow, and file folders selectable in chat, including nested and empty folders. Keep distinct folder IDs when names collide or folders are attached in a batch.
- Resolve folder mentions through authorized application reads and preserve canonical nested paths for folders, tables, and knowledge bases. Recheck access and folder locations each turn.
- Keep knowledge folder delegation limited to workspace reads, preserving organization restrictions and the existing folder mutation policies.
- Preserve folder context types so Copilot discovers descendants before reading their contents.

Companion: simstudioai/mothership#485

## Type of Change
- [x] Bug fix

## Testing
- 330 tests passed across 20 files, including mention selection, clipboard handling, authorization, canonical paths, and VFS operations.
- Expanded knowledge application and chat regression run: 350 tests passed, including operation-policy checks.
- Type checking, repository lint, all 46 audits, block-registry checks, and generated-artifact checks passed.
- Completed all eight cleanup review passes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
