### PR TITLE
feat(helm): derive chart appVersion from the release, and lint with ct

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -39,12 +39,18 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          # ct diffs the chart against the PR base to decide whether the version
+          # was bumped, so a shallow clone would leave it nothing to compare.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.16.4
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -64,8 +70,33 @@ jobs:
       - name: Image inventory is current
         run: bun run images:check
 
-      - name: Helm lint
-        run: helm lint helm/sim --values helm/sim/ci/default-values.yaml
+      # ct is the CNCF chart linter (ingress-nginx, prometheus-community and
+      # external-secrets all gate on it). Beyond `helm lint` it runs yamllint over
+      # Chart.yaml and every values file, validates Chart.yaml against a schema,
+      # and — the reason the hand-rolled version-bump job is gone — enforces that
+      # the chart version increases whenever chart content changes.
+      #
+      # `--chart-dirs helm --target-branch` is load-bearing. Passing `--charts`
+      # instead silently DISABLES the version-increment check ("Version increment
+      # checking disabled.") and still exits 0, which would leave a gate that
+      # never fails. On a push there is no base to diff, so `--charts` is correct
+      # there and the version check simply does not apply.
+      #
+      # Maintainer validation is off because it resolves `maintainers[].name`
+      # against real forge accounts, and ours is the display name "Sim Team".
+      # Turning it on means changing what Artifact Hub shows.
+      - name: Chart lint (ct)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          args=(--validate-maintainers=false)
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            args+=(--chart-dirs helm --target-branch "${BASE_REF}")
+          else
+            args+=(--charts helm/sim)
+          fi
+          ct lint "${args[@]}"
 
       - name: Helm unit tests
         run: |
@@ -122,39 +153,6 @@ jobs:
               --set externalDatabase.password=ci-dummy-password > /dev/null
           done
 
-  version-bump:
-    name: Chart version bumped
-    if: github.event_name == 'pull_request'
-    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          fetch-depth: 0
-          # The version gate only reads history and fetches a public branch, so
-          # it never needs the token left behind in .git/config.
-          persist-credentials: false
-      - name: Require a Chart.yaml version bump when chart content changes
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-          base="origin/${BASE_REF}"
-          git fetch origin "${BASE_REF}"
-          merge_base=$(git merge-base "$base" HEAD)
-          changed=$(git diff --name-only "$merge_base" HEAD)
-          if echo "$changed" | grep -q '^helm/sim/'; then
-            base_version=$(git show "$merge_base:helm/sim/Chart.yaml" | awk '/^version:/ {print $2}')
-            head_version=$(awk '/^version:/ {print $2}' helm/sim/Chart.yaml)
-            echo "base=$base_version head=$head_version"
-            if [ "$base_version" = "$head_version" ]; then
-              echo "::error::helm/sim/** changed but Chart.yaml version did not (still $head_version). Bump it per SemVer."
-              exit 1
-            fi
-          else
-            echo "No chart changes; skipping."
-          fi
-
   install:
     name: Install on kind and run helm test
     needs: chart
@@ -180,7 +178,7 @@ jobs:
           helm install sim helm/sim \
             --namespace sim --create-namespace \
             --values helm/sim/ci/default-values.yaml \
-            --values helm/sim/ci/kind-values.yaml \
+            --values helm/sim/ci/kind-overlay.yaml \
             --wait --timeout 15m
 
       - name: Diagnostics on failure
@@ -259,7 +257,7 @@ jobs:
       # (detect-version in ci.yml), so appVersion legitimately names a release
       # that does not exist yet while that release is still being built. Failing
       # on any mismatch would race that workflow and block the very publish the
-      # bump was for. `helm/sim/ci/kind-values.yaml` documents the same
+      # bump was for. `helm/sim/ci/kind-overlay.yaml` documents the same
       # circularity, and it is why appVersion went unbumped for so long.
       #
       # Compares against the latest GitHub release rather than a hardcoded value

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -193,6 +193,49 @@ jobs:
       - name: Run helm test
         run: helm test sim --namespace sim --timeout 5m
 
+  # Resolved once and shared, so the two publish paths cannot package the same
+  # immutable chart version with different appVersions -- they run in parallel,
+  # and a release becoming public between two independent API calls would be
+  # enough to make the OCI artifact and the HTTP repo install different Sims.
+  release-version:
+    name: Resolve the app release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'simstudioai/sim'
+    runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    permissions:
+      contents: read # Read the release list.
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      # On a release merge the tag does not exist yet -- this commit is what cuts
+      # it -- so the subject is the only source available, and the latest release
+      # is the source of truth for every other push.
+      #
+      # The subject pattern MUST stay identical to detect-version in ci.yml, which
+      # is what actually creates the tag and builds the images. If this one
+      # matched a subject that one rejects, the chart would publish naming a
+      # release that was never cut.
+      - name: Resolve the app release
+        id: resolve
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          subject=${HEAD_COMMIT_MESSAGE%%$'\n'*}
+          if [[ "$subject" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+): ]]; then
+            resolved="${BASH_REMATCH[1]}"
+            echo "Release commit; shipping the chart with ${resolved}."
+          else
+            resolved=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
+            echo "Not a release commit; shipping the chart with the latest release ${resolved}."
+          fi
+          if [ -z "$resolved" ]; then
+            echo "::error::Could not resolve an app release to ship this chart with."
+            exit 1
+          fi
+          echo "version=${resolved}" >> "$GITHUB_OUTPUT"
+
   # Publishes the chart to GHCR as an OCI artifact. Self-hosters cannot admit a
   # chart pulled from a git checkout — they need an immutable, versioned artifact
   # they can pin by digest and mirror into an internal registry — so shipping the
