### PR TITLE
fix(chat): align organization focus and loading with workspace

### DIFF
--- a/apps/sim/app/o/[organizationId]/components/organization-sidebar/components/chats-section/chats-section.test.tsx
+++ b/apps/sim/app/o/[organizationId]/components/organization-sidebar/components/chats-section/chats-section.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { act } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OrganizationChat } from '@/app/o/[organizationId]/components/organization-sidebar/hooks'
@@ -9,7 +10,16 @@ import type { OrganizationChat } from '@/app/o/[organizationId]/components/organ
 const hoverState = vi.hoisted(() => ({ isOpen: false }))
 
 vi.mock('next/link', () => ({
-  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+  default: ({
+    href,
+    children,
+    prefetch: _prefetch,
+    ...props
+  }: {
+    href: string
+    children: React.ReactNode
+    prefetch?: boolean
+  }) => (
     <a href={href} {...props}>
       {children}
     </a>
@@ -36,6 +46,8 @@ const CHATS: OrganizationChat[] = Array.from({ length: 8 }, (_, index) => ({
 
 let container: HTMLDivElement
 let root: Root
+let queryClient: QueryClient
+let prefetchQuery: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
   ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -48,6 +60,8 @@ beforeEach(() => {
     }
   )
   hoverState.isOpen = false
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  prefetchQuery = vi.spyOn(queryClient, 'prefetchQuery').mockResolvedValue()
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -56,22 +70,25 @@ beforeEach(() => {
 afterEach(async () => {
   await act(async () => root.unmount())
   container.remove()
+  queryClient.clear()
   vi.unstubAllGlobals()
 })
 
 async function render(props: Partial<Parameters<typeof ChatsSection>[0]> = {}) {
   await act(async () => {
     root.render(
-      <ChatsSection
-        chats={CHATS}
-        isLoading={false}
-        isCollapsed={false}
-        pathname={null}
-        menuOpenHref={null}
-        onContextMenu={() => {}}
-        onMoreClick={() => {}}
-        {...props}
-      />
+      <QueryClientProvider client={queryClient}>
+        <ChatsSection
+          chats={CHATS}
+          isLoading={false}
+          isCollapsed={false}
+          pathname={null}
+          menuOpenHref={null}
+          onContextMenu={() => {}}
+          onMoreClick={() => {}}
+          {...props}
+        />
+      </QueryClientProvider>
     )
   })
 }
@@ -103,6 +120,28 @@ describe('ChatsSection', () => {
     await act(async () => button?.click())
 
     expect(onMoreClick).toHaveBeenCalledWith(expect.anything(), '/o/org-1/chat/chat-2')
+    expect(prefetchQuery).not.toHaveBeenCalled()
+  })
+
+  it.each([false, true])(
+    'prefetches focused destination history with collapsed=%s',
+    async (isCollapsed) => {
+      hoverState.isOpen = isCollapsed
+      await render({ isCollapsed })
+      prefetchQuery.mockClear()
+      const link = document.body.querySelector<HTMLAnchorElement>('a[href="/o/org-1/chat/chat-3"]')!
+      await act(async () => link.focus())
+      expect(prefetchQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['mothership-chats', 'detail', 'chat-3'] })
+      )
+    }
+  )
+
+  it('does not prefetch the active conversation', async () => {
+    await render({ pathname: '/o/org-1/chat/chat-3' })
+    const link = container.querySelector<HTMLAnchorElement>('a[href="/o/org-1/chat/chat-3"]')!
+    await act(async () => link.focus())
+    expect(prefetchQuery).not.toHaveBeenCalled()
   })
 
   it('shows the empty state when there are no chats', async () => {

--- a/apps/sim/app/o/[organizationId]/components/organization-sidebar/components/chats-section/chats-section.tsx
+++ b/apps/sim/app/o/[organizationId]/components/organization-sidebar/components/chats-section/chats-section.tsx
@@ -2,10 +2,10 @@
 
 import { chipVariants, cn, DropdownMenuItem, Loader, OverflowText, Skeleton } from '@sim/emcn'
 import { MoreHorizontal, Pin, Task } from '@sim/emcn/icons'
-import Link from 'next/link'
 import type { OrganizationChat } from '@/app/o/[organizationId]/components/organization-sidebar/hooks'
 import { ConversationListItem } from '@/app/workspace/[workspaceId]/components'
 import {
+  ChatNavigationLink,
   CollapsedSidebarMenu,
   SidebarSection,
 } from '@/app/workspace/[workspaceId]/w/components/sidebar/components'
@@ -41,8 +41,10 @@ function ChatRow({ chat, isCurrentRoute, isMenuOpen, onContextMenu, onMoreClick 
   const showStatusDot = Boolean(chat.isActive) || (!isCurrentRoute && Boolean(chat.isUnread))
 
   return (
-    <Link
+    <ChatNavigationLink
       href={chat.href}
+      chatId={chat.id}
+      isCurrentRoute={isCurrentRoute}
       className={chipVariants({ active: isCurrentRoute || isMenuOpen, fullWidth: true })}
       onContextMenu={(e) => onContextMenu(e, chat.href)}
     >
@@ -83,7 +85,7 @@ function ChatRow({ chat, isCurrentRoute, isMenuOpen, onContextMenu, onMoreClick 
           <MoreHorizontal className='size-[14px] text-[var(--text-icon)]' />
         </button>
       </div>
-    </Link>
+    </ChatNavigationLink>
   )
 }
 
@@ -140,13 +142,18 @@ export function ChatsSection({
                 const isCurrentRoute = pathname === chat.href
                 return (
                   <DropdownMenuItem key={chat.id} asChild active={isCurrentRoute}>
-                    <Link href={chat.href} onContextMenu={(e) => onContextMenu(e, chat.href)}>
+                    <ChatNavigationLink
+                      href={chat.href}
+                      chatId={chat.id}
+                      isCurrentRoute={isCurrentRoute}
+                      onContextMenu={(e) => onContextMenu(e, chat.href)}
+                    >
                       <ConversationListItem
                         title={chat.name}
                         isActive={Boolean(chat.isActive)}
                         isUnread={Boolean(chat.isUnread) && !isCurrentRoute}
                       />
-                    </Link>
+                    </ChatNavigationLink>
                   </DropdownMenuItem>
                 )
               })

--- a/apps/sim/app/o/[organizationId]/home/components/composer/composer.tsx
+++ b/apps/sim/app/o/[organizationId]/home/components/composer/composer.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { useRef } from 'react'
 import { Button, cn } from '@sim/emcn'
 import { ArrowUp } from '@sim/emcn/icons'
 import { useAnimatedPlaceholder } from '@/hooks/use-animated-placeholder'
+import { useChatInputFocus } from '@/hooks/use-chat-input-focus'
 
 const SEND_BUTTON_BASE = 'size-[28px] rounded-full border-0 p-0 transition-colors'
 const SEND_BUTTON_ACTIVE =
@@ -32,6 +34,8 @@ export function Composer({
   onSubmit,
   onStop,
 }: ComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  useChatInputFocus({ textareaRef })
   const canSubmit = value.trim().length > 0
   const animatedPlaceholder = useAnimatedPlaceholder(isInitialView)
   const placeholder = isInitialView ? animatedPlaceholder : 'Send message to Sim'
@@ -50,6 +54,7 @@ export function Composer({
         )}
       >
         <textarea
+          ref={textareaRef}
           value={value}
           onChange={(event) => onChange(event.target.value)}
           onKeyDown={(event) => {

--- a/apps/sim/app/o/[organizationId]/home/organization-home.test.tsx
+++ b/apps/sim/app/o/[organizationId]/home/organization-home.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { act, type ComponentProps } from 'react'
+import { act, type ComponentProps, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -95,6 +95,52 @@ describe('organization home', () => {
     )
     expect(container.textContent).not.toContain('Get started')
     expect(mocks.consume).not.toHaveBeenCalled()
+  })
+  it('keeps the composer available when messages exist while history is pending', async () => {
+    mocks.chat.mockReturnValue({
+      messages: [{ id: 'message-a', role: 'user', content: 'A question' }],
+      isChatHistoryPending: true,
+      sendMessage: mocks.send,
+    })
+    await act(async () => root.render(<OrganizationHome chatId='chat-a' />))
+    expect(mocks.renderer).toHaveBeenCalledWith(
+      expect.objectContaining({ isLoading: false }),
+      undefined
+    )
+  })
+  it('isolates conversation state when switching cached chats', async () => {
+    mocks.chat.mockReturnValue({
+      messages: [],
+      isChatHistoryPending: false,
+      sendMessage: mocks.send,
+    })
+    mocks.renderer.mockImplementation(({ composer }: { composer: ReactNode }) => composer)
+    await act(async () => root.render(<OrganizationHome chatId='chat-a' />))
+    await act(async () => composerProps().onChange('A draft for chat A'))
+    await act(async () => root.render(<OrganizationHome chatId='chat-a' />))
+    expect(composerProps().value).toBe('A draft for chat A')
+    await act(async () => root.render(<OrganizationHome chatId='chat-b' />))
+    expect(composerProps().value).toBe('')
+    expect(mocks.chat).toHaveBeenLastCalledWith({ organizationId: 'organization-a' }, 'chat-b')
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+  it('preserves the conversation when the first send adopts a chat ID', async () => {
+    mocks.renderer.mockImplementation(({ composer }: { composer: ReactNode }) => composer)
+    await act(async () => root.render(<OrganizationHome />))
+    await act(async () => composerProps().onChange('A follow-up draft'))
+    mocks.chat.mockReturnValue({
+      messages: [{ id: 'message-a', role: 'user', content: 'First question' }],
+      resolvedChatId: 'chat-a',
+      isChatHistoryPending: true,
+      isSending: true,
+      sendMessage: mocks.send,
+    })
+    await act(async () => root.render(<OrganizationHome />))
+    expect(composerProps().value).toBe('A follow-up draft')
+    expect(mocks.renderer).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId: 'chat-a', isLoading: false, isSending: true }),
+      undefined
+    )
   })
   it.each([
     { isAdmin: true, integrationHref: '/o/organization-a/settings/integrations' },

--- a/apps/sim/app/o/[organizationId]/home/organization-home.tsx
+++ b/apps/sim/app/o/[organizationId]/home/organization-home.tsx
@@ -17,9 +17,9 @@ interface OrganizationHomeProps {
 
 /** Search and private Assistant chats for the routed organization. */
 export function OrganizationHome(props: OrganizationHomeProps) {
-  const { searchAccess } = useOrganizationContext()
+  const { organization, searchAccess } = useOrganizationContext()
   if (!searchAccess.memberScoped) return null
-  return <OrganizationHomeContent {...props} />
+  return <OrganizationHomeContent key={`${organization.id}:${props.chatId ?? 'new'}`} {...props} />
 }
 
 function OrganizationHomeContent({ userName, chatId }: OrganizationHomeProps) {
@@ -82,7 +82,7 @@ function OrganizationHomeContent({ userName, chatId }: OrganizationHomeProps) {
           messages={chat.messages}
           isSending={chat.isSending}
           isReconnecting={chat.isReconnecting}
-          isLoading={Boolean(chatId) && chat.isChatHistoryPending}
+          isLoading={Boolean(chatId) && !chat.messages.length && chat.isChatHistoryPending}
           onSubmit={send}
           onStopGeneration={() => {
             void chat.stopGeneration()

--- a/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/home/components/user-input/user-input.tsx
@@ -41,6 +41,7 @@ import type {
 import { useFileAttachments } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks'
 import type { AttachedFile } from '@/app/workspace/[workspaceId]/w/[workflowId]/components/panel/components/copilot/components/user-input/hooks/use-file-attachments'
 import { mentionifyIntegrations } from '@/blocks/integration-matcher'
+import { useChatInputFocus } from '@/hooks/use-chat-input-focus'
 import { useSettingsNavigation } from '@/hooks/use-settings-navigation'
 import { type SpeechToTextError, useSpeechToText } from '@/hooks/use-speech-to-text'
 import { type DraftPayload, useMothershipDraftsStore } from '@/stores/mothership-drafts/store'
@@ -49,16 +50,6 @@ import type { ChatContext } from '@/stores/panel'
 export type { FileAttachmentForApi } from '@/app/workspace/[workspaceId]/home/types'
 
 const logger = createLogger('UserInput')
-
-/**
- * Whether the element is somewhere the user could be typing. Focusing the composer on mount
- * must not steal focus from another field, but may take it from a link or button — opening a
- * chat leaves the sidebar link focused, and the composer should win.
- */
-function isTextEntry(element: HTMLElement): boolean {
-  const tag = element.tagName
-  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || element.isContentEditable
-}
 
 interface UserInputProps {
   defaultValue?: string
@@ -168,6 +159,7 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
   const editorRef = useRef(editor)
   editorRef.current = editor
   const textareaRef = editor.textareaRef
+  useChatInputFocus({ textareaRef })
 
   /**
    * Attaches context chips pushed from elsewhere in the app (browser/terminal
@@ -548,16 +540,6 @@ const UserInputImpl = forwardRef<UserInputHandle, UserInputProps>(function UserI
     }
     wasSendingRef.current = isSending
   }, [isSending, textareaRef])
-
-  useEffect(() => {
-    const raf = window.requestAnimationFrame(() => {
-      if (!document.hasFocus()) return
-      const active = document.activeElement
-      if (active instanceof HTMLElement && isTextEntry(active)) return
-      textareaRef.current?.focus()
-    })
-    return () => window.cancelAnimationFrame(raf)
-  }, [textareaRef])
 
   /**
    * Menu rows are excluded alongside buttons: the mode switcher's items are

--- a/apps/sim/hooks/use-chat-input-focus.test.tsx
+++ b/apps/sim/hooks/use-chat-input-focus.test.tsx
@@ -1,0 +1,108 @@
+/** @vitest-environment jsdom */
+import { act, useRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useChatInputFocus } from '@/hooks/use-chat-input-focus'
+
+function ChatInput() {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  useChatInputFocus({ textareaRef })
+  return <textarea ref={textareaRef} />
+}
+
+describe('useChatInputFocus', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let activeWindow: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+    vi.useFakeTimers()
+    activeWindow = vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  function flushFocus() {
+    act(() => vi.advanceTimersToNextFrame())
+  }
+
+  it('focuses the newly mounted composer after navigation from the sidebar', () => {
+    const link = document.createElement('a')
+    link.href = '#chat'
+    container.appendChild(link)
+    link.focus()
+    act(() => root.render(<ChatInput />))
+    flushFocus()
+    expect(document.activeElement).toBe(container.querySelector('textarea'))
+  })
+
+  it.each(['input', 'textarea', 'select', 'contenteditable'])(
+    'preserves focus in another %s',
+    (kind) => {
+      const field = document.createElement(kind === 'contenteditable' ? 'div' : kind)
+      if (kind === 'contenteditable') {
+        field.setAttribute('contenteditable', 'true')
+        field.tabIndex = 0
+        Object.defineProperty(field, 'isContentEditable', { value: true })
+      }
+      document.body.appendChild(field)
+      try {
+        act(() => root.render(<ChatInput />))
+        field.focus()
+        flushFocus()
+        expect(document.activeElement).toBe(field)
+      } finally {
+        field.remove()
+      }
+    }
+  )
+
+  it('does not focus a composer in an inactive window', () => {
+    activeWindow.mockReturnValue(false)
+    act(() => root.render(<ChatInput />))
+    flushFocus()
+    expect(document.activeElement).not.toBe(container.querySelector('textarea'))
+  })
+
+  it('does not refocus or move the caret on ordinary rerenders', () => {
+    act(() => root.render(<ChatInput />))
+    flushFocus()
+    const textarea = container.querySelector('textarea')!
+    textarea.value = 'Draft question'
+    textarea.setSelectionRange(2, 5)
+    const focus = vi.spyOn(textarea, 'focus')
+    act(() => root.render(<ChatInput />))
+    flushFocus()
+    expect(focus).not.toHaveBeenCalled()
+    expect([textarea.selectionStart, textarea.selectionEnd]).toEqual([2, 5])
+  })
+
+  it('cancels the previous composer focus during rapid chat switches', () => {
+    act(() => root.render(<ChatInput key='chat-a' />))
+    const previous = container.querySelector('textarea')!
+    const focus = vi.spyOn(previous, 'focus')
+    act(() => root.render(<ChatInput key='chat-b' />))
+    flushFocus()
+    expect(focus).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(container.querySelector('textarea'))
+    expect(document.activeElement).not.toBe(previous)
+  })
+
+  it('cancels focus when the composer unmounts before the frame', () => {
+    act(() => root.render(<ChatInput />))
+    const focus = vi.spyOn(container.querySelector('textarea')!, 'focus')
+    act(() => root.render(null))
+    flushFocus()
+    expect(focus).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/hooks/use-chat-input-focus.ts
+++ b/apps/sim/hooks/use-chat-input-focus.ts
@@ -1,0 +1,23 @@
+import { type RefObject, useEffect } from 'react'
+
+interface UseChatInputFocusProps {
+  textareaRef: RefObject<HTMLTextAreaElement | null>
+}
+
+/** Focuses a newly opened chat without interrupting typing elsewhere or an inactive window. */
+export function useChatInputFocus({ textareaRef }: UseChatInputFocusProps) {
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      if (!document.hasFocus()) return
+      const active = document.activeElement
+      if (
+        active instanceof HTMLElement &&
+        (['INPUT', 'TEXTAREA', 'SELECT'].includes(active.tagName) || active.isContentEditable)
+      ) {
+        return
+      }
+      textareaRef.current?.focus()
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [textareaRef])
+}


### PR DESCRIPTION
## Summary

- Reuse workspace chat prefetch and guarded input focus in organization chats.
- Reset conversation state on navigation and keep the composer visible when messages are already available.

## Type of Change

- [x] Bug fix

## Testing

902 chat and navigation regression tests pass. Manually verified organization home, cached chat switches, collapsed chat navigation, draft isolation, and workspace input focus. Type checking, lint, all 46 audits, block registry, and docs manifest checks pass.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
