### PR TITLE
improvement(docs): reduce search screenshot display sizes

### DIFF
--- a/apps/docs/content/docs/search/confluence.mdx
+++ b/apps/docs/content/docs/search/confluence.mdx
@@ -58,7 +58,7 @@ Enter **Confluence Domain**, then choose one or more **Spaces**. The picker show
 
 Open **More options** to change **Content Type**, **Filter by Label**, or **Metadata tags**. The default includes pages; choose **All content** for pages and blog posts. Leave the label filter empty unless you want a smaller scope.
 
-<Image
+<Image className="mx-auto h-auto w-full max-w-md"
   src="/static/search/confluence-setup.jpg"
   alt="Confluence central source setup with an indexing account, domain, and spaces"
   width={520}
@@ -101,7 +101,7 @@ Have an Atlassian organization admin create a service account under **Directory 
 
 Select the service account, then **Create credentials → API token → Next**. This is the credential type accepted by Sim's service-account form.
 
-<Image
+<Image className="mx-auto h-auto w-full max-w-xl"
   src="/static/credentials/atlassian/admin-auth-type-picker.png"
   alt="Atlassian Administration authentication selector with API token selected"
   width={1334}

--- a/apps/docs/content/docs/search/connect-your-account.mdx
+++ b/apps/docs/content/docs/search/connect-your-account.mdx
@@ -25,7 +25,7 @@ Open **Integrations** in the main sidebar, find the provider or source, and sele
 
 Use **Add source** beside **Add another [provider] source** when you need another supported repository, site, or project scope. Connecting an existing source does not ask you to configure it again.
 
-<Image src="/static/search/connect-account.png" alt="Organization Integrations showing approved providers and Connect account actions" width={738} height={680} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/connect-account.png" alt="Organization Integrations showing approved providers and Connect account actions" width={738} height={680} />
 
 
 </Step>
@@ -37,7 +37,7 @@ In the new tab, select **Connect** and complete the provider's authorization. Ch
 
 Return to Integrations when the connection completes, or select **Return to Search** to open your organization’s Search page. Your account is saved when authorization completes; there is no separate submit step. If the popup was blocked or closed, allow popups and select **Connect account** again. While authorization is pending, use **Open again**.
 
-<Image src="/static/search/member-enrollment.jpg" alt="Gmail account connection with Connect and Return to Search actions" width={680} height={305} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/member-enrollment.jpg" alt="Gmail account connection with Connect and Return to Search actions" width={680} height={305} />
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/search/github.mdx
+++ b/apps/docs/content/docs/search/github.mdx
@@ -45,7 +45,7 @@ https://<your-sim-domain>/api/auth/oauth2/callback/github-repositories
 
 Authorization starts from Sim so the callback can finish the pending connection. The connector polls GitHub's API and does not need a webhook.
 
-<Image src="/static/search/github-app-callback.jpg" alt="GitHub App registration with the Redirect URI, expiring tokens enabled, and installation authorization, Device Flow, and webhooks disabled" width={768} height={929} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/github-app-callback.jpg" alt="GitHub App registration with the Redirect URI, expiring tokens enabled, and installation authorization, Device Flow, and webhooks disabled" width={768} height={929} />
 
 *Example registration. Replace `sim.example.com` with your Sim domain.*
 
@@ -56,11 +56,11 @@ Authorization starts from Sim so the callback can finish the pending connection.
 
 Expand **Permissions → Repository permissions**. Set **Contents → Access: Read-only**; leave the mandatory **Metadata** permission at **Read-only**.
 
-<Image src="/static/search/github-app-repository-permissions.jpg" alt="GitHub repository permissions with Contents set to Read-only and Metadata shown as mandatory Read-only" width={768} height={929} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/github-app-repository-permissions.jpg" alt="GitHub repository permissions with Contents set to Read-only and Metadata shown as mandatory Read-only" width={768} height={929} />
 
 Expand **Account permissions** and set **Email addresses → Access: Read-only**.
 
-<Image src="/static/search/github-app-email-permission.jpg" alt="GitHub account permissions with only Email addresses selected for Read-only access" width={768} height={929} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/github-app-email-permission.jpg" alt="GitHub account permissions with only Email addresses selected for Read-only access" width={768} height={929} />
 
 | Permission area | Permission | Access |
 |---|---|---|