@@ -204,7 +247,7 @@ jobs:
   # A separate workflow would race those instead of waiting for them.
   publish:
     name: Publish chart to GHCR
-    needs: [chart, install]
+    needs: [chart, install, release-version]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'simstudioai/sim'
     runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 15
@@ -237,37 +280,12 @@ jobs:
         with:
           bun-version: 1.4.1
 
-      # The release this chart ships with. On a release merge the tag does not
-      # exist yet -- it is cut by this very commit (detect-version in ci.yml) --
-      # so the subject is the only source available, and the source of truth for
-      # every other push is the latest release.
-      - name: Resolve the app release
-        id: release
-        env:
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          subject=${HEAD_COMMIT_MESSAGE%%$'\n'*}
-          if [[ "$subject" =~ ^[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+): ]]; then
-            resolved="${BASH_REMATCH[1]}"
-            echo "Release commit; shipping the chart with ${resolved}."
-          else
-            resolved=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
-            echo "Not a release commit; shipping the chart with the latest release ${resolved}."
-          fi
-          if [ -z "$resolved" ]; then
-            echo "::error::Could not resolve an app release to ship this chart with."
-            exit 1
-          fi
-          echo "version=${resolved}" >> "$GITHUB_OUTPUT"
-
       # Derives appVersion rather than checking it, so the published chart cannot
       # be pinned to an older Sim than the release it ships with. The committed
       # value is kept current too, but nothing depends on a human remembering.
       - name: Sync chart appVersion to the release
         env:
-          APP_VERSION: ${{ steps.release.outputs.version }}
+          APP_VERSION: ${{ needs.release-version.outputs.version }}
         run: bun run scripts/sync-chart-appversion.ts --version "${APP_VERSION}"
 
       - name: Package chart
@@ -422,7 +440,7 @@ jobs:
   # the job holding the signing identity.
   publish-http:
     name: Publish chart to the Helm repo
-    needs: [chart, install]
+    needs: [chart, install, release-version]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'simstudioai/sim'
     runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-2vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 15
@@ -457,39 +475,13 @@ jobs:
         with:
           bun-version: 1.4.1
 
-      # The release this chart ships with. On a release merge the tag does not
-      # exist yet -- it is cut by this very commit (detect-version in ci.yml) --
-      # so the subject is the only source available, and the source of truth for
-      # every other push is the latest release.
-      - name: Resolve the app release
-        if: steps.pages.outputs.exists == 'true'
-        id: release
-        env:
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          subject=${HEAD_COMMIT_MESSAGE%%$'\n'*}
-          if [[ "$subject" =~ ^[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+): ]]; then
-            resolved="${BASH_REMATCH[1]}"
-            echo "Release commit; shipping the chart with ${resolved}."
-          else
-            resolved=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
-            echo "Not a release commit; shipping the chart with the latest release ${resolved}."
-          fi
-          if [ -z "$resolved" ]; then
-            echo "::error::Could not resolve an app release to ship this chart with."
-            exit 1
-          fi
-          echo "version=${resolved}" >> "$GITHUB_OUTPUT"
-
       # Derives appVersion rather than checking it, so the published chart cannot
       # be pinned to an older Sim than the release it ships with. The committed
       # value is kept current too, but nothing depends on a human remembering.
       - name: Sync chart appVersion to the release
         if: steps.pages.outputs.exists == 'true'
         env:
-          APP_VERSION: ${{ steps.release.outputs.version }}
+          APP_VERSION: ${{ needs.release-version.outputs.version }}
         run: bun run scripts/sync-chart-appversion.ts --version "${APP_VERSION}"
 
       - name: Configure Git

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -232,6 +232,44 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.4.1
+
+      # The release this chart ships with. On a release merge the tag does not
+      # exist yet -- it is cut by this very commit (detect-version in ci.yml) --
+      # so the subject is the only source available, and the source of truth for
+      # every other push is the latest release.
+      - name: Resolve the app release
+        id: release
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          subject=${HEAD_COMMIT_MESSAGE%%$'\n'*}
+          if [[ "$subject" =~ ^[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+): ]]; then
+            resolved="${BASH_REMATCH[1]}"
+            echo "Release commit; shipping the chart with ${resolved}."
+          else
+            resolved=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
+            echo "Not a release commit; shipping the chart with the latest release ${resolved}."
+          fi
+          if [ -z "$resolved" ]; then
+            echo "::error::Could not resolve an app release to ship this chart with."
+            exit 1
+          fi
+          echo "version=${resolved}" >> "$GITHUB_OUTPUT"
+
+      # Derives appVersion rather than checking it, so the published chart cannot
+      # be pinned to an older Sim than the release it ships with. The committed
+      # value is kept current too, but nothing depends on a human remembering.
+      - name: Sync chart appVersion to the release
+        env:
+          APP_VERSION: ${{ steps.release.outputs.version }}
+        run: bun run scripts/sync-chart-appversion.ts --version "${APP_VERSION}"
+
       - name: Package chart
         id: package
         run: |
