### PR TITLE
fix(providers): bound overlong tool wire names

### DIFF
--- a/apps/sim/providers/tool-identity.test.ts
+++ b/apps/sim/providers/tool-identity.test.ts
@@ -83,9 +83,38 @@ describe('provider tool identities', () => {
 
     assignProviderToolIdentities(tools)
 
-    expect(tools[0].id).toBe(longId)
+    expect(tools[0].id).toHaveLength(64)
+    expect(tools[0].id).toMatch(/__sim_1$/)
+    expect(tools[0].canonicalId).toBe(longId)
     expect(tools[1].id).toHaveLength(64)
     expect(tools[1].id).toMatch(/__sim_2$/)
+  })
+
+  it('preserves ids at the limit and aliases unique overlong ids without collisions', () => {
+    const prefix = 'a'.repeat(57)
+    const longId = `${prefix}${'b'.repeat(8)}`
+    const otherLongId = `${prefix}${'c'.repeat(8)}`
+    const reservedId = `${prefix}__sim_1`
+    const tools = [
+      providerTool(longId, 'a'),
+      providerTool(otherLongId, 'b'),
+      providerTool(reservedId, 'reserved'),
+      providerTool('d'.repeat(64), 'at-limit'),
+    ]
+
+    const identities = assignProviderToolIdentities(tools)
+    const wireIds = tools.map((tool) => tool.id)
+
+    expect(new Set(wireIds).size).toBe(4)
+    expect(wireIds.every((id) => id.length <= 64)).toBe(true)
+    expect(tools[2].id).toBe(reservedId)
+    expect(tools[3].id).toBe('d'.repeat(64))
+    expect(identities.toolIdByWireId.get(tools[0].id)).toBe(longId)
+    expect(identities.toolIdByWireId.get(tools[1].id)).toBe(otherLongId)
+    expect(tools[0].params.oauthCredential).toBe('a')
+
+    assignProviderToolIdentities(tools)
+    expect(tools.map((tool) => tool.id)).toEqual(wireIds)
   })
 
   it('projects provider response names back to their canonical ids', () => {

--- a/apps/sim/providers/tool-identity.ts
+++ b/apps/sim/providers/tool-identity.ts
@@ -18,10 +18,10 @@ function buildProviderAlias(toolId: string, occurrence: number, attempt: number)
 }
 
 /**
- * Gives duplicate configured tools deterministic provider-safe wire ids.
+ * Gives duplicate or overlong configured tools deterministic provider-safe wire ids.
  *
- * The first occurrence and every already-unique tool keep their existing id for backwards
- * compatibility. Later occurrences receive opaque ordinal aliases; resource and credential ids
+ * Unique ids within the provider limit keep their existing id for backwards compatibility.
+ * Overlong ids and later occurrences receive opaque ordinal aliases; resource and credential ids
  * never enter the provider-visible name. Tool objects are updated in place so their instance-bound
  * params and secret provenance remain attached to the exact object selected by provider adapters.
  */
@@ -47,7 +47,7 @@ export function assignProviderToolIdentities(
     occurrences.set(canonicalId, occurrence)
 
     let wireId = canonicalId
-    if (usedWireIds.has(wireId)) {
+    if (wireId.length > MAX_PROVIDER_TOOL_ID_LENGTH || usedWireIds.has(wireId)) {
       let attempt = 0
       do {
         wireId = buildProviderAlias(canonicalId, occurrence, attempt)


### PR DESCRIPTION
## Summary
- Reuse existing provider-only aliases for unique and first-occurrence tool IDs longer than 64 characters.
- Preserve canonical IDs for execution, logs, forced selection, and instance-bound credentials; keep valid short IDs unchanged.
- Reuse existing collision handling and response/stream projection instead of renaming integrations or adding another naming framework.

## Why
The existing duplicate-name aliaser already bounds generated names, but passed the first/unique overlong name through unchanged. Claude documents a 64-character tool-name limit: https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools . This addresses length only, not a general character-policy redesign.

## Validation
- 201 focused provider identity/binding/utility tests passed.
- App type-check, changed-file Biome, API validation, and git diff --check passed.
- Independent code review checked execution mapping, forced selection, collisions, and repeat-call stability.
- Only two existing files changed; one new regression case plus an updated boundary case.