@@ -111,7 +111,7 @@ As a Sim organization admin, open **Settings → Sources → Add integration** a
 
 Enter **Repository** as `owner/repo`. Open **More options** only if you need a different branch, path or extension filters, metadata tags, or a dedicated indexing account. **Sync documents with** defaults to **Connected members**.
 
-<Image src="/static/search/github-setup.jpg" alt="GitHub source setup with a required Repository field and More options" width={520} height={254} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/github-setup.jpg" alt="GitHub source setup with a required Repository field and More options" width={520} height={254} />
 
 | Field | What to enter |
 |---|---|

--- a/apps/docs/content/docs/search/gitlab.mdx
+++ b/apps/docs/content/docs/search/gitlab.mdx
@@ -9,7 +9,7 @@ import { Image } from '@/components/ui/image'
 
 GitLab Search uses an administrator connection to sync a project's content and permissions. Teammates do not connect individual GitLab accounts. They sign in to the Sim organization with a verified email matching their confirmed GitLab email.
 
-<Image src="/static/search/gitlab-setup.jpg" alt="GitLab source setup in Sim Search" width={520} height={479} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/gitlab-setup.jpg" alt="GitLab source setup in Sim Search" width={520} height={479} />
 
 Admin setup uses your organization's **Settings → Sources** page. Teammates do not need a personal GitLab connection. For workspace Search, use **Search → Add source** instead.
 
@@ -30,7 +30,7 @@ Use a self-managed GitLab instance running version **17.4 or later**. Setup need
 
 Sign in to your self-managed GitLab instance as an instance administrator, then open **Avatar → Edit profile → Access → Personal access tokens**. On current releases choose **Generate token → Legacy token**; older versions show **Add new token** or the token form directly.
 