@@ -246,44 +284,6 @@ jobs:
             echo "path=dist/${name}-${version}.tgz"
             echo "repository=ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts/${name}"
           } >> "$GITHUB_OUTPUT"
-
-      # `appVersion` is what the image tags default to, so a stale one publishes
-      # a chart that silently installs an old Sim -- and because published chart
-      # versions are immutable, every stale value is frozen forever. It sat six
-      # releases behind before this check existed, bumped only by hand.
-      #
-      # BEHIND is the failure. AHEAD is normal and must not be blocked: a
-      # version tag is cut by the main-branch merge commit that releases it
-      # (detect-version in ci.yml), so appVersion legitimately names a release
-      # that does not exist yet while that release is still being built. Failing
-      # on any mismatch would race that workflow and block the very publish the
-      # bump was for. `helm/sim/ci/kind-overlay.yaml` documents the same
-      # circularity, and it is why appVersion went unbumped for so long.
-      #
-      # Compares against the latest GitHub release rather than a hardcoded value
-      # so the check cannot go stale itself. Prereleases and drafts are excluded:
-      # the `/releases/latest` endpoint already returns neither.
-      - name: appVersion does not lag the app release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          app_version=$(helm show chart helm/sim | awk '/^appVersion:/ {print $2}' | tr -d '"')
-          latest=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
-          if [ -z "$latest" ]; then
-            echo "::error::Could not resolve the latest release; refusing to publish unverified."
-            exit 1
-          fi
-          if [ "$app_version" = "$latest" ]; then
-            echo "appVersion ${app_version} matches the latest release."
-            exit 0
-          fi
-          oldest=$(printf '%s\n%s\n' "$app_version" "$latest" | sort -V | head -1)
-          if [ "$oldest" = "$app_version" ]; then
-            echo "::error::Chart.yaml appVersion is ${app_version} but the latest release is ${latest}. Bump appVersion (and the chart version) so the chart does not publish an install pinned to an older Sim."
-            exit 1
-          fi
-          echo "::notice::appVersion ${app_version} is ahead of the latest release ${latest}, which is expected while that release is still being cut."
 
       # Chart versions are immutable once published: whoever pinned a version
       # must keep resolving the same bytes forever. The PR gate above already
@@ -451,6 +451,46 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "::warning::No gh-pages branch, so the HTTP chart repo was not updated. Create it and point GitHub Pages at it to activate this job. The OCI publish is unaffected."
           fi
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.4.1
+
+      # The release this chart ships with. On a release merge the tag does not
+      # exist yet -- it is cut by this very commit (detect-version in ci.yml) --
+      # so the subject is the only source available, and the source of truth for
+      # every other push is the latest release.
+      - name: Resolve the app release
+        if: steps.pages.outputs.exists == 'true'
+        id: release
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          subject=${HEAD_COMMIT_MESSAGE%%$'\n'*}
+          if [[ "$subject" =~ ^[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+): ]]; then
+            resolved="${BASH_REMATCH[1]}"
+            echo "Release commit; shipping the chart with ${resolved}."
+          else
+            resolved=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
+            echo "Not a release commit; shipping the chart with the latest release ${resolved}."
+          fi
+          if [ -z "$resolved" ]; then
+            echo "::error::Could not resolve an app release to ship this chart with."
+            exit 1
+          fi
+          echo "version=${resolved}" >> "$GITHUB_OUTPUT"
+
+      # Derives appVersion rather than checking it, so the published chart cannot
+      # be pinned to an older Sim than the release it ships with. The committed
+      # value is kept current too, but nothing depends on a human remembering.
+      - name: Sync chart appVersion to the release
+        if: steps.pages.outputs.exists == 'true'
+        env:
+          APP_VERSION: ${{ steps.release.outputs.version }}
+        run: bun run scripts/sync-chart-appversion.ts --version "${APP_VERSION}"
 
       - name: Configure Git
         if: steps.pages.outputs.exists == 'true'

--- a/helm/sim/Chart.yaml
+++ b/helm/sim/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sim
 description: A Helm chart for Sim - the open-source AI workspace where teams build, deploy, and manage AI agents
 type: application
-version: 1.11.1
-appVersion: "v0.8.24"
+version: 1.11.2
+appVersion: "v0.8.26"
 kubeVersion: ">=1.25.0-0"
 home: https://sim.ai
 icon: https://raw.githubusercontent.com/simstudioai/sim/main/apps/sim/public/logo/primary/primary.svg

