### PR TITLE
fix(selectors): preserve server truncation in option lists

### DIFF
--- a/apps/sim/hooks/queries/selectors.test.tsx
+++ b/apps/sim/hooks/queries/selectors.test.tsx
@@ -235,6 +235,70 @@ describe('generic selector queries', () => {
     }
   )
 
+  it.each([true, false, undefined])(
+    'preserves flat selector truncation %s and clears it after a complete refetch',
+    async (truncated) => {
+      const items = [{ id: 'label-1', label: 'First label' }]
+      mockExecuteSelectorRequest.mockResolvedValue({
+        kind: 'list',
+        items,
+        ...(truncated !== undefined ? { truncated } : {}),
+      })
+      const hook = renderHookWithClient(() =>
+        useSelectorOptions('gmail.labels', {
+          context: { workspaceId: 'workspace-1', oauthCredential: 'credential-1' },
+          surfaceId: 'connector:gmail:label',
+        })
+      )
+
+      await waitFor(() => expect(hook.getResult().isSuccess).toBe(true))
+      expect(hook.getResult()).toMatchObject({
+        data: items,
+        hasMore: false,
+        truncated: truncated === true,
+      })
+
+      const refreshedItems = [{ id: 'label-2', label: 'Complete results' }]
+      mockExecuteSelectorRequest.mockResolvedValue({ kind: 'list', items: refreshedItems })
+      act(() => hook.getResult().refetch())
+
+      await waitFor(() => expect(hook.getResult().data).toEqual(refreshedItems))
+      expect(hook.getResult()).toMatchObject({ hasMore: false, truncated: false })
+    }
+  )
+
+  it('retains server truncation from earlier pages after loading the final page', async () => {
+    mockExecuteSelectorRequest.mockImplementation(
+      async ({ request }: { request: { cursor?: string } }) =>
+        request.cursor
+          ? { kind: 'list', items: [{ id: 'workspace-2', label: 'Second' }], truncated: false }
+          : {
+              kind: 'list',
+              items: [{ id: 'workspace-1', label: 'First' }],
+              nextCursor: 'next-page',
+              truncated: true,
+            }
+    )
+    const hook = renderHookWithClient(() =>
+      useSelectorOptions('bitbucket.workspaces', {
+        context: { workspaceId: 'workspace-1', oauthCredential: 'credential-1' },
+        surfaceId: 'canvas:block-1:workspace',
+      })
+    )
+
+    await waitFor(() => expect(hook.getResult().hasMore).toBe(true))
+    expect(hook.getResult().truncated).toBe(true)
+
+    act(() => hook.getResult().loadMore())
+    await waitFor(() =>
+      expect(hook.getResult().data).toEqual([
+        { id: 'workspace-1', label: 'First' },
+        { id: 'workspace-2', label: 'Second' },
+      ])
+    )
+    expect(hook.getResult()).toMatchObject({ hasMore: false, truncated: true })
+  })
+
   it('loads paginated selectors on demand without putting cursors in the base key', async () => {
     mockExecuteSelectorRequest.mockImplementation(
       async ({ request }: { request: { cursor?: string } }) =>

--- a/apps/sim/hooks/queries/selectors.ts
+++ b/apps/sim/hooks/queries/selectors.ts
@@ -12,13 +12,16 @@ import {
 } from '@/lib/selectors/manifest'
 import type {
   SelectorContext,
+  SelectorExecutionResult,
   SelectorOption,
   SelectorPage,
   SelectorScope,
 } from '@/lib/selectors/types'
 import { selectorKeys } from '@/hooks/queries/utils/selector-keys'
 
-const EMPTY_PAGE: SelectorPage = { items: [] }
+type SelectorListResult = Extract<SelectorExecutionResult, { kind: 'list' }>
+
+const EMPTY_PAGE: SelectorListResult = { kind: 'list', items: [] }
 let nextOpaqueRevision = 1
 
 export type SelectorClientContext = SelectorContext & {
@@ -167,7 +170,7 @@ export function useSelectorOptions(
     prepared.revision
   )
 
-  const flatQuery = useQuery<SelectorOption[]>({
+  const flatQuery = useQuery<SelectorListResult>({
     // rq-lint-allow: context and search are represented by an opaque privacy revision.
     queryKey: baseKey,
     queryFn: async ({ signal }) => {
@@ -182,14 +185,14 @@ export function useSelectorOptions(
         signal,
       })
       if (result.kind !== 'list') throw new Error('Selector returned an unexpected detail result')
-      return result.items
+      return result
     },
     enabled: !supportsPagination && prepared.ready,
     staleTime: prepared.manifest.staleTime,
     gcTime: 0,
   })
 
-  const pagedQuery = useInfiniteQuery<SelectorPage>({
+  const pagedQuery = useInfiniteQuery<SelectorListResult>({
     // rq-lint-allow: context and search are represented by an opaque privacy revision.
     queryKey: [...baseKey, 'paged'],
     queryFn: async ({ pageParam, signal }) => {
@@ -306,7 +309,10 @@ export function useSelectorOptions(
       isFetchingMore: pagedQuery.isFetchingNextPage || isLoadingAll,
       isLoadingAll,
       hasMore: canLoadMore,
-      truncated: collectedOptions.overflowed || (Boolean(pagedQuery.hasNextPage) && reachedLoadCap),
+      truncated:
+        pagedQuery.data?.pages.some((page) => page.truncated === true) === true ||
+        collectedOptions.overflowed ||
+        (Boolean(pagedQuery.hasNextPage) && reachedLoadCap),
       error: (pagedQuery.error as Error | null) ?? null,
       isSuccess: pagedQuery.isSuccess,
       loadMore,
@@ -321,13 +327,13 @@ export function useSelectorOptions(
     }
   }
   return {
-    data: flatQuery.data,
+    data: flatQuery.data?.items,
     isLoading: flatQuery.isLoading,
     isFetching: flatQuery.isFetching,
     isFetchingMore: false,
     isLoadingAll: false,
     hasMore: false,
-    truncated: false,
+    truncated: flatQuery.data?.truncated === true,
     error: (flatQuery.error as Error | null) ?? null,
     isSuccess: flatQuery.isSuccess,
     loadMore: () => undefined,

--- a/packages/emcn/src/components/combobox/combobox.dom.test.tsx
+++ b/packages/emcn/src/components/combobox/combobox.dom.test.tsx
@@ -262,12 +262,16 @@ describe('Combobox pagination', () => {
     expect(document.body.textContent).not.toContain('Search all options')
   })
 
-  it('explains when provider results remain beyond the safety limit', () => {
-    render(<Combobox options={OPTIONS} truncated />)
+  it('explains truncated results without assuming a provider limit', () => {
+    render(<Combobox options={OPTIONS} truncated searchable />)
 
     click(trigger())
 
-    expect(document.body.textContent).toContain('Showing the first 10,000 options')
+    expect(document.body.textContent).toContain('Showing partial results')
+
+    type(trigger('input[placeholder="Search..."]') as HTMLInputElement, 'missing')
+
+    expect(document.body.textContent).toContain('No matches in partial results')
   })
 })
 

--- a/packages/emcn/src/components/combobox/combobox.tsx
+++ b/packages/emcn/src/components/combobox/combobox.tsx
@@ -691,7 +691,7 @@ const Combobox = memo(
       const isLoadingContinuation = isLoadingMore || isLoadingAll
       const resolvedEmptyMessage =
         truncated && hasActiveSearch
-          ? 'No matches in the first 10,000 options'
+          ? 'No matches in partial results'
           : hasMore && hasActiveSearch
             ? 'No matches in loaded options'
             : hasMore
@@ -728,7 +728,7 @@ const Combobox = memo(
           </Button>
         ) : truncated && filteredOptions.length > 0 ? (
           <div className='py-2 text-center text-[var(--text-muted)] text-caption'>
-            Showing the first 10,000 options
+            Showing partial results
           </div>
         ) : null
 


### PR DESCRIPTION
## Summary

- Preserve server-reported truncation in flat selector results instead of discarding it when caching options.
- Retain truncation from any loaded page alongside existing local pagination and option limits.
- Use count-independent partial-results messages because provider caps need not equal 10,000 options.

No API contract, authorization, provider adapter, query-key, or pagination-control changes.

## Type of Change

- [x] Bug fix

## Testing

- 41 selector hook, client, application projection, and option-budget tests passed.
- 22 existing Combobox DOM tests passed, including updated partial-result messaging coverage.
- App and EMCN package type-checks passed.
- Biome on all four changed files, API validation, and git diff --check passed.
- Controlled Chrome smoke using the real selector hook, contract response parsing, and Combobox with synthetic selector HTTP responses: truncated flat results remain selectable, partial-result and no-match warnings appear, complete responses omit those warnings, and a terminal page does not clear an earlier page truncation flag.
- This was synthetic UI validation, not a live provider test. The temporary local fixture was removed before publishing, and the development server was stopped.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced