### PR TITLE
fix(landing): disable native dragging of navbar logos

### DIFF
--- a/apps/sim/app/(landing)/components/navbar/components/nav-menu-chip/components/nav-menu-logo-marquee/nav-menu-logo-marquee.test.tsx
+++ b/apps/sim/app/(landing)/components/navbar/components/nav-menu-chip/components/nav-menu-logo-marquee/nav-menu-logo-marquee.test.tsx
@@ -10,9 +10,15 @@ vi.mock('@sim/emcn', () => ({
 }))
 
 vi.mock('next/image', () => ({
-  default: ({ alt, className }: { alt: string; className?: string }) => (
-    <img alt={alt} className={className} />
-  ),
+  default: ({
+    alt,
+    className,
+    draggable,
+  }: {
+    alt: string
+    className?: string
+    draggable?: boolean
+  }) => <img alt={alt} className={className} draggable={draggable} />,
 }))
 
 import { LOGOS } from '@/app/(landing)/components/logos'
@@ -23,7 +29,7 @@ afterEach(() => {
 })
 
 describe('NavMenuLogoMarquee', () => {
-  it('loops two copies of the shared logo row and hides the second from assistive technology', () => {
+  it('loops two non-draggable logo rows and hides the second from assistive technology', () => {
     const host = document.createElement('div')
     document.body.append(host)
     act(() => {
@@ -42,6 +48,10 @@ describe('NavMenuLogoMarquee', () => {
     expect(named).toEqual(LOGOS.map((logo) => logo.name))
     for (const img of rows[1].querySelectorAll('img')) {
       expect(img.getAttribute('alt')).toBe('')
+    }
+
+    for (const img of host.querySelectorAll('img')) {
+      expect(img.getAttribute('draggable')).toBe('false')
     }
 
     const track = rows[0].parentElement

--- a/apps/sim/app/(landing)/components/navbar/components/nav-menu-chip/components/nav-menu-logo-marquee/nav-menu-logo-marquee.tsx
+++ b/apps/sim/app/(landing)/components/navbar/components/nav-menu-chip/components/nav-menu-logo-marquee/nav-menu-logo-marquee.tsx
@@ -48,6 +48,7 @@ export function NavMenuLogoMarquee() {
                     height={logo.height}
                     width={Math.round(logo.height * logo.aspect)}
                     loading='lazy'
+                    draggable={false}
                     className={MUTED_MARK}
                   />
                 </li>


### PR DESCRIPTION
## Summary

- Disable native image dragging on navbar logos so dragging a logo no longer creates a browser ghost image.
- Keep the carousel's automatic scrolling and hover-to-pause behavior.

## Type of Change

- [x] Bug fix

## Testing

- All 24 navbar tests pass, including drag-prevention assertions for both logo rows.
- Confirmed the carousel test fails when `draggable={false}` is removed.
- Repo-wide lint, all 46 audits (including API boundary validation), block registry checks, and docs manifest validation pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