--- a/helm/sim/ci/full-values.yaml
+++ b/helm/sim/ci/full-values.yaml
@@ -21,10 +21,10 @@ ingress:
   enabled: true
   app:
     host: ci.example.com
-    paths: [{ path: /, pathType: Prefix }]
+    paths: [{path: /, pathType: Prefix}]
   realtime:
     host: ci-ws.example.com
-    paths: [{ path: /, pathType: Prefix }]
+    paths: [{path: /, pathType: Prefix}]
   tls:
     enabled: true
 

--- a/helm/sim/ci/kind-overlay.yaml
+++ b/helm/sim/ci/kind-overlay.yaml
@@ -1,6 +1,10 @@
-# CI-only overlay for the kind install test: shrink resource requests so the
-# default configuration schedules on a small CI runner. Layered on top of
-# ci/default-values.yaml. Dummy sizing — never use in a deployment.
+# CI-only OVERLAY for the kind install test. The name deliberately avoids the
+# `ci/*-values.yaml` suffix: `ct lint` treats every file matching that glob as a
+# standalone values set, and this one is a partial layered on default-values.yaml.
+#
+# Shrinks resource requests so the default configuration schedules on a small CI
+# runner. Layered on top of ci/default-values.yaml. Dummy sizing — never use in
+# a deployment.
 
 # Pin every first-party image to the published :latest rather than letting the
 # tag default to Chart.AppVersion. appVersion names the release the chart ships

--- a/helm/sim/images.yaml
+++ b/helm/sim/images.yaml
@@ -22,22 +22,22 @@
 # render it twice. That override also CHANGES where the chart pulls from, to
 # `<your-registry>/nvidia/k8s-device-plugin` — mirror the device plugin there
 # instead of to the `mirror` path listed below, or the pull fails.
-appVersion: v0.8.24
+appVersion: v0.8.26
 images:
   - source: busybox:1.36
     mirror: busybox:1.36
   - source: curlimages/curl:8.5.0
     mirror: curlimages/curl:8.5.0
-  - source: ghcr.io/simstudioai/copilot:v0.8.24
-    mirror: simstudioai/copilot:v0.8.24
-  - source: ghcr.io/simstudioai/migrations:v0.8.24
-    mirror: simstudioai/migrations:v0.8.24
-  - source: ghcr.io/simstudioai/pii:v0.8.24
-    mirror: simstudioai/pii:v0.8.24
-  - source: ghcr.io/simstudioai/realtime:v0.8.24
-    mirror: simstudioai/realtime:v0.8.24
-  - source: ghcr.io/simstudioai/simstudio:v0.8.24
-    mirror: simstudioai/simstudio:v0.8.24
+  - source: ghcr.io/simstudioai/copilot:v0.8.26
+    mirror: simstudioai/copilot:v0.8.26
+  - source: ghcr.io/simstudioai/migrations:v0.8.26
+    mirror: simstudioai/migrations:v0.8.26
+  - source: ghcr.io/simstudioai/pii:v0.8.26
+    mirror: simstudioai/pii:v0.8.26
+  - source: ghcr.io/simstudioai/realtime:v0.8.26
+    mirror: simstudioai/realtime:v0.8.26
+  - source: ghcr.io/simstudioai/simstudio:v0.8.26
+    mirror: simstudioai/simstudio:v0.8.26
   - source: nvcr.io/nvidia/k8s-device-plugin:v0.18.2
     mirror: nvcr.io/nvidia/k8s-device-plugin:v0.18.2
   - source: ollama/ollama:0.23.2

--- a/helm/sim/values.yaml
+++ b/helm/sim/values.yaml
@@ -5,10 +5,10 @@ global:
   # Use registry for all images, not just simstudioai/* images
   useRegistryForAllImages: false
   imagePullSecrets: []
-  
+
   # Common labels applied to all resources
   commonLabels: {}
-  
+
   # Storage class for persistent volumes
   storageClass: ""
 
@@ -108,7 +108,7 @@ app:
     # Generate secure 32-character secrets using: openssl rand -hex 32
     BETTER_AUTH_SECRET: ""  # REQUIRED - set via --set flag or external secret manager
     ENCRYPTION_KEY: ""      # REQUIRED - set via --set flag or external secret manager
-    INTERNAL_API_SECRET: "" # REQUIRED - set via --set flag or external secret manager, used for internal service-to-service authentication
+    INTERNAL_API_SECRET: ""  # REQUIRED - set via --set flag or external secret manager, used for internal service-to-service authentication
 
     # Optional: Scheduled Jobs Authentication
     # Generate using: openssl rand -hex 32
@@ -120,7 +120,7 @@ app:
     # Generate with: openssl rand -hex 32 (produces the required 64-hex-char / 32-byte value).
     API_ENCRYPTION_KEY: ""  # OPTIONAL - encrypts API keys at rest; if unset, keys are stored in plain text
     REDIS_URL: ""           # OPTIONAL - external Redis connection string. Overrides the bundled Redis (see the `redis:` section) and suppresses its Deployment. A REDIS_URL from a pre-created Secret or External Secrets also wins, without needing to be repeated here.
