### PR TITLE
fix(file-editor): preserve pasted content and literal markdown

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/bullet-list.ts
@@ -10,4 +10,14 @@ export const JoiningBulletList = BulletList.extend({
   addInputRules() {
     return joinListInputRules(this.parent?.() ?? [], this.type)
   },
+  renderMarkdown(node, helpers, context) {
+    const firstParagraph = node.content?.[0]?.content?.[0]
+    const startsEmpty = firstParagraph?.type === 'paragraph' && !firstParagraph.content?.length
+    const nested = context.parentType === 'listItem' || context.parentType === 'taskItem'
+    const followsText =
+      context.previousNode?.type === 'paragraph' && Boolean(context.previousNode.content?.length)
+    const rendered = helpers.renderChildren(node.content ?? [], '\n')
+    /** Separate an opening empty bullet from its parent's text so it cannot become a Setext heading. */
+    return nested && startsEmpty && followsText ? `\n${rendered}` : rendered
+  },
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
@@ -233,9 +233,14 @@ afterEach(async () => {
 })
 
 describe('loaded rich editor lifecycle', () => {
-  it.each(['paste', 'drop'] as const)(
-    '%s uploads a standalone display-only image from another document',
-    async (method) => {
+  it.each([
+    { method: 'paste', caption: false },
+    { method: 'drop', caption: false },
+    { method: 'paste', caption: true },
+    { method: 'drop', caption: true },
+  ] as const)(
+    '$method uploads a display-only image from another document (caption: $caption)',
+    async ({ method, caption }) => {
       await render('before TARGET after')
       const editor = getEditor()
       await act(async () => editor.commands.setTextSelection({ from: 8, to: 14 }))
@@ -243,7 +248,8 @@ describe('loaded rich editor lifecycle', () => {
         vi.spyOn(editor.view, 'posAtCoords').mockReturnValue({ pos: 8, inside: 0 })
       const src = '/api/workspaces/another-workspace/files/inline?fileId=another-image'
       const image = new File(['image'], 'image.png', { type: 'image/png' })
-      const html = `<img src="${window.location.origin}${src}">`
+      const img = `<img src="${window.location.origin}${src}" alt="Original" width="140">`
+      const html = caption ? `<p>Caption<a href="/destination">${img}</a></p><p>Tail</p>` : img
       uploadFile.mockResolvedValueOnce({ file: { url: '/api/files/view/uploaded-image' } })
       const event = new MouseEvent(method, { bubbles: true, cancelable: true })
       Object.defineProperty(event, method === 'paste' ? 'clipboardData' : 'dataTransfer', {
@@ -263,11 +269,19 @@ describe('loaded rich editor lifecycle', () => {
       })
       expect(editor.getMarkdown()).toContain('/api/files/view/uploaded-image')
       expect(editor.getMarkdown()).not.toContain('/inline?')
-      const storedSrc = editor.getJSON().content?.find((node) => node.type === 'image')?.attrs?.src
+      let storedSrc = ''
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'image' || node.type.name === 'inlineImage')
+          storedSrc = node.attrs.src
+      })
       expect(extractEmbeddedFileRef(storedSrc)).toEqual({ fileId: 'uploaded-image' })
       expect(editor.state.doc.textContent).toBe(
-        method === 'paste' ? 'before  after' : 'before TARGET after'
+        `before ${caption ? 'CaptionTail' : ''}${method === 'paste' ? '' : 'TARGET'} after`
       )
+      expect(editor.view.dom.querySelector('img')?.getAttribute('alt')).toBe('Original')
+      expect(editor.getMarkdown()).toContain('width="140"')
+      if (caption)
+        expect(editor.view.dom.querySelector('a')?.getAttribute('href')).toBe('/destination')
     }
   )
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-lifecycle.test.tsx
@@ -12,6 +12,7 @@ import { exportWorkspaceFileSnapshotBodySchema } from '@/lib/api/contracts/works
 import { SIM_SELECTION_MIME } from '@/lib/copilot/chat/selection-clipboard'
 import type { FileDownloadSource } from '@/lib/uploads/client/download'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
+import { extractEmbeddedFileRef } from '@/lib/uploads/utils/embedded-image-ref'
 import { useFileDocCollaboration } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/use-file-doc-collaboration'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
 import { ImageUploadPlaceholders } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload'
@@ -215,6 +216,7 @@ async function pasteImage(editor: Editor) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  uploadFile.mockReset()
   collaborationRef.current = null
   vi.spyOn(toast, 'warning').mockReturnValue('test-toast')
   vi.spyOn(toast, 'info').mockReturnValue('uploading-toast')
@@ -231,6 +233,44 @@ afterEach(async () => {
 })
 
 describe('loaded rich editor lifecycle', () => {
+  it.each(['paste', 'drop'] as const)(
+    '%s uploads a standalone display-only image from another document',
+    async (method) => {
+      await render('before TARGET after')
+      const editor = getEditor()
+      await act(async () => editor.commands.setTextSelection({ from: 8, to: 14 }))
+      if (method === 'drop')
+        vi.spyOn(editor.view, 'posAtCoords').mockReturnValue({ pos: 8, inside: 0 })
+      const src = '/api/workspaces/another-workspace/files/inline?fileId=another-image'
+      const image = new File(['image'], 'image.png', { type: 'image/png' })
+      const html = `<img src="${window.location.origin}${src}">`
+      uploadFile.mockResolvedValueOnce({ file: { url: '/api/files/view/uploaded-image' } })
+      const event = new MouseEvent(method, { bubbles: true, cancelable: true })
+      Object.defineProperty(event, method === 'paste' ? 'clipboardData' : 'dataTransfer', {
+        value: {
+          files: [image],
+          items: [],
+          types: ['Files', 'text/html'],
+          getData: (type: string) => (type === 'text/html' ? html : ''),
+        },
+      })
+      await act(async () => editor.view.dom.dispatchEvent(event))
+      expect(event.defaultPrevented).toBe(true)
+      expect(uploadFile).toHaveBeenCalledExactlyOnceWith({
+        workspaceId: FILE.workspaceId,
+        file: image,
+        folderId: null,
+      })
+      expect(editor.getMarkdown()).toContain('/api/files/view/uploaded-image')
+      expect(editor.getMarkdown()).not.toContain('/inline?')
+      const storedSrc = editor.getJSON().content?.find((node) => node.type === 'image')?.attrs?.src
+      expect(extractEmbeddedFileRef(storedSrc)).toEqual({ fileId: 'uploaded-image' })
+      expect(editor.state.doc.textContent).toBe(
+        method === 'paste' ? 'before  after' : 'before TARGET after'
+      )
+    }
+  )
+
   it('captures immediate collaborative edits with current shared frontmatter without saving', async () => {
     const provider = new FakeFileDocProvider()
     const doc = new Y.Doc()

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions.ts
@@ -174,7 +174,16 @@ const BlockSafeParagraph = Paragraph.extend({
   },
   renderMarkdown: (node: JSONContent, h, context) => {
     if (!node.content?.length && context.parentType === 'blockquote') return '<p></p>'
-    const rendered = h.renderChildren(node.content ?? [])
+    let rendered = h.renderChildren(node.content ?? [])
+    const first = node.content?.[0]
+    if (
+      context.parentType === 'blockquote' &&
+      first?.type === 'text' &&
+      !first.marks?.length &&
+      /^\[![A-Za-z]+\]/.test(first.text ?? '')
+    ) {
+      rendered = rendered.replace(/^\\\[!([A-Za-z]+)\\\]/, '[!$1]')
+    }
     let codeDelimiter = 0
     return rendered
       .split('\n')

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/field-upload.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/field-upload.test.tsx
@@ -65,9 +65,10 @@ function editor() {
 async function submit(
   method: 'paste' | 'drop',
   target: Editor,
-  files = [new File(['image'], 'image.png', { type: 'image/png' })]
+  files = [new File(['image'], 'image.png', { type: 'image/png' })],
+  selection: number | { from: number; to: number } = 8
 ) {
-  await act(async () => target.commands.setTextSelection(8))
+  await act(async () => target.commands.setTextSelection(selection))
   if (method === 'drop') vi.spyOn(target.view, 'posAtCoords').mockReturnValue({ pos: 8, inside: 0 })
   const transfer = { files, items: [], types: ['Files'], getData: () => '' }
   const event = new Event(method, { bubbles: true, cancelable: true })
@@ -81,6 +82,67 @@ async function submit(
 }
 
 describe('field upload completion boundary', () => {
+  it('replaces the selected range only after a pasted image finishes uploading', async () => {
+    const pending = Promise.withResolvers<{ url: string; alt: string }>()
+    upload.mockReturnValueOnce(pending.promise)
+    await render()
+    const owner = editor()
+    const before = owner.getJSON()
+    await submit('paste', owner, undefined, { from: 8, to: 14 })
+    expect(owner.getJSON()).toEqual(before)
+    await act(async () =>
+      pending.resolve({ url: 'https://sim.ai/replacement.png', alt: 'Replacement' })
+    )
+    expect(owner.state.doc.textContent).toBe('before  after')
+    expect(host.querySelectorAll('img')).toHaveLength(1)
+    await act(async () => owner.commands.undo())
+    expect(owner.getJSON()).toEqual(before)
+  })
+
+  it.each(['paste', 'drop'] as const)(
+    '%s preserves the whole HTML slice when the payload also contains a bitmap file',
+    async (method) => {
+      await render()
+      const owner = editor()
+      await act(async () => owner.commands.setTextSelection({ from: 8, to: 14 }))
+      if (method === 'drop')
+        vi.spyOn(owner.view, 'posAtCoords').mockReturnValue({ pos: 8, inside: 0 })
+      const html =
+        '<p>Lead</p><h2>Caption</h2><p><a href="https://sim.ai/link"><img src="https://sim.ai/one.png" alt="One" width="123"></a>Tail<img src="https://sim.ai/two.png" alt="Two" width="234"></p>'
+      const transfer = {
+        files: [new File(['image'], 'image.png', { type: 'image/png' })],
+        items: [],
+        types: ['text/html', 'text/plain', 'Files'],
+        getData: (type: string) =>
+          type === 'text/html' ? html : type === 'text/plain' ? 'CaptionTail' : '',
+      }
+      const event = new MouseEvent(method, { bubbles: true, cancelable: true })
+      Object.defineProperty(event, method === 'paste' ? 'clipboardData' : 'dataTransfer', {
+        value: transfer,
+      })
+      await act(async () => owner.view.dom.dispatchEvent(event))
+      expect(event.defaultPrevented).toBe(true)
+      expect(upload).not.toHaveBeenCalled()
+      expect(host.querySelector('h2')?.textContent).toBe('Caption')
+      expect(owner.state.doc.textContent).toContain('Tail')
+      expect(Array.from(host.querySelectorAll('img')).map((image) => image.alt)).toEqual([
+        'One',
+        'Two',
+      ])
+      const images: Array<{ src: string; width: string; href: string | null }> = []
+      owner.state.doc.descendants((node) => {
+        if (node.type.name === 'image' || node.type.name === 'inlineImage') {
+          images.push({ src: node.attrs.src, width: node.attrs.width, href: node.attrs.href })
+        }
+      })
+      expect(images).toEqual([
+        { src: 'https://sim.ai/one.png', width: '123', href: 'https://sim.ai/link' },
+        { src: 'https://sim.ai/two.png', width: '234', href: null },
+      ])
+      expect(() => owner.state.doc.check()).not.toThrow()
+    }
+  )
+
   it('invalidates an upload even when streaming ends before completion', async () => {
     const pending = Promise.withResolvers<{ url: string; alt: string }>()
     upload.mockReturnValueOnce(pending.promise)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/field-upload.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/field-upload.test.tsx
@@ -82,6 +82,51 @@ async function submit(
 }
 
 describe('field upload completion boundary', () => {
+  it.each(['paste', 'drop'] as const)(
+    '%s uploads a non-portable image without losing its accompanying fragment',
+    async (method) => {
+      const pending = Promise.withResolvers<{ url: string; alt: string }>()
+      upload.mockReturnValueOnce(pending.promise)
+      await render()
+      const owner = editor()
+      const before = owner.getJSON()
+      await act(async () => owner.commands.setTextSelection({ from: 8, to: 14 }))
+      if (method === 'drop')
+        vi.spyOn(owner.view, 'posAtCoords').mockReturnValue({ pos: 8, inside: 0 })
+      const html =
+        '<p>Lead</p><h2>Caption</h2><p><a href="/destination"><img src="/api/workspaces/source/files/inline?fileId=image" alt="Original alt" width="123"></a><strong>Tail</strong><img src="/other.png" alt="Other"></p>'
+      const event = new MouseEvent(method, { bubbles: true, cancelable: true })
+      Object.defineProperty(event, method === 'paste' ? 'clipboardData' : 'dataTransfer', {
+        value: {
+          files: [new File(['image'], 'image.png', { type: 'image/png' })],
+          items: [],
+          types: ['Files', 'text/html'],
+          getData: (type: string) => (type === 'text/html' ? html : ''),
+        },
+      })
+      await act(async () => owner.view.dom.dispatchEvent(event))
+      expect(upload).toHaveBeenCalledOnce()
+      expect(owner.getJSON()).toEqual(before)
+      await act(async () => owner.commands.insertContentAt(1, 'prefix '))
+      await act(async () => pending.resolve({ url: '/api/files/view/uploaded', alt: 'New alt' }))
+      expect(owner.state.doc.textContent).toBe(
+        method === 'paste'
+          ? 'prefix before LeadCaptionTail after'
+          : 'prefix before LeadCaptionTailTARGET after'
+      )
+      expect(host.querySelector('h2')?.textContent).toBe('Caption')
+      expect(host.querySelector('strong')?.textContent).toBe('Tail')
+      expect(host.querySelector('a')?.getAttribute('href')).toBe('/destination')
+      expect(
+        Array.from(host.querySelectorAll('img')).map((image) => image.getAttribute('src'))
+      ).toEqual(['/api/files/view/uploaded', '/other.png'])
+      expect(host.querySelector('img')?.getAttribute('alt')).toBe('Original alt')
+      expect(owner.getMarkdown()).toContain('width="123"')
+      expect(owner.getMarkdown()).not.toContain('/inline?')
+      expect(() => owner.state.doc.check()).not.toThrow()
+    }
+  )
+
   it('replaces the selected range only after a pasted image finishes uploading', async () => {
     const pending = Promise.withResolvers<{ url: string; alt: string }>()
     upload.mockReturnValueOnce(pending.promise)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/heading-image.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/heading-image.test.ts
@@ -3,7 +3,7 @@ import { FILE_DOC_SEED } from '@sim/realtime-protocol/file-doc'
 import { Editor, getSchema } from '@tiptap/core'
 import { DOMParser, DOMSerializer } from '@tiptap/pm/model'
 import { NodeSelection } from '@tiptap/pm/state'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import * as Y from 'yjs'
 import { markdownToYDoc, yDocToFileMarkdown, yDocToMarkdown } from '@/lib/collab-doc/converter'
 import {
@@ -13,7 +13,7 @@ import {
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/apply-streamed-markdown'
 import { FileCollaboration } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-collaboration'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
-import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
+import { dispatchEditorDrop } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drop.test-helpers'
 import { isImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-node'
 import {
   beginImageUploads,
@@ -333,13 +333,7 @@ describe('heading images', () => {
       seed.destroy()
       const originalAttrs = a.editor.state.doc.nodeAt(imagePositions(a.editor)[0])?.attrs
       a.editor.commands.setNodeSelection(imagePositions(a.editor)[0])
-      vi.spyOn(a.editor.view, 'posAtCoords').mockReturnValue({ pos: 8, inside: 0 })
-      expect(
-        moveDraggedImageNode(a.editor.view, new MouseEvent('drop') as DragEvent, {
-          images: [],
-          html: '<img src="/logo.png">',
-        })
-      ).toBe(true)
+      expect(dispatchEditorDrop(a.editor, 8).defaultPrevented).toBe(true)
       expect(a.editor.state.doc.nodeAt(8)?.type.name).toBe('inlineImage')
       expect(a.editor.state.doc.nodeAt(8)?.attrs).toEqual(originalAttrs)
       b.editor.commands.insertContentAt(b.editor.state.doc.content.size - 1, ' preserved')

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-collaboration.test.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-collaboration.test.tsx
@@ -13,7 +13,7 @@ import {
   ResizableImage,
   ResizableInlineImage,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image'
-import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
+import { dispatchEditorDrop } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drop.test-helpers'
 import { isImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-node'
 
 let host: HTMLDivElement
@@ -126,16 +126,8 @@ async function addPeerSibling(sameSource = true): Promise<number> {
 }
 
 function movePeerImage(from: number, to: number): void {
-  const image = peer.state.doc.nodeAt(from)!
   peer.commands.setNodeSelection(from)
-  vi.spyOn(peer.view, 'posAtCoords').mockReturnValue({ pos: to, inside: 0 })
-  expect(
-    moveDraggedImageNode(
-      peer.view,
-      new MouseEvent('drop', { clientX: 0, clientY: 0, cancelable: true }) as DragEvent,
-      { images: [], html: `<img src="${image.attrs.src}">` }
-    )
-  ).toBe(true)
+  expect(dispatchEditorDrop(peer, to).defaultPrevented).toBe(true)
 }
 
 async function setNestedImages(depth: number): Promise<void> {
@@ -220,15 +212,9 @@ describe('image resizing during real peer Yjs updates', () => {
       local.setOptions({ editorProps: { handleScrollToSelection: () => false } })
       yUndoPluginKey.getState(local.state).undoManager.clear()
       const dropPosition = target === 'heading' ? 8 : imagePosition(local) + 5
-      vi.spyOn(local.view, 'posAtCoords').mockReturnValue({ pos: dropPosition, inside: 0 })
       await act(async () => {
         local.view.focus()
-        expect(
-          moveDraggedImageNode(local.view, new MouseEvent('drop') as DragEvent, {
-            images: [],
-            html: '<img src="https://sim.ai/image.png">',
-          })
-        ).toBe(true)
+        expect(dispatchEditorDrop(local, dropPosition).defaultPrevented).toBe(true)
       })
       expect(local.state.selection).toBeInstanceOf(NodeSelection)
       expect(host.querySelector(`${target === 'heading' ? 'h2' : 'p'} img`)).not.toBeNull()

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move.test.ts
@@ -1,211 +1,117 @@
-/**
- * @vitest-environment node
- *
- * Dragging an image to reposition it inside a document must MOVE it, not import it again.
- *
- * The browser enriches a dragged `<img>` with an image `File`, and TipTap's image node view runs its
- * own `dragstart` that bypasses ProseMirror's serialization — so the drop looks exactly like an
- * external image drop, and the upload path stored a fresh copy of the image on every nudge while the
- * original never moved.
- */
-import { type Node as PMNode, Schema } from '@tiptap/pm/model'
-import { EditorState, NodeSelection } from '@tiptap/pm/state'
-import type { EditorView } from '@tiptap/pm/view'
-import { describe, expect, it, vi } from 'vitest'
-import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
+/** @vitest-environment jsdom */
+import { Editor } from '@tiptap/core'
+import { NodeSelection } from '@tiptap/pm/state'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { dispatchEditorDrop } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drop.test-helpers'
 import { isImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-node'
 
-const schema = new Schema({
-  nodes: {
-    doc: { content: 'block+' },
-    paragraph: { group: 'block', content: 'inline*' },
-    heading: { group: 'block', content: 'inline*' },
-    codeBlock: { group: 'block', content: 'text*', code: true },
-    image: { group: 'block', attrs: { src: {} }, draggable: true },
-    inlineImage: { group: 'inline', inline: true, attrs: { src: {} }, draggable: true },
-    text: { group: 'inline' },
-  },
+const editors: Editor[] = []
+afterEach(() => {
+  for (const editor of editors.splice(0)) editor.destroy()
 })
 
-const SRC = '/api/workspaces/ws-1/files/inline?fileId=f1'
-
-function imageHtml(src: string): string {
-  return `<img src="${src}">`
-}
-
-/** A doc of `paragraph, image, paragraph` with the image node-selected, and a view around it. */
-function selectedImageView(): { view: EditorView; dispatched: { state: () => EditorState } } {
-  const doc = schema.node('doc', null, [
-    schema.node('paragraph', null, [schema.text('before')]),
-    schema.node('image', { src: SRC }),
-    schema.node('paragraph', null, [schema.text('after')]),
-  ])
-  let state = EditorState.create({ doc })
-  state = state.apply(state.tr.setSelection(NodeSelection.create(state.doc, 8)))
-
-  const view = {
-    get state() {
-      return state
-    },
-    posAtCoords: () => ({ pos: 0, inside: -1 }),
-    dispatch: vi.fn((tr) => {
-      state = state.apply(tr)
-    }),
-  } as unknown as EditorView
-
-  return { view, dispatched: { state: () => state } }
-}
-
-function dropEvent(): DragEvent {
-  return { clientX: 10, clientY: 10, preventDefault: vi.fn() } as unknown as DragEvent
-}
-
-function imageCount(doc: PMNode): number {
-  let count = 0
-  doc.descendants((node) => {
-    if (isImageNode(node)) count += 1
+function createEditor() {
+  const editor = new Editor({
+    extensions: createMarkdownContentExtensions(),
+    content: '<h2>Heading</h2><img src="/image.png" alt="Original" width="120"><p>After</p>',
+    editorProps: { handleScrollToSelection: () => false },
   })
-  return count
+  editors.push(editor)
+  editor.commands.setNodeSelection(9)
+  return editor
 }
 
-describe('moveDraggedImageNode', () => {
-  it.each([
-    ['inside a heading', 3, 'inlineImage'],
-    ['inside a paragraph after the source', 12, 'inlineImage'],
-    ['between blocks', 9, 'image'],
-    ['inside a text-only code block', 18, 'image'],
-  ] as const)('moves a block image to %s', (_label, dropPos, expectedType) => {
-    const doc = schema.node('doc', null, [
-      schema.node('heading', null, [schema.text('Before')]),
-      schema.node('image', { src: SRC }),
-      schema.node('paragraph', null, [schema.text('After')]),
-      schema.node('codeBlock', null, [schema.text('Code')]),
-    ])
-    let state = EditorState.create({ doc, selection: NodeSelection.create(doc, 8) })
-    const view = {
-      get state() {
-        return state
-      },
-      posAtCoords: () => ({ pos: dropPos }),
-      dispatch: (tr) => {
-        state = state.apply(tr)
-      },
-    } as unknown as EditorView
+function images(editor: Editor) {
+  const result: { type: string; src: string; alt: string; width: string | null }[] = []
+  editor.state.doc.descendants((node) => {
+    if (isImageNode(node))
+      result.push({
+        type: node.type.name,
+        src: node.attrs.src,
+        alt: node.attrs.alt,
+        width: node.attrs.width,
+      })
+  })
+  return result
+}
 
-    expect(moveDraggedImageNode(view, dropEvent(), { images: [], html: imageHtml(SRC) })).toBe(true)
-    expect(() => state.doc.check()).not.toThrow()
-    expect(imageCount(state.doc)).toBe(1)
-    expect(state.doc.textContent).toBe(doc.textContent)
-    expect(state.selection).toBeInstanceOf(NodeSelection)
-    expect((state.selection as NodeSelection).node.type.name).toBe(expectedType)
-    expect((state.selection as NodeSelection).node.attrs.src).toBe(SRC)
-    if (expectedType === 'inlineImage') {
-      expect(state.selection.from).toBe(dropPos > 8 ? dropPos - 1 : dropPos)
+describe('image drop ownership and placement', () => {
+  it.each([
+    ['heading', 4, 'inlineImage'],
+    ['paragraph', 13, 'inlineImage'],
+    ['block boundary', 0, 'image'],
+  ])('moves to a %s without duplicating or changing text', (_label, position, type) => {
+    const editor = createEditor()
+    const text = editor.state.doc.textContent
+    expect(dispatchEditorDrop(editor, Number(position)).defaultPrevented).toBe(true)
+    expect(images(editor)).toEqual([{ type, src: '/image.png', alt: 'Original', width: '120' }])
+    expect(editor.state.doc.textContent).toBe(text)
+    expect(editor.state.selection).toBeInstanceOf(NodeSelection)
+    expect(() => editor.state.doc.check()).not.toThrow()
+    expect(editor.commands.undo()).toBe(true)
+    expect(images(editor)[0].type).toBe('image')
+  })
+
+  it.each([0, 4])('copies with the platform modifier at position %s', (position) => {
+    const editor = createEditor()
+    dispatchEditorDrop(editor, position, { copy: true })
+    expect(images(editor)).toHaveLength(2)
+    expect(editor.state.doc.textContent).toBe('HeadingAfter')
+  })
+
+  it.each([0, 4])(
+    'copies an external same-URL image instead of moving the selection at %s',
+    (position) => {
+      const editor = createEditor()
+      dispatchEditorDrop(editor, position, {
+        html: '<img src="/image.png" alt="External" width="240">',
+      })
+      expect(images(editor)).toHaveLength(2)
+      expect(images(editor)).toContainEqual({
+        type: 'image',
+        src: '/image.png',
+        alt: 'Original',
+        width: '120',
+      })
+      expect(
+        images(editor).some((image) => image.alt === 'External' && image.width === '240')
+      ).toBe(true)
     }
+  )
+
+  it('preserves every image and accompanying text from an external rich drop', () => {
+    const editor = createEditor()
+    dispatchEditorDrop(editor, 0, {
+      html: '<p>Caption</p><img src="/image.png"><p>Between</p><img src="/second.png"><p>End</p>',
+    })
+    expect(images(editor)).toHaveLength(3)
+    expect(editor.state.doc.textContent).toBe('CaptionBetweenEndHeadingAfter')
   })
 
-  it.each([
-    ['document start', 0, 'image'],
-    ['between blocks', 10, 'image'],
-    ['document end', 17, 'image'],
-    ['inside a heading', 2, 'inlineImage'],
-    ['inside a paragraph', 12, 'inlineImage'],
-  ] as const)('keeps the moved image selected at %s', (_label, dropPos, expectedType) => {
-    const doc = schema.node('doc', null, [
-      schema.node('heading', null, [
-        schema.text('Before'),
-        schema.node('inlineImage', { src: SRC }),
-        schema.text('!'),
-      ]),
-      schema.node('paragraph', null, [schema.text('After')]),
-    ])
-    let state = EditorState.create({ doc, selection: NodeSelection.create(doc, 7) })
-    const view = {
-      get state() {
-        return state
-      },
-      posAtCoords: () => ({ pos: dropPos }),
-      dispatch: (tr) => {
-        state = state.apply(tr)
-      },
-    } as unknown as EditorView
-
-    expect(moveDraggedImageNode(view, dropEvent(), { images: [], html: imageHtml(SRC) })).toBe(true)
-    expect(() => state.doc.check()).not.toThrow()
-    expect(imageCount(state.doc)).toBe(1)
-    expect(state.doc.textContent).toBe(doc.textContent)
-    expect(state.selection).toBeInstanceOf(NodeSelection)
-    expect((state.selection as NodeSelection).node.type.name).toBe(expectedType)
-    expect((state.selection as NodeSelection).node.attrs.src).toBe(SRC)
+  it('moves an inline image back to a block boundary', () => {
+    const editor = createEditor()
+    dispatchEditorDrop(editor, 4)
+    expect(images(editor)[0].type).toBe('inlineImage')
+    dispatchEditorDrop(editor, 0)
+    expect(images(editor)).toHaveLength(1)
+    expect(editor.state.doc.firstChild?.type.name).toBe('image')
+    expect(editor.state.doc.textContent).toBe('HeadingAfter')
   })
 
-  it('moves the dragged image instead of leaving it to be re-uploaded', () => {
-    const { view, dispatched } = selectedImageView()
-    const event = dropEvent()
-
-    expect(moveDraggedImageNode(view, event, { images: [], html: imageHtml(SRC) })).toBe(true)
-    expect(event.preventDefault).toHaveBeenCalled()
-    expect(imageCount(dispatched.state().doc)).toBe(1)
-    expect(dispatched.state().doc.firstChild?.type.name).toBe('image')
-  })
-
-  it('still claims the drop when the browser also attached the image as a file', () => {
-    const { view } = selectedImageView()
-    const file = new File([''], 'shot.png', { type: 'image/png' })
-
-    expect(moveDraggedImageNode(view, dropEvent(), { images: [file], html: imageHtml(SRC) })).toBe(
-      true
-    )
-  })
-
-  it('resolves the rendered src through the host before comparing', () => {
-    const { view } = selectedImageView()
-    const rendered = '/api/files/public/tok/inline?fileId=f1'
-
-    expect(
-      moveDraggedImageNode(view, dropEvent(), {
-        images: [],
-        html: imageHtml(rendered),
-        resolveSrc: () => rendered,
+  it.each(['delete', 'resize'])(
+    'does not overwrite a source that changed during the drag: %s',
+    (action) => {
+      const editor = createEditor()
+      dispatchEditorDrop(editor, 4, {
+        beforeDrop: () => {
+          if (action === 'delete') editor.commands.deleteSelection()
+          else editor.commands.updateAttributes('image', { width: '333' })
+        },
       })
-    ).toBe(true)
-  })
-
-  it('leaves a genuinely new image to the upload path', () => {
-    const { view } = selectedImageView()
-    const file = new File([''], 'other.png', { type: 'image/png' })
-
-    expect(
-      moveDraggedImageNode(view, dropEvent(), {
-        images: [file],
-        html: imageHtml('https://elsewhere.test/other.png'),
-      })
-    ).toBe(false)
-  })
-
-  it('leaves a multi-file drop to the upload path', () => {
-    const { view } = selectedImageView()
-    const files = [
-      new File([''], 'a.png', { type: 'image/png' }),
-      new File([''], 'b.png', { type: 'image/png' }),
-    ]
-
-    expect(moveDraggedImageNode(view, dropEvent(), { images: files, html: imageHtml(SRC) })).toBe(
-      false
-    )
-  })
-
-  it('ignores a drop with no image selected', () => {
-    const doc = schema.node('doc', null, [schema.node('paragraph', null, [schema.text('hi')])])
-    const state = EditorState.create({ doc })
-    const view = {
-      state,
-      posAtCoords: () => ({ pos: 1 }),
-      dispatch: vi.fn(),
-    } as unknown as EditorView
-
-    expect(moveDraggedImageNode(view, dropEvent(), { images: [], html: imageHtml(SRC) })).toBe(
-      false
-    )
-  })
+      expect(editor.state.doc.textContent).toBe('HeadingAfter')
+      expect(images(editor)).toHaveLength(action === 'delete' ? 0 : 1)
+      if (action === 'resize') expect(images(editor)[0].width).toBe('333')
+    }
+  )
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move.ts
@@ -3,73 +3,50 @@ import { NodeSelection } from '@tiptap/pm/state'
 import { dropPoint } from '@tiptap/pm/transform'
 import type { EditorView } from '@tiptap/pm/view'
 import { isImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-node'
-import { htmlReferencesSrc } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste'
 
-interface MoveDraggedImageOptions {
-  /** Image files on the drop, from `extractImageFiles`. */
-  images: File[]
-  /** The drop's `text/html`, which the browser enriches with the dragged node's rendered src. */
-  html: string
-  /**
-   * Maps a node's stored `src` to the URL actually rendered into `<img src>`, when the host rewrites
-   * it (the file editor's display-layer resolve). Omit where stored and rendered are the same.
-   */
-  resolveSrc?: (src: string | undefined) => string | undefined
-}
-
-/**
- * Repositions an image the user dragged from inside this editor, returning true when it consumed
- * the drop.
- *
- * TipTap's image node view runs its own `dragstart`, which bypasses ProseMirror's clipboard
- * serialization — no PM `text/html`, and `view.dragging` never set — so neither ProseMirror's default
- * move nor the `slice` argument to `handleDrop` sees anything. What survives is a NodeSelection on the
- * dragged image plus the browser's native enrichment, whose html carries the absolute rendered URL of
- * exactly that node. That pair is the signal, and without acting on it the drop falls through to the
- * upload path and stores a second copy of an image the document already has.
- *
- * The move is the same shape as ProseMirror's own: compute the drop point against the pre-delete doc,
- * delete the source, then map the insert position through that delete. A null `dropPoint` (no valid
- * insertion point) is a handled no-op — the node stays put, still selected — rather than a raw-position
- * fallback, which `tr.insert` can throw on.
- *
- * The gate accepts at most one file rather than exactly one: some drag transports carry the html
- * alone. A genuinely external drop can never reference the currently selected node's own rendered src.
- */
+/** Adapt a single image between block and inline destinations; leave all other drops to ProseMirror. */
 export function moveDraggedImageNode(
   view: EditorView,
   event: DragEvent,
-  { images, html, resolveSrc }: MoveDraggedImageOptions
+  slice: Slice,
+  moved: boolean
 ): boolean {
-  const { selection } = view.state
-  if (images.length > 1) return false
-  if (!(selection instanceof NodeSelection) || !isImageNode(selection.node)) return false
-
-  const src = selection.node.attrs.src
-  const rendered = typeof src === 'string' ? (resolveSrc?.(src) ?? src) : undefined
-  if (!htmlReferencesSrc(html, rendered)) return false
-
-  event.preventDefault()
+  const image = slice.content.firstChild
+  if (
+    slice.openStart ||
+    slice.openEnd ||
+    slice.content.childCount !== 1 ||
+    !image ||
+    !isImageNode(image)
+  ) {
+    return false
+  }
   const coords = view.posAtCoords({ left: event.clientX, top: event.clientY })
-  if (!coords) return true
-
+  if (!coords) return false
   const $drop = view.state.doc.resolve(coords.pos)
-  const { image, inlineImage } = view.state.schema.nodes
+  const { image: blockImage, inlineImage } = view.state.schema.nodes
+  if (!blockImage || !inlineImage) return false
   const type = $drop.parent.canReplaceWith($drop.index(), $drop.index(), inlineImage)
     ? inlineImage
-    : image
-  const node =
-    selection.node.type === type
-      ? selection.node
-      : type.create(selection.node.attrs, null, selection.node.marks)
-  const tr = view.state.tr
+    : blockImage
+  if (image.type === type) return false
+
+  /** Tiptap's data-drag-handle selects the dragged image before ProseMirror starts the drag. */
+  const source = view.state.selection
+  /** Do not delete a replacement selection if the dragged image changed or disappeared. */
+  if (moved && (!view.dragging || !(source instanceof NodeSelection) || !source.node.eq(image))) {
+    return true
+  }
+  const node = type.create(image.attrs, null, image.marks)
   const insertPos = dropPoint(view.state.doc, coords.pos, new Slice(Fragment.from(node), 0, 0))
   if (insertPos === null) return true
 
-  tr.delete(selection.from, selection.to)
+  const tr = view.state.tr
+  if (moved) tr.delete(source.from, source.to)
   const mapped = tr.mapping.map(insertPos)
   tr.insert(mapped, node)
   tr.setSelection(NodeSelection.create(tr.doc, mapped))
-  view.dispatch(tr.scrollIntoView())
+  view.focus()
+  view.dispatch(tr.setMeta('uiEvent', 'drop'))
   return true
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drop.test-helpers.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drop.test-helpers.ts
@@ -1,0 +1,56 @@
+import type { Editor } from '@tiptap/core'
+import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
+
+interface DropOptions {
+  html?: string
+  copy?: boolean
+  beforeDrop?: () => void
+}
+
+/** Exercise ProseMirror's drag ownership and drop pipeline, including platform copy modifiers. */
+export function dispatchEditorDrop(editor: Editor, position: number, options: DropOptions = {}) {
+  const data = new Map<string, string>()
+  const transfer = {
+    files: [],
+    items: [],
+    types: [],
+    effectAllowed: 'copyMove',
+    clearData: () => data.clear(),
+    setData: (type: string, value: string) => data.set(type, value),
+    getData: (type: string) => data.get(type) ?? '',
+    setDragImage: () => {},
+  }
+  const event = (type: string) => {
+    const result = new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: 1,
+      clientY: 1,
+      altKey: options.copy,
+      ctrlKey: options.copy,
+    })
+    Object.defineProperty(result, 'dataTransfer', { value: transfer })
+    return result
+  }
+  const view = editor.view
+  const originalCoords = view.posAtCoords
+  const originalHandler = view.props.handleDrop
+  view.setProps({ handleDrop: moveDraggedImageNode })
+  try {
+    if (options.html === undefined) {
+      view.posAtCoords = () => ({ pos: view.state.selection.from, inside: -1 })
+      view.dispatchEvent(event('dragstart'))
+    } else {
+      view.dragging = null
+      data.set('text/html', options.html)
+    }
+    options.beforeDrop?.()
+    view.posAtCoords = () => ({ pos: position, inside: -1 })
+    const drop = event('drop')
+    view.dispatchEvent(drop)
+    return drop
+  } finally {
+    view.posAtCoords = originalCoords
+    view.setProps({ handleDrop: originalHandler })
+  }
+}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste.test.ts
@@ -2,22 +2,14 @@
  * @vitest-environment jsdom
  */
 import { Editor } from '@tiptap/core'
+import { DOMParser, type Slice } from '@tiptap/pm/model'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { extractEmbeddedFileRef } from '@/lib/uploads/utils/embedded-image-ref'
-import {
-  createPublicFileContentSource,
-  createWorkspaceFileContentSource,
-} from '@/hooks/use-file-content-source'
-import { createMarkdownEditorExtensions } from './editor-extensions'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
 import {
   extractImageFiles,
-  findHostedImageAttrs,
-  hasHostedImageHtml,
-  htmlReferencesSrc,
-  isInlineRouteSrc,
-  shouldSkipFileUpload,
+  normalizePastedImageSources,
   toSameOriginPath,
-} from './image-paste'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste'
 
 // jsdom lacks `elementFromPoint`; the Placeholder extension's viewport tracking calls it on mount.
 beforeEach(() => {
@@ -84,289 +76,99 @@ describe('extractImageFiles', () => {
   })
 })
 
-describe('hasHostedImageHtml', () => {
-  const isHosted = (src: string) => src.startsWith('/api/files/view/')
+describe('normalizePastedImageSources', () => {
+  const origin = 'https://editor.example'
+  const stored = '/api/files/view/image-a'
+  const displayed = '/api/workspaces/workspace-a/files/inline?fileId=image-a'
 
-  it('detects an <img> whose src is recognized as one of our own hosted files', () => {
-    expect(hasHostedImageHtml('<img src="/api/files/view/wf_abc" alt="x">', isHosted)).toBe(true)
-  })
-
-  it('is false when the html has no img, or the img src is not one of ours', () => {
-    expect(hasHostedImageHtml('<p>hello</p>', isHosted)).toBe(false)
-    expect(hasHostedImageHtml('<img src="https://other-site.com/photo.jpg">', isHosted)).toBe(false)
-    expect(hasHostedImageHtml('', isHosted)).toBe(false)
-  })
-
-  it('matches a hosted img among multiple candidates', () => {
-    expect(
-      hasHostedImageHtml(
-        '<img src="https://other-site.com/a.png"><img src="/api/files/view/wf_abc">',
-        isHosted
-      )
-    ).toBe(true)
-  })
-
-  // Regression: the browser doesn't put the node's persisted `attrs.src` (`/api/files/view/...`)
-  // onto the clipboard when a rendered <img> is copied — it puts the actual DOM `src`, which is
-  // `resolveImageSrc`'s REWRITTEN display URL (`/…/files/inline?key=…`/`?fileId=…`). A predicate
-  // that only recognizes the persisted shape (as `extractEmbeddedFileRef` alone does) never matches
-  // a real same-page copy, silently falling through to the re-upload path it exists to avoid.
-  it('recognizes the real rendered <img src> end-to-end, not just the persisted reference shape', () => {
-    const ws = createWorkspaceFileContentSource('ws-1')
-    const renderedFromKey = ws.resolveImageSrc(
-      '/api/files/serve/workspace/ws-1/1700000000000-deadbeefdeadbeef-photo.png'
-    )
-    const renderedFromFileId = ws.resolveImageSrc('/api/files/view/wf_abc')
-    expect(renderedFromKey).toMatch(/^\/api\/workspaces\/ws-1\/files\/inline\?key=/)
-    expect(renderedFromFileId).toBe('/api/workspaces/ws-1/files/inline?fileId=wf_abc')
-
-    // extractEmbeddedFileRef alone (the persisted-content recognizer) does NOT match either
-    // rendered form — that's the exact gap isInlineRouteSrc closes.
-    expect(extractEmbeddedFileRef(renderedFromKey as string)).toBeNull()
-    expect(extractEmbeddedFileRef(renderedFromFileId as string)).toBeNull()
-
-    const isHostedReal = (src: string) => extractEmbeddedFileRef(src) !== null
-    expect(hasHostedImageHtml(`<img src="${renderedFromKey}">`, isHostedReal)).toBe(true)
-    expect(hasHostedImageHtml(`<img src="${renderedFromFileId}">`, isHostedReal)).toBe(true)
-  })
-
-  it('recognizes the public-share inline route too', () => {
-    const pub = createPublicFileContentSource('tok_1', '/api/files/public/tok_1/content')
-    const rendered = pub.resolveImageSrc('/api/files/view/wf_abc')
-    expect(rendered).toBe('/api/files/public/tok_1/inline?fileId=wf_abc')
-    expect(hasHostedImageHtml(`<img src="${rendered}">`, () => false)).toBe(true)
-  })
-
-  it('matches a valid unquoted src attribute (unquoted attribute values are valid HTML)', () => {
-    expect(hasHostedImageHtml('<img src=/api/files/view/wf_abc>', isHosted)).toBe(true)
-    expect(hasHostedImageHtml("<img alt='x' src=/api/files/view/wf_abc alt=y>", isHosted)).toBe(
-      true
-    )
-    expect(hasHostedImageHtml('<img src=https://other-site.com/a.png>', isHosted)).toBe(false)
-  })
-
-  it('matches single-quoted src attributes too', () => {
-    expect(hasHostedImageHtml("<img src='/api/files/view/wf_abc'>", isHosted)).toBe(true)
-  })
-})
-
-describe('shouldSkipFileUpload (shared by paste and drop)', () => {
-  const isHosted = (src: string) => src.startsWith('/api/files/view/')
-  const hostedHtml = '<img src="/api/files/view/wf_abc">'
-
-  it('skips upload for a single already-hosted image', () => {
-    expect(shouldSkipFileUpload([imageFile()], hostedHtml, isHosted)).toBe(true)
-  })
-
-  it('does not skip when there is no html, or the html is not one of ours', () => {
-    expect(shouldSkipFileUpload([imageFile()], '', isHosted)).toBe(false)
-    expect(shouldSkipFileUpload([imageFile()], '<img src="https://x.com/a.png">', isHosted)).toBe(
-      false
-    )
-  })
-
-  it('does not skip when there are no files to upload in the first place', () => {
-    expect(shouldSkipFileUpload([], hostedHtml, isHosted)).toBe(false)
-  })
-
-  // Regression: a genuinely mixed paste/drop (the hosted image plus a separate new one) must
-  // still upload the new file — bailing out entirely here would silently drop it.
-  it('does not skip a mixed paste/drop carrying more than one image file', () => {
-    expect(
-      shouldSkipFileUpload([imageFile('a.png'), imageFile('b.png')], hostedHtml, isHosted)
-    ).toBe(false)
-  })
-
-  // Regression: this must be content-based (the accompanying html), not keyed off any mutable
-  // per-drag flag like ProseMirror's `view.dragging` — that flag can go briefly stale (cleared up
-  // to ~50ms late via `dragend` when a prior internal drag was dropped outside the view), and a
-  // flag-based check would incorrectly suppress upload of an unrelated new file dropped in that
-  // window. This function only reacts to what THIS specific event's `html`/`images` contain.
-  it('is a pure function of the images/html actually offered, independent of any drag-session flag', () => {
-    expect(shouldSkipFileUpload([imageFile()], '', isHosted)).toBe(false)
-    expect(shouldSkipFileUpload([imageFile()], hostedHtml, isHosted)).toBe(true)
-  })
-})
-
-describe('isInlineRouteSrc', () => {
-  it('recognizes the workspace- and public-scoped inline route with key or fileId', () => {
-    expect(isInlineRouteSrc('/api/workspaces/ws-1/files/inline?key=workspace%2Fws-1%2Fa.png')).toBe(
-      true
-    )
-    expect(isInlineRouteSrc('/api/workspaces/ws-1/files/inline?fileId=wf_abc')).toBe(true)
-    expect(isInlineRouteSrc('/api/files/public/tok_1/inline?fileId=wf_abc')).toBe(true)
-  })
-
-  it('rejects non-inline paths, unrecognized query params, and external/absolute origins', () => {
-    expect(isInlineRouteSrc('/api/files/serve/workspace/ws-1/a.png')).toBe(false)
-    expect(isInlineRouteSrc('/api/workspaces/ws-1/files/inline')).toBe(false)
-    expect(isInlineRouteSrc('/api/workspaces/ws-1/files/inline?other=1')).toBe(false)
-    expect(isInlineRouteSrc('https://other-site.com/files/inline?key=x')).toBe(false)
-    expect(isInlineRouteSrc('data:image/png;base64,aaaa')).toBe(false)
-  })
-})
-
-describe('findHostedImageAttrs', () => {
-  const ws = createWorkspaceFileContentSource('ws-1')
-
-  function docWithImages(...attrs: Array<Record<string, unknown>>): Editor {
-    return new Editor({
-      extensions: createMarkdownEditorExtensions({ placeholder: '' }),
-      content: {
-        type: 'doc',
-        content: attrs.map((a) => ({ type: 'image', attrs: a })),
-      },
-    })
-  }
-
-  // Regression: this is the exact mechanism that avoids persisting the display-layer inline URL
-  // (Cursor's "Paste persists display image URLs" finding) — cloning the REAL node's attrs rather
-  // than re-deriving a node from the clipboard html's rewritten src.
-  it('finds the existing node whose RESOLVED (display) src matches, and returns its REAL persisted attrs', () => {
-    const persistedSrc = '/api/files/view/wf_abc'
-    const editor = docWithImages({ src: persistedSrc, alt: 'photo', width: '300' })
-    const renderedSrc = ws.resolveImageSrc(persistedSrc) as string
-    expect(renderedSrc).not.toBe(persistedSrc) // sanity: the rendered form really differs
-
-    const match = findHostedImageAttrs(editor.state.doc, [renderedSrc], ws.resolveImageSrc)
-    expect(match).not.toBeNull()
-    expect(match?.src).toBe(persistedSrc) // the REAL persisted src, not the rendered one
-    expect(match?.alt).toBe('photo')
-    expect(match?.width).toBe('300')
-  })
-
-  it('returns null when no node in the doc resolves to any target src', () => {
-    const editor = docWithImages({ src: '/api/files/view/wf_other' })
-    const match = findHostedImageAttrs(
-      editor.state.doc,
-      ['/api/workspaces/ws-1/files/inline?fileId=wf_abc'],
-      ws.resolveImageSrc
-    )
-    expect(match).toBeNull()
-  })
-
-  it('returns null for an empty doc or an empty target list', () => {
-    const editor = docWithImages()
-    expect(findHostedImageAttrs(editor.state.doc, ['/anything'], ws.resolveImageSrc)).toBeNull()
-    const editorWithImage = docWithImages({ src: '/api/files/view/wf_abc' })
-    expect(findHostedImageAttrs(editorWithImage.state.doc, [], ws.resolveImageSrc)).toBeNull()
-  })
-
-  it('matches the first of several images, not just the last', () => {
-    const editor = docWithImages(
-      { src: '/api/files/view/wf_one', alt: 'one' },
-      { src: '/api/files/view/wf_two', alt: 'two' }
-    )
-    const renderedTwo = ws.resolveImageSrc('/api/files/view/wf_two') as string
-    const match = findHostedImageAttrs(editor.state.doc, [renderedTwo], ws.resolveImageSrc)
-    expect(match?.alt).toBe('two')
-  })
-
-  it('returns a defensive copy, not a live reference to the node attrs object', () => {
-    const persistedSrc = '/api/files/view/wf_abc'
-    const editor = docWithImages({ src: persistedSrc, alt: 'photo' })
-    const renderedSrc = ws.resolveImageSrc(persistedSrc) as string
-    const match = findHostedImageAttrs(editor.state.doc, [renderedSrc], ws.resolveImageSrc)
-    expect(match).not.toBeNull()
-    if (match) match.alt = 'mutated'
-    let originalAlt: unknown
-    editor.state.doc.descendants((node) => {
-      if (node.type.name === 'image') originalAlt = node.attrs.alt
-    })
-    expect(originalAlt).toBe('photo')
-  })
-})
-
-describe('origin-aware src normalization (browser-native drag/copy enrichment uses ABSOLUTE urls)', () => {
-  const ORIGIN = 'https://www.staging.sim.ai'
-
-  it('toSameOriginPath: relative passes through; same-origin absolute → path+query; cross-origin → null', () => {
-    expect(toSameOriginPath('/api/files/view/wf_a', ORIGIN)).toBe('/api/files/view/wf_a')
-    expect(toSameOriginPath(`${ORIGIN}/api/workspaces/ws-1/files/inline?fileId=wf_a`, ORIGIN)).toBe(
-      '/api/workspaces/ws-1/files/inline?fileId=wf_a'
-    )
-    expect(toSameOriginPath('https://evil.example.com/api/files/view/wf_a', ORIGIN)).toBeNull()
-  })
-
-  it('isInlineRouteSrc accepts the same-origin ABSOLUTE inline route (the real dragged-img src on staging)', () => {
-    expect(isInlineRouteSrc(`${ORIGIN}/api/workspaces/ws-1/files/inline?fileId=wf_a`, ORIGIN)).toBe(
-      true
-    )
-    expect(
-      isInlineRouteSrc(
-        'https://evil.example.com/api/workspaces/ws-1/files/inline?fileId=wf_a',
-        ORIGIN
-      )
-    ).toBe(false)
-  })
-
-  it('hasHostedImageHtml matches absolute same-origin srcs and rejects cross-origin ones', () => {
-    const isHosted = (src: string) => extractEmbeddedFileRef(src) !== null
-    expect(hasHostedImageHtml(`<img src="${ORIGIN}/api/files/view/wf_a">`, isHosted, ORIGIN)).toBe(
-      true
-    )
-    expect(
-      hasHostedImageHtml(
-        `<img src="${ORIGIN}/api/workspaces/ws-1/files/inline?fileId=wf_a">`,
-        isHosted,
-        ORIGIN
-      )
-    ).toBe(true)
-    expect(
-      hasHostedImageHtml(
-        '<img src="https://evil.example.com/api/files/view/wf_a">',
-        isHosted,
-        ORIGIN
-      )
-    ).toBe(false)
-  })
-
-  it('findHostedImageAttrs matches when the clipboard html carries the absolute rendered url', () => {
-    const ws = createWorkspaceFileContentSource('ws-1')
+  function withEditor(test: (editor: Editor, parse: (html: string) => Slice) => void) {
     const editor = new Editor({
       extensions: createMarkdownEditorExtensions({ placeholder: '' }),
-      content: {
-        type: 'doc',
-        content: [{ type: 'image', attrs: { src: '/api/files/view/wf_abc', alt: 'photo' } }],
-      },
+      content: `<p>Existing</p><img src="${stored}" width="999" alt="Do not copy these attributes">`,
     })
-    const absolute = `${ORIGIN}/api/workspaces/ws-1/files/inline?fileId=wf_abc`
-    const match = findHostedImageAttrs(editor.state.doc, [absolute], ws.resolveImageSrc, ORIGIN)
-    expect(match?.src).toBe('/api/files/view/wf_abc')
+    const parse = (html: string) => {
+      const container = document.createElement('div')
+      container.innerHTML = html
+      return DOMParser.fromSchema(editor.schema).parseSlice(container)
+    }
+    try {
+      test(editor, parse)
+    } finally {
+      editor.destroy()
+    }
+  }
+
+  it('preserves the full fragment, image attributes, links and open boundaries', () => {
+    withEditor((editor, parse) => {
+      const html = (src: string) =>
+        '<h2>Heading <img src="' +
+        src +
+        '" width="120" alt="First"></h2>' +
+        '<p><strong>Caption</strong> <a href="/destination"><img src="' +
+        src +
+        '" width="240" alt="Second"></a> tail</p>' +
+        '<p><img src="https://external.example/image.png" alt="External"></p>'
+      const slice = parse(html(origin + displayed))
+      const result = normalizePastedImageSources(slice, editor.state.doc, () => displayed, origin)
+      expect(result.eq(parse(html(stored)))).toBe(true)
+      expect(result.openStart).toBe(slice.openStart)
+      expect(result.openEnd).toBe(slice.openEnd)
+    })
+  })
+
+  it('normalizes absolute canonical references without needing a matching document image', () => {
+    withEditor((editor, parse) => {
+      const slice = parse(`<p>Before <img src="${origin}/api/files/view/image-b"> After</p>`)
+      const result = normalizePastedImageSources(slice, editor.state.doc, undefined, origin)
+      expect(result.eq(parse('<p>Before <img src="/api/files/view/image-b"> After</p>'))).toBe(true)
+    })
+  })
+
+  it.each([
+    `https://other.example${displayed}`,
+    '/api/workspaces/another-workspace/files/inline?fileId=image-a',
+    '/api/files/public/another-share/inline?fileId=image-a',
+    '/assets/image.png',
+  ])('does not infer stored identity from an unfamiliar URL: %s', (src) => {
+    withEditor((editor, parse) => {
+      const slice = parse(`<img src="${src}">`)
+      expect(
+        normalizePastedImageSources(slice, editor.state.doc, () => displayed, origin).eq(slice)
+      ).toBe(true)
+    })
+  })
+
+  it('leaves text-only and native stored-image fragments unchanged', () => {
+    withEditor((editor, parse) => {
+      for (const slice of [parse('<p><em>Text</em></p>'), parse(`<img src="${stored}">`)]) {
+        expect(normalizePastedImageSources(slice, editor.state.doc, () => displayed, origin)).toBe(
+          slice
+        )
+      }
+    })
+  })
+
+  it('does not rewrite a URL in accompanying text', () => {
+    withEditor((editor, parse) => {
+      const slice = parse(`<p>${displayed}<img src="${origin}${displayed}"></p>`)
+      const result = normalizePastedImageSources(slice, editor.state.doc, () => displayed, origin)
+      expect(result.eq(parse(`<p>${displayed}<img src="${stored}"></p>`))).toBe(true)
+    })
   })
 })
 
-describe('htmlReferencesSrc (the "this drop is MY dragged image" check)', () => {
-  const ORIGIN = 'https://www.staging.sim.ai'
-  const RESOLVED = '/api/workspaces/ws-1/files/inline?fileId=wf_a'
-
-  it('true when the html img src is the absolute form of the resolved src', () => {
-    expect(htmlReferencesSrc(`<img src="${ORIGIN}${RESOLVED}">`, RESOLVED, ORIGIN)).toBe(true)
-  })
-
-  it('true for the relative form too (ProseMirror-serialized html)', () => {
-    expect(htmlReferencesSrc(`<img src="${RESOLVED}">`, RESOLVED, ORIGIN)).toBe(true)
-  })
-
-  // Identity must work for cross-origin srcs too: a doc's image may legitimately point at a CDN or
-  // badge URL, and dragging THAT node to reorder it must still match — under the previous
-  // same-origin-path comparison it fell into the duplicate-upload branch instead.
-  it('matches an external (cross-origin) image against its own exact absolute url', () => {
-    const EXTERNAL = 'https://cdn.example.com/badge.svg'
-    expect(htmlReferencesSrc(`<img src="${EXTERNAL}">`, EXTERNAL, ORIGIN)).toBe(true)
-    expect(
-      htmlReferencesSrc('<img src="https://cdn.example.com/other.svg">', EXTERNAL, ORIGIN)
-    ).toBe(false)
-  })
-
-  it('false for a different image, empty html, missing resolved src, or cross-origin', () => {
-    expect(htmlReferencesSrc(`<img src="${ORIGIN}/api/other?fileId=wf_b">`, RESOLVED, ORIGIN)).toBe(
-      false
+describe('toSameOriginPath', () => {
+  it('accepts relative and same-origin URLs only', () => {
+    expect(toSameOriginPath('/api/files/view/image-a', 'https://editor.example')).toBe(
+      '/api/files/view/image-a'
     )
-    expect(htmlReferencesSrc('', RESOLVED, ORIGIN)).toBe(false)
-    expect(htmlReferencesSrc(`<img src="${ORIGIN}${RESOLVED}">`, undefined, ORIGIN)).toBe(false)
     expect(
-      htmlReferencesSrc(`<img src="https://evil.example.com${RESOLVED}">`, RESOLVED, ORIGIN)
-    ).toBe(false)
+      toSameOriginPath('https://editor.example/api/files/view/image-a', 'https://editor.example')
+    ).toBe('/api/files/view/image-a')
+    expect(
+      toSameOriginPath('https://other.example/api/files/view/image-a', 'https://editor.example')
+    ).toBeNull()
+    expect(toSameOriginPath('data:image/png;base64,AAAA', 'https://editor.example')).toBeNull()
+    expect(toSameOriginPath('http://[', 'https://editor.example')).toBeNull()
   })
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste.test.ts
@@ -7,7 +7,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
 import {
   extractImageFiles,
+  getImageFileFallback,
   normalizePastedImageSources,
+  resolveImageFileFallback,
   toSameOriginPath,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste'
 
@@ -97,6 +99,42 @@ describe('normalizePastedImageSources', () => {
       editor.destroy()
     }
   }
+
+  it.each([
+    'blob:https://editor.example/temporary-image',
+    '/api/workspaces/source/files/inline?fileId=image',
+    '/api/files/public/share/inline?fileId=image',
+  ])('resolves a bitmap for repeated non-portable images inside a complete fragment: %s', (src) => {
+    withEditor((editor, parse) => {
+      const html = (source: string) =>
+        `<h2>Heading <img src="${source}" width="120" alt="First"></h2><p><a href="/destination"><img src="${source}" width="240" alt="Second"></a>Caption<img src="/other.png"></p>`
+      const slice = parse(html(src))
+      const fallback = getImageFileFallback(slice, [imageFile()])
+      expect(fallback).not.toBeNull()
+      expect(fallback?.source).toBe(src)
+      expect(
+        resolveImageFileFallback(fallback!, '/api/files/view/uploaded').eq(
+          parse(html('/api/files/view/uploaded'))
+        )
+      ).toBe(true)
+      expect(editor.state.doc.textContent).toContain('Existing')
+    })
+  })
+
+  it('does not associate bitmap bytes with an ambiguous source or file ordering', () => {
+    withEditor((_editor, parse) => {
+      const twoSources = parse(
+        '<p><img src="blob:https://editor.example/a"><img src="blob:https://editor.example/b"></p>'
+      )
+      expect(getImageFileFallback(twoSources, [imageFile()])).toBeNull()
+      expect(
+        getImageFileFallback(twoSources, [imageFile('one.png'), imageFile('two.png')])
+      ).toBeNull()
+      expect(
+        getImageFileFallback(parse('<p>Caption<img src="/portable.png"></p>'), [imageFile()])
+      ).toBeNull()
+    })
+  })
 
   it('preserves the full fragment, image attributes, links and open boundaries', () => {
     withEditor((editor, parse) => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste.ts
@@ -1,11 +1,8 @@
-import { extractImgSrcs } from '@/lib/uploads/utils/embedded-image-ref'
+import { Fragment, type Node, Slice } from '@tiptap/pm/model'
+import { extractEmbeddedFileRef } from '@/lib/uploads/utils/embedded-image-ref'
 import { isImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-node'
 
-/**
- * Extract image `File` objects from a paste/drop payload. Reads `files` first, then falls back to
- * `items` — many browsers expose a pasted or copied image (e.g. a screenshot) only through
- * `DataTransfer.items` with an empty `files` list, so reading `files` alone misses them.
- */
+/** Clipboard image files may be exposed only through `items`, rather than `files`. */
 export function extractImageFiles(transfer: DataTransfer | null): File[] {
   if (!transfer) return []
   const fromFiles = Array.from(transfer.files).filter((file) => file.type.startsWith('image/'))
@@ -16,29 +13,28 @@ export function extractImageFiles(transfer: DataTransfer | null): File[] {
     .filter((file): file is File => file !== null)
 }
 
-/** Query params under which the inline route addresses a workspace file. */
-const INLINE_ROUTE_QUERY_KEYS = new Set(['key', 'fileId'])
-
-/**
- * The page's own origin — clipboard/dataTransfer srcs on any other origin are never ours.
- * Deliberately `window.location.origin`, NOT `getBaseUrl()`: the browser serializes a dragged/copied
- * `<img>`'s URL against the origin the page is ACTUALLY being viewed on, which can legitimately
- * differ from the configured `NEXT_PUBLIC_APP_URL` (localhost dev against a shared env, preview
- * deploys, apex-vs-www) — comparing against the configured URL would silently fail on any such
- * origin, which is the exact bug class this normalization exists to fix.
- */
 function runtimeOrigin(): string {
   return typeof window === 'undefined' ? '' : window.location.origin
 }
 
-/**
- * Normalizes a clipboard/dataTransfer img `src` to an origin-relative `pathname?query`, or `null`
- * when it belongs to a different origin. The browser's NATIVE drag/copy enrichment (dragging or
- * "Copy Image" on a rendered `<img>`) serializes the ABSOLUTE resolved URL —
- * `https://host/api/workspaces/…/inline?…` — while everything the app compares against (persisted
- * refs, `resolveImageSrc` output) is origin-relative, so both must be brought into the same space
- * before comparing. A cross-origin src must never be treated as ours.
- */
+/** A native image copy can carry bytes for a display URL that cannot survive sharing or reload. */
+export function needsImageFileFallback(slice: Slice, files: readonly File[]): boolean {
+  if (files.length !== 1 || slice.content.childCount !== 1) return false
+  let node = slice.content.firstChild!
+  if (node.type.name === 'paragraph' && node.childCount === 1) node = node.firstChild!
+  if (!isImageNode(node) || typeof node.attrs.src !== 'string') return false
+  try {
+    const url = new URL(node.attrs.src, runtimeOrigin() || 'http://placeholder')
+    return (
+      url.protocol === 'blob:' ||
+      /^\/api\/(?:workspaces\/[^/]+\/files|files\/public\/[^/]+)\/inline$/.test(url.pathname)
+    )
+  } catch {
+    return false
+  }
+}
+
+/** Normalize native clipboard URLs against the actual page origin, never another host. */
 export function toSameOriginPath(src: string, origin = runtimeOrigin()): string | null {
   try {
     const base = origin || 'http://placeholder'
@@ -51,152 +47,46 @@ export function toSameOriginPath(src: string, origin = runtimeOrigin()): string 
 }
 
 /**
- * True for the *display-layer* inline route `resolveImageSrc` (see `use-file-content-source.tsx`)
- * rewrites an embed to — workspace-scoped `/api/workspaces/{workspaceId}/files/inline?key=…`/`?fileId=…`
- * or public-share-scoped `/api/files/public/{token}/inline?key=…`/`?fileId=…`. This is the shape
- * actually rendered into `<img src>`, and so what a same-page copy's `text/html` clipboard payload
- * actually contains (absolute — see {@link toSameOriginPath}) — NOT the raw stored reference
- * `extractEmbeddedFileRef` (in `@/lib/uploads/utils/embedded-image-ref`) recognizes, which only
- * matches the persisted `src` before that rewrite. Checked separately from (rather than folded into)
- * `extractEmbeddedFileRef` since that helper is shared with server-side authorization/export code
- * operating on persisted content, where this display-only shape should never legitimately appear.
+ * Restore recognized stored image references without replacing the rest of the pasted fragment.
+ * Display-only routes are resolved only through images already present in this document.
  */
-export function isInlineRouteSrc(src: string, origin = runtimeOrigin()): boolean {
-  const path = toSameOriginPath(src, origin)
-  if (path === null) return false
-  try {
-    const parsed = new URL(path, 'http://placeholder')
-    if (!parsed.pathname.endsWith('/inline')) return false
-    for (const key of parsed.searchParams.keys()) {
-      if (INLINE_ROUTE_QUERY_KEYS.has(key)) return true
-    }
-    return false
-  } catch {
-    return false
-  }
-}
-
-/**
- * True when `html` contains an `<img>` whose `src` is already one of our own hosted workspace file
- * references. Copying a rendered `<img>` that's already on the page (e.g. Cmd+C after clicking it to
- * select it) makes the browser put BOTH `text/html` (the real serialized node, with its real hosted
- * `src`) AND a synthesized image `File` onto the clipboard — the same "drag a web image out" behavior
- * that {@link extractImageFiles} alone can't tell apart from a genuinely new external image paste.
- * Srcs are normalized origin-relative first ({@link toSameOriginPath}): ProseMirror's own clipboard
- * serialization writes the persisted relative src, but the BROWSER's native enrichment writes the
- * absolute resolved URL.
- */
-export function hasHostedImageHtml(
-  html: string,
-  isHostedRef: (src: string) => boolean,
+export function normalizePastedImageSources(
+  slice: Slice,
+  doc: Node,
+  resolveSrc: (src: string | undefined) => string | undefined = (src) => src,
   origin = runtimeOrigin()
-): boolean {
-  return extractImgSrcs(html).some((src) => {
-    const path = toSameOriginPath(src, origin)
-    return path !== null && (isHostedRef(path) || isInlineRouteSrc(path, origin))
+): Slice {
+  let hasImage = false
+  slice.content.descendants((node) => {
+    if (isImageNode(node)) hasImage = true
+    return !hasImage
   })
-}
-
-/** Resolves `src` to a full absolute URL against `origin`, or `null` when unparseable. */
-function toAbsoluteUrl(src: string, origin: string): string | null {
-  try {
-    return new URL(src, origin || 'http://placeholder').href
-  } catch {
-    return null
-  }
-}
-
-/**
- * True when `html` contains an `<img>` whose src resolves to the same ABSOLUTE URL as
- * `resolvedSrc` (a `resolveImageSrc` output for a node already in this document). This is the
- * "that drop is MY dragged image" check for internal drag-reorder: TipTap's node-view dragstart
- * bypasses ProseMirror's serialization entirely (no PM `text/html`, no `view.dragging`) but
- * NodeSelects the dragged image, and the browser's native enrichment carries the absolute rendered
- * URL of exactly that node.
- *
- * Deliberately compares full absolute URLs rather than same-origin paths ({@link toSameOriginPath}):
- * identity is the question here, not hosted-by-us membership — a doc's image may legitimately have a
- * cross-origin `src` (a README badge, a CDN image), and dragging THAT node to reorder it must match
- * too, or it falls into the duplicate-upload path. Relative and absolute spellings of the same URL
- * still compare equal because both sides resolve against the page origin.
- */
-export function htmlReferencesSrc(
-  html: string,
-  resolvedSrc: string | undefined,
-  origin = runtimeOrigin()
-): boolean {
-  if (!html || !resolvedSrc) return false
-  const target = toAbsoluteUrl(resolvedSrc, origin)
-  if (target === null) return false
-  return extractImgSrcs(html).some((src) => toAbsoluteUrl(src, origin) === target)
-}
-
-/**
- * True when a paste or drop should be diverted away from the upload-from-file path — it carries
- * exactly one image file, and the accompanying `text/html` shows it's a same-page copy of an
- * already-hosted image (see {@link hasHostedImageHtml}) rather than a genuinely new external image.
- * Content-based (not `view.dragging`-based, for the drop case): `view.dragging` can go briefly stale
- * (cleared up to ~50ms late by ProseMirror's own `dragend` handler when a prior internal drag was
- * dropped outside this view) and must never suppress upload of an unrelated, genuinely new file that
- * happens to land in that window — this check only reacts to what THIS specific event's `html`
- * actually contains. Gated on exactly one file — a genuinely mixed paste/drop (the hosted image plus a
- * separate new one) must still upload the new file, not have the whole paste/drop diverted.
- */
-export function shouldSkipFileUpload(
-  images: File[],
-  html: string,
-  isHostedRef: (src: string) => boolean
-): boolean {
-  return images.length === 1 && Boolean(html) && hasHostedImageHtml(html, isHostedRef)
-}
-
-/** Minimal shape of a ProseMirror image node — just enough to read its type name and attrs. */
-interface ImageLikeNode {
-  type: { name: string }
-  attrs: Record<string, unknown>
-}
-
-/** Minimal shape of a ProseMirror doc — just enough to walk its nodes. */
-interface DescendantsDoc {
-  descendants: (callback: (node: ImageLikeNode) => boolean | undefined) => void
-}
-
-/**
- * Finds the first `image` node already in `doc` whose *rendered* src (`resolveImageSrc(node.attrs.src)`)
- * matches one of `targetSrcs`, and returns its attrs — a defensive copy, safe to hand straight to
- * `insertContentAt`. Returns `null` if no match is found (e.g. the source node was deleted, or this is
- * genuinely a different document than the one the html was copied from).
- *
- * Used to clone a same-page copy/drag of an already-hosted image faithfully — the exact persisted
- * `src` (and every other attribute: width, height, href, title…) — rather than re-deriving a node from
- * the clipboard/dataTransfer `html`, whose `src` is `resolveImageSrc`'s rewritten *display* URL, not the
- * real persisted one. Inserting a node built from that display URL would bake it into the document,
- * which public share/export/referenced-by-doc tracking don't recognize (they only match the persisted
- * shape) — this lookup avoids ever constructing such a node in the first place. Both sides of the
- * comparison are normalized origin-relative ({@link toSameOriginPath}): the clipboard html may carry
- * the browser's absolute URLs.
- */
-export function findHostedImageAttrs(
-  doc: DescendantsDoc,
-  targetSrcs: string[],
-  resolveImageSrc: (src: string | undefined) => string | undefined,
-  origin = runtimeOrigin()
-): Record<string, unknown> | null {
-  const targets = new Set(
-    targetSrcs.map((src) => toSameOriginPath(src, origin)).filter((p): p is string => p !== null)
-  )
-  let found: Record<string, unknown> | null = null
+  if (!hasImage) return slice
+  const sources = new Map<string, string>()
   doc.descendants((node) => {
-    if (found) return false
-    if (isImageNode(node)) {
-      const resolved = resolveImageSrc(node.attrs.src as string | undefined)
-      const resolvedPath = resolved ? toSameOriginPath(resolved, origin) : null
-      if (resolvedPath && targets.has(resolvedPath)) {
-        found = { ...node.attrs }
-        return false
-      }
-    }
-    return true
+    if (!isImageNode(node) || typeof node.attrs.src !== 'string') return
+    const resolved = resolveSrc(node.attrs.src)
+    if (!resolved) return
+    const path = toSameOriginPath(resolved, origin)
+    if (path) sources.set(path, node.attrs.src)
   })
-  return found
+  let changed = false
+  const normalize = (fragment: Fragment): Fragment => {
+    const children: Node[] = []
+    fragment.forEach((node) => {
+      if (isImageNode(node) && typeof node.attrs.src === 'string') {
+        const path = toSameOriginPath(node.attrs.src, origin)
+        const src = path && (sources.get(path) ?? (extractEmbeddedFileRef(path) ? path : null))
+        if (src && src !== node.attrs.src) {
+          changed = true
+          children.push(node.type.create({ ...node.attrs, src }, node.content, node.marks))
+        } else children.push(node)
+      } else {
+        children.push(node.isLeaf ? node : node.copy(normalize(node.content)))
+      }
+    })
+    return Fragment.fromArray(children)
+  }
+  const content = normalize(slice.content)
+  return changed ? new Slice(content, slice.openStart, slice.openEnd) : slice
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste.ts
@@ -17,14 +17,14 @@ function runtimeOrigin(): string {
   return typeof window === 'undefined' ? '' : window.location.origin
 }
 
-/** A native image copy can carry bytes for a display URL that cannot survive sharing or reload. */
-export function needsImageFileFallback(slice: Slice, files: readonly File[]): boolean {
-  if (files.length !== 1 || slice.content.childCount !== 1) return false
-  let node = slice.content.firstChild!
-  if (node.type.name === 'paragraph' && node.childCount === 1) node = node.firstChild!
-  if (!isImageNode(node) || typeof node.attrs.src !== 'string') return false
+export interface ImageFileFallback {
+  slice: Slice
+  source: string
+}
+
+function isNonPortableImageSource(src: string): boolean {
   try {
-    const url = new URL(node.attrs.src, runtimeOrigin() || 'http://placeholder')
+    const url = new URL(src, runtimeOrigin() || 'http://placeholder')
     return (
       url.protocol === 'blob:' ||
       /^\/api\/(?:workspaces\/[^/]+\/files|files\/public\/[^/]+)\/inline$/.test(url.pathname)
@@ -32,6 +32,30 @@ export function needsImageFileFallback(slice: Slice, files: readonly File[]): bo
   } catch {
     return false
   }
+}
+
+/** Associate a single attached bitmap with its source, without guessing a multi-file ordering. */
+export function getImageFileFallback(
+  slice: Slice,
+  files: readonly File[]
+): ImageFileFallback | null {
+  if (files.length !== 1) return null
+  const sources = new Set<string>()
+  slice.content.descendants((node) => {
+    if (
+      isImageNode(node) &&
+      typeof node.attrs.src === 'string' &&
+      isNonPortableImageSource(node.attrs.src)
+    ) {
+      sources.add(node.attrs.src)
+    }
+  })
+  return sources.size === 1 ? { slice, source: sources.values().next().value! } : null
+}
+
+/** Replace the uploaded image's source while retaining the original fragment and node attributes. */
+export function resolveImageFileFallback(fallback: ImageFileFallback, uploadedSrc: string): Slice {
+  return mapImageSources(fallback.slice, (src) => (src === fallback.source ? uploadedSrc : src))
 }
 
 /** Normalize native clipboard URLs against the actual page origin, never another host. */
@@ -70,14 +94,20 @@ export function normalizePastedImageSources(
     const path = toSameOriginPath(resolved, origin)
     if (path) sources.set(path, node.attrs.src)
   })
+  return mapImageSources(slice, (source) => {
+    const path = toSameOriginPath(source, origin)
+    return (path && (sources.get(path) ?? (extractEmbeddedFileRef(path) ? path : null))) || source
+  })
+}
+
+function mapImageSources(slice: Slice, map: (src: string) => string): Slice {
   let changed = false
   const normalize = (fragment: Fragment): Fragment => {
     const children: Node[] = []
     fragment.forEach((node) => {
       if (isImageNode(node) && typeof node.attrs.src === 'string') {
-        const path = toSameOriginPath(node.attrs.src, origin)
-        const src = path && (sources.get(path) ?? (extractEmbeddedFileRef(path) ? path : null))
-        if (src && src !== node.attrs.src) {
+        const src = map(node.attrs.src)
+        if (src !== node.attrs.src) {
           changed = true
           children.push(node.type.create({ ...node.attrs, src }, node.content, node.marks))
         } else children.push(node)

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.test.ts
@@ -2,7 +2,8 @@
 import { Editor } from '@tiptap/core'
 import Collaboration from '@tiptap/extension-collaboration'
 import { undoDepth } from '@tiptap/pm/history'
-import { afterEach, describe, expect, it } from 'vitest'
+import { DOMParser } from '@tiptap/pm/model'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as Y from 'yjs'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
 import {
@@ -13,6 +14,7 @@ import {
   ImageUploadPlaceholders,
   removeImageUpload,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload'
+import { createRichMarkdownPasteAdmission } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission'
 
 let editor: Editor
 afterEach(() => editor?.destroy())
@@ -26,6 +28,33 @@ function mount(content = '<p>abcd</p>') {
 }
 
 describe('image upload anchors', () => {
+  it('rechecks the paste budget when an uploaded fragment completes after intervening edits', () => {
+    const rejected = vi.fn()
+    editor = new Editor({
+      extensions: [
+        ...createMarkdownContentExtensions(),
+        ImageUploadPlaceholders,
+        createRichMarkdownPasteAdmission({
+          maxResultBytes: 100,
+          maxResultCharacters: 100,
+          getCurrentText: () => editor.getMarkdown(),
+          onRejected: rejected,
+        }),
+      ],
+      content: '<p>Seed</p>',
+    })
+    const [id] = beginImageUploads(editor, { from: 5, to: 5 }, ['image'])
+    editor.commands.insertContentAt(1, 'x'.repeat(70))
+    const before = editor.getJSON()
+    const container = document.createElement('div')
+    container.innerHTML = '<p>Pasted caption <img src="/new.png"></p>'
+    const fragment = DOMParser.fromSchema(editor.schema).parseSlice(container)
+    expect(finishImageUpload(editor, id, '/new.png', 'image', fragment)).toBe(false)
+    expect(rejected).toHaveBeenCalledWith('paste')
+    expect(editor.getJSON()).toEqual(before)
+    expect(findImageUpload(editor, id)).toBeNull()
+  })
+
   it.each([false, true])(
     'safely cancels an anchor replaced by a peer update (unrelated paragraph=%s)',
     (unrelated) => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload.ts
@@ -156,10 +156,16 @@ export function removeImageUpload(editor: Editor, id: string): void {
 }
 
 /**
- * Commit one image at its surviving range. The first successful image replaces the captured content;
+ * Commit uploaded content at its surviving range. The first successful upload replaces the captured content;
  * its queued siblings become insertion anchors after it. Cancellation and failure never delete text.
  */
-export function finishImageUpload(editor: Editor, id: string, src: string, alt: string): boolean {
+export function finishImageUpload(
+  editor: Editor,
+  id: string,
+  src: string,
+  alt: string,
+  fragment?: Slice
+): boolean {
   if (editor.isDestroyed) return false
   const upload = uploadPlaceholderKey.getState(editor.state)?.uploads.get(id)
   if (!upload) return false
@@ -167,18 +173,25 @@ export function finishImageUpload(editor: Editor, id: string, src: string, alt: 
     removeImageUpload(editor, id)
     return false
   }
-  const inserted = editor
+  const ran = editor
     .chain()
-    .insertContentAt(
-      { from: upload.from, to: upload.to },
-      { type: imageTypeAt(editor.state.doc, upload.from), attrs: { src, alt } },
-      { updateSelection: false }
-    )
+    .command(({ tr, commands }) => {
+      if (fragment) {
+        tr.replaceRange(upload.from, upload.to, fragment).setMeta('uiEvent', 'paste')
+        return true
+      }
+      return commands.insertContentAt(
+        { from: upload.from, to: upload.to },
+        { type: imageTypeAt(editor.state.doc, upload.from), attrs: { src, alt } },
+        { updateSelection: false }
+      )
+    })
     .command(({ tr }) => {
       tr.setMeta(uploadPlaceholderKey, { complete: id } satisfies UploadPlaceholderAction)
       return true
     })
     .run()
+  const inserted = ran && findImageUpload(editor, id) === null
   if (!inserted) removeImageUpload(editor, id)
   return inserted
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image.tsx
@@ -222,9 +222,6 @@ export function ResizableImageView({ node, selected, editor, getPos }: ReactNode
       src={source.resolveImageSrc(attrs.src)}
       alt={attrs.alt ?? ''}
       title={attrs.title ?? undefined}
-      // When editable, the image itself is the drag handle — grab anywhere on it to reorder. (The node
-      // view's wrapper is forced `draggable=false` by the React renderer, so the handle must be a child;
-      // the resize button sits outside this element, so it keeps its own pointer behavior.)
       draggable={editable}
       data-drag-handle={editable ? '' : undefined}
       style={imageStyle}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap.test.ts
@@ -8,9 +8,14 @@
  */
 import { Editor } from '@tiptap/core'
 import { GapCursor } from '@tiptap/pm/gapcursor'
+import { undoDepth } from '@tiptap/pm/history'
 import { AllSelection, NodeSelection } from '@tiptap/pm/state'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Y from 'yjs'
+import { FileCollaboration } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/collaboration/file-collaboration'
 import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { RichMarkdownKeymap } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap'
 import { postProcessSerializedMarkdown } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
 import { parseMarkdownToDoc } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
 import {
@@ -395,7 +400,7 @@ describe('list Backspace (clear / outdent)', () => {
     pressBackspace(editor)
 
     const { md, reparsed } = markdownRoundTrip(editor)
-    expect(md.trim()).toBe('- one\n- \n- three')
+    expect(md.trim()).toBe('- one\n-\n- three')
     expect(reparsed).toBe(md)
     editor.destroy()
   })
@@ -484,10 +489,7 @@ describe('empty nested bullet does not corrupt its parent (Enter → Tab)', () =
     Element.prototype.scrollIntoView = vi.fn()
   })
 
-  it('serializes a stranded empty sub-bullet away instead of turning the parent into a heading', () => {
-    // Repro: type a bullet, Enter for a new bullet, Tab to indent it into an empty sub-bullet, then
-    // leave it. The serialized `- one\n  - ` would re-parse as `- ## one` (Setext underline). The
-    // serialize step must strip the empty sub-bullet so the parent stays a bullet and round-trips.
+  it('preserves an empty sub-bullet without turning the parent into a heading', () => {
     const editor = editorWith('')
     editor.commands.setContent('- one', { contentType: 'markdown' })
     editor.commands.focus()
@@ -500,12 +502,14 @@ describe('empty nested bullet does not corrupt its parent (Enter → Tab)', () =
     pressKey(editor, 'Tab')
 
     const saved = postProcessSerializedMarkdown(editor.getMarkdown())
-    expect(saved).toBe('- one\n')
+    const before = editor.getJSON().content?.[0]
 
     // Reloading the saved markdown keeps a bullet — never a heading.
     editor.commands.setContent(saved, { contentType: 'markdown' })
     expect(blockShape(editor)).not.toContain('heading')
     expect(blockShape(editor)).toContain('bulletList')
+    expect(editor.getJSON().content?.[0]).toEqual(before)
+    expect(postProcessSerializedMarkdown(editor.getMarkdown())).toBe(saved)
     editor.destroy()
   })
 })
@@ -615,6 +619,49 @@ describe('empty list-item Enter', () => {
 })
 
 describe('list item descendant preservation', () => {
+  it.each([
+    '- Parent\n  - Child\n- After',
+    '1. Parent\n   1. Child\n2. After',
+    '- [ ] Parent\n  - [ ] Child\n- [ ] After',
+  ])(
+    'does not move a collaborative caret or emit a Yjs replacement for an empty parent: %s',
+    (markdown) => {
+      const localDoc = new Y.Doc()
+      const peerDoc = new Y.Doc()
+      const createEditor = (document: Y.Doc) =>
+        new Editor({
+          extensions: [
+            ...createMarkdownContentExtensions({}, { disableHistory: true }),
+            RichMarkdownKeymap,
+            FileCollaboration.configure({ document }),
+          ],
+          editorProps: { handleScrollToSelection: () => true },
+        })
+      const local = createEditor(localDoc)
+      local.commands.setContent(parseMarkdownToDoc(`Before\n\n${markdown}`))
+      Y.applyUpdate(peerDoc, Y.encodeStateAsUpdate(localDoc))
+      const peer = createEditor(peerDoc)
+      try {
+        emptyItem(local, 'Parent')
+        Y.applyUpdate(peerDoc, Y.encodeStateAsUpdate(localDoc))
+        const before = local.getJSON()
+        const selection = local.state.selection.toJSON()
+        const updates = vi.fn()
+        localDoc.on('update', updates)
+        for (const key of ['Backspace', 'Backspace', 'Enter']) pressKey(local, key)
+        expect(local.state.selection.toJSON()).toEqual(selection)
+        expect(local.getJSON()).toEqual(before)
+        expect(peer.getJSON()).toEqual(before)
+        expect(updates).not.toHaveBeenCalled()
+      } finally {
+        local.destroy()
+        peer.destroy()
+        localDoc.destroy()
+        peerDoc.destroy()
+      }
+    }
+  )
+
   it.each(['Backspace', 'Enter'])(
     '%s preserves nested descendants without lifting their parent',
     (key) => {
@@ -627,19 +674,60 @@ describe('list item descendant preservation', () => {
         }
       })
       const before = editor.getJSON()
+      const selectionBefore = editor.state.selection.toJSON()
+      const historyBefore = undoDepth(editor.state)
       pressKey(editor, key)
 
-      expect(editor.state.selection.$from.parent.textContent).toBe('one')
+      expect(editor.state.selection.toJSON()).toEqual(selectionBefore)
       expect(editor.state.doc.textContent).toBe('onechildgrandchildthree')
       expect(editor.getHTML()).toContain('<strong>child</strong>')
       expect(editor.state.doc.child(0).type.name).toBe('bulletList')
       expect(editor.state.doc.child(0).childCount).toBe(3)
       expect(editor.state.doc.child(0).child(1).textContent).toBe('childgrandchild')
-      expect(editor.commands.undo()).toBe(true)
+      expect(undoDepth(editor.state)).toBe(historyBefore)
       expect(editor.getJSON()).toEqual(before)
       editor.destroy()
     }
   )
+
+  it.each([
+    ['bulletList', 'listItem'],
+    ['orderedList', 'listItem'],
+    ['taskList', 'taskItem'],
+  ])('keeps the caret in a required empty %s parent after repeated Backspace', (list, item) => {
+    const paragraph = (text: string) => ({
+      type: 'paragraph',
+      content: text ? [{ type: 'text', text }] : [],
+    })
+    const editor = editorWith('')
+    editor.commands.setContent({
+      type: 'doc',
+      content: [
+        paragraph('Before'),
+        {
+          type: list,
+          content: [
+            {
+              type: item,
+              content: [
+                paragraph(''),
+                { type: list, content: [{ type: item, content: [paragraph('Child')] }] },
+              ],
+            },
+            { type: item, content: [paragraph('After')] },
+          ],
+        },
+      ],
+    })
+    editor.commands.setTextSelection(11)
+    const before = editor.state.doc
+    const selectionBefore = editor.state.selection.toJSON()
+    pressBackspace(editor)
+    pressBackspace(editor)
+    expect(editor.state.doc.eq(before)).toBe(true)
+    expect(editor.state.selection.toJSON()).toEqual(selectionBefore)
+    editor.destroy()
+  })
 
   it.each(['Backspace', 'Enter'])(
     '%s removes a replaceable leading paragraph while retaining the whole list',

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/keymap.ts
@@ -3,6 +3,7 @@ import { Extension } from '@tiptap/core'
 import { GapCursor } from '@tiptap/pm/gapcursor'
 import type { ResolvedPos } from '@tiptap/pm/model'
 import { NodeSelection, Plugin, PluginKey, Selection } from '@tiptap/pm/state'
+import { replaceStep } from '@tiptap/pm/transform'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
 import {
   MENTION_PLUGIN_KEY,
@@ -99,7 +100,11 @@ function removeEmptyWrappedBlock(editor: Editor, $from: ResolvedPos): boolean {
   const end = $from.after(depth)
   return editor.commands.command(({ tr, dispatch }) => {
     if (dispatch) {
-      tr.delete(start, end)
+      const step = replaceStep(tr.doc, start, end)
+      const next = step?.apply(tr.doc).doc
+      /** A required leading paragraph can be replaced with itself; keep its caret and history. */
+      if (!step || !next || next.eq(tr.doc)) return true
+      tr.step(step)
       const $gap = tr.doc.resolve(start)
       tr.setSelection(
         Selection.findFrom($gap, -1, true) ??

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-item.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-item.test.ts
@@ -75,7 +75,7 @@ describe('Markdown list item schema', () => {
       expect(list.child(index).firstChild?.type.name).toBe('paragraph')
     }
     expect(list.child(1).textContent).toBe('')
-    expect(serializeMarkdownBody('- Before\n-\n- Following')).toBe('- Before\n- \n- Following\n\n')
+    expect(serializeMarkdownBody('- Before\n-\n- Following')).toBe('- Before\n-\n- Following\n\n')
   })
 
   it.each(BLOCK_FIRST_ITEMS)(

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-item.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/list-item.ts
@@ -16,6 +16,6 @@ export const MarkdownListItem = ListItem.extend({
   renderMarkdown: (node, helpers, context) => {
     const rendered = ListItem.config.renderMarkdown?.(node, helpers, context) ?? ''
     /** Marked misreads an opening empty `- ` line as prose when it has a trailing space. */
-    return rendered.replace(/^-[ \t]+\n/, '-\n')
+    return rendered.replace(/^-[ \t]+(?=\n|$)/, '-')
   },
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity.test.ts
@@ -1,64 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { Editor, type JSONContent } from '@tiptap/core'
 import { describe, expect, it } from 'vitest'
-import { postProcessSerializedMarkdown } from './markdown-fidelity'
+import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
+import { postProcessSerializedMarkdown } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import { parseMarkdownToDoc } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
 
-describe('postProcessSerializedMarkdown — empty list-item stripping', () => {
-  it('drops a nested empty bullet that would re-parse as a Setext heading', () => {
-    // `- one\n  - ` re-parses as `- ## one` (the `  - ` acts as a Setext underline). Stripping the
-    // empty bullet on serialize keeps the parent a bullet and makes the round-trip stable.
-    expect(postProcessSerializedMarkdown('- one\n  - \n\n')).toBe('- one\n')
+describe('Markdown serialization boundaries', () => {
+  it.each([
+    '<pre>[https://example.com](https://example.com)</pre>\n',
+    '<details>\n> \\[!NOTE\\]\nparent\n  - \n</details>\n',
+    '````\n```\n- \n```\n````\n',
+    '> \\[!NOTE\\]\n> quoted source\n',
+  ])('does not rewrite syntax in assembled output: %s', (source) => {
+    expect(postProcessSerializedMarkdown(source)).toBe(source)
   })
 
-  it('drops a nested empty ordered item', () => {
-    expect(postProcessSerializedMarkdown('1. one\n   2. \n')).toBe('1. one\n')
-  })
-
-  it('preserves a top-level empty bullet (placeholder / imported blank — round-trips faithfully)', () => {
-    // A top-level empty item is not Setext-hazardous and round-trips as an empty item, so it must be
-    // kept: it may be a placeholder row the user is about to fill, or an intentionally-blank imported item.
-    expect(postProcessSerializedMarkdown('- one\n- \n')).toBe('- one\n- \n')
-    expect(postProcessSerializedMarkdown('- one\n- \n- three\n')).toBe('- one\n- \n- three\n')
-    expect(postProcessSerializedMarkdown('1. one\n2. \n')).toBe('1. one\n2. \n')
-  })
-
-  it('keeps bullets that have content', () => {
-    expect(postProcessSerializedMarkdown('- a\n- b\n')).toBe('- a\n- b\n')
-    expect(postProcessSerializedMarkdown('- a\n  - b\n')).toBe('- a\n  - b\n')
-  })
-
-  it('keeps a nested empty parent whose next line is an indented child (no orphaning)', () => {
-    expect(postProcessSerializedMarkdown('- top\n  - \n    - child\n')).toBe(
-      '- top\n  - \n    - child\n'
+  it('normalizes only the final separator', () => {
+    expect(postProcessSerializedMarkdown('\nfirst\n\n\n\nsecond\n\n\n')).toBe(
+      '\nfirst\n\n\n\nsecond\n'
     )
   })
 
-  it('keeps a nested empty item that follows a same-indent sibling (real placeholder, no Setext hazard)', () => {
-    // `  - ` after `  - two` (same indent) is a real empty item the parser keeps — it does NOT underline
-    // a shallower parent's text, so it must not be stripped. (Only `  - ` directly under `- one` does.)
-    expect(postProcessSerializedMarkdown('- one\n  - two\n  - \n  - three\n')).toBe(
-      '- one\n  - two\n  - \n  - three\n'
-    )
-    // The hazard case — empty item directly under the shallower parent — is still stripped.
-    expect(postProcessSerializedMarkdown('- one\n  - \n  - three\n')).toBe('- one\n  - three\n')
-  })
-
-  it('keeps a thematic break and empty checklist items (not Setext-hazardous)', () => {
-    expect(postProcessSerializedMarkdown('text\n\n---\n\nmore\n')).toBe('text\n\n---\n\nmore\n')
-    expect(postProcessSerializedMarkdown('- [ ] a\n- [ ] \n')).toBe('- [ ] a\n- [ ] \n')
-  })
-
-  it('leaves marker-only lines inside a fenced code block untouched', () => {
-    const code = '```\n- \n-\n1. \n```\n'
-    expect(postProcessSerializedMarkdown(code)).toBe(code)
-  })
-
-  it('leaves marker-only lines inside a tilde (~~~) fence untouched', () => {
-    const code = '~~~\n- \n1. \n~~~\n'
-    expect(postProcessSerializedMarkdown(code)).toBe(code)
-  })
-
-  it('does not strip inside an unterminated fence (fence stays open to EOF)', () => {
-    // A fence with no closing delimiter must keep every interior line, including marker-only ones.
-    const code = '```\n- \n-\n'
-    expect(postProcessSerializedMarkdown(code)).toBe(code)
-  })
+  it.each(['bulletList', 'orderedList', 'taskList'])(
+    'preserves empty nested %s items and their siblings across reload',
+    (listType) => {
+      const itemType = listType === 'taskList' ? 'taskItem' : 'listItem'
+      const paragraph = (text = ''): JSONContent => ({
+        type: 'paragraph',
+        content: text ? [{ type: 'text', text }] : [],
+      })
+      const item = (content: JSONContent[]): JSONContent => ({ type: itemType, content })
+      const editor = new Editor({
+        extensions: createMarkdownContentExtensions(),
+        content: {
+          type: 'doc',
+          content: [
+            {
+              type: listType,
+              content: [
+                item([
+                  paragraph('Parent'),
+                  { type: listType, content: [item([paragraph()]), item([paragraph('Child')])] },
+                ]),
+              ],
+            },
+          ],
+        },
+      })
+      try {
+        editor.commands.setContent(editor.getJSON())
+        const before = editor.getJSON().content?.[0]
+        const saved = postProcessSerializedMarkdown(editor.getMarkdown())
+        editor.commands.setContent(parseMarkdownToDoc(saved))
+        expect(editor.getJSON().content?.[0]).toEqual(before)
+        expect(postProcessSerializedMarkdown(editor.getMarkdown())).toBe(saved)
+      } finally {
+        editor.destroy()
+      }
+    }
+  )
 })

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity.ts
@@ -7,34 +7,6 @@
 const BOM = '\uFEFF'
 const FRONTMATTER_REGEX = /^---\r?\n(?:[\s\S]*?\r?\n)?---[ \t]*(?=\r?\n|$)(?:\r?\n)*/
 const FRONTMATTER_KEY_REGEX = /^(?:[A-Za-z0-9_-]+|'(?:[^']|'')*'|"(?:[^"\\]|\\.)*")[ \t]*:/
-const ESCAPED_CALLOUT_REGEX = /^(\s*>(?:\s*>)*\s*)\\\[!([A-Za-z]+)\\\]/gm
-
-/**
- * Alternates a code region (fenced block or inline span \u2014 never rewritten) with an inline link whose
- * destination has no title and isn't angle-bracketed. The code branch is listed first so a link inside
- * code is consumed as code and left untouched. The destination stops at `)` / whitespace, so a link
- * carrying a title (`[x](url "t")`) never matches and is preserved verbatim.
- */
-const CODE_OR_PLAIN_LINK_REGEX =
-  /(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`)|\[([^\]]+)]\(([^)\s<>]+)\)/g
-const HTTP_URL_REGEX = /^https?:\/\/\S+$/i
-
-/**
- * Collapses an autolinked destination back to its bare form: our normalizing serializer rewrites a bare
- * URL or `<url>` autolink to `[url](url)` and a bare email to `[a@b.com](mailto:a@b.com)`, which churns
- * every README's links into explicit-link syntax on the first save. When the visible text already equals
- * the destination (a plain `http(s)` URL, or an email behind `mailto:`), GFM re-autolinks the bare form,
- * so emitting it round-trips identically with a far quieter diff. Links inside code and titled links are
- * left untouched (see {@link CODE_OR_PLAIN_LINK_REGEX}).
- */
-function collapseAutolinkedUrls(markdown: string): string {
-  return markdown.replace(CODE_OR_PLAIN_LINK_REGEX, (match, code, text, href) => {
-    if (code) return code
-    if (text === href && HTTP_URL_REGEX.test(href)) return href
-    if (href === `mailto:${text}`) return text
-    return match
-  })
-}
 
 export interface SplitMarkdown {
   /** Out-of-band leading prefix (a BOM and/or the frontmatter block), byte-exact, or `''`. */
@@ -112,84 +84,7 @@ export function normalizeLinkHref(href: string): string {
   return `https://${trimmed}`
 }
 
-/** A line that is a bullet/ordered list marker with no content (`-`, `  - `, `1. `). Task items (`- [ ]`) don't match. */
-const EMPTY_LIST_ITEM_LINE = /^([ \t]*)(?:[-*+]|\d+[.)])[ \t]*$/
-/** A fenced code-block delimiter (``` or ~~~), used to leave code interiors untouched. */
-const FENCE_DELIMITER = /^[ \t]*(`{3,}|~{3,})/
-/** Leading indentation of a line, used to detect whether an empty list item has indented children. */
-const LEADING_INDENT = /^[ \t]*/
-
-/**
- * Removes only the *nested* empty list-item marker lines that re-parse as a Setext heading underline:
- * a nested empty bullet (`  - `) sitting DIRECTLY under a shallower parent line silently turns that
- * parent's text into an `## heading` and drops the bullet on the next load (a data-corrupting
- * round-trip). The strip is therefore scoped by three conditions, all required:
- * - *indented* (`indent > 0`): a top-level empty bullet (`- ` / `1. `) round-trips faithfully as an
- *   empty item, never a heading, so a placeholder/blank imported row is preserved.
- * - the immediately-preceding line is *shallower* (the parent whose text the underline would consume):
- *   an empty item after a *same-indent sibling* (`  - two` then `  - `) does NOT corrupt — the parser
- *   keeps it as a real empty item — so it is preserved. A blank line above also breaks the hazard.
- * - no more-indented children on the next non-blank line, so its children are never orphaned.
- *
- * Operates only on the editor's own serialized output, which uses fenced (never 4-space-indented) code
- * blocks and `\n` newlines — so tracking fences is sufficient and a bare `-` inside an indented code
- * block or a `-\r` line is not a case that can occur here.
- */
-function stripEmptyListItemLines(markdown: string): string {
-  const lines = markdown.split('\n')
-  const kept: string[] = []
-  let fence: string | null = null
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
-    const delimiter = line.match(FENCE_DELIMITER)?.[1]
-    if (fence) {
-      kept.push(line)
-      if (delimiter && delimiter[0] === fence[0] && delimiter.length >= fence.length) fence = null
-      continue
-    }
-    if (delimiter) {
-      fence = delimiter
-      kept.push(line)
-      continue
-    }
-    const empty = line.match(EMPTY_LIST_ITEM_LINE)
-    if (empty) {
-      const indent = empty[1].length
-      let next = i + 1
-      while (next < lines.length && lines[next].trim() === '') next++
-      const hasChildren =
-        next < lines.length && (lines[next].match(LEADING_INDENT)?.[0].length ?? 0) > indent
-      // The Setext-underline hazard exists only when the empty item follows a SHALLOWER parent line
-      // (whose text the underline would consume). An empty item after a same/deeper-indent sibling
-      // (`  - two` then `  - `) is a real empty item the parser keeps — a nested placeholder between
-      // siblings must not be lost. Uses the preceding non-blank line's indent; a lone empty item with
-      // nothing above it (`prevIndent = -1`) has no parent text to corrupt but stays stripped as before.
-      let prevIdx = i - 1
-      while (prevIdx >= 0 && lines[prevIdx].trim() === '') prevIdx--
-      const prevIndent = prevIdx >= 0 ? (lines[prevIdx].match(LEADING_INDENT)?.[0].length ?? 0) : -1
-      if (indent > 0 && !hasChildren && prevIndent < indent) continue
-    }
-    kept.push(line)
-  }
-  return kept.join('\n')
-}
-
-/**
- * Cleans up serializer output: drops empty list-item marker lines that would otherwise corrupt on
- * round-trip ({@link stripEmptyListItemLines}), restores callout markers the serializer
- * backslash-escapes (`> \[!NOTE\]` → `> [!NOTE]`), and collapses trailing blank lines to a single
- * newline. Interior blank runs are NOT collapsed here — blank lines inside a fenced code block (or a
- * verbatim raw-markdown-snippet) are significant, and a global collapse would corrupt them. An interior
- * run between top-level blocks is significant too: it is how an empty paragraph is written, and
- * {@link parseMarkdownToDoc} reads exactly the count back out, so collapsing it here would delete the
- * document's spacing. Only the TRAILING run is collapsed — it can carry no paragraph (see
- * `clampEmptyParagraphs`) and would otherwise churn the file on every save. The table serializer's
- * spurious surrounding blank lines are trimmed at the source (PipeSafeTable), so no global
- * leading-newline strip is needed here — avoiding clobbering content that legitimately begins with
- * whitespace.
- */
+/** Normalize the document's final separator without rewriting literal content or interior spacing. */
 export function postProcessSerializedMarkdown(markdown: string): string {
-  return collapseAutolinkedUrls(
-    stripEmptyListItemLines(markdown).replace(ESCAPED_CALLOUT_REGEX, '$1[!$2]')
-  ).replace(/\n+$/, '\n')
+  return markdown.replace(/\n+$/, '\n')
 }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse.ts
@@ -1,4 +1,5 @@
 import { Editor, type JSONContent } from '@tiptap/core'
+import type { Token } from 'marked'
 import { createMarkdownContentExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/extensions'
 import {
   applyFrontmatter,
@@ -26,6 +27,29 @@ function markdownManager() {
   const manager = parserEditor().markdown
   if (!manager) throw new Error('Markdown extension is not installed on the parser editor')
   return manager
+}
+
+/** Count only resolved references, never label-like text inside opaque HTML, code or link titles. */
+export function hasUnusedMarkdownReference(content: string): boolean {
+  const marked = markdownManager().instance
+  const lexer = new marked.Lexer(marked.defaults)
+  const tokens = lexer.lex(splitFrontmatter(content).body)
+  const unused = new Set(Object.keys(tokens.links))
+  if (!unused.size) return false
+  const rules = marked.Lexer.rules.inline.gfm
+  const countReference = (token: Token) => {
+    if (token.type !== 'link' && token.type !== 'image') return
+    const match = rules.reflink.exec(token.raw) ?? rules.nolink.exec(token.raw)
+    if (match?.[0] !== token.raw) return
+    const label = (match[2] || match[1]).replace(/\s+/g, ' ').toLowerCase()
+    unused.delete(label)
+  }
+  marked.walkTokens(tokens, (token) => {
+    /** Ordered-list paragraphs are tokenized before later definitions; resolve them in full context. */
+    if (token.type === 'paragraph') marked.walkTokens(lexer.inlineTokens(token.raw), countReference)
+    else countReference(token)
+  })
+  return unused.size > 0
 }
 
 /**

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/ordered-list.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/ordered-list.ts
@@ -61,9 +61,12 @@ export function createJoiningOrderedList() {
           ),
         })),
       }
-      const parsed = parse?.(resolved, helpers) ?? []
+      const parsedList = parse?.(resolved, helpers) ?? []
+      if (Array.isArray(parsedList)) return parsedList
+      /** Use the registered item parser so empty items retain their schema-required paragraph. */
+      const parsed = { ...parsedList, content: helpers.parseChildren(resolved.items) }
       /** The stock parser's truthy default turns a valid zero start into one. */
-      if (groups[0]?.start === 0 && !Array.isArray(parsed) && 'type' in parsed) {
+      if (groups[0]?.start === 0) {
         return { ...parsed, attrs: { ...parsed.attrs, start: 0 } }
       }
       return parsed

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -47,8 +47,10 @@ import { findHeadingPos } from '@/app/workspace/[workspaceId]/files/components/f
 import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
 import {
   extractImageFiles,
-  needsImageFileFallback,
+  getImageFileFallback,
+  type ImageFileFallback,
   normalizePastedImageSources,
+  resolveImageFileFallback,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste'
 import {
   beginImageUploads,
@@ -593,10 +595,14 @@ export function LoadedRichMarkdownEditor({
    * Uploads are sequential; every position is anchored before awaiting so queued images also follow
    * edits. Capture the editor instance, never a later file's editor, for completion and teardown.
    */
-  const insertImagesRef = useRef<(images: File[], range: Range) => Promise<void>>(() =>
-    Promise.resolve()
-  )
-  const insertImages = async (images: File[], range: Range) => {
+  const insertImagesRef = useRef<
+    (images: File[], range: Range, fallback?: ImageFileFallback | null) => Promise<void>
+  >(() => Promise.resolve())
+  const insertImages = async (
+    images: File[],
+    range: Range,
+    fallback?: ImageFileFallback | null
+  ) => {
     const editor = editorInstanceRef.current
     if (!editor) return
     const anchors = beginImageUploads(
@@ -618,7 +624,13 @@ export function LoadedRichMarkdownEditor({
         .catch(() => null)
       toast.dismiss(uploadingToastId)
       if (result) {
-        const inserted = finishImageUpload(editor, anchor, result.file.url, image.name)
+        const inserted = finishImageUpload(
+          editor,
+          anchor,
+          result.file.url,
+          image.name,
+          fallback ? resolveImageFileFallback(fallback, result.file.url) : undefined
+        )
         if (!inserted && !editor.isDestroyed) {
           toast.info('The image was uploaded to the workspace but was not inserted.')
         }
@@ -733,24 +745,25 @@ export function LoadedRichMarkdownEditor({
         if (currentEditor && isPlainTextPaste(currentEditor)) return false
         const html = event.clipboardData?.getData('text/html') ?? ''
         const images = extractImageFiles(event.clipboardData)
-        if (html && slice.content.size > 0 && !needsImageFileFallback(slice, images)) return false
+        const fallback = getImageFileFallback(slice, images)
+        if (html && slice.content.size > 0 && !fallback) return false
         if (images.length === 0) return false
         event.preventDefault()
-        void insertImagesRef.current(images, view.state.selection)
+        void insertImagesRef.current(images, view.state.selection, fallback)
         return true
       },
       handleDrop: (view, event, slice, moved) => {
         if (!view.editable) return false
         const html = event.dataTransfer?.getData('text/html') ?? ''
         const images = extractImageFiles(event.dataTransfer)
-        const uploadFallback = needsImageFileFallback(slice, images)
+        const uploadFallback = getImageFileFallback(slice, images)
         if (!uploadFallback && moveDraggedImageNode(view, event, slice, moved)) return true
         if (html && slice.content.size > 0 && !uploadFallback) return false
         if (images.length > 0) {
           event.preventDefault()
           const dropPos = view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos
           const at = dropPos ?? view.state.selection.from
-          void insertImagesRef.current(images, { from: at, to: at })
+          void insertImagesRef.current(images, { from: at, to: at }, uploadFallback)
           return true
         }
         if (event.dataTransfer?.files.length) {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.tsx
@@ -25,7 +25,6 @@ import {
 } from '@/lib/copilot/chat/selection-context'
 import type { FileDownloadSource } from '@/lib/uploads/client/download'
 import type { WorkspaceFileRecord } from '@/lib/uploads/contexts/workspace'
-import { extractEmbeddedFileRef, extractImgSrcs } from '@/lib/uploads/utils/embedded-image-ref'
 import { FindBar } from '@/app/workspace/[workspaceId]/components'
 import { FileSaveConflict } from '@/app/workspace/[workspaceId]/files/components/file-viewer/file-save-conflict'
 import { PreviewLoadingFrame } from '@/app/workspace/[workspaceId]/files/components/file-viewer/preview-shared'
@@ -46,11 +45,10 @@ import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/fi
 import { useMarkdownFind } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/find'
 import { findHeadingPos } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/heading-anchors'
 import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
-import { imageTypeAt } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-node'
 import {
   extractImageFiles,
-  findHostedImageAttrs,
-  shouldSkipFileUpload,
+  needsImageFileFallback,
+  normalizePastedImageSources,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste'
 import {
   beginImageUploads,
@@ -631,35 +629,6 @@ export function LoadedRichMarkdownEditor({
   }
 
   /**
-   * A same-page copy/drag of an already-hosted `<img>` carries the clipboard/dataTransfer `html`'s
-   * *display* src (`source.resolveImageSrc`'s rewrite), not the real persisted one — inserting a node
-   * built straight from that html would bake the display-only URL into the document, breaking public
-   * share/export/referenced-by-doc tracking for it (they only recognize the persisted shape).
-   * `findHostedImageAttrs` finds the real, already-present node with a matching resolved src instead,
-   * so the clone gets the exact real `src` (and every other attribute — width, href, title…) rather
-   * than a re-derived guess. Returns `false` (falls through to a normal upload) if no match is found,
-   * which is always correct, just occasionally a redundant upload — unlike blindly trusting the html.
-   */
-  const cloneHostedImageRef = useRef<(imgSrcs: string[], range: Range) => boolean>(() => false)
-  const cloneHostedImage = (imgSrcs: string[], range: Range) => {
-    const editor = editorInstanceRef.current
-    if (!editor) return false
-    const matchedAttrs = findHostedImageAttrs(editor.state.doc, imgSrcs, source.resolveImageSrc)
-    if (!matchedAttrs) return false
-    try {
-      return editor
-        .chain()
-        .insertContentAt(range, {
-          type: imageTypeAt(editor.state.doc, range.from),
-          attrs: matchedAttrs,
-        })
-        .run()
-    } catch {
-      return false
-    }
-  }
-
-  /**
    * Extensions: the shared module set for the local path, or a per-instance set
    * carrying this document's Collaboration + CollaborationCaret. Built once (collab
    * is decided at mount), since `useEditor` fixes the extension set at creation.
@@ -756,67 +725,27 @@ export function LoadedRichMarkdownEditor({
         window.open(normalized, '_blank', 'noopener,noreferrer')
         return true
       },
-      /**
-       * Inserts pasted image files at the caret. A same-page copy of an already-hosted `<img>` (e.g.
-       * Cmd+C after clicking it to select it) makes the browser add BOTH `text/html` (the real node,
-       * with its real hosted `src`) AND a synthesized image `File` to the clipboard — indistinguishable
-       * from a genuine external image paste by `clipboardData` files/items alone. When the HTML sibling
-       * already names one of our own hosted files, look up the matching node already in this doc and
-       * clone ITS real attrs (see `cloneHostedImageRef`) instead of re-uploading the pasted bytes as a
-       * brand-new, distinct file — letting the editor's DEFAULT html-based paste do that clone instead
-       * would persist the html's display-layer src rather than the real one. Only applied when exactly
-       * one image file is offered: a genuinely mixed paste (the hosted image plus a separate new one)
-       * must still upload the new file rather than have the whole paste diverted by this bypass.
-       */
-      handlePaste: (view, event) => {
+      transformPasted: (slice, view) =>
+        normalizePastedImageSources(slice, view.state.doc, resolveImageSrcRef.current),
+      handlePaste: (view, event, slice) => {
         if (!view.editable) return false
         const currentEditor = editorInstanceRef.current
         if (currentEditor && isPlainTextPaste(currentEditor)) return false
-        const images = extractImageFiles(event.clipboardData)
         const html = event.clipboardData?.getData('text/html') ?? ''
-        if (shouldSkipFileUpload(images, html, (src) => extractEmbeddedFileRef(src) !== null)) {
-          const cloned = cloneHostedImageRef.current(extractImgSrcs(html), view.state.selection)
-          if (cloned) {
-            event.preventDefault()
-            return true
-          }
-        }
+        const images = extractImageFiles(event.clipboardData)
+        if (html && slice.content.size > 0 && !needsImageFileFallback(slice, images)) return false
         if (images.length === 0) return false
         event.preventDefault()
         void insertImagesRef.current(images, view.state.selection)
         return true
       },
-      /**
-       * Inserts dropped image files at the drop point. Any other file drop (e.g. a PDF) is swallowed so
-       * the browser doesn't navigate away from the editor; internal text drags carry no files and fall
-       * through to the default behavior.
-       *
-       * Drag-REORDER of an image node is the deceptive case, and {@link moveDraggedImageNode} owns it —
-       * uploading would duplicate the image (the original never moves), and falling through to
-       * ProseMirror is no better, since with `view.dragging` unset its default drop PARSES the html into
-       * a copy (persisting the display-layer src, which share/export tracking don't recognize) and never
-       * deletes the original.
-       *
-       * PM-serialized drags (a text selection spanning an image, dragged from a textblock) still reach
-       * the `shouldSkipFileUpload` bail below: PM set `view.dragging` for those itself, so its default
-       * move logic is correct there.
-       */
-      handleDrop: (view, event) => {
+      handleDrop: (view, event, slice, moved) => {
         if (!view.editable) return false
-        const images = extractImageFiles(event.dataTransfer)
         const html = event.dataTransfer?.getData('text/html') ?? ''
-        if (
-          moveDraggedImageNode(view, event, {
-            images,
-            html,
-            resolveSrc: resolveImageSrcRef.current,
-          })
-        ) {
-          return true
-        }
-        if (shouldSkipFileUpload(images, html, (src) => extractEmbeddedFileRef(src) !== null)) {
-          return false
-        }
+        const images = extractImageFiles(event.dataTransfer)
+        const uploadFallback = needsImageFileFallback(slice, images)
+        if (!uploadFallback && moveDraggedImageNode(view, event, slice, moved)) return true
+        if (html && slice.content.size > 0 && !uploadFallback) return false
         if (images.length > 0) {
           event.preventDefault()
           const dropPos = view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos
@@ -885,7 +814,6 @@ export function LoadedRichMarkdownEditor({
     routerRef.current = router
     resolveImageSrcRef.current = source.resolveImageSrc
     insertImagesRef.current = insertImages
-    cloneHostedImageRef.current = cloneHostedImage
     editorInstanceRef.current = editor
   })
 

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
@@ -3,32 +3,37 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { ChipTextarea, chipFieldSurfaceClass, cn, toast } from '@sim/emcn'
 import { formatPasteLimit, PASTE_LIMITS } from '@sim/utils/paste'
-import type { JSONContent } from '@tiptap/core'
+import type { JSONContent, Range } from '@tiptap/core'
 import { EditorContent, useEditor } from '@tiptap/react'
+import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/editor-extensions'
+import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
+import {
+  extractImageFiles,
+  needsImageFileFallback,
+  normalizePastedImageSources,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste'
 import {
   beginImageUploads,
   findImageUpload,
   finishImageUpload,
   removeImageUpload,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-upload'
-import { assessRawMarkdownPaste } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission'
-import { createMarkdownEditorExtensions } from './editor-extensions'
-import { moveDraggedImageNode } from './image-drag-move'
-import { extractImageFiles, isInlineRouteSrc, shouldSkipFileUpload } from './image-paste'
 import {
   applyFrontmatter,
   postProcessSerializedMarkdown,
   splitFrontmatter,
-} from './markdown-fidelity'
-import { parseMarkdownToDoc } from './markdown-parse'
-import { useEditorMentions } from './mention'
-import { EditorBubbleMenu } from './menus/bubble-menu'
-import { LinkHoverCard } from './menus/link-hover-card'
-import { normalizeMarkdownContent } from './normalize-content'
-import { isRoundTripSafe } from './round-trip-safety'
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
+import { parseMarkdownToDoc } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+import { isPlainTextPaste } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-paste'
+import { useEditorMentions } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/mention'
+import { EditorBubbleMenu } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/bubble-menu'
+import { LinkHoverCard } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/menus/link-hover-card'
+import { normalizeMarkdownContent } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/normalize-content'
+import { assessRawMarkdownPaste } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/paste-admission'
+import { isRoundTripSafe } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety'
 import '@sim/emcn/components/code/code.css'
-import '../document-table.css'
-import './rich-markdown-editor.css'
+import '@/app/workspace/[workspaceId]/files/components/file-viewer/document-table.css'
+import '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-editor.css'
 
 /**
  * Sends the formatting toolbar back to its body portal instead of anchoring it inside the editor's
@@ -176,14 +181,14 @@ function LoadedRichMarkdownField({
    * Reuse the file editor's mapped anchors without adding upload chrome to embedded fields.
    * A streamed replacement invalidates the batch even if editing resumes before upload completes.
    */
-  async function insertImages(images: File[], at: number) {
+  async function insertImages(images: File[], range: Range) {
     const upload = uploadImageRef.current
     const owner = editorInstanceRef.current
     if (!upload || !owner || owner.isDestroyed || !owner.isEditable) return
     const generation = uploadGenerationRef.current
     const anchors = beginImageUploads(
       owner,
-      { from: at, to: at },
+      range,
       images.map(() => '')
     )
     const canInsert = () =>
@@ -257,14 +262,19 @@ function LoadedRichMarkdownField({
         'data-paste-max-html-bytes': String(PASTE_LIMITS.RICH_MARKDOWN_BYTES),
         'data-paste-handles-images': uploadImage ? 'true' : 'false',
       },
-      handlePaste: (view, event) => {
+      transformPasted: (slice, view) => normalizePastedImageSources(slice, view.state.doc),
+      handlePaste: (view, event, slice) => {
+        if (!view.editable) return false
+        const currentEditor = editorInstanceRef.current
+        if (currentEditor && isPlainTextPaste(currentEditor)) return false
         const images = uploadImageRef.current ? extractImageFiles(event.clipboardData) : []
-        /* Copying an image already in the document puts its file on the clipboard too. Let the
-           html through instead of uploading a second copy of something already hosted. */
         const clipboardHtml = event.clipboardData?.getData('text/html') ?? ''
-        if (images.length > 0 && !shouldSkipFileUpload(images, clipboardHtml, isInlineRouteSrc)) {
+        if (
+          images.length > 0 &&
+          (!clipboardHtml || !slice.content.size || needsImageFileFallback(slice, images))
+        ) {
           event.preventDefault()
-          void insertImages(images, view.state.selection.from)
+          void insertImages(images, view.state.selection)
           return true
         }
         const handler = onPasteTextRef.current
@@ -273,23 +283,19 @@ function LoadedRichMarkdownField({
         if (!text) return false
         return handler(text)
       },
-      /**
-       * Mirrors the file editor's order: reposition an image dragged from inside the document, then
-       * bail on a same-page copy of an already-hosted one so ProseMirror inserts it from the html
-       * instead of uploading a duplicate, then upload anything genuinely new. Any remaining file drop
-       * is swallowed so the browser doesn't navigate to it and tear down the host; internal text drags
-       * carry no files and fall through.
-       */
-      handleDrop: (view, event) => {
+      handleDrop: (view, event, slice, moved) => {
+        if (!view.editable) return false
         const html = event.dataTransfer?.getData('text/html') ?? ''
         const images = uploadImageRef.current ? extractImageFiles(event.dataTransfer) : []
-        if (moveDraggedImageNode(view, event, { images, html })) return true
-        if (shouldSkipFileUpload(images, html, isInlineRouteSrc)) return false
+        const uploadFallback = needsImageFileFallback(slice, images)
+        if (!uploadFallback && moveDraggedImageNode(view, event, slice, moved)) return true
+        if (html && slice.content.size > 0 && !uploadFallback) return false
         if (event.dataTransfer?.files.length) {
           event.preventDefault()
           if (images.length > 0) {
             const dropPos = view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos
-            void insertImages(images, dropPos ?? view.state.selection.from)
+            const at = dropPos ?? view.state.selection.from
+            void insertImages(images, { from: at, to: at })
           }
           return true
         }
@@ -427,7 +433,7 @@ function LoadedRichMarkdownField({
               pendingImagePosRef.current ?? editorInstanceRef.current?.state.selection.from ?? 0
             pendingImagePosRef.current = null
             input.value = ''
-            if (images.length > 0) void insertImages(images, at)
+            if (images.length > 0) void insertImages(images, { from: at, to: at })
           }}
         />
       )}

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/rich-markdown-field.tsx
@@ -9,8 +9,10 @@ import { createMarkdownEditorExtensions } from '@/app/workspace/[workspaceId]/fi
 import { moveDraggedImageNode } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-drag-move'
 import {
   extractImageFiles,
-  needsImageFileFallback,
+  getImageFileFallback,
+  type ImageFileFallback,
   normalizePastedImageSources,
+  resolveImageFileFallback,
 } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/image-paste'
 import {
   beginImageUploads,
@@ -181,7 +183,7 @@ function LoadedRichMarkdownField({
    * Reuse the file editor's mapped anchors without adding upload chrome to embedded fields.
    * A streamed replacement invalidates the batch even if editing resumes before upload completes.
    */
-  async function insertImages(images: File[], range: Range) {
+  async function insertImages(images: File[], range: Range, fallback?: ImageFileFallback | null) {
     const upload = uploadImageRef.current
     const owner = editorInstanceRef.current
     if (!upload || !owner || owner.isDestroyed || !owner.isEditable) return
@@ -203,7 +205,14 @@ function LoadedRichMarkdownField({
         if (!anchor || findImageUpload(owner, anchor) === null) continue
         const result = await upload(image).catch(() => null)
         if (!canInsert()) break
-        if (result) finishImageUpload(owner, anchor, result.url, result.alt)
+        if (result)
+          finishImageUpload(
+            owner,
+            anchor,
+            result.url,
+            result.alt,
+            fallback ? resolveImageFileFallback(fallback, result.url) : undefined
+          )
         else removeImageUpload(owner, anchor)
       }
     } finally {
@@ -269,12 +278,10 @@ function LoadedRichMarkdownField({
         if (currentEditor && isPlainTextPaste(currentEditor)) return false
         const images = uploadImageRef.current ? extractImageFiles(event.clipboardData) : []
         const clipboardHtml = event.clipboardData?.getData('text/html') ?? ''
-        if (
-          images.length > 0 &&
-          (!clipboardHtml || !slice.content.size || needsImageFileFallback(slice, images))
-        ) {
+        const fallback = getImageFileFallback(slice, images)
+        if (images.length > 0 && (!clipboardHtml || !slice.content.size || fallback)) {
           event.preventDefault()
-          void insertImages(images, view.state.selection)
+          void insertImages(images, view.state.selection, fallback)
           return true
         }
         const handler = onPasteTextRef.current
@@ -287,7 +294,7 @@ function LoadedRichMarkdownField({
         if (!view.editable) return false
         const html = event.dataTransfer?.getData('text/html') ?? ''
         const images = uploadImageRef.current ? extractImageFiles(event.dataTransfer) : []
-        const uploadFallback = needsImageFileFallback(slice, images)
+        const uploadFallback = getImageFileFallback(slice, images)
         if (!uploadFallback && moveDraggedImageNode(view, event, slice, moved)) return true
         if (html && slice.content.size > 0 && !uploadFallback) return false
         if (event.dataTransfer?.files.length) {
@@ -295,7 +302,7 @@ function LoadedRichMarkdownField({
           if (images.length > 0) {
             const dropPos = view.posAtCoords({ left: event.clientX, top: event.clientY })?.pos
             const at = dropPos ?? view.state.selection.from
-            void insertImages(images, { from: at, to: at })
+            void insertImages(images, { from: at, to: at }, uploadFallback)
           }
           return true
         }

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety.test.ts
@@ -13,6 +13,41 @@ import { isRoundTripSafe } from '@/app/workspace/[workspaceId]/files/components/
 
 describe('isRoundTripSafe', () => {
   it.each([
+    '<pre>[https://example.com](https://example.com)</pre>',
+    '<!-- [https://example.com](https://example.com) -->',
+    '<span>[https://example.com](https://example.com)</span>',
+    '<details>\n> \\[!NOTE\\]\nparent\n  - \n</details>',
+    '````\n```\n[https://example.com](https://example.com)\n```\n````',
+  ])('preserves literal content on its first serialization: %s', (source) => {
+    const once = serializeMarkdownDocument(source)
+    expect(once.trimEnd()).toBe(source)
+    expect(serializeMarkdownDocument(once)).toBe(once)
+    expect(isRoundTripSafe(source)).toBe(true)
+  })
+
+  it.each([
+    'See [label](/path "[unused]").',
+    '`[unused]`',
+    '<span>[unused]</span>',
+    '<!-- [unused] -->',
+    '    [unused]',
+    '\\[unused]',
+  ])('does not count literal reference labels as definition usage: %s', (body) => {
+    expect(isRoundTripSafe(`${body}\n\n[unused]: https://example.com`)).toBe(false)
+  })
+
+  it.each(['[label][used]', '[used][]', '[USED]', '![image][used]', '> [label][used]'])(
+    'recognizes parsed reference usage: %s',
+    (body) => {
+      expect(isRoundTripSafe(`${body}\n\n[used]: https://example.com`)).toBe(true)
+    }
+  )
+
+  it('does not confuse different reference labels sharing one destination', () => {
+    expect(isRoundTripSafe('[used]\n\n[used]: /image\n[unused]: /image')).toBe(false)
+  })
+
+  it.each([
     { field: 'alt', linked: false },
     { field: 'title', linked: false },
     { field: 'alt', linked: true },
@@ -223,7 +258,8 @@ describe('isRoundTripSafe', () => {
     expect(isRoundTripSafe('A [shortcut] ref.\n\n[shortcut]: https://example.com')).toBe(true)
     expect(isRoundTripSafe('Case [Foo] insensitive.\n\n[foo]: https://example.com')).toBe(true)
     expect(isRoundTripSafe('A note.\n\n[^x]: the footnote body')).toBe(true)
-    expect(isRoundTripSafe('See [ foo ] here.\n\n[foo]: https://example.com')).toBe(true)
+    /** The installed lexer does not resolve the padded shortcut; its definition would be dropped. */
+    expect(isRoundTripSafe('See [ foo ] here.\n\n[foo]: https://example.com')).toBe(false)
   })
 
   it('does not flag HTML/comments/entities inside tilde or nested code fences', () => {

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip-safety.ts
@@ -3,7 +3,10 @@ import { decodeHtmlEntities } from '@tiptap/core'
 import { Lexer, Marked, type Token, Tokenizer } from 'marked'
 import { extractImgSrcs } from '@/lib/uploads/utils/embedded-image-ref'
 import { splitFrontmatter } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-fidelity'
-import { serializeMarkdownDocument } from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
+import {
+  hasUnusedMarkdownReference,
+  serializeMarkdownDocument,
+} from '@/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/markdown-parse'
 
 /**
  * Constructs the editor drops or mangles in a way that survives a second serialization
@@ -144,45 +147,6 @@ function inspectMarkdownFidelity(content: string) {
 }
 
 /**
- * A link/image reference definition line: `[label]: destination "optional title"` (up to 3 leading
- * spaces). The `(?!\^)` excludes GFM footnote definitions (`[^id]: …`) — those are preserved verbatim
- * by the footnote node and round-trip regardless of whether their reference is present, so they must
- * not be treated as droppable orphan definitions.
- */
-const REFERENCE_DEFINITION = /^ {0,3}\[(?!\^)([^\]]+)]:[ \t]+\S[^\n]*$/gm
-
-/** CommonMark reference labels match case-insensitively with internal whitespace collapsed. */
-function normalizeReferenceLabel(label: string): string {
-  return label.trim().replace(/\s+/g, ' ').toLowerCase()
-}
-
-/**
- * True when `content` defines a link/image reference that nothing uses. A *used* reference inlines
- * losslessly on serialize (`[x][id]` + `[id]: url` → `[x](url)`), but an *unused* definition is dropped
- * entirely — a silent deletion the idempotency probe can't see (the drop happens on the first pass,
- * which is then stable). We open such a file read-only rather than lose the definition on first edit.
- * Conservative: a label counts as used if it appears bracketed anywhere in the body, so the rare
- * inline-text collision errs toward editable, never toward a false read-only.
- */
-function hasOrphanReferenceDefinition(content: string): boolean {
-  const labels = new Set<string>()
-  for (const match of content.matchAll(REFERENCE_DEFINITION)) {
-    labels.add(normalizeReferenceLabel(match[1]))
-  }
-  if (labels.size === 0) return false
-  const body = content
-    .replace(REFERENCE_DEFINITION, '')
-    .replace(/\s+/g, ' ')
-    .replace(/\[\s+/g, '[')
-    .replace(/\s+\]/g, ']')
-    .toLowerCase()
-  for (const label of labels) {
-    if (!body.includes(`[${label}]`)) return true
-  }
-  return false
-}
-
-/**
  * Whether `content` fits the rich editor's rendering budget and survives its Markdown round-trip
  * without known data loss or autosave churn. A refusal keeps rich preview read-only and offers
  * source editing; the character cap is a performance boundary, separate from fidelity checks.
@@ -198,8 +162,8 @@ export function isRoundTripSafe(content: string): boolean {
   const stripped = stripCode(content)
   if (STABLE_LOSS_PATTERNS.some((pattern) => pattern.test(stripped.replaceAll('&quot;', ''))))
     return false
-  if (hasOrphanReferenceDefinition(stripped)) return false
   try {
+    if (hasUnusedMarkdownReference(content)) return false
     const source = inspectMarkdownFidelity(content)
     if (source.hasTaskReference || source.hasUnsupportedImageContext || source.hasUnsafeQuotes)
       return false

--- a/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip.test.ts
+++ b/apps/sim/app/workspace/[workspaceId]/files/components/file-viewer/rich-markdown-editor/round-trip.test.ts
@@ -97,13 +97,11 @@ describe('markdown-fidelity utils', () => {
   })
 
   it('restores escaped callout markers', () => {
-    expect(postProcessSerializedMarkdown('> \\[!NOTE\\]\n> hi')).toBe('> [!NOTE]\n> hi')
+    expect(roundTrip('> [!NOTE]\n> hi').trim()).toBe('> [!NOTE]\n> hi')
   })
 
   it('restores escaped callout markers in nested blockquotes', () => {
-    expect(postProcessSerializedMarkdown('> > \\[!WARNING\\]\n> > hi')).toBe(
-      '> > [!WARNING]\n> > hi'
-    )
+    expect(roundTrip('> > [!WARNING]\n> > hi').trim()).toBe('> > [!WARNING]\n> > hi')
   })
 
   it('normalizes link hrefs', () => {
@@ -611,19 +609,23 @@ describe('highlight ==mark==', () => {
 })
 
 describe('autolink / bare-URL preservation', () => {
-  it('keeps a bare URL bare instead of rewriting it to [url](url)', () => {
-    expect(roundTrip('visit https://sim.ai today').trim()).toBe('visit https://sim.ai today')
+  it('uses the native link serializer without changing link text or destinations', () => {
+    expect(roundTrip('visit https://sim.ai today').trim()).toBe(
+      'visit [https://sim.ai](https://sim.ai) today'
+    )
     expect(roundTrip('both https://a.com and https://b.com').trim()).toBe(
-      'both https://a.com and https://b.com'
+      'both [https://a.com](https://a.com) and [https://b.com](https://b.com)'
     )
   })
 
-  it('collapses an angle autolink and a bare email to their bare form', () => {
-    expect(roundTrip('see <https://sim.ai> here').trim()).toBe('see https://sim.ai here')
-    expect(roundTrip('mail <a@b.com> now').trim()).toBe('mail a@b.com now')
+  it('preserves autolink and email destinations using explicit Markdown links', () => {
+    expect(roundTrip('see <https://sim.ai> here').trim()).toBe(
+      'see [https://sim.ai](https://sim.ai) here'
+    )
+    expect(roundTrip('mail <a@b.com> now').trim()).toBe('mail [a@b.com](mailto:a@b.com) now')
   })
 
-  it('preserves explicit and titled links (only bare autolinks collapse)', () => {
+  it('preserves explicit and titled links', () => {
     expect(roundTrip('[Sim](https://sim.ai)').trim()).toBe('[Sim](https://sim.ai)')
     expect(roundTrip('[https://a.com](https://b.com)').trim()).toBe(
       '[https://a.com](https://b.com)'


### PR DESCRIPTION
## Summary
- Preserve the caret and undo history when an empty parent list paragraph cannot be removed.
- Use ProseMirror's drag ownership and complete clipboard fragments, preserving image links, dimensions, and accompanying content. Upload non-portable bitmap references without dropping their surrounding HTML, and replace the selected range correctly in embedded fields.
- Preserve literal Markdown/HTML and empty list items with node-local serialization. Detect unused reference definitions without confusing code or HTML with reference use.

## Type of Change
- [x] Bug fix

## Testing
- 1,686 file-editor tests passed across 84 files, including real Yjs, native ProseMirror event-pipeline, async upload, and paste-admission regressions. Another 158 realtime file-document tests passed.
- Tested local two-client editing, clipboard content, image dragging, reconnect, and reload persistence.
- Repository type checks, lint, all 46 CI audits, artifact generation, block-registry, and docs-manifest checks passed.
- Concurrent collaborative list restructuring is unchanged and remains a separate investigation.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