-<Image src="https://handbook.gitlab.com/images/security/product-security/security-platforms-and-architecture/service-account-access-token-page.png" alt="Official GitLab example of the Access Tokens page with the Add new token button" width={1759} height={586} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="https://handbook.gitlab.com/images/security/product-security/security-platforms-and-architecture/service-account-access-token-page.png" alt="Official GitLab example of the Access Tokens page with the Add new token button" width={1759} height={586} />
 
 *Official [GitLab Handbook example](https://handbook.gitlab.com/handbook/security/product-security/security-platforms-architecture/product-security-engineering/runbooks/rotate-service-account-personal-access-tokens/). Navigation and button labels vary by version. The example's existing `api` tokens are unrelated to Sim; use the scopes below.*
 
@@ -63,7 +63,7 @@ Open **Settings → Sources → Add integration** and choose **GitLab**. On its 
 
 **More options** contains the repository and issue filters, **Max Items**, and **Metadata tags**. Unlike member-account sources, GitLab retains this optional item limit.
 
-<Image src="/static/search/gitlab-options.jpg" alt="GitLab source setup with More options expanded for repository and issue filters, item limit, and metadata tags" width={520} height={625} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/gitlab-options.jpg" alt="GitLab source setup with More options expanded for repository and issue filters, item limit, and metadata tags" width={520} height={625} />
 
 Select **Connect & Sync**. Sim validates the token and source policy, then starts indexing.
 

--- a/apps/docs/content/docs/search/gmail.mdx
+++ b/apps/docs/content/docs/search/gmail.mdx
@@ -39,7 +39,7 @@ Click **Add source**. Gmail appears in the provider's **Sources** list. Each per
 </Step>
 </Steps>
 
-<Image src="/static/search/gmail-setup.jpg" alt="Gmail Search source configuration" width={520} height={329} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/gmail-setup.jpg" alt="Gmail Search source configuration" width={520} height={329} />
 
 ## Connect your account
 
@@ -93,7 +93,7 @@ Users do not need to create Google Cloud credentials. The deployment operator co
 https://<your-sim-domain>/api/auth/oauth2/callback/google-email
 ```
 
-<Image src="/static/search/google-oauth-web-client.png" alt="Google Cloud Web application client form with Sim's Gmail, Calendar, and Drive callback URLs" width={768} height={929} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/google-oauth-web-client.png" alt="Google Cloud Web application client form with Sim's Gmail, Calendar, and Drive callback URLs" width={768} height={929} />
 
 This Google Cloud example uses one client for all three services. Replace `https://sim.example.com` with your Sim origin and add only the callbacks for services you enable.
 

--- a/apps/docs/content/docs/search/google-calendar.mdx
+++ b/apps/docs/content/docs/search/google-calendar.mdx
@@ -41,7 +41,7 @@ Keep the default date range for the previous and next 30 days. **More options** 
 </Step>
 </Steps>
 
-<Image src="/static/search/google-calendar-setup.jpg" alt="Google Calendar Search source configuration" width={520} height={397} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/google-calendar-setup.jpg" alt="Google Calendar Search source configuration" width={520} height={397} />
 
 <Callout type="info">
   `primary` means the connected person's main calendar. A calendar selected from the list is a specific calendar ID, even when it is your main calendar. That same ID applies to every member, and only members with access to it can search its events.
@@ -100,7 +100,7 @@ The deployment operator configures Google OAuth once; teammates then use the nor
 https://<your-sim-domain>/api/auth/oauth2/callback/google-calendar
 ```
 
-<Image src="/static/search/google-oauth-web-client.png" alt="Google Cloud Web application client form with Sim's Gmail, Calendar, and Drive callback URLs" width={768} height={929} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/google-oauth-web-client.png" alt="Google Cloud Web application client form with Sim's Gmail, Calendar, and Drive callback URLs" width={768} height={929} />
 
 This Google Cloud example uses one client for all three services. Replace `https://sim.example.com` with your Sim origin and add only the callbacks for services you enable.
 

--- a/apps/docs/content/docs/search/google-drive.mdx
+++ b/apps/docs/content/docs/search/google-drive.mdx
@@ -56,7 +56,7 @@ Open **Settings → Sources → Google Drive → Sources → Add source**. This 
 
 This requires a Google Workspace domain and a Workspace super administrator to authorize domain-wide delegation. Consumer Gmail accounts cannot use this path.
 
-<Image src="/static/search/google-drive-setup.jpg" alt="Google Drive central source setup with an indexing account, sharing policy, and folder scope" width={520} height={404} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/google-drive-setup.jpg" alt="Google Drive central source setup with an indexing account, sharing policy, and folder scope" width={520} height={404} />
 
 <Steps>
 <Step>
@@ -65,11 +65,11 @@ This requires a Google Workspace domain and a Workspace super administrator to a
 
 In [Google Cloud Console](https://console.cloud.google.com/), select your project and enable **Google Drive API** and **Admin SDK API** under **APIs & Services → Library**. Then open **IAM & Admin → Service Accounts → Create service account**, enter a name, and finish creation. Google Cloud project roles do not grant access to Workspace files; they are not required for this crawl.
 
-<Image src="/static/search/google-create-service-account.png" alt="Google Cloud Console form for creating a service account" width={1024} height={735} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/google-create-service-account.png" alt="Google Cloud Console form for creating a service account" width={1024} height={735} />
 
 Open the service account's **Keys** tab and choose **Add key → Create new key → JSON**, then select **Create** to download the key. Store it securely; you will add it to Sim next. See [Google's key creation guide](https://docs.cloud.google.com/iam/docs/keys-create-delete#creating).
 
-<Image src="/static/search/google-create-private-key.png" alt="Google Cloud Create private key dialog with JSON selected" width={1024} height={502} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/google-create-private-key.png" alt="Google Cloud Create private key dialog with JSON selected" width={1024} height={502} />
 
 </Step>
 <Step>
@@ -78,7 +78,7 @@ Open the service account's **Keys** tab and choose **Add key → Create new key 
 
 In the service account's **Details**, expand **Advanced settings** and copy its numeric **Client ID**. Sign in to the [Workspace Admin Console](https://admin.google.com/ac/owl/domainwidedelegation) as a super administrator. Open **Security → Access and data control → API controls → Manage Domain Wide Delegation → Add new**.
 
-<Image src="/static/search/google-domain-delegation.png" alt="Google Workspace Admin Console Add a new client ID dialog with Client ID and OAuth scopes fields" width={768} height={929} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/google-domain-delegation.png" alt="Google Workspace Admin Console Add a new client ID dialog with Client ID and OAuth scopes fields" width={768} height={929} />
 
 Paste that Client ID into **Client ID**, then enter these exact scopes as a comma-separated list under **OAuth scopes**:
 
@@ -97,7 +97,7 @@ These are Search's central crawl scopes. The general [Google service account gui
 
 Under **Indexing account**, choose the service-account connection action, or select an existing service account. Paste the JSON key into **Add Google Service Account**, give it a name, and add it. Sim returns you to the source form with that credential selected.
 
-<Image src="/static/search/google-service-account.jpg" alt="Add Google Service Account credential modal in Sim" width={520} height={562} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/google-service-account.jpg" alt="Add Google Service Account credential modal in Sim" width={520} height={562} />
 
 </Step>
 <Step>
@@ -146,7 +146,7 @@ The deployment operator configures Google OAuth for member accounts and **Accoun
 https://<your-sim-domain>/api/auth/oauth2/callback/google-drive
 ```
 
-<Image src="/static/search/google-oauth-web-client.png" alt="Google Cloud Web application client form with Sim's Gmail, Calendar, and Drive callback URLs" width={768} height={929} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/google-oauth-web-client.png" alt="Google Cloud Web application client form with Sim's Gmail, Calendar, and Drive callback URLs" width={768} height={929} />
 
 This Google Cloud example uses one client for all three services. Replace `https://sim.example.com` with your Sim origin and add only the callbacks for services you enable.
 

--- a/apps/docs/content/docs/search/index.mdx
+++ b/apps/docs/content/docs/search/index.mdx
@@ -39,7 +39,7 @@ Open **Integrations** in the main sidebar and select **Connect account** if prom
 </Step>
 </Steps>
 
-<Image src="/static/search/add-source.jpg" alt="Organization Sources settings with the Add integration action" width={738} height={720} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/add-source.jpg" alt="Organization Sources settings with the Add integration action" width={738} height={720} />
 
 Source availability depends on the deployment and organization policy. An unavailable source needs operator configuration before setup can continue.
 
@@ -84,13 +84,13 @@ These requests are separate from organization invitations. They let recipients c
 
 **Revoke all account access** withdraws every account that person contributed to the organization, including other providers. It does not remove their organization membership.
 
-<Image src="/static/search/request-connections.jpg" alt="Request Gmail connections with an Emails field and Send requests action" width={520} height={290} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/request-connections.jpg" alt="Request Gmail connections with an Emails field and Send requests action" width={520} height={290} />
 
 ## Manage sources and documents
 
 Open **Settings → Sources → [integration]**, then select a source. Providers with personal connections have **Sources** and **Accounts** tabs; providers such as GitLab open directly to the source list. Multiple sources can have different folder, repository, space, or project scopes.
 
-<Image src="/static/search/integration-provider.jpg" alt="Integration detail with Sources and Accounts tabs and a nested source list" width={738} height={390} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/integration-provider.jpg" alt="Integration detail with Sources and Accounts tabs and a nested source list" width={738} height={390} />
 
 | Source tab | What you can do |
 | --- | --- |
@@ -100,9 +100,9 @@ Open **Settings → Sources → [integration]**, then select a source. Providers
 
 Use the source header to sync, pause, resume, or remove that source. The back link returns to its integration. **Deactivate** on the integration page makes its content unavailable in Search, Assistant, and MCP while preserving its sources and connected accounts; **Activate** enables it again.
 
-<Image src="/static/search/source-settings.jpg" alt="Gmail source Settings tab with label, date range, and search filters" width={1022} height={680} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/source-settings.jpg" alt="Gmail source Settings tab with label, date range, and search filters" width={1022} height={680} />
 
-<Image src="/static/search/source-sync-history.jpg" alt="Source Sync history with no connected accounts or synced members" width={1022} height={430} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/source-sync-history.jpg" alt="Source Sync history with no connected accounts or synced members" width={1022} height={430} />
 
 ## Search, Assistant, and MCP
 
@@ -141,7 +141,7 @@ A completed sync means the source was checked; some documents may still be index
 
 As an admin, open **Settings → Sources → [integration] → Sources → [source]**. In **Documents**, select **Failed** from the status dropdown to inspect those files. Use the search field to find a document by name. Select **Retry indexing** beside a file to try again. **Exclude** removes a file from search; select **Excluded** and then **Restore** to include it again. Fix a disconnected account or source configuration before retrying a sync that needs attention.
 
-<Image src="/static/search/source-documents.jpg" alt="Empty source Documents tab with search and an Included status filter" width={1022} height={430} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="/static/search/source-documents.jpg" alt="Empty source Documents tab with search and an Included status filter" width={1022} height={430} />
 
 Temporary indexing-capacity waits retry automatically in the background. If automatic retries are exhausted, the document appears as failed so an admin can retry it. Other searchable documents remain available while this work finishes.
 

--- a/apps/docs/content/docs/search/jira.mdx
+++ b/apps/docs/content/docs/search/jira.mdx
@@ -45,7 +45,7 @@ If you already know the project keys, use the switch beside **Projects** to sele
 
 **Account for browsing** only populates the project picker. It does not enroll you or share that account's issue access with teammates.
 
-<Image
+<Image className="mx-auto h-auto w-full max-w-md"
   src="/static/search/jira-setup.jpg"
   alt="Jira source setup with an account for browsing and required site and project fields"
   width={520}
@@ -110,7 +110,7 @@ First, open a missing issue in Jira using the same account you connected to Sim.
 
 For company-managed projects, an admin can open **Settings → System → Admin Helper → Permission Helper**, enter the affected user and issue key, and check **Browse Projects**. The result explains which permission condition failed. Fix access in Jira, then let the next Sim sync finish. See Atlassian's [Permission Helper instructions](https://support.atlassian.com/jira-cloud-administration/docs/check-a-users-access-from-a-work-item/) and [illustrated permissions tutorial](https://www.atlassian.com/software/jira/guides/permissions/tutorials).
 
-<Image
+<Image className="mx-auto h-auto w-full max-w-xl"
   src="https://dam-cdn.atl.orangelogic.com/AssetLink/3ud2hh403t5og84cwcs2kp38cd6dn0d3.png"
   alt="Atlassian illustration of Jira's Permission helper with User and Issue fields and Browse Projects selected"
   width={2880}
@@ -127,7 +127,7 @@ The deployment operator configures one shared Jira OAuth integration. Teammates 
 1. Open the [Atlassian developer console](https://developer.atlassian.com/console/myapps/) and select your deployment's **OAuth 2.0 integration**, or create one for the deployment.
 2. Under **Authorization**, configure **OAuth 2.0 (3LO)**. Add `https://<your-sim-domain>/api/auth/oauth2/callback/jira` to **Callback URLs**, keeping any callbacks already used by your deployment, then save.
 
-   <Image
+   <Image className="mx-auto h-auto w-full max-w-md"
      src="/static/search/atlassian-oauth-callback.png"
      alt="Atlassian OAuth Authorization form with an example Sim Jira callback URL"
      width={768}

--- a/apps/docs/content/docs/search/slack.mdx
+++ b/apps/docs/content/docs/search/slack.mdx
@@ -8,7 +8,7 @@ import { Image } from '@/components/ui/image'
 
 Slack Search indexes channel messages and threads. A Sim organization admin configures your Slack app once, then each teammate authorizes their own Slack account. Their results are limited to the selected public channels and private channels they can access. DMs and group DMs are not indexed.
 
-<Image src="/static/search/slack-setup.jpg" alt="Slack app setup for Sim Search with application and client credential fields" width={520} height={502} />
+<Image className="mx-auto h-auto w-full max-w-md" src="/static/search/slack-setup.jpg" alt="Slack app setup for Sim Search with application and client credential fields" width={520} height={502} />
 
 ## Before you start
 
@@ -34,7 +34,7 @@ Open **Settings → Sources → Add integration** and choose **Slack**. Select *
 
 On the [Slack Apps page](https://api.slack.com/apps), create an app for the target workspace, or use an app dedicated to your Sim organization. Under **OAuth & Permissions**, add the user scopes and both redirect URLs listed below. Keep **Token Rotation** disabled.
 
-<Image src="https://docs.slack.dev/assets/images/basic-information-page-e7d531fe4721830376d61a91de5d933e.png" alt="Slack app settings showing Basic Information and App Credentials" width={2692} height={1538} />
+<Image className="mx-auto h-auto w-full max-w-xl" src="https://docs.slack.dev/assets/images/basic-information-page-e7d531fe4721830376d61a91de5d933e.png" alt="Slack app settings showing Basic Information and App Credentials" width={2692} height={1538} />
 
 *Official Slack example: [Basic Information](https://docs.slack.dev/tools/bolt-python/creating-an-app/#create-a-new-app). Use your own app's credentials.*
 


### PR DESCRIPTION
## Summary

- Cap dialog and portrait screenshots at 448px and wider screenshots at 576px across the Search guides.
- Preserve responsive sizing, aspect ratios, original image quality, and the existing media viewer.

## Type of Change

- [x] Improvement

## Testing

Checked all 32 screenshots across 10 guides at desktop and 390px mobile widths, verified the image viewer, and confirmed no image overflow. Documentation type checking, lint, all 46 audits, block registry, and docs manifest checks pass. Only image display classes changed; original assets and guide content are unchanged.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing (presentation-only change; verified in the browser)
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