-    
+
     # Email & Communication
     # Configure one provider — the mailer auto-detects in priority order:
     # Resend → AWS SES → SMTP → Azure Communication Services → Gmail.
@@ -436,7 +436,7 @@ app:
     type: ClusterIP
     port: 3000
     targetPort: 3000
-  
+
   # Health checks
   # startupProbe shields a slow Next.js cold start (large bundle, 4Gi memory limits) from
   # liveness restarts. Once it succeeds, liveness + readiness take over. Total cold-start
@@ -498,7 +498,7 @@ realtime:
     requests:
       memory: "512Mi"
       cpu: "250m"
-  
+
   # Node selector for pod scheduling (leave empty to allow scheduling on any node)
   nodeSelector: {}
 
@@ -514,7 +514,7 @@ realtime:
   securityContext:
     runAsNonRoot: true
     runAsUser: 1001
-  
+
   # Environment variables — Secret-bound. See `envDefaults` below for chart-shipped defaults.
   env:
     # Application URLs — must mirror the public origin used by the main app.
@@ -540,13 +540,13 @@ realtime:
     BETTER_AUTH_URL: "http://localhost:3000"
     ALLOWED_ORIGINS: "http://localhost:3000"
     NODE_ENV: "production"
-  
+
   # Service configuration
   service:
     type: ClusterIP
     port: 3002
     targetPort: 3002
-  
+
   # Health checks
   # Startup probe absorbs cold-start time. Total budget: 30 * 5s = 150s.
   startupProbe:
@@ -630,7 +630,7 @@ redis:
 migrations:
   # Enable/disable the migrations init container
   enabled: true
-  
+
   # Image configuration
   image:
     repository: simstudioai/migrations
@@ -638,7 +638,7 @@ migrations:
     tag: ""
     digest: ""
     pullPolicy: IfNotPresent
-  
+
   # Resource limits and requests
   resources:
     limits:
@@ -646,11 +646,11 @@ migrations:
     requests:
       memory: "512Mi"
       cpu: "100m"
-  
+
   # Pod security context
   podSecurityContext:
     fsGroup: 1001
-  
+
   # Container security context
   securityContext:
     runAsNonRoot: true
@@ -660,13 +660,13 @@ migrations:
 postgresql:
   # Enable/disable internal PostgreSQL deployment
   enabled: true
-  
+
   # Image configuration
   image:
     repository: pgvector/pgvector
     tag: pg17
     pullPolicy: IfNotPresent
-  
+
   # Authentication configuration
   auth:
     username: postgres
@@ -679,10 +679,10 @@ postgresql:
       name: ""           # Name of existing Kubernetes secret. Must contain the
                          # password under the key POSTGRES_PASSWORD — key
                          # remapping is not supported.
-  
+
   # Node selector for database pod scheduling (leave empty to allow scheduling on any node)
   nodeSelector: {}
-  
+
   # Resource limits and requests
   resources:
     limits:
@@ -690,7 +690,7 @@ postgresql:
     requests:
       memory: "1Gi"
       cpu: "500m"
-  
+
   # Pod security context
   # PostgreSQL image's `postgres` user is uid/gid 999.
   podSecurityContext:
@@ -740,20 +740,20 @@ postgresql:
     # additionalDnsNames:
     #   - postgres.example.com
     #   - db.example.com
-  
+
   # PostgreSQL configuration
   config:
     maxConnections: 1000
     sharedBuffers: "1280MB"
     maxWalSize: "4GB"
     minWalSize: "80MB"
-  
+
   # Service configuration
   service:
     type: ClusterIP
     port: 5432
     targetPort: 5432
-  
+
   # Health checks
   # startupProbe shields liveness from slow first-boot scenarios (pgvector
   # extension init, WAL replay after a crash on a large data dir). Gives
@@ -839,18 +839,18 @@ ollama:
     strategy: "time-slicing"
     # Number of time-slicing replicas (only used when strategy is "time-slicing")
     timeSlicingReplicas: 5
-  
+
   # Node selector for GPU workloads (adjust labels based on your cluster configuration)
   nodeSelector:
     accelerator: nvidia
-  
+
   # Tolerations for GPU nodes (adjust based on your cluster's GPU node taints)
   tolerations:
     - key: "sku"
       operator: "Equal"
       value: "gpu"
       effect: "NoSchedule"
-  
+
   # Resource limits and requests
   resources:
     limits:
@@ -859,7 +859,7 @@ ollama:
     requests:
       memory: "4Gi"
       cpu: "1000m"
-  
+
   # Pod security context
   # The upstream ollama/ollama image is built to run as root and writes models to
   # /root/.ollama by default. To meet Pod Security Standards "restricted", we run
@@ -888,7 +888,7 @@ ollama:
     # Point it at a path under the writable PVC mount instead.
     HOME: "/tmp"
     OLLAMA_MODELS: "/data/models"
-  
+
   # Persistence configuration
   persistence:
     enabled: true
@@ -896,13 +896,13 @@ ollama:
     size: 100Gi
     accessModes:
       - ReadWriteOnce
-  
+
   # Service configuration
   service:
     type: ClusterIP
     port: 11434
     targetPort: 11434
-  
+
   # Health checks
   startupProbe:
     httpGet:
@@ -912,7 +912,7 @@ ollama:
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 10
-  
+
   livenessProbe:
     httpGet:
       path: /
@@ -921,7 +921,7 @@ ollama:
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 5
-  
+
   readinessProbe:
     httpGet:
       path: /
@@ -1099,10 +1099,10 @@ ingressInternal:
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
-  
+
   # Annotations to add to the service account
   annotations: {}
-  
+
   # The name of the service account to use
   name: ""
 
@@ -1324,7 +1324,7 @@ tolerations: []
 cronjobs:
   # Enable/disable all cron jobs
   enabled: true
-  
+
   # Individual job configurations
   jobs:
     scheduleExecution:
@@ -1335,7 +1335,7 @@ cronjobs:
       concurrencyPolicy: Forbid
       successfulJobsHistoryLimit: 3
       failedJobsHistoryLimit: 1
-      
+
     gmailWebhookPoll:
       enabled: true
       name: gmail-webhook-poll
@@ -1344,7 +1344,7 @@ cronjobs:
       concurrencyPolicy: Forbid
       successfulJobsHistoryLimit: 3
       failedJobsHistoryLimit: 1
-      
+
     outlookWebhookPoll:
       enabled: true
       name: outlook-webhook-poll
@@ -1574,7 +1574,7 @@ cronjobs:
     repository: curlimages/curl
     tag: 8.5.0
     pullPolicy: IfNotPresent
-    
+
   resources:
     limits:
       memory: "128Mi"
@@ -1582,15 +1582,15 @@ cronjobs:
     requests:
       memory: "64Mi"
       cpu: "50m"
-      
+
   restartPolicy: OnFailure
   activeDeadlineSeconds: 300
   startingDeadlineSeconds: 60
-  
+
   # Pod security context
   podSecurityContext:
     fsGroup: 1001
-  
+
   # Container security context
   securityContext:
     runAsNonRoot: true
@@ -1600,16 +1600,16 @@ cronjobs:
 telemetry:
   # Enable/disable telemetry collection
   enabled: false
-  
+
   # OpenTelemetry Collector image
   image:
     repository: otel/opentelemetry-collector-contrib
     tag: 0.91.0
     pullPolicy: IfNotPresent
-  
+
   # Number of collector replicas
   replicaCount: 1
-  
+
   # Resource limits and requests
   resources:
     limits:
@@ -1618,20 +1618,20 @@ telemetry:
     requests:
       memory: "256Mi"
       cpu: "100m"
-  
+
   # Node selector for telemetry pod scheduling (leave empty to allow scheduling on any node)
   nodeSelector: {}
-  
+
   # Tolerations for telemetry workloads
   tolerations: []
-  
+
   # Affinity for telemetry workloads
   affinity: {}
-  
+
   # Service configuration
   service:
     type: ClusterIP
-  
+
   # Jaeger tracing backend
   jaeger:
     enabled: false
@@ -1640,13 +1640,13 @@ telemetry:
     endpoint: "jaeger-collector:4317"
     tls:
       enabled: false
-  
+
   # Prometheus metrics backend
   prometheus:
     enabled: false
     endpoint: "http://prometheus-server/api/v1/write"
     auth: ""
-  
+
   # Generic OTLP backend
   otlp:
     enabled: false
@@ -1667,7 +1667,7 @@ telemetry:
 copilot:
   # Enable/disable the copilot service
   enabled: false
-  
+
   # Server deployment configuration
   server:
     # Image configuration
@@ -1680,7 +1680,7 @@ copilot:
 
     # Number of replicas
     replicaCount: 1
-    
+
     # Resource limits and requests
     resources:
       limits:
@@ -1689,21 +1689,21 @@ copilot:
       requests:
         memory: "1Gi"
         cpu: "500m"
-    
+
     # Node selector for pod scheduling
     # Leave empty to run on same infrastructure as main Sim platform
     # Or specify labels to isolate on dedicated nodes: { "workload-type": "copilot" }
     nodeSelector: {}
-    
+
     # Pod security context
     podSecurityContext:
       fsGroup: 1001
-    
+
     # Container security context
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001
-    
+
     # Environment variables that go through the chart-managed Secret (or ExternalSecret
     # when externalSecrets.enabled=true). Every non-empty key here must have a matching
     # externalSecrets.remoteRefs.copilot entry under ESO — reserve this block for values
@@ -1748,13 +1748,13 @@ copilot:
       create: true
       name: ""
       annotations: {}
-    
+
     # Service configuration
     service:
       type: ClusterIP
       port: 8080
       targetPort: 8080
-    
+
     # Health checks
     # Startup probe absorbs cold-start time. Total budget: 30 * 5s = 150s.
     startupProbe:
@@ -1799,18 +1799,18 @@ copilot:
       repository: postgres
       tag: 17-alpine
       pullPolicy: IfNotPresent
-    
+
     # Authentication configuration
     auth:
       username: copilot
       password: ""  # REQUIRED - set via --set flag or external secret manager
       database: copilot
-    
+
     # Node selector for database pod scheduling
     # Leave empty to run on same infrastructure as main Sim platform
     # Or specify labels to isolate on dedicated nodes: { "workload-type": "copilot" }
     nodeSelector: {}
-    
+
     # Resource limits and requests
     resources:
       limits:
@@ -1819,7 +1819,7 @@ copilot:
       requests:
         memory: "512Mi"
         cpu: "250m"
-    
+
     # Pod security context
     # PostgreSQL image's `postgres` user is uid/gid 999.
     podSecurityContext:
@@ -1875,19 +1875,19 @@ copilot:
       periodSeconds: 3
       timeoutSeconds: 5
       failureThreshold: 10
-  
+
   # External database configuration (use when connecting to a managed database)
   database:
     existingSecretName: ""
     secretKey: DATABASE_URL
     url: ""
-  
+
   # Migration job configuration (Copilot migrations run as a Helm-hook Job,
   # unlike the app migrations which run as an init container)
   migrations:
     # Enable/disable the Copilot migrations Job
     enabled: true
-    
+
     # Image configuration (same as server)
     image:
       repository: simstudioai/copilot
@@ -1904,16 +1904,16 @@ copilot:
       requests:
         memory: "256Mi"
         cpu: "100m"
-    
+
     # Pod security context
     podSecurityContext:
       fsGroup: 1001
-    
+
     # Container security context
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001
-    
+
     # Job configuration
     backoffLimit: 3
     restartPolicy: OnFailure

--- a/scripts/sync-chart-appversion.ts
+++ b/scripts/sync-chart-appversion.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * Writes the application release a chart ships with into `helm/sim/Chart.yaml`
+ * and regenerates the image inventory that derives from it.
+ *
+ * `appVersion` is what the chart's image tags default to, so a stale one
+ * publishes a chart that silently installs an older Sim, and `helm/sim/images.yaml`
+ * — the list an operator mirrors into a disconnected registry — names the wrong
+ * tags with it. Because published chart versions are immutable, a stale value is
+ * frozen the moment it ships.
+ *
+ * It was bumped by hand and drifted for forty releases, then twice more after a
+ * check started catching it. The check could only refuse to publish; it could not
+ * supply the value. The publish jobs run this instead, so the number is derived
+ * from the release rather than remembered.
+ *
+ * Only node builtins are imported so this runs on a CI job with no dependencies
+ * installed, matching `generate-image-manifest.ts`.
+ *
+ * @example
+ * ```
+ * bun run scripts/sync-chart-appversion.ts --version v0.8.26
+ * bun run scripts/sync-chart-appversion.ts --version v0.8.26 --check
+ * ```
+ */
+import { spawnSync } from 'node:child_process'
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const CHART_PATH = resolve(ROOT, 'helm/sim/Chart.yaml')
+
+/** A release tag as this repository cuts them: `v1.2.3`. */
+const RELEASE_TAG = /^v\d+\.\d+\.\d+$/
+
+/** Matches the top-level `appVersion:` key, quoted or bare. */
+const APP_VERSION_LINE = /^appVersion:.*$/m
+
+function parseArgs(argv: string[]): { version: string; check: boolean } {
+  const versionIndex = argv.indexOf('--version')
+  const version = versionIndex === -1 ? '' : (argv[versionIndex + 1] ?? '')
+  if (!RELEASE_TAG.test(version)) {
+    throw new Error(
+      `--version must be a release tag like v1.2.3, got ${version ? `"${version}"` : '<missing>'}`
+    )
+  }
+  return { version, check: argv.includes('--check') }
+}
+
+async function main() {
+  const { version, check } = parseArgs(process.argv.slice(2))
+
+  const chart = await readFile(CHART_PATH, 'utf8')
+  if (!APP_VERSION_LINE.test(chart)) {
+    throw new Error(`No top-level appVersion key in ${CHART_PATH}`)
+  }
+
+  const next = chart.replace(APP_VERSION_LINE, `appVersion: "${version}"`)
+  const changed = next !== chart
+
+  if (check) {
+    if (changed) {
+      console.error(
+        `helm/sim/Chart.yaml appVersion does not match ${version}. Run:\n` +
+          `  bun run scripts/sync-chart-appversion.ts --version ${version}`
+      )
+      process.exit(1)
+    }
+    console.log(`appVersion is already ${version}.`)
+    return
+  }
+
+  if (changed) {
+    await writeFile(CHART_PATH, next)
+    console.log(`Set appVersion to ${version}.`)
+  } else {
+    console.log(`appVersion was already ${version}.`)
+  }
+
+  /**
+   * The inventory embeds appVersion in every first-party image tag, so it has to
+   * follow. Spawned rather than imported because the generator writes on import
+   * of its own main and owns its formatting.
+   */
+  const generated = spawnSync('bun', ['run', 'scripts/generate-image-manifest.ts'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  })
+  if (generated.status !== 0) {
+    throw new Error(`generate-image-manifest.ts exited with ${generated.status}`)
+  }
+}
+
+if (import.meta.main) await main()

--- a/scripts/sync-chart-appversion.ts
+++ b/scripts/sync-chart-appversion.ts
@@ -22,6 +22,9 @@
  * bun run scripts/sync-chart-appversion.ts --version v0.8.26
  * bun run scripts/sync-chart-appversion.ts --version v0.8.26 --check
  * ```
+ *
+ * `--check` verifies both halves: that Chart.yaml names the version and that the
+ * inventory generated from it is current.
  */
 import { spawnSync } from 'node:child_process'
 import { readFile, writeFile } from 'node:fs/promises'
@@ -67,7 +70,17 @@ async function main() {
       )
       process.exit(1)
     }
-    console.log(`appVersion is already ${version}.`)
+    /**
+     * The inventory derives from appVersion, so a matching Chart.yaml alone does
+     * not mean the pair is consistent -- checking only half of what this script
+     * writes would report success over a stale inventory.
+     */
+    const verified = spawnSync('bun', ['run', 'scripts/generate-image-manifest.ts', '--check'], {
+      cwd: ROOT,
+      stdio: 'inherit',
+    })
+    if (verified.status !== 0) process.exit(verified.status ?? 1)
+    console.log(`appVersion is ${version} and the image inventory matches.`)
     return
   }
 


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled chart lint and version-bump job with [`ct`](https://github.com/helm/chart-testing), the CNCF chart linter that ingress-nginx, prometheus-community and external-secrets all gate on.
- Makes the publish jobs **derive** `appVersion` from the release instead of checking it, so the chart can no longer publish pinned to an older Sim — and can no longer be blocked from publishing at all.
- Removes the post-merge `appVersion` check, now unreachable by construction. Replaces #7633, which is closed.

## Why the previous approach failed
`appVersion` sets the chart's default image tags, and `images.yaml` — the list an operator mirrors into a disconnected registry — derives from it. It was bumped by hand, drifted forty releases, then drifted **twice more** after a check started catching it.

That is the tell. The check could refuse to publish but could not supply the value, so all it reliably produced was a red build on every release and a chart that never shipped. **Only chart 1.11.0 was ever published** — 1.11.1 and 1.11.2 never made it out.

#7633's answer was a second, earlier gate that parsed PR titles. That guards ground truth with a heuristic, and its failure mode is passing silently — it already had a bug where a real release title with a leading space was read as "not a release". There are also no required status checks configured on `main` (only `deletion`, `non_fast_forward`, `pull_request`), so neither gate blocks anything today.

## What it does instead
On a release merge the tag does not exist yet — that commit is what cuts it — so the version comes from the commit subject, falling back to the latest release for every other push. Both publish paths run the same script before packaging, so the OCI artifact and the HTTP repo cannot disagree.

Precedent is **cert-manager**, whose chart also lives in its application repo and which injects at package time (`helm package --app-version=$(VERSION)`, `make/manifests.mk`). The projects that commit the value and bump by hand — argo-cd, ingress-nginx, prometheus-community — all keep their chart in a **separate** repo, where a human is already editing `Chart.yaml` as the unit of change. We are the former shape, which is why this kept drifting.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
Verified rather than assumed:

- **`ct` fails when it should.** In a scratch repo with a real remote: chart content changed without a bump → `chart version not ok. Needs a version bump!`, exit 1; the same change with a bump → `Chart version ok.` Passing `--charts` instead of `--chart-dirs`/`--target-branch` silently **disables** the version check and still exits 0, so the PR path uses the latter.
- **Version resolution across six subjects**: release commit, multi-line body carrying a decoy version, ordinary push, leading whitespace, shell metacharacters (no expansion), and a version not at the start.
- **Script exit codes checked directly**, not through a pipe — a gate that cannot fail is the thing being replaced here.
- **Whitespace changes are inert**: no non-comment line changed in `values.yaml`, and both rendered manifest sets are byte-identical before and after.
- `helm lint`, 108 chart unit tests, `images:check`, `check:cron-parity`, `bun run lint`, 46 audits, `docs-manifest:check`, `check:script-tests`. actionlint clean; zizmor `--persona=pedantic` reports zero findings.
- A default install now renders `v0.8.26` images, up from `v0.8.24`.

## Notes
`ci/kind-values.yaml` → `ci/kind-overlay.yaml`: `ct` treats every `ci/*-values.yaml` as a standalone values set, but that file is a partial layered on `default-values.yaml`, so linting it alone tripped the chart's own required-secret guards.

Maintainer validation is left off. It resolves `maintainers[].name` against real forge accounts and ours is the display name `Sim Team`; enabling it means changing what Artifact Hub shows. One-line flip if you want it.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
