### PR TITLE
fix(docs): preserve tool outputs and nullable types

### DIFF
--- a/apps/docs/content/docs/integrations/affinity.mdx
+++ b/apps/docs/content/docs/integrations/affinity.mdx
@@ -5,7 +5,7 @@ description: Read and write companies, people, lists, notes, and relationships i
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="affinity"
   color="#1B1C1E"
 />
@@ -123,9 +123,9 @@ Add a selectable option to a dropdown field on a list. A ranked or status option
 | `text` | string | The option label |
 | `type` | string | dropdown, ranked-dropdown, or status-dropdown |
 | `rank` | number | Sort order, on ranked and status options |
-| `color` | string | white, gray, blue, green, purple, orange, or red |
+| `color` | string (nullable) | white, gray, blue, green, purple, orange, or red |
 | `statusCategory` | string | open, won, lost, or on-hold, on status options |
-| `winRate` | number | Win rate of a status option |
+| `winRate` | number (nullable) | Win rate of a status option |
 
 ### Affinity Create Merge
 
@@ -175,13 +175,13 @@ Write a note — attached to companies, persons, and opportunities, anchored to 
 | `content` | json | The note body as \{html\} |
 | `creator` | object | Person who authored the note |
 |   ↳ `id` | number | The person's unique identifier |
-|   ↳ `firstName` | string | The person's first name |
-|   ↳ `lastName` | string | The person's last name |
-|   ↳ `primaryEmailAddress` | string | The person's primary email address |
+|   ↳ `firstName` | string (nullable) | The person's first name |
+|   ↳ `lastName` | string (nullable) | The person's last name |
+|   ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |   ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 | `mentions` | array | Persons mentioned in the note body |
 | `createdAt` | string | When the note was created |
-| `updatedAt` | string | When the note was last updated |
+| `updatedAt` | string (nullable) | When the note was last updated |
 | `repliesCount` | number | Number of replies, on root notes only |
 | `parent` | json | The note being replied to, on reply notes only |
 | `interaction` | json | The meeting, call, chat message, or email the note is anchored to |
@@ -215,18 +215,18 @@ Create a reminder on one company, person, or opportunity. A recurring reminder r
 | `id` | number | The reminder's unique identifier |
 | `type` | string | one-time or recurring |
 | `status` | string | active, overdue, or completed |
-| `content` | string | The reminder text |
+| `content` | string (nullable) | The reminder text |
 | `dueDate` | string | When the reminder is due |
 | `creator` | json | User who created the reminder, as \{id\} |
 | `owner` | json | User the reminder is assigned to, as \{id\} |
-| `completer` | json | User who completed it, as \{id\} |
-| `company` | json | Tagged company, as \{id\} |
-| `person` | json | Tagged person, as \{id\} |
-| `opportunity` | json | Tagged opportunity, as \{id\} |
-| `completedAt` | string | When the reminder was completed |
-| `recurrence` | json | Recurrence as \{resetTrigger, periodDays\}, null on a one-time reminder |
+| `completer` | json (nullable) | User who completed it, as \{id\} |
+| `company` | json (nullable) | Tagged company, as \{id\} |
+| `person` | json (nullable) | Tagged person, as \{id\} |
+| `opportunity` | json (nullable) | Tagged opportunity, as \{id\} |
+| `completedAt` | string (nullable) | When the reminder was completed |
+| `recurrence` | json (nullable) | Recurrence as \{resetTrigger, periodDays\}, null on a one-time reminder |
 | `createdAt` | string | When the reminder was created |
-| `updatedAt` | string | When the reminder was last updated |
+| `updatedAt` | string (nullable) | When the reminder was last updated |
 
 ### Affinity Delete List Field Dropdown Option
 
@@ -285,14 +285,14 @@ Look up one company by ID. Field data is returned only for the Field IDs or Fiel
 | --------- | ---- | ----------- |
 | `id` | number | The company's unique identifier |
 | `name` | string | The company name |
-| `domain` | string | The primary domain |
+| `domain` | string (nullable) | The primary domain |
 | `domains` | array | Every domain associated with the company |
 | `isGlobal` | boolean | Whether this is an Affinity Data global company profile |
 | `fields` | array | Requested field values. Absent unless Field IDs or Field Types was supplied |
 |   ↳ `id` | string | The field's unique identifier |
 |   ↳ `name` | string | The field name |
 |   ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|   ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|   ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |   ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 
 ### Affinity Get Current User
@@ -316,7 +316,7 @@ Verify an Affinity API key and return the tenant, the user behind the key, and t
 | `user` | object | The user the key authenticates as |
 |   ↳ `id` | number | The user's unique identifier |
 |   ↳ `firstName` | string | The user's first name |
-|   ↳ `lastName` | string | The user's last name |
+|   ↳ `lastName` | string (nullable) | The user's last name |
 |   ↳ `emailAddress` | string | The user's email address |
 | `grant` | object | How the request is authenticated and what it may reach |
 |   ↳ `type` | string | api-key or access-token |
@@ -343,7 +343,7 @@ Read one non-list field value from a company or person.
 | `id` | string | The field's unique identifier |
 | `name` | string | The field name |
 | `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-| `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+| `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 | `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 
 ### Affinity Get List
@@ -391,7 +391,7 @@ Read one row of a list with its entity. Field data is returned only for the Fiel
 | `type` | string | company, person, or opportunity |
 | `listId` | number | The list the entry belongs to |
 | `createdAt` | string | When the entity was added to the list |
-| `creatorId` | number | User who added the entity |
+| `creatorId` | number (nullable) | User who added the entity |
 | `entity` | json | The company, person, or opportunity on the row, including its field values |
 
 ### Affinity Get List Entry Field
@@ -414,7 +414,7 @@ Read one field value on a list row.
 | `id` | string | The field's unique identifier |
 | `name` | string | The field name |
 | `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-| `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+| `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 | `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 
 ### Affinity Get List Field Dropdown Option
@@ -438,9 +438,9 @@ Read one dropdown option on a list field.
 | `text` | string | The option label |
 | `type` | string | dropdown, ranked-dropdown, or status-dropdown |
 | `rank` | number | Sort order, on ranked and status options |
-| `color` | string | white, gray, blue, green, purple, orange, or red |
+| `color` | string (nullable) | white, gray, blue, green, purple, orange, or red |
 | `statusCategory` | string | open, won, lost, or on-hold, on status options |
-| `winRate` | number | Win rate of a status option |
+| `winRate` | number (nullable) | Win rate of a status option |
 
 ### Affinity Get Merge
 
@@ -462,8 +462,8 @@ Read the status of one company or person merge, including why it failed if it di
 | `status` | string | in-progress, success, or failed |
 | `taskId` | string | Task that groups this merge with its siblings |
 | `startedAt` | string | When the merge started |
-| `completedAt` | string | When the merge finished |
-| `errorMessage` | string | Why the merge failed |
+| `completedAt` | string (nullable) | When the merge finished |
+| `errorMessage` | string (nullable) | Why the merge failed |
 | `primaryCompanyId` | number | Company kept by a company merge |
 | `duplicateCompanyId` | number | Company folded in by a company merge |
 | `primaryPersonId` | number | Person kept by a person merge |
@@ -510,13 +510,13 @@ Read one note with its body, author, mentions, and attached records.
 | `content` | json | The note body as \{html\} |
 | `creator` | object | Person who authored the note |
 |   ↳ `id` | number | The person's unique identifier |
-|   ↳ `firstName` | string | The person's first name |
-|   ↳ `lastName` | string | The person's last name |
-|   ↳ `primaryEmailAddress` | string | The person's primary email address |
+|   ↳ `firstName` | string (nullable) | The person's first name |
+|   ↳ `lastName` | string (nullable) | The person's last name |
+|   ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |   ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 | `mentions` | array | Persons mentioned in the note body |
 | `createdAt` | string | When the note was created |
-| `updatedAt` | string | When the note was last updated |
+| `updatedAt` | string (nullable) | When the note was last updated |
 | `repliesCount` | number | Number of replies, on root notes only |
 | `parent` | json | The note being replied to, on reply notes only |
 | `interaction` | json | The meeting, call, chat message, or email the note is anchored to |
@@ -566,15 +566,15 @@ Look up one person by ID. Field data is returned only for the Field IDs or Field
 | --------- | ---- | ----------- |
 | `id` | number | The person's unique identifier |
 | `firstName` | string | The person's first name |
-| `lastName` | string | The person's last name |
-| `primaryEmailAddress` | string | The person's primary email address |
+| `lastName` | string (nullable) | The person's last name |
+| `primaryEmailAddress` | string (nullable) | The person's primary email address |
 | `emailAddresses` | array | Every email address on the person |
 | `type` | string | Whether the person is internal or external |
 | `fields` | array | Requested field values. Absent unless Field IDs or Field Types was supplied |
 |   ↳ `id` | string | The field's unique identifier |
 |   ↳ `name` | string | The field name |
 |   ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|   ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|   ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |   ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 
 ### Affinity Get Saved View
@@ -636,10 +636,10 @@ Read one internal user. A user and their person record share the same numeric ID
 | --------- | ---- | ----------- |
 | `id` | number | The user's unique identifier, shared with their person ID |
 | `firstName` | string | The user's first name |
-| `lastName` | string | The user's last name |
-| `primaryEmailAddress` | string | The user's primary email address |
+| `lastName` | string (nullable) | The user's last name |
+| `primaryEmailAddress` | string (nullable) | The user's primary email address |
 | `emailAddresses` | array | Every email address, for callers with the Manage Users permission |
-| `photoUrl` | string | URL of the user's photo |
+| `photoUrl` | string (nullable) | URL of the user's photo |
 | `status` | string | active, invited, or deactivated |
 | `role` | string | Account role, for callers with the Manage Users permission |
 
@@ -663,17 +663,17 @@ Page through logged calls and their participants. Only calls the API key holder 
 | `calls` | array | Logged calls, newest page first |
 |   ↳ `id` | number | The call's unique identifier |
 |   ↳ `loggingType` | string | How the call was logged |
-|   ↳ `title` | string | The call title |
+|   ↳ `title` | string (nullable) | The call title |
 |   ↳ `startTime` | string | When the call started |
-|   ↳ `endTime` | string | When the call ended |
+|   ↳ `endTime` | string (nullable) | When the call ended |
 |   ↳ `allDay` | boolean | Whether the call spans the whole day |
-|   ↳ `creator` | json | Who logged the call |
+|   ↳ `creator` | json (nullable) | Who logged the call |
 |   ↳ `createdAt` | string | When the record was created |
-|   ↳ `updatedAt` | string | When the record was last updated |
+|   ↳ `updatedAt` | string (nullable) | When the record was last updated |
 |   ↳ `attendeesPreview` | json | Attendees, with a total count |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Chat Messages
 
@@ -699,16 +699,16 @@ Page through logged chat messages and their participants. Only messages the API 
 |   ↳ `direction` | string | sent or received |
 |   ↳ `creator` | object | Person who sent the message |
 |     ↳ `id` | number | The person's unique identifier |
-|     ↳ `firstName` | string | The person's first name |
-|     ↳ `lastName` | string | The person's last name |
-|     ↳ `primaryEmailAddress` | string | The person's primary email address |
+|     ↳ `firstName` | string (nullable) | The person's first name |
+|     ↳ `lastName` | string (nullable) | The person's last name |
+|     ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |     ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 |   ↳ `createdAt` | string | When the record was created |
-|   ↳ `updatedAt` | string | When the record was last updated |
+|   ↳ `updatedAt` | string (nullable) | When the record was last updated |
 |   ↳ `participantsPreview` | json | Participants, with a total count |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Companies
 
@@ -732,18 +732,18 @@ Page through companies. Companies come back without field data unless Field IDs 
 | `companies` | array | Companies with any requested field values |
 |   ↳ `id` | number | The company's unique identifier |
 |   ↳ `name` | string | The company name |
-|   ↳ `domain` | string | The primary domain |
+|   ↳ `domain` | string (nullable) | The primary domain |
 |   ↳ `domains` | array | Every domain associated with the company |
 |   ↳ `isGlobal` | boolean | Whether this is an Affinity Data global company profile |
 |   ↳ `fields` | array | Requested field values. Absent unless Field IDs or Field Types was supplied |
 |     ↳ `id` | string | The field's unique identifier |
 |     ↳ `name` | string | The field name |
 |     ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|     ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|     ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |     ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Coworker Connections
 
@@ -767,9 +767,9 @@ Find warm paths into a company through shared work history: who in your Affinity
 |   ↳ `target` | json | The person to reach, as \{fullName, title, linkedinUrl, currentCompany\} |
 |   ↳ `connections` | array | People in your Affinity data who might know the target, each with the inference that links them |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Emails
 
@@ -793,15 +793,15 @@ Page through email metadata — subject, participants, and timestamps. Affinity 
 |   ↳ `sentAt` | string | When the email was sent |
 |   ↳ `loggingType` | string | How the email was logged |
 |   ↳ `direction` | string | sent or received |
-|   ↳ `subject` | string | The subject line |
+|   ↳ `subject` | string (nullable) | The subject line |
 |   ↳ `createdAt` | string | When the record was created |
-|   ↳ `updatedAt` | string | When the record was last updated |
+|   ↳ `updatedAt` | string (nullable) | When the record was last updated |
 |   ↳ `from` | json | Sender, as \{emailAddress, person\} |
 |   ↳ `toParticipantsPreview` | json | To recipients, with a total count |
 |   ↳ `ccParticipantsPreview` | json | Cc recipients, with a total count |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Entity Field Values
 
@@ -827,11 +827,11 @@ Page through a company's or person's non-list field values. List fields are not 
 |   ↳ `id` | string | The field's unique identifier |
 |   ↳ `name` | string | The field name |
 |   ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|   ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|   ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |   ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Entity List Entries
 
@@ -856,16 +856,16 @@ Page through a company's or person's rows across every list, each carrying that 
 |   ↳ `listId` | number | The list the entry belongs to |
 |   ↳ `listName` | string | Name of that list |
 |   ↳ `createdAt` | string | When the entity was added to the list |
-|   ↳ `creatorId` | number | User who added the entity |
+|   ↳ `creatorId` | number (nullable) | User who added the entity |
 |   ↳ `fields` | array | Field values on the row, including list-specific fields |
 |     ↳ `id` | string | The field's unique identifier |
 |     ↳ `name` | string | The field name |
 |     ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|     ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|     ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |     ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Entity Lists
 
@@ -893,8 +893,8 @@ List every list a company or person appears on that the caller can view.
 |   ↳ `isPublic` | boolean | Whether the list is visible to the organization |
 |   ↳ `createdAt` | string | When the list was created |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Entity Notes
 
@@ -922,13 +922,13 @@ List the notes relevant to one company, person, or opportunity — directly atta
 |   ↳ `content` | json | The note body as \{html\} |
 |   ↳ `creator` | object | Person who authored the note |
 |     ↳ `id` | number | The person's unique identifier |
-|     ↳ `firstName` | string | The person's first name |
-|     ↳ `lastName` | string | The person's last name |
-|     ↳ `primaryEmailAddress` | string | The person's primary email address |
+|     ↳ `firstName` | string (nullable) | The person's first name |
+|     ↳ `lastName` | string (nullable) | The person's last name |
+|     ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |     ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 |   ↳ `mentions` | array | Persons mentioned in the note body |
 |   ↳ `createdAt` | string | When the note was created |
-|   ↳ `updatedAt` | string | When the note was last updated |
+|   ↳ `updatedAt` | string (nullable) | When the note was last updated |
 |   ↳ `repliesCount` | number | Number of replies, on root notes only |
 |   ↳ `parent` | json | The note being replied to, on reply notes only |
 |   ↳ `interaction` | json | The meeting, call, chat message, or email the note is anchored to |
@@ -937,9 +937,9 @@ List the notes relevant to one company, person, or opportunity — directly atta
 |   ↳ `companiesPreview` | json | Attached companies, with a count |
 |   ↳ `opportunitiesPreview` | json | Attached opportunities, with a count |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Entity Relationships
 
@@ -965,22 +965,22 @@ List who knows a company or person, scored 0.0 to 1.0 by how much the two actual
 | `relationships` | array | Scored relationships involving the entity |
 |   ↳ `person1` | object | One side of the relationship |
 |     ↳ `id` | number | The person's unique identifier |
-|     ↳ `firstName` | string | The person's first name |
-|     ↳ `lastName` | string | The person's last name |
-|     ↳ `primaryEmailAddress` | string | The person's primary email address |
+|     ↳ `firstName` | string (nullable) | The person's first name |
+|     ↳ `lastName` | string (nullable) | The person's last name |
+|     ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |     ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 |   ↳ `person2` | object | The other side of the relationship |
 |     ↳ `id` | number | The person's unique identifier |
-|     ↳ `firstName` | string | The person's first name |
-|     ↳ `lastName` | string | The person's last name |
-|     ↳ `primaryEmailAddress` | string | The person's primary email address |
+|     ↳ `firstName` | string (nullable) | The person's first name |
+|     ↳ `lastName` | string (nullable) | The person's last name |
+|     ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |     ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 |   ↳ `interactionScore` | number | Strength of the relationship, between 0.0 and 1.0 |
-|   ↳ `linkedIn` | json | When the two connected on LinkedIn, as \{connectedOn\} |
+|   ↳ `linkedIn` | json (nullable) | When the two connected on LinkedIn, as \{connectedOn\} |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Field Dropdown Options
 
@@ -1005,12 +1005,12 @@ List the selectable options on a dropdown or ranked-dropdown company or person f
 |   ↳ `text` | string | The option label |
 |   ↳ `type` | string | dropdown, ranked-dropdown, or status-dropdown |
 |   ↳ `rank` | number | Sort order, on ranked and status options |
-|   ↳ `color` | string | white, gray, blue, green, purple, orange, or red |
+|   ↳ `color` | string (nullable) | white, gray, blue, green, purple, orange, or red |
 |   ↳ `statusCategory` | string | open, won, lost, or on-hold, on status options |
-|   ↳ `winRate` | number | Win rate of a status option |
+|   ↳ `winRate` | number (nullable) | Win rate of a status option |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Field Metadata
 
@@ -1035,14 +1035,14 @@ List the non-list company or person fields, with the value type, filter operator
 |   ↳ `id` | string | The field's unique identifier |
 |   ↳ `name` | string | The field name |
 |   ↳ `type` | string | enriched, global, list, or relationship-intelligence |
-|   ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|   ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |   ↳ `valueType` | string | The value shape: person, person-multi, company, company-multi, filterable-text, filterable-text-multi, number, number-multi, datetime, location, location-multi, text, ranked-dropdown, dropdown, dropdown-multi, formula-number, or interaction |
-|   ↳ `createdAt` | string | When the field was created |
-|   ↳ `filterability` | json | Supported filter operators, or the attributes that can be filtered on. Only present when requested through Includes |
-|   ↳ `sortability` | json | Whether the field can be sorted on, and by which attributes. Only present when requested through Includes |
+|   ↳ `createdAt` | string (nullable) | When the field was created |
+|   ↳ `filterability` | json (nullable) | Supported filter operators, or the attributes that can be filtered on. Only present when requested through Includes |
+|   ↳ `sortability` | json (nullable) | Whether the field can be sorted on, and by which attributes. Only present when requested through Includes |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Field Value Changes
 
@@ -1067,14 +1067,14 @@ Page through field value changes across the whole workspace. Built for delta syn
 |   ↳ `type` | string | The value type the change applies to |
 |   ↳ `field` | json | The changed field as \{id, entityType, name, type\} |
 |   ↳ `entity` | json | The entity whose field changed, as \{id\} |
-|   ↳ `listEntry` | json | The list entry the change happened on, for list fields |
-|   ↳ `changer` | json | User who made the change |
+|   ↳ `listEntry` | json (nullable) | The list entry the change happened on, for list fields |
+|   ↳ `changer` | json (nullable) | User who made the change |
 |   ↳ `changedAt` | string | When the change happened |
 |   ↳ `actionType` | string | add, update, or delete |
 |   ↳ `value` | json | The value that was added, set, or removed |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Investor Executive Connections
 
@@ -1098,9 +1098,9 @@ Find warm paths into a company through investment history: which investors in yo
 |   ↳ `target` | json | The person to reach, as \{fullName, title, linkedinUrl, currentCompany\} |
 |   ↳ `connections` | array | People in your Affinity data who might know the target, each with the inference that links them |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List List Entries
 
@@ -1126,11 +1126,11 @@ Page through the rows of a list. Rows come back without field data unless Field 
 |   ↳ `type` | string | company, person, or opportunity |
 |   ↳ `listId` | number | The list the entry belongs to |
 |   ↳ `createdAt` | string | When the entity was added to the list |
-|   ↳ `creatorId` | number | User who added the entity |
+|   ↳ `creatorId` | number (nullable) | User who added the entity |
 |   ↳ `entity` | json | The company, person, or opportunity on the row, including its field values |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List List Entry Field Value Changes
 
@@ -1156,14 +1156,14 @@ Page through the history of one list row — who changed which field, when, and 
 |   ↳ `type` | string | The value type the change applies to |
 |   ↳ `field` | json | The changed field as \{id, entityType, name, type\} |
 |   ↳ `entity` | json | The entity whose field changed, as \{id\} |
-|   ↳ `listEntry` | json | The list entry the change happened on, for list fields |
-|   ↳ `changer` | json | User who made the change |
+|   ↳ `listEntry` | json (nullable) | The list entry the change happened on, for list fields |
+|   ↳ `changer` | json (nullable) | User who made the change |
 |   ↳ `changedAt` | string | When the change happened |
 |   ↳ `actionType` | string | add, update, or delete |
 |   ↳ `value` | json | The value that was added, set, or removed |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List List Entry Fields
 
@@ -1189,11 +1189,11 @@ Page through every field value on one list row, including the list-specific colu
 |   ↳ `id` | string | The field's unique identifier |
 |   ↳ `name` | string | The field name |
 |   ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|   ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|   ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |   ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List List Field Dropdown Options
 
@@ -1218,12 +1218,12 @@ List the selectable options on a dropdown, ranked-dropdown, or status-dropdown f
 |   ↳ `text` | string | The option label |
 |   ↳ `type` | string | dropdown, ranked-dropdown, or status-dropdown |
 |   ↳ `rank` | number | Sort order, on ranked and status options |
-|   ↳ `color` | string | white, gray, blue, green, purple, orange, or red |
+|   ↳ `color` | string (nullable) | white, gray, blue, green, purple, orange, or red |
 |   ↳ `statusCategory` | string | open, won, lost, or on-hold, on status options |
-|   ↳ `winRate` | number | Win rate of a status option |
+|   ↳ `winRate` | number (nullable) | Win rate of a status option |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List List Fields
 
@@ -1248,14 +1248,14 @@ List the fields available on one list, including its list-specific columns. Use 
 |   ↳ `id` | string | The field's unique identifier |
 |   ↳ `name` | string | The field name |
 |   ↳ `type` | string | enriched, global, list, or relationship-intelligence |
-|   ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|   ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |   ↳ `valueType` | string | The value shape: person, person-multi, company, company-multi, filterable-text, filterable-text-multi, number, number-multi, datetime, location, location-multi, text, ranked-dropdown, dropdown, dropdown-multi, formula-number, or interaction |
-|   ↳ `createdAt` | string | When the field was created |
-|   ↳ `filterability` | json | Supported filter operators, or the attributes that can be filtered on. Only present when requested through Includes |
-|   ↳ `sortability` | json | Whether the field can be sorted on, and by which attributes. Only present when requested through Includes |
+|   ↳ `createdAt` | string (nullable) | When the field was created |
+|   ↳ `filterability` | json (nullable) | Supported filter operators, or the attributes that can be filtered on. Only present when requested through Includes |
+|   ↳ `sortability` | json (nullable) | Whether the field can be sorted on, and by which attributes. Only present when requested through Includes |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Lists
 
@@ -1283,8 +1283,8 @@ Page through the lists in the organization that the caller can view.
 |   ↳ `createdAt` | string | When the list was created |
 |   ↳ `type` | string | company, opportunity, or person — the entity kind the list holds |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Meetings
 
@@ -1306,18 +1306,18 @@ Page through past and upcoming meetings with their organizer and attendees.
 | `meetings` | array | Meetings with their attendees |
 |   ↳ `id` | number | The call's unique identifier |
 |   ↳ `loggingType` | string | automated or manual |
-|   ↳ `title` | string | The call title |
+|   ↳ `title` | string (nullable) | The call title |
 |   ↳ `startTime` | string | When the call started |
-|   ↳ `endTime` | string | When the call ended |
+|   ↳ `endTime` | string (nullable) | When the call ended |
 |   ↳ `allDay` | boolean | Whether the call spans the whole day |
-|   ↳ `creator` | json | Who logged the call |
+|   ↳ `creator` | json (nullable) | Who logged the call |
 |   ↳ `createdAt` | string | When the record was created |
-|   ↳ `updatedAt` | string | When the record was last updated |
+|   ↳ `updatedAt` | string (nullable) | When the record was last updated |
 |   ↳ `attendeesPreview` | json | Attendees, with a total count |
-|   ↳ `organizer` | json | Who organized the meeting |
+|   ↳ `organizer` | json (nullable) | Who organized the meeting |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Merge Tasks
 
@@ -1342,8 +1342,8 @@ Page through merge tasks, each summarizing how many of its merges are in progres
 |   ↳ `status` | string | in-progress, success, or failed |
 |   ↳ `resultsSummary` | json | Counts of the grouped merges as \{total, inProgress, success, failed\} |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Merges
 
@@ -1368,15 +1368,15 @@ Page through the company or person merges the organization has run, with the sta
 |   ↳ `status` | string | in-progress, success, or failed |
 |   ↳ `taskId` | string | Task that groups this merge with its siblings |
 |   ↳ `startedAt` | string | When the merge started |
-|   ↳ `completedAt` | string | When the merge finished |
-|   ↳ `errorMessage` | string | Why the merge failed |
+|   ↳ `completedAt` | string (nullable) | When the merge finished |
+|   ↳ `errorMessage` | string (nullable) | Why the merge failed |
 |   ↳ `primaryCompanyId` | number | Company kept by a company merge |
 |   ↳ `duplicateCompanyId` | number | Company folded in by a company merge |
 |   ↳ `primaryPersonId` | number | Person kept by a person merge |
 |   ↳ `duplicatePersonId` | number | Person folded in by a person merge |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Note Attached Companies
 
@@ -1399,11 +1399,11 @@ List the companies directly attached to one note.
 | `companies` | array | Companies attached to the note |
 |   ↳ `id` | number | The company's unique identifier |
 |   ↳ `name` | string | The company name |
-|   ↳ `domain` | string | The company's primary domain |
+|   ↳ `domain` | string (nullable) | The company's primary domain |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Note Attached Opportunities
 
@@ -1431,9 +1431,9 @@ List the opportunities directly attached to one note.
 |   ↳ `isRestricted` | boolean | Whether list permissions restrict access to the opportunity |
 |   ↳ `isRedacted` | boolean | Whether the opportunity fields were redacted |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Note Attached Persons
 
@@ -1455,14 +1455,14 @@ List the persons directly attached to one note.
 | --------- | ---- | ----------- |
 | `persons` | array | Persons attached to the note |
 |   ↳ `id` | number | The person's unique identifier |
-|   ↳ `firstName` | string | The person's first name |
-|   ↳ `lastName` | string | The person's last name |
-|   ↳ `primaryEmailAddress` | string | The person's primary email address |
+|   ↳ `firstName` | string (nullable) | The person's first name |
+|   ↳ `lastName` | string (nullable) | The person's last name |
+|   ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |   ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Note Replies
 
@@ -1489,13 +1489,13 @@ Page through the replies on one note, including AI Notetaker replies.
 |   ↳ `content` | json | The note body as \{html\} |
 |   ↳ `creator` | object | Person who authored the note |
 |     ↳ `id` | number | The person's unique identifier |
-|     ↳ `firstName` | string | The person's first name |
-|     ↳ `lastName` | string | The person's last name |
-|     ↳ `primaryEmailAddress` | string | The person's primary email address |
+|     ↳ `firstName` | string (nullable) | The person's first name |
+|     ↳ `lastName` | string (nullable) | The person's last name |
+|     ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |     ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 |   ↳ `mentions` | array | Persons mentioned in the note body |
 |   ↳ `createdAt` | string | When the note was created |
-|   ↳ `updatedAt` | string | When the note was last updated |
+|   ↳ `updatedAt` | string (nullable) | When the note was last updated |
 |   ↳ `repliesCount` | number | Number of replies, on root notes only |
 |   ↳ `parent` | json | The note being replied to, on reply notes only |
 |   ↳ `interaction` | json | The meeting, call, chat message, or email the note is anchored to |
@@ -1504,9 +1504,9 @@ Page through the replies on one note, including AI Notetaker replies.
 |   ↳ `companiesPreview` | json | Attached companies, with a count |
 |   ↳ `opportunitiesPreview` | json | Attached opportunities, with a count |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Notes
 
@@ -1533,13 +1533,13 @@ Page through every note the caller can see. Replies are excluded.
 |   ↳ `content` | json | The note body as \{html\} |
 |   ↳ `creator` | object | Person who authored the note |
 |     ↳ `id` | number | The person's unique identifier |
-|     ↳ `firstName` | string | The person's first name |
-|     ↳ `lastName` | string | The person's last name |
-|     ↳ `primaryEmailAddress` | string | The person's primary email address |
+|     ↳ `firstName` | string (nullable) | The person's first name |
+|     ↳ `lastName` | string (nullable) | The person's last name |
+|     ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |     ↳ `type` | string | Whether the person is internal, a collaborator, or external |
 |   ↳ `mentions` | array | Persons mentioned in the note body |
 |   ↳ `createdAt` | string | When the note was created |
-|   ↳ `updatedAt` | string | When the note was last updated |
+|   ↳ `updatedAt` | string (nullable) | When the note was last updated |
 |   ↳ `repliesCount` | number | Number of replies, on root notes only |
 |   ↳ `parent` | json | The note being replied to, on reply notes only |
 |   ↳ `interaction` | json | The meeting, call, chat message, or email the note is anchored to |
@@ -1548,9 +1548,9 @@ Page through every note the caller can see. Replies are excluded.
 |   ↳ `companiesPreview` | json | Attached companies, with a count |
 |   ↳ `opportunitiesPreview` | json | Attached opportunities, with a count |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Opportunities
 
@@ -1577,8 +1577,8 @@ Page through opportunities. Field data lives on the list entry, not here — rea
 |   ↳ `isRestricted` | boolean | Whether list permissions restrict access to the opportunity |
 |   ↳ `isRedacted` | boolean | Whether the opportunity fields were redacted |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Persons
 
@@ -1602,19 +1602,19 @@ Page through persons. Persons come back without field data unless Field IDs or F
 | `persons` | array | Persons with any requested field values |
 |   ↳ `id` | number | The person's unique identifier |
 |   ↳ `firstName` | string | The person's first name |
-|   ↳ `lastName` | string | The person's last name |
-|   ↳ `primaryEmailAddress` | string | The person's primary email address |
+|   ↳ `lastName` | string (nullable) | The person's last name |
+|   ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |   ↳ `emailAddresses` | array | Every email address on the person |
 |   ↳ `type` | string | Whether the person is internal or external |
 |   ↳ `fields` | array | Requested field values. Absent unless Field IDs or Field Types was supplied |
 |     ↳ `id` | string | The field's unique identifier |
 |     ↳ `name` | string | The field name |
 |     ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|     ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|     ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |     ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Reminders
 
@@ -1638,22 +1638,22 @@ Page through the reminders the caller can see. Filter by status to surface what 
 |   ↳ `id` | number | The reminder's unique identifier |
 |   ↳ `type` | string | one-time or recurring |
 |   ↳ `status` | string | active, overdue, or completed |
-|   ↳ `content` | string | The reminder text |
+|   ↳ `content` | string (nullable) | The reminder text |
 |   ↳ `dueDate` | string | When the reminder is due |
 |   ↳ `creator` | json | User who created the reminder, as \{id\} |
 |   ↳ `owner` | json | User the reminder is assigned to, as \{id\} |
-|   ↳ `completer` | json | User who completed it, as \{id\} |
-|   ↳ `company` | json | Tagged company, as \{id\} |
-|   ↳ `person` | json | Tagged person, as \{id\} |
-|   ↳ `opportunity` | json | Tagged opportunity, as \{id\} |
-|   ↳ `completedAt` | string | When the reminder was completed |
-|   ↳ `recurrence` | json | Recurrence as \{resetTrigger, periodDays\}, null on a one-time reminder |
+|   ↳ `completer` | json (nullable) | User who completed it, as \{id\} |
+|   ↳ `company` | json (nullable) | Tagged company, as \{id\} |
+|   ↳ `person` | json (nullable) | Tagged person, as \{id\} |
+|   ↳ `opportunity` | json (nullable) | Tagged opportunity, as \{id\} |
+|   ↳ `completedAt` | string (nullable) | When the reminder was completed |
+|   ↳ `recurrence` | json (nullable) | Recurrence as \{resetTrigger, periodDays\}, null on a one-time reminder |
 |   ↳ `createdAt` | string | When the reminder was created |
-|   ↳ `updatedAt` | string | When the reminder was last updated |
+|   ↳ `updatedAt` | string (nullable) | When the reminder was last updated |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Saved View Entries
 
@@ -1678,11 +1678,11 @@ Page through the rows of a saved view. The view's own filters and columns decide
 |   ↳ `type` | string | company, person, or opportunity |
 |   ↳ `listId` | number | The list the entry belongs to |
 |   ↳ `createdAt` | string | When the entity was added to the list |
-|   ↳ `creatorId` | number | User who added the entity |
+|   ↳ `creatorId` | number (nullable) | User who added the entity |
 |   ↳ `entity` | json | The company, person, or opportunity on the row, including its field values |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Saved Views
 
@@ -1707,8 +1707,8 @@ List the saved views on a list that the caller can view.
 |   ↳ `type` | string | sheet, board, or dashboard |
 |   ↳ `createdAt` | string | When the saved view was created |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity List Transcript Fragments
 
@@ -1734,9 +1734,9 @@ Page through everything said in a meeting, segment by segment with the speaker.
 |   ↳ `startTimestamp` | string | When the segment starts |
 |   ↳ `endTimestamp` | string | When the segment ends |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Transcripts
 
@@ -1758,9 +1758,9 @@ Page through meeting transcript metadata. Read one transcript to get what was ac
 | --------- | ---- | ----------- |
 | `transcripts` | array | Transcript metadata, without the spoken content |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity List Users
 
@@ -1783,15 +1783,15 @@ Page through the internal users in the organization. Email addresses and roles a
 | `users` | array | Internal users in the organization |
 |   ↳ `id` | number | The user's unique identifier, shared with their person ID |
 |   ↳ `firstName` | string | The user's first name |
-|   ↳ `lastName` | string | The user's last name |
-|   ↳ `primaryEmailAddress` | string | The user's primary email address |
+|   ↳ `lastName` | string (nullable) | The user's last name |
+|   ↳ `primaryEmailAddress` | string (nullable) | The user's primary email address |
 |   ↳ `emailAddresses` | array | Every email address, for callers with the Manage Users permission |
-|   ↳ `photoUrl` | string | URL of the user's photo |
+|   ↳ `photoUrl` | string (nullable) | URL of the user's photo |
 |   ↳ `status` | string | active, invited, or deactivated |
 |   ↳ `role` | string | Account role, for callers with the Manage Users permission |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
 
 ### Affinity Search Companies
 
@@ -1819,19 +1819,19 @@ Search companies by filters, sorts, and a free-text term. Requires the "Export A
 | `companies` | array | Matching companies with any requested field values |
 |   ↳ `id` | number | The company's unique identifier |
 |   ↳ `name` | string | The company name |
-|   ↳ `domain` | string | The primary domain |
+|   ↳ `domain` | string (nullable) | The primary domain |
 |   ↳ `domains` | array | Every domain associated with the company |
 |   ↳ `isGlobal` | boolean | Whether this is an Affinity Data global company profile |
 |   ↳ `fields` | array | Requested field values. Absent unless Field IDs or Field Types was supplied |
 |     ↳ `id` | string | The field's unique identifier |
 |     ↳ `name` | string | The field name |
 |     ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|     ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|     ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |     ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity Search Files
 
@@ -1853,7 +1853,7 @@ Search files by keyword, ordered by relevance. Narrow to specific files or to on
 | --------- | ---- | ----------- |
 | `results` | array | Matching files, most relevant first |
 |   ↳ `file` | json | The matched file as \{id, name\} |
-|   ↳ `pageNumber` | number | Page the match was found on, for paginated documents |
+|   ↳ `pageNumber` | number (nullable) | Page the match was found on, for paginated documents |
 |   ↳ `preview` | string | Snippet of the file around the match |
 | `count` | number | Number of matches returned |
 
@@ -1886,12 +1886,12 @@ Search the rows of one list by filters, sorts, and a free-text term. Requires th
 |   ↳ `type` | string | company, person, or opportunity |
 |   ↳ `listId` | number | The list the entry belongs to |
 |   ↳ `createdAt` | string | When the entity was added to the list |
-|   ↳ `creatorId` | number | User who added the entity |
+|   ↳ `creatorId` | number (nullable) | User who added the entity |
 |   ↳ `entity` | json | The company, person, or opportunity on the row, including its field values |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity Search Notes
 
@@ -1942,20 +1942,20 @@ Search persons by filters, sorts, and a free-text term. Requires the "Export All
 | `persons` | array | Matching persons with any requested field values |
 |   ↳ `id` | number | The person's unique identifier |
 |   ↳ `firstName` | string | The person's first name |
-|   ↳ `lastName` | string | The person's last name |
-|   ↳ `primaryEmailAddress` | string | The person's primary email address |
+|   ↳ `lastName` | string (nullable) | The person's last name |
+|   ↳ `primaryEmailAddress` | string (nullable) | The person's primary email address |
 |   ↳ `emailAddresses` | array | Every email address on the person |
 |   ↳ `type` | string | Whether the person is internal or external |
 |   ↳ `fields` | array | Requested field values. Absent unless Field IDs or Field Types was supplied |
 |     ↳ `id` | string | The field's unique identifier |
 |     ↳ `name` | string | The field name |
 |     ↳ `type` | string | enriched, global, list, relationship-intelligence, or hidden |
-|     ↳ `enrichmentSource` | string | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
+|     ↳ `enrichmentSource` | string (nullable) | affinity-data, dealroom, eventbrite, or mailchimp for an enriched field |
 |     ↳ `value` | json | The typed value as \{type, data\}, where type names the value type \(person, company, dropdown, number, location, datetime, text, interaction, …\) and data carries the value or null |
 | `count` | number | Number of rows on this page |
-| `nextCursor` | string | Cursor for the next page, or null on the last page |
-| `prevCursor` | string | Cursor for the previous page, or null on the first page |
-| `totalCount` | number | Total size of the collection, only when Total Count was requested |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null on the last page |
+| `prevCursor` | string (nullable) | Cursor for the previous page, or null on the first page |
+| `totalCount` | number (nullable) | Total size of the collection, only when Total Count was requested |
 
 ### Affinity Semantic Search
 
@@ -1977,7 +1977,7 @@ Find companies from a description in plain language — industry, technology, st
 | `companies` | array | Matching companies, best match first |
 |   ↳ `id` | number | The company's unique identifier |
 |   ↳ `name` | string | The company name |
-|   ↳ `domain` | string | The company's primary domain |
+|   ↳ `domain` | string (nullable) | The company's primary domain |
 |   ↳ `domains` | array | Every domain associated with the company |
 |   ↳ `isGlobal` | boolean | Whether this is an Affinity Data global company profile |
 |   ↳ `score` | string | How well the company matched the prompt |
@@ -2073,5 +2073,3 @@ Rewrite a note's body or replace which records it is attached to. Each list of I
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether Affinity accepted the change |
 | `id` | string | Identifier of the resource that was changed |
-
-

--- a/apps/docs/content/docs/integrations/agentmail.mdx
+++ b/apps/docs/content/docs/integrations/agentmail.mdx
@@ -5,7 +5,7 @@ description: Manage email inboxes, threads, and messages with AgentMail
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="agentmail"
   color="#000000"
 />
@@ -573,5 +573,3 @@ Add or remove labels on an email thread in AgentMail
 | --------- | ---- | ----------- |
 | `threadId` | string | Unique identifier for the thread |
 | `labels` | array | Current labels on the thread |
-
-

--- a/apps/docs/content/docs/integrations/agentphone.mdx
+++ b/apps/docs/content/docs/integrations/agentphone.mdx
@@ -5,7 +5,7 @@ description: Provision numbers, send SMS and iMessage, and place voice calls wit
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="agentphone"
   color="linear-gradient(135deg, #1a1a1a 0%, #0a2a14 100%)"
 />
@@ -610,5 +610,3 @@ Update conversation metadata (stored state). Pass null to clear existing metadat
 |   ↳ `mediaUrl` | string | Media URL if any |
 |   ↳ `mediaUrls` | array | All attached media URLs |
 |   ↳ `receivedAt` | string | ISO 8601 timestamp |
-
-

--- a/apps/docs/content/docs/integrations/agiloft.mdx
+++ b/apps/docs/content/docs/integrations/agiloft.mdx
@@ -5,7 +5,7 @@ description: Manage records in Agiloft CLM
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="agiloft"
   color="#001028"
 />
@@ -475,5 +475,3 @@ Create an Agiloft record, or update it when a record already matches the given f
 | `id` | string | ID of the created or updated record |
 | `created` | boolean | True when a new record was created, false when an existing one was updated |
 | `callbackId` | string | Returned for a queued upsert; pass it to Async Status to poll the result |
-
-

--- a/apps/docs/content/docs/integrations/ahrefs.mdx
+++ b/apps/docs/content/docs/integrations/ahrefs.mdx
@@ -5,7 +5,7 @@ description: SEO analysis with Ahrefs
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="ahrefs"
   color="#FFFFFF"
 />
@@ -652,5 +652,3 @@ Get aggregate competitor stats for an Ahrefs Rank Tracker project: each competit
 |   ↳ `pos4To10` | number | Keywords ranking in positions 4-10 |
 |   ↳ `shareOfVoice` | number | Organic traffic share percentage |
 |   ↳ `shareOfTrafficValue` | number | Organic traffic value share percentage |
-
-

--- a/apps/docs/content/docs/integrations/airtable.mdx
+++ b/apps/docs/content/docs/integrations/airtable.mdx
@@ -5,7 +5,7 @@ description: Read, create, and update Airtable
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="airtable"
   color="#FFFFFF"
 />
@@ -266,8 +266,6 @@ Get the schema of all tables, fields, and views in an Airtable base
 | `tables` | json | Array of table schemas with fields and views |
 | `metadata` | json | Operation metadata including total tables count |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -315,4 +313,3 @@ Trigger workflow from Airtable record changes like create, update, and delete ev
 |   ↳ `recordId` | string | Record ID |
 |   ↳ `changeType` | string | Type of change \(created, changed, destroyed\) |
 |   ↳ `cellValuesByFieldId` | object | Cell values by field ID |
-

--- a/apps/docs/content/docs/integrations/airweave.mdx
+++ b/apps/docs/content/docs/integrations/airweave.mdx
@@ -5,7 +5,7 @@ description: Search your synced data collections
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="airweave"
   color="#6366F1"
 />
@@ -53,5 +53,3 @@ Search your synced data collections using Airweave. Supports semantic search wit
 |   ↳ `breadcrumbs` | array | Navigation path to the result within its source |
 |   ↳ `url` | string | URL to the original content |
 | `completion` | string | AI-generated answer to the query \(when generateAnswer is enabled\) |
-
-

--- a/apps/docs/content/docs/integrations/algolia.mdx
+++ b/apps/docs/content/docs/integrations/algolia.mdx
@@ -5,7 +5,7 @@ description: Search and manage Algolia indices
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="algolia"
   color="#003DFF"
 />
@@ -418,5 +418,3 @@ Check whether an Algolia indexing task has finished publishing
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | string | Task status: "published" once the operation has been applied, "notPublished" while still pending |
-
-

--- a/apps/docs/content/docs/integrations/amplitude.mdx
+++ b/apps/docs/content/docs/integrations/amplitude.mdx
@@ -5,7 +5,7 @@ description: Track events and query analytics from Amplitude
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="amplitude"
   color="#13294B"
 />
@@ -384,5 +384,3 @@ Measure how many users return to perform an action after a starting action.
 |   ↳ `values` | json | Per-cohort-date retention counts keyed by date |
 |   ↳ `combined` | json | Deduplicated aggregate retention across all cohorts |
 | `seriesMeta` | array | Segment/event index metadata for each series entry |
-
-

--- a/apps/docs/content/docs/integrations/apify.mdx
+++ b/apps/docs/content/docs/integrations/apify.mdx
@@ -5,7 +5,7 @@ description: Run Apify actors and retrieve results
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="apify"
   color="#FFFFFF"
 />
@@ -144,5 +144,3 @@ Get the status and details of an APIFY actor run
 | `datasetId` | string | Default dataset ID for the run |
 | `keyValueStoreId` | string | Default key-value store ID for the run |
 | `stats` | json | Run statistics \(memory, CPU, duration\) |
-
-

--- a/apps/docs/content/docs/integrations/apollo.mdx
+++ b/apps/docs/content/docs/integrations/apollo.mdx
@@ -5,7 +5,7 @@ description: Search, enrich, and manage contacts with Apollo.io
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="apollo"
   color="#EBF212"
 />
@@ -648,5 +648,3 @@ Get list of team's linked email accounts in Apollo
 | --------- | ---- | ----------- |
 | `email_accounts` | json | Array of team email accounts linked in Apollo |
 | `total` | number | Total count of email accounts |
-
-

--- a/apps/docs/content/docs/integrations/appconfig.mdx
+++ b/apps/docs/content/docs/integrations/appconfig.mdx
@@ -5,7 +5,7 @@ description: Manage and retrieve configuration with AWS AppConfig
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="appconfig"
   color="linear-gradient(45deg, #B0084D 0%, #FF4F8B 100%)"
 />
@@ -679,5 +679,3 @@ Stop an in-progress AWS AppConfig deployment
 | `message` | string | Operation status message |
 | `deploymentNumber` | number | Deployment sequence number |
 | `state` | string | Deployment state after stopping |
-
-

--- a/apps/docs/content/docs/integrations/arxiv.mdx
+++ b/apps/docs/content/docs/integrations/arxiv.mdx
@@ -5,7 +5,7 @@ description: Search and retrieve academic papers from ArXiv
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="arxiv"
   color="#FFFFFF"
 />
@@ -77,5 +77,3 @@ Search for papers by a specific author on ArXiv.
 | --------- | ---- | ----------- |
 | `authorPapers` | json | Array of papers authored by the specified author |
 | `totalResults` | number | Total number of papers found for the author |
-
-

--- a/apps/docs/content/docs/integrations/asana.mdx
+++ b/apps/docs/content/docs/integrations/asana.mdx
@@ -5,7 +5,7 @@ description: Interact with Asana
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="asana"
   color="#FFFFFF"
 />
@@ -381,5 +381,3 @@ List all sections in an Asana project
 |   ↳ `gid` | string | Section GID |
 |   ↳ `name` | string | Section name |
 |   ↳ `resource_type` | string | Resource type \(section\) |
-
-

--- a/apps/docs/content/docs/integrations/ashby.mdx
+++ b/apps/docs/content/docs/integrations/ashby.mdx
@@ -5,7 +5,7 @@ description: Manage candidates, jobs, and applications in Ashby
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="ashby"
   color="#5D4ED6"
 />
@@ -74,43 +74,85 @@ Adds a tag to a candidate in Ashby and returns the updated candidate.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Candidate UUID |
+| `name` | string | Full name |
+| `primaryEmailAddress` | object | Primary email contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `primaryPhoneNumber` | object | Primary phone contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `emailAddresses` | array | All email addresses |
+|   ↳ `value` | string | Email address |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `phoneNumbers` | array | All phone numbers |
+|   ↳ `value` | string | Phone number |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `socialLinks` | array | Social network links |
+|   ↳ `type` | string | Link type \(LinkedIn, GitHub, Twitter, etc.\) |
+|   ↳ `url` | string | Profile URL |
+| `linkedInUrl` | string | LinkedIn profile URL |
+| `githubUrl` | string | GitHub profile URL |
+| `profileUrl` | string | URL to the candidate Ashby profile |
+| `position` | string | Current position or title |
+| `company` | string | Current company |
+| `school` | string | Most recent school |
+| `timezone` | string | Candidate timezone |
+| `location` | object | Candidate location |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `locationSummary` | string | Human-readable location summary |
+|   ↳ `locationComponents` | array | Structured location parts \(city, region, country, etc.\) |
+|     ↳ `type` | string | Component type |
+|     ↳ `name` | string | Component value |
+| `tags` | array | Tags applied to the candidate |
+|   ↳ `id` | string | Tag UUID |
+|   ↳ `title` | string | Tag title |
+|   ↳ `isArchived` | boolean | Whether archived |
+| `applicationIds` | array | IDs of associated applications |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `resumeFileHandle` | object | Resume file reference |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `fileHandles` | array | All uploaded file references |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `creditedToUser` | object | User credited with sourcing |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `fraudStatus` | string | Fraud detection status |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
 
 ### Ashby Anonymize Candidate
 
@@ -128,43 +170,85 @@ Strips personally identifiable information from a candidate in Ashby. This does 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Candidate UUID |
+| `name` | string | Full name |
+| `primaryEmailAddress` | object | Primary email contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `primaryPhoneNumber` | object | Primary phone contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `emailAddresses` | array | All email addresses |
+|   ↳ `value` | string | Email address |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `phoneNumbers` | array | All phone numbers |
+|   ↳ `value` | string | Phone number |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `socialLinks` | array | Social network links |
+|   ↳ `type` | string | Link type \(LinkedIn, GitHub, Twitter, etc.\) |
+|   ↳ `url` | string | Profile URL |
+| `linkedInUrl` | string | LinkedIn profile URL |
+| `githubUrl` | string | GitHub profile URL |
+| `profileUrl` | string | URL to the candidate Ashby profile |
+| `position` | string | Current position or title |
+| `company` | string | Current company |
+| `school` | string | Most recent school |
+| `timezone` | string | Candidate timezone |
+| `location` | object | Candidate location |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `locationSummary` | string | Human-readable location summary |
+|   ↳ `locationComponents` | array | Structured location parts \(city, region, country, etc.\) |
+|     ↳ `type` | string | Component type |
+|     ↳ `name` | string | Component value |
+| `tags` | array | Tags applied to the candidate |
+|   ↳ `id` | string | Tag UUID |
+|   ↳ `title` | string | Tag title |
+|   ↳ `isArchived` | boolean | Whether archived |
+| `applicationIds` | array | IDs of associated applications |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `resumeFileHandle` | object | Resume file reference |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `fileHandles` | array | All uploaded file references |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `creditedToUser` | object | User credited with sourcing |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `fraudStatus` | string | Fraud detection status |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
 
 ### Ashby Change Application Source
 
@@ -184,43 +268,90 @@ Changes the source attributed to an existing application, so programmatically cr
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Application UUID |
+| `status` | string | Status \(Active, Hired, Archived, Lead\) |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `candidate` | object | Associated candidate summary |
+|   ↳ `id` | string | Candidate UUID |
+|   ↳ `name` | string | Candidate name |
+|   ↳ `primaryEmailAddress` | object | Primary email |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+|   ↳ `primaryPhoneNumber` | object | Primary phone |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `currentInterviewStage` | object | Current interview stage |
+|   ↳ `id` | string | Stage UUID |
+|   ↳ `title` | string | Stage title |
+|   ↳ `type` | string | Stage type |
+|   ↳ `orderInInterviewPlan` | number | Position in plan |
+|   ↳ `interviewStageGroupId` | string | Stage group UUID |
+|   ↳ `interviewPlanId` | string | Interview plan UUID |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `archiveReason` | object | Reason for archival \(when archived\) |
+|   ↳ `id` | string | Reason UUID |
+|   ↳ `text` | string | Reason text |
+|   ↳ `reasonType` | string | Reason category |
+|   ↳ `isArchived` | boolean | Whether the reason is archived |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `archivedAt` | string | ISO 8601 archive timestamp |
+| `job` | object | Associated job summary |
+|   ↳ `id` | string | Job UUID |
+|   ↳ `title` | string | Job title |
+|   ↳ `locationId` | string | Location UUID |
+|   ↳ `departmentId` | string | Department UUID |
+| `creditedToUser` | object | User credited with the application |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `hiringTeam` | array | Hiring team members |
+|   ↳ `userId` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `role` | string | Hiring team role |
+| `appliedViaJobPostingId` | string | Job posting UUID the candidate applied through |
+| `submitterClientIp` | string | Submitter IP address |
+| `submitterUserAgent` | string | Submitter browser user agent |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
+| `applicationHistory` | array | Stage history \(only populated by application.info, empty for list endpoints\) |
+|   ↳ `id` | string | History entry UUID |
+|   ↳ `stageId` | string | Interview stage UUID |
+|   ↳ `stageNumber` | number | Stage order number |
+|   ↳ `title` | string | Stage title at the time |
+|   ↳ `enteredStageAt` | string | ISO 8601 timestamp the stage was entered |
+|   ↳ `actorId` | string | User UUID who triggered the stage change |
 
 ### Ashby Change Application Stage
 
@@ -241,43 +372,90 @@ Moves an application to a different interview stage. Requires an archive reason 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Application UUID |
+| `status` | string | Status \(Active, Hired, Archived, Lead\) |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `candidate` | object | Associated candidate summary |
+|   ↳ `id` | string | Candidate UUID |
+|   ↳ `name` | string | Candidate name |
+|   ↳ `primaryEmailAddress` | object | Primary email |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+|   ↳ `primaryPhoneNumber` | object | Primary phone |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `currentInterviewStage` | object | Current interview stage |
+|   ↳ `id` | string | Stage UUID |
+|   ↳ `title` | string | Stage title |
+|   ↳ `type` | string | Stage type |
+|   ↳ `orderInInterviewPlan` | number | Position in plan |
+|   ↳ `interviewStageGroupId` | string | Stage group UUID |
+|   ↳ `interviewPlanId` | string | Interview plan UUID |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `archiveReason` | object | Reason for archival \(when archived\) |
+|   ↳ `id` | string | Reason UUID |
+|   ↳ `text` | string | Reason text |
+|   ↳ `reasonType` | string | Reason category |
+|   ↳ `isArchived` | boolean | Whether the reason is archived |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `archivedAt` | string | ISO 8601 archive timestamp |
+| `job` | object | Associated job summary |
+|   ↳ `id` | string | Job UUID |
+|   ↳ `title` | string | Job title |
+|   ↳ `locationId` | string | Location UUID |
+|   ↳ `departmentId` | string | Department UUID |
+| `creditedToUser` | object | User credited with the application |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `hiringTeam` | array | Hiring team members |
+|   ↳ `userId` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `role` | string | Hiring team role |
+| `appliedViaJobPostingId` | string | Job posting UUID the candidate applied through |
+| `submitterClientIp` | string | Submitter IP address |
+| `submitterUserAgent` | string | Submitter browser user agent |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
+| `applicationHistory` | array | Stage history \(only populated by application.info, empty for list endpoints\) |
+|   ↳ `id` | string | History entry UUID |
+|   ↳ `stageId` | string | Interview stage UUID |
+|   ↳ `stageNumber` | number | Stage order number |
+|   ↳ `title` | string | Stage title at the time |
+|   ↳ `enteredStageAt` | string | ISO 8601 timestamp the stage was entered |
+|   ↳ `actorId` | string | User UUID who triggered the stage change |
 
 ### Ashby Create Application
 
@@ -302,43 +480,90 @@ Creates a new application for a candidate on a job. Optionally specify interview
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Application UUID |
+| `status` | string | Status \(Active, Hired, Archived, Lead\) |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `candidate` | object | Associated candidate summary |
+|   ↳ `id` | string | Candidate UUID |
+|   ↳ `name` | string | Candidate name |
+|   ↳ `primaryEmailAddress` | object | Primary email |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+|   ↳ `primaryPhoneNumber` | object | Primary phone |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `currentInterviewStage` | object | Current interview stage |
+|   ↳ `id` | string | Stage UUID |
+|   ↳ `title` | string | Stage title |
+|   ↳ `type` | string | Stage type |
+|   ↳ `orderInInterviewPlan` | number | Position in plan |
+|   ↳ `interviewStageGroupId` | string | Stage group UUID |
+|   ↳ `interviewPlanId` | string | Interview plan UUID |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `archiveReason` | object | Reason for archival \(when archived\) |
+|   ↳ `id` | string | Reason UUID |
+|   ↳ `text` | string | Reason text |
+|   ↳ `reasonType` | string | Reason category |
+|   ↳ `isArchived` | boolean | Whether the reason is archived |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `archivedAt` | string | ISO 8601 archive timestamp |
+| `job` | object | Associated job summary |
+|   ↳ `id` | string | Job UUID |
+|   ↳ `title` | string | Job title |
+|   ↳ `locationId` | string | Location UUID |
+|   ↳ `departmentId` | string | Department UUID |
+| `creditedToUser` | object | User credited with the application |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `hiringTeam` | array | Hiring team members |
+|   ↳ `userId` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `role` | string | Hiring team role |
+| `appliedViaJobPostingId` | string | Job posting UUID the candidate applied through |
+| `submitterClientIp` | string | Submitter IP address |
+| `submitterUserAgent` | string | Submitter browser user agent |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
+| `applicationHistory` | array | Stage history \(only populated by application.info, empty for list endpoints\) |
+|   ↳ `id` | string | History entry UUID |
+|   ↳ `stageId` | string | Interview stage UUID |
+|   ↳ `stageNumber` | number | Stage order number |
+|   ↳ `title` | string | Stage title at the time |
+|   ↳ `enteredStageAt` | string | ISO 8601 timestamp the stage was entered |
+|   ↳ `actorId` | string | User UUID who triggered the stage change |
 
 ### Ashby Create Candidate
 
@@ -366,43 +591,85 @@ Creates a new candidate record in Ashby.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Candidate UUID |
+| `name` | string | Full name |
+| `primaryEmailAddress` | object | Primary email contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `primaryPhoneNumber` | object | Primary phone contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `emailAddresses` | array | All email addresses |
+|   ↳ `value` | string | Email address |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `phoneNumbers` | array | All phone numbers |
+|   ↳ `value` | string | Phone number |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `socialLinks` | array | Social network links |
+|   ↳ `type` | string | Link type \(LinkedIn, GitHub, Twitter, etc.\) |
+|   ↳ `url` | string | Profile URL |
+| `linkedInUrl` | string | LinkedIn profile URL |
+| `githubUrl` | string | GitHub profile URL |
+| `profileUrl` | string | URL to the candidate Ashby profile |
+| `position` | string | Current position or title |
+| `company` | string | Current company |
+| `school` | string | Most recent school |
+| `timezone` | string | Candidate timezone |
+| `location` | object | Candidate location |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `locationSummary` | string | Human-readable location summary |
+|   ↳ `locationComponents` | array | Structured location parts \(city, region, country, etc.\) |
+|     ↳ `type` | string | Component type |
+|     ↳ `name` | string | Component value |
+| `tags` | array | Tags applied to the candidate |
+|   ↳ `id` | string | Tag UUID |
+|   ↳ `title` | string | Tag title |
+|   ↳ `isArchived` | boolean | Whether archived |
+| `applicationIds` | array | IDs of associated applications |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `resumeFileHandle` | object | Resume file reference |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `fileHandles` | array | All uploaded file references |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `creditedToUser` | object | User credited with sourcing |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `fraudStatus` | string | Fraud detection status |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
 
 ### Ashby Create Note
 
@@ -470,43 +737,90 @@ Retrieves full details about a single application by its ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Application UUID |
+| `status` | string | Status \(Active, Hired, Archived, Lead\) |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `candidate` | object | Associated candidate summary |
+|   ↳ `id` | string | Candidate UUID |
+|   ↳ `name` | string | Candidate name |
+|   ↳ `primaryEmailAddress` | object | Primary email |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+|   ↳ `primaryPhoneNumber` | object | Primary phone |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `currentInterviewStage` | object | Current interview stage |
+|   ↳ `id` | string | Stage UUID |
+|   ↳ `title` | string | Stage title |
+|   ↳ `type` | string | Stage type |
+|   ↳ `orderInInterviewPlan` | number | Position in plan |
+|   ↳ `interviewStageGroupId` | string | Stage group UUID |
+|   ↳ `interviewPlanId` | string | Interview plan UUID |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `archiveReason` | object | Reason for archival \(when archived\) |
+|   ↳ `id` | string | Reason UUID |
+|   ↳ `text` | string | Reason text |
+|   ↳ `reasonType` | string | Reason category |
+|   ↳ `isArchived` | boolean | Whether the reason is archived |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `archivedAt` | string | ISO 8601 archive timestamp |
+| `job` | object | Associated job summary |
+|   ↳ `id` | string | Job UUID |
+|   ↳ `title` | string | Job title |
+|   ↳ `locationId` | string | Location UUID |
+|   ↳ `departmentId` | string | Department UUID |
+| `creditedToUser` | object | User credited with the application |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `hiringTeam` | array | Hiring team members |
+|   ↳ `userId` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `role` | string | Hiring team role |
+| `appliedViaJobPostingId` | string | Job posting UUID the candidate applied through |
+| `submitterClientIp` | string | Submitter IP address |
+| `submitterUserAgent` | string | Submitter browser user agent |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
+| `applicationHistory` | array | Stage history \(only populated by application.info, empty for list endpoints\) |
+|   ↳ `id` | string | History entry UUID |
+|   ↳ `stageId` | string | Interview stage UUID |
+|   ↳ `stageNumber` | number | Stage order number |
+|   ↳ `title` | string | Stage title at the time |
+|   ↳ `enteredStageAt` | string | ISO 8601 timestamp the stage was entered |
+|   ↳ `actorId` | string | User UUID who triggered the stage change |
 
 ### Ashby Get Candidate
 
@@ -524,43 +838,85 @@ Retrieves full details about a single candidate by their ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Candidate UUID |
+| `name` | string | Full name |
+| `primaryEmailAddress` | object | Primary email contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `primaryPhoneNumber` | object | Primary phone contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `emailAddresses` | array | All email addresses |
+|   ↳ `value` | string | Email address |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `phoneNumbers` | array | All phone numbers |
+|   ↳ `value` | string | Phone number |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `socialLinks` | array | Social network links |
+|   ↳ `type` | string | Link type \(LinkedIn, GitHub, Twitter, etc.\) |
+|   ↳ `url` | string | Profile URL |
+| `linkedInUrl` | string | LinkedIn profile URL |
+| `githubUrl` | string | GitHub profile URL |
+| `profileUrl` | string | URL to the candidate Ashby profile |
+| `position` | string | Current position or title |
+| `company` | string | Current company |
+| `school` | string | Most recent school |
+| `timezone` | string | Candidate timezone |
+| `location` | object | Candidate location |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `locationSummary` | string | Human-readable location summary |
+|   ↳ `locationComponents` | array | Structured location parts \(city, region, country, etc.\) |
+|     ↳ `type` | string | Component type |
+|     ↳ `name` | string | Component value |
+| `tags` | array | Tags applied to the candidate |
+|   ↳ `id` | string | Tag UUID |
+|   ↳ `title` | string | Tag title |
+|   ↳ `isArchived` | boolean | Whether archived |
+| `applicationIds` | array | IDs of associated applications |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `resumeFileHandle` | object | Resume file reference |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `fileHandles` | array | All uploaded file references |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `creditedToUser` | object | User credited with sourcing |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `fraudStatus` | string | Fraud detection status |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
 
 ### Ashby Get Job
 
@@ -578,43 +934,103 @@ Retrieves full details about a single job by its ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Job UUID |
+| `title` | string | Job title |
+| `confidential` | boolean | Whether the job is confidential |
+| `status` | string | Status \(Open, Closed, Draft, Archived\) |
+| `employmentType` | string | Employment type \(FullTime, PartTime, Intern, Contract, Temporary\) |
+| `locationId` | string | Primary location UUID |
+| `departmentId` | string | Department UUID |
+| `defaultInterviewPlanId` | string | Default interview plan UUID |
+| `interviewPlanIds` | array | All interview plan UUIDs |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `jobPostingIds` | array | Associated job posting UUIDs |
+| `customRequisitionId` | string | Custom requisition identifier |
+| `brandId` | string | Brand UUID |
+| `hiringTeam` | array | Hiring team members |
+|   ↳ `userId` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `role` | string | Hiring team role |
+| `author` | object | Job author \(creator\) |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
+| `openedAt` | string | ISO 8601 opened timestamp |
+| `closedAt` | string | ISO 8601 closed timestamp |
+| `location` | object | Primary location details |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `name` | string | Location name |
+|   ↳ `externalName` | string | External display name |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `isRemote` | boolean | Whether remote |
+|   ↳ `workplaceType` | string | Workplace type \(OnSite, Remote, Hybrid\) |
+|   ↳ `parentLocationId` | string | Parent location UUID |
+|   ↳ `type` | string | Location type |
+|   ↳ `address` | object | Postal address |
+|     ↳ `addressCountry` | string | Country |
+|     ↳ `addressRegion` | string | State or region |
+|     ↳ `addressLocality` | string | City or locality |
+|     ↳ `postalCode` | string | Postal code |
+|     ↳ `streetAddress` | string | Street address |
+| `openings` | array | Headcount openings associated with the job |
+|   ↳ `id` | string | Opening UUID |
+|   ↳ `openedAt` | string | Opening open timestamp |
+|   ↳ `closedAt` | string | Opening close timestamp |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `archivedAt` | string | Archive timestamp |
+|   ↳ `closeReasonId` | string | Close reason UUID |
+|   ↳ `openingState` | string | Opening state \(Approved, Open, Filled, Closed, Draft\) |
+|   ↳ `latestVersion` | object | Latest opening version |
+|     ↳ `id` | string | Version UUID |
+|     ↳ `identifier` | string | Human-readable identifier |
+|     ↳ `description` | string | Opening description |
+|     ↳ `authorId` | string | Author user UUID |
+|     ↳ `createdAt` | string | Version creation timestamp |
+|     ↳ `teamId` | string | Team UUID |
+|     ↳ `jobIds` | array | Associated job UUIDs |
+|     ↳ `targetHireDate` | string | Target hire date |
+|     ↳ `targetStartDate` | string | Target start date |
+|     ↳ `isBackfill` | boolean | Whether this is a backfill opening |
+|     ↳ `employmentType` | string | Employment type |
+|     ↳ `locationIds` | array | Location UUIDs |
+|     ↳ `hiringTeam` | array | Hiring team members |
+|       ↳ `userId` | string | User UUID |
+|       ↳ `firstName` | string | First name |
+|       ↳ `lastName` | string | Last name |
+|       ↳ `email` | string | Email |
+|       ↳ `role` | string | Hiring team role |
+|     ↳ `customFields` | array | Custom field values |
+|       ↳ `id` | string | Custom field UUID |
+|       ↳ `title` | string | Field title |
+|       ↳ `isPrivate` | boolean | Whether the field is private |
+|       ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|       ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `compensation` | object | Compensation tiers for the job. Only present when the request includes the `compensation` expand parameter. |
+|   ↳ `compensationTiers` | array | List of compensation tiers |
+|     ↳ `id` | string | Tier ID |
+|     ↳ `title` | string | Tier title |
+|     ↳ `additionalInformation` | string | Additional information about the tier |
+|     ↳ `tierSummary` | string | Human-readable summary of the tier |
 
 ### Ashby Get Job Posting
 
@@ -704,43 +1120,45 @@ Retrieves full details about a single offer by its ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
-| `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `id` | string | Offer UUID |
+| `decidedAt` | string | Timestamp the offer was decided |
+| `applicationId` | string | Associated application UUID |
+| `acceptanceStatus` | string | Acceptance status \(Accepted, Declined, Pending, etc.\) |
+| `offerStatus` | string | Offer status \(e.g. WaitingOnCandidateResponse, CandidateAccepted\) |
+| `latestVersion` | object | Most recent version of the offer with pricing and metadata |
+|   ↳ `id` | string | Version UUID |
+|   ↳ `startDate` | string | Offer start date |
+|   ↳ `salary` | object | Salary details |
+|     ↳ `currencyCode` | string | ISO 4217 currency code |
+|     ↳ `value` | number | Salary amount |
+|   ↳ `createdAt` | string | Version creation timestamp |
+|   ↳ `openingId` | string | Associated opening UUID |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+|   ↳ `fileHandles` | array | Offer letter file handles \(unsigned .pdf, .docx, and signed .pdf when generated\) |
+|     ↳ `id` | string | File UUID |
+|     ↳ `name` | string | File name |
+|     ↳ `handle` | string | File handle used with file.info |
+|   ↳ `author` | object | User who authored the version |
+|     ↳ `id` | string | User UUID |
+|     ↳ `firstName` | string | First name |
+|     ↳ `lastName` | string | Last name |
+|     ↳ `email` | string | Email |
+|     ↳ `globalRole` | string | Role |
+|     ↳ `isEnabled` | boolean | Whether enabled |
+|     ↳ `updatedAt` | string | Last update timestamp |
+|     ↳ `managerId` | string | User ID of the user's manager |
+|     ↳ `customFields` | array | Custom field values |
+|       ↳ `id` | string | Custom field UUID |
+|       ↳ `title` | string | Field title |
+|       ↳ `isPrivate` | boolean | Whether the field is private |
+|       ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|       ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+|   ↳ `approvalStatus` | string | Approval workflow status |
 
 ### Ashby Get Opening
 
@@ -757,43 +1175,38 @@ Retrieves one Ashby headcount opening by UUID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
-| `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `id` | string | Opening UUID |
+| `openedAt` | string | Opening open timestamp |
+| `closedAt` | string | Opening close timestamp |
+| `isArchived` | boolean | Whether archived |
+| `archivedAt` | string | Archive timestamp |
+| `closeReasonId` | string | Close reason UUID |
+| `openingState` | string | Opening state \(Approved, Open, Filled, Closed, Draft\) |
+| `latestVersion` | object | Latest opening version |
+|   ↳ `id` | string | Version UUID |
+|   ↳ `identifier` | string | Human-readable identifier |
+|   ↳ `description` | string | Opening description |
+|   ↳ `authorId` | string | Author user UUID |
+|   ↳ `createdAt` | string | Version creation timestamp |
+|   ↳ `teamId` | string | Team UUID |
+|   ↳ `jobIds` | array | Associated job UUIDs |
+|   ↳ `targetHireDate` | string | Target hire date |
+|   ↳ `targetStartDate` | string | Target start date |
+|   ↳ `isBackfill` | boolean | Whether this is a backfill opening |
+|   ↳ `employmentType` | string | Employment type |
+|   ↳ `locationIds` | array | Location UUIDs |
+|   ↳ `hiringTeam` | array | Hiring team members |
+|     ↳ `userId` | string | User UUID |
+|     ↳ `firstName` | string | First name |
+|     ↳ `lastName` | string | Last name |
+|     ↳ `email` | string | Email |
+|     ↳ `role` | string | Hiring team role |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
 
 ### Ashby List Application Feedback
 
@@ -1367,43 +1780,85 @@ Removes a tag from a candidate in Ashby and returns the updated candidate.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Candidate UUID |
+| `name` | string | Full name |
+| `primaryEmailAddress` | object | Primary email contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `primaryPhoneNumber` | object | Primary phone contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `emailAddresses` | array | All email addresses |
+|   ↳ `value` | string | Email address |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `phoneNumbers` | array | All phone numbers |
+|   ↳ `value` | string | Phone number |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `socialLinks` | array | Social network links |
+|   ↳ `type` | string | Link type \(LinkedIn, GitHub, Twitter, etc.\) |
+|   ↳ `url` | string | Profile URL |
+| `linkedInUrl` | string | LinkedIn profile URL |
+| `githubUrl` | string | GitHub profile URL |
+| `profileUrl` | string | URL to the candidate Ashby profile |
+| `position` | string | Current position or title |
+| `company` | string | Current company |
+| `school` | string | Most recent school |
+| `timezone` | string | Candidate timezone |
+| `location` | object | Candidate location |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `locationSummary` | string | Human-readable location summary |
+|   ↳ `locationComponents` | array | Structured location parts \(city, region, country, etc.\) |
+|     ↳ `type` | string | Component type |
+|     ↳ `name` | string | Component value |
+| `tags` | array | Tags applied to the candidate |
+|   ↳ `id` | string | Tag UUID |
+|   ↳ `title` | string | Tag title |
+|   ↳ `isArchived` | boolean | Whether archived |
+| `applicationIds` | array | IDs of associated applications |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `resumeFileHandle` | object | Resume file reference |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `fileHandles` | array | All uploaded file references |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `creditedToUser` | object | User credited with sourcing |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `fraudStatus` | string | Fraud detection status |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
 
 ### Ashby Search Candidates
 
@@ -1459,43 +1914,39 @@ Searches Ashby headcount openings by human-readable identifier.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
-| `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `openings` | array | Headcount openings associated with the job |
+|   ↳ `id` | string | Opening UUID |
+|   ↳ `openedAt` | string | Opening open timestamp |
+|   ↳ `closedAt` | string | Opening close timestamp |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `archivedAt` | string | Archive timestamp |
+|   ↳ `closeReasonId` | string | Close reason UUID |
+|   ↳ `openingState` | string | Opening state \(Approved, Open, Filled, Closed, Draft\) |
+|   ↳ `latestVersion` | object | Latest opening version |
+|     ↳ `id` | string | Version UUID |
+|     ↳ `identifier` | string | Human-readable identifier |
+|     ↳ `description` | string | Opening description |
+|     ↳ `authorId` | string | Author user UUID |
+|     ↳ `createdAt` | string | Version creation timestamp |
+|     ↳ `teamId` | string | Team UUID |
+|     ↳ `jobIds` | array | Associated job UUIDs |
+|     ↳ `targetHireDate` | string | Target hire date |
+|     ↳ `targetStartDate` | string | Target start date |
+|     ↳ `isBackfill` | boolean | Whether this is a backfill opening |
+|     ↳ `employmentType` | string | Employment type |
+|     ↳ `locationIds` | array | Location UUIDs |
+|     ↳ `hiringTeam` | array | Hiring team members |
+|       ↳ `userId` | string | User UUID |
+|       ↳ `firstName` | string | First name |
+|       ↳ `lastName` | string | Last name |
+|       ↳ `email` | string | Email |
+|       ↳ `role` | string | Hiring team role |
+|     ↳ `customFields` | array | Custom field values |
+|       ↳ `id` | string | Custom field UUID |
+|       ↳ `title` | string | Field title |
+|       ↳ `isPrivate` | boolean | Whether the field is private |
+|       ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|       ↳ `value` | string | Raw field value \(type depends on fieldType\) |
 
 ### Ashby Search Users
 
@@ -1553,43 +2004,12 @@ Sets several custom field values on one Ashby Application, Candidate, Job, or Op
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
-| `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `customFields` | array | The custom fields as stored on the object after the write |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
 
 ### Ashby Update Candidate
 
@@ -1622,43 +2042,85 @@ Updates an existing candidate record in Ashby. Only provided fields are changed.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Candidate UUID |
+| `name` | string | Full name |
+| `primaryEmailAddress` | object | Primary email contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `primaryPhoneNumber` | object | Primary phone contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `emailAddresses` | array | All email addresses |
+|   ↳ `value` | string | Email address |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `phoneNumbers` | array | All phone numbers |
+|   ↳ `value` | string | Phone number |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `socialLinks` | array | Social network links |
+|   ↳ `type` | string | Link type \(LinkedIn, GitHub, Twitter, etc.\) |
+|   ↳ `url` | string | Profile URL |
+| `linkedInUrl` | string | LinkedIn profile URL |
+| `githubUrl` | string | GitHub profile URL |
+| `profileUrl` | string | URL to the candidate Ashby profile |
+| `position` | string | Current position or title |
+| `company` | string | Current company |
+| `school` | string | Most recent school |
+| `timezone` | string | Candidate timezone |
+| `location` | object | Candidate location |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `locationSummary` | string | Human-readable location summary |
+|   ↳ `locationComponents` | array | Structured location parts \(city, region, country, etc.\) |
+|     ↳ `type` | string | Component type |
+|     ↳ `name` | string | Component value |
+| `tags` | array | Tags applied to the candidate |
+|   ↳ `id` | string | Tag UUID |
+|   ↳ `title` | string | Tag title |
+|   ↳ `isArchived` | boolean | Whether archived |
+| `applicationIds` | array | IDs of associated applications |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `resumeFileHandle` | object | Resume file reference |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `fileHandles` | array | All uploaded file references |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `creditedToUser` | object | User credited with sourcing |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `fraudStatus` | string | Fraud detection status |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
 
 ### Ashby Transfer Application
 
@@ -1680,43 +2142,90 @@ Transfers an application to another job, interview plan, and stage.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Application UUID |
+| `status` | string | Status \(Active, Hired, Archived, Lead\) |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `candidate` | object | Associated candidate summary |
+|   ↳ `id` | string | Candidate UUID |
+|   ↳ `name` | string | Candidate name |
+|   ↳ `primaryEmailAddress` | object | Primary email |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+|   ↳ `primaryPhoneNumber` | object | Primary phone |
+|     ↳ `value` | string | Value \(email or phone number\) |
+|     ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|     ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `currentInterviewStage` | object | Current interview stage |
+|   ↳ `id` | string | Stage UUID |
+|   ↳ `title` | string | Stage title |
+|   ↳ `type` | string | Stage type |
+|   ↳ `orderInInterviewPlan` | number | Position in plan |
+|   ↳ `interviewStageGroupId` | string | Stage group UUID |
+|   ↳ `interviewPlanId` | string | Interview plan UUID |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `archiveReason` | object | Reason for archival \(when archived\) |
+|   ↳ `id` | string | Reason UUID |
+|   ↳ `text` | string | Reason text |
+|   ↳ `reasonType` | string | Reason category |
+|   ↳ `isArchived` | boolean | Whether the reason is archived |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `archivedAt` | string | ISO 8601 archive timestamp |
+| `job` | object | Associated job summary |
+|   ↳ `id` | string | Job UUID |
+|   ↳ `title` | string | Job title |
+|   ↳ `locationId` | string | Location UUID |
+|   ↳ `departmentId` | string | Department UUID |
+| `creditedToUser` | object | User credited with the application |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `hiringTeam` | array | Hiring team members |
+|   ↳ `userId` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `role` | string | Hiring team role |
+| `appliedViaJobPostingId` | string | Job posting UUID the candidate applied through |
+| `submitterClientIp` | string | Submitter IP address |
+| `submitterUserAgent` | string | Submitter browser user agent |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
+| `applicationHistory` | array | Stage history \(only populated by application.info, empty for list endpoints\) |
+|   ↳ `id` | string | History entry UUID |
+|   ↳ `stageId` | string | Interview stage UUID |
+|   ↳ `stageNumber` | number | Stage order number |
+|   ↳ `title` | string | Stage title at the time |
+|   ↳ `enteredStageAt` | string | ISO 8601 timestamp the stage was entered |
+|   ↳ `actorId` | string | User UUID who triggered the stage change |
 
 ### Ashby Upload Candidate File
 
@@ -1736,43 +2245,85 @@ Securely uploads a file and attaches it to an Ashby candidate.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Candidate UUID |
+| `name` | string | Full name |
+| `primaryEmailAddress` | object | Primary email contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `primaryPhoneNumber` | object | Primary phone contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `emailAddresses` | array | All email addresses |
+|   ↳ `value` | string | Email address |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `phoneNumbers` | array | All phone numbers |
+|   ↳ `value` | string | Phone number |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `socialLinks` | array | Social network links |
+|   ↳ `type` | string | Link type \(LinkedIn, GitHub, Twitter, etc.\) |
+|   ↳ `url` | string | Profile URL |
+| `linkedInUrl` | string | LinkedIn profile URL |
+| `githubUrl` | string | GitHub profile URL |
+| `profileUrl` | string | URL to the candidate Ashby profile |
+| `position` | string | Current position or title |
+| `company` | string | Current company |
+| `school` | string | Most recent school |
+| `timezone` | string | Candidate timezone |
+| `location` | object | Candidate location |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `locationSummary` | string | Human-readable location summary |
+|   ↳ `locationComponents` | array | Structured location parts \(city, region, country, etc.\) |
+|     ↳ `type` | string | Component type |
+|     ↳ `name` | string | Component value |
+| `tags` | array | Tags applied to the candidate |
+|   ↳ `id` | string | Tag UUID |
+|   ↳ `title` | string | Tag title |
+|   ↳ `isArchived` | boolean | Whether archived |
+| `applicationIds` | array | IDs of associated applications |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `resumeFileHandle` | object | Resume file reference |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `fileHandles` | array | All uploaded file references |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `creditedToUser` | object | User credited with sourcing |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `fraudStatus` | string | Fraud detection status |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
+| `updatedAt` | string | ISO 8601 last update timestamp |
 
 ### Ashby Upload Resume
 
@@ -1792,45 +2343,85 @@ Securely uploads a resume and sets it as the Ashby candidate resume.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `candidates` | json | List of candidates with rich fields \(id, name, primaryEmailAddress, primaryPhoneNumber, emailAddresses\[\], phoneNumbers\[\], socialLinks\[\], linkedInUrl, githubUrl, profileUrl, position, company, school, timezone, location with locationComponents\[\], tags\[\], applicationIds\[\], customFields\[\], resumeFileHandle, fileHandles\[\], source with sourceType, creditedToUser, fraudStatus, createdAt, updatedAt\) |
-| `jobs` | json | List of jobs \(id, title, confidential, status, employmentType, locationId, departmentId, defaultInterviewPlanId, interviewPlanIds\[\], customFields\[\], jobPostingIds\[\], customRequisitionId, brandId, hiringTeam\[\], author, createdAt, updatedAt, openedAt, closedAt, location with address, openings\[\] with latestVersion\) |
-| `applications` | json | List of applications \(id, status, customFields\[\], candidate summary, currentInterviewStage, source with sourceType, archiveReason with customFields\[\], archivedAt, job summary, creditedToUser, hiringTeam\[\], appliedViaJobPostingId, submitterClientIp, submitterUserAgent, createdAt, updatedAt\) |
-| `notes` | json | List of notes \(id, content, author, isPrivate, createdAt\) |
-| `offers` | json | List of offers \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion with id/startDate/salary/createdAt/openingId/customFields\[\]/fileHandles\[\]/author/approvalStatus\) |
-| `archiveReasons` | json | List of archive reasons \(id, text, reasonType \[RejectedByCandidate/RejectedByOrg/Other\], isArchived\) |
-| `sources` | json | List of sources \(id, title, isArchived, sourceType \{id, title, isArchived\}\) |
-| `customFields` | json | For List Custom Fields, the field definitions \(id, title, isPrivate, fieldType, objectType, isArchived, isRequired, selectableValues\[\] \{label, value, isArchived\}\). For Set Custom Field Values, the field values written to the object \(id, title, isPrivate, valueLabel, value\) |
-| `customField` | json | A single custom field value after a write \(id, title, isPrivate, valueLabel, value\) |
-| `departments` | json | List of departments \(id, name, externalName, isArchived, parentId, createdAt, updatedAt\) |
-| `locations` | json | List of locations \(id, name, externalName, isArchived, isRemote, workplaceType, parentLocationId, type, address with addressCountry/Region/Locality/postalCode/streetAddress\) |
-| `jobPostings` | json | List of job postings \(id, title, jobId, departmentName, teamName, locationName, locationIds, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensationTierSummary, shouldDisplayCompensationOnJobBoard, updatedAt\) |
-| `openings` | json | List of openings \(id, openedAt, closedAt, isArchived, archivedAt, closeReasonId, openingState, latestVersion with identifier/description/authorId/createdAt/teamId/jobIds\[\]/targetHireDate/targetStartDate/isBackfill/employmentType/locationIds\[\]/hiringTeam\[\]/customFields\[\]\) |
-| `users` | json | List of users \(id, firstName, lastName, email, globalRole, isEnabled, updatedAt\) |
-| `interviewSchedules` | json | List of interview schedules \(id, applicationId, interviewStageId, interviewEvents\[\] with interviewerUserIds/startTime/endTime/feedbackLink/location/meetingLink/hasSubmittedFeedback, status, scheduledBy, createdAt, updatedAt\) |
-| `interviewPlans` | json | Interview plans \(id, title, isArchived, createdAt, updatedAt\) |
-| `interviewStages` | json | Ordered interview stages for a plan |
-| `feedback` | json | Submitted application feedback with form definitions and values |
-| `history` | json | Application stage history and allowed actions |
-| `tags` | json | List of candidate tags \(id, title, isArchived\) |
-| `id` | string | Resource UUID |
-| `name` | string | Resource name |
-| `title` | string | Job title or job posting title |
-| `status` | string | Status |
-| `candidate` | json | Candidate summary \(id, name, primaryEmailAddress, primaryPhoneNumber\). For full candidate fields use the candidates list output or the get/create/update candidate operations. |
-| `job` | json | Job details \(id, title, status, employmentType, locationId, departmentId, hiringTeam\[\], author, location, openings\[\], createdAt, updatedAt\) |
-| `application` | json | Application details \(id, status, customFields\[\], candidate, currentInterviewStage, source, archiveReason, job, hiringTeam\[\], createdAt, updatedAt\) |
-| `offer` | json | Offer details \(id, decidedAt, applicationId, acceptanceStatus, offerStatus, latestVersion\) |
-| `jobPosting` | json | Job posting details \(id, title, descriptionPlain, descriptionHtml, descriptionSocial, descriptionParts, departmentName, teamName, teamNameHierarchy\[\], jobId, locationName, locationIds, address, isRemote, workplaceType, employmentType, isListed, publishedDate, applicationDeadline, externalLink, applyLink, compensation, updatedAt, job \[included when expandJob=true\]\) |
-| `content` | string | Note content |
-| `author` | json | Note author \(id, firstName, lastName, email\) |
-| `isPrivate` | boolean | Whether the note is private |
+| `id` | string | Candidate UUID |
+| `name` | string | Full name |
+| `primaryEmailAddress` | object | Primary email contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `primaryPhoneNumber` | object | Primary phone contact info |
+|   ↳ `value` | string | Value \(email or phone number\) |
+|   ↳ `type` | string | Contact type \(Personal, Work, Other\) |
+|   ↳ `isPrimary` | boolean | Whether this is the primary contact |
+| `emailAddresses` | array | All email addresses |
+|   ↳ `value` | string | Email address |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `phoneNumbers` | array | All phone numbers |
+|   ↳ `value` | string | Phone number |
+|   ↳ `type` | string | Contact type |
+|   ↳ `isPrimary` | boolean | Whether primary |
+| `socialLinks` | array | Social network links |
+|   ↳ `type` | string | Link type \(LinkedIn, GitHub, Twitter, etc.\) |
+|   ↳ `url` | string | Profile URL |
+| `linkedInUrl` | string | LinkedIn profile URL |
+| `githubUrl` | string | GitHub profile URL |
+| `profileUrl` | string | URL to the candidate Ashby profile |
+| `position` | string | Current position or title |
+| `company` | string | Current company |
+| `school` | string | Most recent school |
+| `timezone` | string | Candidate timezone |
+| `location` | object | Candidate location |
+|   ↳ `id` | string | Location UUID |
+|   ↳ `locationSummary` | string | Human-readable location summary |
+|   ↳ `locationComponents` | array | Structured location parts \(city, region, country, etc.\) |
+|     ↳ `type` | string | Component type |
+|     ↳ `name` | string | Component value |
+| `tags` | array | Tags applied to the candidate |
+|   ↳ `id` | string | Tag UUID |
+|   ↳ `title` | string | Tag title |
+|   ↳ `isArchived` | boolean | Whether archived |
+| `applicationIds` | array | IDs of associated applications |
+| `customFields` | array | Custom field values |
+|   ↳ `id` | string | Custom field UUID |
+|   ↳ `title` | string | Field title |
+|   ↳ `isPrivate` | boolean | Whether the field is private |
+|   ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|   ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `resumeFileHandle` | object | Resume file reference |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `fileHandles` | array | All uploaded file references |
+|   ↳ `id` | string | File UUID |
+|   ↳ `name` | string | File name |
+|   ↳ `handle` | string | File handle used with file.info |
+| `source` | object | Attribution source |
+|   ↳ `id` | string | Source UUID |
+|   ↳ `title` | string | Source title |
+|   ↳ `isArchived` | boolean | Whether archived |
+|   ↳ `sourceType` | object | Source type grouping |
+|     ↳ `id` | string | Source type UUID |
+|     ↳ `title` | string | Source type title |
+|     ↳ `isArchived` | boolean | Whether archived |
+| `creditedToUser` | object | User credited with sourcing |
+|   ↳ `id` | string | User UUID |
+|   ↳ `firstName` | string | First name |
+|   ↳ `lastName` | string | Last name |
+|   ↳ `email` | string | Email |
+|   ↳ `globalRole` | string | Role |
+|   ↳ `isEnabled` | boolean | Whether enabled |
+|   ↳ `updatedAt` | string | Last update timestamp |
+|   ↳ `managerId` | string | User ID of the user's manager |
+|   ↳ `customFields` | array | Custom field values |
+|     ↳ `id` | string | Custom field UUID |
+|     ↳ `title` | string | Field title |
+|     ↳ `isPrivate` | boolean | Whether the field is private |
+|     ↳ `valueLabel` | json | Human-readable value label, present only for ValueSelect and MultiValueSelect fields. A string for ValueSelect, an array of strings for MultiValueSelect. |
+|     ↳ `value` | string | Raw field value \(type depends on fieldType\) |
+| `fraudStatus` | string | Fraud detection status |
 | `createdAt` | string | ISO 8601 creation timestamp |
-| `applicationId` | string | UUID of the deleted application |
-| `moreDataAvailable` | boolean | Whether more pages exist |
-| `nextCursor` | string | Pagination cursor for next page |
-| `nextSyncCursor` | string | Ashby's opaque token for the next incremental list run, exposed as a cursor so it remains usable in workflow output |
-
-
+| `updatedAt` | string | ISO 8601 last update timestamp |
 
 ## Triggers
 
@@ -2324,4 +2915,3 @@ Trigger workflow when an e-signature request changes state
 | `offerId` | string | Related offer UUID |
 | `offerVersionId` | string | Related offer version UUID |
 | `eventType` | string | Signature request event: sent, cancelled, completed, or deleted |
-

--- a/apps/docs/content/docs/integrations/athena.mdx
+++ b/apps/docs/content/docs/integrations/athena.mdx
@@ -5,7 +5,7 @@ description: Run SQL queries on data in Amazon S3 using AWS Athena
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="athena"
   color="linear-gradient(45deg, #4D27A8 0%, #A166FF 100%)"
 />
@@ -746,5 +746,3 @@ Get the configuration of an Athena workgroup, including its result location, enc
 | `requesterPaysEnabled` | boolean | Whether Requester Pays S3 buckets may be queried |
 | `enableMinimumEncryptionConfiguration` | boolean | Whether a minimum encryption level is enforced |
 | `executionRole` | string | Execution role ARN for Spark or IAM Identity Center workgroups |
-
-

--- a/apps/docs/content/docs/integrations/attio.mdx
+++ b/apps/docs/content/docs/integrations/attio.mdx
@@ -5,7 +5,7 @@ description: Manage records, notes, tasks, lists, comments, and more in Attio CR
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="attio"
   color="#1D1E20"
 />
@@ -1224,8 +1224,6 @@ Update an attribute (schema field) on an Attio object or list
 | `config` | json | Type-dependent attribute configuration |
 | `createdAt` | string | When the attribute was created |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1726,4 +1724,3 @@ Trigger workflow when a new member is added to the Attio workspace
 | `eventType` | string | The type of event \(e.g. record.created, note.created\) |
 | `workspaceId` | string | The workspace ID |
 | `workspaceMemberId` | string | The workspace member ID |
-

--- a/apps/docs/content/docs/integrations/azure_data_explorer.mdx
+++ b/apps/docs/content/docs/integrations/azure_data_explorer.mdx
@@ -5,7 +5,7 @@ description: Query and manage Azure Data Explorer (Kusto) clusters with KQL
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="azure_data_explorer"
   color="#FFFFFF"
 />
@@ -76,11 +76,11 @@ Run a Kusto Query Language (KQL) query against an Azure Data Explorer database a
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -107,11 +107,11 @@ Run an Azure Data Explorer management command (a control command starting with "
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -136,11 +136,11 @@ List the databases on an Azure Data Explorer cluster that the service principal 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -167,11 +167,11 @@ List the tables in an Azure Data Explorer database, with their folder and docstr
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -199,11 +199,11 @@ Read the column schema of an Azure Data Explorer table in CSL form (e.g., "Times
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name of the table |
-| `schema` | string | Comma-separated CSL column schema \(name:type\) |
-| `databaseName` | string | The table's database |
-| `folder` | string | The table's folder |
-| `docString` | string | The table's docstring |
+| `tableName` | string (nullable) | Name of the table |
+| `schema` | string (nullable) | Comma-separated CSL column schema \(name:type\) |
+| `databaseName` | string (nullable) | The table's database |
+| `folder` | string (nullable) | The table's folder |
+| `docString` | string (nullable) | The table's docstring |
 
 ### Azure Data Explorer Show Database Schema
 
@@ -224,11 +224,11 @@ Read the full schema of an Azure Data Explorer database as a flat list of every 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -255,11 +255,11 @@ Read size, row count, hot-cache footprint, and effective policies for a table �
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -285,11 +285,11 @@ List the stored functions in an Azure Data Explorer database, with their paramet
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -319,11 +319,11 @@ Push rows directly into an Azure Data Explorer table with .ingest inline. Data i
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -355,11 +355,11 @@ Materialize the result of a KQL query into a table with .set, .append, .set-or-a
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -388,11 +388,11 @@ Create a table in an Azure Data Explorer database from a CSL column schema. Succ
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -420,11 +420,11 @@ Drop a table from an Azure Data Explorer database. This permanently deletes the 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -452,11 +452,11 @@ List ingestion failures recorded for a database, with the failing table, error c
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
@@ -483,15 +483,13 @@ Check the state of administrative operations on a cluster, such as an async inge
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `tableName` | string | Name Kusto assigned to the returned result table |
+| `tableName` | string (nullable) | Name Kusto assigned to the returned result table |
 | `columns` | array | Column metadata for the result table |
 |   ↳ `name` | string | Column name |
-|   ↳ `type` | string | Kusto scalar type |
-|   ↳ `dataType` | string | Approximate .NET type |
+|   ↳ `type` | string (nullable) | Kusto scalar type |
+|   ↳ `dataType` | string (nullable) | Approximate .NET type |
 | `rows` | array | Result rows as positional arrays matching the columns order |
 | `records` | array | Result rows keyed by column name |
 | `rowCount` | number | Rows carried in this result, after the row cap |
 | `totalRowCount` | number | Rows Kusto returned, before the row cap was applied |
 | `truncated` | boolean | Whether rows were dropped to stay within the row cap — narrow the query if true |
-
-

--- a/apps/docs/content/docs/integrations/azure_devops.mdx
+++ b/apps/docs/content/docs/integrations/azure_devops.mdx
@@ -5,7 +5,7 @@ description: Interact with Azure DevOps pipelines, builds, and work items
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="azure_devops"
   color="#0078D4"
 />
@@ -505,9 +505,9 @@ Add a comment to a work item in Azure DevOps.
 |     ↳ `version` | number | Comment version |
 |     ↳ `text` | string | Comment text |
 |     ↳ `renderedText` | string | Rendered HTML comment text when available |
-|     ↳ `createdBy` | string | Display name of the comment author, or null |
+|     ↳ `createdBy` | string (nullable) | Display name of the comment author, or null |
 |     ↳ `createdDate` | string | ISO timestamp when comment was created |
-|     ↳ `modifiedBy` | string | Display name of the last modifier, or null |
+|     ↳ `modifiedBy` | string (nullable) | Display name of the last modifier, or null |
 |     ↳ `modifiedDate` | string | ISO timestamp when comment was modified |
 |     ↳ `isDeleted` | boolean | Whether the comment is deleted |
 |     ↳ `url` | string | API URL for the comment |
@@ -546,14 +546,12 @@ List comments for an Azure DevOps work item.
 |     ↳ `version` | number | Comment version |
 |     ↳ `text` | string | Comment text |
 |     ↳ `renderedText` | string | Rendered HTML comment text when available |
-|     ↳ `createdBy` | string | Display name of the comment author |
+|     ↳ `createdBy` | string (nullable) | Display name of the comment author |
 |     ↳ `createdDate` | string | ISO 8601 creation timestamp |
-|     ↳ `modifiedBy` | string | Display name of the last modifier |
+|     ↳ `modifiedBy` | string (nullable) | Display name of the last modifier |
 |     ↳ `modifiedDate` | string | ISO 8601 modified timestamp |
 |     ↳ `isDeleted` | boolean | Whether the comment is deleted |
 |     ↳ `url` | string | API URL for the comment |
-
-
 
 ## Triggers
 
@@ -625,4 +623,3 @@ Trigger workflow when a work item is created in Azure DevOps
 | `description` | string | Work item description \(HTML\), or null if not set |
 | `projectName` | string | Azure DevOps project name |
 | `workItemUrl` | string | API URL for the work item resource |
-

--- a/apps/docs/content/docs/integrations/bitbucket.mdx
+++ b/apps/docs/content/docs/integrations/bitbucket.mdx
@@ -5,7 +5,7 @@ description: Work with Bitbucket Cloud repositories, pull requests, and pipeline
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="bitbucket"
   color="#FFFFFF"
 />
@@ -36,18 +36,18 @@ List Bitbucket Cloud workspaces available to the authenticated account
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Workspace access records |
 |   ↳ `type` | string | Bitbucket workspace-access object type |
-|   ↳ `slug` | string | Workspace slug |
-|   ↳ `uuid` | string | Workspace UUID |
-|   ↳ `administrator` | boolean | Whether the caller administers the workspace |
-|   ↳ `selfUrl` | string | Workspace API URL |
-|   ↳ `avatarUrl` | string | Workspace avatar URL |
+|   ↳ `slug` | string (nullable) | Workspace slug |
+|   ↳ `uuid` | string (nullable) | Workspace UUID |
+|   ↳ `administrator` | boolean (nullable) | Whether the caller administers the workspace |
+|   ↳ `selfUrl` | string (nullable) | Workspace API URL |
+|   ↳ `avatarUrl` | string (nullable) | Workspace avatar URL |
 
 ### Bitbucket List Repositories
 
@@ -69,40 +69,40 @@ List repositories in a Bitbucket Cloud workspace
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Repositories |
 |   ↳ `type` | string | Bitbucket repository object type |
-|   ↳ `uuid` | string | Repository UUID |
-|   ↳ `slug` | string | Repository slug |
-|   ↳ `name` | string | Repository name |
-|   ↳ `fullName` | string | Workspace and repository full name |
-|   ↳ `description` | string | Repository description |
-|   ↳ `isPrivate` | boolean | Whether the repository is private |
-|   ↳ `scm` | string | Source control system |
-|   ↳ `language` | string | Primary repository language |
-|   ↳ `size` | number | Repository size in bytes |
-|   ↳ `createdOn` | string | Repository creation timestamp |
-|   ↳ `updatedOn` | string | Repository update timestamp |
-|   ↳ `mainBranch` | string | Main branch name |
-|   ↳ `owner` | object | Repository owner |
+|   ↳ `uuid` | string (nullable) | Repository UUID |
+|   ↳ `slug` | string (nullable) | Repository slug |
+|   ↳ `name` | string (nullable) | Repository name |
+|   ↳ `fullName` | string (nullable) | Workspace and repository full name |
+|   ↳ `description` | string (nullable) | Repository description |
+|   ↳ `isPrivate` | boolean (nullable) | Whether the repository is private |
+|   ↳ `scm` | string (nullable) | Source control system |
+|   ↳ `language` | string (nullable) | Primary repository language |
+|   ↳ `size` | number (nullable) | Repository size in bytes |
+|   ↳ `createdOn` | string (nullable) | Repository creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Repository update timestamp |
+|   ↳ `mainBranch` | string (nullable) | Main branch name |
+|   ↳ `owner` | object (nullable) | Repository owner |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `project` | object | Containing Bitbucket project |
-|     ↳ `uuid` | string | Project UUID |
-|     ↳ `key` | string | Project key |
-|     ↳ `name` | string | Project name |
-|   ↳ `selfUrl` | string | Repository API URL |
-|   ↳ `htmlUrl` | string | Repository web URL |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `project` | object (nullable) | Containing Bitbucket project |
+|     ↳ `uuid` | string (nullable) | Project UUID |
+|     ↳ `key` | string (nullable) | Project key |
+|     ↳ `name` | string (nullable) | Project name |
+|   ↳ `selfUrl` | string (nullable) | Repository API URL |
+|   ↳ `htmlUrl` | string (nullable) | Repository web URL |
 
 ### Bitbucket Get Repository
 
@@ -121,33 +121,33 @@ Get a Bitbucket Cloud repository
 | --------- | ---- | ----------- |
 | `repository` | object | Repository details |
 |   ↳ `type` | string | Bitbucket repository object type |
-|   ↳ `uuid` | string | Repository UUID |
-|   ↳ `slug` | string | Repository slug |
-|   ↳ `name` | string | Repository name |
-|   ↳ `fullName` | string | Workspace and repository full name |
-|   ↳ `description` | string | Repository description |
-|   ↳ `isPrivate` | boolean | Whether the repository is private |
-|   ↳ `scm` | string | Source control system |
-|   ↳ `language` | string | Primary repository language |
-|   ↳ `size` | number | Repository size in bytes |
-|   ↳ `createdOn` | string | Repository creation timestamp |
-|   ↳ `updatedOn` | string | Repository update timestamp |
-|   ↳ `mainBranch` | string | Main branch name |
-|   ↳ `owner` | object | Repository owner |
+|   ↳ `uuid` | string (nullable) | Repository UUID |
+|   ↳ `slug` | string (nullable) | Repository slug |
+|   ↳ `name` | string (nullable) | Repository name |
+|   ↳ `fullName` | string (nullable) | Workspace and repository full name |
+|   ↳ `description` | string (nullable) | Repository description |
+|   ↳ `isPrivate` | boolean (nullable) | Whether the repository is private |
+|   ↳ `scm` | string (nullable) | Source control system |
+|   ↳ `language` | string (nullable) | Primary repository language |
+|   ↳ `size` | number (nullable) | Repository size in bytes |
+|   ↳ `createdOn` | string (nullable) | Repository creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Repository update timestamp |
+|   ↳ `mainBranch` | string (nullable) | Main branch name |
+|   ↳ `owner` | object (nullable) | Repository owner |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `project` | object | Containing Bitbucket project |
-|     ↳ `uuid` | string | Project UUID |
-|     ↳ `key` | string | Project key |
-|     ↳ `name` | string | Project name |
-|   ↳ `selfUrl` | string | Repository API URL |
-|   ↳ `htmlUrl` | string | Repository web URL |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `project` | object (nullable) | Containing Bitbucket project |
+|     ↳ `uuid` | string (nullable) | Project UUID |
+|     ↳ `key` | string (nullable) | Project key |
+|     ↳ `name` | string (nullable) | Project name |
+|   ↳ `selfUrl` | string (nullable) | Repository API URL |
+|   ↳ `htmlUrl` | string (nullable) | Repository web URL |
 
 ### Bitbucket List Branches
 
@@ -169,48 +169,48 @@ List branches in a Bitbucket Cloud repository
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Branches |
 |   ↳ `type` | string | Bitbucket branch object type |
-|   ↳ `name` | string | Branch name |
-|   ↳ `target` | object | Commit targeted by the branch |
+|   ↳ `name` | string (nullable) | Branch name |
+|   ↳ `target` | object (nullable) | Commit targeted by the branch |
 |     ↳ `type` | string | Bitbucket commit object type |
-|     ↳ `hash` | string | Commit hash |
-|     ↳ `date` | string | Commit timestamp |
-|     ↳ `message` | string | Full commit message |
-|     ↳ `summary` | string | Raw commit summary |
-|     ↳ `authorRaw` | string | Raw author value stored by Git |
-|     ↳ `author` | object | Matched Bitbucket account, when available |
+|     ↳ `hash` | string (nullable) | Commit hash |
+|     ↳ `date` | string (nullable) | Commit timestamp |
+|     ↳ `message` | string (nullable) | Full commit message |
+|     ↳ `summary` | string (nullable) | Raw commit summary |
+|     ↳ `authorRaw` | string (nullable) | Raw author value stored by Git |
+|     ↳ `author` | object (nullable) | Matched Bitbucket account, when available |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `committerRaw` | string | Raw committer value stored by Git |
-|     ↳ `committer` | object | Matched Bitbucket committer account, when available |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `committerRaw` | string (nullable) | Raw committer value stored by Git |
+|     ↳ `committer` | object (nullable) | Matched Bitbucket committer account, when available |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `parents` | array | Parent commits |
-|       ↳ `hash` | string | Parent commit hash |
-|     ↳ `selfUrl` | string | Commit API URL |
-|     ↳ `htmlUrl` | string | Commit web URL |
-|   ↳ `mergeStrategies` | array | Merge strategies available for the branch |
-|   ↳ `defaultMergeStrategy` | string | Default merge strategy |
-|   ↳ `selfUrl` | string | Branch API URL |
-|   ↳ `htmlUrl` | string | Branch web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `parents` | array (nullable) | Parent commits |
+|       ↳ `hash` | string (nullable) | Parent commit hash |
+|     ↳ `selfUrl` | string (nullable) | Commit API URL |
+|     ↳ `htmlUrl` | string (nullable) | Commit web URL |
+|   ↳ `mergeStrategies` | array (nullable) | Merge strategies available for the branch |
+|   ↳ `defaultMergeStrategy` | string (nullable) | Default merge strategy |
+|   ↳ `selfUrl` | string (nullable) | Branch API URL |
+|   ↳ `htmlUrl` | string (nullable) | Branch web URL |
 
 ### Bitbucket Create Branch
 
@@ -231,41 +231,41 @@ Create a branch at a commit hash or existing ref
 | --------- | ---- | ----------- |
 | `branch` | object | Created branch |
 |   ↳ `type` | string | Bitbucket branch object type |
-|   ↳ `name` | string | Branch name |
-|   ↳ `target` | object | Commit targeted by the branch |
+|   ↳ `name` | string (nullable) | Branch name |
+|   ↳ `target` | object (nullable) | Commit targeted by the branch |
 |     ↳ `type` | string | Bitbucket commit object type |
-|     ↳ `hash` | string | Commit hash |
-|     ↳ `date` | string | Commit timestamp |
-|     ↳ `message` | string | Full commit message |
-|     ↳ `summary` | string | Raw commit summary |
-|     ↳ `authorRaw` | string | Raw author value stored by Git |
-|     ↳ `author` | object | Matched Bitbucket account, when available |
+|     ↳ `hash` | string (nullable) | Commit hash |
+|     ↳ `date` | string (nullable) | Commit timestamp |
+|     ↳ `message` | string (nullable) | Full commit message |
+|     ↳ `summary` | string (nullable) | Raw commit summary |
+|     ↳ `authorRaw` | string (nullable) | Raw author value stored by Git |
+|     ↳ `author` | object (nullable) | Matched Bitbucket account, when available |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `committerRaw` | string | Raw committer value stored by Git |
-|     ↳ `committer` | object | Matched Bitbucket committer account, when available |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `committerRaw` | string (nullable) | Raw committer value stored by Git |
+|     ↳ `committer` | object (nullable) | Matched Bitbucket committer account, when available |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `parents` | array | Parent commits |
-|       ↳ `hash` | string | Parent commit hash |
-|     ↳ `selfUrl` | string | Commit API URL |
-|     ↳ `htmlUrl` | string | Commit web URL |
-|   ↳ `mergeStrategies` | array | Merge strategies available for the branch |
-|   ↳ `defaultMergeStrategy` | string | Default merge strategy |
-|   ↳ `selfUrl` | string | Branch API URL |
-|   ↳ `htmlUrl` | string | Branch web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `parents` | array (nullable) | Parent commits |
+|       ↳ `hash` | string (nullable) | Parent commit hash |
+|     ↳ `selfUrl` | string (nullable) | Commit API URL |
+|     ↳ `htmlUrl` | string (nullable) | Commit web URL |
+|   ↳ `mergeStrategies` | array (nullable) | Merge strategies available for the branch |
+|   ↳ `defaultMergeStrategy` | string (nullable) | Default merge strategy |
+|   ↳ `selfUrl` | string (nullable) | Branch API URL |
+|   ↳ `htmlUrl` | string (nullable) | Branch web URL |
 
 ### Bitbucket Delete Branch
 
@@ -303,41 +303,41 @@ List repository commits in reverse chronological order
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Commits |
 |   ↳ `type` | string | Bitbucket commit object type |
-|   ↳ `hash` | string | Commit hash |
-|   ↳ `date` | string | Commit timestamp |
-|   ↳ `message` | string | Full commit message |
-|   ↳ `summary` | string | Raw commit summary |
-|   ↳ `authorRaw` | string | Raw author value stored by Git |
-|   ↳ `author` | object | Matched Bitbucket account, when available |
+|   ↳ `hash` | string (nullable) | Commit hash |
+|   ↳ `date` | string (nullable) | Commit timestamp |
+|   ↳ `message` | string (nullable) | Full commit message |
+|   ↳ `summary` | string (nullable) | Raw commit summary |
+|   ↳ `authorRaw` | string (nullable) | Raw author value stored by Git |
+|   ↳ `author` | object (nullable) | Matched Bitbucket account, when available |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `committerRaw` | string | Raw committer value stored by Git |
-|   ↳ `committer` | object | Matched Bitbucket committer account, when available |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `committerRaw` | string (nullable) | Raw committer value stored by Git |
+|   ↳ `committer` | object (nullable) | Matched Bitbucket committer account, when available |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `parents` | array | Parent commits |
-|     ↳ `hash` | string | Parent commit hash |
-|   ↳ `selfUrl` | string | Commit API URL |
-|   ↳ `htmlUrl` | string | Commit web URL |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `parents` | array (nullable) | Parent commits |
+|     ↳ `hash` | string (nullable) | Parent commit hash |
+|   ↳ `selfUrl` | string (nullable) | Commit API URL |
+|   ↳ `htmlUrl` | string (nullable) | Commit web URL |
 
 ### Bitbucket Get Commit
 
@@ -357,34 +357,34 @@ Get a repository commit by its full SHA-1
 | --------- | ---- | ----------- |
 | `commit` | object | Commit details |
 |   ↳ `type` | string | Bitbucket commit object type |
-|   ↳ `hash` | string | Commit hash |
-|   ↳ `date` | string | Commit timestamp |
-|   ↳ `message` | string | Full commit message |
-|   ↳ `summary` | string | Raw commit summary |
-|   ↳ `authorRaw` | string | Raw author value stored by Git |
-|   ↳ `author` | object | Matched Bitbucket account, when available |
+|   ↳ `hash` | string (nullable) | Commit hash |
+|   ↳ `date` | string (nullable) | Commit timestamp |
+|   ↳ `message` | string (nullable) | Full commit message |
+|   ↳ `summary` | string (nullable) | Raw commit summary |
+|   ↳ `authorRaw` | string (nullable) | Raw author value stored by Git |
+|   ↳ `author` | object (nullable) | Matched Bitbucket account, when available |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `committerRaw` | string | Raw committer value stored by Git |
-|   ↳ `committer` | object | Matched Bitbucket committer account, when available |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `committerRaw` | string (nullable) | Raw committer value stored by Git |
+|   ↳ `committer` | object (nullable) | Matched Bitbucket committer account, when available |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `parents` | array | Parent commits |
-|     ↳ `hash` | string | Parent commit hash |
-|   ↳ `selfUrl` | string | Commit API URL |
-|   ↳ `htmlUrl` | string | Commit web URL |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `parents` | array (nullable) | Parent commits |
+|     ↳ `hash` | string (nullable) | Parent commit hash |
+|   ↳ `selfUrl` | string (nullable) | Commit API URL |
+|   ↳ `htmlUrl` | string (nullable) | Commit web URL |
 
 ### Bitbucket List Directory
 
@@ -408,20 +408,20 @@ List one shallow repository directory at a full commit SHA-1
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Directory entries |
 |   ↳ `type` | string | Entry type, such as commit_file or commit_directory |
-|   ↳ `path` | string | Repository-relative path |
-|   ↳ `commitHash` | string | Resolved commit hash |
-|   ↳ `size` | number | File size in bytes when the entry is a file |
-|   ↳ `attributes` | array | File attributes when the entry is a file |
-|   ↳ `isBinary` | boolean | Whether file attributes include the binary marker |
-|   ↳ `selfUrl` | string | Source API URL |
-|   ↳ `metadataUrl` | string | Source metadata API URL |
+|   ↳ `path` | string (nullable) | Repository-relative path |
+|   ↳ `commitHash` | string (nullable) | Resolved commit hash |
+|   ↳ `size` | number (nullable) | File size in bytes when the entry is a file |
+|   ↳ `attributes` | array (nullable) | File attributes when the entry is a file |
+|   ↳ `isBinary` | boolean (nullable) | Whether file attributes include the binary marker |
+|   ↳ `selfUrl` | string (nullable) | Source API URL |
+|   ↳ `metadataUrl` | string (nullable) | Source metadata API URL |
 
 ### Bitbucket Get File Metadata
 
@@ -442,12 +442,12 @@ Inspect file size and attributes at a full repository commit SHA-1
 | --------- | ---- | ----------- |
 | `file` | object | File metadata |
 |   ↳ `type` | string | Entry type \(commit_file\) |
-|   ↳ `path` | string | Repository-relative path |
-|   ↳ `commitHash` | string | Resolved commit hash |
-|   ↳ `escapedPath` | string | Escaped display path |
-|   ↳ `size` | number | File size in bytes |
-|   ↳ `attributes` | array | File attributes reported by Bitbucket |
-|   ↳ `isBinary` | boolean | Whether the documented attributes include the binary marker |
+|   ↳ `path` | string (nullable) | Repository-relative path |
+|   ↳ `commitHash` | string (nullable) | Resolved commit hash |
+|   ↳ `escapedPath` | string (nullable) | Escaped display path |
+|   ↳ `size` | number (nullable) | File size in bytes |
+|   ↳ `attributes` | array (nullable) | File attributes reported by Bitbucket |
+|   ↳ `isBinary` | boolean (nullable) | Whether the documented attributes include the binary marker |
 
 ### Bitbucket Get File
 
@@ -467,12 +467,12 @@ Read bounded UTF-8 text from a file at a full repository commit SHA-1
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Bounded UTF-8 file text; null for binary content |
-| `binary` | boolean | Whether documented metadata identifies binary content; null when unknown |
-| `truncated` | boolean | Whether later content was omitted; null when binary size is unknown |
+| `content` | string (nullable) | Bounded UTF-8 file text; null for binary content |
+| `binary` | boolean (nullable) | Whether documented metadata identifies binary content; null when unknown |
+| `truncated` | boolean (nullable) | Whether later content was omitted; null when binary size is unknown |
 | `returnedBytes` | number | Provider bytes read for the returned file |
-| `fullBytes` | number | Full file byte size when reported |
-| `contentType` | string | Response MIME type |
+| `fullBytes` | number (nullable) | Full file byte size when reported |
+| `contentType` | string (nullable) | Response MIME type |
 
 ### Bitbucket List Pull Requests
 
@@ -495,80 +495,80 @@ List pull requests in a Bitbucket Cloud repository
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Pull requests |
 |   ↳ `type` | string | Bitbucket pull request object type |
-|   ↳ `id` | number | Repository-scoped pull request ID |
-|   ↳ `title` | string | Pull request title |
-|   ↳ `description` | string | Pull request description |
-|   ↳ `state` | string | Pull request state |
-|   ↳ `draft` | boolean | Whether the pull request is a draft |
-|   ↳ `queued` | boolean | Whether the pull request is queued |
-|   ↳ `author` | object | Pull request author |
+|   ↳ `id` | number (nullable) | Repository-scoped pull request ID |
+|   ↳ `title` | string (nullable) | Pull request title |
+|   ↳ `description` | string (nullable) | Pull request description |
+|   ↳ `state` | string (nullable) | Pull request state |
+|   ↳ `draft` | boolean (nullable) | Whether the pull request is a draft |
+|   ↳ `queued` | boolean (nullable) | Whether the pull request is queued |
+|   ↳ `author` | object (nullable) | Pull request author |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `closedBy` | object | Account that closed the pull request |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `closedBy` | object (nullable) | Account that closed the pull request |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `source` | object | Source endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `destination` | object | Destination endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `mergeCommitHash` | string | Merge commit hash |
-|   ↳ `commentCount` | number | Comment count |
-|   ↳ `taskCount` | number | Open task count |
-|   ↳ `closeSourceBranch` | boolean | Whether merging closes the source branch |
-|   ↳ `reason` | string | Reason the pull request was declined |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `reviewers` | array | Explicit reviewers |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `source` | object (nullable) | Source endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `destination` | object (nullable) | Destination endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `mergeCommitHash` | string (nullable) | Merge commit hash |
+|   ↳ `commentCount` | number (nullable) | Comment count |
+|   ↳ `taskCount` | number (nullable) | Open task count |
+|   ↳ `closeSourceBranch` | boolean (nullable) | Whether merging closes the source branch |
+|   ↳ `reason` | string (nullable) | Reason the pull request was declined |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `reviewers` | array (nullable) | Explicit reviewers |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `participants` | array | Pull request participants |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `participants` | array (nullable) | Pull request participants |
 |     ↳ `type` | string | Bitbucket participant object type |
-|     ↳ `user` | object | Participating account |
+|     ↳ `user` | object (nullable) | Participating account |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `role` | string | Participant role |
-|     ↳ `approved` | boolean | Whether the participant approved |
-|     ↳ `state` | string | Review state |
-|     ↳ `participatedOn` | string | Timestamp of the participant action |
-|   ↳ `selfUrl` | string | Pull request API URL |
-|   ↳ `htmlUrl` | string | Pull request web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `role` | string (nullable) | Participant role |
+|     ↳ `approved` | boolean (nullable) | Whether the participant approved |
+|     ↳ `state` | string (nullable) | Review state |
+|     ↳ `participatedOn` | string (nullable) | Timestamp of the participant action |
+|   ↳ `selfUrl` | string (nullable) | Pull request API URL |
+|   ↳ `htmlUrl` | string (nullable) | Pull request web URL |
 
 ### Bitbucket Get Pull Request
 
@@ -588,73 +588,73 @@ Get a pull request by repository-scoped ID
 | --------- | ---- | ----------- |
 | `pullRequest` | object | Pull request details |
 |   ↳ `type` | string | Bitbucket pull request object type |
-|   ↳ `id` | number | Repository-scoped pull request ID |
-|   ↳ `title` | string | Pull request title |
-|   ↳ `description` | string | Pull request description |
-|   ↳ `state` | string | Pull request state |
-|   ↳ `draft` | boolean | Whether the pull request is a draft |
-|   ↳ `queued` | boolean | Whether the pull request is queued |
-|   ↳ `author` | object | Pull request author |
+|   ↳ `id` | number (nullable) | Repository-scoped pull request ID |
+|   ↳ `title` | string (nullable) | Pull request title |
+|   ↳ `description` | string (nullable) | Pull request description |
+|   ↳ `state` | string (nullable) | Pull request state |
+|   ↳ `draft` | boolean (nullable) | Whether the pull request is a draft |
+|   ↳ `queued` | boolean (nullable) | Whether the pull request is queued |
+|   ↳ `author` | object (nullable) | Pull request author |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `closedBy` | object | Account that closed the pull request |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `closedBy` | object (nullable) | Account that closed the pull request |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `source` | object | Source endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `destination` | object | Destination endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `mergeCommitHash` | string | Merge commit hash |
-|   ↳ `commentCount` | number | Comment count |
-|   ↳ `taskCount` | number | Open task count |
-|   ↳ `closeSourceBranch` | boolean | Whether merging closes the source branch |
-|   ↳ `reason` | string | Reason the pull request was declined |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `reviewers` | array | Explicit reviewers |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `source` | object (nullable) | Source endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `destination` | object (nullable) | Destination endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `mergeCommitHash` | string (nullable) | Merge commit hash |
+|   ↳ `commentCount` | number (nullable) | Comment count |
+|   ↳ `taskCount` | number (nullable) | Open task count |
+|   ↳ `closeSourceBranch` | boolean (nullable) | Whether merging closes the source branch |
+|   ↳ `reason` | string (nullable) | Reason the pull request was declined |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `reviewers` | array (nullable) | Explicit reviewers |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `participants` | array | Pull request participants |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `participants` | array (nullable) | Pull request participants |
 |     ↳ `type` | string | Bitbucket participant object type |
-|     ↳ `user` | object | Participating account |
+|     ↳ `user` | object (nullable) | Participating account |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `role` | string | Participant role |
-|     ↳ `approved` | boolean | Whether the participant approved |
-|     ↳ `state` | string | Review state |
-|     ↳ `participatedOn` | string | Timestamp of the participant action |
-|   ↳ `selfUrl` | string | Pull request API URL |
-|   ↳ `htmlUrl` | string | Pull request web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `role` | string (nullable) | Participant role |
+|     ↳ `approved` | boolean (nullable) | Whether the participant approved |
+|     ↳ `state` | string (nullable) | Review state |
+|     ↳ `participatedOn` | string (nullable) | Timestamp of the participant action |
+|   ↳ `selfUrl` | string (nullable) | Pull request API URL |
+|   ↳ `htmlUrl` | string (nullable) | Pull request web URL |
 
 ### Bitbucket Create Pull Request
 
@@ -680,73 +680,73 @@ Create a pull request between repository branches
 | --------- | ---- | ----------- |
 | `pullRequest` | object | Created pull request |
 |   ↳ `type` | string | Bitbucket pull request object type |
-|   ↳ `id` | number | Repository-scoped pull request ID |
-|   ↳ `title` | string | Pull request title |
-|   ↳ `description` | string | Pull request description |
-|   ↳ `state` | string | Pull request state |
-|   ↳ `draft` | boolean | Whether the pull request is a draft |
-|   ↳ `queued` | boolean | Whether the pull request is queued |
-|   ↳ `author` | object | Pull request author |
+|   ↳ `id` | number (nullable) | Repository-scoped pull request ID |
+|   ↳ `title` | string (nullable) | Pull request title |
+|   ↳ `description` | string (nullable) | Pull request description |
+|   ↳ `state` | string (nullable) | Pull request state |
+|   ↳ `draft` | boolean (nullable) | Whether the pull request is a draft |
+|   ↳ `queued` | boolean (nullable) | Whether the pull request is queued |
+|   ↳ `author` | object (nullable) | Pull request author |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `closedBy` | object | Account that closed the pull request |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `closedBy` | object (nullable) | Account that closed the pull request |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `source` | object | Source endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `destination` | object | Destination endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `mergeCommitHash` | string | Merge commit hash |
-|   ↳ `commentCount` | number | Comment count |
-|   ↳ `taskCount` | number | Open task count |
-|   ↳ `closeSourceBranch` | boolean | Whether merging closes the source branch |
-|   ↳ `reason` | string | Reason the pull request was declined |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `reviewers` | array | Explicit reviewers |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `source` | object (nullable) | Source endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `destination` | object (nullable) | Destination endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `mergeCommitHash` | string (nullable) | Merge commit hash |
+|   ↳ `commentCount` | number (nullable) | Comment count |
+|   ↳ `taskCount` | number (nullable) | Open task count |
+|   ↳ `closeSourceBranch` | boolean (nullable) | Whether merging closes the source branch |
+|   ↳ `reason` | string (nullable) | Reason the pull request was declined |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `reviewers` | array (nullable) | Explicit reviewers |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `participants` | array | Pull request participants |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `participants` | array (nullable) | Pull request participants |
 |     ↳ `type` | string | Bitbucket participant object type |
-|     ↳ `user` | object | Participating account |
+|     ↳ `user` | object (nullable) | Participating account |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `role` | string | Participant role |
-|     ↳ `approved` | boolean | Whether the participant approved |
-|     ↳ `state` | string | Review state |
-|     ↳ `participatedOn` | string | Timestamp of the participant action |
-|   ↳ `selfUrl` | string | Pull request API URL |
-|   ↳ `htmlUrl` | string | Pull request web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `role` | string (nullable) | Participant role |
+|     ↳ `approved` | boolean (nullable) | Whether the participant approved |
+|     ↳ `state` | string (nullable) | Review state |
+|     ↳ `participatedOn` | string (nullable) | Timestamp of the participant action |
+|   ↳ `selfUrl` | string (nullable) | Pull request API URL |
+|   ↳ `htmlUrl` | string (nullable) | Pull request web URL |
 
 ### Bitbucket Merge Pull Request
 
@@ -768,77 +768,77 @@ Start an asynchronous pull request merge and return a task to poll when needed
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | string | Whether the merge completed or remains pending |
-| `taskId` | string | Async merge task ID |
-| `taskUrl` | string | Validated task polling URL |
-| `pullRequest` | object | Merged pull request when completed synchronously |
+| `taskId` | string (nullable) | Async merge task ID |
+| `taskUrl` | string (nullable) | Validated task polling URL |
+| `pullRequest` | object (nullable) | Merged pull request when completed synchronously |
 |   ↳ `type` | string | Bitbucket pull request object type |
-|   ↳ `id` | number | Repository-scoped pull request ID |
-|   ↳ `title` | string | Pull request title |
-|   ↳ `description` | string | Pull request description |
-|   ↳ `state` | string | Pull request state |
-|   ↳ `draft` | boolean | Whether the pull request is a draft |
-|   ↳ `queued` | boolean | Whether the pull request is queued |
-|   ↳ `author` | object | Pull request author |
+|   ↳ `id` | number (nullable) | Repository-scoped pull request ID |
+|   ↳ `title` | string (nullable) | Pull request title |
+|   ↳ `description` | string (nullable) | Pull request description |
+|   ↳ `state` | string (nullable) | Pull request state |
+|   ↳ `draft` | boolean (nullable) | Whether the pull request is a draft |
+|   ↳ `queued` | boolean (nullable) | Whether the pull request is queued |
+|   ↳ `author` | object (nullable) | Pull request author |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `closedBy` | object | Account that closed the pull request |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `closedBy` | object (nullable) | Account that closed the pull request |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `source` | object | Source endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `destination` | object | Destination endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `mergeCommitHash` | string | Merge commit hash |
-|   ↳ `commentCount` | number | Comment count |
-|   ↳ `taskCount` | number | Open task count |
-|   ↳ `closeSourceBranch` | boolean | Whether merging closes the source branch |
-|   ↳ `reason` | string | Reason the pull request was declined |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `reviewers` | array | Explicit reviewers |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `source` | object (nullable) | Source endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `destination` | object (nullable) | Destination endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `mergeCommitHash` | string (nullable) | Merge commit hash |
+|   ↳ `commentCount` | number (nullable) | Comment count |
+|   ↳ `taskCount` | number (nullable) | Open task count |
+|   ↳ `closeSourceBranch` | boolean (nullable) | Whether merging closes the source branch |
+|   ↳ `reason` | string (nullable) | Reason the pull request was declined |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `reviewers` | array (nullable) | Explicit reviewers |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `participants` | array | Pull request participants |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `participants` | array (nullable) | Pull request participants |
 |     ↳ `type` | string | Bitbucket participant object type |
-|     ↳ `user` | object | Participating account |
+|     ↳ `user` | object (nullable) | Participating account |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `role` | string | Participant role |
-|     ↳ `approved` | boolean | Whether the participant approved |
-|     ↳ `state` | string | Review state |
-|     ↳ `participatedOn` | string | Timestamp of the participant action |
-|   ↳ `selfUrl` | string | Pull request API URL |
-|   ↳ `htmlUrl` | string | Pull request web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `role` | string (nullable) | Participant role |
+|     ↳ `approved` | boolean (nullable) | Whether the participant approved |
+|     ↳ `state` | string (nullable) | Review state |
+|     ↳ `participatedOn` | string (nullable) | Timestamp of the participant action |
+|   ↳ `selfUrl` | string (nullable) | Pull request API URL |
+|   ↳ `htmlUrl` | string (nullable) | Pull request web URL |
 
 ### Bitbucket Get Merge Task Status
 
@@ -858,76 +858,76 @@ Poll the status of an asynchronous pull request merge task
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `taskStatus` | string | PENDING or SUCCESS |
-| `selfUrl` | string | Merge task API URL |
-| `mergeResult` | object | Merged pull request when the task succeeds |
+| `selfUrl` | string (nullable) | Merge task API URL |
+| `mergeResult` | object (nullable) | Merged pull request when the task succeeds |
 |   ↳ `type` | string | Bitbucket pull request object type |
-|   ↳ `id` | number | Repository-scoped pull request ID |
-|   ↳ `title` | string | Pull request title |
-|   ↳ `description` | string | Pull request description |
-|   ↳ `state` | string | Pull request state |
-|   ↳ `draft` | boolean | Whether the pull request is a draft |
-|   ↳ `queued` | boolean | Whether the pull request is queued |
-|   ↳ `author` | object | Pull request author |
+|   ↳ `id` | number (nullable) | Repository-scoped pull request ID |
+|   ↳ `title` | string (nullable) | Pull request title |
+|   ↳ `description` | string (nullable) | Pull request description |
+|   ↳ `state` | string (nullable) | Pull request state |
+|   ↳ `draft` | boolean (nullable) | Whether the pull request is a draft |
+|   ↳ `queued` | boolean (nullable) | Whether the pull request is queued |
+|   ↳ `author` | object (nullable) | Pull request author |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `closedBy` | object | Account that closed the pull request |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `closedBy` | object (nullable) | Account that closed the pull request |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `source` | object | Source endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `destination` | object | Destination endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `mergeCommitHash` | string | Merge commit hash |
-|   ↳ `commentCount` | number | Comment count |
-|   ↳ `taskCount` | number | Open task count |
-|   ↳ `closeSourceBranch` | boolean | Whether merging closes the source branch |
-|   ↳ `reason` | string | Reason the pull request was declined |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `reviewers` | array | Explicit reviewers |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `source` | object (nullable) | Source endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `destination` | object (nullable) | Destination endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `mergeCommitHash` | string (nullable) | Merge commit hash |
+|   ↳ `commentCount` | number (nullable) | Comment count |
+|   ↳ `taskCount` | number (nullable) | Open task count |
+|   ↳ `closeSourceBranch` | boolean (nullable) | Whether merging closes the source branch |
+|   ↳ `reason` | string (nullable) | Reason the pull request was declined |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `reviewers` | array (nullable) | Explicit reviewers |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `participants` | array | Pull request participants |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `participants` | array (nullable) | Pull request participants |
 |     ↳ `type` | string | Bitbucket participant object type |
-|     ↳ `user` | object | Participating account |
+|     ↳ `user` | object (nullable) | Participating account |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `role` | string | Participant role |
-|     ↳ `approved` | boolean | Whether the participant approved |
-|     ↳ `state` | string | Review state |
-|     ↳ `participatedOn` | string | Timestamp of the participant action |
-|   ↳ `selfUrl` | string | Pull request API URL |
-|   ↳ `htmlUrl` | string | Pull request web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `role` | string (nullable) | Participant role |
+|     ↳ `approved` | boolean (nullable) | Whether the participant approved |
+|     ↳ `state` | string (nullable) | Review state |
+|     ↳ `participatedOn` | string (nullable) | Timestamp of the participant action |
+|   ↳ `selfUrl` | string (nullable) | Pull request API URL |
+|   ↳ `htmlUrl` | string (nullable) | Pull request web URL |
 
 ### Bitbucket Decline Pull Request
 
@@ -947,73 +947,73 @@ Decline an open pull request
 | --------- | ---- | ----------- |
 | `pullRequest` | object | Declined pull request |
 |   ↳ `type` | string | Bitbucket pull request object type |
-|   ↳ `id` | number | Repository-scoped pull request ID |
-|   ↳ `title` | string | Pull request title |
-|   ↳ `description` | string | Pull request description |
-|   ↳ `state` | string | Pull request state |
-|   ↳ `draft` | boolean | Whether the pull request is a draft |
-|   ↳ `queued` | boolean | Whether the pull request is queued |
-|   ↳ `author` | object | Pull request author |
+|   ↳ `id` | number (nullable) | Repository-scoped pull request ID |
+|   ↳ `title` | string (nullable) | Pull request title |
+|   ↳ `description` | string (nullable) | Pull request description |
+|   ↳ `state` | string (nullable) | Pull request state |
+|   ↳ `draft` | boolean (nullable) | Whether the pull request is a draft |
+|   ↳ `queued` | boolean (nullable) | Whether the pull request is queued |
+|   ↳ `author` | object (nullable) | Pull request author |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `closedBy` | object | Account that closed the pull request |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `closedBy` | object (nullable) | Account that closed the pull request |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `source` | object | Source endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `destination` | object | Destination endpoint |
-|     ↳ `branchName` | string | Branch name |
-|     ↳ `commitHash` | string | Commit hash |
-|     ↳ `repositoryUuid` | string | Repository UUID |
-|     ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `mergeCommitHash` | string | Merge commit hash |
-|   ↳ `commentCount` | number | Comment count |
-|   ↳ `taskCount` | number | Open task count |
-|   ↳ `closeSourceBranch` | boolean | Whether merging closes the source branch |
-|   ↳ `reason` | string | Reason the pull request was declined |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `reviewers` | array | Explicit reviewers |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `source` | object (nullable) | Source endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `destination` | object (nullable) | Destination endpoint |
+|     ↳ `branchName` | string (nullable) | Branch name |
+|     ↳ `commitHash` | string (nullable) | Commit hash |
+|     ↳ `repositoryUuid` | string (nullable) | Repository UUID |
+|     ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `mergeCommitHash` | string (nullable) | Merge commit hash |
+|   ↳ `commentCount` | number (nullable) | Comment count |
+|   ↳ `taskCount` | number (nullable) | Open task count |
+|   ↳ `closeSourceBranch` | boolean (nullable) | Whether merging closes the source branch |
+|   ↳ `reason` | string (nullable) | Reason the pull request was declined |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `reviewers` | array (nullable) | Explicit reviewers |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `participants` | array | Pull request participants |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `participants` | array (nullable) | Pull request participants |
 |     ↳ `type` | string | Bitbucket participant object type |
-|     ↳ `user` | object | Participating account |
+|     ↳ `user` | object (nullable) | Participating account |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `role` | string | Participant role |
-|     ↳ `approved` | boolean | Whether the participant approved |
-|     ↳ `state` | string | Review state |
-|     ↳ `participatedOn` | string | Timestamp of the participant action |
-|   ↳ `selfUrl` | string | Pull request API URL |
-|   ↳ `htmlUrl` | string | Pull request web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `role` | string (nullable) | Participant role |
+|     ↳ `approved` | boolean (nullable) | Whether the participant approved |
+|     ↳ `state` | string (nullable) | Review state |
+|     ↳ `participatedOn` | string (nullable) | Timestamp of the participant action |
+|   ↳ `selfUrl` | string (nullable) | Pull request API URL |
+|   ↳ `htmlUrl` | string (nullable) | Pull request web URL |
 
 ### Bitbucket Approve Pull Request
 
@@ -1033,19 +1033,19 @@ Approve a pull request as the authenticated account
 | --------- | ---- | ----------- |
 | `participant` | object | Approval participant record |
 |   ↳ `type` | string | Bitbucket participant object type |
-|   ↳ `user` | object | Participating account |
+|   ↳ `user` | object (nullable) | Participating account |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `role` | string | Participant role |
-|   ↳ `approved` | boolean | Whether the participant approved |
-|   ↳ `state` | string | Review state |
-|   ↳ `participatedOn` | string | Timestamp of the participant action |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `role` | string (nullable) | Participant role |
+|   ↳ `approved` | boolean (nullable) | Whether the participant approved |
+|   ↳ `state` | string (nullable) | Review state |
+|   ↳ `participatedOn` | string (nullable) | Timestamp of the participant action |
 
 ### Bitbucket Request Pull Request Changes
 
@@ -1065,19 +1065,19 @@ Request changes on a pull request as the authenticated account
 | --------- | ---- | ----------- |
 | `participant` | object | Change-request participant record |
 |   ↳ `type` | string | Bitbucket participant object type |
-|   ↳ `user` | object | Participating account |
+|   ↳ `user` | object (nullable) | Participating account |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `role` | string | Participant role |
-|   ↳ `approved` | boolean | Whether the participant approved |
-|   ↳ `state` | string | Review state |
-|   ↳ `participatedOn` | string | Timestamp of the participant action |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `role` | string (nullable) | Participant role |
+|   ↳ `approved` | boolean (nullable) | Whether the participant approved |
+|   ↳ `state` | string (nullable) | Review state |
+|   ↳ `participatedOn` | string (nullable) | Timestamp of the participant action |
 
 ### Bitbucket Get Pull Request Diff
 
@@ -1101,7 +1101,7 @@ Read a bounded UTF-8 unified diff for one pull request file
 | `decodingLossy` | boolean | Whether invalid UTF-8 source bytes were replaced while decoding |
 | `truncated` | boolean | Whether later diff text was omitted |
 | `returnedBytes` | number | Provider bytes read for the returned diff |
-| `fullBytes` | number | Full diff byte size when reported |
+| `fullBytes` | number (nullable) | Full diff byte size when reported |
 
 ### Bitbucket Get Pull Request Diffstat
 
@@ -1122,20 +1122,20 @@ List per-file change statistics for a pull request
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Per-file diff statistics |
 |   ↳ `type` | string | Diffstat object type |
-|   ↳ `status` | string | File change status |
-|   ↳ `linesAdded` | number | Lines added |
-|   ↳ `linesRemoved` | number | Lines removed |
-|   ↳ `oldPath` | string | Old file path |
-|   ↳ `newPath` | string | New file path |
-|   ↳ `oldCommitHash` | string | Old file commit hash |
-|   ↳ `newCommitHash` | string | New file commit hash |
+|   ↳ `status` | string (nullable) | File change status |
+|   ↳ `linesAdded` | number (nullable) | Lines added |
+|   ↳ `linesRemoved` | number (nullable) | Lines removed |
+|   ↳ `oldPath` | string (nullable) | Old file path |
+|   ↳ `newPath` | string (nullable) | New file path |
+|   ↳ `oldCommitHash` | string (nullable) | Old file commit hash |
+|   ↳ `newCommitHash` | string (nullable) | New file commit hash |
 
 ### Bitbucket List Pull Request Comments
 
@@ -1158,48 +1158,48 @@ List global, inline, and reply comments on a pull request
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Pull request comments |
 |   ↳ `type` | string | Bitbucket comment object type |
-|   ↳ `id` | number | Comment ID |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `content` | string | Raw comment content |
-|   ↳ `user` | object | Comment author |
+|   ↳ `id` | number (nullable) | Comment ID |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `content` | string (nullable) | Raw comment content |
+|   ↳ `user` | object (nullable) | Comment author |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `deleted` | boolean | Whether the comment was deleted |
-|   ↳ `parentId` | number | Parent comment ID |
-|   ↳ `inline` | object | Inline comment anchor |
-|     ↳ `path` | string | Anchored file path |
-|     ↳ `from` | number | Ending line in the old file |
-|     ↳ `to` | number | Ending line in the new file |
-|     ↳ `startFrom` | number | Starting line in the old file |
-|     ↳ `startTo` | number | Starting line in the new file |
-|   ↳ `pending` | boolean | Whether the comment is pending |
-|   ↳ `resolution` | object | Comment resolution details |
-|     ↳ `resolver` | object | Account that resolved the comment |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `deleted` | boolean (nullable) | Whether the comment was deleted |
+|   ↳ `parentId` | number (nullable) | Parent comment ID |
+|   ↳ `inline` | object (nullable) | Inline comment anchor |
+|     ↳ `path` | string (nullable) | Anchored file path |
+|     ↳ `from` | number (nullable) | Ending line in the old file |
+|     ↳ `to` | number (nullable) | Ending line in the new file |
+|     ↳ `startFrom` | number (nullable) | Starting line in the old file |
+|     ↳ `startTo` | number (nullable) | Starting line in the new file |
+|   ↳ `pending` | boolean (nullable) | Whether the comment is pending |
+|   ↳ `resolution` | object (nullable) | Comment resolution details |
+|     ↳ `resolver` | object (nullable) | Account that resolved the comment |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `resolvedOn` | string | Resolution timestamp |
-|   ↳ `selfUrl` | string | Comment API URL |
-|   ↳ `htmlUrl` | string | Comment web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `resolvedOn` | string (nullable) | Resolution timestamp |
+|   ↳ `selfUrl` | string (nullable) | Comment API URL |
+|   ↳ `htmlUrl` | string (nullable) | Comment web URL |
 
 ### Bitbucket Create Pull Request Comment
 
@@ -1221,41 +1221,41 @@ Create a global comment or reply on a pull request
 | --------- | ---- | ----------- |
 | `comment` | object | Created comment |
 |   ↳ `type` | string | Bitbucket comment object type |
-|   ↳ `id` | number | Comment ID |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `content` | string | Raw comment content |
-|   ↳ `user` | object | Comment author |
+|   ↳ `id` | number (nullable) | Comment ID |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `content` | string (nullable) | Raw comment content |
+|   ↳ `user` | object (nullable) | Comment author |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `deleted` | boolean | Whether the comment was deleted |
-|   ↳ `parentId` | number | Parent comment ID |
-|   ↳ `inline` | object | Inline comment anchor |
-|     ↳ `path` | string | Anchored file path |
-|     ↳ `from` | number | Ending line in the old file |
-|     ↳ `to` | number | Ending line in the new file |
-|     ↳ `startFrom` | number | Starting line in the old file |
-|     ↳ `startTo` | number | Starting line in the new file |
-|   ↳ `pending` | boolean | Whether the comment is pending |
-|   ↳ `resolution` | object | Comment resolution details |
-|     ↳ `resolver` | object | Account that resolved the comment |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `deleted` | boolean (nullable) | Whether the comment was deleted |
+|   ↳ `parentId` | number (nullable) | Parent comment ID |
+|   ↳ `inline` | object (nullable) | Inline comment anchor |
+|     ↳ `path` | string (nullable) | Anchored file path |
+|     ↳ `from` | number (nullable) | Ending line in the old file |
+|     ↳ `to` | number (nullable) | Ending line in the new file |
+|     ↳ `startFrom` | number (nullable) | Starting line in the old file |
+|     ↳ `startTo` | number (nullable) | Starting line in the new file |
+|   ↳ `pending` | boolean (nullable) | Whether the comment is pending |
+|   ↳ `resolution` | object (nullable) | Comment resolution details |
+|     ↳ `resolver` | object (nullable) | Account that resolved the comment |
 |       ↳ `type` | string | Bitbucket account object type |
-|       ↳ `uuid` | string | Bitbucket account UUID |
-|       ↳ `accountId` | string | Atlassian account ID |
-|       ↳ `displayName` | string | Account display name |
-|       ↳ `createdOn` | string | Account creation timestamp |
-|       ↳ `selfUrl` | string | Account API URL |
-|       ↳ `htmlUrl` | string | Account web URL |
-|       ↳ `avatarUrl` | string | Account avatar URL |
-|     ↳ `resolvedOn` | string | Resolution timestamp |
-|   ↳ `selfUrl` | string | Comment API URL |
-|   ↳ `htmlUrl` | string | Comment web URL |
+|       ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|       ↳ `accountId` | string (nullable) | Atlassian account ID |
+|       ↳ `displayName` | string (nullable) | Account display name |
+|       ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|       ↳ `selfUrl` | string (nullable) | Account API URL |
+|       ↳ `htmlUrl` | string (nullable) | Account web URL |
+|       ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|     ↳ `resolvedOn` | string (nullable) | Resolution timestamp |
+|   ↳ `selfUrl` | string (nullable) | Comment API URL |
+|   ↳ `htmlUrl` | string (nullable) | Comment web URL |
 
 ### Bitbucket List Pull Request Commit Statuses
 
@@ -1278,23 +1278,23 @@ List commit statuses associated with a pull request
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Pull request commit statuses |
 |   ↳ `type` | string | Bitbucket commit-status object type |
-|   ↳ `key` | string | Vendor-unique status key |
-|   ↳ `refName` | string | Reference name at status creation time |
-|   ↳ `url` | string | External build URL |
-|   ↳ `state` | string | Commit status state |
-|   ↳ `name` | string | Build name |
-|   ↳ `description` | string | Build description |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `updatedOn` | string | Update timestamp |
-|   ↳ `selfUrl` | string | Status API URL |
-|   ↳ `commitUrl` | string | Commit API URL |
+|   ↳ `key` | string (nullable) | Vendor-unique status key |
+|   ↳ `refName` | string (nullable) | Reference name at status creation time |
+|   ↳ `url` | string (nullable) | External build URL |
+|   ↳ `state` | string (nullable) | Commit status state |
+|   ↳ `name` | string (nullable) | Build name |
+|   ↳ `description` | string (nullable) | Build description |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `updatedOn` | string (nullable) | Update timestamp |
+|   ↳ `selfUrl` | string (nullable) | Status API URL |
+|   ↳ `commitUrl` | string (nullable) | Commit API URL |
 
 ### Bitbucket List Pipelines
 
@@ -1322,44 +1322,44 @@ List pipelines for a Bitbucket Cloud repository
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Pipelines |
 |   ↳ `type` | string | Bitbucket pipeline object type |
-|   ↳ `uuid` | string | Pipeline UUID |
-|   ↳ `buildNumber` | number | Pipeline build number |
-|   ↳ `creator` | object | Pipeline creator |
+|   ↳ `uuid` | string (nullable) | Pipeline UUID |
+|   ↳ `buildNumber` | number (nullable) | Pipeline build number |
+|   ↳ `creator` | object (nullable) | Pipeline creator |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `target` | object | Pipeline target |
-|     ↳ `type` | string | Target object type |
-|     ↳ `refType` | string | Reference type |
-|     ↳ `refName` | string | Reference name |
-|     ↳ `commitHash` | string | Target commit hash |
-|     ↳ `selectorType` | string | Pipeline selector type |
-|     ↳ `selectorPattern` | string | Pipeline selector pattern |
-|   ↳ `triggerType` | string | Pipeline trigger object type |
-|   ↳ `state` | object | Pipeline state |
-|     ↳ `name` | string | State name |
-|     ↳ `stage` | string | In-progress stage name |
-|     ↳ `result` | string | Completed result name |
-|     ↳ `errorKey` | string | Completed-error key |
-|     ↳ `errorMessage` | string | Completed-error message |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `completedOn` | string | Completion timestamp |
-|   ↳ `buildSecondsUsed` | number | Build seconds used |
-|   ↳ `selfUrl` | string | Pipeline API URL |
-|   ↳ `stepsUrl` | string | Pipeline steps API URL |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `target` | object (nullable) | Pipeline target |
+|     ↳ `type` | string (nullable) | Target object type |
+|     ↳ `refType` | string (nullable) | Reference type |
+|     ↳ `refName` | string (nullable) | Reference name |
+|     ↳ `commitHash` | string (nullable) | Target commit hash |
+|     ↳ `selectorType` | string (nullable) | Pipeline selector type |
+|     ↳ `selectorPattern` | string (nullable) | Pipeline selector pattern |
+|   ↳ `triggerType` | string (nullable) | Pipeline trigger object type |
+|   ↳ `state` | object (nullable) | Pipeline state |
+|     ↳ `name` | string (nullable) | State name |
+|     ↳ `stage` | string (nullable) | In-progress stage name |
+|     ↳ `result` | string (nullable) | Completed result name |
+|     ↳ `errorKey` | string (nullable) | Completed-error key |
+|     ↳ `errorMessage` | string (nullable) | Completed-error message |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `completedOn` | string (nullable) | Completion timestamp |
+|   ↳ `buildSecondsUsed` | number (nullable) | Build seconds used |
+|   ↳ `selfUrl` | string (nullable) | Pipeline API URL |
+|   ↳ `stepsUrl` | string (nullable) | Pipeline steps API URL |
 
 ### Bitbucket Get Pipeline
 
@@ -1379,37 +1379,37 @@ Get a pipeline by UUID
 | --------- | ---- | ----------- |
 | `pipeline` | object | Pipeline details |
 |   ↳ `type` | string | Bitbucket pipeline object type |
-|   ↳ `uuid` | string | Pipeline UUID |
-|   ↳ `buildNumber` | number | Pipeline build number |
-|   ↳ `creator` | object | Pipeline creator |
+|   ↳ `uuid` | string (nullable) | Pipeline UUID |
+|   ↳ `buildNumber` | number (nullable) | Pipeline build number |
+|   ↳ `creator` | object (nullable) | Pipeline creator |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `target` | object | Pipeline target |
-|     ↳ `type` | string | Target object type |
-|     ↳ `refType` | string | Reference type |
-|     ↳ `refName` | string | Reference name |
-|     ↳ `commitHash` | string | Target commit hash |
-|     ↳ `selectorType` | string | Pipeline selector type |
-|     ↳ `selectorPattern` | string | Pipeline selector pattern |
-|   ↳ `triggerType` | string | Pipeline trigger object type |
-|   ↳ `state` | object | Pipeline state |
-|     ↳ `name` | string | State name |
-|     ↳ `stage` | string | In-progress stage name |
-|     ↳ `result` | string | Completed result name |
-|     ↳ `errorKey` | string | Completed-error key |
-|     ↳ `errorMessage` | string | Completed-error message |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `completedOn` | string | Completion timestamp |
-|   ↳ `buildSecondsUsed` | number | Build seconds used |
-|   ↳ `selfUrl` | string | Pipeline API URL |
-|   ↳ `stepsUrl` | string | Pipeline steps API URL |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `target` | object (nullable) | Pipeline target |
+|     ↳ `type` | string (nullable) | Target object type |
+|     ↳ `refType` | string (nullable) | Reference type |
+|     ↳ `refName` | string (nullable) | Reference name |
+|     ↳ `commitHash` | string (nullable) | Target commit hash |
+|     ↳ `selectorType` | string (nullable) | Pipeline selector type |
+|     ↳ `selectorPattern` | string (nullable) | Pipeline selector pattern |
+|   ↳ `triggerType` | string (nullable) | Pipeline trigger object type |
+|   ↳ `state` | object (nullable) | Pipeline state |
+|     ↳ `name` | string (nullable) | State name |
+|     ↳ `stage` | string (nullable) | In-progress stage name |
+|     ↳ `result` | string (nullable) | Completed result name |
+|     ↳ `errorKey` | string (nullable) | Completed-error key |
+|     ↳ `errorMessage` | string (nullable) | Completed-error message |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `completedOn` | string (nullable) | Completion timestamp |
+|   ↳ `buildSecondsUsed` | number (nullable) | Build seconds used |
+|   ↳ `selfUrl` | string (nullable) | Pipeline API URL |
+|   ↳ `stepsUrl` | string (nullable) | Pipeline steps API URL |
 
 ### Bitbucket Trigger Pipeline
 
@@ -1431,37 +1431,37 @@ Run the repository pipeline selected by a branch or ref target
 | --------- | ---- | ----------- |
 | `pipeline` | object | Triggered pipeline |
 |   ↳ `type` | string | Bitbucket pipeline object type |
-|   ↳ `uuid` | string | Pipeline UUID |
-|   ↳ `buildNumber` | number | Pipeline build number |
-|   ↳ `creator` | object | Pipeline creator |
+|   ↳ `uuid` | string (nullable) | Pipeline UUID |
+|   ↳ `buildNumber` | number (nullable) | Pipeline build number |
+|   ↳ `creator` | object (nullable) | Pipeline creator |
 |     ↳ `type` | string | Bitbucket account object type |
-|     ↳ `uuid` | string | Bitbucket account UUID |
-|     ↳ `accountId` | string | Atlassian account ID |
-|     ↳ `displayName` | string | Account display name |
-|     ↳ `createdOn` | string | Account creation timestamp |
-|     ↳ `selfUrl` | string | Account API URL |
-|     ↳ `htmlUrl` | string | Account web URL |
-|     ↳ `avatarUrl` | string | Account avatar URL |
-|   ↳ `repositoryFullName` | string | Repository full name |
-|   ↳ `target` | object | Pipeline target |
-|     ↳ `type` | string | Target object type |
-|     ↳ `refType` | string | Reference type |
-|     ↳ `refName` | string | Reference name |
-|     ↳ `commitHash` | string | Target commit hash |
-|     ↳ `selectorType` | string | Pipeline selector type |
-|     ↳ `selectorPattern` | string | Pipeline selector pattern |
-|   ↳ `triggerType` | string | Pipeline trigger object type |
-|   ↳ `state` | object | Pipeline state |
-|     ↳ `name` | string | State name |
-|     ↳ `stage` | string | In-progress stage name |
-|     ↳ `result` | string | Completed result name |
-|     ↳ `errorKey` | string | Completed-error key |
-|     ↳ `errorMessage` | string | Completed-error message |
-|   ↳ `createdOn` | string | Creation timestamp |
-|   ↳ `completedOn` | string | Completion timestamp |
-|   ↳ `buildSecondsUsed` | number | Build seconds used |
-|   ↳ `selfUrl` | string | Pipeline API URL |
-|   ↳ `stepsUrl` | string | Pipeline steps API URL |
+|     ↳ `uuid` | string (nullable) | Bitbucket account UUID |
+|     ↳ `accountId` | string (nullable) | Atlassian account ID |
+|     ↳ `displayName` | string (nullable) | Account display name |
+|     ↳ `createdOn` | string (nullable) | Account creation timestamp |
+|     ↳ `selfUrl` | string (nullable) | Account API URL |
+|     ↳ `htmlUrl` | string (nullable) | Account web URL |
+|     ↳ `avatarUrl` | string (nullable) | Account avatar URL |
+|   ↳ `repositoryFullName` | string (nullable) | Repository full name |
+|   ↳ `target` | object (nullable) | Pipeline target |
+|     ↳ `type` | string (nullable) | Target object type |
+|     ↳ `refType` | string (nullable) | Reference type |
+|     ↳ `refName` | string (nullable) | Reference name |
+|     ↳ `commitHash` | string (nullable) | Target commit hash |
+|     ↳ `selectorType` | string (nullable) | Pipeline selector type |
+|     ↳ `selectorPattern` | string (nullable) | Pipeline selector pattern |
+|   ↳ `triggerType` | string (nullable) | Pipeline trigger object type |
+|   ↳ `state` | object (nullable) | Pipeline state |
+|     ↳ `name` | string (nullable) | State name |
+|     ↳ `stage` | string (nullable) | In-progress stage name |
+|     ↳ `result` | string (nullable) | Completed result name |
+|     ↳ `errorKey` | string (nullable) | Completed-error key |
+|     ↳ `errorMessage` | string (nullable) | Completed-error message |
+|   ↳ `createdOn` | string (nullable) | Creation timestamp |
+|   ↳ `completedOn` | string (nullable) | Completion timestamp |
+|   ↳ `buildSecondsUsed` | number (nullable) | Build seconds used |
+|   ↳ `selfUrl` | string (nullable) | Pipeline API URL |
+|   ↳ `stepsUrl` | string (nullable) | Pipeline steps API URL |
 
 ### Bitbucket Stop Pipeline
 
@@ -1500,28 +1500,28 @@ List the steps in a pipeline
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `page` | object | Pagination information |
-|   ↳ `size` | number | Total result count reported by Bitbucket |
-|   ↳ `page` | number | Current page number |
-|   ↳ `pageLen` | number | Number of results requested per page |
-|   ↳ `nextUrl` | string | Validated URL for the next page |
-|   ↳ `previousUrl` | string | Validated URL for the previous page |
+|   ↳ `size` | number (nullable) | Total result count reported by Bitbucket |
+|   ↳ `page` | number (nullable) | Current page number |
+|   ↳ `pageLen` | number (nullable) | Number of results requested per page |
+|   ↳ `nextUrl` | string (nullable) | Validated URL for the next page |
+|   ↳ `previousUrl` | string (nullable) | Validated URL for the previous page |
 | `items` | array | Pipeline steps |
 |   ↳ `type` | string | Bitbucket pipeline-step object type |
-|   ↳ `uuid` | string | Pipeline step UUID |
-|   ↳ `startedOn` | string | Step start timestamp |
-|   ↳ `completedOn` | string | Step completion timestamp |
-|   ↳ `state` | object | Pipeline step state |
-|     ↳ `name` | string | State name |
-|     ↳ `result` | string | Completed result name |
-|     ↳ `errorKey` | string | Completed-error key |
-|     ↳ `errorMessage` | string | Completed-error message |
-|   ↳ `imageName` | string | Build container image name |
-|   ↳ `setupCommands` | array | Setup commands |
-|     ↳ `name` | string | Command name |
-|     ↳ `command` | string | Executable command |
-|   ↳ `scriptCommands` | array | Build script commands |
-|     ↳ `name` | string | Command name |
-|     ↳ `command` | string | Executable command |
+|   ↳ `uuid` | string (nullable) | Pipeline step UUID |
+|   ↳ `startedOn` | string (nullable) | Step start timestamp |
+|   ↳ `completedOn` | string (nullable) | Step completion timestamp |
+|   ↳ `state` | object (nullable) | Pipeline step state |
+|     ↳ `name` | string (nullable) | State name |
+|     ↳ `result` | string (nullable) | Completed result name |
+|     ↳ `errorKey` | string (nullable) | Completed-error key |
+|     ↳ `errorMessage` | string (nullable) | Completed-error message |
+|   ↳ `imageName` | string (nullable) | Build container image name |
+|   ↳ `setupCommands` | array (nullable) | Setup commands |
+|     ↳ `name` | string (nullable) | Command name |
+|     ↳ `command` | string (nullable) | Executable command |
+|   ↳ `scriptCommands` | array (nullable) | Build script commands |
+|     ↳ `name` | string (nullable) | Command name |
+|     ↳ `command` | string (nullable) | Executable command |
 
 ### Bitbucket Get Pipeline Step Log
 
@@ -1543,9 +1543,7 @@ Read a bounded UTF-8 tail of a pipeline step log
 | --------- | ---- | ----------- |
 | `log` | string | Bounded trailing UTF-8 log text |
 | `truncated` | boolean | Whether earlier log output was omitted |
-| `totalBytes` | number | Full log byte size when reported |
-
-
+| `totalBytes` | number (nullable) | Full log byte size when reported |
 
 ## Triggers
 
@@ -2214,4 +2212,3 @@ Trigger workflow when a Bitbucket repository is updated
 | `repository` | json | Repository where the event occurred |
 | `payload` | json | Full parsed Bitbucket webhook payload |
 | `changes` | json | Repository fields changed by the update |
-

--- a/apps/docs/content/docs/integrations/box.mdx
+++ b/apps/docs/content/docs/integrations/box.mdx
@@ -5,7 +5,7 @@ description: Manage files, folders, and e-signatures with Box
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="box"
   color="#FFFFFF"
 />
@@ -416,5 +416,3 @@ Resend a Box Sign request to signers who have not yet signed
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `message` | string | Success confirmation message |
-
-

--- a/apps/docs/content/docs/integrations/brandfetch.mdx
+++ b/apps/docs/content/docs/integrations/brandfetch.mdx
@@ -5,7 +5,7 @@ description: Look up brand assets, logos, colors, and company info
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="brandfetch"
   color="#000000"
 />
@@ -84,5 +84,3 @@ Search for brands by name and find their domains and logos
 |   ↳ `domain` | string | Brand domain |
 |   ↳ `claimed` | boolean | Whether the brand profile is claimed |
 |   ↳ `icon` | string | Brand icon URL |
-
-

--- a/apps/docs/content/docs/integrations/brex.mdx
+++ b/apps/docs/content/docs/integrations/brex.mdx
@@ -5,7 +5,7 @@ description: Manage expenses, receipts, transactions, and team data in Brex
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="brex"
   color="#171717"
 />
@@ -1099,5 +1099,3 @@ Create a money transfer from a Brex cash account to a vendor
 | `displayName` | string | Human-readable name of the transfer |
 | `externalMemo` | string | External memo of the transfer |
 | `isPproEnabled` | boolean | Whether Principal Protection \(PPRO\) is enabled for the transfer |
-
-

--- a/apps/docs/content/docs/integrations/brightdata.mdx
+++ b/apps/docs/content/docs/integrations/brightdata.mdx
@@ -5,7 +5,7 @@ description: Scrape websites, search engines, and extract structured data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="brightdata"
   color="#FFFFFF"
 />
@@ -205,5 +205,3 @@ Cancel an active Bright Data scraping job using its snapshot ID. Terminates data
 | --------- | ---- | ----------- |
 | `snapshotId` | string | The snapshot ID that was cancelled |
 | `cancelled` | boolean | Whether the cancellation was successful |
-
-

--- a/apps/docs/content/docs/integrations/browser_use.mdx
+++ b/apps/docs/content/docs/integrations/browser_use.mdx
@@ -5,7 +5,7 @@ description: Run browser automation tasks
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="browser_use"
   color="#181C1E"
 />
@@ -66,5 +66,3 @@ Runs a browser automation task using BrowserUse
 | `liveUrl` | string | Embeddable live browser session URL \(active during execution\) |
 | `shareUrl` | string | Public shareable URL for the recorded session \(post-run\) |
 | `sessionId` | string | Browser Use session identifier |
-
-

--- a/apps/docs/content/docs/integrations/buffer.mdx
+++ b/apps/docs/content/docs/integrations/buffer.mdx
@@ -5,7 +5,7 @@ description: Schedule and publish social media posts across connected channels
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="buffer"
   color="#FFFFFF"
 />
@@ -64,21 +64,21 @@ Create a post in Buffer for a channel — add it to the queue, share it immediat
 |   ↳ `via` | string | How the post was created \(buffer, network, api\) |
 |   ↳ `channelId` | string | Channel the post belongs to |
 |   ↳ `channelService` | string | Social network of the channel |
-|   ↳ `schedulingType` | string | How the post publishes \(automatic or notification\) |
+|   ↳ `schedulingType` | string (nullable) | How the post publishes \(automatic or notification\) |
 |   ↳ `shareMode` | string | Share mode used for the post |
 |   ↳ `isCustomScheduled` | boolean | Whether the post has a custom schedule |
 |   ↳ `sharedNow` | boolean | Whether the post was shared immediately |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `dueAt` | string | Scheduled publish time \(ISO 8601\) |
-|   ↳ `sentAt` | string | Publish timestamp \(ISO 8601\) |
-|   ↳ `externalLink` | string | Link to the published post on the social network |
-|   ↳ `error` | object | Publishing error details when the post failed |
+|   ↳ `dueAt` | string (nullable) | Scheduled publish time \(ISO 8601\) |
+|   ↳ `sentAt` | string (nullable) | Publish timestamp \(ISO 8601\) |
+|   ↳ `externalLink` | string (nullable) | Link to the published post on the social network |
+|   ↳ `error` | object (nullable) | Publishing error details when the post failed |
 |     ↳ `message` | string | Error message |
-|     ↳ `supportUrl` | string | Support article URL |
-|     ↳ `rawError` | string | Raw error from the network |
+|     ↳ `supportUrl` | string (nullable) | Support article URL |
+|     ↳ `rawError` | string (nullable) | Raw error from the network |
 |   ↳ `assets` | array | Media attached to the post |
-|     ↳ `id` | string | Asset ID |
+|     ↳ `id` | string (nullable) | Asset ID |
 |     ↳ `type` | string | Asset type |
 |     ↳ `mimeType` | string | MIME type of the asset |
 |     ↳ `source` | string | Source URL of the asset |
@@ -114,21 +114,21 @@ Edit an existing Buffer post — update its text, schedule, or media. Attaching 
 |   ↳ `via` | string | How the post was created \(buffer, network, api\) |
 |   ↳ `channelId` | string | Channel the post belongs to |
 |   ↳ `channelService` | string | Social network of the channel |
-|   ↳ `schedulingType` | string | How the post publishes \(automatic or notification\) |
+|   ↳ `schedulingType` | string (nullable) | How the post publishes \(automatic or notification\) |
 |   ↳ `shareMode` | string | Share mode used for the post |
 |   ↳ `isCustomScheduled` | boolean | Whether the post has a custom schedule |
 |   ↳ `sharedNow` | boolean | Whether the post was shared immediately |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `dueAt` | string | Scheduled publish time \(ISO 8601\) |
-|   ↳ `sentAt` | string | Publish timestamp \(ISO 8601\) |
-|   ↳ `externalLink` | string | Link to the published post on the social network |
-|   ↳ `error` | object | Publishing error details when the post failed |
+|   ↳ `dueAt` | string (nullable) | Scheduled publish time \(ISO 8601\) |
+|   ↳ `sentAt` | string (nullable) | Publish timestamp \(ISO 8601\) |
+|   ↳ `externalLink` | string (nullable) | Link to the published post on the social network |
+|   ↳ `error` | object (nullable) | Publishing error details when the post failed |
 |     ↳ `message` | string | Error message |
-|     ↳ `supportUrl` | string | Support article URL |
-|     ↳ `rawError` | string | Raw error from the network |
+|     ↳ `supportUrl` | string (nullable) | Support article URL |
+|     ↳ `rawError` | string (nullable) | Raw error from the network |
 |   ↳ `assets` | array | Media attached to the post |
-|     ↳ `id` | string | Asset ID |
+|     ↳ `id` | string (nullable) | Asset ID |
 |     ↳ `type` | string | Asset type |
 |     ↳ `mimeType` | string | MIME type of the asset |
 |     ↳ `source` | string | Source URL of the asset |
@@ -162,28 +162,28 @@ List posts in a Buffer organization, optionally filtered by channel and status (
 |   ↳ `via` | string | How the post was created \(buffer, network, api\) |
 |   ↳ `channelId` | string | Channel the post belongs to |
 |   ↳ `channelService` | string | Social network of the channel |
-|   ↳ `schedulingType` | string | How the post publishes \(automatic or notification\) |
+|   ↳ `schedulingType` | string (nullable) | How the post publishes \(automatic or notification\) |
 |   ↳ `shareMode` | string | Share mode used for the post |
 |   ↳ `isCustomScheduled` | boolean | Whether the post has a custom schedule |
 |   ↳ `sharedNow` | boolean | Whether the post was shared immediately |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `dueAt` | string | Scheduled publish time \(ISO 8601\) |
-|   ↳ `sentAt` | string | Publish timestamp \(ISO 8601\) |
-|   ↳ `externalLink` | string | Link to the published post on the social network |
-|   ↳ `error` | object | Publishing error details when the post failed |
+|   ↳ `dueAt` | string (nullable) | Scheduled publish time \(ISO 8601\) |
+|   ↳ `sentAt` | string (nullable) | Publish timestamp \(ISO 8601\) |
+|   ↳ `externalLink` | string (nullable) | Link to the published post on the social network |
+|   ↳ `error` | object (nullable) | Publishing error details when the post failed |
 |     ↳ `message` | string | Error message |
-|     ↳ `supportUrl` | string | Support article URL |
-|     ↳ `rawError` | string | Raw error from the network |
+|     ↳ `supportUrl` | string (nullable) | Support article URL |
+|     ↳ `rawError` | string (nullable) | Raw error from the network |
 |   ↳ `assets` | array | Media attached to the post |
-|     ↳ `id` | string | Asset ID |
+|     ↳ `id` | string (nullable) | Asset ID |
 |     ↳ `type` | string | Asset type |
 |     ↳ `mimeType` | string | MIME type of the asset |
 |     ↳ `source` | string | Source URL of the asset |
 |     ↳ `thumbnail` | string | Thumbnail URL of the asset |
 | `pageInfo` | object | Pagination info for fetching the next page |
 |   ↳ `hasNextPage` | boolean | Whether more results are available |
-|   ↳ `endCursor` | string | Cursor to pass as "after" for the next page |
+|   ↳ `endCursor` | string (nullable) | Cursor to pass as "after" for the next page |
 
 ### Buffer Get Post
 
@@ -207,21 +207,21 @@ Get a single Buffer post by ID, including its status, schedule, and media
 |   ↳ `via` | string | How the post was created \(buffer, network, api\) |
 |   ↳ `channelId` | string | Channel the post belongs to |
 |   ↳ `channelService` | string | Social network of the channel |
-|   ↳ `schedulingType` | string | How the post publishes \(automatic or notification\) |
+|   ↳ `schedulingType` | string (nullable) | How the post publishes \(automatic or notification\) |
 |   ↳ `shareMode` | string | Share mode used for the post |
 |   ↳ `isCustomScheduled` | boolean | Whether the post has a custom schedule |
 |   ↳ `sharedNow` | boolean | Whether the post was shared immediately |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `dueAt` | string | Scheduled publish time \(ISO 8601\) |
-|   ↳ `sentAt` | string | Publish timestamp \(ISO 8601\) |
-|   ↳ `externalLink` | string | Link to the published post on the social network |
-|   ↳ `error` | object | Publishing error details when the post failed |
+|   ↳ `dueAt` | string (nullable) | Scheduled publish time \(ISO 8601\) |
+|   ↳ `sentAt` | string (nullable) | Publish timestamp \(ISO 8601\) |
+|   ↳ `externalLink` | string (nullable) | Link to the published post on the social network |
+|   ↳ `error` | object (nullable) | Publishing error details when the post failed |
 |     ↳ `message` | string | Error message |
-|     ↳ `supportUrl` | string | Support article URL |
-|     ↳ `rawError` | string | Raw error from the network |
+|     ↳ `supportUrl` | string (nullable) | Support article URL |
+|     ↳ `rawError` | string (nullable) | Raw error from the network |
 |   ↳ `assets` | array | Media attached to the post |
-|     ↳ `id` | string | Asset ID |
+|     ↳ `id` | string (nullable) | Asset ID |
 |     ↳ `type` | string | Asset type |
 |     ↳ `mimeType` | string | MIME type of the asset |
 |     ↳ `source` | string | Source URL of the asset |
@@ -263,7 +263,7 @@ List the social media channels connected to a Buffer organization, including the
 | `channels` | array | Channels connected to the organization |
 |   ↳ `id` | string | Channel ID |
 |   ↳ `name` | string | Channel name |
-|   ↳ `displayName` | string | Channel display name |
+|   ↳ `displayName` | string (nullable) | Channel display name |
 |   ↳ `service` | string | Social network \(instagram, linkedin, twitter, ...\) |
 |   ↳ `serviceId` | string | ID of the account on the social network |
 |   ↳ `avatar` | string | Channel avatar URL |
@@ -294,9 +294,9 @@ Save a content idea to a Buffer organization for later drafting and scheduling
 | `idea` | object | The created idea |
 |   ↳ `id` | string | Idea ID |
 |   ↳ `organizationId` | string | Organization the idea belongs to |
-|   ↳ `groupId` | string | Idea group ID |
-|   ↳ `title` | string | Idea title |
-|   ↳ `text` | string | Idea text content |
+|   ↳ `groupId` | string (nullable) | Idea group ID |
+|   ↳ `title` | string (nullable) | Idea title |
+|   ↳ `text` | string (nullable) | Idea text content |
 
 ### Buffer Get Ideas
 
@@ -318,12 +318,12 @@ List content ideas saved in a Buffer organization
 | `ideas` | array | Content ideas in the organization |
 |   ↳ `id` | string | Idea ID |
 |   ↳ `organizationId` | string | Organization the idea belongs to |
-|   ↳ `groupId` | string | Idea group ID |
-|   ↳ `title` | string | Idea title |
-|   ↳ `text` | string | Idea text content |
+|   ↳ `groupId` | string (nullable) | Idea group ID |
+|   ↳ `title` | string (nullable) | Idea title |
+|   ↳ `text` | string (nullable) | Idea text content |
 | `pageInfo` | object | Pagination info for fetching the next page |
 |   ↳ `hasNextPage` | boolean | Whether more results are available |
-|   ↳ `endCursor` | string | Cursor to pass as "after" for the next page |
+|   ↳ `endCursor` | string (nullable) | Cursor to pass as "after" for the next page |
 
 ### Buffer Get Idea Groups
 
@@ -362,12 +362,10 @@ Get the authenticated Buffer account, including its organizations and their IDs 
 | `account` | object | The authenticated Buffer account |
 |   ↳ `id` | string | Account ID |
 |   ↳ `email` | string | Account email |
-|   ↳ `name` | string | Account holder name |
-|   ↳ `timezone` | string | Account timezone |
+|   ↳ `name` | string (nullable) | Account holder name |
+|   ↳ `timezone` | string (nullable) | Account timezone |
 |   ↳ `organizations` | array | Organizations the account belongs to |
 |     ↳ `id` | string | Organization ID |
 |     ↳ `name` | string | Organization name |
 |     ↳ `channelCount` | number | Number of connected channels |
 |     ↳ `ownerEmail` | string | Email of the organization owner |
-
-

--- a/apps/docs/content/docs/integrations/calcom.mdx
+++ b/apps/docs/content/docs/integrations/calcom.mdx
@@ -5,7 +5,7 @@ description: Manage Cal.com bookings, event types, schedules, and availability
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="calcom"
   color="#292929"
 />
@@ -764,8 +764,6 @@ Get available booking slots for a Cal.com event type within a time range
 | `status` | string | Response status |
 | `data` | json | Available time slots grouped by date \(YYYY-MM-DD keys\). Each date maps to an array of slot objects with start time, optional end time, and seated event info. |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1134,4 +1132,3 @@ Trigger workflow on any Cal.com webhook event (configure event types in Cal.com)
 | `triggerEvent` | string | The webhook event type \(e.g., BOOKING_CREATED, MEETING_ENDED\) |
 | `createdAt` | string | When the webhook event was created \(ISO 8601\) |
 | `payload` | json | Complete webhook payload \(structure varies by event type\) |
-

--- a/apps/docs/content/docs/integrations/calendly.mdx
+++ b/apps/docs/content/docs/integrations/calendly.mdx
@@ -5,7 +5,7 @@ description: Manage Calendly scheduling and events
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="calendly"
   color="#FFFFFF"
 />
@@ -688,8 +688,6 @@ Retrieve the submissions of a routing form, including answers and routing result
 |   ↳ `next_page_token` | string | Token for next page |
 |   ↳ `previous_page_token` | string | Token for previous page |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -882,4 +880,3 @@ Trigger workflow from any Calendly webhook event
 | `created_at` | string | Webhook event creation timestamp |
 | `created_by` | string | URI of the Calendly user who created this webhook |
 | `payload` | object | Complete event payload \(structure varies by event type\) |
-

--- a/apps/docs/content/docs/integrations/cbinsights.mdx
+++ b/apps/docs/content/docs/integrations/cbinsights.mdx
@@ -5,7 +5,7 @@ description: Research private markets — firmographics, funding, and predictive
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="cbinsights"
   color="#FFFFFF"
 />
@@ -69,9 +69,9 @@ Resolve company names or websites to CB Insights organization IDs. This endpoint
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `orgs` | json | Matched organizations as \[\{orgId, name, description, aliases, urls\}\] |
-| `nextPageToken` | string | Token for the next page, or null when there are no more results |
-| `totalHits` | number | Total number of matching records |
-| `totalHitsRelation` | string | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
+| `nextPageToken` | string (nullable) | Token for the next page, or null when there are no more results |
+| `totalHits` | number (nullable) | Total number of matching records |
+| `totalHitsRelation` | string (nullable) | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
 
 ### CB Insights Search Firmographics
 
@@ -126,9 +126,9 @@ Search profiles of private companies, public companies, and investors by market,
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `orgs` | json | Matching profiles as \[\{orgId, summary, taxonomy, financials, headcount, identifiers, businessModels, competitors, expertCollections, parentOrgs, childOrgs\}\] |
-| `nextPageToken` | string | Token for the next page, or null when there are no more results |
-| `totalHits` | number | Total number of matching records |
-| `totalHitsRelation` | string | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
+| `nextPageToken` | string (nullable) | Token for the next page, or null when there are no more results |
+| `totalHits` | number (nullable) | Total number of matching records |
+| `totalHitsRelation` | string (nullable) | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
 
 ### CB Insights Get Organization Fundings
 
@@ -150,9 +150,9 @@ Retrieve the funding rounds one organization has received, its cap table history
 | --------- | ---- | ----------- |
 | `fundings` | json | Rounds as \[\{dealId, date, round, roundCategory, amountInMillions, valuationInMillions, investors, insights, sources\}\] |
 | `capTableHistory` | json | Ownership structure as \[\{dealId, roundType, issuancePrice, conversionPrice, percentageOwned, sharesAuthorized, terms\}\] |
-| `nextPageToken` | string | Token for the next page, or null when there are no more results |
-| `totalHits` | number | Total number of matching records |
-| `totalHitsRelation` | string | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
+| `nextPageToken` | string (nullable) | Token for the next page, or null when there are no more results |
+| `totalHits` | number (nullable) | Total number of matching records |
+| `totalHitsRelation` | string (nullable) | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
 
 ### CB Insights Get Organization Investments
 
@@ -173,9 +173,9 @@ Retrieve the rounds in which one organization invested in another, with AI-gener
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `investments` | json | Rounds as \[\{dealId, date, round, roundCategory, amountInMillions, valuationInMillions, recipient, investors, insights, sources\}\] |
-| `nextPageToken` | string | Token for the next page, or null when there are no more results |
-| `totalHits` | number | Total number of matching records |
-| `totalHitsRelation` | string | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
+| `nextPageToken` | string (nullable) | Token for the next page, or null when there are no more results |
+| `totalHits` | number (nullable) | Total number of matching records |
+| `totalHitsRelation` | string (nullable) | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
 
 ### CB Insights Get Organization Portfolio Exits
 
@@ -231,7 +231,7 @@ Retrieve an organization's leadership team and board members with their educatio
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `people` | json | People as \[\{personId, givenName, middleName, surname, email, linkedInUrl, education, workExperience, boardAssociations\}\] |
-| `mosaicManagement` | number | Management factor of the Mosaic Score, measuring the pedigree and track record of the leadership team |
+| `mosaicManagement` | number (nullable) | Management factor of the Mosaic Score, measuring the pedigree and track record of the leadership team |
 
 ### CB Insights Get Organization Outlook
 
@@ -249,9 +249,9 @@ Retrieve an organization's current Mosaic Score, Commercial Maturity level, and 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `mosaicScore` | json | Mosaic Score on a 0-1000 scale: \{overall, management, market, momentum, money\}, each with scoreValue, asOfDate, and scoreInsights |
-| `commercialMaturity` | json | Commercial Maturity on a 1-5 scale: \{maturityLevel: \{level, stage, stageDescription, asOfDate\}, commercialMaturitySignals\}. Available only for a subset of companies. |
-| `exitProbability` | json | Two-year exit probability: \{ipo, mna, exitSignals, incompleteRoundType\}. A pending round zeroes the probabilities rather than omitting them. |
+| `mosaicScore` | json (nullable) | Mosaic Score on a 0-1000 scale: \{overall, management, market, momentum, money\}, each with scoreValue, asOfDate, and scoreInsights |
+| `commercialMaturity` | json (nullable) | Commercial Maturity on a 1-5 scale: \{maturityLevel: \{level, stage, stageDescription, asOfDate\}, commercialMaturitySignals\}. Available only for a subset of companies. |
+| `exitProbability` | json (nullable) | Two-year exit probability: \{ipo, mna, exitSignals, incompleteRoundType\}. A pending round zeroes the probabilities rather than omitting them. |
 
 ### CB Insights Get Organization Funding Window
 
@@ -269,11 +269,11 @@ Retrieve the estimated window in which an organization is likely to raise its ne
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `windowStart` | string | Estimated start of the next funding window, as YYYY-MM-DD |
-| `windowEnd` | string | Estimated end of the next funding window, as YYYY-MM-DD |
-| `cohortNextRoundRate` | number | Share of the cohort that historically raised another round, as a decimal between 0 and 1 |
-| `cohortCriteria` | json | How the comparison cohort was defined: \{cohortGeo, cohortRoundCategory, cohortLandscapes\} |
-| `latestFunding` | json | The latest equity-backed round: \{date, dealId\} |
+| `windowStart` | string (nullable) | Estimated start of the next funding window, as YYYY-MM-DD |
+| `windowEnd` | string (nullable) | Estimated end of the next funding window, as YYYY-MM-DD |
+| `cohortNextRoundRate` | number (nullable) | Share of the cohort that historically raised another round, as a decimal between 0 and 1 |
+| `cohortCriteria` | json (nullable) | How the comparison cohort was defined: \{cohortGeo, cohortRoundCategory, cohortLandscapes\} |
+| `latestFunding` | json (nullable) | The latest equity-backed round: \{date, dealId\} |
 
 ### CB Insights Get Organization Revenue
 
@@ -291,9 +291,9 @@ Retrieve reported and estimated revenue by calendar year for one organization, w
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `orgId` | number | CB Insights organization ID |
-| `orgName` | string | The organization's name |
-| `orgUrl` | string | The organization's website |
+| `orgId` | number (nullable) | CB Insights organization ID |
+| `orgName` | string (nullable) | The organization's name |
+| `orgUrl` | string (nullable) | The organization's website |
 | `revenue` | json | Revenue by year as \[\{calendarYear, lowestValue, averageValue, highestValue, isActual, reportedMetric, yoyGrowthPercent, sources\}\] |
 
 ### CB Insights Get Mosaic History
@@ -359,7 +359,7 @@ Retrieve an organization's historical two-year IPO and M&A exit probabilities, e
 | --------- | ---- | ----------- |
 | `ipo` | json | IPO probability over time as \[\{asOfDate, exitProbability, meanProbability, ratioToMean\}\] |
 | `mna` | json | M&A probability over time as \[\{asOfDate, exitProbability, meanProbability, ratioToMean\}\] |
-| `incompleteRoundType` | string | An in-progress round, if any. A pending round zeroes every probability; a rumored round zeroes only the matching exit type. |
+| `incompleteRoundType` | string (nullable) | An in-progress round, if any. A pending round zeroes every probability; a rumored round zeroes only the matching exit type. |
 
 ### CB Insights Get Strategy Map
 
@@ -377,8 +377,8 @@ Retrieve the companies related to an organization, grouped into industry categor
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `orgName` | string | The organization's name |
-| `logoUrl` | string | URL of the organization's logo |
+| `orgName` | string (nullable) | The organization's name |
+| `logoUrl` | string (nullable) | URL of the organization's logo |
 | `categories` | json | Industry categories as \[\{name, companies: \[\{orgId, name, logoUrl, connections: \{businessRelationships, investments, acquisitions\}\}\]\}\] |
 
 ### CB Insights Get Scouting Report
@@ -397,9 +397,9 @@ Generate an AI-written Scouting Report on a private company covering its busines
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `orgInfo` | json | Firmographics and proprietary scores for the company: \{id, name, url, description, foundedYear, headcount, address, stage, totalFunding, lastFundingDate, overallMosaicScore, commercialMaturity\} |
-| `reportMarkdown` | string | The Scouting Report as Markdown, including citations |
-| `reportJson` | string | The Scouting Report as a JSON string. Citation links are not included in this form — use reportMarkdown when they matter. |
+| `orgInfo` | json (nullable) | Firmographics and proprietary scores for the company: \{id, name, url, description, foundedYear, headcount, address, stage, totalFunding, lastFundingDate, overallMosaicScore, commercialMaturity\} |
+| `reportMarkdown` | string (nullable) | The Scouting Report as Markdown, including citations |
+| `reportJson` | string (nullable) | The Scouting Report as a JSON string. Citation links are not included in this form — use reportMarkdown when they matter. |
 
 ### CB Insights List Fundings
 
@@ -420,9 +420,9 @@ Retrieve funding rounds and cap table history for up to 100 organizations at onc
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `orgs` | json | Organizations as \[\{orgId, fundings, capTableHistory\}\]. An organization with no data is omitted from the response. |
-| `nextPageToken` | string | Token for the next page, or null when there are no more results |
-| `totalHits` | number | Total number of matching records |
-| `totalHitsRelation` | string | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
+| `nextPageToken` | string (nullable) | Token for the next page, or null when there are no more results |
+| `totalHits` | number (nullable) | Total number of matching records |
+| `totalHitsRelation` | string (nullable) | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
 
 ### CB Insights List Investments
 
@@ -443,9 +443,9 @@ Retrieve the rounds up to 100 organizations participated in as investors, with A
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `orgs` | json | Organizations as \[\{orgId, investments\}\]. An organization with no data is omitted from the response. |
-| `nextPageToken` | string | Token for the next page, or null when there are no more results |
-| `totalHits` | number | Total number of matching records |
-| `totalHitsRelation` | string | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
+| `nextPageToken` | string (nullable) | Token for the next page, or null when there are no more results |
+| `totalHits` | number (nullable) | Total number of matching records |
+| `totalHitsRelation` | string (nullable) | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
 
 ### CB Insights List Portfolio Exits
 
@@ -466,9 +466,9 @@ Retrieve exit rounds for companies up to 100 organizations invested in before th
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `orgs` | json | Organizations as \[\{orgId, portfolioExits\}\]. An organization with no data is omitted from the response. |
-| `nextPageToken` | string | Token for the next page, or null when there are no more results |
-| `totalHits` | number | Total number of matching records |
-| `totalHitsRelation` | string | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
+| `nextPageToken` | string (nullable) | Token for the next page, or null when there are no more results |
+| `totalHits` | number (nullable) | Total number of matching records |
+| `totalHitsRelation` | string (nullable) | Whether totalHits is exact \('eq'\) or a floor \('gte', used above 10,000\) |
 
 ### CB Insights List Business Relationships
 
@@ -488,7 +488,7 @@ Retrieve partnerships, client/vendor relationships, and licensing activity for u
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `orgs` | json | Organizations as \[\{orgId, businessRelationships\}\] |
-| `nextPageToken` | string | Token for the next page, or null when there are no more results |
+| `nextPageToken` | string (nullable) | Token for the next page, or null when there are no more results |
 
 ### CB Insights List Management and Board
 
@@ -580,9 +580,9 @@ Ask ChatCBI a question in natural language and get an answer grounded in CB Insi
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `chatId` | string | Conversation ID. Pass it back as chatId to continue this conversation. |
-| `title` | string | Title CB Insights gave the conversation |
-| `message` | string | ChatCBI's answer, as Markdown |
+| `chatId` | string (nullable) | Conversation ID. Pass it back as chatId to continue this conversation. |
+| `title` | string (nullable) | Title CB Insights gave the conversation |
+| `message` | string (nullable) | ChatCBI's answer, as Markdown |
 | `sources` | json | Sources behind the answer as \[\{sourceIndex, result: \{title, url, date, thumbnailUrl\}\}\] |
 | `relatedContent` | json | Related references as \[\{title, url, date, thumbnailUrl\}\] |
 | `suggestions` | json | Suggested follow-up questions |
@@ -603,7 +603,5 @@ Retrieve the raw structured CB Insights data relevant to a question, for feeding
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `data` | string | Retrieved records as a JSON string, keyed by source \(companySearch, dealSearch, markets, scoutingReports, businessRelationships, revenue, investments, and others\) |
+| `data` | string (nullable) | Retrieved records as a JSON string, keyed by source \(companySearch, dealSearch, markets, scoutingReports, businessRelationships, revenue, investments, and others\) |
 | `guidance` | json | Notes describing what each returned data source contains |
-
-

--- a/apps/docs/content/docs/integrations/circleback.mdx
+++ b/apps/docs/content/docs/integrations/circleback.mdx
@@ -5,7 +5,7 @@ description: AI-powered meeting notes, action items, and transcripts
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="circleback"
   color="linear-gradient(180deg, #E0F7FA 0%, #FFFFFF 100%)"
 />
@@ -70,37 +70,37 @@ Lists meetings from Circleback with optional ownership, status, tag, and attende
 | --------- | ---- | ----------- |
 | `meetings` | array | The meetings on this page |
 |   ↳ `id` | string | The Circleback meeting ID |
-|   ↳ `name` | string | The meeting name |
+|   ↳ `name` | string (nullable) | The meeting name |
 |   ↳ `createdAt` | string | When the meeting was created \(ISO 8601\) |
 |   ↳ `updatedAt` | string | When the meeting was last updated \(ISO 8601\) |
-|   ↳ `duration` | number | The meeting duration in seconds |
-|   ↳ `url` | string | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
-|   ↳ `recordingUrl` | string | The URL of the meeting recording file, valid for 24 hours |
+|   ↳ `duration` | number (nullable) | The meeting duration in seconds |
+|   ↳ `url` | string (nullable) | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
+|   ↳ `recordingUrl` | string (nullable) | The URL of the meeting recording file, valid for 24 hours |
 |   ↳ `tags` | array | Tags added to the meeting |
 |     ↳ `id` | number | The unique identifier of the tag |
 |     ↳ `name` | string | The display name of the tag |
-|     ↳ `description` | string | A description of the tag |
-|   ↳ `icalUid` | string | The identifier of the calendar event associated with the meeting |
+|     ↳ `description` | string (nullable) | A description of the tag |
+|   ↳ `icalUid` | string (nullable) | The identifier of the calendar event associated with the meeting |
 |   ↳ `attendees` | array | The meeting attendees |
 |     ↳ `profileId` | number | The unique identifier of the attendee profile |
-|     ↳ `name` | string | The attendee name |
-|     ↳ `title` | string | The attendee job title |
-|     ↳ `companyName` | string | The name of the company the attendee belongs to |
-|     ↳ `email` | string | The attendee email address |
+|     ↳ `name` | string (nullable) | The attendee name |
+|     ↳ `title` | string (nullable) | The attendee job title |
+|     ↳ `companyName` | string (nullable) | The name of the company the attendee belongs to |
+|     ↳ `email` | string (nullable) | The attendee email address |
 |     ↳ `isCalendarEventOrganizer` | boolean | Whether the attendee organized the calendar event |
 |     ↳ `isCalendarInvitee` | boolean | Whether the attendee was invited on the calendar event |
-|   ↳ `notes` | string | The meeting notes with Markdown formatting |
-|   ↳ `privateNotes` | string | The authenticated user private notes for the meeting |
+|   ↳ `notes` | string (nullable) | The meeting notes with Markdown formatting |
+|   ↳ `privateNotes` | string (nullable) | The authenticated user private notes for the meeting |
 |   ↳ `actionItems` | array | Action items created for the meeting |
 |     ↳ `id` | number | The unique identifier of the action item |
 |     ↳ `title` | string | The action item title |
 |     ↳ `description` | string | The action item description |
-|     ↳ `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+|     ↳ `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
 |     ↳ `status` | string | The completion status, PENDING or DONE |
 |   ↳ `insights` | json | Insight results for the meeting, keyed by the name of the user-created insight |
-|   ↳ `linkAccess` | string | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
-|   ↳ `calendarEvent` | json | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
-| `nextCursor` | string | Pagination cursor for the next page, or null on the last page |
+|   ↳ `linkAccess` | string (nullable) | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
+|   ↳ `calendarEvent` | json (nullable) | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
+| `nextCursor` | string (nullable) | Pagination cursor for the next page, or null on the last page |
 | `hasMore` | boolean | Whether another page of meetings is available |
 
 ### Circleback Get Meeting
@@ -119,36 +119,36 @@ Gets a Circleback meeting by ID, including notes, attendees, action items, insig
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `id` | string | The Circleback meeting ID |
-| `name` | string | The meeting name |
+| `name` | string (nullable) | The meeting name |
 | `createdAt` | string | When the meeting was created \(ISO 8601\) |
 | `updatedAt` | string | When the meeting was last updated \(ISO 8601\) |
-| `duration` | number | The meeting duration in seconds |
-| `url` | string | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
-| `recordingUrl` | string | The URL of the meeting recording file, valid for 24 hours |
+| `duration` | number (nullable) | The meeting duration in seconds |
+| `url` | string (nullable) | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
+| `recordingUrl` | string (nullable) | The URL of the meeting recording file, valid for 24 hours |
 | `tags` | array | Tags added to the meeting |
 |   ↳ `id` | number | The unique identifier of the tag |
 |   ↳ `name` | string | The display name of the tag |
-|   ↳ `description` | string | A description of the tag |
-| `icalUid` | string | The identifier of the calendar event associated with the meeting |
+|   ↳ `description` | string (nullable) | A description of the tag |
+| `icalUid` | string (nullable) | The identifier of the calendar event associated with the meeting |
 | `attendees` | array | The meeting attendees |
 |   ↳ `profileId` | number | The unique identifier of the attendee profile |
-|   ↳ `name` | string | The attendee name |
-|   ↳ `title` | string | The attendee job title |
-|   ↳ `companyName` | string | The name of the company the attendee belongs to |
-|   ↳ `email` | string | The attendee email address |
+|   ↳ `name` | string (nullable) | The attendee name |
+|   ↳ `title` | string (nullable) | The attendee job title |
+|   ↳ `companyName` | string (nullable) | The name of the company the attendee belongs to |
+|   ↳ `email` | string (nullable) | The attendee email address |
 |   ↳ `isCalendarEventOrganizer` | boolean | Whether the attendee organized the calendar event |
 |   ↳ `isCalendarInvitee` | boolean | Whether the attendee was invited on the calendar event |
-| `notes` | string | The meeting notes with Markdown formatting |
-| `privateNotes` | string | The authenticated user private notes for the meeting |
+| `notes` | string (nullable) | The meeting notes with Markdown formatting |
+| `privateNotes` | string (nullable) | The authenticated user private notes for the meeting |
 | `actionItems` | array | Action items created for the meeting |
 |   ↳ `id` | number | The unique identifier of the action item |
 |   ↳ `title` | string | The action item title |
 |   ↳ `description` | string | The action item description |
-|   ↳ `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+|   ↳ `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
 |   ↳ `status` | string | The completion status, PENDING or DONE |
 | `insights` | json | Insight results for the meeting, keyed by the name of the user-created insight |
-| `linkAccess` | string | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
-| `calendarEvent` | json | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
+| `linkAccess` | string (nullable) | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
+| `calendarEvent` | json (nullable) | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
 
 ### Circleback Search Meetings
 
@@ -171,37 +171,37 @@ Searches Circleback meetings by name and content, with optional filters for spec
 | --------- | ---- | ----------- |
 | `meetings` | array | The matching meetings on this page |
 |   ↳ `id` | string | The Circleback meeting ID |
-|   ↳ `name` | string | The meeting name |
+|   ↳ `name` | string (nullable) | The meeting name |
 |   ↳ `createdAt` | string | When the meeting was created \(ISO 8601\) |
 |   ↳ `updatedAt` | string | When the meeting was last updated \(ISO 8601\) |
-|   ↳ `duration` | number | The meeting duration in seconds |
-|   ↳ `url` | string | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
-|   ↳ `recordingUrl` | string | The URL of the meeting recording file, valid for 24 hours |
+|   ↳ `duration` | number (nullable) | The meeting duration in seconds |
+|   ↳ `url` | string (nullable) | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
+|   ↳ `recordingUrl` | string (nullable) | The URL of the meeting recording file, valid for 24 hours |
 |   ↳ `tags` | array | Tags added to the meeting |
 |     ↳ `id` | number | The unique identifier of the tag |
 |     ↳ `name` | string | The display name of the tag |
-|     ↳ `description` | string | A description of the tag |
-|   ↳ `icalUid` | string | The identifier of the calendar event associated with the meeting |
+|     ↳ `description` | string (nullable) | A description of the tag |
+|   ↳ `icalUid` | string (nullable) | The identifier of the calendar event associated with the meeting |
 |   ↳ `attendees` | array | The meeting attendees |
 |     ↳ `profileId` | number | The unique identifier of the attendee profile |
-|     ↳ `name` | string | The attendee name |
-|     ↳ `title` | string | The attendee job title |
-|     ↳ `companyName` | string | The name of the company the attendee belongs to |
-|     ↳ `email` | string | The attendee email address |
+|     ↳ `name` | string (nullable) | The attendee name |
+|     ↳ `title` | string (nullable) | The attendee job title |
+|     ↳ `companyName` | string (nullable) | The name of the company the attendee belongs to |
+|     ↳ `email` | string (nullable) | The attendee email address |
 |     ↳ `isCalendarEventOrganizer` | boolean | Whether the attendee organized the calendar event |
 |     ↳ `isCalendarInvitee` | boolean | Whether the attendee was invited on the calendar event |
-|   ↳ `notes` | string | The meeting notes with Markdown formatting |
-|   ↳ `privateNotes` | string | The authenticated user private notes for the meeting |
+|   ↳ `notes` | string (nullable) | The meeting notes with Markdown formatting |
+|   ↳ `privateNotes` | string (nullable) | The authenticated user private notes for the meeting |
 |   ↳ `actionItems` | array | Action items created for the meeting |
 |     ↳ `id` | number | The unique identifier of the action item |
 |     ↳ `title` | string | The action item title |
 |     ↳ `description` | string | The action item description |
-|     ↳ `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+|     ↳ `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
 |     ↳ `status` | string | The completion status, PENDING or DONE |
 |   ↳ `insights` | json | Insight results for the meeting, keyed by the name of the user-created insight |
-|   ↳ `linkAccess` | string | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
-|   ↳ `calendarEvent` | json | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
-| `nextCursor` | string | Pagination cursor for the next page, or null on the last page |
+|   ↳ `linkAccess` | string (nullable) | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
+|   ↳ `calendarEvent` | json (nullable) | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
+| `nextCursor` | string (nullable) | Pagination cursor for the next page, or null on the last page |
 | `hasMore` | boolean | Whether another page of results is available |
 
 ### Circleback Get Transcript
@@ -220,7 +220,7 @@ Gets the full transcript for a Circleback meeting.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `transcript` | array | The transcript segments in order |
-|   ↳ `speaker` | string | The speaker name |
+|   ↳ `speaker` | string (nullable) | The speaker name |
 |   ↳ `text` | string | The words spoken |
 |   ↳ `timestamp` | number | The timestamp in seconds that marks the beginning of the segment |
 
@@ -243,9 +243,9 @@ Updates the name, notes, or private notes of a Circleback meeting. The API retur
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `id` | string | The Circleback meeting ID |
-| `name` | string | The updated meeting name, when the name was updated |
-| `notes` | string | The updated meeting notes, when the notes were updated |
-| `privateNotes` | string | The updated private notes, when the private notes were updated |
+| `name` | string (nullable) | The updated meeting name, when the name was updated |
+| `notes` | string (nullable) | The updated meeting notes, when the notes were updated |
+| `privateNotes` | string (nullable) | The updated private notes, when the private notes were updated |
 | `updatedAt` | string | When the meeting was last updated \(ISO 8601\) |
 
 ### Circleback Delete Meeting
@@ -264,36 +264,36 @@ Deletes a Circleback meeting. Only the owner of the meeting can delete it. Retur
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `id` | string | The Circleback meeting ID |
-| `name` | string | The meeting name |
+| `name` | string (nullable) | The meeting name |
 | `createdAt` | string | When the meeting was created \(ISO 8601\) |
 | `updatedAt` | string | When the meeting was last updated \(ISO 8601\) |
-| `duration` | number | The meeting duration in seconds |
-| `url` | string | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
-| `recordingUrl` | string | The URL of the meeting recording file, valid for 24 hours |
+| `duration` | number (nullable) | The meeting duration in seconds |
+| `url` | string (nullable) | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
+| `recordingUrl` | string (nullable) | The URL of the meeting recording file, valid for 24 hours |
 | `tags` | array | Tags added to the meeting |
 |   ↳ `id` | number | The unique identifier of the tag |
 |   ↳ `name` | string | The display name of the tag |
-|   ↳ `description` | string | A description of the tag |
-| `icalUid` | string | The identifier of the calendar event associated with the meeting |
+|   ↳ `description` | string (nullable) | A description of the tag |
+| `icalUid` | string (nullable) | The identifier of the calendar event associated with the meeting |
 | `attendees` | array | The meeting attendees |
 |   ↳ `profileId` | number | The unique identifier of the attendee profile |
-|   ↳ `name` | string | The attendee name |
-|   ↳ `title` | string | The attendee job title |
-|   ↳ `companyName` | string | The name of the company the attendee belongs to |
-|   ↳ `email` | string | The attendee email address |
+|   ↳ `name` | string (nullable) | The attendee name |
+|   ↳ `title` | string (nullable) | The attendee job title |
+|   ↳ `companyName` | string (nullable) | The name of the company the attendee belongs to |
+|   ↳ `email` | string (nullable) | The attendee email address |
 |   ↳ `isCalendarEventOrganizer` | boolean | Whether the attendee organized the calendar event |
 |   ↳ `isCalendarInvitee` | boolean | Whether the attendee was invited on the calendar event |
-| `notes` | string | The meeting notes with Markdown formatting |
-| `privateNotes` | string | The authenticated user private notes for the meeting |
+| `notes` | string (nullable) | The meeting notes with Markdown formatting |
+| `privateNotes` | string (nullable) | The authenticated user private notes for the meeting |
 | `actionItems` | array | Action items created for the meeting |
 |   ↳ `id` | number | The unique identifier of the action item |
 |   ↳ `title` | string | The action item title |
 |   ↳ `description` | string | The action item description |
-|   ↳ `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+|   ↳ `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
 |   ↳ `status` | string | The completion status, PENDING or DONE |
 | `insights` | json | Insight results for the meeting, keyed by the name of the user-created insight |
-| `linkAccess` | string | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
-| `calendarEvent` | json | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
+| `linkAccess` | string (nullable) | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
+| `calendarEvent` | json (nullable) | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
 
 ### Circleback List Action Items
 
@@ -320,16 +320,16 @@ Lists action items across the authenticated user meetings, filtered by assignee,
 |   ↳ `id` | number | The unique identifier of the action item |
 |   ↳ `title` | string | The action item title |
 |   ↳ `description` | string | The action item description |
-|   ↳ `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
-|   ↳ `completedAt` | string | When the action item was marked done, or null if not completed |
-|   ↳ `meetingId` | string | The ID of the meeting the action item belongs to, or null |
+|   ↳ `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+|   ↳ `completedAt` | string (nullable) | When the action item was marked done, or null if not completed |
+|   ↳ `meetingId` | string (nullable) | The ID of the meeting the action item belongs to, or null |
 |   ↳ `status` | string | The completion status, PENDING or DONE |
 |   ↳ `meetings` | array | The meetings the action item is associated with |
 |     ↳ `id` | string | The Circleback meeting ID |
-|     ↳ `name` | string | The meeting name |
+|     ↳ `name` | string (nullable) | The meeting name |
 |     ↳ `createdAt` | string | When the meeting was created \(ISO 8601\) |
 |   ↳ `canEditActionItem` | boolean | Whether the caller may edit the action item. Returned only by the list operation |
-| `nextCursor` | string | Pagination cursor for the next page, or null on the last page |
+| `nextCursor` | string (nullable) | Pagination cursor for the next page, or null on the last page |
 | `hasMore` | boolean | Whether another page of action items is available |
 
 ### Circleback Update Action Item
@@ -354,13 +354,13 @@ Updates the title, description, status, or assignee of a Circleback action item.
 | `id` | number | The unique identifier of the action item |
 | `title` | string | The action item title |
 | `description` | string | The action item description |
-| `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
-| `completedAt` | string | When the action item was marked done, or null if not completed |
-| `meetingId` | string | The ID of the meeting the action item belongs to, or null |
+| `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+| `completedAt` | string (nullable) | When the action item was marked done, or null if not completed |
+| `meetingId` | string (nullable) | The ID of the meeting the action item belongs to, or null |
 | `status` | string | The completion status, PENDING or DONE |
 | `meetings` | array | The meetings the action item is associated with |
 |   ↳ `id` | string | The Circleback meeting ID |
-|   ↳ `name` | string | The meeting name |
+|   ↳ `name` | string (nullable) | The meeting name |
 |   ↳ `createdAt` | string | When the meeting was created \(ISO 8601\) |
 | `canEditActionItem` | boolean | Whether the caller may edit the action item. Returned only by the list operation |
 
@@ -382,13 +382,13 @@ Deletes a Circleback action item. Returns the deleted action item.
 | `id` | number | The unique identifier of the action item |
 | `title` | string | The action item title |
 | `description` | string | The action item description |
-| `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
-| `completedAt` | string | When the action item was marked done, or null if not completed |
-| `meetingId` | string | The ID of the meeting the action item belongs to, or null |
+| `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+| `completedAt` | string (nullable) | When the action item was marked done, or null if not completed |
+| `meetingId` | string (nullable) | The ID of the meeting the action item belongs to, or null |
 | `status` | string | The completion status, PENDING or DONE |
 | `meetings` | array | The meetings the action item is associated with |
 |   ↳ `id` | string | The Circleback meeting ID |
-|   ↳ `name` | string | The meeting name |
+|   ↳ `name` | string (nullable) | The meeting name |
 |   ↳ `createdAt` | string | When the meeting was created \(ISO 8601\) |
 | `canEditActionItem` | boolean | Whether the caller may edit the action item. Returned only by the list operation |
 
@@ -416,7 +416,7 @@ Lists upcoming calendar events from the authenticated user connected calendars, 
 |   ↳ `title` | string | The title of the calendar meeting |
 |   ↳ `icalUid` | string | The iCalendar UID of the calendar event |
 |   ↳ `attendees` | array | The attendees invited to the calendar meeting |
-|     ↳ `name` | string | The name of the attendee |
+|     ↳ `name` | string (nullable) | The name of the attendee |
 |     ↳ `email` | string | The email address of the attendee |
 |     ↳ `isOrganizer` | boolean | Whether the attendee organized the calendar meeting |
 |     ↳ `status` | string | The attendee response to the invitation: accepted, declined, tentative, or not_available |
@@ -428,14 +428,14 @@ Lists upcoming calendar events from the authenticated user connected calendars, 
 |   ↳ `isHostedByMe` | boolean | Whether the current user organized the calendar meeting |
 |   ↳ `location` | string | The location of the calendar meeting |
 |   ↳ `meetingId` | string | The Circleback meeting associated with the calendar meeting, when one exists |
-|   ↳ `meetingPlatform` | string | The conferencing platform hosting the meeting, when detected |
-|   ↳ `organizerEmail` | string | The email address of the meeting organizer |
-|   ↳ `platform` | string | The conferencing platform hosting the meeting, when detected. Alias of meetingPlatform |
-|   ↳ `overrideShouldRecord` | boolean | Whether the user manually overrode the automatic recording decision, or null when no override is set |
+|   ↳ `meetingPlatform` | string (nullable) | The conferencing platform hosting the meeting, when detected |
+|   ↳ `organizerEmail` | string (nullable) | The email address of the meeting organizer |
+|   ↳ `platform` | string (nullable) | The conferencing platform hosting the meeting, when detected. Alias of meetingPlatform |
+|   ↳ `overrideShouldRecord` | boolean (nullable) | Whether the user manually overrode the automatic recording decision, or null when no override is set |
 |   ↳ `recurringEventId` | string | The identifier of the recurring event series the meeting belongs to |
 |   ↳ `willRecord` | boolean | Whether the notetaker will join and record the meeting |
 |   ↳ `willRecordReason` | string | A human-readable explanation of why the meeting will or will not be recorded |
-| `nextCursor` | string | Pagination cursor for the next page, or null on the last page |
+| `nextCursor` | string (nullable) | Pagination cursor for the next page, or null on the last page |
 | `hasMore` | boolean | Whether another page of calendar events is available |
 
 ### Circleback List Companies
@@ -456,10 +456,10 @@ Lists the companies whose people attend the authenticated user meetings, with op
 | --------- | ---- | ----------- |
 | `companies` | array | The companies on this page |
 |   ↳ `id` | number | The unique identifier of the company |
-|   ↳ `name` | string | The company name |
-|   ↳ `avatarUrl` | string | The URL of the company logo image |
+|   ↳ `name` | string (nullable) | The company name |
+|   ↳ `avatarUrl` | string (nullable) | The URL of the company logo image |
 |   ↳ `domain` | string | The company website domain |
-| `nextCursor` | string | Pagination cursor for the next page, or null on the last page |
+| `nextCursor` | string (nullable) | Pagination cursor for the next page, or null on the last page |
 | `hasMore` | boolean | Whether another page of companies is available |
 
 ### Circleback Get Company
@@ -477,8 +477,8 @@ Gets a company by its domain from Circleback, including its people and external 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `name` | string | The company name |
-| `avatarUrl` | string | The URL of the company logo image |
+| `name` | string (nullable) | The company name |
+| `avatarUrl` | string (nullable) | The URL of the company logo image |
 | `domain` | string | The company website domain |
 | `externalLinks` | array | Links to the company on external platforms and connected integrations |
 |   ↳ `url` | string | The URL of the external resource |
@@ -486,12 +486,12 @@ Gets a company by its domain from Circleback, including its people and external 
 |   ↳ `type` | string | The platform or integration the link points to, such as Attio, HubSpot, Linear, Salesforce, Zoho, linkedin, or website |
 | `people` | array | People at the company the authenticated user has met with |
 |   ↳ `id` | number | The unique identifier of the person |
-|   ↳ `title` | string | The person job title |
-|   ↳ `companyId` | number | The unique identifier of the company the person belongs to |
-|   ↳ `companyName` | string | The name of the company the person belongs to |
-|   ↳ `email` | string | The person email address |
-|   ↳ `firstName` | string | The person first name |
-|   ↳ `lastName` | string | The person last name |
+|   ↳ `title` | string (nullable) | The person job title |
+|   ↳ `companyId` | number (nullable) | The unique identifier of the company the person belongs to |
+|   ↳ `companyName` | string (nullable) | The name of the company the person belongs to |
+|   ↳ `email` | string (nullable) | The person email address |
+|   ↳ `firstName` | string (nullable) | The person first name |
+|   ↳ `lastName` | string (nullable) | The person last name |
 
 ### Circleback List People
 
@@ -513,13 +513,13 @@ Lists the people who attend the authenticated user meetings, ordered by most rec
 | --------- | ---- | ----------- |
 | `people` | array | The people on this page |
 |   ↳ `id` | number | The unique identifier of the person |
-|   ↳ `title` | string | The person job title |
-|   ↳ `companyId` | number | The unique identifier of the company the person belongs to |
-|   ↳ `companyName` | string | The name of the company the person belongs to |
-|   ↳ `email` | string | The person email address |
-|   ↳ `firstName` | string | The person first name |
-|   ↳ `lastName` | string | The person last name |
-| `nextCursor` | string | Pagination cursor for the next page, or null on the last page |
+|   ↳ `title` | string (nullable) | The person job title |
+|   ↳ `companyId` | number (nullable) | The unique identifier of the company the person belongs to |
+|   ↳ `companyName` | string (nullable) | The name of the company the person belongs to |
+|   ↳ `email` | string (nullable) | The person email address |
+|   ↳ `firstName` | string (nullable) | The person first name |
+|   ↳ `lastName` | string (nullable) | The person last name |
+| `nextCursor` | string (nullable) | Pagination cursor for the next page, or null on the last page |
 | `hasMore` | boolean | Whether another page of people is available |
 
 ### Circleback Get Person
@@ -538,12 +538,12 @@ Gets a person by their profile ID from Circleback, including their profile detai
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `id` | number | The unique identifier of the person |
-| `title` | string | The person job title |
-| `companyId` | number | The unique identifier of the company the person belongs to |
-| `companyName` | string | The name of the company the person belongs to |
-| `email` | string | The person email address |
-| `firstName` | string | The person first name |
-| `lastName` | string | The person last name |
+| `title` | string (nullable) | The person job title |
+| `companyId` | number (nullable) | The unique identifier of the company the person belongs to |
+| `companyName` | string (nullable) | The name of the company the person belongs to |
+| `email` | string (nullable) | The person email address |
+| `firstName` | string (nullable) | The person first name |
+| `lastName` | string (nullable) | The person last name |
 | `externalLinks` | array | Links to the person on external platforms and connected integrations |
 |   ↳ `url` | string | The URL of the external resource |
 |   ↳ `objectType` | string | Whether the link refers to a person or a company |
@@ -566,7 +566,7 @@ Lists every tag available to the authenticated Circleback user.
 | `tags` | array | Every tag available to the authenticated user |
 |   ↳ `id` | number | The unique identifier of the tag |
 |   ↳ `name` | string | The display name of the tag |
-|   ↳ `description` | string | A description of the tag |
+|   ↳ `description` | string (nullable) | A description of the tag |
 
 ### Circleback Create Tag
 
@@ -586,7 +586,7 @@ Creates a new tag in Circleback. If a tag with the same name already exists, a c
 | --------- | ---- | ----------- |
 | `id` | number | The unique identifier of the tag |
 | `name` | string | The display name of the tag |
-| `description` | string | A description of the tag |
+| `description` | string (nullable) | A description of the tag |
 
 ### Circleback Update Tag
 
@@ -607,7 +607,7 @@ Updates the name or description of a Circleback tag.
 | --------- | ---- | ----------- |
 | `id` | number | The unique identifier of the tag |
 | `name` | string | The display name of the tag |
-| `description` | string | A description of the tag |
+| `description` | string (nullable) | A description of the tag |
 
 ### Circleback Delete Tag
 
@@ -626,7 +626,7 @@ Permanently deletes a Circleback tag and removes it from every meeting it was ap
 | --------- | ---- | ----------- |
 | `id` | number | The unique identifier of the tag |
 | `name` | string | The display name of the tag |
-| `description` | string | A description of the tag |
+| `description` | string (nullable) | A description of the tag |
 
 ### Circleback Add Tag to Meetings
 
@@ -646,36 +646,36 @@ Applies an existing Circleback tag to one or more meetings and returns the updat
 | --------- | ---- | ----------- |
 | `meetings` | array | The updated meetings |
 |   ↳ `id` | string | The Circleback meeting ID |
-|   ↳ `name` | string | The meeting name |
+|   ↳ `name` | string (nullable) | The meeting name |
 |   ↳ `createdAt` | string | When the meeting was created \(ISO 8601\) |
 |   ↳ `updatedAt` | string | When the meeting was last updated \(ISO 8601\) |
-|   ↳ `duration` | number | The meeting duration in seconds |
-|   ↳ `url` | string | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
-|   ↳ `recordingUrl` | string | The URL of the meeting recording file, valid for 24 hours |
+|   ↳ `duration` | number (nullable) | The meeting duration in seconds |
+|   ↳ `url` | string (nullable) | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
+|   ↳ `recordingUrl` | string (nullable) | The URL of the meeting recording file, valid for 24 hours |
 |   ↳ `tags` | array | Tags added to the meeting |
 |     ↳ `id` | number | The unique identifier of the tag |
 |     ↳ `name` | string | The display name of the tag |
-|     ↳ `description` | string | A description of the tag |
-|   ↳ `icalUid` | string | The identifier of the calendar event associated with the meeting |
+|     ↳ `description` | string (nullable) | A description of the tag |
+|   ↳ `icalUid` | string (nullable) | The identifier of the calendar event associated with the meeting |
 |   ↳ `attendees` | array | The meeting attendees |
 |     ↳ `profileId` | number | The unique identifier of the attendee profile |
-|     ↳ `name` | string | The attendee name |
-|     ↳ `title` | string | The attendee job title |
-|     ↳ `companyName` | string | The name of the company the attendee belongs to |
-|     ↳ `email` | string | The attendee email address |
+|     ↳ `name` | string (nullable) | The attendee name |
+|     ↳ `title` | string (nullable) | The attendee job title |
+|     ↳ `companyName` | string (nullable) | The name of the company the attendee belongs to |
+|     ↳ `email` | string (nullable) | The attendee email address |
 |     ↳ `isCalendarEventOrganizer` | boolean | Whether the attendee organized the calendar event |
 |     ↳ `isCalendarInvitee` | boolean | Whether the attendee was invited on the calendar event |
-|   ↳ `notes` | string | The meeting notes with Markdown formatting |
-|   ↳ `privateNotes` | string | The authenticated user private notes for the meeting |
+|   ↳ `notes` | string (nullable) | The meeting notes with Markdown formatting |
+|   ↳ `privateNotes` | string (nullable) | The authenticated user private notes for the meeting |
 |   ↳ `actionItems` | array | Action items created for the meeting |
 |     ↳ `id` | number | The unique identifier of the action item |
 |     ↳ `title` | string | The action item title |
 |     ↳ `description` | string | The action item description |
-|     ↳ `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+|     ↳ `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
 |     ↳ `status` | string | The completion status, PENDING or DONE |
 |   ↳ `insights` | json | Insight results for the meeting, keyed by the name of the user-created insight |
-|   ↳ `linkAccess` | string | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
-|   ↳ `calendarEvent` | json | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
+|   ↳ `linkAccess` | string (nullable) | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
+|   ↳ `calendarEvent` | json (nullable) | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
 
 ### Circleback Remove Tag from Meetings
 
@@ -695,38 +695,36 @@ Removes a Circleback tag from one or more meetings and returns the updated meeti
 | --------- | ---- | ----------- |
 | `meetings` | array | The updated meetings |
 |   ↳ `id` | string | The Circleback meeting ID |
-|   ↳ `name` | string | The meeting name |
+|   ↳ `name` | string (nullable) | The meeting name |
 |   ↳ `createdAt` | string | When the meeting was created \(ISO 8601\) |
 |   ↳ `updatedAt` | string | When the meeting was last updated \(ISO 8601\) |
-|   ↳ `duration` | number | The meeting duration in seconds |
-|   ↳ `url` | string | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
-|   ↳ `recordingUrl` | string | The URL of the meeting recording file, valid for 24 hours |
+|   ↳ `duration` | number (nullable) | The meeting duration in seconds |
+|   ↳ `url` | string (nullable) | The URL of the virtual meeting \(Zoom, Google Meet, or Microsoft Teams\) |
+|   ↳ `recordingUrl` | string (nullable) | The URL of the meeting recording file, valid for 24 hours |
 |   ↳ `tags` | array | Tags added to the meeting |
 |     ↳ `id` | number | The unique identifier of the tag |
 |     ↳ `name` | string | The display name of the tag |
-|     ↳ `description` | string | A description of the tag |
-|   ↳ `icalUid` | string | The identifier of the calendar event associated with the meeting |
+|     ↳ `description` | string (nullable) | A description of the tag |
+|   ↳ `icalUid` | string (nullable) | The identifier of the calendar event associated with the meeting |
 |   ↳ `attendees` | array | The meeting attendees |
 |     ↳ `profileId` | number | The unique identifier of the attendee profile |
-|     ↳ `name` | string | The attendee name |
-|     ↳ `title` | string | The attendee job title |
-|     ↳ `companyName` | string | The name of the company the attendee belongs to |
-|     ↳ `email` | string | The attendee email address |
+|     ↳ `name` | string (nullable) | The attendee name |
+|     ↳ `title` | string (nullable) | The attendee job title |
+|     ↳ `companyName` | string (nullable) | The name of the company the attendee belongs to |
+|     ↳ `email` | string (nullable) | The attendee email address |
 |     ↳ `isCalendarEventOrganizer` | boolean | Whether the attendee organized the calendar event |
 |     ↳ `isCalendarInvitee` | boolean | Whether the attendee was invited on the calendar event |
-|   ↳ `notes` | string | The meeting notes with Markdown formatting |
-|   ↳ `privateNotes` | string | The authenticated user private notes for the meeting |
+|   ↳ `notes` | string (nullable) | The meeting notes with Markdown formatting |
+|   ↳ `privateNotes` | string (nullable) | The authenticated user private notes for the meeting |
 |   ↳ `actionItems` | array | Action items created for the meeting |
 |     ↳ `id` | number | The unique identifier of the action item |
 |     ↳ `title` | string | The action item title |
 |     ↳ `description` | string | The action item description |
-|     ↳ `assignee` | json | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
+|     ↳ `assignee` | json (nullable) | The assignee as an object with profileId, name, title, companyName, and email, or null if unassigned |
 |     ↳ `status` | string | The completion status, PENDING or DONE |
 |   ↳ `insights` | json | Insight results for the meeting, keyed by the name of the user-created insight |
-|   ↳ `linkAccess` | string | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
-|   ↳ `calendarEvent` | json | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
-
-
+|   ↳ `linkAccess` | string (nullable) | Who can access the meeting through its shareable link: Editor, Viewer, or LimitedViewer |
+|   ↳ `calendarEvent` | json (nullable) | The associated calendar event as an object with id, icalUid, description, platform, and platformId, or null |
 
 ## Triggers
 
@@ -878,4 +876,3 @@ Generic webhook trigger for all Circleback events
 |   ↳ `duration` | number | Duration in seconds |
 |   ↳ `createdAt` | string | Creation timestamp |
 |   ↳ `recordingUrl` | string | Recording URL |
-

--- a/apps/docs/content/docs/integrations/clay.mdx
+++ b/apps/docs/content/docs/integrations/clay.mdx
@@ -5,7 +5,7 @@ description: Populate Clay workbook
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="clay"
   color="#FFFFFF"
 />
@@ -46,5 +46,3 @@ Populate Clay with data from a JSON file. Enables direct communication and notif
 |   ↳ `headers` | object | Response headers from Clay |
 |   ↳ `timestamp` | string | ISO timestamp when webhook was received |
 |   ↳ `contentType` | string | Content type of the response |
-
-

--- a/apps/docs/content/docs/integrations/clerk.mdx
+++ b/apps/docs/content/docs/integrations/clerk.mdx
@@ -5,7 +5,7 @@ description: Manage users, organizations, and sessions in Clerk
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="clerk"
   color="#131316"
 />
@@ -1078,8 +1078,6 @@ Revoke an actor token before it is used or expires
 | `updatedAt` | number | Last update timestamp |
 | `success` | boolean | Operation success status |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1474,4 +1472,3 @@ Trigger workflow on any Clerk webhook event
 | `timestamp` | number | Timestamp in milliseconds when the event occurred |
 | `instance_id` | string | Identifier of your Clerk instance |
 | `data` | json | Raw event `data` object \(shape varies by event type\) |
-

--- a/apps/docs/content/docs/integrations/clickhouse.mdx
+++ b/apps/docs/content/docs/integrations/clickhouse.mdx
@@ -5,7 +5,7 @@ description: Connect to a ClickHouse database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="clickhouse"
   color="#f9ff69"
 />
@@ -663,5 +663,3 @@ List configured clusters, shards, and replicas
 | `message` | string | Operation status message |
 | `rows` | array | Array of cluster node rows |
 | `rowCount` | number | Number of rows returned |
-
-

--- a/apps/docs/content/docs/integrations/clickup.mdx
+++ b/apps/docs/content/docs/integrations/clickup.mdx
@@ -5,7 +5,7 @@ description: Interact with ClickUp
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="clickup"
   color="#FFFFFF"
 />
@@ -285,13 +285,13 @@ Upload a file to a ClickUp task as an attachment
 | --------- | ---- | ----------- |
 | `attachment` | json | The created attachment |
 |   ↳ `id` | string | Attachment ID |
-|   ↳ `version` | string | Attachment version |
-|   ↳ `title` | string | Attachment title |
-|   ↳ `extension` | string | File extension |
-|   ↳ `url` | string | URL of the uploaded attachment |
-|   ↳ `date` | number | Upload timestamp \(Unix ms\) |
-|   ↳ `thumbnailSmall` | string | Small thumbnail URL |
-|   ↳ `thumbnailLarge` | string | Large thumbnail URL |
+|   ↳ `version` | string (nullable) | Attachment version |
+|   ↳ `title` | string (nullable) | Attachment title |
+|   ↳ `extension` | string (nullable) | File extension |
+|   ↳ `url` | string (nullable) | URL of the uploaded attachment |
+|   ↳ `date` | number (nullable) | Upload timestamp \(Unix ms\) |
+|   ↳ `thumbnailSmall` | string (nullable) | Small thumbnail URL |
+|   ↳ `thumbnailLarge` | string (nullable) | Large thumbnail URL |
 | `files` | file[] | The uploaded attachment file |
 
 ### ClickUp Add Tag To Task
@@ -394,11 +394,11 @@ List the custom fields accessible in a ClickUp list
 | --------- | ---- | ----------- |
 | `fields` | array | Custom fields accessible in the list |
 |   ↳ `id` | string | Custom field ID |
-|   ↳ `name` | string | Custom field name |
-|   ↳ `type` | string | Custom field type \(e.g. text, number, drop_down\) |
-|   ↳ `typeConfig` | json | Type-specific configuration \(e.g. dropdown options\) |
-|   ↳ `dateCreated` | string | Creation timestamp \(Unix ms\) |
-|   ↳ `hideFromGuests` | boolean | Whether the field is hidden from guests |
+|   ↳ `name` | string (nullable) | Custom field name |
+|   ↳ `type` | string (nullable) | Custom field type \(e.g. text, number, drop_down\) |
+|   ↳ `typeConfig` | json (nullable) | Type-specific configuration \(e.g. dropdown options\) |
+|   ↳ `dateCreated` | string (nullable) | Creation timestamp \(Unix ms\) |
+|   ↳ `hideFromGuests` | boolean (nullable) | Whether the field is hidden from guests |
 
 ### ClickUp Get Workspaces
 
@@ -415,9 +415,9 @@ List the ClickUp workspaces (teams) available to the connected account
 | --------- | ---- | ----------- |
 | `workspaces` | array | Workspaces available to the connected account |
 |   ↳ `id` | string | Workspace ID |
-|   ↳ `name` | string | Workspace name |
-|   ↳ `color` | string | Workspace color |
-|   ↳ `avatar` | string | Workspace avatar URL |
+|   ↳ `name` | string (nullable) | Workspace name |
+|   ↳ `color` | string (nullable) | Workspace color |
+|   ↳ `avatar` | string (nullable) | Workspace avatar URL |
 
 ### ClickUp Get Spaces
 
@@ -436,13 +436,13 @@ List the spaces in a ClickUp workspace
 | --------- | ---- | ----------- |
 | `spaces` | array | Spaces in the workspace |
 |   ↳ `id` | string | Space ID |
-|   ↳ `name` | string | Space name |
-|   ↳ `private` | boolean | Whether the space is private |
-|   ↳ `archived` | boolean | Whether the space is archived |
+|   ↳ `name` | string (nullable) | Space name |
+|   ↳ `private` | boolean (nullable) | Whether the space is private |
+|   ↳ `archived` | boolean (nullable) | Whether the space is archived |
 |   ↳ `statuses` | array | Task statuses available in the space |
-|     ↳ `status` | string | Status name |
-|     ↳ `color` | string | Status color |
-|     ↳ `type` | string | Status type |
+|     ↳ `status` | string (nullable) | Status name |
+|     ↳ `color` | string (nullable) | Status color |
+|     ↳ `type` | string (nullable) | Status type |
 
 ### ClickUp Get Folders
 
@@ -803,8 +803,6 @@ Get the currently running time entry in a ClickUp workspace (null when no timer 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeEntry` | json | The running time entry \(duration is negative while running\); null when no timer is running |
-
-
 
 ## Triggers
 
@@ -1586,4 +1584,3 @@ Trigger workflow on any ClickUp event (subscribes to all events)
 | `listId` | string | ID of the affected list \(list events only\) |
 | `folderId` | string | ID of the affected folder \(folder events only\) |
 | `spaceId` | string | ID of the affected space \(space events only\) |
-

--- a/apps/docs/content/docs/integrations/cloudflare.mdx
+++ b/apps/docs/content/docs/integrations/cloudflare.mdx
@@ -5,7 +5,7 @@ description: Manage DNS, WAF, Zero Trust access, and edge infrastructure
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="cloudflare"
   color="#F5F6FA"
 />
@@ -1709,5 +1709,3 @@ Reads the configuration of a remotely-managed Cloudflare Tunnel — its ingress 
 | `source` | string | Where the configuration is managed: local or cloudflare |
 | `created_at` | string | Creation timestamp |
 | `config` | json | Tunnel configuration with ingress rules, originRequest defaults, and warp-routing settings |
-
-

--- a/apps/docs/content/docs/integrations/cloudformation.mdx
+++ b/apps/docs/content/docs/integrations/cloudformation.mdx
@@ -5,7 +5,7 @@ description: Manage and inspect AWS CloudFormation stacks, resources, and drift
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="cloudformation"
   color="linear-gradient(45deg, #B0084D 0%, #FF4F8B 100%)"
 />
@@ -359,5 +359,3 @@ Validate a CloudFormation template for syntax and structural correctness
 | `capabilities` | array | Required capabilities \(e.g., CAPABILITY_IAM\) |
 | `capabilitiesReason` | string | Reason capabilities are required |
 | `declaredTransforms` | array | Transforms used in the template \(e.g., AWS::Serverless-2016-10-31\) |
-
-

--- a/apps/docs/content/docs/integrations/cloudtrail.mdx
+++ b/apps/docs/content/docs/integrations/cloudtrail.mdx
@@ -5,7 +5,7 @@ description: Audit who did what in AWS with CloudTrail event history and Lake qu
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="cloudtrail"
   color="linear-gradient(45deg, #B0084D 0%, #FF4F8B 100%)"
 />
@@ -219,10 +219,10 @@ List the ARN, name, and home Region of every CloudTrail trail visible to the acc
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `trails` | array | Trail summaries |
-|   ↳ `trailArn` | string | ARN of the trail |
-|   ↳ `name` | string | Trail name |
-|   ↳ `homeRegion` | string | Region in which the trail was created |
-| `nextToken` | string | Pagination token for the next page of trails, or null on the last page |
+|   ↳ `trailArn` | string (nullable) | ARN of the trail |
+|   ↳ `name` | string (nullable) | Trail name |
+|   ↳ `homeRegion` | string (nullable) | Region in which the trail was created |
+| `nextToken` | string (nullable) | Pagination token for the next page of trails, or null on the last page |
 
 ### CloudTrail Get Event Selectors
 
@@ -432,22 +432,22 @@ Retrieve the configuration of a single CloudTrail Lake event data store
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `eventDataStoreArn` | string | ARN of the event data store |
-| `name` | string | Name of the event data store |
-| `status` | string | CREATED, ENABLED, PENDING_DELETION, or an ingestion state |
+| `eventDataStoreArn` | string (nullable) | ARN of the event data store |
+| `name` | string (nullable) | Name of the event data store |
+| `status` | string (nullable) | CREATED, ENABLED, PENDING_DELETION, or an ingestion state |
 | `advancedEventSelectors` | array | Advanced event selectors that define what the store ingests |
-|   ↳ `name` | string | Name of the advanced event selector |
+|   ↳ `name` | string (nullable) | Name of the advanced event selector |
 |   ↳ `fieldSelectors` | array | Field selectors, each with field plus its equals, startsWith, endsWith, notEquals, notStartsWith, and notEndsWith values |
-| `multiRegionEnabled` | boolean | Whether the store collects events from all Regions |
-| `organizationEnabled` | boolean | Whether the store collects events for the organization |
-| `retentionPeriod` | number | Retention period in days |
-| `terminationProtectionEnabled` | boolean | Whether termination protection is enabled |
-| `createdTimestamp` | string | When the store was created \(ISO 8601\) |
-| `updatedTimestamp` | string | When the store was last updated \(ISO 8601\) |
-| `kmsKeyId` | string | KMS key used to encrypt the store |
-| `billingMode` | string | EXTENDABLE_RETENTION_PRICING or FIXED_RETENTION_PRICING |
-| `federationStatus` | string | Lake Formation federation status |
-| `federationRoleArn` | string | ARN of the role used for Lake Formation federation |
+| `multiRegionEnabled` | boolean (nullable) | Whether the store collects events from all Regions |
+| `organizationEnabled` | boolean (nullable) | Whether the store collects events for the organization |
+| `retentionPeriod` | number (nullable) | Retention period in days |
+| `terminationProtectionEnabled` | boolean (nullable) | Whether termination protection is enabled |
+| `createdTimestamp` | string (nullable) | When the store was created \(ISO 8601\) |
+| `updatedTimestamp` | string (nullable) | When the store was last updated \(ISO 8601\) |
+| `kmsKeyId` | string (nullable) | KMS key used to encrypt the store |
+| `billingMode` | string (nullable) | EXTENDABLE_RETENTION_PRICING or FIXED_RETENTION_PRICING |
+| `federationStatus` | string (nullable) | Lake Formation federation status |
+| `federationRoleArn` | string (nullable) | ARN of the role used for Lake Formation federation |
 | `partitionKeys` | array | Partition keys of the event data store |
 |   ↳ `name` | string | Partition key name |
 |   ↳ `type` | string | Partition key data type |
@@ -474,5 +474,3 @@ List the tags on CloudTrail trails, event data stores, dashboards, or channels
 |   ↳ `resourceId` | string | ARN of the tagged resource |
 |   ↳ `tags` | array | Tags on the resource, as key and value |
 | `nextToken` | string | Reserved for future use by AWS |
-
-

--- a/apps/docs/content/docs/integrations/cloudwatch.mdx
+++ b/apps/docs/content/docs/integrations/cloudwatch.mdx
@@ -5,7 +5,7 @@ description: Query and monitor AWS CloudWatch logs, metrics, and alarms
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="cloudwatch"
   color="linear-gradient(45deg, #B0084D 0%, #FF4F8B 100%)"
 />
@@ -384,5 +384,3 @@ Delete a CloudWatch alarm mute rule, restoring alarm notifications
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the mute rule was deleted successfully |
 | `muteRuleName` | string | Name of the mute rule that was deleted |
-
-

--- a/apps/docs/content/docs/integrations/codepipeline.mdx
+++ b/apps/docs/content/docs/integrations/codepipeline.mdx
@@ -5,7 +5,7 @@ description: Run, monitor, and approve AWS CodePipeline pipelines
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="codepipeline"
   color="linear-gradient(45deg, #2E27AD 0%, #527FFF 100%)"
 />
@@ -359,5 +359,3 @@ Re-enable artifacts transitioning into or out of a CodePipeline stage after it w
 | `pipelineName` | string | Pipeline name |
 | `stageName` | string | Stage whose transition was enabled |
 | `transitionType` | string | Transition type that was enabled \(Inbound or Outbound\) |
-
-

--- a/apps/docs/content/docs/integrations/confluence.mdx
+++ b/apps/docs/content/docs/integrations/confluence.mdx
@@ -5,7 +5,7 @@ description: Interact with Confluence
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="confluence_v2"
   color="#FFFFFF"
 />
@@ -1376,8 +1376,6 @@ Get display name and profile info for a Confluence user by account ID.
 | `profilePicture` | string | Path to the user profile picture |
 | `publicName` | string | Public name of the user |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -2156,4 +2154,3 @@ Trigger workflow on any Confluence webhook event
 | `content` | json | Content object \(present in label events\) |
 | `user` | json | User object \(present in user events\) |
 | `files` | file[] | Attachment file content \(present in attachment events when includeFileContent is enabled\) |
-

--- a/apps/docs/content/docs/integrations/context_dev.mdx
+++ b/apps/docs/content/docs/integrations/context_dev.mdx
@@ -5,7 +5,7 @@ description: Scrape, crawl, search, extract, and enrich web and brand data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="context_dev"
   color="#ffffff"
 />
@@ -625,5 +625,3 @@ Identify the brand behind a raw bank/card transaction descriptor and return its 
 |   ↳ `industries` | json | Industry taxonomy \(eic industry/subindustry pairs\) |
 |   ↳ `links` | json | Key brand links \(careers, privacy, terms, blog, pricing, contact\) |
 |   ↳ `primary_language` | string | Primary language of the brand site |
-
-

--- a/apps/docs/content/docs/integrations/convex.mdx
+++ b/apps/docs/content/docs/integrations/convex.mdx
@@ -5,7 +5,7 @@ description: Use Convex database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="convex"
   color="#FFFFFF"
 />
@@ -170,5 +170,3 @@ List documents that changed after a snapshot or previous delta cursor. Deleted d
 | `documents` | array | Changed documents, each including _table and _ts fields |
 | `hasMore` | boolean | Whether more delta pages remain |
 | `cursor` | string | Cursor to pass back in when fetching the next page of deltas |
-
-

--- a/apps/docs/content/docs/integrations/crowdstrike.mdx
+++ b/apps/docs/content/docs/integrations/crowdstrike.mdx
@@ -5,7 +5,7 @@ description: Investigate and respond to CrowdStrike Falcon alerts, hosts, IOCs, 
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="crowdstrike"
   color="#E01F3D"
 />
@@ -961,5 +961,3 @@ Update custom CrowdStrike Falcon indicators of compromise by ID (PATCH /iocs/ent
 |   ↳ `code` | number | CrowdStrike error code |
 |   ↳ `id` | string | Identifier the error applies to |
 |   ↳ `message` | string | Error message |
-
-

--- a/apps/docs/content/docs/integrations/crunchbase.mdx
+++ b/apps/docs/content/docs/integrations/crunchbase.mdx
@@ -5,7 +5,7 @@ description: Search and look up companies, people, funding rounds, and acquisiti
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="crunchbase"
   color="#0287D1"
 />
@@ -64,9 +64,9 @@ Search Crunchbase companies, investors, and schools with filter predicates on fu
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `count` | number | Total number of organizations matching the query |
+| `count` | number (nullable) | Total number of organizations matching the query |
 | `entities` | json | Matching organizations as \[\{uuid, properties\}\], where properties holds the requested field_ids |
-| `nextAfterId` | string | UUID of the last row, to pass as afterId for the next page |
+| `nextAfterId` | string (nullable) | UUID of the last row, to pass as afterId for the next page |
 
 ### Crunchbase Get Organization
 
@@ -85,11 +85,11 @@ Look up a single Crunchbase organization by permalink or UUID, returning the req
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `uuid` | string | Crunchbase UUID of the organization |
-| `name` | string | Organization name |
-| `permalink` | string | Crunchbase permalink of the organization |
+| `uuid` | string (nullable) | Crunchbase UUID of the organization |
+| `name` | string (nullable) | Organization name |
+| `permalink` | string (nullable) | Crunchbase permalink of the organization |
 | `properties` | json | Requested organization fields, keyed by field_id |
-| `cards` | json | Requested related-entity cards, keyed by card_id |
+| `cards` | json (nullable) | Requested related-entity cards, keyed by card_id |
 
 ### Crunchbase Search People
 
@@ -111,9 +111,9 @@ Search Crunchbase people — founders, executives, and investors — with filter
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `count` | number | Total number of people matching the query |
+| `count` | number (nullable) | Total number of people matching the query |
 | `entities` | json | Matching people as \[\{uuid, properties\}\], where properties holds the requested field_ids |
-| `nextAfterId` | string | UUID of the last row, to pass as afterId for the next page |
+| `nextAfterId` | string (nullable) | UUID of the last row, to pass as afterId for the next page |
 
 ### Crunchbase Get Person
 
@@ -132,11 +132,11 @@ Look up a single Crunchbase person by permalink or UUID, returning the requested
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `uuid` | string | Crunchbase UUID of the person |
-| `name` | string | Full name of the person |
-| `permalink` | string | Crunchbase permalink of the person |
+| `uuid` | string (nullable) | Crunchbase UUID of the person |
+| `name` | string (nullable) | Full name of the person |
+| `permalink` | string (nullable) | Crunchbase permalink of the person |
 | `properties` | json | Requested person fields, keyed by field_id |
-| `cards` | json | Requested related-entity cards, keyed by card_id |
+| `cards` | json (nullable) | Requested related-entity cards, keyed by card_id |
 
 ### Crunchbase Search Funding Rounds
 
@@ -158,9 +158,9 @@ Search Crunchbase funding rounds with filter predicates on announced date, inves
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `count` | number | Total number of funding rounds matching the query |
+| `count` | number (nullable) | Total number of funding rounds matching the query |
 | `entities` | json | Matching funding rounds as \[\{uuid, properties\}\], where properties holds the requested field_ids |
-| `nextAfterId` | string | UUID of the last row, to pass as afterId for the next page |
+| `nextAfterId` | string (nullable) | UUID of the last row, to pass as afterId for the next page |
 
 ### Crunchbase Get Funding Round
 
@@ -179,11 +179,11 @@ Look up a single Crunchbase funding round by permalink or UUID, returning the re
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `uuid` | string | Crunchbase UUID of the funding round |
-| `name` | string | Funding round name |
-| `permalink` | string | Crunchbase permalink of the funding round |
+| `uuid` | string (nullable) | Crunchbase UUID of the funding round |
+| `name` | string (nullable) | Funding round name |
+| `permalink` | string (nullable) | Crunchbase permalink of the funding round |
 | `properties` | json | Requested funding round fields, keyed by field_id |
-| `cards` | json | Requested related-entity cards, keyed by card_id |
+| `cards` | json (nullable) | Requested related-entity cards, keyed by card_id |
 
 ### Crunchbase Search Acquisitions
 
@@ -205,9 +205,9 @@ Search Crunchbase acquisitions with filter predicates on announced date, price, 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `count` | number | Total number of acquisitions matching the query |
+| `count` | number (nullable) | Total number of acquisitions matching the query |
 | `entities` | json | Matching acquisitions as \[\{uuid, properties\}\], where properties holds the requested field_ids |
-| `nextAfterId` | string | UUID of the last row, to pass as afterId for the next page |
+| `nextAfterId` | string (nullable) | UUID of the last row, to pass as afterId for the next page |
 
 ### Crunchbase Get Acquisition
 
@@ -226,11 +226,11 @@ Look up a single Crunchbase acquisition by permalink or UUID, returning the requ
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `uuid` | string | Crunchbase UUID of the acquisition |
-| `name` | string | Acquisition name |
-| `permalink` | string | Crunchbase permalink of the acquisition |
+| `uuid` | string (nullable) | Crunchbase UUID of the acquisition |
+| `name` | string (nullable) | Acquisition name |
+| `permalink` | string (nullable) | Crunchbase permalink of the acquisition |
 | `properties` | json | Requested acquisition fields, keyed by field_id |
-| `cards` | json | Requested related-entity cards, keyed by card_id |
+| `cards` | json (nullable) | Requested related-entity cards, keyed by card_id |
 
 ### Crunchbase Search Entities
 
@@ -253,9 +253,9 @@ Search any Crunchbase collection — events, jobs, ipos, funds, investments, pre
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `count` | number | Total number of entities matching the query |
+| `count` | number (nullable) | Total number of entities matching the query |
 | `entities` | json | Matching entities as \[\{uuid, properties\}\], where properties holds the requested field_ids |
-| `nextAfterId` | string | UUID of the last row, to pass as afterId for the next page |
+| `nextAfterId` | string (nullable) | UUID of the last row, to pass as afterId for the next page |
 
 ### Crunchbase Get Entity
 
@@ -275,11 +275,11 @@ Look up a single entity in any Crunchbase collection — events, jobs, ipos, fun
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `uuid` | string | Crunchbase UUID of the entity |
-| `name` | string | Name of the entity |
-| `permalink` | string | Crunchbase permalink of the entity |
+| `uuid` | string (nullable) | Crunchbase UUID of the entity |
+| `name` | string (nullable) | Name of the entity |
+| `permalink` | string (nullable) | Crunchbase permalink of the entity |
 | `properties` | json | Requested entity fields, keyed by field_id |
-| `cards` | json | Requested related-entity cards, keyed by card_id |
+| `cards` | json (nullable) | Requested related-entity cards, keyed by card_id |
 
 ### Crunchbase Get Entity Card
 
@@ -305,7 +305,7 @@ Page through one related-entity card of a Crunchbase entity — an investor's in
 | --------- | ---- | ----------- |
 | `items` | json | Card items for this page, each holding the requested card_field_ids |
 | `properties` | json | Properties of the parent entity returned alongside the card |
-| `nextAfterId` | string | UUID of the last card item, to pass as afterId for the next page |
+| `nextAfterId` | string (nullable) | UUID of the last card item, to pass as afterId for the next page |
 
 ### Crunchbase Autocomplete
 
@@ -347,7 +347,7 @@ List entities Crunchbase has deleted, so a mirrored copy can be pruned in step w
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `entities` | json | Deleted entities as \[\{deleted_at, identifier: \{uuid, value, permalink, entity_def_id\}\}\] |
-| `nextAfterId` | string | UUID of the last row, to pass as afterId for the next page |
+| `nextAfterId` | string (nullable) | UUID of the last row, to pass as afterId for the next page |
 
 ### Crunchbase Get Fields Metadata
 
@@ -365,5 +365,3 @@ List the field ids, types, and descriptions each Crunchbase collection publishes
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `csv` | string | Field metadata as CSV, one row per field with its collection, id, type, and description |
-
-

--- a/apps/docs/content/docs/integrations/cursor.mdx
+++ b/apps/docs/content/docs/integrations/cursor.mdx
@@ -5,7 +5,7 @@ description: Launch and manage Cursor cloud agents to work on GitHub repositorie
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="cursor_v2"
   color="#1E1E1E"
 />
@@ -252,5 +252,3 @@ Retrieve details about the API key currently in use. Returns API-aligned fields 
 | `apiKeyName` | string | Name of the API key |
 | `createdAt` | string | API key creation timestamp |
 | `userEmail` | string | Email of the key owner |
-
-

--- a/apps/docs/content/docs/integrations/dagster.mdx
+++ b/apps/docs/content/docs/integrations/dagster.mdx
@@ -5,7 +5,7 @@ description: Orchestrate data pipelines and manage job runs with Dagster
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="dagster"
   color="#ffffff"
 />
@@ -467,5 +467,3 @@ DESTRUCTIVE: permanently wipes ALL materialization history (every partition) for
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the asset was wiped successfully |
 | `assetKey` | string | Slash-joined asset key that was wiped |
-
-

--- a/apps/docs/content/docs/integrations/databricks.mdx
+++ b/apps/docs/content/docs/integrations/databricks.mdx
@@ -5,7 +5,7 @@ description: Run SQL queries and manage jobs on Databricks
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="databricks"
   color="#F9F7F4"
 />
@@ -379,5 +379,3 @@ Get the state, configuration, and resource details of a single Databricks cluste
 |   ↳ `clusterSource` | string | Origin \(API, UI, JOB, MODELS, PIPELINE, PIPELINE_MAINTENANCE, SQL\) |
 |   ↳ `autoterminationMinutes` | number | Minutes of inactivity before auto-termination \(0 = disabled\) |
 |   ↳ `startTime` | number | Cluster start timestamp \(epoch ms\) |
-
-

--- a/apps/docs/content/docs/integrations/datadog.mdx
+++ b/apps/docs/content/docs/integrations/datadog.mdx
@@ -5,7 +5,7 @@ description: Monitor infrastructure, applications, and logs with Datadog
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="datadog"
   color="#632CA6"
 />
@@ -1264,5 +1264,3 @@ List service definitions from the Datadog Service Catalog. Requires the `apm_ser
 |   ↳ `type` | string | Resource type \(service_definitions\) |
 |   ↳ `schema` | object | The service definition schema. Its shape depends on the requested schema version |
 |   ↳ `meta` | object | Ingestion metadata such as origin and last modified time |
-
-

--- a/apps/docs/content/docs/integrations/datagma.mdx
+++ b/apps/docs/content/docs/integrations/datagma.mdx
@@ -5,7 +5,7 @@ description: Find verified B2B emails, mobile phones, and enrich person or compa
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="datagma"
   color="#FFFFFF"
 />
@@ -159,5 +159,3 @@ Check remaining credit balance on a Datagma account. Free — no credits consume
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `credits` | number | Remaining Datagma credits |
-
-

--- a/apps/docs/content/docs/integrations/daytona.mdx
+++ b/apps/docs/content/docs/integrations/daytona.mdx
@@ -5,7 +5,7 @@ description: Run code and commands in secure cloud sandboxes
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="daytona"
   color="#FFFFFF"
 />
@@ -278,5 +278,3 @@ Clone a Git repository into a Daytona sandbox
 | --------- | ---- | ----------- |
 | `repoUrl` | string | URL of the cloned repository |
 | `clonePath` | string | Path the repository was cloned into |
-
-

--- a/apps/docs/content/docs/integrations/deployments.mdx
+++ b/apps/docs/content/docs/integrations/deployments.mdx
@@ -5,7 +5,7 @@ description: Manage workflow deployments
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="deployments"
   color="#0C0C0C"
 />
@@ -126,5 +126,3 @@ Fetch a single deployment version of a workflow, including its metadata and the 
 | `isActive` | boolean | Whether this version is currently live |
 | `createdAt` | string | When this version was deployed \(ISO 8601\) |
 | `deployedState` | json | The full workflow state snapshot \(blocks, edges, loops, parallels, variables\) |
-
-

--- a/apps/docs/content/docs/integrations/devin.mdx
+++ b/apps/docs/content/docs/integrations/devin.mdx
@@ -5,7 +5,7 @@ description: Autonomous AI software engineer
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="devin"
   color="#12141A"
 />
@@ -335,5 +335,3 @@ Terminate a Devin session. Optionally archive the session instead of permanently
 | `structuredOutput` | json | Structured output from the session |
 | `playbookId` | string | Associated playbook ID |
 | `isArchived` | boolean | Whether the session is archived |
-
-

--- a/apps/docs/content/docs/integrations/discord.mdx
+++ b/apps/docs/content/docs/integrations/discord.mdx
@@ -5,7 +5,7 @@ description: Interact with Discord
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="discord"
   color="#5865F2"
 />
@@ -948,5 +948,3 @@ Delete a Discord webhook
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `message` | string | Success or error message |
-
-

--- a/apps/docs/content/docs/integrations/docusign.mdx
+++ b/apps/docs/content/docs/integrations/docusign.mdx
@@ -5,7 +5,7 @@ description: Send documents for e-signature via DocuSign
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="docusign"
   color="#FFFFFF"
 />
@@ -215,5 +215,3 @@ Get the recipient status details for a DocuSign envelope
 |   ↳ `name` | string | Recipient name |
 |   ↳ `email` | string | Recipient email |
 |   ↳ `status` | string | Recipient status |
-
-

--- a/apps/docs/content/docs/integrations/downdetector.mdx
+++ b/apps/docs/content/docs/integrations/downdetector.mdx
@@ -5,7 +5,7 @@ description: Monitor outages and service status with Downdetector
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="downdetector"
   color="#FFFFFF"
 />
@@ -377,5 +377,3 @@ List all available Downdetector sites (regional status-page domains). Each site 
 |   ↳ `name` | string | Site name |
 |   ↳ `domain` | string | Site domain |
 |   ↳ `countryId` | number | Country id for the site |
-
-

--- a/apps/docs/content/docs/integrations/dropbox.mdx
+++ b/apps/docs/content/docs/integrations/dropbox.mdx
@@ -5,7 +5,7 @@ description: Upload, download, share, and manage files in Dropbox
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="dropbox"
   color="#0061FF"
 />
@@ -340,5 +340,3 @@ Restore a specific revision of a file to the given path
 |   ↳ `size` | number | Size of the file in bytes |
 |   ↳ `rev` | string | Revision identifier of the restored file |
 |   ↳ `server_modified` | string | Server modification time |
-
-

--- a/apps/docs/content/docs/integrations/dropcontact.mdx
+++ b/apps/docs/content/docs/integrations/dropcontact.mdx
@@ -5,7 +5,7 @@ description: Enrich B2B contacts with verified email, phone, and company data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="dropcontact"
   color="#0ABA9F"
 />
@@ -83,5 +83,3 @@ Enrich a contact with verified B2B email, phone, company data, and LinkedIn info
 | `job_function` | string | Job function \(e.g. Sales, Engineering\) |
 | `company_turnover` | string | Company revenue/turnover range |
 | `company_results` | string | Company net results |
-
-

--- a/apps/docs/content/docs/integrations/dspy.mdx
+++ b/apps/docs/content/docs/integrations/dspy.mdx
@@ -5,7 +5,7 @@ description: Run predictions using self-hosted DSPy programs
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="dspy"
   color="#FFFFFF"
 />
@@ -108,5 +108,3 @@ Run a ReAct agent using a self-hosted DSPy ReAct program endpoint for multi-step
 |   ↳ `observation` | string | The observation/result from the tool execution |
 | `status` | string | Response status from the DSPy server \(success or error\) |
 | `rawOutput` | json | The complete raw output from the DSPy program \(result.toDict\(\)\) |
-
-

--- a/apps/docs/content/docs/integrations/dub.mdx
+++ b/apps/docs/content/docs/integrations/dub.mdx
@@ -5,7 +5,7 @@ description: Link management with Dub
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="dub"
   color="#181C1E"
 />
@@ -558,5 +558,3 @@ Retrieve the folders defined in the workspace, so the right folder ID can be use
 | --------- | ---- | ----------- |
 | `folders` | json | Array of folder objects \(id, name, accessLevel\) |
 | `count` | number | Number of folders returned |
-
-

--- a/apps/docs/content/docs/integrations/duckduckgo.mdx
+++ b/apps/docs/content/docs/integrations/duckduckgo.mdx
@@ -5,7 +5,7 @@ description: Search with DuckDuckGo
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="duckduckgo"
   color="#FFFFFF"
 />
@@ -60,5 +60,3 @@ Search the web using DuckDuckGo Instant Answers API. Returns instant answers, ab
 |   ↳ `FirstURL` | string | URL of the result |
 |   ↳ `Text` | string | Description of the result |
 |   ↳ `Result` | string | HTML result snippet |
-
-

--- a/apps/docs/content/docs/integrations/dynamodb.mdx
+++ b/apps/docs/content/docs/integrations/dynamodb.mdx
@@ -5,7 +5,7 @@ description: Get, put, query, scan, update, and delete items in Amazon DynamoDB 
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="dynamodb"
   color="linear-gradient(45deg, #2E27AD 0%, #527FFF 100%)"
 />
@@ -195,5 +195,3 @@ Introspect DynamoDB to list tables or get detailed schema information for a spec
 | `message` | string | Operation status message |
 | `tables` | array | List of table names in the region |
 | `tableDetails` | json | Detailed schema information for a specific table |
-
-

--- a/apps/docs/content/docs/integrations/dynatrace.mdx
+++ b/apps/docs/content/docs/integrations/dynatrace.mdx
@@ -5,7 +5,7 @@ description: Manage Dynatrace problems, metrics, entities, logs, SLOs, settings,
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="dynatrace"
   color="#FFFFFF"
 />
@@ -148,10 +148,10 @@ Close a Dynatrace problem and record the closing comment.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `problemId` | string | ID of the closed problem |
-| `closeTimestamp` | number | Timestamp when closing was triggered, in UTC milliseconds |
-| `closing` | boolean | Whether the problem is in the process of being closed |
-| `comment` | object | The closing comment that was recorded |
+| `problemId` | string (nullable) | ID of the closed problem |
+| `closeTimestamp` | number (nullable) | Timestamp when closing was triggered, in UTC milliseconds |
+| `closing` | boolean (nullable) | Whether the problem is in the process of being closed |
+| `comment` | object (nullable) | The closing comment that was recorded |
 
 ### Dynatrace List Problem Comments
 
@@ -193,7 +193,7 @@ Add a comment to a Dynatrace problem.
 | --------- | ---- | ----------- |
 | `problemId` | string | ID of the problem the comment was added to |
 | `message` | string | Text of the comment that was added |
-| `context` | string | Context of the comment |
+| `context` | string (nullable) | Context of the comment |
 
 ### Dynatrace Query Metrics
 
@@ -218,10 +218,10 @@ Read metric data points from Dynatrace using a metric selector, with optional en
 | --------- | ---- | ----------- |
 | `result` | array | One entry per queried metric |
 |   ↳ `metricId` | string | Metric key including transformations |
-|   ↳ `dataPointCountRatio` | number | Queried data points relative to the query limit |
-|   ↳ `dimensionCountRatio` | number | Queried dimension tuples relative to the query limit |
+|   ↳ `dataPointCountRatio` | number (nullable) | Queried data points relative to the query limit |
+|   ↳ `dimensionCountRatio` | number (nullable) | Queried dimension tuples relative to the query limit |
 |   ↳ `appliedOptionalFilters` | array | Optional filters Dynatrace applied to the query |
-|   ↳ `dql` | json | DQL translation of the query, when available |
+|   ↳ `dql` | json (nullable) | DQL translation of the query, when available |
 |     ↳ `status` | string | Whether the translation succeeded |
 |     ↳ `query` | string | The equivalent DQL query |
 |   ↳ `warnings` | array | Warnings for this metric |
@@ -230,7 +230,7 @@ Read metric data points from Dynatrace using a metric selector, with optional en
 |     ↳ `dimensionMap` | json | Dimension values keyed by dimension key |
 |     ↳ `timestamps` | array | Timestamps in UTC milliseconds, one per value |
 |     ↳ `values` | array | Metric values. Null where no data exists |
-| `resolution` | string | Resolution Dynatrace actually used |
+| `resolution` | string (nullable) | Resolution Dynatrace actually used |
 
 ### Dynatrace List Metrics
 
@@ -291,15 +291,15 @@ Push custom metric data points into Dynatrace using the metric line protocol, on
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `linesOk` | number | Number of accepted data points |
-| `linesInvalid` | number | Number of rejected data points |
-| `ingestError` | json | Details of the invalid lines |
+| `linesOk` | number (nullable) | Number of accepted data points |
+| `linesInvalid` | number (nullable) | Number of rejected data points |
+| `ingestError` | json (nullable) | Details of the invalid lines |
 |   ↳ `code` | number | Error code |
 |   ↳ `message` | string | Error message |
 |   ↳ `invalidLines` | array | The rejected lines |
 |     ↳ `line` | number | Line number in the payload |
 |     ↳ `error` | string | Why the line was rejected |
-| `warnings` | json | Warnings raised during ingestion, such as changed metric keys |
+| `warnings` | json (nullable) | Warnings raised during ingestion, such as changed metric keys |
 |   ↳ `message` | string | Warning message |
 |   ↳ `changedMetricKeys` | array | Lines whose metric key Dynatrace rewrote |
 |     ↳ `line` | number | Line number in the payload |
@@ -369,9 +369,9 @@ List the monitored entity types available in the environment, with the propertie
 | --------- | ---- | ----------- |
 | `types` | array | Available entity types |
 |   ↳ `type` | string | Entity type \(e.g., HOST, SERVICE\) |
-|   ↳ `displayName` | string | Display name of the type |
-|   ↳ `dimensionKey` | string | Metric dimension key of the type |
-|   ↳ `entityLimitExceeded` | boolean | Whether the environment exceeded the entity limit for this type |
+|   ↳ `displayName` | string (nullable) | Display name of the type |
+|   ↳ `dimensionKey` | string (nullable) | Metric dimension key of the type |
+|   ↳ `entityLimitExceeded` | boolean (nullable) | Whether the environment exceeded the entity limit for this type |
 |   ↳ `fromRelationships` | array | Relationships originating at this type |
 |     ↳ `id` | string | Relationship ID |
 |     ↳ `toTypes` | array | Entity types the relationship points to |
@@ -442,9 +442,9 @@ Push an event into Dynatrace — a deployment marker, custom annotation, or cust
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `reportCount` | number | Number of events Dynatrace reported |
+| `reportCount` | number (nullable) | Number of events Dynatrace reported |
 | `eventIngestResults` | array | One result per ingested event |
-|   ↳ `correlationId` | string | Correlation ID of the ingested event |
+|   ↳ `correlationId` | string (nullable) | Correlation ID of the ingested event |
 |   ↳ `status` | string | OK, INVALID_ENTITY_TYPE, INVALID_METADATA, or INVALID_TIMESTAMPS |
 
 ### Dynatrace Search Logs
@@ -472,11 +472,11 @@ Search log records in Dynatrace by query and timeframe, for troubleshooting and 
 |   ↳ `timestamp` | number | Log timestamp in UTC milliseconds |
 |   ↳ `status` | string | Log level: ERROR, WARN, INFO, NONE, or NOT_APPLICABLE |
 |   ↳ `content` | string | Log message content |
-|   ↳ `eventType` | string | Event type of the record |
+|   ↳ `eventType` | string (nullable) | Event type of the record |
 |   ↳ `additionalColumns` | json | Additional log attributes keyed by column name |
-| `sliceSize` | number | Number of records in this slice |
-| `nextSliceKey` | string | Cursor for the next slice. Null when the result is complete |
-| `warnings` | string | Warning raised while searching |
+| `sliceSize` | number (nullable) | Number of records in this slice |
+| `nextSliceKey` | string (nullable) | Cursor for the next slice. Null when the result is complete |
+| `warnings` | string (nullable) | Warning raised while searching |
 
 ### Dynatrace Ingest Logs
 
@@ -496,7 +496,7 @@ Push log events into Dynatrace. Accepts a single log event object or an array of
 | --------- | ---- | ----------- |
 | `accepted` | boolean | True when Dynatrace accepted every log event \(HTTP 204\) |
 | `statusCode` | number | HTTP status Dynatrace returned. 204 is full success, 200 is partial success |
-| `details` | json | Partial-success body, present only when some events were rejected. The reference does not document its shape, so it is passed through as-is |
+| `details` | json (nullable) | Partial-success body, present only when some events were rejected. The reference does not document its shape, so it is passed through as-is |
 
 ### Dynatrace List SLOs
 
@@ -616,21 +616,21 @@ Read the Dynatrace audit log — who changed which configuration, when, and whet
 |   ↳ `logId` | string | Audit log entry ID |
 |   ↳ `eventType` | string | Type of the audited change |
 |   ↳ `category` | string | Category of the audited change |
-|   ↳ `entityId` | string | ID of the changed entity |
+|   ↳ `entityId` | string (nullable) | ID of the changed entity |
 |   ↳ `environmentId` | string | Environment the change happened in |
 |   ↳ `user` | string | User or token that made the change |
 |   ↳ `userType` | string | Type of the acting user |
-|   ↳ `userOrigin` | string | Origin of the request |
+|   ↳ `userOrigin` | string (nullable) | Origin of the request |
 |   ↳ `timestamp` | number | Change timestamp in UTC milliseconds |
 |   ↳ `success` | boolean | Whether the change succeeded |
-|   ↳ `message` | string | Description of the change |
-|   ↳ `patch` | json | JSON patch describing the change. Its shape follows whatever settings object was edited, so it is dynamic |
-|   ↳ `settingsSchemaId` | string | Settings schema ID \(dt.settings.schema_id\) |
-|   ↳ `settingsScopeId` | string | Settings scope ID \(dt.settings.scope_id\) |
-|   ↳ `settingsKey` | string | Settings key \(dt.settings.key\) |
-|   ↳ `settingsObjectId` | string | Settings object ID \(dt.settings.object_id\) |
-|   ↳ `settingsObjectSummary` | string | Settings object summary \(dt.settings.object_summary\) |
-|   ↳ `settingsScopeName` | string | Settings scope name \(dt.settings.scope_name\) |
+|   ↳ `message` | string (nullable) | Description of the change |
+|   ↳ `patch` | json (nullable) | JSON patch describing the change. Its shape follows whatever settings object was edited, so it is dynamic |
+|   ↳ `settingsSchemaId` | string (nullable) | Settings schema ID \(dt.settings.schema_id\) |
+|   ↳ `settingsScopeId` | string (nullable) | Settings scope ID \(dt.settings.scope_id\) |
+|   ↳ `settingsKey` | string (nullable) | Settings key \(dt.settings.key\) |
+|   ↳ `settingsObjectId` | string (nullable) | Settings object ID \(dt.settings.object_id\) |
+|   ↳ `settingsObjectSummary` | string (nullable) | Settings object summary \(dt.settings.object_summary\) |
+|   ↳ `settingsScopeName` | string (nullable) | Settings scope name \(dt.settings.scope_name\) |
 
 ### Dynatrace Mute Security Problem
 
@@ -651,8 +651,8 @@ Mute a single Dynatrace vulnerability with a reason, for triaging false positive
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `securityProblemId` | string | ID of the muted security problem |
-| `reason` | string | Reason recorded for the mute |
-| `comment` | string | Comment recorded for the mute |
+| `reason` | string (nullable) | Reason recorded for the mute |
+| `comment` | string (nullable) | Comment recorded for the mute |
 | `alreadyInState` | boolean | True when Dynatrace reported the problem was already muted \(HTTP 204\) |
 
 ### Dynatrace Unmute Security Problem
@@ -674,8 +674,8 @@ Unmute a single Dynatrace vulnerability, returning it to the active triage queue
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `securityProblemId` | string | ID of the unmuted security problem |
-| `reason` | string | Reason recorded for the unmute |
-| `comment` | string | Comment recorded for the unmute |
+| `reason` | string (nullable) | Reason recorded for the unmute |
+| `comment` | string (nullable) | Comment recorded for the unmute |
 | `alreadyInState` | boolean | True when Dynatrace reported the problem was already unmuted \(HTTP 204\) |
 
 ### Dynatrace Mute Security Problems
@@ -820,7 +820,7 @@ Add custom tags to every monitored entity an entity selector matches. Tags drive
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `appliedTags` | array | Tags that were applied |
-| `matchedEntitiesCount` | number | How many entities the selector matched and were tagged |
+| `matchedEntitiesCount` | number (nullable) | How many entities the selector matched and were tagged |
 
 ### Dynatrace Delete Tag
 
@@ -843,7 +843,7 @@ Remove a custom tag from every monitored entity an entity selector matches. Dele
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `matchedEntitiesCount` | number | How many entities the selector matched and had the tag removed from |
+| `matchedEntitiesCount` | number (nullable) | How many entities the selector matched and had the tag removed from |
 
 ### Dynatrace List Settings Schemas
 
@@ -928,9 +928,9 @@ Create a settings object — a maintenance window, alerting profile, management 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `results` | array | One result per submitted object |
-|   ↳ `code` | number | Per-object HTTP status |
-|   ↳ `objectId` | string | ID of the created object |
-|   ↳ `writeError` | json | Validation error for this object, when it failed |
+|   ↳ `code` | number (nullable) | Per-object HTTP status |
+|   ↳ `objectId` | string (nullable) | ID of the created object |
+|   ↳ `writeError` | json (nullable) | Validation error for this object, when it failed |
 |     ↳ `code` | number | Error code |
 |     ↳ `message` | string | Error message |
 |     ↳ `constraintViolations` | array | Which part of the value failed validation |
@@ -939,7 +939,7 @@ Create a settings object — a maintenance window, alerting profile, management 
 |       ↳ `parameterLocation` | string | HEADER, PATH, PAYLOAD_BODY, or QUERY |
 |       ↳ `path` | string | Path to the offending field |
 |   ↳ `invalidValue` | json | The value that was rejected. Mirrors the submitted schema-defined value, so the shape is dynamic |
-| `objectId` | string | ID of the created object, lifted from the first result |
+| `objectId` | string (nullable) | ID of the created object, lifted from the first result |
 
 ### Dynatrace Update Settings Object
 
@@ -961,7 +961,7 @@ Update an existing settings object. Pass the update token from Get Settings Obje
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `objectId` | string | ID of the updated object |
+| `objectId` | string (nullable) | ID of the updated object |
 | `code` | number | Status Dynatrace reported for the update |
 
 ### Dynatrace Delete Settings Object
@@ -1027,9 +1027,9 @@ Trigger an on-demand batch execution of synthetic monitors, for gating a deploy 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `batchId` | string | ID of the batch, to poll with Get Synthetic Batch |
-| `triggeredCount` | number | How many executions were triggered |
-| `triggeringProblemsCount` | number | How many executions could not be triggered |
+| `batchId` | string (nullable) | ID of the batch, to poll with Get Synthetic Batch |
+| `triggeredCount` | number (nullable) | How many executions were triggered |
+| `triggeringProblemsCount` | number (nullable) | How many executions could not be triggered |
 | `triggered` | array | Triggered executions, grouped by monitor |
 |   ↳ `monitorId` | string | Monitor that was triggered |
 |   ↳ `executions` | array | One entry per location the monitor ran from |
@@ -1058,13 +1058,13 @@ Get the status and failures of an on-demand synthetic batch execution. Poll it a
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `batchId` | string | ID of the batch |
-| `batchStatus` | string | RUNNING, SUCCESS, FAILED, FAILED_TO_EXECUTE, or NOT_TRIGGERED |
-| `executedCount` | number | Executions completed |
-| `failedCount` | number | Executions that failed |
-| `failedToExecuteCount` | number | Executions that never ran |
-| `triggeredCount` | number | Executions triggered |
-| `triggeringProblemsCount` | number | Executions that could not be triggered |
+| `batchId` | string (nullable) | ID of the batch |
+| `batchStatus` | string (nullable) | RUNNING, SUCCESS, FAILED, FAILED_TO_EXECUTE, or NOT_TRIGGERED |
+| `executedCount` | number (nullable) | Executions completed |
+| `failedCount` | number (nullable) | Executions that failed |
+| `failedToExecuteCount` | number (nullable) | Executions that never ran |
+| `triggeredCount` | number (nullable) | Executions triggered |
+| `triggeringProblemsCount` | number (nullable) | Executions that could not be triggered |
 | `failedExecutions` | array | Executions that ran and failed |
 |   ↳ `errorCode` | string | Error code Dynatrace reported |
 |   ↳ `executionId` | string | Execution ID |
@@ -1088,7 +1088,7 @@ Get the status and failures of an on-demand synthetic batch execution. Poll it a
 |   ↳ `executionId` | string | Execution ID, when one was assigned |
 |   ↳ `locationId` | string | Location the execution targeted |
 | `metadata` | json | Key-value metadata supplied when the batch was triggered. Keys are caller-defined, so the shape is dynamic |
-| `userId` | string | Who triggered the batch |
+| `userId` | string (nullable) | Who triggered the batch |
 
 ### Dynatrace Get Problem Comment
 
@@ -1131,7 +1131,7 @@ Replace the text of an existing comment on a Dynatrace problem.
 | `problemId` | string | ID of the problem |
 | `commentId` | string | ID of the updated comment |
 | `message` | string | Text the comment now carries |
-| `context` | string | Context of the comment |
+| `context` | string (nullable) | Context of the comment |
 
 ### Dynatrace Delete Problem Comment
 
@@ -1181,7 +1181,7 @@ Create a service-level objective from a metric expression, target, and evaluatio
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `sloId` | string | ID of the created SLO, read from the Location header |
+| `sloId` | string (nullable) | ID of the created SLO, read from the Location header |
 | `name` | string | Name the SLO was created with |
 
 ### Dynatrace Update SLO
@@ -1233,5 +1233,3 @@ Delete a service-level objective.
 | --------- | ---- | ----------- |
 | `sloId` | string | ID of the deleted SLO |
 | `deleted` | boolean | Always true — a failed delete raises instead |
-
-

--- a/apps/docs/content/docs/integrations/elasticsearch.mdx
+++ b/apps/docs/content/docs/integrations/elasticsearch.mdx
@@ -5,7 +5,7 @@ description: Search, index, and manage data in Elasticsearch
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="elasticsearch"
   color="#FFFFFF"
 />
@@ -374,5 +374,3 @@ List all indices in the Elasticsearch cluster with their health, status, and sta
 | --------- | ---- | ----------- |
 | `message` | string | Summary message about the indices |
 | `indices` | json | Array of index information objects \(index, health, status, docsCount, storeSize, primaryShards, replicaShards\). System indices are omitted unless includeSystemIndices is set. |
-
-

--- a/apps/docs/content/docs/integrations/elevenlabs.mdx
+++ b/apps/docs/content/docs/integrations/elevenlabs.mdx
@@ -5,7 +5,7 @@ description: Generate and transform audio with ElevenLabs
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="elevenlabs"
   color="#181C1E"
 />
@@ -254,5 +254,3 @@ Get account and subscription information for the ElevenLabs user
 |   ↳ `canExtendCharacterLimit` | boolean | Whether the character limit can be extended |
 |   ↳ `status` | string | Subscription status |
 |   ↳ `nextCharacterCountResetUnix` | number | Unix timestamp when the character count resets |
-
-

--- a/apps/docs/content/docs/integrations/emailbison.mdx
+++ b/apps/docs/content/docs/integrations/emailbison.mdx
@@ -5,7 +5,7 @@ description: Manage Email Bison leads, campaigns, replies, and tags
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="emailbison"
   color="#FB7A22"
 />
@@ -53,19 +53,27 @@ Retrieves leads from Email Bison with optional search and tag filters.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+|   ↳ `id` | number | Lead ID |
+|   ↳ `first_name` | string | Lead first name |
+|   ↳ `last_name` | string | Lead last name |
+|   ↳ `email` | string | Lead email address |
+|   ↳ `title` | string | Lead title |
+|   ↳ `company` | string | Lead company |
+|   ↳ `notes` | string | Lead notes |
+|   ↳ `status` | string | Lead status |
+|   ↳ `custom_variables` | array | Lead custom variables |
+|     ↳ `name` | string | Custom variable name |
+|     ↳ `value` | string | Custom variable value |
+|   ↳ `lead_campaign_data` | array | Lead campaign data returned by Email Bison |
+|   ↳ `overall_stats` | object | Lead engagement stats |
+|     ↳ `emails_sent` | number | Emails sent |
+|     ↳ `opens` | number | Email opens |
+|     ↳ `replies` | number | Replies |
+|     ↳ `unique_replies` | number | Unique replies |
+|     ↳ `unique_opens` | number | Unique opens |
+|   ↳ `created_at` | string | Lead creation timestamp |
+|   ↳ `updated_at` | string | Lead update timestamp |
+| `count` | number | Number of leads returned |
 
 ### Email Bison Get Lead
 
@@ -83,20 +91,26 @@ Retrieves a lead by Email Bison lead ID or email address.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
+| `id` | number | Lead ID |
 | `first_name` | string | Lead first name |
 | `last_name` | string | Lead last name |
 | `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+| `title` | string | Lead title |
+| `company` | string | Lead company |
+| `notes` | string | Lead notes |
+| `status` | string | Lead status |
+| `custom_variables` | array | Lead custom variables |
+|   ↳ `name` | string | Custom variable name |
+|   ↳ `value` | string | Custom variable value |
+| `lead_campaign_data` | array | Lead campaign data returned by Email Bison |
+| `overall_stats` | object | Lead engagement stats |
+|   ↳ `emails_sent` | number | Emails sent |
+|   ↳ `opens` | number | Email opens |
+|   ↳ `replies` | number | Replies |
+|   ↳ `unique_replies` | number | Unique replies |
+|   ↳ `unique_opens` | number | Unique opens |
+| `created_at` | string | Lead creation timestamp |
+| `updated_at` | string | Lead update timestamp |
 
 ### Email Bison Create Lead
 
@@ -120,20 +134,26 @@ Creates a single lead in Email Bison.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
+| `id` | number | Lead ID |
 | `first_name` | string | Lead first name |
 | `last_name` | string | Lead last name |
 | `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+| `title` | string | Lead title |
+| `company` | string | Lead company |
+| `notes` | string | Lead notes |
+| `status` | string | Lead status |
+| `custom_variables` | array | Lead custom variables |
+|   ↳ `name` | string | Custom variable name |
+|   ↳ `value` | string | Custom variable value |
+| `lead_campaign_data` | array | Lead campaign data returned by Email Bison |
+| `overall_stats` | object | Lead engagement stats |
+|   ↳ `emails_sent` | number | Emails sent |
+|   ↳ `opens` | number | Email opens |
+|   ↳ `replies` | number | Replies |
+|   ↳ `unique_replies` | number | Unique replies |
+|   ↳ `unique_opens` | number | Unique opens |
+| `created_at` | string | Lead creation timestamp |
+| `updated_at` | string | Lead update timestamp |
 
 ### Email Bison Update Lead
 
@@ -158,20 +178,26 @@ Updates an existing Email Bison lead. Fields omitted from a PUT update may be cl
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
+| `id` | number | Lead ID |
 | `first_name` | string | Lead first name |
 | `last_name` | string | Lead last name |
 | `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+| `title` | string | Lead title |
+| `company` | string | Lead company |
+| `notes` | string | Lead notes |
+| `status` | string | Lead status |
+| `custom_variables` | array | Lead custom variables |
+|   ↳ `name` | string | Custom variable name |
+|   ↳ `value` | string | Custom variable value |
+| `lead_campaign_data` | array | Lead campaign data returned by Email Bison |
+| `overall_stats` | object | Lead engagement stats |
+|   ↳ `emails_sent` | number | Emails sent |
+|   ↳ `opens` | number | Email opens |
+|   ↳ `replies` | number | Replies |
+|   ↳ `unique_replies` | number | Unique replies |
+|   ↳ `unique_opens` | number | Unique opens |
+| `created_at` | string | Lead creation timestamp |
+| `updated_at` | string | Lead update timestamp |
 
 ### Email Bison List Campaigns
 
@@ -188,20 +214,35 @@ Retrieves Email Bison campaigns.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
 | `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+|   ↳ `id` | number | Campaign ID |
+|   ↳ `uuid` | string | Campaign UUID |
+|   ↳ `name` | string | Campaign name |
+|   ↳ `type` | string | Campaign type |
+|   ↳ `status` | string | Campaign status |
+|   ↳ `emails_sent` | number | Emails sent |
+|   ↳ `opened` | number | Total opens |
+|   ↳ `unique_opens` | number | Unique opens |
+|   ↳ `replied` | number | Total replies |
+|   ↳ `unique_replies` | number | Unique replies |
+|   ↳ `bounced` | number | Bounces |
+|   ↳ `unsubscribed` | number | Unsubscribes |
+|   ↳ `interested` | number | Interested replies |
+|   ↳ `total_leads_contacted` | number | Total leads contacted |
+|   ↳ `total_leads` | number | Total leads |
+|   ↳ `max_emails_per_day` | number | Maximum emails per day |
+|   ↳ `max_new_leads_per_day` | number | Maximum new leads per day |
+|   ↳ `plain_text` | boolean | Whether campaign emails are plain text |
+|   ↳ `open_tracking` | boolean | Whether open tracking is enabled |
+|   ↳ `can_unsubscribe` | boolean | Whether recipients can unsubscribe |
+|   ↳ `unsubscribe_text` | string | Unsubscribe text |
+|   ↳ `tags` | array | Campaign tags |
+|     ↳ `id` | number | Tag ID |
+|     ↳ `name` | string | Tag name |
+|     ↳ `default` | boolean | Whether this is a default tag |
+|   ↳ `created_at` | string | Campaign creation timestamp |
+|   ↳ `updated_at` | string | Campaign update timestamp |
+| `count` | number | Number of campaigns returned |
 
 ### Email Bison Create Campaign
 
@@ -220,20 +261,33 @@ Creates a new Email Bison campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+| `id` | number | Campaign ID |
+| `uuid` | string | Campaign UUID |
+| `name` | string | Campaign name |
+| `type` | string | Campaign type |
+| `status` | string | Campaign status |
+| `emails_sent` | number | Emails sent |
+| `opened` | number | Total opens |
+| `unique_opens` | number | Unique opens |
+| `replied` | number | Total replies |
+| `unique_replies` | number | Unique replies |
+| `bounced` | number | Bounces |
+| `unsubscribed` | number | Unsubscribes |
+| `interested` | number | Interested replies |
+| `total_leads_contacted` | number | Total leads contacted |
+| `total_leads` | number | Total leads |
+| `max_emails_per_day` | number | Maximum emails per day |
+| `max_new_leads_per_day` | number | Maximum new leads per day |
+| `plain_text` | boolean | Whether campaign emails are plain text |
+| `open_tracking` | boolean | Whether open tracking is enabled |
+| `can_unsubscribe` | boolean | Whether recipients can unsubscribe |
+| `unsubscribe_text` | string | Unsubscribe text |
+| `tags` | array | Campaign tags |
+|   ↳ `id` | number | Tag ID |
+|   ↳ `name` | string | Tag name |
+|   ↳ `default` | boolean | Whether this is a default tag |
+| `created_at` | string | Campaign creation timestamp |
+| `updated_at` | string | Campaign update timestamp |
 
 ### Email Bison Update Campaign
 
@@ -260,20 +314,33 @@ Updates Email Bison campaign settings.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+| `id` | number | Campaign ID |
+| `uuid` | string | Campaign UUID |
+| `name` | string | Campaign name |
+| `type` | string | Campaign type |
+| `status` | string | Campaign status |
+| `emails_sent` | number | Emails sent |
+| `opened` | number | Total opens |
+| `unique_opens` | number | Unique opens |
+| `replied` | number | Total replies |
+| `unique_replies` | number | Unique replies |
+| `bounced` | number | Bounces |
+| `unsubscribed` | number | Unsubscribes |
+| `interested` | number | Interested replies |
+| `total_leads_contacted` | number | Total leads contacted |
+| `total_leads` | number | Total leads |
+| `max_emails_per_day` | number | Maximum emails per day |
+| `max_new_leads_per_day` | number | Maximum new leads per day |
+| `plain_text` | boolean | Whether campaign emails are plain text |
+| `open_tracking` | boolean | Whether open tracking is enabled |
+| `can_unsubscribe` | boolean | Whether recipients can unsubscribe |
+| `unsubscribe_text` | string | Unsubscribe text |
+| `tags` | array | Campaign tags |
+|   ↳ `id` | number | Tag ID |
+|   ↳ `name` | string | Tag name |
+|   ↳ `default` | boolean | Whether this is a default tag |
+| `created_at` | string | Campaign creation timestamp |
+| `updated_at` | string | Campaign update timestamp |
 
 ### Email Bison Update Campaign Status
 
@@ -292,20 +359,33 @@ Pauses, resumes, or archives an Email Bison campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+| `id` | number | Campaign ID |
+| `uuid` | string | Campaign UUID |
+| `name` | string | Campaign name |
+| `type` | string | Campaign type |
+| `status` | string | Campaign status |
+| `emails_sent` | number | Emails sent |
+| `opened` | number | Total opens |
+| `unique_opens` | number | Unique opens |
+| `replied` | number | Total replies |
+| `unique_replies` | number | Unique replies |
+| `bounced` | number | Bounces |
+| `unsubscribed` | number | Unsubscribes |
+| `interested` | number | Interested replies |
+| `total_leads_contacted` | number | Total leads contacted |
+| `total_leads` | number | Total leads |
+| `max_emails_per_day` | number | Maximum emails per day |
+| `max_new_leads_per_day` | number | Maximum new leads per day |
+| `plain_text` | boolean | Whether campaign emails are plain text |
+| `open_tracking` | boolean | Whether open tracking is enabled |
+| `can_unsubscribe` | boolean | Whether recipients can unsubscribe |
+| `unsubscribe_text` | string | Unsubscribe text |
+| `tags` | array | Campaign tags |
+|   ↳ `id` | number | Tag ID |
+|   ↳ `name` | string | Tag name |
+|   ↳ `default` | boolean | Whether this is a default tag |
+| `created_at` | string | Campaign creation timestamp |
+| `updated_at` | string | Campaign update timestamp |
 
 ### Email Bison Attach Leads to Campaign
 
@@ -325,18 +405,6 @@ Adds existing Email Bison leads to a campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
 
@@ -363,20 +431,16 @@ Retrieves Email Bison replies with optional status, folder, campaign, sender, le
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
 | `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+|   ↳ `id` | number | Reply ID |
+|   ↳ `subject` | string | Reply subject |
+|   ↳ `text_body` | string | Reply text body |
+|   ↳ `from_email_address` | string | Sender email |
+|   ↳ `primary_to_email_address` | string | Primary recipient |
+|   ↳ `date_received` | string | Date received |
+|   ↳ `interested` | boolean | Whether the reply is marked interested |
+|   ↳ `read` | boolean | Whether the reply is read |
+| `count` | number | Number of replies returned |
 
 ### Email Bison List Tags
 
@@ -393,20 +457,13 @@ Retrieves all Email Bison tags for the authenticated workspace.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
 | `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+|   ↳ `id` | number | Tag ID |
+|   ↳ `name` | string | Tag name |
+|   ↳ `default` | boolean | Whether this is a default tag |
+|   ↳ `created_at` | string | Tag creation timestamp |
+|   ↳ `updated_at` | string | Tag update timestamp |
+| `count` | number | Number of tags returned |
 
 ### Email Bison Create Tag
 
@@ -424,20 +481,11 @@ Creates a new Email Bison tag.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
-| `success` | boolean | Whether the action succeeded |
-| `message` | string | Action message |
+| `id` | number | Tag ID |
+| `name` | string | Tag name |
+| `default` | boolean | Whether this is a default tag |
+| `created_at` | string | Tag creation timestamp |
+| `updated_at` | string | Tag update timestamp |
 
 ### Email Bison Attach Tags to Leads
 
@@ -457,22 +505,8 @@ Attaches Email Bison tags to one or more leads.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads |
-| `campaigns` | array | List of campaigns |
-| `replies` | array | List of replies |
-| `tags` | array | List of tags |
-| `count` | number | Number of returned records |
-| `id` | number | Record ID |
-| `uuid` | string | Record UUID |
-| `name` | string | Campaign or tag name |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `email` | string | Lead email address |
-| `status` | string | Record status |
 | `success` | boolean | Whether the action succeeded |
 | `message` | string | Action message |
-
-
 
 ## Triggers
 
@@ -1639,4 +1673,3 @@ Trigger when warmup is disabled for a sender email receiving too many bounces
 |   ↳ `interested` | number | Sender email interested count |
 |   ↳ `created_at` | string | Sender email creation timestamp |
 |   ↳ `updated_at` | string | Sender email update timestamp |
-

--- a/apps/docs/content/docs/integrations/embeddings.mdx
+++ b/apps/docs/content/docs/integrations/embeddings.mdx
@@ -5,7 +5,7 @@ description: Generate embeddings
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="embeddings"
   color="#7B4DFF"
 />
@@ -51,11 +51,13 @@ Generate embeddings from text using OpenAI's embedding models
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `embeddings` | json | Generated embeddings |
+| `embeddings` | json | Generated embedding vectors, one per input, in input order |
 | `model` | string | Model used |
 | `provider` | string | Provider used |
-| `dimensions` | number | Dimensionality of each vector |
+| `dimensions` | number | Dimensionality of each returned vector |
 | `usage` | json | Token usage |
+|   ↳ `prompt_tokens` | number | Tokens in the input |
+|   ↳ `total_tokens` | number | Total tokens billed |
 
 ### OpenRouter Embeddings
 
@@ -75,11 +77,13 @@ Generate embeddings through OpenRouter
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `embeddings` | json | Generated embeddings |
+| `embeddings` | json | Generated embedding vectors, one per input, in input order |
 | `model` | string | Model used |
 | `provider` | string | Provider used |
-| `dimensions` | number | Dimensionality of each vector |
+| `dimensions` | number | Dimensionality of each returned vector |
 | `usage` | json | Token usage |
+|   ↳ `prompt_tokens` | number | Tokens in the input |
+|   ↳ `total_tokens` | number | Total tokens billed |
 
 ### Gemini Embeddings
 
@@ -99,11 +103,13 @@ Generate embeddings from text using Google's Gemini embedding models
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `embeddings` | json | Generated embeddings |
+| `embeddings` | json | Generated embedding vectors, one per input, in input order |
 | `model` | string | Model used |
 | `provider` | string | Provider used |
-| `dimensions` | number | Dimensionality of each vector |
+| `dimensions` | number | Dimensionality of each returned vector |
 | `usage` | json | Token usage |
+|   ↳ `prompt_tokens` | number | Tokens in the input |
+|   ↳ `total_tokens` | number | Total tokens billed |
 
 ### Cohere Embeddings
 
@@ -123,11 +129,13 @@ Generate embeddings from text using Cohere's embedding models
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `embeddings` | json | Generated embeddings |
+| `embeddings` | json | Generated embedding vectors, one per input, in input order |
 | `model` | string | Model used |
 | `provider` | string | Provider used |
-| `dimensions` | number | Dimensionality of each vector |
+| `dimensions` | number | Dimensionality of each returned vector |
 | `usage` | json | Token usage |
+|   ↳ `prompt_tokens` | number | Tokens in the input |
+|   ↳ `total_tokens` | number | Total tokens billed |
 
 ### Mistral Embeddings
 
@@ -147,11 +155,13 @@ Generate embeddings from text using Mistral's embedding models
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `embeddings` | json | Generated embeddings |
+| `embeddings` | json | Generated embedding vectors, one per input, in input order |
 | `model` | string | Model used |
 | `provider` | string | Provider used |
-| `dimensions` | number | Dimensionality of each vector |
+| `dimensions` | number | Dimensionality of each returned vector |
 | `usage` | json | Token usage |
+|   ↳ `prompt_tokens` | number | Tokens in the input |
+|   ↳ `total_tokens` | number | Total tokens billed |
 
 ### Ollama Embeddings
 
@@ -168,10 +178,10 @@ Generate embeddings on a self-hosted Ollama server
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `embeddings` | json | Generated embeddings |
+| `embeddings` | json | Generated embedding vectors, one per input, in input order |
 | `model` | string | Model used |
 | `provider` | string | Provider used |
-| `dimensions` | number | Dimensionality of each vector |
+| `dimensions` | number | Dimensionality of each returned vector |
 | `usage` | json | Token usage |
-
-
+|   ↳ `prompt_tokens` | number | Tokens in the input |
+|   ↳ `total_tokens` | number | Total tokens billed |

--- a/apps/docs/content/docs/integrations/enrich.mdx
+++ b/apps/docs/content/docs/integrations/enrich.mdx
@@ -5,7 +5,7 @@ description: B2B data enrichment and LinkedIn intelligence with Enrich.so
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="enrich"
   color="#E5E5E6"
 />
@@ -1028,5 +1028,3 @@ Get a company logo image URL by domain.
 | --------- | ---- | ----------- |
 | `logoUrl` | string | URL to fetch the company logo |
 | `domain` | string | Domain that was looked up |
-
-

--- a/apps/docs/content/docs/integrations/enrichment.mdx
+++ b/apps/docs/content/docs/integrations/enrichment.mdx
@@ -5,7 +5,7 @@ description: Enrich data with a Sim enrichment
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="enrichment"
   color="#9333EA"
 />
@@ -42,5 +42,3 @@ Run a Sim enrichment (e.g. Work Email, Phone Number) and return its outputs
 | --------- | ---- | ----------- |
 | `matched` | boolean | Whether the enrichment found a result |
 | `provider` | string | Provider whose result was returned \(e.g. "Hunter", "People Data Labs"\) |
-
-

--- a/apps/docs/content/docs/integrations/enrow.mdx
+++ b/apps/docs/content/docs/integrations/enrow.mdx
@@ -5,7 +5,7 @@ description: Find and verify B2B emails with triple-verified accuracy
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="enrow"
   color="#FFFFFF"
 />
@@ -67,5 +67,3 @@ Verify the deliverability of an email address using the Enrow async verifier. Su
 | `id` | string | Enrow job identifier used for polling |
 | `email` | string | Email address found or verified |
 | `qualification` | string | Enrow quality result: "valid" or "invalid" |
-
-

--- a/apps/docs/content/docs/integrations/exa.mdx
+++ b/apps/docs/content/docs/integrations/exa.mdx
@@ -5,7 +5,7 @@ description: Search with Exa AI
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="exa"
   color="#1F40ED"
 />
@@ -208,10 +208,8 @@ Run a deep research task with Exa Agent. Handles multi-step list building, enric
 | --------- | ---- | ----------- |
 | `runId` | string | Identifier of the agent run, reusable as previousRunId |
 | `status` | string | Final status of the agent run |
-| `stopReason` | string | Why the agent stopped, such as schema_satisfied |
+| `stopReason` | string (nullable) | Why the agent stopped, such as schema_satisfied |
 | `text` | string | The written answer produced by the agent |
 | `structured` | json | Structured result matching outputSchema, when one was supplied |
 | `grounding` | json | Field-level citations backing the agent output |
 | `research` | array | The agent answer in the shape the retired Research operation emitted, so workflows that reference it keep resolving |
-
-

--- a/apps/docs/content/docs/integrations/extend.mdx
+++ b/apps/docs/content/docs/integrations/extend.mdx
@@ -5,7 +5,7 @@ description: Parse and extract content from documents
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="extend_v2"
   color="#000000"
 />
@@ -49,5 +49,3 @@ Parse and extract content from documents using Extend AI
 | `blocks` | json | Block-level document elements with type and content |
 | `pageCount` | number | Number of pages processed |
 | `creditsUsed` | number | API credits consumed |
-
-

--- a/apps/docs/content/docs/integrations/fathom.mdx
+++ b/apps/docs/content/docs/integrations/fathom.mdx
@@ -5,7 +5,7 @@ description: Access meeting recordings, transcripts, and summaries
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="fathom"
   color="#181C1E"
 />
@@ -223,8 +223,6 @@ List teams in your Fathom organization.
 |   ↳ `created_at` | string | Date the team was created |
 | `next_cursor` | string | Pagination cursor for next page |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -315,4 +313,3 @@ Generic webhook trigger for all Fathom events
 | `transcript` | array | Array of transcript entries with speaker, text, and timestamp |
 | `action_items` | array | Array of action items extracted from the meeting |
 | `crm_matches` | json | Matched CRM contacts, companies, and deals from linked CRM |
-

--- a/apps/docs/content/docs/integrations/file.mdx
+++ b/apps/docs/content/docs/integrations/file.mdx
@@ -5,7 +5,7 @@ description: Read, search, get content, fetch, write, append, compress, decompre
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="file_v5"
   color="#F5F5F5"
 />
@@ -379,5 +379,3 @@ Move an existing workspace file into a folder. Moves the file itself; use Move F
 | --------- | ---- | ----------- |
 | `fileId` | string | The file that was moved. |
 | `folderPath` | string | The folder the file now lives in. |
-
-

--- a/apps/docs/content/docs/integrations/findymail.mdx
+++ b/apps/docs/content/docs/integrations/findymail.mdx
@@ -5,7 +5,7 @@ description: Find and verify B2B emails, phones, employees, and company data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="findymail"
   color="#FFFFFF"
 />
@@ -279,5 +279,3 @@ Retrieve the remaining finder and verifier credits for the authenticated account
 | --------- | ---- | ----------- |
 | `credits` | number | Remaining finder credits |
 | `verifier_credits` | number | Remaining verifier credits |
-
-

--- a/apps/docs/content/docs/integrations/firecrawl.mdx
+++ b/apps/docs/content/docs/integrations/firecrawl.mdx
@@ -5,7 +5,7 @@ description: Scrape, search, crawl, map, and extract web data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="firecrawl"
   color="#181C1E"
 />
@@ -405,5 +405,3 @@ Retrieve the remaining and allocated Firecrawl credits for the team.
 | `planCredits` | number | Credits allocated in the current plan |
 | `billingPeriodStart` | string | Start of the current billing period |
 | `billingPeriodEnd` | string | End of the current billing period |
-
-

--- a/apps/docs/content/docs/integrations/fireflies.mdx
+++ b/apps/docs/content/docs/integrations/fireflies.mdx
@@ -5,7 +5,7 @@ description: Interact with Fireflies.ai meeting transcripts and recordings
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="fireflies_v2"
   color="#100730"
 />
@@ -261,8 +261,6 @@ List all contacts from your Fireflies.ai meetings
 | --------- | ---- | ----------- |
 | `contacts` | array | List of contacts from meetings |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -285,4 +283,3 @@ Trigger workflow when a Fireflies meeting transcription is complete
 | `eventType` | string | The type of event \(e.g. Transcription completed, meeting.transcribed\) |
 | `clientReferenceId` | string | Custom reference ID if set during upload |
 | `timestamp` | number | Unix timestamp in milliseconds when the event was fired \(V2 webhooks\) |
-

--- a/apps/docs/content/docs/integrations/flint.mdx
+++ b/apps/docs/content/docs/integrations/flint.mdx
@@ -5,7 +5,7 @@ description: Run background agent tasks on your Flint sites
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="flint"
   color="#F6F54F"
 />
@@ -89,5 +89,3 @@ Get the status and results of a background Flint agent task.
 | `pagesModified` | array | Pages modified by the task \(populated when completed\) |
 | `pagesDeleted` | array | Pages deleted by the task \(populated when completed\) |
 | `errorMessage` | string | Error message when the task failed |
-
-

--- a/apps/docs/content/docs/integrations/gamma.mdx
+++ b/apps/docs/content/docs/integrations/gamma.mdx
@@ -5,7 +5,7 @@ description: Generate presentations, documents, and webpages with AI
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="gamma"
   color="#002253"
 />
@@ -152,5 +152,3 @@ List available folders in your Gamma workspace. Returns folder IDs and names for
 |   ↳ `name` | string | Folder display name |
 | `hasMore` | boolean | Whether more results are available on the next page |
 | `nextCursor` | string | Pagination cursor to pass as the after parameter for the next page |
-
-

--- a/apps/docs/content/docs/integrations/github.mdx
+++ b/apps/docs/content/docs/integrations/github.mdx
@@ -5,7 +5,7 @@ description: Interact with GitHub or trigger workflows from GitHub events
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="github_v2"
   color="#181C1E"
 />
@@ -51,21 +51,21 @@ Fetch PR details including diff and files changed
 |   ↳ `label` | string | Branch label \(owner:branch\) |
 |   ↳ `ref` | string | Branch name |
 |   ↳ `sha` | string | Commit SHA |
-|   ↳ `repo_full_name` | string | Full name \(owner/repo\) of the branch's repository |
+|   ↳ `repo_full_name` | string (nullable) | Full name \(owner/repo\) of the branch's repository |
 | `base` | object | Branch reference info |
 |   ↳ `label` | string | Branch label \(owner:branch\) |
 |   ↳ `ref` | string | Branch name |
 |   ↳ `sha` | string | Commit SHA |
-|   ↳ `repo_full_name` | string | Full name \(owner/repo\) of the branch's repository |
+|   ↳ `repo_full_name` | string (nullable) | Full name \(owner/repo\) of the branch's repository |
 | `id` | number | Pull request ID |
 | `number` | number | Pull request number |
 | `title` | string | PR title |
 | `state` | string | PR state \(open/closed\) |
 | `html_url` | string | GitHub web URL |
 | `diff_url` | string | Raw diff URL |
-| `body` | string | PR description |
+| `body` | string (nullable) | PR description |
 | `merged` | boolean | Whether PR is merged |
-| `mergeable` | boolean | Whether PR is mergeable |
+| `mergeable` | boolean (nullable) | Whether PR is mergeable |
 | `merged_by` | object | GitHub user object |
 |   ↳ `login` | string | GitHub username |
 |   ↳ `id` | number | User ID |
@@ -80,8 +80,8 @@ Fetch PR details including diff and files changed
 | `changed_files` | number | Number of changed files |
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
-| `closed_at` | string | Close timestamp |
-| `merged_at` | string | Merge timestamp |
+| `closed_at` | string (nullable) | Close timestamp |
+| `merged_at` | string (nullable) | Merge timestamp |
 | `files` | array | Array of changed file objects |
 |   ↳ `sha` | string | Blob SHA |
 |   ↳ `filename` | string | File path |
@@ -683,7 +683,7 @@ Submit a review for a pull request. Use APPROVE, REQUEST_CHANGES, or COMMENT. A 
 | `state` | string | Review state \(APPROVED/CHANGES_REQUESTED/COMMENTED\) |
 | `html_url` | string | GitHub web URL for the review |
 | `pull_request_url` | string | API URL of the reviewed pull request |
-| `commit_id` | string | SHA of the reviewed commit |
+| `commit_id` | string (nullable) | SHA of the reviewed commit |
 | `submitted_at` | string | Review submission timestamp |
 
 ### GitHub Get File Content
@@ -3414,8 +3414,6 @@ List users who have starred a repository
 |   ↳ `repos_url` | string | Repos API URL |
 | `count` | number | Number of stargazers returned |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -4611,4 +4609,3 @@ Trigger workflow from GitHub events like push, pull requests, issues, and more
 | `event_type` | string | Type of GitHub event \(e.g., push, pull_request, issues\) |
 | `action` | string | The action that was performed \(e.g., opened, closed, synchronize\) |
 | `branch` | string | Branch name extracted from ref |
-

--- a/apps/docs/content/docs/integrations/github.mdx
+++ b/apps/docs/content/docs/integrations/github.mdx
@@ -66,7 +66,7 @@ Fetch PR details including diff and files changed
 | `body` | string (nullable) | PR description |
 | `merged` | boolean | Whether PR is merged |
 | `mergeable` | boolean (nullable) | Whether PR is mergeable |
-| `merged_by` | object | GitHub user object |
+| `merged_by` | object (nullable) | GitHub user object |
 |   ↳ `login` | string | GitHub username |
 |   ↳ `id` | number | User ID |
 |   ↳ `avatar_url` | string | Avatar image URL |
@@ -673,7 +673,7 @@ Submit a review for a pull request. Use APPROVE, REQUEST_CHANGES, or COMMENT. A 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `id` | number | Review ID |
-| `user` | object | GitHub user object |
+| `user` | object (nullable) | GitHub user object |
 |   ↳ `login` | string | GitHub username |
 |   ↳ `id` | number | User ID |
 |   ↳ `avatar_url` | string | Avatar image URL |

--- a/apps/docs/content/docs/integrations/gitlab.mdx
+++ b/apps/docs/content/docs/integrations/gitlab.mdx
@@ -5,7 +5,7 @@ description: Interact with GitLab projects, issues, merge requests, and pipeline
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="gitlab"
   color="#FFFFFF"
 />
@@ -1236,64 +1236,8 @@ Block a GitLab user, preventing them from signing in or accessing the instance
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `projects` | json | List of projects |
-| `project` | json | Project details |
-| `groups` | json | List of groups |
-| `group` | json | Group details |
-| `memberships` | json | A user's project and group memberships |
-| `issues` | json | List of issues |
-| `issue` | json | Issue details |
-| `mergeRequests` | json | List of merge requests |
-| `mergeRequest` | json | Merge request details |
-| `mergeRequestIid` | number | Merge request internal ID \(IID\) |
-| `pipelines` | json | List of pipelines |
-| `pipeline` | json | Pipeline details |
-| `note` | json | Comment/note details |
-| `tree` | json | Repository tree entries |
-| `content` | string | File contents \(decoded\) |
-| `fileName` | string | File name |
-| `filePath` | string | Path to the file in the repository |
-| `branch` | string | Branch the file was committed to |
-| `branches` | json | List of branches |
-| `commits` | json | List of commits |
-| `commit` | json | A single commit \(e.g. latest commit in a comparison\) |
-| `name` | string | Created branch name |
-| `protected` | boolean | Whether the branch is protected |
-| `size` | number | File size in bytes |
-| `ref` | string | The branch, tag, or commit SHA |
-| `blobId` | string | The blob ID |
-| `lastCommitId` | string | The last commit ID that modified the file |
-| `webUrl` | string | Web URL |
-| `changes` | json | Merge request file changes/diffs |
-| `changesCount` | number | Number of changed files returned \(first 100\) |
-| `hasMore` | boolean | Whether more changed files exist beyond the first 100 |
-| `approvalsRequired` | number | Approvals required |
-| `approvalsLeft` | number | Approvals remaining |
-| `approvedBy` | json | List of approvers |
-| `jobs` | json | Pipeline jobs |
-| `log` | string | Job log output |
-| `id` | number | Job ID |
-| `status` | string | Job status |
-| `diffs` | json | File diffs between two compared references |
-| `compareTimeout` | boolean | Whether the comparison timed out |
-| `compareSameRef` | boolean | Whether both compared references match |
-| `releases` | json | List of releases |
-| `release` | json | Release details |
-| `members` | json | List of project or group members |
-| `member` | json | A single member |
-| `alreadyMember` | boolean | Whether the user was already a member |
-| `invitations` | json | List of pending invitations |
-| `invitation` | json | A single invitation |
-| `accessRequests` | json | List of pending access requests |
-| `accessRequest` | json | A single access request |
-| `samlGroupLinks` | json | List of SAML group links |
-| `samlGroupLink` | json | A single SAML group link |
-| `message` | json | Per-email invitation result detail |
-| `users` | json | List of matching users |
-| `user` | json | User details |
-| `total` | number | Total number of items available across all pages |
-| `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
-| `success` | boolean | Operation success status |
+| `success` | boolean | Whether the action succeeded |
+| `user` | object | The updated user, when returned by GitLab |
 
 ### GitLab Unblock User
 
@@ -1310,64 +1254,8 @@ Unblock a previously blocked GitLab user
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `projects` | json | List of projects |
-| `project` | json | Project details |
-| `groups` | json | List of groups |
-| `group` | json | Group details |
-| `memberships` | json | A user's project and group memberships |
-| `issues` | json | List of issues |
-| `issue` | json | Issue details |
-| `mergeRequests` | json | List of merge requests |
-| `mergeRequest` | json | Merge request details |
-| `mergeRequestIid` | number | Merge request internal ID \(IID\) |
-| `pipelines` | json | List of pipelines |
-| `pipeline` | json | Pipeline details |
-| `note` | json | Comment/note details |
-| `tree` | json | Repository tree entries |
-| `content` | string | File contents \(decoded\) |
-| `fileName` | string | File name |
-| `filePath` | string | Path to the file in the repository |
-| `branch` | string | Branch the file was committed to |
-| `branches` | json | List of branches |
-| `commits` | json | List of commits |
-| `commit` | json | A single commit \(e.g. latest commit in a comparison\) |
-| `name` | string | Created branch name |
-| `protected` | boolean | Whether the branch is protected |
-| `size` | number | File size in bytes |
-| `ref` | string | The branch, tag, or commit SHA |
-| `blobId` | string | The blob ID |
-| `lastCommitId` | string | The last commit ID that modified the file |
-| `webUrl` | string | Web URL |
-| `changes` | json | Merge request file changes/diffs |
-| `changesCount` | number | Number of changed files returned \(first 100\) |
-| `hasMore` | boolean | Whether more changed files exist beyond the first 100 |
-| `approvalsRequired` | number | Approvals required |
-| `approvalsLeft` | number | Approvals remaining |
-| `approvedBy` | json | List of approvers |
-| `jobs` | json | Pipeline jobs |
-| `log` | string | Job log output |
-| `id` | number | Job ID |
-| `status` | string | Job status |
-| `diffs` | json | File diffs between two compared references |
-| `compareTimeout` | boolean | Whether the comparison timed out |
-| `compareSameRef` | boolean | Whether both compared references match |
-| `releases` | json | List of releases |
-| `release` | json | Release details |
-| `members` | json | List of project or group members |
-| `member` | json | A single member |
-| `alreadyMember` | boolean | Whether the user was already a member |
-| `invitations` | json | List of pending invitations |
-| `invitation` | json | A single invitation |
-| `accessRequests` | json | List of pending access requests |
-| `accessRequest` | json | A single access request |
-| `samlGroupLinks` | json | List of SAML group links |
-| `samlGroupLink` | json | A single SAML group link |
-| `message` | json | Per-email invitation result detail |
-| `users` | json | List of matching users |
-| `user` | json | User details |
-| `total` | number | Total number of items available across all pages |
-| `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
-| `success` | boolean | Operation success status |
+| `success` | boolean | Whether the action succeeded |
+| `user` | object | The updated user, when returned by GitLab |
 
 ### GitLab Deactivate User
 
@@ -1384,64 +1272,8 @@ Deactivate a dormant GitLab user
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `projects` | json | List of projects |
-| `project` | json | Project details |
-| `groups` | json | List of groups |
-| `group` | json | Group details |
-| `memberships` | json | A user's project and group memberships |
-| `issues` | json | List of issues |
-| `issue` | json | Issue details |
-| `mergeRequests` | json | List of merge requests |
-| `mergeRequest` | json | Merge request details |
-| `mergeRequestIid` | number | Merge request internal ID \(IID\) |
-| `pipelines` | json | List of pipelines |
-| `pipeline` | json | Pipeline details |
-| `note` | json | Comment/note details |
-| `tree` | json | Repository tree entries |
-| `content` | string | File contents \(decoded\) |
-| `fileName` | string | File name |
-| `filePath` | string | Path to the file in the repository |
-| `branch` | string | Branch the file was committed to |
-| `branches` | json | List of branches |
-| `commits` | json | List of commits |
-| `commit` | json | A single commit \(e.g. latest commit in a comparison\) |
-| `name` | string | Created branch name |
-| `protected` | boolean | Whether the branch is protected |
-| `size` | number | File size in bytes |
-| `ref` | string | The branch, tag, or commit SHA |
-| `blobId` | string | The blob ID |
-| `lastCommitId` | string | The last commit ID that modified the file |
-| `webUrl` | string | Web URL |
-| `changes` | json | Merge request file changes/diffs |
-| `changesCount` | number | Number of changed files returned \(first 100\) |
-| `hasMore` | boolean | Whether more changed files exist beyond the first 100 |
-| `approvalsRequired` | number | Approvals required |
-| `approvalsLeft` | number | Approvals remaining |
-| `approvedBy` | json | List of approvers |
-| `jobs` | json | Pipeline jobs |
-| `log` | string | Job log output |
-| `id` | number | Job ID |
-| `status` | string | Job status |
-| `diffs` | json | File diffs between two compared references |
-| `compareTimeout` | boolean | Whether the comparison timed out |
-| `compareSameRef` | boolean | Whether both compared references match |
-| `releases` | json | List of releases |
-| `release` | json | Release details |
-| `members` | json | List of project or group members |
-| `member` | json | A single member |
-| `alreadyMember` | boolean | Whether the user was already a member |
-| `invitations` | json | List of pending invitations |
-| `invitation` | json | A single invitation |
-| `accessRequests` | json | List of pending access requests |
-| `accessRequest` | json | A single access request |
-| `samlGroupLinks` | json | List of SAML group links |
-| `samlGroupLink` | json | A single SAML group link |
-| `message` | json | Per-email invitation result detail |
-| `users` | json | List of matching users |
-| `user` | json | User details |
-| `total` | number | Total number of items available across all pages |
-| `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
-| `success` | boolean | Operation success status |
+| `success` | boolean | Whether the action succeeded |
+| `user` | object | The updated user, when returned by GitLab |
 
 ### GitLab Activate User
 
@@ -1458,64 +1290,8 @@ Reactivate a deactivated GitLab user
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `projects` | json | List of projects |
-| `project` | json | Project details |
-| `groups` | json | List of groups |
-| `group` | json | Group details |
-| `memberships` | json | A user's project and group memberships |
-| `issues` | json | List of issues |
-| `issue` | json | Issue details |
-| `mergeRequests` | json | List of merge requests |
-| `mergeRequest` | json | Merge request details |
-| `mergeRequestIid` | number | Merge request internal ID \(IID\) |
-| `pipelines` | json | List of pipelines |
-| `pipeline` | json | Pipeline details |
-| `note` | json | Comment/note details |
-| `tree` | json | Repository tree entries |
-| `content` | string | File contents \(decoded\) |
-| `fileName` | string | File name |
-| `filePath` | string | Path to the file in the repository |
-| `branch` | string | Branch the file was committed to |
-| `branches` | json | List of branches |
-| `commits` | json | List of commits |
-| `commit` | json | A single commit \(e.g. latest commit in a comparison\) |
-| `name` | string | Created branch name |
-| `protected` | boolean | Whether the branch is protected |
-| `size` | number | File size in bytes |
-| `ref` | string | The branch, tag, or commit SHA |
-| `blobId` | string | The blob ID |
-| `lastCommitId` | string | The last commit ID that modified the file |
-| `webUrl` | string | Web URL |
-| `changes` | json | Merge request file changes/diffs |
-| `changesCount` | number | Number of changed files returned \(first 100\) |
-| `hasMore` | boolean | Whether more changed files exist beyond the first 100 |
-| `approvalsRequired` | number | Approvals required |
-| `approvalsLeft` | number | Approvals remaining |
-| `approvedBy` | json | List of approvers |
-| `jobs` | json | Pipeline jobs |
-| `log` | string | Job log output |
-| `id` | number | Job ID |
-| `status` | string | Job status |
-| `diffs` | json | File diffs between two compared references |
-| `compareTimeout` | boolean | Whether the comparison timed out |
-| `compareSameRef` | boolean | Whether both compared references match |
-| `releases` | json | List of releases |
-| `release` | json | Release details |
-| `members` | json | List of project or group members |
-| `member` | json | A single member |
-| `alreadyMember` | boolean | Whether the user was already a member |
-| `invitations` | json | List of pending invitations |
-| `invitation` | json | A single invitation |
-| `accessRequests` | json | List of pending access requests |
-| `accessRequest` | json | A single access request |
-| `samlGroupLinks` | json | List of SAML group links |
-| `samlGroupLink` | json | A single SAML group link |
-| `message` | json | Per-email invitation result detail |
-| `users` | json | List of matching users |
-| `user` | json | User details |
-| `total` | number | Total number of items available across all pages |
-| `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
-| `success` | boolean | Operation success status |
+| `success` | boolean | Whether the action succeeded |
+| `user` | object | The updated user, when returned by GitLab |
 
 ### GitLab Ban User
 
@@ -1532,64 +1308,8 @@ Ban a GitLab user
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `projects` | json | List of projects |
-| `project` | json | Project details |
-| `groups` | json | List of groups |
-| `group` | json | Group details |
-| `memberships` | json | A user's project and group memberships |
-| `issues` | json | List of issues |
-| `issue` | json | Issue details |
-| `mergeRequests` | json | List of merge requests |
-| `mergeRequest` | json | Merge request details |
-| `mergeRequestIid` | number | Merge request internal ID \(IID\) |
-| `pipelines` | json | List of pipelines |
-| `pipeline` | json | Pipeline details |
-| `note` | json | Comment/note details |
-| `tree` | json | Repository tree entries |
-| `content` | string | File contents \(decoded\) |
-| `fileName` | string | File name |
-| `filePath` | string | Path to the file in the repository |
-| `branch` | string | Branch the file was committed to |
-| `branches` | json | List of branches |
-| `commits` | json | List of commits |
-| `commit` | json | A single commit \(e.g. latest commit in a comparison\) |
-| `name` | string | Created branch name |
-| `protected` | boolean | Whether the branch is protected |
-| `size` | number | File size in bytes |
-| `ref` | string | The branch, tag, or commit SHA |
-| `blobId` | string | The blob ID |
-| `lastCommitId` | string | The last commit ID that modified the file |
-| `webUrl` | string | Web URL |
-| `changes` | json | Merge request file changes/diffs |
-| `changesCount` | number | Number of changed files returned \(first 100\) |
-| `hasMore` | boolean | Whether more changed files exist beyond the first 100 |
-| `approvalsRequired` | number | Approvals required |
-| `approvalsLeft` | number | Approvals remaining |
-| `approvedBy` | json | List of approvers |
-| `jobs` | json | Pipeline jobs |
-| `log` | string | Job log output |
-| `id` | number | Job ID |
-| `status` | string | Job status |
-| `diffs` | json | File diffs between two compared references |
-| `compareTimeout` | boolean | Whether the comparison timed out |
-| `compareSameRef` | boolean | Whether both compared references match |
-| `releases` | json | List of releases |
-| `release` | json | Release details |
-| `members` | json | List of project or group members |
-| `member` | json | A single member |
-| `alreadyMember` | boolean | Whether the user was already a member |
-| `invitations` | json | List of pending invitations |
-| `invitation` | json | A single invitation |
-| `accessRequests` | json | List of pending access requests |
-| `accessRequest` | json | A single access request |
-| `samlGroupLinks` | json | List of SAML group links |
-| `samlGroupLink` | json | A single SAML group link |
-| `message` | json | Per-email invitation result detail |
-| `users` | json | List of matching users |
-| `user` | json | User details |
-| `total` | number | Total number of items available across all pages |
-| `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
-| `success` | boolean | Operation success status |
+| `success` | boolean | Whether the action succeeded |
+| `user` | object | The updated user, when returned by GitLab |
 
 ### GitLab Unban User
 
@@ -1606,64 +1326,8 @@ Unban a previously banned GitLab user
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `projects` | json | List of projects |
-| `project` | json | Project details |
-| `groups` | json | List of groups |
-| `group` | json | Group details |
-| `memberships` | json | A user's project and group memberships |
-| `issues` | json | List of issues |
-| `issue` | json | Issue details |
-| `mergeRequests` | json | List of merge requests |
-| `mergeRequest` | json | Merge request details |
-| `mergeRequestIid` | number | Merge request internal ID \(IID\) |
-| `pipelines` | json | List of pipelines |
-| `pipeline` | json | Pipeline details |
-| `note` | json | Comment/note details |
-| `tree` | json | Repository tree entries |
-| `content` | string | File contents \(decoded\) |
-| `fileName` | string | File name |
-| `filePath` | string | Path to the file in the repository |
-| `branch` | string | Branch the file was committed to |
-| `branches` | json | List of branches |
-| `commits` | json | List of commits |
-| `commit` | json | A single commit \(e.g. latest commit in a comparison\) |
-| `name` | string | Created branch name |
-| `protected` | boolean | Whether the branch is protected |
-| `size` | number | File size in bytes |
-| `ref` | string | The branch, tag, or commit SHA |
-| `blobId` | string | The blob ID |
-| `lastCommitId` | string | The last commit ID that modified the file |
-| `webUrl` | string | Web URL |
-| `changes` | json | Merge request file changes/diffs |
-| `changesCount` | number | Number of changed files returned \(first 100\) |
-| `hasMore` | boolean | Whether more changed files exist beyond the first 100 |
-| `approvalsRequired` | number | Approvals required |
-| `approvalsLeft` | number | Approvals remaining |
-| `approvedBy` | json | List of approvers |
-| `jobs` | json | Pipeline jobs |
-| `log` | string | Job log output |
-| `id` | number | Job ID |
-| `status` | string | Job status |
-| `diffs` | json | File diffs between two compared references |
-| `compareTimeout` | boolean | Whether the comparison timed out |
-| `compareSameRef` | boolean | Whether both compared references match |
-| `releases` | json | List of releases |
-| `release` | json | Release details |
-| `members` | json | List of project or group members |
-| `member` | json | A single member |
-| `alreadyMember` | boolean | Whether the user was already a member |
-| `invitations` | json | List of pending invitations |
-| `invitation` | json | A single invitation |
-| `accessRequests` | json | List of pending access requests |
-| `accessRequest` | json | A single access request |
-| `samlGroupLinks` | json | List of SAML group links |
-| `samlGroupLink` | json | A single SAML group link |
-| `message` | json | Per-email invitation result detail |
-| `users` | json | List of matching users |
-| `user` | json | User details |
-| `total` | number | Total number of items available across all pages |
-| `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
-| `success` | boolean | Operation success status |
+| `success` | boolean | Whether the action succeeded |
+| `user` | object | The updated user, when returned by GitLab |
 
 ### GitLab Approve User
 
@@ -1680,64 +1344,8 @@ Approve a GitLab user whose signup is pending administrator approval
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `projects` | json | List of projects |
-| `project` | json | Project details |
-| `groups` | json | List of groups |
-| `group` | json | Group details |
-| `memberships` | json | A user's project and group memberships |
-| `issues` | json | List of issues |
-| `issue` | json | Issue details |
-| `mergeRequests` | json | List of merge requests |
-| `mergeRequest` | json | Merge request details |
-| `mergeRequestIid` | number | Merge request internal ID \(IID\) |
-| `pipelines` | json | List of pipelines |
-| `pipeline` | json | Pipeline details |
-| `note` | json | Comment/note details |
-| `tree` | json | Repository tree entries |
-| `content` | string | File contents \(decoded\) |
-| `fileName` | string | File name |
-| `filePath` | string | Path to the file in the repository |
-| `branch` | string | Branch the file was committed to |
-| `branches` | json | List of branches |
-| `commits` | json | List of commits |
-| `commit` | json | A single commit \(e.g. latest commit in a comparison\) |
-| `name` | string | Created branch name |
-| `protected` | boolean | Whether the branch is protected |
-| `size` | number | File size in bytes |
-| `ref` | string | The branch, tag, or commit SHA |
-| `blobId` | string | The blob ID |
-| `lastCommitId` | string | The last commit ID that modified the file |
-| `webUrl` | string | Web URL |
-| `changes` | json | Merge request file changes/diffs |
-| `changesCount` | number | Number of changed files returned \(first 100\) |
-| `hasMore` | boolean | Whether more changed files exist beyond the first 100 |
-| `approvalsRequired` | number | Approvals required |
-| `approvalsLeft` | number | Approvals remaining |
-| `approvedBy` | json | List of approvers |
-| `jobs` | json | Pipeline jobs |
-| `log` | string | Job log output |
-| `id` | number | Job ID |
-| `status` | string | Job status |
-| `diffs` | json | File diffs between two compared references |
-| `compareTimeout` | boolean | Whether the comparison timed out |
-| `compareSameRef` | boolean | Whether both compared references match |
-| `releases` | json | List of releases |
-| `release` | json | Release details |
-| `members` | json | List of project or group members |
-| `member` | json | A single member |
-| `alreadyMember` | boolean | Whether the user was already a member |
-| `invitations` | json | List of pending invitations |
-| `invitation` | json | A single invitation |
-| `accessRequests` | json | List of pending access requests |
-| `accessRequest` | json | A single access request |
-| `samlGroupLinks` | json | List of SAML group links |
-| `samlGroupLink` | json | A single SAML group link |
-| `message` | json | Per-email invitation result detail |
-| `users` | json | List of matching users |
-| `user` | json | User details |
-| `total` | number | Total number of items available across all pages |
-| `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
-| `success` | boolean | Operation success status |
+| `success` | boolean | Whether the action succeeded |
+| `user` | object | The updated user, when returned by GitLab |
 
 ### GitLab Reject User
 
@@ -1754,64 +1362,8 @@ Reject a GitLab user whose signup is pending administrator approval
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `projects` | json | List of projects |
-| `project` | json | Project details |
-| `groups` | json | List of groups |
-| `group` | json | Group details |
-| `memberships` | json | A user's project and group memberships |
-| `issues` | json | List of issues |
-| `issue` | json | Issue details |
-| `mergeRequests` | json | List of merge requests |
-| `mergeRequest` | json | Merge request details |
-| `mergeRequestIid` | number | Merge request internal ID \(IID\) |
-| `pipelines` | json | List of pipelines |
-| `pipeline` | json | Pipeline details |
-| `note` | json | Comment/note details |
-| `tree` | json | Repository tree entries |
-| `content` | string | File contents \(decoded\) |
-| `fileName` | string | File name |
-| `filePath` | string | Path to the file in the repository |
-| `branch` | string | Branch the file was committed to |
-| `branches` | json | List of branches |
-| `commits` | json | List of commits |
-| `commit` | json | A single commit \(e.g. latest commit in a comparison\) |
-| `name` | string | Created branch name |
-| `protected` | boolean | Whether the branch is protected |
-| `size` | number | File size in bytes |
-| `ref` | string | The branch, tag, or commit SHA |
-| `blobId` | string | The blob ID |
-| `lastCommitId` | string | The last commit ID that modified the file |
-| `webUrl` | string | Web URL |
-| `changes` | json | Merge request file changes/diffs |
-| `changesCount` | number | Number of changed files returned \(first 100\) |
-| `hasMore` | boolean | Whether more changed files exist beyond the first 100 |
-| `approvalsRequired` | number | Approvals required |
-| `approvalsLeft` | number | Approvals remaining |
-| `approvedBy` | json | List of approvers |
-| `jobs` | json | Pipeline jobs |
-| `log` | string | Job log output |
-| `id` | number | Job ID |
-| `status` | string | Job status |
-| `diffs` | json | File diffs between two compared references |
-| `compareTimeout` | boolean | Whether the comparison timed out |
-| `compareSameRef` | boolean | Whether both compared references match |
-| `releases` | json | List of releases |
-| `release` | json | Release details |
-| `members` | json | List of project or group members |
-| `member` | json | A single member |
-| `alreadyMember` | boolean | Whether the user was already a member |
-| `invitations` | json | List of pending invitations |
-| `invitation` | json | A single invitation |
-| `accessRequests` | json | List of pending access requests |
-| `accessRequest` | json | A single access request |
-| `samlGroupLinks` | json | List of SAML group links |
-| `samlGroupLink` | json | A single SAML group link |
-| `message` | json | Per-email invitation result detail |
-| `users` | json | List of matching users |
-| `user` | json | User details |
-| `total` | number | Total number of items available across all pages |
-| `truncated` | boolean | Whether returned content \(file content or job log\) was truncated |
-| `success` | boolean | Operation success status |
+| `success` | boolean | Whether the action succeeded |
+| `user` | object | The updated user, when returned by GitLab |
 
 ### GitLab Delete User Identity
 
@@ -1870,8 +1422,6 @@ Delete a SAML group link from a GitLab group (GitLab Premium/Ultimate)
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the SAML group link was deleted successfully |
-
-
 
 ## Triggers
 
@@ -2100,4 +1650,3 @@ Trigger workflow when commits are pushed to a GitLab project
 |   ↳ `web_url` | string | Project web URL |
 |   ↳ `path_with_namespace` | string | Full path \(namespace/project\) |
 | `commits` | json | Array of commit objects included in this push |
-

--- a/apps/docs/content/docs/integrations/gmail.mdx
+++ b/apps/docs/content/docs/integrations/gmail.mdx
@@ -5,7 +5,7 @@ description: Send, read, search, and move Gmail messages or trigger workflows fr
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="gmail_v2"
   color="#FFFFFF"
 />
@@ -300,8 +300,6 @@ Remove label(s) from a Gmail message. Returns API-aligned fields only.
 | `threadId` | string | Gmail thread ID |
 | `labelIds` | array | Updated email labels |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -341,4 +339,3 @@ Triggers when new emails are received in Gmail (requires Gmail credentials)
 |   ↳ `hasAttachments` | boolean | Whether email has attachments |
 |   ↳ `attachments` | file[] | Array of email attachments as files \(if includeAttachments is enabled\) |
 | `timestamp` | string | Event timestamp |
-

--- a/apps/docs/content/docs/integrations/gong.mdx
+++ b/apps/docs/content/docs/integrations/gong.mdx
@@ -5,7 +5,7 @@ description: Revenue intelligence and conversation analytics
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="gong"
   color="#8039DF"
 />
@@ -1141,8 +1141,6 @@ Erase all Gong data (calls, leads, contacts) referencing a phone number. Asynchr
 | --------- | ---- | ----------- |
 | `requestId` | string | A Gong request reference ID for troubleshooting purposes |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1239,4 +1237,3 @@ Generic webhook trigger for all Gong events
 | `trackers` | array | Keyword and smart trackers from call content \(same shape as Gong extensive-calls `content.trackers`\) |
 | `topics` | array | Topic segments with durations from call content \(`content.topics`\) |
 | `highlights` | array | AI-generated highlights from call content \(`content.highlights`\) |
-

--- a/apps/docs/content/docs/integrations/google_ads.mdx
+++ b/apps/docs/content/docs/integrations/google_ads.mdx
@@ -5,7 +5,7 @@ description: Query campaigns, ad groups, and performance metrics
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_ads"
   color="#FFFFFF"
 />
@@ -186,5 +186,3 @@ Get performance metrics for individual ads over a date range
 |   ↳ `conversions` | number | Number of conversions |
 |   ↳ `date` | string | Date for this row \(YYYY-MM-DD\) |
 | `totalCount` | number | Total number of result rows |
-
-

--- a/apps/docs/content/docs/integrations/google_appsheet.mdx
+++ b/apps/docs/content/docs/integrations/google_appsheet.mdx
@@ -5,7 +5,7 @@ description: Read, add, edit, and delete rows in a Google AppSheet table
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_appsheet"
   color="#FFFFFF"
 />
@@ -122,5 +122,3 @@ Delete rows from an AppSheet table. Each row only needs to include the key colum
 | `rows` | array | Rows deleted by AppSheet |
 | `metadata` | json | Operation metadata |
 |   ↳ `rowCount` | number | Number of rows deleted |
-
-

--- a/apps/docs/content/docs/integrations/google_bigquery.mdx
+++ b/apps/docs/content/docs/integrations/google_bigquery.mdx
@@ -5,7 +5,7 @@ description: Query, list, and insert data in Google BigQuery
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_bigquery"
   color="#FFFFFF"
 />
@@ -311,5 +311,3 @@ Insert rows into a Google BigQuery table using streaming insert
 |     ↳ `reason` | string | Short error code summarizing the error |
 |     ↳ `location` | string | Where the error occurred |
 |     ↳ `message` | string | Human-readable error description |
-
-

--- a/apps/docs/content/docs/integrations/google_books.mdx
+++ b/apps/docs/content/docs/integrations/google_books.mdx
@@ -5,7 +5,7 @@ description: Search and retrieve book information
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_books"
   color="#FFFFFF"
 />
@@ -97,5 +97,3 @@ Get detailed information about a specific book volume
 | `thumbnailUrl` | string | Book cover thumbnail URL |
 | `isbn10` | string | ISBN-10 identifier |
 | `isbn13` | string | ISBN-13 identifier |
-
-

--- a/apps/docs/content/docs/integrations/google_calendar.mdx
+++ b/apps/docs/content/docs/integrations/google_calendar.mdx
@@ -5,7 +5,7 @@ description: Manage Google Calendar events
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_calendar_v2"
   color="#FFFFFF"
 />
@@ -480,8 +480,6 @@ Revoke an access control rule (sharing) from a calendar. Returns API-aligned fie
 | `ruleId` | string | Removed ACL rule ID |
 | `deleted` | boolean | Whether removal was successful |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -523,4 +521,3 @@ Triggers when events are created, updated, or cancelled in Google Calendar
 |   ↳ `organizer` | json | Event organizer |
 | `calendarId` | string | Calendar ID |
 | `timestamp` | string | Event processing timestamp in ISO format |
-

--- a/apps/docs/content/docs/integrations/google_contacts.mdx
+++ b/apps/docs/content/docs/integrations/google_contacts.mdx
@@ -5,7 +5,7 @@ description: Manage Google Contacts
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_contacts"
   color="#FFFFFF"
 />
@@ -145,5 +145,3 @@ Delete a contact from Google Contacts
 | --------- | ---- | ----------- |
 | `content` | string | Contact deletion confirmation message |
 | `metadata` | json | Deletion details including resource name |
-
-

--- a/apps/docs/content/docs/integrations/google_docs.mdx
+++ b/apps/docs/content/docs/integrations/google_docs.mdx
@@ -5,7 +5,7 @@ description: Read, write, create, and edit documents
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_docs"
   color="#FFFFFF"
 />
@@ -376,5 +376,3 @@ Delete one or more named ranges from a Google Docs document by their ID or by na
 |   ↳ `title` | string | Document title |
 |   ↳ `mimeType` | string | Document MIME type |
 |   ↳ `url` | string | Document URL |
-
-

--- a/apps/docs/content/docs/integrations/google_drive.mdx
+++ b/apps/docs/content/docs/integrations/google_drive.mdx
@@ -5,7 +5,7 @@ description: Manage files, folders, and permissions
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_drive"
   color="#FFFFFF"
 />
@@ -869,8 +869,6 @@ Get information about the user and their Google Drive (storage quota, capabiliti
 | `exportFormats` | json | Map of Google Workspace MIME types and their exportable formats |
 | `maxUploadSize` | string | Maximum upload size in bytes |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -910,4 +908,3 @@ Triggers when files are created, modified, or deleted in Google Drive
 |   ↳ `starred` | boolean | Whether file is starred |
 | `eventType` | string | Change type: "created", "modified", or "deleted" |
 | `timestamp` | string | Event timestamp in ISO format |
-

--- a/apps/docs/content/docs/integrations/google_forms.mdx
+++ b/apps/docs/content/docs/integrations/google_forms.mdx
@@ -5,7 +5,7 @@ description: Manage Google Forms and responses
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_forms"
   color="#FFFFFF"
 />
@@ -256,8 +256,6 @@ Renew a notification watch for another 7 days
 | `expireTime` | string | The new expiration time |
 | `state` | string | The watch state |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -286,4 +284,3 @@ Trigger workflow from Google Form submissions (via Apps Script forwarder)
 | `formId` | string | Google Form ID |
 | `answers` | object | Normalized map of question -&gt; answer |
 | `raw` | object | Original payload \(when enabled\) |
-

--- a/apps/docs/content/docs/integrations/google_groups.mdx
+++ b/apps/docs/content/docs/integrations/google_groups.mdx
@@ -5,7 +5,7 @@ description: Manage Google Workspace Groups and their members
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_groups"
   color="#E8F0FE"
 />
@@ -418,5 +418,3 @@ Update the settings for a Google Group including access permissions, moderation,
 | `enableCollaborativeInbox` | string | Whether collaborative inbox is enabled |
 | `whoCanDiscoverGroup` | string | Who can discover the group |
 | `defaultSender` | string | Default sender identity |
-
-

--- a/apps/docs/content/docs/integrations/google_maps.mdx
+++ b/apps/docs/content/docs/integrations/google_maps.mdx
@@ -5,7 +5,7 @@ description: Geocoding, directions, places, and distance calculations
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_maps"
   color="#FFFFFF"
 />
@@ -531,5 +531,3 @@ Validate and standardize a postal address
 | `missingComponentTypes` | array | Types of address components that are missing |
 | `unconfirmedComponentTypes` | array | Types of components that could not be confirmed |
 | `unresolvedTokens` | array | Input tokens that could not be resolved |
-
-

--- a/apps/docs/content/docs/integrations/google_meet.mdx
+++ b/apps/docs/content/docs/integrations/google_meet.mdx
@@ -5,7 +5,7 @@ description: Create and manage Google Meet meetings
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_meet"
   color="#FFFFFF"
 />
@@ -140,5 +140,3 @@ List participants of a conference record
 | `participants` | json | List of participants with name, times, display name, and user type |
 | `nextPageToken` | string | Token for next page of results |
 | `totalSize` | number | Total number of participants |
-
-

--- a/apps/docs/content/docs/integrations/google_pagespeed.mdx
+++ b/apps/docs/content/docs/integrations/google_pagespeed.mdx
@@ -5,7 +5,7 @@ description: Analyze webpage performance with Google PageSpeed Insights
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_pagespeed"
   color="#FFFFFF"
 />
@@ -80,5 +80,3 @@ Analyze a webpage for performance, accessibility, SEO, and best practices using 
 | `overallCategory` | string | Overall loading experience category \(FAST, AVERAGE, SLOW, or NONE\) |
 | `analysisTimestamp` | string | UTC timestamp of the analysis |
 | `lighthouseVersion` | string | Version of Lighthouse used for the analysis |
-
-

--- a/apps/docs/content/docs/integrations/google_search.mdx
+++ b/apps/docs/content/docs/integrations/google_search.mdx
@@ -5,7 +5,7 @@ description: Search the web
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_search"
   color="#FFFFFF"
 />
@@ -76,5 +76,3 @@ Search the web with the Custom Search API
 |   ↳ `formattedSearchTime` | string | Formatted search time for display |
 |   ↳ `formattedTotalResults` | string | Formatted total results count for display |
 | `nextPageStartIndex` | number | Start index for the next page of results \(null if no further results\) |
-
-

--- a/apps/docs/content/docs/integrations/google_sheets.mdx
+++ b/apps/docs/content/docs/integrations/google_sheets.mdx
@@ -5,7 +5,7 @@ description: Read, write, and update data with sheet selection
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_sheets_v2"
   color="#FFFFFF"
 />
@@ -379,8 +379,6 @@ Permanently delete a Google Sheets spreadsheet using the Google Drive API
 | `spreadsheetId` | string | The ID of the deleted spreadsheet |
 | `deleted` | boolean | Whether the spreadsheet was successfully deleted |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -414,4 +412,3 @@ Triggers when new rows are added to a Google Sheet
 | `spreadsheetId` | string | The spreadsheet ID |
 | `sheetName` | string | The sheet tab name |
 | `timestamp` | string | Event timestamp in ISO format |
-

--- a/apps/docs/content/docs/integrations/google_slides.mdx
+++ b/apps/docs/content/docs/integrations/google_slides.mdx
@@ -5,7 +5,7 @@ description: Read, write, and create presentations
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_slides_v2"
   color="#FFFFFF"
 />
@@ -1385,5 +1385,3 @@ Export a presentation to PDF, PPTX, ODP, TXT, PNG, JPEG, or SVG via the Drive ex
 |   ↳ `presentationId` | string | The presentation ID |
 |   ↳ `url` | string | URL to the presentation |
 |   ↳ `exportFormat` | string | Export format used |
-
-

--- a/apps/docs/content/docs/integrations/google_tasks.mdx
+++ b/apps/docs/content/docs/integrations/google_tasks.mdx
@@ -5,7 +5,7 @@ description: Manage Google Tasks
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_tasks"
   color="#FFFFFF"
 />
@@ -199,5 +199,3 @@ Retrieve all task lists for the authenticated user
 |   ↳ `updated` | string | Last modification time \(RFC 3339 timestamp\) |
 |   ↳ `selfLink` | string | URL pointing to this task list |
 | `nextPageToken` | string | Token for retrieving the next page of results |
-
-

--- a/apps/docs/content/docs/integrations/google_translate.mdx
+++ b/apps/docs/content/docs/integrations/google_translate.mdx
@@ -5,7 +5,7 @@ description: Translate text using Google Cloud Translation
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_translate"
   color="#FFFFFF"
 />
@@ -61,5 +61,3 @@ Detect the language of text using the Google Cloud Translation API.
 | --------- | ---- | ----------- |
 | `language` | string | The detected language code \(e.g., "en", "es", "fr"\) |
 | `confidence` | number | Confidence score of the detection |
-
-

--- a/apps/docs/content/docs/integrations/google_vault.mdx
+++ b/apps/docs/content/docs/integrations/google_vault.mdx
@@ -5,7 +5,7 @@ description: Search, export, and manage matters, holds, exports, and saved queri
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="google_vault"
   color="#E8F0FE"
 />
@@ -444,5 +444,3 @@ Delete a saved query from a matter
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the saved query was deleted |
-
-

--- a/apps/docs/content/docs/integrations/grafana.mdx
+++ b/apps/docs/content/docs/integrations/grafana.mdx
@@ -5,7 +5,7 @@ description: Interact with Grafana dashboards, alerts, and annotations
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="grafana"
   color="#FFFFFF"
 />
@@ -154,9 +154,9 @@ Delete a dashboard by its UID
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `title` | string | The title of the deleted dashboard |
+| `title` | string (nullable) | The title of the deleted dashboard |
 | `message` | string | Confirmation message |
-| `id` | number | The ID of the deleted dashboard |
+| `id` | number (nullable) | The ID of the deleted dashboard |
 
 ### Grafana List Alert Rules
 
@@ -503,8 +503,8 @@ Update an existing annotation
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `annotationId` | number | The annotation that was updated, echoed from the request — Grafana answers a patch with only a message and returns no id |
-| `message` | string | Confirmation message from Grafana, e.g. "Annotation patched" |
+| `annotationId` | number (nullable) | The annotation that was updated, echoed from the request — Grafana answers a patch with only a message and returns no id |
+| `message` | string (nullable) | Confirmation message from Grafana, e.g. "Annotation patched" |
 
 ### Grafana Delete Annotation
 
@@ -615,7 +615,7 @@ Test connectivity to a data source by its UID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | string | Verdict Grafana returned for the data source, e.g. OK or ERROR. An unhealthy source reports here rather than failing the tool |
-| `message` | string | The plugin's diagnostic detail, which carries the reason on a failed check |
+| `message` | string (nullable) | The plugin's diagnostic detail, which carries the reason on a failed check |
 | `details` | json | Extra structured detail, when the data source plugin supplies any |
 
 ### Grafana List Folders
@@ -774,9 +774,9 @@ Delete a folder by its UID
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | number | Numeric id of the deleted folder, as returned by Grafana |
-| `uid` | string | The UID that was deleted, echoed from the request |
-| `message` | string | Grafana's confirmation message |
+| `id` | number (nullable) | Numeric id of the deleted folder, as returned by Grafana |
+| `uid` | string (nullable) | The UID that was deleted, echoed from the request |
+| `message` | string (nullable) | Grafana's confirmation message |
 
 ### Grafana Get Health
 
@@ -820,8 +820,8 @@ Replace a contact point by its UID. Grafana has no partial update for contact po
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `uid` | string | The UID that was updated, echoed from the request — Grafana answers a contact point update with only a message and returns no object |
-| `message` | string | Confirmation message from Grafana, e.g. "contactpoint updated" |
+| `uid` | string (nullable) | The UID that was updated, echoed from the request — Grafana answers a contact point update with only a message and returns no object |
+| `message` | string (nullable) | Confirmation message from Grafana, e.g. "contactpoint updated" |
 
 ### Grafana Delete Contact Point
 
@@ -840,8 +840,8 @@ Permanently delete a contact point by its UID. Grafana refuses the delete while 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `uid` | string | The UID that was deleted, echoed from the request |
-| `message` | string | Confirmation message from Grafana, e.g. "contactpoint deleted" |
+| `uid` | string (nullable) | The UID that was deleted, echoed from the request |
+| `message` | string (nullable) | Confirmation message from Grafana, e.g. "contactpoint deleted" |
 
 ### Grafana Move Folder
 
@@ -861,21 +861,21 @@ Move a folder under a different parent folder, or to the root by leaving the par
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | number | The numeric ID of the folder |
-| `uid` | string | The UID of the folder |
-| `title` | string | The title of the folder |
-| `url` | string | The URL path of the folder |
-| `parentUid` | string | UID of the new parent folder, absent once moved to the root |
+| `id` | number (nullable) | The numeric ID of the folder |
+| `uid` | string (nullable) | The UID of the folder |
+| `title` | string (nullable) | The title of the folder |
+| `url` | string (nullable) | The URL path of the folder |
+| `parentUid` | string (nullable) | UID of the new parent folder, absent once moved to the root |
 | `parents` | array | Folder ancestry from the root down to the parent \(uid, title, url\) |
-| `hasAcl` | boolean | Whether the folder has custom ACL permissions |
-| `canSave` | boolean | Whether the caller can save the folder |
-| `canEdit` | boolean | Whether the caller can edit the folder |
-| `canAdmin` | boolean | Whether the caller can administer the folder |
-| `createdBy` | string | Login that created the folder |
-| `created` | string | Creation timestamp |
-| `updatedBy` | string | Login that last updated the folder |
-| `updated` | string | Last update timestamp |
-| `version` | number | Folder revision number |
+| `hasAcl` | boolean (nullable) | Whether the folder has custom ACL permissions |
+| `canSave` | boolean (nullable) | Whether the caller can save the folder |
+| `canEdit` | boolean (nullable) | Whether the caller can edit the folder |
+| `canAdmin` | boolean (nullable) | Whether the caller can administer the folder |
+| `createdBy` | string (nullable) | Login that created the folder |
+| `created` | string (nullable) | Creation timestamp |
+| `updatedBy` | string (nullable) | Login that last updated the folder |
+| `updated` | string (nullable) | Last update timestamp |
+| `version` | number (nullable) | Folder revision number |
 
 ### Grafana Get Alert Rule Group
 
@@ -895,9 +895,9 @@ Read an alert rule group: its evaluation interval and every rule in it. The inte
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `title` | string | Name of the rule group |
-| `folderUid` | string | UID of the folder holding the group |
-| `interval` | number | How often the group is evaluated, as an integer. Grafana returns seconds here rather than a duration string |
+| `title` | string (nullable) | Name of the rule group |
+| `folderUid` | string (nullable) | UID of the folder holding the group |
+| `interval` | number (nullable) | How often the group is evaluated, as an integer. Grafana returns seconds here rather than a duration string |
 | `rules` | array | Provisioned alert rules in the group |
 |   ↳ `id` | number | Alert rule numeric ID |
 |   ↳ `uid` | string | Alert rule UID |
@@ -944,8 +944,6 @@ Run one or more queries against a Grafana data source that has a backend impleme
 |   ↳ `refId` | string | The query this frame came from |
 |   ↳ `fields` | array | Field metadata in column order |
 |     ↳ `name` | string | Field name, e.g. time or A-series |
-|     ↳ `type` | string | Field type, e.g. time or number |
+|     ↳ `type` | string (nullable) | Field type, e.g. time or number |
 |   ↳ `rowCount` | number | Number of rows in the frame |
 |   ↳ `rows` | array | Rows keyed by field name |
-
-

--- a/apps/docs/content/docs/integrations/grain.mdx
+++ b/apps/docs/content/docs/integrations/grain.mdx
@@ -5,7 +5,7 @@ description: Access meeting recordings, transcripts, and AI summaries
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="grain_v2"
   color="#F6FAF9"
 />
@@ -242,8 +242,6 @@ Delete a webhook by ID (v2 API)
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `success` | boolean | True when webhook was successfully deleted |
-
-
 
 ## Triggers
 
@@ -530,4 +528,3 @@ Trigger on progress updates for recordings uploaded to Grain
 | `type` | string | Event type \(e.g., recording_added\) |
 | `user_id` | string | User UUID who triggered the event |
 | `data` | object | Event data object \(recording, highlight, etc.\) |
-

--- a/apps/docs/content/docs/integrations/granola.mdx
+++ b/apps/docs/content/docs/integrations/granola.mdx
@@ -5,7 +5,7 @@ description: Access meeting notes, transcripts, and audit events from Granola
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="granola"
   color="#B2C147"
 />
@@ -297,8 +297,6 @@ Deletes a Granola webhook endpoint by ID, stopping its event deliveries immediat
 | `id` | string | ID of the deleted webhook endpoint |
 | `deleted` | boolean | Whether the endpoint was deleted |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -403,4 +401,3 @@ Trigger workflow when the first AI summary for a Granola note is generated
 | `occurred_at` | string | ISO 8601 timestamp of when the event occurred. |
 | `changed_fields` | json | Note fields that changed. Present on note.edited events \(currently always \["summary"\]\); null otherwise. |
 | `payload` | json | Full raw webhook body as delivered by Granola. |
-

--- a/apps/docs/content/docs/integrations/greenhouse.mdx
+++ b/apps/docs/content/docs/integrations/greenhouse.mdx
@@ -5,7 +5,7 @@ description: Manage candidates, jobs, and applications in Greenhouse
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="greenhouse"
   color="#469776"
 />
@@ -493,8 +493,6 @@ Lists all interview stages for a specific job in Greenhouse
 |         ↳ `question` | string | Question text |
 | `count` | number | Number of stages returned |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -819,4 +817,3 @@ Trigger on whichever event types you select for this URL in Greenhouse. Sim does
 | `candidateId` | number | Candidate id when `payload.application.candidate.id` is present |
 | `jobId` | number | Job id from `payload.job.id` or flat `payload.job_id` when present |
 | `payload` | json | Full event payload |
-

--- a/apps/docs/content/docs/integrations/greptile.mdx
+++ b/apps/docs/content/docs/integrations/greptile.mdx
@@ -5,7 +5,7 @@ description: AI-powered codebase search and Q&A
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="greptile"
   color="#181C1E"
 />
@@ -133,5 +133,3 @@ Check the indexing status of a repository. Use this to verify if a repository is
 | `numFiles` | number | Total number of files in the repository |
 | `sampleQuestions` | array | Sample questions for the indexed repository |
 | `sha` | string | Git commit SHA of the indexed version |
-
-

--- a/apps/docs/content/docs/integrations/harmonic.mdx
+++ b/apps/docs/content/docs/integrations/harmonic.mdx
@@ -5,7 +5,7 @@ description: Search and enrich private-market contacts
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="harmonic"
   color="#FFFFFF"
 />
@@ -58,26 +58,26 @@ Ask Harmonic Scout to find people using natural language and return a stable, wo
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `contacts` | array | People matching the Scout request, normalized for downstream workflow use |
-|   ↳ `personUrn` | string | Harmonic person URN |
-|   ↳ `personId` | number | Numeric Harmonic person ID |
-|   ↳ `fullName` | string | Full name |
-|   ↳ `firstName` | string | First name |
-|   ↳ `lastName` | string | Last name |
-|   ↳ `headline` | string | LinkedIn headline or current title |
-|   ↳ `currentTitles` | array | Current job titles |
-|   ↳ `currentCompanyNames` | array | Current company names |
-|   ↳ `currentCompanyUrns` | array | Current Harmonic company URNs |
-|   ↳ `primaryEmail` | string | Primary known email address |
-|   ↳ `emails` | array | Known email addresses |
-|   ↳ `phoneNumbers` | array | Known phone numbers |
-|   ↳ `linkedinUrl` | string | LinkedIn profile URL |
-|   ↳ `formattedLocation` | string | Formatted location |
-|   ↳ `city` | string | City |
-|   ↳ `state` | string | State or region |
-|   ↳ `country` | string | Country |
-|   ↳ `profilePictureUrl` | string | Profile picture URL |
-|   ↳ `summary` | string | Scout-generated contact summary |
-|   ↳ `isRedacted` | boolean | Whether Harmonic marks the person record as redacted |
+|   ↳ `personUrn` | string (nullable) | Harmonic person URN |
+|   ↳ `personId` | number (nullable) | Numeric Harmonic person ID |
+|   ↳ `fullName` | string (nullable) | Full name |
+|   ↳ `firstName` | string (nullable) | First name |
+|   ↳ `lastName` | string (nullable) | Last name |
+|   ↳ `headline` | string (nullable) | LinkedIn headline or current title |
+|   ↳ `currentTitles` | array (nullable) | Current job titles |
+|   ↳ `currentCompanyNames` | array (nullable) | Current company names |
+|   ↳ `currentCompanyUrns` | array (nullable) | Current Harmonic company URNs |
+|   ↳ `primaryEmail` | string (nullable) | Primary known email address |
+|   ↳ `emails` | array (nullable) | Known email addresses |
+|   ↳ `phoneNumbers` | array (nullable) | Known phone numbers |
+|   ↳ `linkedinUrl` | string (nullable) | LinkedIn profile URL |
+|   ↳ `formattedLocation` | string (nullable) | Formatted location |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `state` | string (nullable) | State or region |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `profilePictureUrl` | string (nullable) | Profile picture URL |
+|   ↳ `summary` | string (nullable) | Scout-generated contact summary |
+|   ↳ `isRedacted` | boolean (nullable) | Whether Harmonic marks the person record as redacted |
 | `taskId` | string | Harmonic Scout task identifier |
 | `status` | string | Final Scout task status \(success\) |
 | `count` | number | Number of contacts returned |
@@ -97,30 +97,30 @@ Resolve a LinkedIn profile URL or email address into a normalized Harmonic conta
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `contact` | object | Normalized Harmonic contact, or null when the person is not yet in Harmonic |
-|   ↳ `personUrn` | string | Harmonic person URN |
-|   ↳ `personId` | number | Numeric Harmonic person ID |
-|   ↳ `fullName` | string | Full name |
-|   ↳ `firstName` | string | First name |
-|   ↳ `lastName` | string | Last name |
-|   ↳ `headline` | string | LinkedIn headline or current title |
-|   ↳ `currentTitles` | array | Current job titles |
-|   ↳ `currentCompanyNames` | array | Current company names |
-|   ↳ `currentCompanyUrns` | array | Current Harmonic company URNs |
-|   ↳ `primaryEmail` | string | Primary known email address |
-|   ↳ `emails` | array | Known email addresses |
-|   ↳ `phoneNumbers` | array | Known phone numbers |
-|   ↳ `linkedinUrl` | string | LinkedIn profile URL |
-|   ↳ `formattedLocation` | string | Formatted location |
-|   ↳ `city` | string | City |
-|   ↳ `state` | string | State or region |
-|   ↳ `country` | string | Country |
-|   ↳ `profilePictureUrl` | string | Profile picture URL |
-|   ↳ `summary` | string | Scout-generated contact summary |
-|   ↳ `isRedacted` | boolean | Whether Harmonic marks the person record as redacted |
-| `enrichmentUrn` | string | Enrichment URN to poll with Get Enrichment Status when Harmonic queued a refresh |
-| `mergedPersonUrn` | string | URN this person was merged into, when Harmonic deduplicated the record |
-| `requestedEntityUrn` | string | Person URN Harmonic matched the request to |
+| `contact` | object (nullable) | Normalized Harmonic contact, or null when the person is not yet in Harmonic |
+|   ↳ `personUrn` | string (nullable) | Harmonic person URN |
+|   ↳ `personId` | number (nullable) | Numeric Harmonic person ID |
+|   ↳ `fullName` | string (nullable) | Full name |
+|   ↳ `firstName` | string (nullable) | First name |
+|   ↳ `lastName` | string (nullable) | Last name |
+|   ↳ `headline` | string (nullable) | LinkedIn headline or current title |
+|   ↳ `currentTitles` | array (nullable) | Current job titles |
+|   ↳ `currentCompanyNames` | array (nullable) | Current company names |
+|   ↳ `currentCompanyUrns` | array (nullable) | Current Harmonic company URNs |
+|   ↳ `primaryEmail` | string (nullable) | Primary known email address |
+|   ↳ `emails` | array (nullable) | Known email addresses |
+|   ↳ `phoneNumbers` | array (nullable) | Known phone numbers |
+|   ↳ `linkedinUrl` | string (nullable) | LinkedIn profile URL |
+|   ↳ `formattedLocation` | string (nullable) | Formatted location |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `state` | string (nullable) | State or region |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `profilePictureUrl` | string (nullable) | Profile picture URL |
+|   ↳ `summary` | string (nullable) | Scout-generated contact summary |
+|   ↳ `isRedacted` | boolean (nullable) | Whether Harmonic marks the person record as redacted |
+| `enrichmentUrn` | string (nullable) | Enrichment URN to poll with Get Enrichment Status when Harmonic queued a refresh |
+| `mergedPersonUrn` | string (nullable) | URN this person was merged into, when Harmonic deduplicated the record |
+| `requestedEntityUrn` | string (nullable) | Person URN Harmonic matched the request to |
 | `found` | boolean | Whether Harmonic returned a person profile |
 | `enrichmentQueued` | boolean | Whether Harmonic queued a background refresh \(HTTP 201\) for this person |
 
@@ -139,27 +139,27 @@ Fetch one Harmonic person by numeric ID or URN, including any email resolved by 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `contact` | object | Normalized Harmonic contact, or null when Harmonic has no such person |
-|   ↳ `personUrn` | string | Harmonic person URN |
-|   ↳ `personId` | number | Numeric Harmonic person ID |
-|   ↳ `fullName` | string | Full name |
-|   ↳ `firstName` | string | First name |
-|   ↳ `lastName` | string | Last name |
-|   ↳ `headline` | string | LinkedIn headline or current title |
-|   ↳ `currentTitles` | array | Current job titles |
-|   ↳ `currentCompanyNames` | array | Current company names |
-|   ↳ `currentCompanyUrns` | array | Current Harmonic company URNs |
-|   ↳ `primaryEmail` | string | Primary known email address |
-|   ↳ `emails` | array | Known email addresses |
-|   ↳ `phoneNumbers` | array | Known phone numbers |
-|   ↳ `linkedinUrl` | string | LinkedIn profile URL |
-|   ↳ `formattedLocation` | string | Formatted location |
-|   ↳ `city` | string | City |
-|   ↳ `state` | string | State or region |
-|   ↳ `country` | string | Country |
-|   ↳ `profilePictureUrl` | string | Profile picture URL |
-|   ↳ `summary` | string | Scout-generated contact summary |
-|   ↳ `isRedacted` | boolean | Whether Harmonic marks the person record as redacted |
+| `contact` | object (nullable) | Normalized Harmonic contact, or null when Harmonic has no such person |
+|   ↳ `personUrn` | string (nullable) | Harmonic person URN |
+|   ↳ `personId` | number (nullable) | Numeric Harmonic person ID |
+|   ↳ `fullName` | string (nullable) | Full name |
+|   ↳ `firstName` | string (nullable) | First name |
+|   ↳ `lastName` | string (nullable) | Last name |
+|   ↳ `headline` | string (nullable) | LinkedIn headline or current title |
+|   ↳ `currentTitles` | array (nullable) | Current job titles |
+|   ↳ `currentCompanyNames` | array (nullable) | Current company names |
+|   ↳ `currentCompanyUrns` | array (nullable) | Current Harmonic company URNs |
+|   ↳ `primaryEmail` | string (nullable) | Primary known email address |
+|   ↳ `emails` | array (nullable) | Known email addresses |
+|   ↳ `phoneNumbers` | array (nullable) | Known phone numbers |
+|   ↳ `linkedinUrl` | string (nullable) | LinkedIn profile URL |
+|   ↳ `formattedLocation` | string (nullable) | Formatted location |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `state` | string (nullable) | State or region |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `profilePictureUrl` | string (nullable) | Profile picture URL |
+|   ↳ `summary` | string (nullable) | Scout-generated contact summary |
+|   ↳ `isRedacted` | boolean (nullable) | Whether Harmonic marks the person record as redacted |
 | `found` | boolean | Whether Harmonic returned a person profile |
 
 ### Harmonic Batch Get People
@@ -178,26 +178,26 @@ Fetch full Harmonic person profiles for up to 500 combined numeric IDs and perso
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `contacts` | array | Fetched Harmonic person profiles normalized as contacts |
-|   ↳ `personUrn` | string | Harmonic person URN |
-|   ↳ `personId` | number | Numeric Harmonic person ID |
-|   ↳ `fullName` | string | Full name |
-|   ↳ `firstName` | string | First name |
-|   ↳ `lastName` | string | Last name |
-|   ↳ `headline` | string | LinkedIn headline or current title |
-|   ↳ `currentTitles` | array | Current job titles |
-|   ↳ `currentCompanyNames` | array | Current company names |
-|   ↳ `currentCompanyUrns` | array | Current Harmonic company URNs |
-|   ↳ `primaryEmail` | string | Primary known email address |
-|   ↳ `emails` | array | Known email addresses |
-|   ↳ `phoneNumbers` | array | Known phone numbers |
-|   ↳ `linkedinUrl` | string | LinkedIn profile URL |
-|   ↳ `formattedLocation` | string | Formatted location |
-|   ↳ `city` | string | City |
-|   ↳ `state` | string | State or region |
-|   ↳ `country` | string | Country |
-|   ↳ `profilePictureUrl` | string | Profile picture URL |
-|   ↳ `summary` | string | Scout-generated contact summary |
-|   ↳ `isRedacted` | boolean | Whether Harmonic marks the person record as redacted |
+|   ↳ `personUrn` | string (nullable) | Harmonic person URN |
+|   ↳ `personId` | number (nullable) | Numeric Harmonic person ID |
+|   ↳ `fullName` | string (nullable) | Full name |
+|   ↳ `firstName` | string (nullable) | First name |
+|   ↳ `lastName` | string (nullable) | Last name |
+|   ↳ `headline` | string (nullable) | LinkedIn headline or current title |
+|   ↳ `currentTitles` | array (nullable) | Current job titles |
+|   ↳ `currentCompanyNames` | array (nullable) | Current company names |
+|   ↳ `currentCompanyUrns` | array (nullable) | Current Harmonic company URNs |
+|   ↳ `primaryEmail` | string (nullable) | Primary known email address |
+|   ↳ `emails` | array (nullable) | Known email addresses |
+|   ↳ `phoneNumbers` | array (nullable) | Known phone numbers |
+|   ↳ `linkedinUrl` | string (nullable) | LinkedIn profile URL |
+|   ↳ `formattedLocation` | string (nullable) | Formatted location |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `state` | string (nullable) | State or region |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `profilePictureUrl` | string (nullable) | Profile picture URL |
+|   ↳ `summary` | string (nullable) | Scout-generated contact summary |
+|   ↳ `isRedacted` | boolean (nullable) | Whether Harmonic marks the person record as redacted |
 | `count` | number | Number of contacts returned |
 
 ### Harmonic Get Company Employees
@@ -220,10 +220,10 @@ List person URNs for a company, filtered by role group and employment status. Pa
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `personUrns` | array | Person URNs for the matching employees; Harmonic returns URNs only |
-| `totalCount` | number | Total matching employees |
-| `pageInfo` | object | Cursor pagination metadata |
-|   ↳ `nextCursor` | string | Cursor for the next page |
-|   ↳ `currentCursor` | string | Cursor for the current page |
+| `totalCount` | number (nullable) | Total matching employees |
+| `pageInfo` | object (nullable) | Cursor pagination metadata |
+|   ↳ `nextCursor` | string (nullable) | Cursor for the next page |
+|   ↳ `currentCursor` | string (nullable) | Cursor for the current page |
 |   ↳ `hasNext` | boolean | Whether another page is available |
 
 ### Harmonic List People Saved Searches
@@ -243,7 +243,7 @@ List the team-shared Harmonic saved searches that target people. Use a returned 
 |   ↳ `savedSearchId` | number | Saved search ID |
 |   ↳ `savedSearchUrn` | string | Saved search URN |
 |   ↳ `name` | string | Saved search name |
-|   ↳ `isPrivate` | boolean | Whether the search is private |
+|   ↳ `isPrivate` | boolean (nullable) | Whether the search is private |
 |   ↳ `savedSearchType` | string | Saved search entity type \(PERSONS\) |
 |   ↳ `userSavedSearchType` | string | User-facing saved search type |
 |   ↳ `creatorUrn` | string | Creator user URN |
@@ -268,31 +268,31 @@ Get one page of a Harmonic people saved search. Full records become contacts; UR
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `contacts` | array | Full person records returned by the saved search, normalized as contacts |
-|   ↳ `personUrn` | string | Harmonic person URN |
-|   ↳ `personId` | number | Numeric Harmonic person ID |
-|   ↳ `fullName` | string | Full name |
-|   ↳ `firstName` | string | First name |
-|   ↳ `lastName` | string | Last name |
-|   ↳ `headline` | string | LinkedIn headline or current title |
-|   ↳ `currentTitles` | array | Current job titles |
-|   ↳ `currentCompanyNames` | array | Current company names |
-|   ↳ `currentCompanyUrns` | array | Current Harmonic company URNs |
-|   ↳ `primaryEmail` | string | Primary known email address |
-|   ↳ `emails` | array | Known email addresses |
-|   ↳ `phoneNumbers` | array | Known phone numbers |
-|   ↳ `linkedinUrl` | string | LinkedIn profile URL |
-|   ↳ `formattedLocation` | string | Formatted location |
-|   ↳ `city` | string | City |
-|   ↳ `state` | string | State or region |
-|   ↳ `country` | string | Country |
-|   ↳ `profilePictureUrl` | string | Profile picture URL |
-|   ↳ `summary` | string | Scout-generated contact summary |
-|   ↳ `isRedacted` | boolean | Whether Harmonic marks the person record as redacted |
+|   ↳ `personUrn` | string (nullable) | Harmonic person URN |
+|   ↳ `personId` | number (nullable) | Numeric Harmonic person ID |
+|   ↳ `fullName` | string (nullable) | Full name |
+|   ↳ `firstName` | string (nullable) | First name |
+|   ↳ `lastName` | string (nullable) | Last name |
+|   ↳ `headline` | string (nullable) | LinkedIn headline or current title |
+|   ↳ `currentTitles` | array (nullable) | Current job titles |
+|   ↳ `currentCompanyNames` | array (nullable) | Current company names |
+|   ↳ `currentCompanyUrns` | array (nullable) | Current Harmonic company URNs |
+|   ↳ `primaryEmail` | string (nullable) | Primary known email address |
+|   ↳ `emails` | array (nullable) | Known email addresses |
+|   ↳ `phoneNumbers` | array (nullable) | Known phone numbers |
+|   ↳ `linkedinUrl` | string (nullable) | LinkedIn profile URL |
+|   ↳ `formattedLocation` | string (nullable) | Formatted location |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `state` | string (nullable) | State or region |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `profilePictureUrl` | string (nullable) | Profile picture URL |
+|   ↳ `summary` | string (nullable) | Scout-generated contact summary |
+|   ↳ `isRedacted` | boolean (nullable) | Whether Harmonic marks the person record as redacted |
 | `personUrns` | array | All person URNs in the page, including rows returned without full profiles |
-| `totalCount` | number | Total matching people |
-| `pageInfo` | object | Cursor pagination metadata |
-|   ↳ `nextCursor` | string | Cursor for the next page |
-|   ↳ `currentCursor` | string | Cursor for the current page |
+| `totalCount` | number (nullable) | Total matching people |
+| `pageInfo` | object (nullable) | Cursor pagination metadata |
+|   ↳ `nextCursor` | string (nullable) | Cursor for the next page |
+|   ↳ `currentCursor` | string (nullable) | Cursor for the current page |
 |   ↳ `hasNext` | boolean | Whether another page is available |
 
 ### Harmonic Get People Saved Search Net-New Results
@@ -313,31 +313,31 @@ Get only the people newly matching a subscribed Harmonic people saved search, so
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `contacts` | array | Newly matching people returned as full profiles, normalized as contacts |
-|   ↳ `personUrn` | string | Harmonic person URN |
-|   ↳ `personId` | number | Numeric Harmonic person ID |
-|   ↳ `fullName` | string | Full name |
-|   ↳ `firstName` | string | First name |
-|   ↳ `lastName` | string | Last name |
-|   ↳ `headline` | string | LinkedIn headline or current title |
-|   ↳ `currentTitles` | array | Current job titles |
-|   ↳ `currentCompanyNames` | array | Current company names |
-|   ↳ `currentCompanyUrns` | array | Current Harmonic company URNs |
-|   ↳ `primaryEmail` | string | Primary known email address |
-|   ↳ `emails` | array | Known email addresses |
-|   ↳ `phoneNumbers` | array | Known phone numbers |
-|   ↳ `linkedinUrl` | string | LinkedIn profile URL |
-|   ↳ `formattedLocation` | string | Formatted location |
-|   ↳ `city` | string | City |
-|   ↳ `state` | string | State or region |
-|   ↳ `country` | string | Country |
-|   ↳ `profilePictureUrl` | string | Profile picture URL |
-|   ↳ `summary` | string | Scout-generated contact summary |
-|   ↳ `isRedacted` | boolean | Whether Harmonic marks the person record as redacted |
+|   ↳ `personUrn` | string (nullable) | Harmonic person URN |
+|   ↳ `personId` | number (nullable) | Numeric Harmonic person ID |
+|   ↳ `fullName` | string (nullable) | Full name |
+|   ↳ `firstName` | string (nullable) | First name |
+|   ↳ `lastName` | string (nullable) | Last name |
+|   ↳ `headline` | string (nullable) | LinkedIn headline or current title |
+|   ↳ `currentTitles` | array (nullable) | Current job titles |
+|   ↳ `currentCompanyNames` | array (nullable) | Current company names |
+|   ↳ `currentCompanyUrns` | array (nullable) | Current Harmonic company URNs |
+|   ↳ `primaryEmail` | string (nullable) | Primary known email address |
+|   ↳ `emails` | array (nullable) | Known email addresses |
+|   ↳ `phoneNumbers` | array (nullable) | Known phone numbers |
+|   ↳ `linkedinUrl` | string (nullable) | LinkedIn profile URL |
+|   ↳ `formattedLocation` | string (nullable) | Formatted location |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `state` | string (nullable) | State or region |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `profilePictureUrl` | string (nullable) | Profile picture URL |
+|   ↳ `summary` | string (nullable) | Scout-generated contact summary |
+|   ↳ `isRedacted` | boolean (nullable) | Whether Harmonic marks the person record as redacted |
 | `personUrns` | array | All newly matching person URNs, including rows returned without full profiles |
-| `cursor` | string | Cursor echoed by Harmonic |
-| `pageInfo` | object | Cursor pagination metadata |
-|   ↳ `nextCursor` | string | Cursor for the next page |
-|   ↳ `currentCursor` | string | Cursor for the current page |
+| `cursor` | string (nullable) | Cursor echoed by Harmonic |
+| `pageInfo` | object (nullable) | Cursor pagination metadata |
+|   ↳ `nextCursor` | string (nullable) | Cursor for the next page |
+|   ↳ `currentCursor` | string (nullable) | Cursor for the current page |
 |   ↳ `hasNext` | boolean | Whether another page is available |
 
 ### Harmonic Clear People Saved Search Net-New Results
@@ -357,7 +357,7 @@ Acknowledge net-new people on a saved search so the next poll returns only fresh
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `cleared` | boolean | Whether Harmonic accepted the acknowledgement |
-| `clearedPersonUrns` | array | Person URNs acknowledged, or null when every net-new result was cleared |
+| `clearedPersonUrns` | array (nullable) | Person URNs acknowledged, or null when every net-new result was cleared |
 
 ### Harmonic Submit Email Enrichment Job
 
@@ -406,12 +406,12 @@ Check a Harmonic bulk email enrichment job. Per-person results appear once the j
 |   ↳ `totalFailed` | number | People whose enrichment failed |
 |   ↳ `totalSkipped` | number | People skipped |
 |   ↳ `totalNotFound` | number | People Harmonic could not resolve |
-| `results` | array | Per-person outcomes; null until the job reaches a terminal status |
+| `results` | array (nullable) | Per-person outcomes; null until the job reaches a terminal status |
 |   ↳ `personUrn` | string | Harmonic person URN |
 |   ↳ `status` | string | Per-person job status \(PENDING, SUCCESS, NOT_FOUND, FAILED, SKIPPED\) |
 | `succeededPersonUrns` | array | Person URNs whose email was found; pass these to Batch Get People |
 | `createdAt` | string | Job creation timestamp |
-| `completedAt` | string | Job completion timestamp |
+| `completedAt` | string (nullable) | Job completion timestamp |
 
 ### Harmonic Get Email Enrichment Usage
 
@@ -445,10 +445,8 @@ Check enrichment jobs Harmonic queued for people it did not already have, and re
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `enrichments` | array | Status of each requested enrichment job |
-|   ↳ `enrichmentUrn` | string | Harmonic enrichment URN |
-|   ↳ `status` | string | Enrichment job status \(QUEUED, IN_PROGRESS, COMPLETE, FAILED, NOT_FOUND, EXPERIENCES_HIDDEN\) |
-|   ↳ `message` | string | Provider status message |
-|   ↳ `enrichedEntityUrn` | string | Resulting company or person URN once enrichment completes |
+|   ↳ `enrichmentUrn` | string (nullable) | Harmonic enrichment URN |
+|   ↳ `status` | string (nullable) | Enrichment job status \(QUEUED, IN_PROGRESS, COMPLETE, FAILED, NOT_FOUND, EXPERIENCES_HIDDEN\) |
+|   ↳ `message` | string (nullable) | Provider status message |
+|   ↳ `enrichedEntityUrn` | string (nullable) | Resulting company or person URN once enrichment completes |
 | `count` | number | Number of enrichment statuses returned |
-
-

--- a/apps/docs/content/docs/integrations/hex.mdx
+++ b/apps/docs/content/docs/integrations/hex.mdx
@@ -5,7 +5,7 @@ description: Run and manage Hex projects
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="hex"
   color="#14151A"
 />
@@ -575,5 +575,3 @@ Update a Hex project status label (e.g., endorsement or custom workspace statuse
 | `createdAt` | string | Creation timestamp |
 | `archivedAt` | string | Archived timestamp |
 | `trashedAt` | string | Trashed timestamp |
-
-

--- a/apps/docs/content/docs/integrations/hubspot.mdx
+++ b/apps/docs/content/docs/integrations/hubspot.mdx
@@ -5,7 +5,7 @@ description: Interact with HubSpot CRM or trigger workflows from HubSpot events
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="hubspot"
   color="#FF7A59"
 />
@@ -2031,8 +2031,6 @@ Create a new list in HubSpot. Specify the object type and processing type (MANUA
 | `listId` | string | The created list ID |
 | `success` | boolean | Operation success status |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -2077,4 +2075,3 @@ Triggers when HubSpot CRM records (contacts, companies, deals, tickets, custom o
 | `previousValue` | string | Previous value before the change \(property_changed events only\) |
 | `listId` | string | HubSpot list ID \(list_membership events only\) |
 | `timestamp` | string | ISO timestamp when Sim emitted the event |
-

--- a/apps/docs/content/docs/integrations/huggingface.mdx
+++ b/apps/docs/content/docs/integrations/huggingface.mdx
@@ -5,7 +5,7 @@ description: Use Hugging Face Inference API
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="huggingface"
   color="#0B0F19"
 />
@@ -51,5 +51,3 @@ Generate completions using Hugging Face Inference API
 |     ↳ `prompt_tokens` | number | Number of tokens in the prompt |
 |     ↳ `completion_tokens` | number | Number of tokens in the completion |
 |     ↳ `total_tokens` | number | Total number of tokens used |
-
-

--- a/apps/docs/content/docs/integrations/hunter.mdx
+++ b/apps/docs/content/docs/integrations/hunter.mdx
@@ -5,7 +5,7 @@ description: Find and verify professional email addresses
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="hunter"
   color="#FFFFFF"
 />
@@ -246,5 +246,3 @@ Returns the total number of email addresses found for a domain or company.
 | `total` | number | Total number of email addresses found |
 | `personal_emails` | number | Number of personal email addresses \(individual employees\) |
 | `generic_emails` | number | Number of generic/role-based email addresses \(e.g., contact@, info@\) |
-
-

--- a/apps/docs/content/docs/integrations/iam.mdx
+++ b/apps/docs/content/docs/integrations/iam.mdx
@@ -5,7 +5,7 @@ description: Manage AWS IAM users, roles, policies, and groups
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="iam"
   color="linear-gradient(45deg, #BD0816 0%, #FF5252 100%)"
 />
@@ -585,5 +585,3 @@ Simulate whether a user, role, or group is allowed to perform specific AWS actio
 | `isTruncated` | boolean | Whether there are more results available |
 | `marker` | string | Pagination marker for the next page of results |
 | `count` | number | Number of evaluation results returned |
-
-

--- a/apps/docs/content/docs/integrations/icypeas.mdx
+++ b/apps/docs/content/docs/integrations/icypeas.mdx
@@ -5,7 +5,7 @@ description: Find and verify professional email addresses
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="icypeas"
   color="#d4d4d4"
 />
@@ -74,5 +74,3 @@ Verify whether an email address is valid and deliverable. Submits the verificati
 | `email` | string | Email address found or verified |
 | `item` | json | Full raw item object returned by the Icypeas results endpoint |
 | `valid` | boolean | Whether the email is valid/deliverable \(true for FOUND/DEBITED status\) |
-
-

--- a/apps/docs/content/docs/integrations/identity_center.mdx
+++ b/apps/docs/content/docs/integrations/identity_center.mdx
@@ -5,7 +5,7 @@ description: Manage temporary elevated access in AWS IAM Identity Center
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="identity_center"
   color="linear-gradient(45deg, #BD0816 0%, #FF5252 100%)"
 />
@@ -50,11 +50,11 @@ List all AWS IAM Identity Center instances in your account
 | `instances` | array | Identity Center instances in the region |
 |   ↳ `instanceArn` | string | ARN of the Identity Center instance |
 |   ↳ `identityStoreId` | string | Identity Store ID backing the instance |
-|   ↳ `name` | string | Instance name |
+|   ↳ `name` | string (nullable) | Instance name |
 |   ↳ `status` | string | Instance status |
-|   ↳ `statusReason` | string | Explanation when the instance is not ACTIVE |
-|   ↳ `ownerAccountId` | string | AWS account that owns the instance |
-|   ↳ `createdDate` | string | ISO 8601 date the instance was created |
+|   ↳ `statusReason` | string (nullable) | Explanation when the instance is not ACTIVE |
+|   ↳ `ownerAccountId` | string (nullable) | AWS account that owns the instance |
+|   ↳ `createdDate` | string (nullable) | ISO 8601 date the instance was created |
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of instances returned |
 
@@ -82,7 +82,7 @@ List all AWS accounts in your organization
 |   ↳ `name` | string | Account name |
 |   ↳ `email` | string | Root email address of the account |
 |   ↳ `status` | string | Account status \(e.g., ACTIVE, SUSPENDED\) |
-|   ↳ `joinedTimestamp` | string | ISO 8601 date the account joined the organization |
+|   ↳ `joinedTimestamp` | string (nullable) | ISO 8601 date the account joined the organization |
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of accounts returned |
 
@@ -132,9 +132,9 @@ List all permission sets defined in an IAM Identity Center instance
 | `permissionSets` | array | Permission sets defined on the instance |
 |   ↳ `permissionSetArn` | string | ARN of the permission set |
 |   ↳ `name` | string | Permission set name |
-|   ↳ `description` | string | Permission set description |
-|   ↳ `sessionDuration` | string | ISO 8601 session duration \(e.g., PT1H\) |
-|   ↳ `createdDate` | string | ISO 8601 date the permission set was created |
+|   ↳ `description` | string (nullable) | Permission set description |
+|   ↳ `sessionDuration` | string (nullable) | ISO 8601 session duration \(e.g., PT1H\) |
+|   ↳ `createdDate` | string (nullable) | ISO 8601 date the permission set was created |
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of permission sets returned |
 
@@ -181,10 +181,10 @@ Resolve an Identity Store user ID to the user behind it. Use to turn the princip
 | --------- | ---- | ----------- |
 | `userId` | string | Identity Store user ID |
 | `userName` | string | Username in the Identity Store |
-| `displayName` | string | Display name of the user, or null when the Identity Store omits it |
-| `email` | string | Primary email address, or null when the user has no email attribute |
-| `userStatus` | string | Account status \(ENABLED or DISABLED\), or null when the Identity Store omits it |
-| `title` | string | Job title, or null when the Identity Store omits it |
+| `displayName` | string (nullable) | Display name of the user, or null when the Identity Store omits it |
+| `email` | string (nullable) | Primary email address, or null when the user has no email attribute |
+| `userStatus` | string (nullable) | Account status \(ENABLED or DISABLED\), or null when the Identity Store omits it |
+| `title` | string (nullable) | Job title, or null when the Identity Store omits it |
 | `externalIds` | array | External identity provider IDs linked to the user |
 |   ↳ `issuer` | string | Identity provider that issued the ID |
 |   ↳ `id` | string | Identifier at the issuer |
@@ -257,8 +257,8 @@ List all groups in the Identity Store
 | --------- | ---- | ----------- |
 | `groups` | array | Groups in the Identity Store |
 |   ↳ `groupId` | string | Identity Store group ID \(use as principalId\) |
-|   ↳ `displayName` | string | Group display name |
-|   ↳ `description` | string | Group description |
+|   ↳ `displayName` | string (nullable) | Group display name |
+|   ↳ `description` | string (nullable) | Group description |
 |   ↳ `externalIds` | array | External identity provider IDs linked to the group |
 |     ↳ `issuer` | string | Identity provider that issued the ID |
 |     ↳ `id` | string | Identifier at the issuer |
@@ -288,7 +288,7 @@ List the users who belong to an Identity Store group
 | `memberships` | array | Members of the group |
 |   ↳ `membershipId` | string | Identity Store membership ID |
 |   ↳ `groupId` | string | Identity Store group ID |
-|   ↳ `userId` | string | Identity Store user ID of the member — resolve with Describe User. Null when the member is not a user. |
+|   ↳ `userId` | string (nullable) | Identity Store user ID of the member — resolve with Describe User. Null when the member is not a user. |
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of memberships returned |
 
@@ -467,5 +467,3 @@ List every principal assigned a specific permission set on a specific AWS accoun
 |   ↳ `principalId` | string | Identity Store user or group ID — resolve with Describe User or Describe Group |
 | `nextToken` | string | Pagination token for the next page of results |
 | `count` | number | Number of assignments returned |
-
-

--- a/apps/docs/content/docs/integrations/imap.mdx
+++ b/apps/docs/content/docs/integrations/imap.mdx
@@ -56,4 +56,3 @@ Triggers when new emails are received via IMAP (works with any email provider)
 |   ↳ `hasAttachments` | boolean | Whether email has attachments |
 |   ↳ `attachments` | file[] | Array of email attachments as files \(if includeAttachments is enabled\) |
 | `timestamp` | string | Event timestamp |
-

--- a/apps/docs/content/docs/integrations/incidentio.mdx
+++ b/apps/docs/content/docs/integrations/incidentio.mdx
@@ -5,7 +5,7 @@ description: Manage incidents with incident.io
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="incidentio"
   color="#FFFFFF"
 />
@@ -1734,7 +1734,7 @@ List the entries of a catalog type in incident.io — for example every service,
 |   ↳ `archived_at` | string | When this entry was archived |
 |   ↳ `created_at` | string | When this entry was created |
 |   ↳ `updated_at` | string | When this entry was last updated |
-| `catalog_type` | object | The catalog type these entries belong to |
+| `catalog_type` | object (nullable) | The catalog type these entries belong to |
 |   ↳ `id` | string | Catalog type ID |
 |   ↳ `name` | string | Human readable name of this type |
 |   ↳ `description` | string | Human readable description of this type |
@@ -2027,8 +2027,6 @@ Revoke a user's membership of a private incident in incident.io
 | --------- | ---- | ----------- |
 | `message` | string | Success message |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -2165,4 +2163,3 @@ Trigger workflow when an incident is updated in incident.io
 | `new_status` | json | New status object \(status-updated events only; null otherwise\). |
 | `previous_status` | json | Previous status object \(status-updated events only; null otherwise\). |
 | `update_message` | string | Update message accompanying a status change \(status-updated events only; null otherwise\). |
-

--- a/apps/docs/content/docs/integrations/infisical.mdx
+++ b/apps/docs/content/docs/integrations/infisical.mdx
@@ -5,7 +5,7 @@ description: Manage secrets with Infisical
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="infisical"
   color="#F7FE62"
 />
@@ -306,5 +306,3 @@ Delete a secret from a project environment.
 |     ↳ `groupId` | string | Group ID |
 |   ↳ `createdAt` | string | Creation timestamp |
 |   ↳ `updatedAt` | string | Last update timestamp |
-
-

--- a/apps/docs/content/docs/integrations/instantly.mdx
+++ b/apps/docs/content/docs/integrations/instantly.mdx
@@ -5,7 +5,7 @@ description: Manage Instantly leads, campaigns, emails, and lead lists
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="instantly"
   color="#FFFFFF"
 />
@@ -63,25 +63,16 @@ Retrieves Instantly V2 leads with search, campaign, list, and pagination filters
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
+| `leads` | array | List of leads |
+|   ↳ `id` | string (nullable) | Lead ID |
+|   ↳ `email` | string (nullable) | Lead email address |
+|   ↳ `first_name` | string (nullable) | Lead first name |
+|   ↳ `last_name` | string (nullable) | Lead last name |
+|   ↳ `company_name` | string (nullable) | Lead company name |
+|   ↳ `campaign` | string (nullable) | Campaign ID |
+|   ↳ `status` | number (nullable) | Lead status |
+| `count` | number | Number of leads returned |
 | `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
 
 ### Instantly Get Lead
 
@@ -98,25 +89,22 @@ Retrieves an Instantly V2 lead by ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
+| `lead` | object | Lead details |
+|   ↳ `id` | string (nullable) | Lead ID |
+|   ↳ `email` | string (nullable) | Lead email address |
+|   ↳ `first_name` | string (nullable) | Lead first name |
+|   ↳ `last_name` | string (nullable) | Lead last name |
+|   ↳ `company_name` | string (nullable) | Lead company name |
+|   ↳ `job_title` | string (nullable) | Lead job title |
+|   ↳ `campaign` | string (nullable) | Campaign ID |
+|   ↳ `status` | number (nullable) | Lead status |
+|   ↳ `payload` | json (nullable) | Lead custom variables |
+| `id` | string | Lead ID |
 | `email_address` | string | Lead email address |
 | `first_name` | string | Lead first name |
 | `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `campaign` | string | Campaign ID |
+| `status` | number | Lead status |
 
 ### Instantly Create Lead
 
@@ -152,25 +140,22 @@ Creates an Instantly V2 lead in a campaign or lead list.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
+| `lead` | object | Lead details |
+|   ↳ `id` | string (nullable) | Lead ID |
+|   ↳ `email` | string (nullable) | Lead email address |
+|   ↳ `first_name` | string (nullable) | Lead first name |
+|   ↳ `last_name` | string (nullable) | Lead last name |
+|   ↳ `company_name` | string (nullable) | Lead company name |
+|   ↳ `job_title` | string (nullable) | Lead job title |
+|   ↳ `campaign` | string (nullable) | Campaign ID |
+|   ↳ `status` | number (nullable) | Lead status |
+|   ↳ `payload` | json (nullable) | Lead custom variables |
+| `id` | string | Lead ID |
 | `email_address` | string | Lead email address |
 | `first_name` | string | Lead first name |
 | `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `campaign` | string | Campaign ID |
+| `status` | number | Lead status |
 
 ### Instantly Patch Lead
 
@@ -198,25 +183,22 @@ Updates fields on an existing Instantly V2 lead.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
+| `lead` | object | Lead details |
+|   ↳ `id` | string (nullable) | Lead ID |
+|   ↳ `email` | string (nullable) | Lead email address |
+|   ↳ `first_name` | string (nullable) | Lead first name |
+|   ↳ `last_name` | string (nullable) | Lead last name |
+|   ↳ `company_name` | string (nullable) | Lead company name |
+|   ↳ `job_title` | string (nullable) | Lead job title |
+|   ↳ `campaign` | string (nullable) | Campaign ID |
+|   ↳ `status` | number (nullable) | Lead status |
+|   ↳ `payload` | json (nullable) | Lead custom variables |
+| `id` | string | Lead ID |
 | `email_address` | string | Lead email address |
 | `first_name` | string | Lead first name |
 | `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `campaign` | string | Campaign ID |
+| `status` | number | Lead status |
 
 ### Instantly Delete Leads
 
@@ -281,25 +263,13 @@ Retrieves Instantly V2 campaigns with search, status, tag, and pagination filter
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
+| `campaigns` | array | List of campaigns |
+|   ↳ `id` | string (nullable) | Campaign ID |
+|   ↳ `name` | string (nullable) | Campaign name |
+|   ↳ `status` | number (nullable) | Campaign status |
+|   ↳ `daily_limit` | number (nullable) | Daily sending limit |
+| `count` | number | Number of campaigns returned |
 | `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
 
 ### Instantly Create Campaign
 
@@ -327,25 +297,16 @@ Creates an Instantly V2 campaign using the documented campaign schedule schema.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `campaign` | object | Campaign details |
+|   ↳ `id` | string (nullable) | Campaign ID |
+|   ↳ `name` | string (nullable) | Campaign name |
+|   ↳ `status` | number (nullable) | Campaign status |
+|   ↳ `daily_limit` | number (nullable) | Daily sending limit |
+|   ↳ `daily_max_leads` | number (nullable) | Daily max new leads |
+|   ↳ `open_tracking` | boolean (nullable) | Whether open tracking is enabled |
+| `id` | string | Campaign ID |
+| `name` | string | Campaign name |
+| `status` | number | Campaign status |
 
 ### Instantly Patch Campaign
 
@@ -374,25 +335,16 @@ Updates documented Instantly V2 campaign fields.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `campaign` | object | Campaign details |
+|   ↳ `id` | string (nullable) | Campaign ID |
+|   ↳ `name` | string (nullable) | Campaign name |
+|   ↳ `status` | number (nullable) | Campaign status |
+|   ↳ `daily_limit` | number (nullable) | Daily sending limit |
+|   ↳ `daily_max_leads` | number (nullable) | Daily max new leads |
+|   ↳ `open_tracking` | boolean (nullable) | Whether open tracking is enabled |
+| `id` | string | Campaign ID |
+| `name` | string | Campaign name |
+| `status` | number | Campaign status |
 
 ### Instantly Activate Campaign
 
@@ -409,25 +361,17 @@ Activates, starts, or resumes an Instantly V2 campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `campaign` | object | Campaign details |
+|   ↳ `id` | string (nullable) | Campaign ID |
+|   ↳ `name` | string (nullable) | Campaign name |
+|   ↳ `status` | number (nullable) | Campaign status |
+|   ↳ `daily_limit` | number (nullable) | Daily sending limit |
+|   ↳ `daily_max_leads` | number (nullable) | Daily max new leads |
+|   ↳ `open_tracking` | boolean (nullable) | Whether open tracking is enabled |
+| `id` | string | Campaign ID |
+| `name` | string | Campaign name |
+| `status` | number | Campaign status |
+| `message` | string | Confirmation message from Instantly |
 
 ### Instantly Pause Campaign
 
@@ -444,25 +388,17 @@ Pauses a running Instantly V2 campaign, stopping further email sends.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `campaign` | object | Campaign details |
+|   ↳ `id` | string (nullable) | Campaign ID |
+|   ↳ `name` | string (nullable) | Campaign name |
+|   ↳ `status` | number (nullable) | Campaign status |
+|   ↳ `daily_limit` | number (nullable) | Daily sending limit |
+|   ↳ `daily_max_leads` | number (nullable) | Daily max new leads |
+|   ↳ `open_tracking` | boolean (nullable) | Whether open tracking is enabled |
+| `id` | string | Campaign ID |
+| `name` | string | Campaign name |
+| `status` | number | Campaign status |
+| `message` | string | Confirmation message from Instantly |
 
 ### Instantly Delete Campaign
 
@@ -479,25 +415,17 @@ Permanently deletes an Instantly V2 campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `campaign` | object | Campaign details |
+|   ↳ `id` | string (nullable) | Campaign ID |
+|   ↳ `name` | string (nullable) | Campaign name |
+|   ↳ `status` | number (nullable) | Campaign status |
+|   ↳ `daily_limit` | number (nullable) | Daily sending limit |
+|   ↳ `daily_max_leads` | number (nullable) | Daily max new leads |
+|   ↳ `open_tracking` | boolean (nullable) | Whether open tracking is enabled |
+| `id` | string | Campaign ID |
+| `name` | string | Campaign name |
+| `status` | number | Campaign status |
+| `message` | string | Confirmation message from Instantly |
 
 ### Instantly List Emails
 
@@ -522,25 +450,14 @@ Retrieves Instantly V2 Unibox emails with search and pagination filters.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
+| `emails` | array | List of emails |
+|   ↳ `id` | string (nullable) | Email ID |
+|   ↳ `subject` | string (nullable) | Email subject |
+|   ↳ `from_address_email` | string (nullable) | Sender email |
+|   ↳ `lead` | string (nullable) | Lead email |
+|   ↳ `thread_id` | string (nullable) | Thread ID |
+| `count` | number | Number of emails returned |
 | `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
 
 ### Instantly Reply To Email
 
@@ -562,25 +479,16 @@ Sends an Instantly V2 reply to an existing Unibox email.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
+| `email` | object | Email details |
+|   ↳ `id` | string (nullable) | Email ID |
+|   ↳ `subject` | string (nullable) | Email subject |
+|   ↳ `from_address_email` | string (nullable) | Sender email |
+|   ↳ `to_address_email_list` | string (nullable) | Recipient email list |
+|   ↳ `thread_id` | string (nullable) | Thread ID |
+|   ↳ `content_preview` | string (nullable) | Email content preview |
+| `id` | string | Email ID |
 | `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
+| `thread_id` | string | Thread ID |
 
 ### Instantly List Lead Lists
 
@@ -600,25 +508,13 @@ Retrieves Instantly V2 lead lists with search and pagination filters.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
+| `lead_lists` | array | List of lead lists |
+|   ↳ `id` | string (nullable) | Lead list ID |
+|   ↳ `name` | string (nullable) | Lead list name |
+|   ↳ `has_enrichment_task` | boolean (nullable) | Whether enrichment is enabled |
+|   ↳ `timestamp_created` | string (nullable) | Creation timestamp |
+| `count` | number | Number of lead lists returned |
 | `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
 
 ### Instantly Create Lead List
 
@@ -637,24 +533,12 @@ Creates an Instantly V2 lead list.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `leads` | array | List of leads \(id, email, first_name, last_name, campaign, status\) |
-| `lead` | json | Lead details \(id, email, first_name, last_name, company_name, job_title, campaign, status, payload\) |
-| `campaigns` | array | List of campaigns \(id, name, status, daily_limit\) |
-| `campaign` | json | Campaign details \(id, name, status, daily_limit, daily_max_leads, open_tracking\) |
-| `emails` | array | List of emails \(id, subject, from_address_email, lead, thread_id\) |
-| `email` | json | Email details \(id, subject, from_address_email, to_address_email_list, thread_id, content_preview\) |
-| `lead_lists` | array | List of lead lists \(id, name, has_enrichment_task, timestamp_created\) |
-| `lead_list` | json | Lead list details \(id, organization_id, has_enrichment_task, owned_by, name, timestamp_created\) |
-| `count` | number | Returned or affected record count |
-| `next_starting_after` | string | Cursor for the next page |
-| `id` | string | Record ID |
-| `name` | string | Record name |
-| `email_address` | string | Lead email address |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `status` | number | Lead or campaign status |
-| `subject` | string | Email subject |
-| `thread_id` | string | Email thread ID |
-| `message` | string | Operation message |
-
-
+| `lead_list` | object | Lead list details |
+|   ↳ `id` | string (nullable) | Lead list ID |
+|   ↳ `organization_id` | string (nullable) | Organization ID |
+|   ↳ `has_enrichment_task` | boolean (nullable) | Whether enrichment is enabled |
+|   ↳ `owned_by` | string (nullable) | Owner user ID |
+|   ↳ `name` | string (nullable) | Lead list name |
+|   ↳ `timestamp_created` | string (nullable) | Creation timestamp |
+| `id` | string | Lead list ID |
+| `name` | string | Lead list name |

--- a/apps/docs/content/docs/integrations/intercom.mdx
+++ b/apps/docs/content/docs/integrations/intercom.mdx
@@ -5,7 +5,7 @@ description: Manage contacts, companies, conversations, tickets, and messages in
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="intercom_v2"
   color="#FFFFFF"
 />
@@ -1075,8 +1075,6 @@ Remove a contact from a company in Intercom
 | `companyId` | string | ID of the company |
 | `name` | string | Name of the company |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1227,4 +1225,3 @@ Trigger workflow on any Intercom webhook event
 | `delivery_attempts` | number | Number of delivery attempts for this notification |
 | `first_sent_at` | number | Unix timestamp of first delivery attempt |
 | `data` | json | Event data containing the affected object. Access via data.item for the resource \(conversation, contact, company, ticket, etc.\) |
-

--- a/apps/docs/content/docs/integrations/jina.mdx
+++ b/apps/docs/content/docs/integrations/jina.mdx
@@ -5,7 +5,7 @@ description: Search the web or extract content from URLs
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="jina"
   color="#333333"
 />
@@ -87,5 +87,3 @@ Search the web and return top 5 results with LLM-friendly content. Each result i
 |   ↳ `usage` | object | Token usage information |
 |     ↳ `tokens` | number | Number of tokens consumed by this request |
 | `tokensUsed` | number | Number of Jina tokens consumed by this request |
-
-

--- a/apps/docs/content/docs/integrations/jira.mdx
+++ b/apps/docs/content/docs/integrations/jira.mdx
@@ -5,7 +5,7 @@ description: Interact with Jira
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="jira"
   color="#FFFFFF"
 />
@@ -1165,8 +1165,6 @@ Get all system and custom fields defined in the Jira instance. Useful for discov
 |   ↳ `customType` | string | Custom field type identifier \(only for custom fields\) |
 | `total` | number | Number of fields returned |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -2225,4 +2223,3 @@ Trigger workflow when a worklog entry is updated on a Jira issue
 |   ↳ `updated` | string | When the worklog entry was last updated \(ISO format\) |
 |   ↳ `issueId` | string | ID of the issue this worklog belongs to |
 |   ↳ `self` | string | REST API URL for this worklog entry |
-

--- a/apps/docs/content/docs/integrations/jira_service_management.mdx
+++ b/apps/docs/content/docs/integrations/jira_service_management.mdx
@@ -5,7 +5,7 @@ description: Interact with Jira Service Management
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="jira_service_management"
   color="#FFFFFF"
 />
@@ -1198,8 +1198,6 @@ Delete an Assets (Insight/CMDB) object by ID
 | `objectId` | string | The deleted object ID |
 | `deleted` | boolean | Whether the object was deleted |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1546,4 +1544,3 @@ Trigger workflow on any Jira Service Management webhook event
 |     ↳ `emailAddress` | string | Comment author email address |
 |   ↳ `created` | string | Comment creation date \(ISO format\) |
 |   ↳ `updated` | string | Comment last updated date \(ISO format\) |
-

--- a/apps/docs/content/docs/integrations/jotform.mdx
+++ b/apps/docs/content/docs/integrations/jotform.mdx
@@ -5,7 +5,7 @@ description: Read submissions, manage forms, and wire up webhooks in Jotform
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="jotform"
   color="#FFFFFF"
 />
@@ -1158,8 +1158,6 @@ Update account settings such as name, email, website, company, industry, or time
 |   ↳ `avatarUrl` | string | Avatar image URL |
 |   ↳ `usage` | string | URL of the monthly usage endpoint |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1189,4 +1187,3 @@ Trigger workflow when a Jotform form receives a new submission
 | `pretty` | string | Human-readable summary of the answers, as comma-separated "Question Label:Answer" pairs. Unanswered questions are left out. |
 | `rawRequest` | json | The submitted form body. Answers are keyed q\{questionId\}_\{slugifiedLabel\} and hold a string, or an object for a multi-part question such as name or address. A file answer instead appears under the plain slugified label as an array of upload URLs, with the chosen filenames under temp_upload. The body also carries form-internal fields such as slug, buildDate, submitSource, and jsExecutionTracker. |
 | `raw` | json | Complete original webhook payload from Jotform |
-

--- a/apps/docs/content/docs/integrations/jupyter.mdx
+++ b/apps/docs/content/docs/integrations/jupyter.mdx
@@ -5,7 +5,7 @@ description: Manage files, notebooks, kernels, and sessions on a Jupyter server
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="jupyter"
   color="#FFFFFF"
 />
@@ -391,5 +391,3 @@ Delete a session on a Jupyter server (does not shut down its kernel)
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the session was deleted |
 | `sessionId` | string | Deleted session ID |
-
-

--- a/apps/docs/content/docs/integrations/kalshi.mdx
+++ b/apps/docs/content/docs/integrations/kalshi.mdx
@@ -5,7 +5,7 @@ description: Access prediction markets and trade on Kalshi
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="kalshi_v2"
   color="#09C285"
 />
@@ -854,5 +854,3 @@ Modify the price or quantity of an existing order on Kalshi (V2 with full API re
 |   ↳ `stop_loss_order_id` | string | Stop loss order ID |
 |   ↳ `amend_count` | number | Amend count |
 |   ↳ `amend_taker_fill_count` | number | Amend taker fill count |
-
-

--- a/apps/docs/content/docs/integrations/ketch.mdx
+++ b/apps/docs/content/docs/integrations/ketch.mdx
@@ -5,7 +5,7 @@ description: Manage privacy consent, subscriptions, and data subject rights
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="ketch"
   color="#9B5CFF"
 />
@@ -136,5 +136,3 @@ Submit a data subject rights request (e.g., access, delete, correct, restrict pr
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the rights request was submitted |
 | `message` | string | Response message from Ketch |
-
-

--- a/apps/docs/content/docs/integrations/knowledge.mdx
+++ b/apps/docs/content/docs/integrations/knowledge.mdx
@@ -5,7 +5,7 @@ description: Use vector search
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="knowledge"
   color="#00B0B0"
 />
@@ -48,7 +48,7 @@ Search for similar content in a knowledge base by relevance
 | `results` | array | Array of search results from the knowledge base |
 |   ↳ `documentId` | string | Document ID |
 |   ↳ `documentName` | string | Document name |
-|   ↳ `sourceUrl` | string | URL to the original source document \(e.g., Confluence page, Google Doc, Notion page\). Null for documents without an external source. |
+|   ↳ `sourceUrl` | string (nullable) | URL to the original source document \(e.g., Confluence page, Google Doc, Notion page\). Null for documents without an external source. |
 |   ↳ `content` | string | Content of the result |
 |   ↳ `chunkIndex` | number | Index of the chunk within the document |
 |   ↳ `similarity` | number | Similarity score of the result |
@@ -420,5 +420,3 @@ Trigger a manual sync for a knowledge base connector
 | --------- | ---- | ----------- |
 | `connectorId` | string | ID of the connector that was synced |
 | `message` | string | Status message from the sync trigger |
-
-

--- a/apps/docs/content/docs/integrations/lambda.mdx
+++ b/apps/docs/content/docs/integrations/lambda.mdx
@@ -5,7 +5,7 @@ description: Invoke, deploy, and manage AWS Lambda functions
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="lambda"
   color="linear-gradient(45deg, #C8511B 0%, #FF9900 100%)"
 />
@@ -67,11 +67,11 @@ Invoke a Lambda function synchronously or asynchronously and return its response
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `statusCode` | number | HTTP status of the invocation \(200 for RequestResponse, 202 for Event, 204 for DryRun\) |
-| `payload` | json | The response returned by the function, parsed as JSON when possible |
-| `functionError` | string | Set to Handled or Unhandled when the function itself returned an error |
-| `logResult` | string | Decoded execution log tail, present only when logType is Tail |
-| `executedVersion` | string | The function version that was executed |
+| `statusCode` | number (nullable) | HTTP status of the invocation \(200 for RequestResponse, 202 for Event, 204 for DryRun\) |
+| `payload` | json (nullable) | The response returned by the function, parsed as JSON when possible |
+| `functionError` | string (nullable) | Set to Handled or Unhandled when the function itself returned an error |
+| `logResult` | string (nullable) | Decoded execution log tail, present only when logType is Tail |
+| `executedVersion` | string (nullable) | The function version that was executed |
 
 ### Lambda List Functions
 
@@ -94,7 +94,7 @@ List Lambda functions with the version-specific configuration of each
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `functions` | array | Lambda functions with their runtime, handler, memory, and state |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda Get Function
 
@@ -114,11 +114,11 @@ Get a function's configuration, code location, tags, and reserved concurrency
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `configuration` | json | The function's configuration \(ARN, runtime, handler, memory, state, layers, VPC, and logging settings\) |
-| `tagsError` | json | Why the tags could not be read, when a partial tag-read failure occurred |
-| `code` | json | Presigned download URL for the deployment package, or the container image URI |
+| `configuration` | json (nullable) | The function's configuration \(ARN, runtime, handler, memory, state, layers, VPC, and logging settings\) |
+| `tagsError` | json (nullable) | Why the tags could not be read, when a partial tag-read failure occurred |
+| `code` | json (nullable) | Presigned download URL for the deployment package, or the container image URI |
 | `tags` | json | The function's tags |
-| `reservedConcurrentExecutions` | number | Concurrency reserved for this function, if any |
+| `reservedConcurrentExecutions` | number (nullable) | Concurrency reserved for this function, if any |
 
 ### Lambda Get Function Configuration
 
@@ -312,7 +312,7 @@ List the published versions of a Lambda function, plus $LATEST
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `versions` | array | Published versions of the function, plus the unpublished $LATEST version |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda Create Alias
 
@@ -422,7 +422,7 @@ List the aliases of a Lambda function
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `aliases` | array | Aliases with their ARNs, target versions, and routing configuration |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda Add Permission
 
@@ -451,7 +451,7 @@ Grant an AWS service, account, or organization permission to use a function
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `statement` | string | The permission statement that was added, as a JSON document string |
+| `statement` | string (nullable) | The permission statement that was added, as a JSON document string |
 
 ### Lambda Remove Permission
 
@@ -493,8 +493,8 @@ Get the resource-based IAM policy attached to a function, version, or alias
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `policy` | string | The resource-based policy, as a JSON document string |
-| `revisionId` | string | Current revision ID of the policy |
+| `policy` | string (nullable) | The resource-based policy, as a JSON document string |
+| `revisionId` | string (nullable) | Current revision ID of the policy |
 
 ### Lambda Create Event Source Mapping
 
@@ -641,7 +641,7 @@ List event source mappings, optionally filtered by function or event source
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `eventSourceMappings` | array | Event source mappings with their UUIDs, state, and batching settings |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda Get Function Concurrency
 
@@ -660,7 +660,7 @@ Get the reserved concurrency configured for a function
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `reservedConcurrentExecutions` | number | Concurrency reserved for this function, or null when none is reserved |
+| `reservedConcurrentExecutions` | number (nullable) | Concurrency reserved for this function, or null when none is reserved |
 
 ### Lambda Set Function Concurrency
 
@@ -680,7 +680,7 @@ Reserve a share of the account concurrency limit for a function
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `reservedConcurrentExecutions` | number | Concurrency now reserved for this function |
+| `reservedConcurrentExecutions` | number (nullable) | Concurrency now reserved for this function |
 
 ### Lambda Delete Function Concurrency
 
@@ -782,7 +782,7 @@ List the provisioned concurrency configurations of a function
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `provisionedConcurrencyConfigs` | array | Provisioned concurrency configurations with their allocation status |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda Create Function URL
 
@@ -900,7 +900,7 @@ List the URL configurations of a function
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `functionUrlConfigs` | array | Function URLs with their auth types, invoke modes, and CORS settings |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda Get Async Invoke Config
 
@@ -986,7 +986,7 @@ List the asynchronous invocation configurations of a function
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `eventInvokeConfigs` | array | Asynchronous invocation configurations for the function versions and aliases |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda List Layers
 
@@ -1009,7 +1009,7 @@ List Lambda layers and the latest version of each
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `layers` | array | Layers with their ARNs and latest matching version |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda List Layer Versions
 
@@ -1033,7 +1033,7 @@ List the versions of a Lambda layer
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `layerVersions` | array | Layer versions with their ARNs, compatible runtimes, and license info |
-| `nextMarker` | string | Pagination token to pass as marker on the next request |
+| `nextMarker` | string (nullable) | Pagination token to pass as marker on the next request |
 
 ### Lambda Get Layer Version
 
@@ -1130,8 +1130,8 @@ Get the Lambda limits and usage of the current AWS account and region
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `accountLimit` | json | Account-level storage and concurrency limits |
-| `accountUsage` | json | Current code storage used and number of functions deployed |
+| `accountLimit` | json (nullable) | Account-level storage and concurrency limits |
+| `accountUsage` | json (nullable) | Current code storage used and number of functions deployed |
 
 ### Lambda Get Recursion Config
 
@@ -1150,7 +1150,7 @@ Get the recursive loop detection setting of a function
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `recursiveLoop` | string | Terminate stops the function after 16 recursive invocations, Allow permits recursion |
+| `recursiveLoop` | string (nullable) | Terminate stops the function after 16 recursive invocations, Allow permits recursion |
 
 ### Lambda Set Recursion Config
 
@@ -1170,7 +1170,7 @@ Set whether Lambda stops a function that invokes itself recursively
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `recursiveLoop` | string | The recursion setting now in effect for the function |
+| `recursiveLoop` | string (nullable) | The recursion setting now in effect for the function |
 
 ### Lambda Get Runtime Management Config
 
@@ -1190,9 +1190,9 @@ Get the runtime update policy of a function version
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updateRuntimeOn` | string | Auto, FunctionUpdate, or Manual runtime update policy |
-| `runtimeVersionArn` | string | ARN of the pinned runtime version, when the policy is Manual |
-| `functionArn` | string | ARN of the function the policy applies to |
+| `updateRuntimeOn` | string (nullable) | Auto, FunctionUpdate, or Manual runtime update policy |
+| `runtimeVersionArn` | string (nullable) | ARN of the pinned runtime version, when the policy is Manual |
+| `functionArn` | string (nullable) | ARN of the function the policy applies to |
 
 ### Lambda Set Runtime Management Config
 
@@ -1214,8 +1214,6 @@ Set how and when Lambda applies runtime updates to a function version
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updateRuntimeOn` | string | The runtime update policy now in effect |
-| `runtimeVersionArn` | string | ARN of the pinned runtime version, when the policy is Manual |
-| `functionArn` | string | ARN of the function the policy applies to |
-
-
+| `updateRuntimeOn` | string (nullable) | The runtime update policy now in effect |
+| `runtimeVersionArn` | string (nullable) | ARN of the pinned runtime version, when the policy is Manual |
+| `functionArn` | string (nullable) | ARN of the function the policy applies to |

--- a/apps/docs/content/docs/integrations/langsmith.mdx
+++ b/apps/docs/content/docs/integrations/langsmith.mdx
@@ -5,7 +5,7 @@ description: Forward workflow runs to LangSmith for observability
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="langsmith"
   color="#181C1E"
 />
@@ -100,7 +100,11 @@ Patch an existing LangSmith run with outputs, status, or timing once it complete
 
 #### Output
 
-This tool does not produce any outputs.
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `accepted` | boolean | Whether the run update was accepted |
+| `runId` | string | ID of the run that was updated |
+| `message` | string | Response message from LangSmith, if provided |
 
 ### LangSmith Get Run
 
@@ -162,5 +166,3 @@ Attach a score, correction, or comment to a LangSmith run.
 | `value` | string | Categorical value recorded for the feedback |
 | `comment` | string | Comment recorded for the feedback |
 | `createdAt` | string | When the feedback was created \(ISO\) |
-
-

--- a/apps/docs/content/docs/integrations/latex.mdx
+++ b/apps/docs/content/docs/integrations/latex.mdx
@@ -5,7 +5,7 @@ description: Compile LaTeX documents into PDFs
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="latex"
   color="#FFFFFF"
 />
@@ -115,5 +115,3 @@ List the system fonts available to the LaTeX compiler, optionally filtered by na
 |   ↳ `name` | string | Full font name |
 |   ↳ `styles` | array | Available styles, e.g. Bold or Italic |
 | `totalMatches` | number | Total number of fonts matching the filter, before truncation |
-
-

--- a/apps/docs/content/docs/integrations/launchdarkly.mdx
+++ b/apps/docs/content/docs/integrations/launchdarkly.mdx
@@ -5,7 +5,7 @@ description: Manage feature flags with LaunchDarkly.
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="launchdarkly"
   color="#191919"
 />
@@ -385,5 +385,3 @@ Update feature flag metadata (name, description, tags, temporary, archived) usin
 |   ↳ `description` | string | The variation description |
 | `maintainerId` | string | The ID of the member who maintains this flag |
 | `maintainerEmail` | string | The email of the member who maintains this flag |
-
-

--- a/apps/docs/content/docs/integrations/leadmagic.mdx
+++ b/apps/docs/content/docs/integrations/leadmagic.mdx
@@ -5,7 +5,7 @@ description: Find and enrich B2B contacts, emails, mobile numbers, and company d
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="leadmagic"
   color="#FFFFFF"
 />
@@ -261,5 +261,3 @@ Retrieve the current credit balance for the authenticated LeadMagic account. Thi
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `credits` | number | Current credit balance |
-
-

--- a/apps/docs/content/docs/integrations/lemlist.mdx
+++ b/apps/docs/content/docs/integrations/lemlist.mdx
@@ -5,7 +5,7 @@ description: Manage outreach activities, leads, and send emails via Lemlist
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="lemlist"
   color="#316BFF"
 />
@@ -116,8 +116,6 @@ Sends an email to a contact through the Lemlist inbox.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `ok` | boolean | Whether the email was sent successfully |
-
-
 
 ## Triggers
 
@@ -472,4 +470,3 @@ Trigger workflow on any Lemlist webhook event
 | `emailId` | string | Lemlist email identifier |
 | `clickedUrl` | string | URL that was clicked \(for emailsClicked events\) |
 | `errorMessage` | string | Error message \(for bounce/failed events\) |
-

--- a/apps/docs/content/docs/integrations/linear.mdx
+++ b/apps/docs/content/docs/integrations/linear.mdx
@@ -5,7 +5,7 @@ description: Interact with Linear issues, projects, and more
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="linear_v2"
   color="#5E6AD2"
 />
@@ -2172,8 +2172,6 @@ List all project statuses in Linear
 |   ↳ `updatedAt` | string | Last updated timestamp \(ISO 8601\) |
 |   ↳ `archivedAt` | string | Archive timestamp \(ISO 8601\) |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -2954,4 +2952,3 @@ Trigger workflow from Linear events you select when creating the webhook in Line
 |   ↳ `url` | string | Actor profile URL in Linear \(distinct from the top-level subject entity `url`\) |
 | `data` | object | Complete entity data object |
 | `updatedFrom` | object | Previous values for changed fields \(only present on update\) |
-

--- a/apps/docs/content/docs/integrations/linkedin.mdx
+++ b/apps/docs/content/docs/integrations/linkedin.mdx
@@ -5,7 +5,7 @@ description: Share posts and manage your LinkedIn presence
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="linkedin"
   color="#0072B1"
 />
@@ -60,5 +60,3 @@ Retrieve your LinkedIn profile information
 | `postId` | string | Created post ID |
 | `profile` | json | LinkedIn profile information |
 | `error` | string | Error message if operation failed |
-
-

--- a/apps/docs/content/docs/integrations/linkup.mdx
+++ b/apps/docs/content/docs/integrations/linkup.mdx
@@ -5,7 +5,7 @@ description: Search the web with Linkup
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="linkup"
   color="#D6D3C7"
 />
@@ -58,5 +58,3 @@ Search the web for information using Linkup
 | --------- | ---- | ----------- |
 | `answer` | string | The sourced answer to the search query |
 | `sources` | array | Array of sources used to compile the answer, each containing name, url, and snippet |
-
-

--- a/apps/docs/content/docs/integrations/linq.mdx
+++ b/apps/docs/content/docs/integrations/linq.mdx
@@ -5,7 +5,7 @@ description: Send iMessage, SMS, and RCS messages and manage conversations with 
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="linq"
   color="#000000"
 />
@@ -484,8 +484,8 @@ List all phone numbers assigned to your partner account, with line health
 | `phoneNumbers` | array | Phone numbers assigned to the account |
 |   ↳ `id` | string | Phone number ID |
 |   ↳ `phoneNumber` | string | Phone number in E.164 format |
-|   ↳ `forwardingNumber` | string | Forwarding number in E.164 format, or null |
-|   ↳ `healthStatus` | json | Line reputation/health status \(status, doc_url\) |
+|   ↳ `forwardingNumber` | string (nullable) | Forwarding number in E.164 format, or null |
+|   ↳ `healthStatus` | json (nullable) | Line reputation/health status \(status, doc_url\) |
 
 ### List Thread Messages
 
@@ -543,10 +543,10 @@ List all webhook subscriptions on your account
 |   ↳ `id` | string | Subscription ID |
 |   ↳ `targetUrl` | string | Endpoint that receives events |
 |   ↳ `subscribedEvents` | json | Subscribed event types |
-|   ↳ `phoneNumbers` | json | Filtered phone numbers \(null = all\) |
+|   ↳ `phoneNumbers` | json (nullable) | Filtered phone numbers \(null = all\) |
 |   ↳ `isActive` | boolean | Whether the subscription is active |
-|   ↳ `createdAt` | string | ISO 8601 creation timestamp |
-|   ↳ `updatedAt` | string | ISO 8601 update timestamp |
+|   ↳ `createdAt` | string (nullable) | ISO 8601 creation timestamp |
+|   ↳ `updatedAt` | string (nullable) | ISO 8601 update timestamp |
 
 ### Mark Chat as Read
 
@@ -786,8 +786,6 @@ Update a webhook subscription (target URL, events, phone filter, or active state
 | `createdAt` | string | ISO 8601 creation timestamp |
 | `updatedAt` | string | ISO 8601 update timestamp |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -932,4 +930,3 @@ Trigger on any Linq webhook event (messages, reactions, chats, and more)
 | `createdAt` | string | ISO 8601 timestamp of when the event occurred |
 | `webhookVersion` | string | Payload schema version of the delivered event |
 | `data` | json | Full event payload \(shape varies by event type — message, reaction, chat, etc.\) |
-

--- a/apps/docs/content/docs/integrations/logfire.mdx
+++ b/apps/docs/content/docs/integrations/logfire.mdx
@@ -5,7 +5,7 @@ description: Query traces, logs, and metrics in Pydantic Logfire
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="logfire"
   color="#000000"
 />
@@ -58,9 +58,9 @@ Run a read-only SQL query against Logfire traces, logs, and metrics. Reads the r
 | --------- | ---- | ----------- |
 | `rows` | array | Result rows. Row fields depend on the query projection. |
 | `columns` | array | Column metadata for the result set |
-|   ↳ `name` | string | Column name |
+|   ↳ `name` | string (nullable) | Column name |
 |   ↳ `datatype` | json | Arrow datatype of the column |
-|   ↳ `nullable` | boolean | Whether the column is nullable |
+|   ↳ `nullable` | boolean (nullable) | Whether the column is nullable |
 | `rowCount` | number | Number of rows returned |
 
 ### Logfire Search Records
@@ -89,21 +89,21 @@ Search Logfire spans and logs using structured filters for message text, service
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `rows` | array | Matching spans and logs, most recent first |
-|   ↳ `startTimestamp` | string | UTC time the span started |
-|   ↳ `endTimestamp` | string | UTC time the span ended |
-|   ↳ `duration` | number | Span duration in seconds. Null for logs. |
-|   ↳ `level` | string | Severity name, such as info, warn, or error |
-|   ↳ `message` | string | Human-readable message |
-|   ↳ `spanName` | string | Template label for similar records |
-|   ↳ `kind` | string | Record kind: span, log, span_event, or pending_span |
-|   ↳ `serviceName` | string | Service that emitted the record |
-|   ↳ `deploymentEnvironment` | string | Deployment environment of the record |
-|   ↳ `traceId` | string | Trace this record belongs to |
-|   ↳ `spanId` | string | Identifier of this span |
-|   ↳ `parentSpanId` | string | Parent span identifier |
-|   ↳ `isException` | boolean | Whether an exception was recorded on the span |
-|   ↳ `exceptionType` | string | Fully qualified exception class name |
-|   ↳ `exceptionMessage` | string | Exception message |
+|   ↳ `startTimestamp` | string (nullable) | UTC time the span started |
+|   ↳ `endTimestamp` | string (nullable) | UTC time the span ended |
+|   ↳ `duration` | number (nullable) | Span duration in seconds. Null for logs. |
+|   ↳ `level` | string (nullable) | Severity name, such as info, warn, or error |
+|   ↳ `message` | string (nullable) | Human-readable message |
+|   ↳ `spanName` | string (nullable) | Template label for similar records |
+|   ↳ `kind` | string (nullable) | Record kind: span, log, span_event, or pending_span |
+|   ↳ `serviceName` | string (nullable) | Service that emitted the record |
+|   ↳ `deploymentEnvironment` | string (nullable) | Deployment environment of the record |
+|   ↳ `traceId` | string (nullable) | Trace this record belongs to |
+|   ↳ `spanId` | string (nullable) | Identifier of this span |
+|   ↳ `parentSpanId` | string (nullable) | Parent span identifier |
+|   ↳ `isException` | boolean (nullable) | Whether an exception was recorded on the span |
+|   ↳ `exceptionType` | string (nullable) | Fully qualified exception class name |
+|   ↳ `exceptionMessage` | string (nullable) | Exception message |
 | `rowCount` | number | Number of rows returned |
 | `sql` | string | SQL query that was executed against Logfire |
 
@@ -128,21 +128,21 @@ Fetch every span and log belonging to a Logfire trace, ordered from earliest to 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `rows` | array | Spans and logs in the trace, earliest first |
-|   ↳ `startTimestamp` | string | UTC time the span started |
-|   ↳ `endTimestamp` | string | UTC time the span ended |
-|   ↳ `duration` | number | Span duration in seconds. Null for logs. |
-|   ↳ `level` | string | Severity name, such as info, warn, or error |
-|   ↳ `message` | string | Human-readable message |
-|   ↳ `spanName` | string | Template label for similar records |
-|   ↳ `kind` | string | Record kind: span, log, span_event, or pending_span |
-|   ↳ `serviceName` | string | Service that emitted the record |
-|   ↳ `deploymentEnvironment` | string | Deployment environment of the record |
-|   ↳ `traceId` | string | Trace this record belongs to |
-|   ↳ `spanId` | string | Identifier of this span |
-|   ↳ `parentSpanId` | string | Parent span identifier |
-|   ↳ `isException` | boolean | Whether an exception was recorded on the span |
-|   ↳ `exceptionType` | string | Fully qualified exception class name |
-|   ↳ `exceptionMessage` | string | Exception message |
+|   ↳ `startTimestamp` | string (nullable) | UTC time the span started |
+|   ↳ `endTimestamp` | string (nullable) | UTC time the span ended |
+|   ↳ `duration` | number (nullable) | Span duration in seconds. Null for logs. |
+|   ↳ `level` | string (nullable) | Severity name, such as info, warn, or error |
+|   ↳ `message` | string (nullable) | Human-readable message |
+|   ↳ `spanName` | string (nullable) | Template label for similar records |
+|   ↳ `kind` | string (nullable) | Record kind: span, log, span_event, or pending_span |
+|   ↳ `serviceName` | string (nullable) | Service that emitted the record |
+|   ↳ `deploymentEnvironment` | string (nullable) | Deployment environment of the record |
+|   ↳ `traceId` | string (nullable) | Trace this record belongs to |
+|   ↳ `spanId` | string (nullable) | Identifier of this span |
+|   ↳ `parentSpanId` | string (nullable) | Parent span identifier |
+|   ↳ `isException` | boolean (nullable) | Whether an exception was recorded on the span |
+|   ↳ `exceptionType` | string (nullable) | Fully qualified exception class name |
+|   ↳ `exceptionMessage` | string (nullable) | Exception message |
 | `rowCount` | number | Number of rows returned |
 | `sql` | string | SQL query that was executed against Logfire |
 
@@ -162,9 +162,7 @@ Resolve which Logfire organization and project a read token belongs to. Useful f
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `organizationName` | string | Logfire organization the read token belongs to |
-| `projectName` | string | Logfire project the read token belongs to |
-| `expiresAt` | string | When the read token expires. Null when it never expires. |
-| `spendingCapReachedAt` | string | When the organization's spending cap was reached, which stops queries. Null when it has not been reached. |
-
-
+| `organizationName` | string (nullable) | Logfire organization the read token belongs to |
+| `projectName` | string (nullable) | Logfire project the read token belongs to |
+| `expiresAt` | string (nullable) | When the read token expires. Null when it never expires. |
+| `spendingCapReachedAt` | string (nullable) | When the organization's spending cap was reached, which stops queries. Null when it has not been reached. |

--- a/apps/docs/content/docs/integrations/logrocket.mdx
+++ b/apps/docs/content/docs/integrations/logrocket.mdx
@@ -5,7 +5,7 @@ description: Summarize sessions, manage users, and tag releases in LogRocket
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="logrocket"
   color="#764ABC"
 />
@@ -187,5 +187,3 @@ Register a release version in LogRocket so uploaded source maps can decode stack
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `version` | string | Release version that was registered |
-
-

--- a/apps/docs/content/docs/integrations/logs.mdx
+++ b/apps/docs/content/docs/integrations/logs.mdx
@@ -5,7 +5,7 @@ description: Query workflow runs and fetch run details
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="logs_v2"
   color="#EAB308"
 />
@@ -76,5 +76,3 @@ Fetch details for a single workflow run by its run ID, including the full trace 
 | `cost` | number | Run cost in credits |
 | `traceSpans` | array | Full trace spans for the run |
 | `finalOutput` | json | Final output of the run |
-
-

--- a/apps/docs/content/docs/integrations/loops.mdx
+++ b/apps/docs/content/docs/integrations/loops.mdx
@@ -5,7 +5,7 @@ description: Manage contacts and send emails with Loops
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="loops"
   color="#FAFAF9"
 />
@@ -321,8 +321,6 @@ Retrieve a single transactional email template from your Loops account by its ID
 | `updatedAt` | string | Last updated timestamp \(ISO 8601\) |
 | `dataVariables` | array | Template data variable names |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -593,4 +591,3 @@ Trigger workflow when a Loops transactional email is sent
 | `contactEmail` | string | Contact email address \(payload `contactIdentity.email`\) |
 | `userId` | string | Contact user ID, when set \(payload `contactIdentity.userId`\) |
 | `mailingLists` | json | Mailing lists the send targeted \(id, name, description, isPublic\); present on campaign and loop sends |
-

--- a/apps/docs/content/docs/integrations/luma.mdx
+++ b/apps/docs/content/docs/integrations/luma.mdx
@@ -5,7 +5,7 @@ description: Manage events and guests on Luma
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="luma"
   color="#000000"
 />
@@ -380,5 +380,3 @@ Update a guest's approval status on a Luma event — approve, decline, waitlist,
 | --------- | ---- | ----------- |
 | `status` | string | The approval status applied to the guest |
 | `guest` | string | The guest identifier \(email or ID\) that was updated |
-
-

--- a/apps/docs/content/docs/integrations/mailchimp.mdx
+++ b/apps/docs/content/docs/integrations/mailchimp.mdx
@@ -5,7 +5,7 @@ description: Manage audiences, campaigns, and marketing automation in Mailchimp
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="mailchimp"
   color="#FFE01B"
 />
@@ -1578,5 +1578,3 @@ Delete a batch operation from Mailchimp
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the batch operation was successfully deleted |
-
-

--- a/apps/docs/content/docs/integrations/mailgun.mdx
+++ b/apps/docs/content/docs/integrations/mailgun.mdx
@@ -5,7 +5,7 @@ description: Send emails and manage mailing lists with Mailgun
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="mailgun"
   color="#C12126"
 />
@@ -199,5 +199,3 @@ Get details of a specific domain
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the request was successful |
 | `domain` | json | Domain details |
-
-

--- a/apps/docs/content/docs/integrations/managed_agent.mdx
+++ b/apps/docs/content/docs/integrations/managed_agent.mdx
@@ -5,7 +5,7 @@ description: Run a Claude Platform Managed Agent
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="managed_agent"
   color="#DA7756"
 />
@@ -278,5 +278,3 @@ Permanently delete a Managed Agent session, its events, and its sandbox. Not rev
 | --------- | ---- | ----------- |
 | `sessionId` | string | The session that was deleted. |
 | `deleted` | boolean | True when the delete was accepted. |
-
-

--- a/apps/docs/content/docs/integrations/manageengine_sdp.mdx
+++ b/apps/docs/content/docs/integrations/manageengine_sdp.mdx
@@ -5,7 +5,7 @@ description: Manage ServiceDesk Plus Cloud requests, problems, changes, assets, 
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="manageengine_sdp"
   color="#FFFFFF"
 />
@@ -88,36 +88,36 @@ Create a request (ticket) in ManageEngine ServiceDesk Plus Cloud with a subject,
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `request` | object | The created request |
+| `request` | object (nullable) | The created request |
 |   ↳ `id` | string | Request ID |
 |   ↳ `display_id` | string | Request number shown in the SDP UI |
 |   ↳ `subject` | string | Request subject |
-|   ↳ `description` | string | Request description \(HTML\) |
-|   ↳ `status` | json | Current status |
+|   ↳ `description` | string (nullable) | Request description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
 |     ↳ `color` | string | Status colour |
 |     ↳ `in_progress` | boolean | Whether the status is in progress |
 |     ↳ `internal_name` | string | Internal status name |
 |     ↳ `stop_timer` | boolean | Whether the SLA timer stops |
-|   ↳ `priority` | json | Priority |
+|   ↳ `priority` | json (nullable) | Priority |
 |     ↳ `color` | string | Priority colour |
-|   ↳ `requester` | json | Requester |
-|   ↳ `technician` | json | Assigned technician |
-|   ↳ `group` | json | Support group |
+|   ↳ `requester` | json (nullable) | Requester |
+|   ↳ `technician` | json (nullable) | Assigned technician |
+|   ↳ `group` | json (nullable) | Support group |
 |     ↳ `site` | string | Site the group belongs to |
 |     ↳ `deleted` | boolean | Whether the group is deleted |
-|   ↳ `category` | json | Category |
-|   ↳ `subcategory` | json | Subcategory |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `template` | json | Request template |
-|   ↳ `site` | json | Site |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `due_by_time` | json | SLA due time |
-|   ↳ `resolved_time` | json | Resolution time |
-|   ↳ `completed_time` | json | Completion time |
+|   ↳ `category` | json (nullable) | Category |
+|   ↳ `subcategory` | json (nullable) | Subcategory |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `template` | json (nullable) | Request template |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `due_by_time` | json (nullable) | SLA due time |
+|   ↳ `resolved_time` | json (nullable) | Resolution time |
+|   ↳ `completed_time` | json (nullable) | Completion time |
 |   ↳ `is_service_request` | boolean | Whether this is a service request rather than an incident |
 |   ↳ `has_notes` | boolean | Whether the request has notes |
-|   ↳ `udf_fields` | json | Portal-defined custom fields |
+|   ↳ `udf_fields` | json (nullable) | Portal-defined custom fields |
 
 ### ManageEngine SDP Get Request
 
@@ -135,36 +135,36 @@ Retrieve a single ManageEngine ServiceDesk Plus Cloud request by ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `request` | object | The request |
+| `request` | object (nullable) | The request |
 |   ↳ `id` | string | Request ID |
 |   ↳ `display_id` | string | Request number shown in the SDP UI |
 |   ↳ `subject` | string | Request subject |
-|   ↳ `description` | string | Request description \(HTML\) |
-|   ↳ `status` | json | Current status |
+|   ↳ `description` | string (nullable) | Request description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
 |     ↳ `color` | string | Status colour |
 |     ↳ `in_progress` | boolean | Whether the status is in progress |
 |     ↳ `internal_name` | string | Internal status name |
 |     ↳ `stop_timer` | boolean | Whether the SLA timer stops |
-|   ↳ `priority` | json | Priority |
+|   ↳ `priority` | json (nullable) | Priority |
 |     ↳ `color` | string | Priority colour |
-|   ↳ `requester` | json | Requester |
-|   ↳ `technician` | json | Assigned technician |
-|   ↳ `group` | json | Support group |
+|   ↳ `requester` | json (nullable) | Requester |
+|   ↳ `technician` | json (nullable) | Assigned technician |
+|   ↳ `group` | json (nullable) | Support group |
 |     ↳ `site` | string | Site the group belongs to |
 |     ↳ `deleted` | boolean | Whether the group is deleted |
-|   ↳ `category` | json | Category |
-|   ↳ `subcategory` | json | Subcategory |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `template` | json | Request template |
-|   ↳ `site` | json | Site |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `due_by_time` | json | SLA due time |
-|   ↳ `resolved_time` | json | Resolution time |
-|   ↳ `completed_time` | json | Completion time |
+|   ↳ `category` | json (nullable) | Category |
+|   ↳ `subcategory` | json (nullable) | Subcategory |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `template` | json (nullable) | Request template |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `due_by_time` | json (nullable) | SLA due time |
+|   ↳ `resolved_time` | json (nullable) | Resolution time |
+|   ↳ `completed_time` | json (nullable) | Completion time |
 |   ↳ `is_service_request` | boolean | Whether this is a service request rather than an incident |
 |   ↳ `has_notes` | boolean | Whether the request has notes |
-|   ↳ `udf_fields` | json | Portal-defined custom fields |
+|   ↳ `udf_fields` | json (nullable) | Portal-defined custom fields |
 
 ### ManageEngine SDP List Requests
 
@@ -192,34 +192,34 @@ List ManageEngine ServiceDesk Plus Cloud requests, with optional search criteria
 |   ↳ `id` | string | Request ID |
 |   ↳ `display_id` | string | Request number shown in the SDP UI |
 |   ↳ `subject` | string | Request subject |
-|   ↳ `description` | string | Request description \(HTML\) |
-|   ↳ `status` | json | Current status |
+|   ↳ `description` | string (nullable) | Request description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
 |     ↳ `color` | string | Status colour |
 |     ↳ `in_progress` | boolean | Whether the status is in progress |
 |     ↳ `internal_name` | string | Internal status name |
 |     ↳ `stop_timer` | boolean | Whether the SLA timer stops |
-|   ↳ `priority` | json | Priority |
+|   ↳ `priority` | json (nullable) | Priority |
 |     ↳ `color` | string | Priority colour |
-|   ↳ `requester` | json | Requester |
-|   ↳ `technician` | json | Assigned technician |
-|   ↳ `group` | json | Support group |
+|   ↳ `requester` | json (nullable) | Requester |
+|   ↳ `technician` | json (nullable) | Assigned technician |
+|   ↳ `group` | json (nullable) | Support group |
 |     ↳ `site` | string | Site the group belongs to |
 |     ↳ `deleted` | boolean | Whether the group is deleted |
-|   ↳ `category` | json | Category |
-|   ↳ `subcategory` | json | Subcategory |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `template` | json | Request template |
-|   ↳ `site` | json | Site |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `due_by_time` | json | SLA due time |
-|   ↳ `resolved_time` | json | Resolution time |
-|   ↳ `completed_time` | json | Completion time |
+|   ↳ `category` | json (nullable) | Category |
+|   ↳ `subcategory` | json (nullable) | Subcategory |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `template` | json (nullable) | Request template |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `due_by_time` | json (nullable) | SLA due time |
+|   ↳ `resolved_time` | json (nullable) | Resolution time |
+|   ↳ `completed_time` | json (nullable) | Completion time |
 |   ↳ `is_service_request` | boolean | Whether this is a service request rather than an incident |
 |   ↳ `has_notes` | boolean | Whether the request has notes |
-|   ↳ `udf_fields` | json | Portal-defined custom fields |
+|   ↳ `udf_fields` | json (nullable) | Portal-defined custom fields |
 | `count` | number | Number of requests returned in this page |
-| `listInfo` | object | Paging metadata echoed by ServiceDesk Plus |
+| `listInfo` | object (nullable) | Paging metadata echoed by ServiceDesk Plus |
 |   ↳ `row_count` | number | Rows returned |
 |   ↳ `start_index` | number | Index the page started at |
 |   ↳ `page` | number | Page number |
@@ -255,36 +255,36 @@ Update a ManageEngine ServiceDesk Plus Cloud request: change its status, priorit
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `request` | object | The updated request |
+| `request` | object (nullable) | The updated request |
 |   ↳ `id` | string | Request ID |
 |   ↳ `display_id` | string | Request number shown in the SDP UI |
 |   ↳ `subject` | string | Request subject |
-|   ↳ `description` | string | Request description \(HTML\) |
-|   ↳ `status` | json | Current status |
+|   ↳ `description` | string (nullable) | Request description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
 |     ↳ `color` | string | Status colour |
 |     ↳ `in_progress` | boolean | Whether the status is in progress |
 |     ↳ `internal_name` | string | Internal status name |
 |     ↳ `stop_timer` | boolean | Whether the SLA timer stops |
-|   ↳ `priority` | json | Priority |
+|   ↳ `priority` | json (nullable) | Priority |
 |     ↳ `color` | string | Priority colour |
-|   ↳ `requester` | json | Requester |
-|   ↳ `technician` | json | Assigned technician |
-|   ↳ `group` | json | Support group |
+|   ↳ `requester` | json (nullable) | Requester |
+|   ↳ `technician` | json (nullable) | Assigned technician |
+|   ↳ `group` | json (nullable) | Support group |
 |     ↳ `site` | string | Site the group belongs to |
 |     ↳ `deleted` | boolean | Whether the group is deleted |
-|   ↳ `category` | json | Category |
-|   ↳ `subcategory` | json | Subcategory |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `template` | json | Request template |
-|   ↳ `site` | json | Site |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `due_by_time` | json | SLA due time |
-|   ↳ `resolved_time` | json | Resolution time |
-|   ↳ `completed_time` | json | Completion time |
+|   ↳ `category` | json (nullable) | Category |
+|   ↳ `subcategory` | json (nullable) | Subcategory |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `template` | json (nullable) | Request template |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `due_by_time` | json (nullable) | SLA due time |
+|   ↳ `resolved_time` | json (nullable) | Resolution time |
+|   ↳ `completed_time` | json (nullable) | Completion time |
 |   ↳ `is_service_request` | boolean | Whether this is a service request rather than an incident |
 |   ↳ `has_notes` | boolean | Whether the request has notes |
-|   ↳ `udf_fields` | json | Portal-defined custom fields |
+|   ↳ `udf_fields` | json (nullable) | Portal-defined custom fields |
 
 ### ManageEngine SDP Delete Request
 
@@ -325,16 +325,16 @@ Add a note to a ManageEngine ServiceDesk Plus Cloud request, optionally making i
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `note` | object | The created note |
+| `note` | object (nullable) | The created note |
 |   ↳ `id` | string | Note ID |
 |   ↳ `description` | string | Note body \(HTML\) |
 |   ↳ `show_to_requester` | boolean | Whether the note is visible to the requester |
 |   ↳ `notify_technician` | boolean | Whether the technician was notified |
 |   ↳ `mark_first_response` | boolean | Whether the note counts as the first response |
 |   ↳ `add_to_linked_requests` | boolean | Whether the note was copied to linked requests |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `created_by` | json | Note author |
-|   ↳ `request` | json | The request the note belongs to |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `created_by` | json (nullable) | Note author |
+|   ↳ `request` | json (nullable) | The request the note belongs to |
 |     ↳ `id` | string | Request ID |
 |     ↳ `display_id` | string | Request number |
 |     ↳ `subject` | string | Request subject |
@@ -369,14 +369,14 @@ List the notes on a ManageEngine ServiceDesk Plus Cloud request.
 |   ↳ `notify_technician` | boolean | Whether the technician was notified |
 |   ↳ `mark_first_response` | boolean | Whether the note counts as the first response |
 |   ↳ `add_to_linked_requests` | boolean | Whether the note was copied to linked requests |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `created_by` | json | Note author |
-|   ↳ `request` | json | The request the note belongs to |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `created_by` | json (nullable) | Note author |
+|   ↳ `request` | json (nullable) | The request the note belongs to |
 |     ↳ `id` | string | Request ID |
 |     ↳ `display_id` | string | Request number |
 |     ↳ `subject` | string | Request subject |
 | `count` | number | Number of notes returned in this page |
-| `listInfo` | object | Paging metadata echoed by ServiceDesk Plus |
+| `listInfo` | object (nullable) | Paging metadata echoed by ServiceDesk Plus |
 |   ↳ `row_count` | number | Rows returned |
 |   ↳ `start_index` | number | Index the page started at |
 |   ↳ `page` | number | Page number |
@@ -413,28 +413,28 @@ Create a problem record in ManageEngine ServiceDesk Plus Cloud with a title, des
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `problem` | object | The created problem |
+| `problem` | object (nullable) | The created problem |
 |   ↳ `id` | string | Problem ID |
-|   ↳ `display_id` | json | Problem number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Problem number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Problem title |
-|   ↳ `description` | string | Problem description \(HTML\) |
-|   ↳ `status` | json | Current status |
-|   ↳ `priority` | json | Priority |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `category` | json | Category |
-|   ↳ `subcategory` | json | Subcategory |
-|   ↳ `group` | json | Support group |
-|   ↳ `site` | json | Site |
-|   ↳ `reported_by` | json | User who reported the problem |
-|   ↳ `technician` | json | Assigned technician |
-|   ↳ `reported_time` | json | Time the problem was reported |
-|   ↳ `due_by_time` | json | Due time |
-|   ↳ `closed_time` | json | Time the problem was closed |
-|   ↳ `root_cause` | json | Root cause analysis |
-|   ↳ `workaround_details` | json | Documented workaround |
-|   ↳ `resolution_details` | json | Documented resolution |
-|   ↳ `known_error_details` | json | Known-error record details |
+|   ↳ `description` | string (nullable) | Problem description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
+|   ↳ `priority` | json (nullable) | Priority |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `category` | json (nullable) | Category |
+|   ↳ `subcategory` | json (nullable) | Subcategory |
+|   ↳ `group` | json (nullable) | Support group |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `reported_by` | json (nullable) | User who reported the problem |
+|   ↳ `technician` | json (nullable) | Assigned technician |
+|   ↳ `reported_time` | json (nullable) | Time the problem was reported |
+|   ↳ `due_by_time` | json (nullable) | Due time |
+|   ↳ `closed_time` | json (nullable) | Time the problem was closed |
+|   ↳ `root_cause` | json (nullable) | Root cause analysis |
+|   ↳ `workaround_details` | json (nullable) | Documented workaround |
+|   ↳ `resolution_details` | json (nullable) | Documented resolution |
+|   ↳ `known_error_details` | json (nullable) | Known-error record details |
 |   ↳ `notes_present` | boolean | Whether the problem has notes |
 
 ### ManageEngine SDP Get Problem
@@ -453,28 +453,28 @@ Retrieve a single ManageEngine ServiceDesk Plus Cloud problem by ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `problem` | object | The problem |
+| `problem` | object (nullable) | The problem |
 |   ↳ `id` | string | Problem ID |
-|   ↳ `display_id` | json | Problem number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Problem number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Problem title |
-|   ↳ `description` | string | Problem description \(HTML\) |
-|   ↳ `status` | json | Current status |
-|   ↳ `priority` | json | Priority |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `category` | json | Category |
-|   ↳ `subcategory` | json | Subcategory |
-|   ↳ `group` | json | Support group |
-|   ↳ `site` | json | Site |
-|   ↳ `reported_by` | json | User who reported the problem |
-|   ↳ `technician` | json | Assigned technician |
-|   ↳ `reported_time` | json | Time the problem was reported |
-|   ↳ `due_by_time` | json | Due time |
-|   ↳ `closed_time` | json | Time the problem was closed |
-|   ↳ `root_cause` | json | Root cause analysis |
-|   ↳ `workaround_details` | json | Documented workaround |
-|   ↳ `resolution_details` | json | Documented resolution |
-|   ↳ `known_error_details` | json | Known-error record details |
+|   ↳ `description` | string (nullable) | Problem description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
+|   ↳ `priority` | json (nullable) | Priority |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `category` | json (nullable) | Category |
+|   ↳ `subcategory` | json (nullable) | Subcategory |
+|   ↳ `group` | json (nullable) | Support group |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `reported_by` | json (nullable) | User who reported the problem |
+|   ↳ `technician` | json (nullable) | Assigned technician |
+|   ↳ `reported_time` | json (nullable) | Time the problem was reported |
+|   ↳ `due_by_time` | json (nullable) | Due time |
+|   ↳ `closed_time` | json (nullable) | Time the problem was closed |
+|   ↳ `root_cause` | json (nullable) | Root cause analysis |
+|   ↳ `workaround_details` | json (nullable) | Documented workaround |
+|   ↳ `resolution_details` | json (nullable) | Documented resolution |
+|   ↳ `known_error_details` | json (nullable) | Known-error record details |
 |   ↳ `notes_present` | boolean | Whether the problem has notes |
 
 ### ManageEngine SDP List Problems
@@ -501,29 +501,29 @@ List ManageEngine ServiceDesk Plus Cloud problems, with optional search criteria
 | --------- | ---- | ----------- |
 | `problems` | array | Matching problems |
 |   ↳ `id` | string | Problem ID |
-|   ↳ `display_id` | json | Problem number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Problem number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Problem title |
-|   ↳ `description` | string | Problem description \(HTML\) |
-|   ↳ `status` | json | Current status |
-|   ↳ `priority` | json | Priority |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `category` | json | Category |
-|   ↳ `subcategory` | json | Subcategory |
-|   ↳ `group` | json | Support group |
-|   ↳ `site` | json | Site |
-|   ↳ `reported_by` | json | User who reported the problem |
-|   ↳ `technician` | json | Assigned technician |
-|   ↳ `reported_time` | json | Time the problem was reported |
-|   ↳ `due_by_time` | json | Due time |
-|   ↳ `closed_time` | json | Time the problem was closed |
-|   ↳ `root_cause` | json | Root cause analysis |
-|   ↳ `workaround_details` | json | Documented workaround |
-|   ↳ `resolution_details` | json | Documented resolution |
-|   ↳ `known_error_details` | json | Known-error record details |
+|   ↳ `description` | string (nullable) | Problem description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
+|   ↳ `priority` | json (nullable) | Priority |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `category` | json (nullable) | Category |
+|   ↳ `subcategory` | json (nullable) | Subcategory |
+|   ↳ `group` | json (nullable) | Support group |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `reported_by` | json (nullable) | User who reported the problem |
+|   ↳ `technician` | json (nullable) | Assigned technician |
+|   ↳ `reported_time` | json (nullable) | Time the problem was reported |
+|   ↳ `due_by_time` | json (nullable) | Due time |
+|   ↳ `closed_time` | json (nullable) | Time the problem was closed |
+|   ↳ `root_cause` | json (nullable) | Root cause analysis |
+|   ↳ `workaround_details` | json (nullable) | Documented workaround |
+|   ↳ `resolution_details` | json (nullable) | Documented resolution |
+|   ↳ `known_error_details` | json (nullable) | Known-error record details |
 |   ↳ `notes_present` | boolean | Whether the problem has notes |
 | `count` | number | Number of problems returned in this page |
-| `listInfo` | object | Paging metadata echoed by ServiceDesk Plus |
+| `listInfo` | object (nullable) | Paging metadata echoed by ServiceDesk Plus |
 |   ↳ `row_count` | number | Rows returned |
 |   ↳ `start_index` | number | Index the page started at |
 |   ↳ `page` | number | Page number |
@@ -561,28 +561,28 @@ Update a ManageEngine ServiceDesk Plus Cloud problem: change its title, status, 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `problem` | object | The updated problem |
+| `problem` | object (nullable) | The updated problem |
 |   ↳ `id` | string | Problem ID |
-|   ↳ `display_id` | json | Problem number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Problem number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Problem title |
-|   ↳ `description` | string | Problem description \(HTML\) |
-|   ↳ `status` | json | Current status |
-|   ↳ `priority` | json | Priority |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `category` | json | Category |
-|   ↳ `subcategory` | json | Subcategory |
-|   ↳ `group` | json | Support group |
-|   ↳ `site` | json | Site |
-|   ↳ `reported_by` | json | User who reported the problem |
-|   ↳ `technician` | json | Assigned technician |
-|   ↳ `reported_time` | json | Time the problem was reported |
-|   ↳ `due_by_time` | json | Due time |
-|   ↳ `closed_time` | json | Time the problem was closed |
-|   ↳ `root_cause` | json | Root cause analysis |
-|   ↳ `workaround_details` | json | Documented workaround |
-|   ↳ `resolution_details` | json | Documented resolution |
-|   ↳ `known_error_details` | json | Known-error record details |
+|   ↳ `description` | string (nullable) | Problem description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
+|   ↳ `priority` | json (nullable) | Priority |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `category` | json (nullable) | Category |
+|   ↳ `subcategory` | json (nullable) | Subcategory |
+|   ↳ `group` | json (nullable) | Support group |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `reported_by` | json (nullable) | User who reported the problem |
+|   ↳ `technician` | json (nullable) | Assigned technician |
+|   ↳ `reported_time` | json (nullable) | Time the problem was reported |
+|   ↳ `due_by_time` | json (nullable) | Due time |
+|   ↳ `closed_time` | json (nullable) | Time the problem was closed |
+|   ↳ `root_cause` | json (nullable) | Root cause analysis |
+|   ↳ `workaround_details` | json (nullable) | Documented workaround |
+|   ↳ `resolution_details` | json (nullable) | Documented resolution |
+|   ↳ `known_error_details` | json (nullable) | Known-error record details |
 |   ↳ `notes_present` | boolean | Whether the problem has notes |
 
 ### ManageEngine SDP Delete Problem
@@ -620,11 +620,11 @@ Add a note to a ManageEngine ServiceDesk Plus Cloud problem.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `note` | object | The created note |
+| `note` | object (nullable) | The created note |
 |   ↳ `id` | string | Note ID |
 |   ↳ `description` | string | Note body \(HTML\) |
-|   ↳ `performed_by` | json | Note author |
-|   ↳ `performed_time` | json | Time the note was added |
+|   ↳ `performed_by` | json (nullable) | Note author |
+|   ↳ `performed_time` | json (nullable) | Time the note was added |
 
 ### ManageEngine SDP List Problem Notes
 
@@ -652,10 +652,10 @@ List the notes on a ManageEngine ServiceDesk Plus Cloud problem.
 | `notes` | array | Notes on the problem |
 |   ↳ `id` | string | Note ID |
 |   ↳ `description` | string | Note body \(HTML\) |
-|   ↳ `performed_by` | json | Note author |
-|   ↳ `performed_time` | json | Time the note was added |
+|   ↳ `performed_by` | json (nullable) | Note author |
+|   ↳ `performed_time` | json (nullable) | Time the note was added |
 | `count` | number | Number of notes returned in this page |
-| `listInfo` | object | Paging metadata echoed by ServiceDesk Plus |
+| `listInfo` | object (nullable) | Paging metadata echoed by ServiceDesk Plus |
 |   ↳ `row_count` | number | Rows returned |
 |   ↳ `start_index` | number | Index the page started at |
 |   ↳ `page` | number | Page number |
@@ -697,32 +697,32 @@ Create a change record in ManageEngine ServiceDesk Plus Cloud with a title, stag
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `change` | object | The created change |
+| `change` | object (nullable) | The created change |
 |   ↳ `id` | string | Change ID |
-|   ↳ `display_id` | json | Change number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Change number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Change title |
-|   ↳ `description` | string | Change description \(HTML\) |
-|   ↳ `status` | json | Current status |
+|   ↳ `description` | string (nullable) | Change description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
 |     ↳ `internal_name` | string | Internal status name |
-|     ↳ `stage` | json | Change stage |
-|   ↳ `change_type` | json | Change type |
+|     ↳ `stage` | json (nullable) | Change stage |
+|   ↳ `change_type` | json (nullable) | Change type |
 |     ↳ `color` | string | Type colour |
 |     ↳ `pre_approved` | boolean | Whether the type is pre-approved |
-|   ↳ `priority` | json | Priority |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `approval_status` | json | Approval status |
-|   ↳ `reason_for_change` | json | Reason for the change |
-|   ↳ `change_requester` | json | User who requested the change |
-|   ↳ `change_owner` | json | Change owner |
-|   ↳ `change_manager` | json | Change manager |
-|   ↳ `group` | json | Support group |
+|   ↳ `priority` | json (nullable) | Priority |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `approval_status` | json (nullable) | Approval status |
+|   ↳ `reason_for_change` | json (nullable) | Reason for the change |
+|   ↳ `change_requester` | json (nullable) | User who requested the change |
+|   ↳ `change_owner` | json (nullable) | Change owner |
+|   ↳ `change_manager` | json (nullable) | Change manager |
+|   ↳ `group` | json (nullable) | Support group |
 |   ↳ `emergency` | boolean | Whether the change is an emergency |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `scheduled_start_time` | json | Scheduled start |
-|   ↳ `scheduled_end_time` | json | Scheduled end |
-|   ↳ `roll_out_plan` | json | Roll-out plan |
-|   ↳ `close_details` | json | Closure details |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `scheduled_start_time` | json (nullable) | Scheduled start |
+|   ↳ `scheduled_end_time` | json (nullable) | Scheduled end |
+|   ↳ `roll_out_plan` | json (nullable) | Roll-out plan |
+|   ↳ `close_details` | json (nullable) | Closure details |
 
 ### ManageEngine SDP Get Change
 
@@ -740,32 +740,32 @@ Retrieve a single ManageEngine ServiceDesk Plus Cloud change by ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `change` | object | The change |
+| `change` | object (nullable) | The change |
 |   ↳ `id` | string | Change ID |
-|   ↳ `display_id` | json | Change number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Change number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Change title |
-|   ↳ `description` | string | Change description \(HTML\) |
-|   ↳ `status` | json | Current status |
+|   ↳ `description` | string (nullable) | Change description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
 |     ↳ `internal_name` | string | Internal status name |
-|     ↳ `stage` | json | Change stage |
-|   ↳ `change_type` | json | Change type |
+|     ↳ `stage` | json (nullable) | Change stage |
+|   ↳ `change_type` | json (nullable) | Change type |
 |     ↳ `color` | string | Type colour |
 |     ↳ `pre_approved` | boolean | Whether the type is pre-approved |
-|   ↳ `priority` | json | Priority |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `approval_status` | json | Approval status |
-|   ↳ `reason_for_change` | json | Reason for the change |
-|   ↳ `change_requester` | json | User who requested the change |
-|   ↳ `change_owner` | json | Change owner |
-|   ↳ `change_manager` | json | Change manager |
-|   ↳ `group` | json | Support group |
+|   ↳ `priority` | json (nullable) | Priority |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `approval_status` | json (nullable) | Approval status |
+|   ↳ `reason_for_change` | json (nullable) | Reason for the change |
+|   ↳ `change_requester` | json (nullable) | User who requested the change |
+|   ↳ `change_owner` | json (nullable) | Change owner |
+|   ↳ `change_manager` | json (nullable) | Change manager |
+|   ↳ `group` | json (nullable) | Support group |
 |   ↳ `emergency` | boolean | Whether the change is an emergency |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `scheduled_start_time` | json | Scheduled start |
-|   ↳ `scheduled_end_time` | json | Scheduled end |
-|   ↳ `roll_out_plan` | json | Roll-out plan |
-|   ↳ `close_details` | json | Closure details |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `scheduled_start_time` | json (nullable) | Scheduled start |
+|   ↳ `scheduled_end_time` | json (nullable) | Scheduled end |
+|   ↳ `roll_out_plan` | json (nullable) | Roll-out plan |
+|   ↳ `close_details` | json (nullable) | Closure details |
 
 ### ManageEngine SDP List Changes
 
@@ -791,32 +791,32 @@ List ManageEngine ServiceDesk Plus Cloud changes, with optional search criteria,
 | --------- | ---- | ----------- |
 | `changes` | array | Matching changes |
 |   ↳ `id` | string | Change ID |
-|   ↳ `display_id` | json | Change number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Change number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Change title |
-|   ↳ `description` | string | Change description \(HTML\) |
-|   ↳ `status` | json | Current status |
+|   ↳ `description` | string (nullable) | Change description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
 |     ↳ `internal_name` | string | Internal status name |
-|     ↳ `stage` | json | Change stage |
-|   ↳ `change_type` | json | Change type |
+|     ↳ `stage` | json (nullable) | Change stage |
+|   ↳ `change_type` | json (nullable) | Change type |
 |     ↳ `color` | string | Type colour |
 |     ↳ `pre_approved` | boolean | Whether the type is pre-approved |
-|   ↳ `priority` | json | Priority |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `approval_status` | json | Approval status |
-|   ↳ `reason_for_change` | json | Reason for the change |
-|   ↳ `change_requester` | json | User who requested the change |
-|   ↳ `change_owner` | json | Change owner |
-|   ↳ `change_manager` | json | Change manager |
-|   ↳ `group` | json | Support group |
+|   ↳ `priority` | json (nullable) | Priority |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `approval_status` | json (nullable) | Approval status |
+|   ↳ `reason_for_change` | json (nullable) | Reason for the change |
+|   ↳ `change_requester` | json (nullable) | User who requested the change |
+|   ↳ `change_owner` | json (nullable) | Change owner |
+|   ↳ `change_manager` | json (nullable) | Change manager |
+|   ↳ `group` | json (nullable) | Support group |
 |   ↳ `emergency` | boolean | Whether the change is an emergency |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `scheduled_start_time` | json | Scheduled start |
-|   ↳ `scheduled_end_time` | json | Scheduled end |
-|   ↳ `roll_out_plan` | json | Roll-out plan |
-|   ↳ `close_details` | json | Closure details |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `scheduled_start_time` | json (nullable) | Scheduled start |
+|   ↳ `scheduled_end_time` | json (nullable) | Scheduled end |
+|   ↳ `roll_out_plan` | json (nullable) | Roll-out plan |
+|   ↳ `close_details` | json (nullable) | Closure details |
 | `count` | number | Number of changes returned in this page |
-| `listInfo` | object | Paging metadata echoed by ServiceDesk Plus |
+| `listInfo` | object (nullable) | Paging metadata echoed by ServiceDesk Plus |
 |   ↳ `row_count` | number | Rows returned |
 |   ↳ `start_index` | number | Index the page started at |
 |   ↳ `page` | number | Page number |
@@ -859,32 +859,32 @@ Update a ManageEngine ServiceDesk Plus Cloud change: move its stage or status, r
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `change` | object | The updated change |
+| `change` | object (nullable) | The updated change |
 |   ↳ `id` | string | Change ID |
-|   ↳ `display_id` | json | Change number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Change number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Change title |
-|   ↳ `description` | string | Change description \(HTML\) |
-|   ↳ `status` | json | Current status |
+|   ↳ `description` | string (nullable) | Change description \(HTML\) |
+|   ↳ `status` | json (nullable) | Current status |
 |     ↳ `internal_name` | string | Internal status name |
-|     ↳ `stage` | json | Change stage |
-|   ↳ `change_type` | json | Change type |
+|     ↳ `stage` | json (nullable) | Change stage |
+|   ↳ `change_type` | json (nullable) | Change type |
 |     ↳ `color` | string | Type colour |
 |     ↳ `pre_approved` | boolean | Whether the type is pre-approved |
-|   ↳ `priority` | json | Priority |
-|   ↳ `urgency` | json | Urgency |
-|   ↳ `impact` | json | Impact |
-|   ↳ `approval_status` | json | Approval status |
-|   ↳ `reason_for_change` | json | Reason for the change |
-|   ↳ `change_requester` | json | User who requested the change |
-|   ↳ `change_owner` | json | Change owner |
-|   ↳ `change_manager` | json | Change manager |
-|   ↳ `group` | json | Support group |
+|   ↳ `priority` | json (nullable) | Priority |
+|   ↳ `urgency` | json (nullable) | Urgency |
+|   ↳ `impact` | json (nullable) | Impact |
+|   ↳ `approval_status` | json (nullable) | Approval status |
+|   ↳ `reason_for_change` | json (nullable) | Reason for the change |
+|   ↳ `change_requester` | json (nullable) | User who requested the change |
+|   ↳ `change_owner` | json (nullable) | Change owner |
+|   ↳ `change_manager` | json (nullable) | Change manager |
+|   ↳ `group` | json (nullable) | Support group |
 |   ↳ `emergency` | boolean | Whether the change is an emergency |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `scheduled_start_time` | json | Scheduled start |
-|   ↳ `scheduled_end_time` | json | Scheduled end |
-|   ↳ `roll_out_plan` | json | Roll-out plan |
-|   ↳ `close_details` | json | Closure details |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `scheduled_start_time` | json (nullable) | Scheduled start |
+|   ↳ `scheduled_end_time` | json (nullable) | Scheduled end |
+|   ↳ `roll_out_plan` | json (nullable) | Roll-out plan |
+|   ↳ `close_details` | json (nullable) | Closure details |
 
 ### ManageEngine SDP Delete Change
 
@@ -921,11 +921,11 @@ Add a note to a ManageEngine ServiceDesk Plus Cloud change.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `note` | object | The created note |
+| `note` | object (nullable) | The created note |
 |   ↳ `id` | string | Note ID |
 |   ↳ `description` | string | Note body \(HTML\) |
-|   ↳ `performed_by` | json | Note author |
-|   ↳ `performed_time` | json | Time the note was added |
+|   ↳ `performed_by` | json (nullable) | Note author |
+|   ↳ `performed_time` | json (nullable) | Time the note was added |
 
 ### ManageEngine SDP List Change Notes
 
@@ -953,10 +953,10 @@ List the notes on a ManageEngine ServiceDesk Plus Cloud change.
 | `notes` | array | Notes on the change |
 |   ↳ `id` | string | Note ID |
 |   ↳ `description` | string | Note body \(HTML\) |
-|   ↳ `performed_by` | json | Note author |
-|   ↳ `performed_time` | json | Time the note was added |
+|   ↳ `performed_by` | json (nullable) | Note author |
+|   ↳ `performed_time` | json (nullable) | Time the note was added |
 | `count` | number | Number of notes returned in this page |
-| `listInfo` | object | Paging metadata echoed by ServiceDesk Plus |
+| `listInfo` | object (nullable) | Paging metadata echoed by ServiceDesk Plus |
 |   ↳ `row_count` | number | Rows returned |
 |   ↳ `start_index` | number | Index the page started at |
 |   ↳ `page` | number | Page number |
@@ -996,30 +996,30 @@ Create an asset in the ManageEngine ServiceDesk Plus Cloud inventory. Requires a
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `asset` | object | The created asset |
+| `asset` | object (nullable) | The created asset |
 |   ↳ `id` | string | Asset ID |
 |   ↳ `name` | string | Asset name |
-|   ↳ `asset_tag` | string | Asset tag |
-|   ↳ `barcode` | string | Barcode |
-|   ↳ `serial_number` | string | Serial number |
-|   ↳ `ip_address` | string | IP address |
-|   ↳ `mac_address` | string | MAC address |
-|   ↳ `location` | string | Location |
-|   ↳ `state` | json | Asset state \(In Use, In Store, ...\) |
+|   ↳ `asset_tag` | string (nullable) | Asset tag |
+|   ↳ `barcode` | string (nullable) | Barcode |
+|   ↳ `serial_number` | string (nullable) | Serial number |
+|   ↳ `ip_address` | string (nullable) | IP address |
+|   ↳ `mac_address` | string (nullable) | MAC address |
+|   ↳ `location` | string (nullable) | Location |
+|   ↳ `state` | json (nullable) | Asset state \(In Use, In Store, ...\) |
 |     ↳ `description` | string | State description |
-|   ↳ `product` | json | Product this asset is an instance of |
+|   ↳ `product` | json (nullable) | Product this asset is an instance of |
 |     ↳ `manufacturer` | string | Manufacturer |
 |     ↳ `part_no` | string | Part number |
-|   ↳ `product_type` | json | Product type |
-|   ↳ `vendor` | json | Vendor |
-|   ↳ `department` | json | Owning department |
-|   ↳ `site` | json | Site |
-|   ↳ `user` | json | User the asset is assigned to |
-|   ↳ `purchase_cost` | number | Purchase cost |
-|   ↳ `total_cost` | number | Total cost |
-|   ↳ `acquisition_date` | json | Acquisition date |
-|   ↳ `expiry_date` | json | Expiry date |
-|   ↳ `warranty_expiry` | json | Warranty expiry date |
+|   ↳ `product_type` | json (nullable) | Product type |
+|   ↳ `vendor` | json (nullable) | Vendor |
+|   ↳ `department` | json (nullable) | Owning department |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `user` | json (nullable) | User the asset is assigned to |
+|   ↳ `purchase_cost` | number (nullable) | Purchase cost |
+|   ↳ `total_cost` | number (nullable) | Total cost |
+|   ↳ `acquisition_date` | json (nullable) | Acquisition date |
+|   ↳ `expiry_date` | json (nullable) | Expiry date |
+|   ↳ `warranty_expiry` | json (nullable) | Warranty expiry date |
 |   ↳ `is_loaned` | boolean | Whether the asset is on loan |
 |   ↳ `is_in_contract` | boolean | Whether the asset is covered by a contract |
 
@@ -1039,30 +1039,30 @@ Retrieve a single ManageEngine ServiceDesk Plus Cloud asset by ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `asset` | object | The asset |
+| `asset` | object (nullable) | The asset |
 |   ↳ `id` | string | Asset ID |
 |   ↳ `name` | string | Asset name |
-|   ↳ `asset_tag` | string | Asset tag |
-|   ↳ `barcode` | string | Barcode |
-|   ↳ `serial_number` | string | Serial number |
-|   ↳ `ip_address` | string | IP address |
-|   ↳ `mac_address` | string | MAC address |
-|   ↳ `location` | string | Location |
-|   ↳ `state` | json | Asset state \(In Use, In Store, ...\) |
+|   ↳ `asset_tag` | string (nullable) | Asset tag |
+|   ↳ `barcode` | string (nullable) | Barcode |
+|   ↳ `serial_number` | string (nullable) | Serial number |
+|   ↳ `ip_address` | string (nullable) | IP address |
+|   ↳ `mac_address` | string (nullable) | MAC address |
+|   ↳ `location` | string (nullable) | Location |
+|   ↳ `state` | json (nullable) | Asset state \(In Use, In Store, ...\) |
 |     ↳ `description` | string | State description |
-|   ↳ `product` | json | Product this asset is an instance of |
+|   ↳ `product` | json (nullable) | Product this asset is an instance of |
 |     ↳ `manufacturer` | string | Manufacturer |
 |     ↳ `part_no` | string | Part number |
-|   ↳ `product_type` | json | Product type |
-|   ↳ `vendor` | json | Vendor |
-|   ↳ `department` | json | Owning department |
-|   ↳ `site` | json | Site |
-|   ↳ `user` | json | User the asset is assigned to |
-|   ↳ `purchase_cost` | number | Purchase cost |
-|   ↳ `total_cost` | number | Total cost |
-|   ↳ `acquisition_date` | json | Acquisition date |
-|   ↳ `expiry_date` | json | Expiry date |
-|   ↳ `warranty_expiry` | json | Warranty expiry date |
+|   ↳ `product_type` | json (nullable) | Product type |
+|   ↳ `vendor` | json (nullable) | Vendor |
+|   ↳ `department` | json (nullable) | Owning department |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `user` | json (nullable) | User the asset is assigned to |
+|   ↳ `purchase_cost` | number (nullable) | Purchase cost |
+|   ↳ `total_cost` | number (nullable) | Total cost |
+|   ↳ `acquisition_date` | json (nullable) | Acquisition date |
+|   ↳ `expiry_date` | json (nullable) | Expiry date |
+|   ↳ `warranty_expiry` | json (nullable) | Warranty expiry date |
 |   ↳ `is_loaned` | boolean | Whether the asset is on loan |
 |   ↳ `is_in_contract` | boolean | Whether the asset is covered by a contract |
 
@@ -1091,31 +1091,31 @@ List ManageEngine ServiceDesk Plus Cloud assets, with optional search criteria, 
 | `assets` | array | Matching assets |
 |   ↳ `id` | string | Asset ID |
 |   ↳ `name` | string | Asset name |
-|   ↳ `asset_tag` | string | Asset tag |
-|   ↳ `barcode` | string | Barcode |
-|   ↳ `serial_number` | string | Serial number |
-|   ↳ `ip_address` | string | IP address |
-|   ↳ `mac_address` | string | MAC address |
-|   ↳ `location` | string | Location |
-|   ↳ `state` | json | Asset state \(In Use, In Store, ...\) |
+|   ↳ `asset_tag` | string (nullable) | Asset tag |
+|   ↳ `barcode` | string (nullable) | Barcode |
+|   ↳ `serial_number` | string (nullable) | Serial number |
+|   ↳ `ip_address` | string (nullable) | IP address |
+|   ↳ `mac_address` | string (nullable) | MAC address |
+|   ↳ `location` | string (nullable) | Location |
+|   ↳ `state` | json (nullable) | Asset state \(In Use, In Store, ...\) |
 |     ↳ `description` | string | State description |
-|   ↳ `product` | json | Product this asset is an instance of |
+|   ↳ `product` | json (nullable) | Product this asset is an instance of |
 |     ↳ `manufacturer` | string | Manufacturer |
 |     ↳ `part_no` | string | Part number |
-|   ↳ `product_type` | json | Product type |
-|   ↳ `vendor` | json | Vendor |
-|   ↳ `department` | json | Owning department |
-|   ↳ `site` | json | Site |
-|   ↳ `user` | json | User the asset is assigned to |
-|   ↳ `purchase_cost` | number | Purchase cost |
-|   ↳ `total_cost` | number | Total cost |
-|   ↳ `acquisition_date` | json | Acquisition date |
-|   ↳ `expiry_date` | json | Expiry date |
-|   ↳ `warranty_expiry` | json | Warranty expiry date |
+|   ↳ `product_type` | json (nullable) | Product type |
+|   ↳ `vendor` | json (nullable) | Vendor |
+|   ↳ `department` | json (nullable) | Owning department |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `user` | json (nullable) | User the asset is assigned to |
+|   ↳ `purchase_cost` | number (nullable) | Purchase cost |
+|   ↳ `total_cost` | number (nullable) | Total cost |
+|   ↳ `acquisition_date` | json (nullable) | Acquisition date |
+|   ↳ `expiry_date` | json (nullable) | Expiry date |
+|   ↳ `warranty_expiry` | json (nullable) | Warranty expiry date |
 |   ↳ `is_loaned` | boolean | Whether the asset is on loan |
 |   ↳ `is_in_contract` | boolean | Whether the asset is covered by a contract |
 | `count` | number | Number of assets returned in this page |
-| `listInfo` | object | Paging metadata echoed by ServiceDesk Plus |
+| `listInfo` | object (nullable) | Paging metadata echoed by ServiceDesk Plus |
 |   ↳ `row_count` | number | Rows returned |
 |   ↳ `start_index` | number | Index the page started at |
 |   ↳ `page` | number | Page number |
@@ -1156,30 +1156,30 @@ Update a ManageEngine ServiceDesk Plus Cloud asset: reassign it, change its stat
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `asset` | object | The updated asset |
+| `asset` | object (nullable) | The updated asset |
 |   ↳ `id` | string | Asset ID |
 |   ↳ `name` | string | Asset name |
-|   ↳ `asset_tag` | string | Asset tag |
-|   ↳ `barcode` | string | Barcode |
-|   ↳ `serial_number` | string | Serial number |
-|   ↳ `ip_address` | string | IP address |
-|   ↳ `mac_address` | string | MAC address |
-|   ↳ `location` | string | Location |
-|   ↳ `state` | json | Asset state \(In Use, In Store, ...\) |
+|   ↳ `asset_tag` | string (nullable) | Asset tag |
+|   ↳ `barcode` | string (nullable) | Barcode |
+|   ↳ `serial_number` | string (nullable) | Serial number |
+|   ↳ `ip_address` | string (nullable) | IP address |
+|   ↳ `mac_address` | string (nullable) | MAC address |
+|   ↳ `location` | string (nullable) | Location |
+|   ↳ `state` | json (nullable) | Asset state \(In Use, In Store, ...\) |
 |     ↳ `description` | string | State description |
-|   ↳ `product` | json | Product this asset is an instance of |
+|   ↳ `product` | json (nullable) | Product this asset is an instance of |
 |     ↳ `manufacturer` | string | Manufacturer |
 |     ↳ `part_no` | string | Part number |
-|   ↳ `product_type` | json | Product type |
-|   ↳ `vendor` | json | Vendor |
-|   ↳ `department` | json | Owning department |
-|   ↳ `site` | json | Site |
-|   ↳ `user` | json | User the asset is assigned to |
-|   ↳ `purchase_cost` | number | Purchase cost |
-|   ↳ `total_cost` | number | Total cost |
-|   ↳ `acquisition_date` | json | Acquisition date |
-|   ↳ `expiry_date` | json | Expiry date |
-|   ↳ `warranty_expiry` | json | Warranty expiry date |
+|   ↳ `product_type` | json (nullable) | Product type |
+|   ↳ `vendor` | json (nullable) | Vendor |
+|   ↳ `department` | json (nullable) | Owning department |
+|   ↳ `site` | json (nullable) | Site |
+|   ↳ `user` | json (nullable) | User the asset is assigned to |
+|   ↳ `purchase_cost` | number (nullable) | Purchase cost |
+|   ↳ `total_cost` | number (nullable) | Total cost |
+|   ↳ `acquisition_date` | json (nullable) | Acquisition date |
+|   ↳ `expiry_date` | json (nullable) | Expiry date |
+|   ↳ `warranty_expiry` | json (nullable) | Warranty expiry date |
 |   ↳ `is_loaned` | boolean | Whether the asset is on loan |
 |   ↳ `is_in_contract` | boolean | Whether the asset is covered by a contract |
 
@@ -1222,26 +1222,26 @@ Add an article to the ManageEngine ServiceDesk Plus Cloud knowledge base under a
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `solution` | object | The created solution |
+| `solution` | object (nullable) | The created solution |
 |   ↳ `id` | string | Solution ID |
-|   ↳ `display_id` | json | Solution number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Solution number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Solution title |
-|   ↳ `description` | string | Solution body \(HTML\) |
-|   ↳ `topic` | json | Topic the solution is filed under |
-|     ↳ `parent_topic` | json | Parent topic |
-|   ↳ `approval_status` | json | Approval status |
-|   ↳ `keywords` | string | Search keywords |
+|   ↳ `description` | string (nullable) | Solution body \(HTML\) |
+|   ↳ `topic` | json (nullable) | Topic the solution is filed under |
+|     ↳ `parent_topic` | json (nullable) | Parent topic |
+|   ↳ `approval_status` | json (nullable) | Approval status |
+|   ↳ `keywords` | string (nullable) | Search keywords |
 |   ↳ `is_public` | boolean | Whether requesters can see the solution |
 |   ↳ `likes` | number | Like count |
 |   ↳ `dislikes` | number | Dislike count |
 |   ↳ `no_of_hits` | number | View count |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `last_updated_time` | json | Last update time |
-|   ↳ `review_date` | json | Date the solution is due for review |
-|   ↳ `expiry_date` | json | Date the solution expires |
-|   ↳ `created_by` | json | Author |
-|   ↳ `last_updated_by` | json | User who last updated the solution |
-|   ↳ `udf_fields` | json | Portal-defined custom fields |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `last_updated_time` | json (nullable) | Last update time |
+|   ↳ `review_date` | json (nullable) | Date the solution is due for review |
+|   ↳ `expiry_date` | json (nullable) | Date the solution expires |
+|   ↳ `created_by` | json (nullable) | Author |
+|   ↳ `last_updated_by` | json (nullable) | User who last updated the solution |
+|   ↳ `udf_fields` | json (nullable) | Portal-defined custom fields |
 
 ### ManageEngine SDP Get Solution
 
@@ -1259,26 +1259,26 @@ Retrieve a single ManageEngine ServiceDesk Plus Cloud knowledge base solution by
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `solution` | object | The solution |
+| `solution` | object (nullable) | The solution |
 |   ↳ `id` | string | Solution ID |
-|   ↳ `display_id` | json | Solution number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Solution number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Solution title |
-|   ↳ `description` | string | Solution body \(HTML\) |
-|   ↳ `topic` | json | Topic the solution is filed under |
-|     ↳ `parent_topic` | json | Parent topic |
-|   ↳ `approval_status` | json | Approval status |
-|   ↳ `keywords` | string | Search keywords |
+|   ↳ `description` | string (nullable) | Solution body \(HTML\) |
+|   ↳ `topic` | json (nullable) | Topic the solution is filed under |
+|     ↳ `parent_topic` | json (nullable) | Parent topic |
+|   ↳ `approval_status` | json (nullable) | Approval status |
+|   ↳ `keywords` | string (nullable) | Search keywords |
 |   ↳ `is_public` | boolean | Whether requesters can see the solution |
 |   ↳ `likes` | number | Like count |
 |   ↳ `dislikes` | number | Dislike count |
 |   ↳ `no_of_hits` | number | View count |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `last_updated_time` | json | Last update time |
-|   ↳ `review_date` | json | Date the solution is due for review |
-|   ↳ `expiry_date` | json | Date the solution expires |
-|   ↳ `created_by` | json | Author |
-|   ↳ `last_updated_by` | json | User who last updated the solution |
-|   ↳ `udf_fields` | json | Portal-defined custom fields |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `last_updated_time` | json (nullable) | Last update time |
+|   ↳ `review_date` | json (nullable) | Date the solution is due for review |
+|   ↳ `expiry_date` | json (nullable) | Date the solution expires |
+|   ↳ `created_by` | json (nullable) | Author |
+|   ↳ `last_updated_by` | json (nullable) | User who last updated the solution |
+|   ↳ `udf_fields` | json (nullable) | Portal-defined custom fields |
 
 ### ManageEngine SDP List Solutions
 
@@ -1304,26 +1304,26 @@ Search the ManageEngine ServiceDesk Plus Cloud knowledge base, with optional sea
 | --------- | ---- | ----------- |
 | `solutions` | array | Matching solutions |
 |   ↳ `id` | string | Solution ID |
-|   ↳ `display_id` | json | Solution number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Solution number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Solution title |
-|   ↳ `description` | string | Solution body \(HTML\) |
-|   ↳ `topic` | json | Topic the solution is filed under |
-|     ↳ `parent_topic` | json | Parent topic |
-|   ↳ `approval_status` | json | Approval status |
-|   ↳ `keywords` | string | Search keywords |
+|   ↳ `description` | string (nullable) | Solution body \(HTML\) |
+|   ↳ `topic` | json (nullable) | Topic the solution is filed under |
+|     ↳ `parent_topic` | json (nullable) | Parent topic |
+|   ↳ `approval_status` | json (nullable) | Approval status |
+|   ↳ `keywords` | string (nullable) | Search keywords |
 |   ↳ `is_public` | boolean | Whether requesters can see the solution |
 |   ↳ `likes` | number | Like count |
 |   ↳ `dislikes` | number | Dislike count |
 |   ↳ `no_of_hits` | number | View count |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `last_updated_time` | json | Last update time |
-|   ↳ `review_date` | json | Date the solution is due for review |
-|   ↳ `expiry_date` | json | Date the solution expires |
-|   ↳ `created_by` | json | Author |
-|   ↳ `last_updated_by` | json | User who last updated the solution |
-|   ↳ `udf_fields` | json | Portal-defined custom fields |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `last_updated_time` | json (nullable) | Last update time |
+|   ↳ `review_date` | json (nullable) | Date the solution is due for review |
+|   ↳ `expiry_date` | json (nullable) | Date the solution expires |
+|   ↳ `created_by` | json (nullable) | Author |
+|   ↳ `last_updated_by` | json (nullable) | User who last updated the solution |
+|   ↳ `udf_fields` | json (nullable) | Portal-defined custom fields |
 | `count` | number | Number of solutions returned in this page |
-| `listInfo` | object | Paging metadata echoed by ServiceDesk Plus |
+| `listInfo` | object (nullable) | Paging metadata echoed by ServiceDesk Plus |
 |   ↳ `row_count` | number | Rows returned |
 |   ↳ `start_index` | number | Index the page started at |
 |   ↳ `page` | number | Page number |
@@ -1354,26 +1354,26 @@ Update a ManageEngine ServiceDesk Plus Cloud knowledge base solution: revise its
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `solution` | object | The updated solution |
+| `solution` | object (nullable) | The updated solution |
 |   ↳ `id` | string | Solution ID |
-|   ↳ `display_id` | json | Solution number shown in the SDP UI \(display_value, value\) |
+|   ↳ `display_id` | json (nullable) | Solution number shown in the SDP UI \(display_value, value\) |
 |   ↳ `title` | string | Solution title |
-|   ↳ `description` | string | Solution body \(HTML\) |
-|   ↳ `topic` | json | Topic the solution is filed under |
-|     ↳ `parent_topic` | json | Parent topic |
-|   ↳ `approval_status` | json | Approval status |
-|   ↳ `keywords` | string | Search keywords |
+|   ↳ `description` | string (nullable) | Solution body \(HTML\) |
+|   ↳ `topic` | json (nullable) | Topic the solution is filed under |
+|     ↳ `parent_topic` | json (nullable) | Parent topic |
+|   ↳ `approval_status` | json (nullable) | Approval status |
+|   ↳ `keywords` | string (nullable) | Search keywords |
 |   ↳ `is_public` | boolean | Whether requesters can see the solution |
 |   ↳ `likes` | number | Like count |
 |   ↳ `dislikes` | number | Dislike count |
 |   ↳ `no_of_hits` | number | View count |
-|   ↳ `created_time` | json | Creation time |
-|   ↳ `last_updated_time` | json | Last update time |
-|   ↳ `review_date` | json | Date the solution is due for review |
-|   ↳ `expiry_date` | json | Date the solution expires |
-|   ↳ `created_by` | json | Author |
-|   ↳ `last_updated_by` | json | User who last updated the solution |
-|   ↳ `udf_fields` | json | Portal-defined custom fields |
+|   ↳ `created_time` | json (nullable) | Creation time |
+|   ↳ `last_updated_time` | json (nullable) | Last update time |
+|   ↳ `review_date` | json (nullable) | Date the solution is due for review |
+|   ↳ `expiry_date` | json (nullable) | Date the solution expires |
+|   ↳ `created_by` | json (nullable) | Author |
+|   ↳ `last_updated_by` | json (nullable) | User who last updated the solution |
+|   ↳ `udf_fields` | json (nullable) | Portal-defined custom fields |
 
 ### ManageEngine SDP Delete Solution
 
@@ -1392,5 +1392,3 @@ Delete an article from the ManageEngine ServiceDesk Plus Cloud knowledge base, a
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the solution was deleted |
-
-

--- a/apps/docs/content/docs/integrations/mem0.mdx
+++ b/apps/docs/content/docs/integrations/mem0.mdx
@@ -5,7 +5,7 @@ description: Agent memory management
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="mem0"
   color="#181C1E"
 />
@@ -111,5 +111,3 @@ Retrieve memories from Mem0 by ID or filter criteria
 | `count` | number | Total number of memories matching the filters |
 | `next` | string | URL for the next page of results |
 | `previous` | string | URL for the previous page of results |
-
-

--- a/apps/docs/content/docs/integrations/memory.mdx
+++ b/apps/docs/content/docs/integrations/memory.mdx
@@ -5,7 +5,7 @@ description: Add memory store
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="memory"
   color="#F64F9E"
 />
@@ -100,5 +100,3 @@ Delete memories by conversationId.
 | `success` | boolean | Whether the memory was deleted successfully |
 | `message` | string | Success or error message |
 | `error` | string | Error message if operation failed |
-
-

--- a/apps/docs/content/docs/integrations/microsoft_ad.mdx
+++ b/apps/docs/content/docs/integrations/microsoft_ad.mdx
@@ -5,7 +5,7 @@ description: Manage identities, licenses, roles, and access in Azure AD (Microso
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="microsoft_ad"
   color="#0078D4"
 />
@@ -976,5 +976,3 @@ Get a single conditional access policy by ID, including the conditions it matche
 |   ↳ `conditions` | json | Conditions that trigger the policy \(users, applications, platforms, locations, risk levels\) |
 |   ↳ `grantControls` | json | Controls enforced when the policy applies, or null when none are configured |
 |   ↳ `sessionControls` | json | Session controls enforced when the policy applies, or null when none are set |
-
-

--- a/apps/docs/content/docs/integrations/microsoft_dataverse.mdx
+++ b/apps/docs/content/docs/integrations/microsoft_dataverse.mdx
@@ -5,7 +5,7 @@ description: Manage records in Microsoft Dataverse tables
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="microsoft_dataverse"
   color="#FFFFFF"
 />
@@ -436,5 +436,3 @@ Retrieve the current authenticated user information from Microsoft Dataverse. Us
 | `businessUnitId` | string | The business unit ID |
 | `organizationId` | string | The organization ID |
 | `success` | boolean | Operation success status |
-
-

--- a/apps/docs/content/docs/integrations/microsoft_dynamics_365.mdx
+++ b/apps/docs/content/docs/integrations/microsoft_dynamics_365.mdx
@@ -5,7 +5,7 @@ description: Manage customers, sales pipelines, and support cases in Dynamics 36
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="microsoft_dynamics_365"
   color="#FFFFFF"
 />
@@ -55,10 +55,10 @@ Query supported standard Microsoft Dynamics 365 CRM records. Supports OData filt
 | --------- | ---- | ----------- |
 | `records` | array | Array of Dataverse records. Each record has dynamic columns based on the table schema. |
 | `count` | number | Number of records returned in the current page |
-| `totalCount` | number | Provider-reported matching-record count, which Dataverse may cap \(requires $count=true\) |
-| `totalCountLimitExceeded` | boolean | Whether Dataverse capped the provider-reported matching-record count |
-| `nextLink` | string | URL for the next page of results |
-| `nextPageSize` | number | Page size that must accompany nextLink on the continuation request |
+| `totalCount` | number (nullable) | Provider-reported matching-record count, which Dataverse may cap \(requires $count=true\) |
+| `totalCountLimitExceeded` | boolean (nullable) | Whether Dataverse capped the provider-reported matching-record count |
+| `nextLink` | string (nullable) | URL for the next page of results |
+| `nextPageSize` | number (nullable) | Page size that must accompany nextLink on the continuation request |
 | `success` | boolean | Operation success status |
 
 ### Get Microsoft Dynamics 365 CRM Record
@@ -155,7 +155,7 @@ Perform a full-text relevance search across Microsoft Dataverse tables. Requires
 |   ↳ `Score` | number | Relevance score for this result |
 | `totalCount` | number | Total number of matching records across all tables |
 | `count` | number | Number of results returned in this page |
-| `facets` | object | Facet results when facets were requested. Keys are facet names, values are arrays of facet value objects with count and value properties. |
+| `facets` | object (nullable) | Facet results when facets were requested. Keys are facet names, values are arrays of facet value objects with count and value properties. |
 | `success` | boolean | Operation success status |
 
 ### Qualify Microsoft Dynamics 365 Lead
@@ -230,5 +230,3 @@ Resolve and close a Dynamics 365 Customer Service case.
 | --------- | ---- | ----------- |
 | `caseId` | string | GUID of the closed case |
 | `success` | boolean | Whether the case was closed successfully |
-
-

--- a/apps/docs/content/docs/integrations/microsoft_excel.mdx
+++ b/apps/docs/content/docs/integrations/microsoft_excel.mdx
@@ -5,7 +5,7 @@ description: Read and write data with sheet selection
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="microsoft_excel_v2"
   color="#FFFFFF"
 />
@@ -214,5 +214,3 @@ Sort a range or table by a column in a Microsoft Excel worksheet
 | `metadata` | object | Spreadsheet metadata |
 |   ↳ `spreadsheetId` | string | The ID of the spreadsheet |
 |   ↳ `spreadsheetUrl` | string | URL to access the spreadsheet |
-
-

--- a/apps/docs/content/docs/integrations/microsoft_planner.mdx
+++ b/apps/docs/content/docs/integrations/microsoft_planner.mdx
@@ -5,7 +5,7 @@ description: Manage tasks, plans, and buckets in Microsoft Planner
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="microsoft_planner"
   color="#FFFFFF"
 />
@@ -413,5 +413,3 @@ Update task details including description, checklist items, and references in Mi
 | `taskDetails` | object | The updated task details object with all properties |
 | `metadata` | object | Metadata including taskId |
 |   ↳ `taskId` | string | Task ID |
-
-

--- a/apps/docs/content/docs/integrations/microsoft_teams.mdx
+++ b/apps/docs/content/docs/integrations/microsoft_teams.mdx
@@ -5,7 +5,7 @@ description: Manage messages, reactions, and members in Teams
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="microsoft_teams"
   color="#FFFFFF"
 />
@@ -421,8 +421,6 @@ List all channels in a Microsoft Teams team
 | `channelCount` | number | Total number of channels |
 | `hasMore` | boolean | Whether Graph indicated additional pages beyond this response |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -502,4 +500,3 @@ Trigger workflow from new messages in Microsoft Teams chats via Microsoft Graph 
 | `text` | string | Message body \(HTML or text\) |
 | `created_at` | string | Message timestamp |
 | `attachments` | file[] | Uploaded attachments as files |
-

--- a/apps/docs/content/docs/integrations/microsoft_word.mdx
+++ b/apps/docs/content/docs/integrations/microsoft_word.mdx
@@ -5,7 +5,7 @@ description: Create, fill, read, edit, and export Word documents
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="microsoft_word"
   color="#FFFFFF"
 />
@@ -269,5 +269,3 @@ Convert a Microsoft Word (.docx) document to PDF using Microsoft Graph and retur
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `file` | file | The converted PDF, stored in execution files |
-
-

--- a/apps/docs/content/docs/integrations/millionverifier.mdx
+++ b/apps/docs/content/docs/integrations/millionverifier.mdx
@@ -5,7 +5,7 @@ description: Verify email deliverability and check account credits
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="millionverifier"
   color="#FFFFFF"
 />
@@ -61,5 +61,3 @@ Retrieve the remaining verification credits for the authenticated account.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `credits` | number | Remaining verification credits |
-
-

--- a/apps/docs/content/docs/integrations/mintlify.mdx
+++ b/apps/docs/content/docs/integrations/mintlify.mdx
@@ -5,7 +5,7 @@ description: Deploy, edit, search, and measure Mintlify documentation
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="mintlify"
   color="#000000"
 />
@@ -57,7 +57,7 @@ Queue a deployment update for a Mintlify documentation project from its configur
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `statusId` | string | Status ID of the queued update. Poll it with Get Update Status. |
+| `statusId` | string (nullable) | Status ID of the queued update. Poll it with Get Update Status. |
 
 ### Mintlify Get Update Status
 
@@ -74,30 +74,30 @@ Get the status of a Mintlify deployment update from its status ID, including log
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Status ID of the update |
-| `projectId` | string | Documentation project ID |
-| `createdAt` | string | ISO 8601 UTC start time |
-| `endedAt` | string | ISO 8601 UTC end time |
-| `status` | string | Update status: queued, in_progress, success, or failure |
-| `summary` | string | Summary of the update status |
+| `id` | string (nullable) | Status ID of the update |
+| `projectId` | string (nullable) | Documentation project ID |
+| `createdAt` | string (nullable) | ISO 8601 UTC start time |
+| `endedAt` | string (nullable) | ISO 8601 UTC end time |
+| `status` | string (nullable) | Update status: queued, in_progress, success, or failure |
+| `summary` | string (nullable) | Summary of the update status |
 | `logs` | array | Deployment log lines |
-| `subdomain` | string | Subdomain of the docs being updated |
-| `screenshot` | string | Screenshot of the docs |
-| `screenshotLight` | string | Light-mode screenshot of the docs |
-| `screenshotDark` | string | Dark-mode screenshot of the docs |
-| `author` | object | Author of the update |
-|   ↳ `name` | string | Author name |
-|   ↳ `avatarUrl` | string | Author avatar image URL |
-|   ↳ `githubUserId` | number | Author GitHub user ID |
-| `commit` | object | Commit that produced the update |
-|   ↳ `sha` | string | Commit SHA |
-|   ↳ `ref` | string | Git ref of the commit |
-|   ↳ `message` | string | Commit message |
-|   ↳ `filesChanged` | object | Files added, modified, and removed by the commit |
+| `subdomain` | string (nullable) | Subdomain of the docs being updated |
+| `screenshot` | string (nullable) | Screenshot of the docs |
+| `screenshotLight` | string (nullable) | Light-mode screenshot of the docs |
+| `screenshotDark` | string (nullable) | Dark-mode screenshot of the docs |
+| `author` | object (nullable) | Author of the update |
+|   ↳ `name` | string (nullable) | Author name |
+|   ↳ `avatarUrl` | string (nullable) | Author avatar image URL |
+|   ↳ `githubUserId` | number (nullable) | Author GitHub user ID |
+| `commit` | object (nullable) | Commit that produced the update |
+|   ↳ `sha` | string (nullable) | Commit SHA |
+|   ↳ `ref` | string (nullable) | Git ref of the commit |
+|   ↳ `message` | string (nullable) | Commit message |
+|   ↳ `filesChanged` | object (nullable) | Files added, modified, and removed by the commit |
 |     ↳ `added` | array | New files added |
 |     ↳ `modified` | array | Existing files that were modified |
 |     ↳ `removed` | array | Files that were removed |
-| `source` | string | Source of the update trigger: internal, github-app-installation, api, github, dashboard, gitlab, or onboarding |
+| `source` | string (nullable) | Source of the update trigger: internal, github-app-installation, api, github, dashboard, gitlab, or onboarding |
 
 ### Mintlify Trigger Preview Deployment
 
@@ -115,8 +115,8 @@ Create or update a Mintlify preview deployment for a Git branch. Redeploys when 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `statusId` | string | Status ID for tracking the preview deployment |
-| `previewUrl` | string | URL where the preview deployment is hosted |
+| `statusId` | string (nullable) | Status ID for tracking the preview deployment |
+| `previewUrl` | string (nullable) | URL where the preview deployment is hosted |
 
 ### Mintlify Trigger Automation
 
@@ -134,9 +134,9 @@ Run a scheduled Mintlify automation immediately instead of waiting for its next 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `schemaId` | string | ID of the triggered automation |
-| `instanceId` | string | ID of the queued automation run, visible in the run history |
-| `jobId` | string | ID of the background job processing the run |
+| `schemaId` | string (nullable) | ID of the triggered automation |
+| `instanceId` | string (nullable) | ID of the queued automation run, visible in the run history |
+| `jobId` | string (nullable) | ID of the background job processing the run |
 
 ### Mintlify Detect AI-Sounding Prose
 
@@ -155,23 +155,23 @@ Analyze a documentation page for AI-generated prose and return flagged passages 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `path` | string | Path from the request |
-| `skipped` | string | Reason the page was skipped \("too_short"\), or null when the page was checked |
-| `predictionShort` | string | Overall verdict for the page: AI, AI-Assisted, Human, or Mixed. Null when the page was skipped. |
-| `fractionAi` | number | Fraction of the page detected as AI-generated \(0-1\). Null when the page was skipped. |
-| `fractionAiAssisted` | number | Fraction of the page detected as AI-assisted \(0-1\). Null when the page was skipped. |
-| `fractionHuman` | number | Fraction of the page detected as human-written \(0-1\). Null when the page was skipped. |
+| `path` | string (nullable) | Path from the request |
+| `skipped` | string (nullable) | Reason the page was skipped \("too_short"\), or null when the page was checked |
+| `predictionShort` | string (nullable) | Overall verdict for the page: AI, AI-Assisted, Human, or Mixed. Null when the page was skipped. |
+| `fractionAi` | number (nullable) | Fraction of the page detected as AI-generated \(0-1\). Null when the page was skipped. |
+| `fractionAiAssisted` | number (nullable) | Fraction of the page detected as AI-assisted \(0-1\). Null when the page was skipped. |
+| `fractionHuman` | number (nullable) | Fraction of the page detected as human-written \(0-1\). Null when the page was skipped. |
 | `windows` | array | Flagged non-human passages with line ranges and suggested rewrites. Empty when the page was skipped. |
 |   ↳ `text` | string | The flagged passage text |
 |   ↳ `label` | string | Detection label, for example AI-Generated |
-|   ↳ `aiAssistanceScore` | number | AI-assistance score for the passage \(0-1\) |
-|   ↳ `confidence` | json | Detection confidence, either a label such as High or a numeric score |
-|   ↳ `startLine` | number | 1-based start line of the passage |
-|   ↳ `endLine` | number | 1-based end line of the passage |
+|   ↳ `aiAssistanceScore` | number (nullable) | AI-assistance score for the passage \(0-1\) |
+|   ↳ `confidence` | json (nullable) | Detection confidence, either a label such as High or a numeric score |
+|   ↳ `startLine` | number (nullable) | 1-based start line of the passage |
+|   ↳ `endLine` | number (nullable) | 1-based end line of the passage |
 |   ↳ `rewrites` | array | Suggested human rewrites of the passage |
 |     ↳ `text` | string | The rewritten passage |
 |     ↳ `rationale` | string | Why the rewrite reads more human |
-| `creditsCharged` | number | AI credits charged for this request \(0 when skipped\) |
+| `creditsCharged` | number (nullable) | AI credits charged for this request \(0 when skipped\) |
 
 ### Mintlify Create Agent Job
 
@@ -189,55 +189,15 @@ Create a background Mintlify agent job that edits your documentation from a prom
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `statusId` | string | Status ID of a queued deployment |
-| `previewUrl` | string | URL where the preview deployment is hosted |
-| `id` | string | Deployment status ID or agent job ID |
-| `projectId` | string | Documentation project ID |
-| `createdAt` | string | Creation timestamp |
-| `endedAt` | string | Deployment end timestamp |
-| `archivedAt` | string | Agent job archive timestamp |
-| `status` | string | Deployment status or agent job status |
-| `summary` | string | Summary of the deployment status |
-| `logs` | array | Deployment log lines |
-| `subdomain` | string | Subdomain of the docs being updated |
-| `screenshot` | string | Screenshot of the docs |
-| `screenshotLight` | string | Light-mode screenshot of the docs |
-| `screenshotDark` | string | Dark-mode screenshot of the docs |
-| `author` | json | Author of the deployment update |
-| `commit` | json | Commit that produced the deployment |
-| `source` | json | Deployment trigger source \(string\) or agent job source repository details \(object\) |
-| `schemaId` | string | ID of the triggered automation |
-| `instanceId` | string | ID of the queued automation run |
-| `jobId` | string | ID of the background job processing an automation run |
-| `model` | string | AI model used for the agent job |
-| `prLink` | string | Pull request URL created by the agent |
-| `path` | string | Documentation page path |
-| `content` | string | Full text content of the page |
-| `skipped` | string | Reason a prose check was skipped |
-| `predictionShort` | string | Prose verdict: AI, AI-Assisted, Human, Mixed |
-| `fractionAi` | number | Fraction of the page detected as AI-generated |
-| `fractionAiAssisted` | number | Fraction detected as AI-assisted |
-| `fractionHuman` | number | Fraction detected as human-written |
-| `windows` | array | Flagged passages with suggested rewrites |
-| `creditsCharged` | number | AI credits charged for the prose check |
-| `results` | array | Documentation search results |
-| `resultCount` | number | Number of search results returned |
-| `text` | string | Assembled assistant answer |
-| `threadId` | string | Assistant thread ID for follow-up messages |
-| `sources` | array | Documentation sources the assistant cited |
-| `feedback` | array | Feedback entries or per-page feedback aggregates |
-| `conversations` | array | Assistant conversation history |
-| `searches` | array | Documentation search terms with hit counts |
-| `totalSearches` | number | Total search events in the date range |
-| `views` | array | Per-page content view event counts |
-| `visitors` | array | Per-page unique visitor counts |
-| `totals` | json | Site-wide human, AI, and total traffic counts |
-| `web` | number | Assistant queries from the documentation site |
-| `api` | number | Assistant queries from API calls |
-| `other` | number | Assistant queries from other sources |
-| `total` | number | Total assistant queries across all caller types |
-| `nextCursor` | string | Cursor for the next page of results |
-| `hasMore` | boolean | Whether additional results are available |
+| `id` | string (nullable) | Unique identifier for the agent job |
+| `status` | string (nullable) | Current job status: active, completed, archived, or failed |
+| `source` | object (nullable) | Source repository information |
+|   ↳ `repository` | string (nullable) | Full GitHub repository URL |
+|   ↳ `ref` | string (nullable) | Git branch the agent is working on |
+| `model` | string (nullable) | AI model used for this job |
+| `prLink` | string (nullable) | GitHub pull request URL created by the agent. Null while the job is active or if no files changed. |
+| `createdAt` | string (nullable) | Timestamp when the job was created |
+| `archivedAt` | string (nullable) | Timestamp when the job was archived |
 
 ### Mintlify Get Agent Job
 
@@ -255,55 +215,15 @@ Retrieve the current status and details of a Mintlify agent job, including the p
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `statusId` | string | Status ID of a queued deployment |
-| `previewUrl` | string | URL where the preview deployment is hosted |
-| `id` | string | Deployment status ID or agent job ID |
-| `projectId` | string | Documentation project ID |
-| `createdAt` | string | Creation timestamp |
-| `endedAt` | string | Deployment end timestamp |
-| `archivedAt` | string | Agent job archive timestamp |
-| `status` | string | Deployment status or agent job status |
-| `summary` | string | Summary of the deployment status |
-| `logs` | array | Deployment log lines |
-| `subdomain` | string | Subdomain of the docs being updated |
-| `screenshot` | string | Screenshot of the docs |
-| `screenshotLight` | string | Light-mode screenshot of the docs |
-| `screenshotDark` | string | Dark-mode screenshot of the docs |
-| `author` | json | Author of the deployment update |
-| `commit` | json | Commit that produced the deployment |
-| `source` | json | Deployment trigger source \(string\) or agent job source repository details \(object\) |
-| `schemaId` | string | ID of the triggered automation |
-| `instanceId` | string | ID of the queued automation run |
-| `jobId` | string | ID of the background job processing an automation run |
-| `model` | string | AI model used for the agent job |
-| `prLink` | string | Pull request URL created by the agent |
-| `path` | string | Documentation page path |
-| `content` | string | Full text content of the page |
-| `skipped` | string | Reason a prose check was skipped |
-| `predictionShort` | string | Prose verdict: AI, AI-Assisted, Human, Mixed |
-| `fractionAi` | number | Fraction of the page detected as AI-generated |
-| `fractionAiAssisted` | number | Fraction detected as AI-assisted |
-| `fractionHuman` | number | Fraction detected as human-written |
-| `windows` | array | Flagged passages with suggested rewrites |
-| `creditsCharged` | number | AI credits charged for the prose check |
-| `results` | array | Documentation search results |
-| `resultCount` | number | Number of search results returned |
-| `text` | string | Assembled assistant answer |
-| `threadId` | string | Assistant thread ID for follow-up messages |
-| `sources` | array | Documentation sources the assistant cited |
-| `feedback` | array | Feedback entries or per-page feedback aggregates |
-| `conversations` | array | Assistant conversation history |
-| `searches` | array | Documentation search terms with hit counts |
-| `totalSearches` | number | Total search events in the date range |
-| `views` | array | Per-page content view event counts |
-| `visitors` | array | Per-page unique visitor counts |
-| `totals` | json | Site-wide human, AI, and total traffic counts |
-| `web` | number | Assistant queries from the documentation site |
-| `api` | number | Assistant queries from API calls |
-| `other` | number | Assistant queries from other sources |
-| `total` | number | Total assistant queries across all caller types |
-| `nextCursor` | string | Cursor for the next page of results |
-| `hasMore` | boolean | Whether additional results are available |
+| `id` | string (nullable) | Unique identifier for the agent job |
+| `status` | string (nullable) | Current job status: active, completed, archived, or failed |
+| `source` | object (nullable) | Source repository information |
+|   ↳ `repository` | string (nullable) | Full GitHub repository URL |
+|   ↳ `ref` | string (nullable) | Git branch the agent is working on |
+| `model` | string (nullable) | AI model used for this job |
+| `prLink` | string (nullable) | GitHub pull request URL created by the agent. Null while the job is active or if no files changed. |
+| `createdAt` | string (nullable) | Timestamp when the job was created |
+| `archivedAt` | string (nullable) | Timestamp when the job was archived |
 
 ### Mintlify Send Agent Message
 
@@ -322,55 +242,15 @@ Send a follow-up instruction to an existing Mintlify agent job. The message is p
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `statusId` | string | Status ID of a queued deployment |
-| `previewUrl` | string | URL where the preview deployment is hosted |
-| `id` | string | Deployment status ID or agent job ID |
-| `projectId` | string | Documentation project ID |
-| `createdAt` | string | Creation timestamp |
-| `endedAt` | string | Deployment end timestamp |
-| `archivedAt` | string | Agent job archive timestamp |
-| `status` | string | Deployment status or agent job status |
-| `summary` | string | Summary of the deployment status |
-| `logs` | array | Deployment log lines |
-| `subdomain` | string | Subdomain of the docs being updated |
-| `screenshot` | string | Screenshot of the docs |
-| `screenshotLight` | string | Light-mode screenshot of the docs |
-| `screenshotDark` | string | Dark-mode screenshot of the docs |
-| `author` | json | Author of the deployment update |
-| `commit` | json | Commit that produced the deployment |
-| `source` | json | Deployment trigger source \(string\) or agent job source repository details \(object\) |
-| `schemaId` | string | ID of the triggered automation |
-| `instanceId` | string | ID of the queued automation run |
-| `jobId` | string | ID of the background job processing an automation run |
-| `model` | string | AI model used for the agent job |
-| `prLink` | string | Pull request URL created by the agent |
-| `path` | string | Documentation page path |
-| `content` | string | Full text content of the page |
-| `skipped` | string | Reason a prose check was skipped |
-| `predictionShort` | string | Prose verdict: AI, AI-Assisted, Human, Mixed |
-| `fractionAi` | number | Fraction of the page detected as AI-generated |
-| `fractionAiAssisted` | number | Fraction detected as AI-assisted |
-| `fractionHuman` | number | Fraction detected as human-written |
-| `windows` | array | Flagged passages with suggested rewrites |
-| `creditsCharged` | number | AI credits charged for the prose check |
-| `results` | array | Documentation search results |
-| `resultCount` | number | Number of search results returned |
-| `text` | string | Assembled assistant answer |
-| `threadId` | string | Assistant thread ID for follow-up messages |
-| `sources` | array | Documentation sources the assistant cited |
-| `feedback` | array | Feedback entries or per-page feedback aggregates |
-| `conversations` | array | Assistant conversation history |
-| `searches` | array | Documentation search terms with hit counts |
-| `totalSearches` | number | Total search events in the date range |
-| `views` | array | Per-page content view event counts |
-| `visitors` | array | Per-page unique visitor counts |
-| `totals` | json | Site-wide human, AI, and total traffic counts |
-| `web` | number | Assistant queries from the documentation site |
-| `api` | number | Assistant queries from API calls |
-| `other` | number | Assistant queries from other sources |
-| `total` | number | Total assistant queries across all caller types |
-| `nextCursor` | string | Cursor for the next page of results |
-| `hasMore` | boolean | Whether additional results are available |
+| `id` | string (nullable) | Unique identifier for the agent job |
+| `status` | string (nullable) | Current job status: active, completed, archived, or failed |
+| `source` | object (nullable) | Source repository information |
+|   ↳ `repository` | string (nullable) | Full GitHub repository URL |
+|   ↳ `ref` | string (nullable) | Git branch the agent is working on |
+| `model` | string (nullable) | AI model used for this job |
+| `prLink` | string (nullable) | GitHub pull request URL created by the agent. Null while the job is active or if no files changed. |
+| `createdAt` | string (nullable) | Timestamp when the job was created |
+| `archivedAt` | string (nullable) | Timestamp when the job was archived |
 
 ### Mintlify Search Documentation
 
@@ -395,9 +275,9 @@ Run a semantic and keyword search across a Mintlify documentation site, with opt
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `results` | array | Matching documentation chunks ordered by relevance |
-|   ↳ `content` | string | The matching content from your documentation |
-|   ↳ `path` | string | Path or URL to the source document |
-|   ↳ `metadata` | json | Additional metadata about the search result |
+|   ↳ `content` | string (nullable) | The matching content from your documentation |
+|   ↳ `path` | string (nullable) | Path or URL to the source document |
+|   ↳ `metadata` | json (nullable) | Additional metadata about the search result |
 | `resultCount` | number | Number of results returned |
 
 ### Mintlify Get Page Content
@@ -417,8 +297,8 @@ Retrieve the full text content of a Mintlify documentation page by its path. Use
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `path` | string | The page path that was requested |
-| `content` | string | Full text content of the page |
+| `path` | string (nullable) | The page path that was requested |
+| `content` | string (nullable) | Full text content of the page |
 
 ### Mintlify Create Assistant Message
 
@@ -446,11 +326,11 @@ Ask the Mintlify assistant, trained on your documentation, a question and get th
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `text` | string | Assembled assistant answer |
-| `threadId` | string | Thread ID for continuing this conversation in a follow-up call |
+| `threadId` | string (nullable) | Thread ID for continuing this conversation in a follow-up call |
 | `sources` | array | Documentation sources the assistant cited |
-|   ↳ `sourceId` | string | Source identifier |
-|   ↳ `url` | string | URL of the cited page |
-|   ↳ `title` | string | Title of the cited page |
+|   ↳ `sourceId` | string (nullable) | Source identifier |
+|   ↳ `url` | string (nullable) | URL of the cited page |
+|   ↳ `title` | string (nullable) | Title of the cited page |
 
 ### Mintlify Get Feedback
 
@@ -474,18 +354,18 @@ Export paginated user feedback from a Mintlify documentation project, with optio
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `feedback` | array | Feedback entries for the requested window |
-|   ↳ `id` | string | Unique feedback identifier |
-|   ↳ `path` | string | Path or URL of the page |
-|   ↳ `comment` | string | Text of the feedback comment |
-|   ↳ `createdAt` | string | Submission timestamp |
-|   ↳ `source` | string | Origin: code_snippet, contextual, agent, or thumbs_only |
-|   ↳ `status` | string | Review status: pending, in_progress, resolved, or dismissed |
-|   ↳ `helpful` | boolean | Whether the user found the content helpful \(contextual feedback only\) |
-|   ↳ `contact` | string | Email the user provided for follow-up \(contextual feedback only\) |
-|   ↳ `code` | string | Code snippet the feedback relates to \(code_snippet feedback only\) |
-|   ↳ `filename` | string | Filename of the code snippet \(code_snippet feedback only\) |
-|   ↳ `lang` | string | Language of the code snippet \(code_snippet feedback only\) |
-| `nextCursor` | string | Cursor for the next page, or null when there are no more results |
+|   ↳ `id` | string (nullable) | Unique feedback identifier |
+|   ↳ `path` | string (nullable) | Path or URL of the page |
+|   ↳ `comment` | string (nullable) | Text of the feedback comment |
+|   ↳ `createdAt` | string (nullable) | Submission timestamp |
+|   ↳ `source` | string (nullable) | Origin: code_snippet, contextual, agent, or thumbs_only |
+|   ↳ `status` | string (nullable) | Review status: pending, in_progress, resolved, or dismissed |
+|   ↳ `helpful` | boolean (nullable) | Whether the user found the content helpful \(contextual feedback only\) |
+|   ↳ `contact` | string (nullable) | Email the user provided for follow-up \(contextual feedback only\) |
+|   ↳ `code` | string (nullable) | Code snippet the feedback relates to \(code_snippet feedback only\) |
+|   ↳ `filename` | string (nullable) | Filename of the code snippet \(code_snippet feedback only\) |
+|   ↳ `lang` | string (nullable) | Language of the code snippet \(code_snippet feedback only\) |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null when there are no more results |
 | `hasMore` | boolean | Whether additional results are available |
 
 ### Mintlify Get Feedback By Page
@@ -509,11 +389,11 @@ Export Mintlify feedback counts aggregated by documentation page path, broken do
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `feedback` | array | Feedback counts aggregated by documentation page path |
-|   ↳ `path` | string | The documentation page path |
-|   ↳ `thumbsUp` | number | Positive contextual feedback entries |
-|   ↳ `thumbsDown` | number | Negative contextual feedback entries |
-|   ↳ `code` | number | Code snippet feedback entries |
-|   ↳ `total` | number | Total feedback entries |
+|   ↳ `path` | string (nullable) | The documentation page path |
+|   ↳ `thumbsUp` | number (nullable) | Positive contextual feedback entries |
+|   ↳ `thumbsDown` | number (nullable) | Negative contextual feedback entries |
+|   ↳ `code` | number (nullable) | Code snippet feedback entries |
+|   ↳ `total` | number (nullable) | Total feedback entries |
 | `hasMore` | boolean | Whether additional results are available |
 
 ### Mintlify Get Assistant Conversations
@@ -536,17 +416,17 @@ Export paginated Mintlify AI assistant conversation history, including the query
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `conversations` | array | Assistant conversations for the requested window |
-|   ↳ `id` | string | Unique conversation identifier |
-|   ↳ `timestamp` | string | When the conversation occurred |
-|   ↳ `query` | string | The user's question |
-|   ↳ `response` | string | The assistant's response |
+|   ↳ `id` | string (nullable) | Unique conversation identifier |
+|   ↳ `timestamp` | string (nullable) | When the conversation occurred |
+|   ↳ `query` | string (nullable) | The user's question |
+|   ↳ `response` | string (nullable) | The assistant's response |
 |   ↳ `sources` | array | Documentation pages referenced in the response |
-|     ↳ `title` | string | Title of the page |
-|     ↳ `url` | string | URL of the page |
-|   ↳ `resolutionStatus` | string | Whether the assistant answered the question: answered or unanswered |
-|   ↳ `queryCategory` | string | Auto-assigned category grouping for the conversation |
-|   ↳ `pageUrl` | string | Full URL of the page where the conversation started |
-| `nextCursor` | string | Cursor for the next page, or null when there are no more results |
+|     ↳ `title` | string (nullable) | Title of the page |
+|     ↳ `url` | string (nullable) | URL of the page |
+|   ↳ `resolutionStatus` | string (nullable) | Whether the assistant answered the question: answered or unanswered |
+|   ↳ `queryCategory` | string (nullable) | Auto-assigned category grouping for the conversation |
+|   ↳ `pageUrl` | string (nullable) | Full URL of the page where the conversation started |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null when there are no more results |
 | `hasMore` | boolean | Whether additional results are available |
 
 ### Mintlify Get Assistant Caller Stats
@@ -566,10 +446,10 @@ Get a breakdown of Mintlify assistant query counts by caller type — web, API, 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `web` | number | Assistant queries originating from the documentation site |
-| `api` | number | Assistant queries originating from API calls |
-| `other` | number | Assistant queries from other sources such as integrations and SDKs |
-| `total` | number | Total assistant queries across all caller types |
+| `web` | number (nullable) | Assistant queries originating from the documentation site |
+| `api` | number (nullable) | Assistant queries originating from API calls |
+| `other` | number (nullable) | Assistant queries from other sources such as integrations and SDKs |
+| `total` | number (nullable) | Total assistant queries across all caller types |
 
 ### Mintlify Get Search Queries
 
@@ -591,13 +471,13 @@ Export Mintlify documentation search terms for a date range, ordered by hit coun
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `searches` | array | Search terms ordered by hit count descending |
-|   ↳ `searchQuery` | string | The search term entered by users |
-|   ↳ `hits` | number | Number of times this term was searched |
-|   ↳ `ctr` | number | Click-through rate for this search term |
-|   ↳ `topClickedPage` | string | Most-clicked result path for this query |
-|   ↳ `lastSearchedAt` | string | Timestamp of the last time this term was searched |
-| `totalSearches` | number | Total search events in the date range, summing all hits rather than distinct queries |
-| `nextCursor` | string | Cursor for the next page, or null when there are no more results |
+|   ↳ `searchQuery` | string (nullable) | The search term entered by users |
+|   ↳ `hits` | number (nullable) | Number of times this term was searched |
+|   ↳ `ctr` | number (nullable) | Click-through rate for this search term |
+|   ↳ `topClickedPage` | string (nullable) | Most-clicked result path for this query |
+|   ↳ `lastSearchedAt` | string (nullable) | Timestamp of the last time this term was searched |
+| `totalSearches` | number (nullable) | Total search events in the date range, summing all hits rather than distinct queries |
+| `nextCursor` | string (nullable) | Cursor for the next page, or null when there are no more results |
 
 ### Mintlify Get Page Views
 
@@ -619,10 +499,10 @@ Export Mintlify per-path and site-wide content view counts for a date range, spl
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `views` | array | Per-page content view event counts |
-|   ↳ `path` | string | The documentation page path |
-|   ↳ `human` | number | Content view events from human traffic |
-|   ↳ `ai` | number | Content view events from AI bot traffic |
-|   ↳ `total` | number | Total content view events |
+|   ↳ `path` | string (nullable) | The documentation page path |
+|   ↳ `human` | number (nullable) | Content view events from human traffic |
+|   ↳ `ai` | number (nullable) | Content view events from AI bot traffic |
+|   ↳ `total` | number (nullable) | Total content view events |
 | `hasMore` | boolean | Whether additional results are available |
 
 ### Mintlify Get Unique Visitors
@@ -645,10 +525,8 @@ Export Mintlify per-path and site-wide approximate distinct visitor counts for a
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `visitors` | array | Per-page unique visitor counts |
-|   ↳ `path` | string | The documentation page path |
-|   ↳ `human` | number | Unique human visitors |
-|   ↳ `ai` | number | Unique AI bot visitors |
-|   ↳ `total` | number | Approximate distinct visitors, deduplicated across human and AI |
+|   ↳ `path` | string (nullable) | The documentation page path |
+|   ↳ `human` | number (nullable) | Unique human visitors |
+|   ↳ `ai` | number (nullable) | Unique AI bot visitors |
+|   ↳ `total` | number (nullable) | Approximate distinct visitors, deduplicated across human and AI |
 | `hasMore` | boolean | Whether additional results are available |
-
-

--- a/apps/docs/content/docs/integrations/mistral_parse.mdx
+++ b/apps/docs/content/docs/integrations/mistral_parse.mdx
@@ -5,7 +5,7 @@ description: Extract text from PDF documents
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="mistral_parse_v3"
   color="#000000"
 />
@@ -73,5 +73,3 @@ Parse PDF documents using Mistral OCR API
 |   ↳ `pages_processed` | number | Total number of pages processed |
 |   ↳ `doc_size_bytes` | number | Document file size in bytes |
 | `document_annotation` | string | Structured annotation data as JSON string \(when applicable\) |
-
-

--- a/apps/docs/content/docs/integrations/modal.mdx
+++ b/apps/docs/content/docs/integrations/modal.mdx
@@ -5,7 +5,7 @@ description: Call deployed Modal functions and endpoints
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="modal"
   color="#000000"
 />
@@ -90,5 +90,3 @@ List the model IDs a Modal proxy token can reach on an endpoint
 | --------- | ---- | ----------- |
 | `models` | array | Models the token can reach on the endpoint |
 | `count` | number | Number of models returned |
-
-

--- a/apps/docs/content/docs/integrations/monday.mdx
+++ b/apps/docs/content/docs/integrations/monday.mdx
@@ -5,7 +5,7 @@ description: Manage Monday.com boards, items, and groups
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="monday"
   color="#FFFFFF"
 />
@@ -538,8 +538,6 @@ Create a new column on a Monday.com board
 |   ↳ `title` | string | Column title |
 |   ↳ `type` | string | Column type |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -805,4 +803,3 @@ Trigger workflow when an update or comment is posted on a Monday.com item
 | `updateId` | string | The ID of the created update |
 | `body` | string | The HTML body of the update |
 | `textBody` | string | The plain text body of the update |
-

--- a/apps/docs/content/docs/integrations/mongodb.mdx
+++ b/apps/docs/content/docs/integrations/mongodb.mdx
@@ -5,7 +5,7 @@ description: Connect to MongoDB database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="mongodb"
   color="#FFFFFF"
 />
@@ -195,5 +195,3 @@ Introspect MongoDB database to list databases, collections, and indexes
 | `message` | string | Operation status message |
 | `databases` | array | Array of database names |
 | `collections` | array | Array of collection info with name, type, document count, and indexes |
-
-

--- a/apps/docs/content/docs/integrations/mssql.mdx
+++ b/apps/docs/content/docs/integrations/mssql.mdx
@@ -5,7 +5,7 @@ description: Connect to Microsoft SQL Server database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="mssql"
   color="#FFFFFF"
 />
@@ -215,5 +215,3 @@ Introspect a Microsoft SQL Server schema to retrieve table structures, columns, 
 |     ↳ `columns` | array | Key columns included in the index, in key order |
 |     ↳ `unique` | boolean | Whether the index enforces uniqueness |
 | `schemas` | array | List of available schemas in the database |
-
-

--- a/apps/docs/content/docs/integrations/mysql.mdx
+++ b/apps/docs/content/docs/integrations/mysql.mdx
@@ -5,7 +5,7 @@ description: Connect to MySQL database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="mysql"
   color="#FFFFFF"
 />
@@ -178,5 +178,3 @@ Introspect MySQL database schema to retrieve table structures, columns, and rela
 | `message` | string | Operation status message |
 | `tables` | array | Array of table schemas with columns, keys, and indexes |
 | `databases` | array | List of available databases on the server |
-
-

--- a/apps/docs/content/docs/integrations/neo4j.mdx
+++ b/apps/docs/content/docs/integrations/neo4j.mdx
@@ -5,7 +5,7 @@ description: Connect to Neo4j graph database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="neo4j"
   color="#FFFFFF"
 />
@@ -198,5 +198,3 @@ Introspect a Neo4j database to discover its schema including node labels, relati
 | `relationshipSchemas` | array | Array of relationship schemas with their properties |
 | `constraints` | array | Array of database constraints |
 | `indexes` | array | Array of database indexes |
-
-

--- a/apps/docs/content/docs/integrations/netsuite.mdx
+++ b/apps/docs/content/docs/integrations/netsuite.mdx
@@ -5,7 +5,7 @@ description: Manage NetSuite records, queries, datasets, batches, and async jobs
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="netsuite"
   color="#FFFFFF"
 />
@@ -60,7 +60,7 @@ List one page of a NetSuite record collection, optionally filtered with a q expr
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | One documented NetSuite collection page |
+| `data` | json (nullable) | One documented NetSuite collection page |
 |   ↳ `links` | array | Oracle HATEOAS links for the response |
 |     ↳ `rel` | string | Link relationship |
 |     ↳ `href` | string | Link target |
@@ -94,7 +94,7 @@ Retrieve one NetSuite record by internal or external ID.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | NetSuite response body; record fields are account-specific and dynamic |
+| `data` | json (nullable) | NetSuite response body; record fields are account-specific and dynamic |
 
 ### NetSuite Create Record
 
@@ -114,7 +114,7 @@ Create a NetSuite record using the account-specific record metadata schema.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for standard HTTP 204 creation; replacement creation can return the documented HTTP 201 post-state object |
+| `data` | json (nullable) | Empty for standard HTTP 204 creation; replacement creation can return the documented HTTP 201 post-state object |
 | `location` | string | Newly created record URL from the Location response header |
 
 ### NetSuite Update Record
@@ -136,7 +136,7 @@ Update fields on an existing NetSuite record with PATCH.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 204 No Content response |
+| `data` | json (nullable) | Empty for the documented HTTP 204 No Content response |
 | `location` | string | Updated record URL from the Location response header |
 
 ### NetSuite Upsert Record
@@ -157,7 +157,7 @@ Create or update a NetSuite record by external ID with PUT.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 204 No Content response |
+| `data` | json (nullable) | Empty for the documented HTTP 204 No Content response |
 | `location` | string | URL of the created or updated record, when NetSuite returns a Location header |
 
 ### NetSuite Delete Record
@@ -177,7 +177,7 @@ Delete one NetSuite record by internal or external ID.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 204 No Content response |
+| `data` | json (nullable) | Empty for the documented HTTP 204 No Content response |
 
 ### NetSuite Get Subresource
 
@@ -197,7 +197,7 @@ Retrieve a record sublist, subrecord, referenced record, or nested subresource.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | NetSuite response body; record fields are account-specific and dynamic |
+| `data` | json (nullable) | NetSuite response body; record fields are account-specific and dynamic |
 
 ### NetSuite Get Record Form
 
@@ -220,7 +220,7 @@ Return a prepopulated create form, or an edit form when a record ID is supplied.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | NetSuite response body; record fields are account-specific and dynamic |
+| `data` | json (nullable) | NetSuite response body; record fields are account-specific and dynamic |
 
 ### NetSuite Get Select Options
 
@@ -244,7 +244,7 @@ Retrieve valid select values for one or more fields on a new or existing record.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Select-options response keyed by requested field ID; each dynamic field contains an _selectOptions object with links, items, count, offset, hasMore, and totalResults |
+| `data` | json (nullable) | Select-options response keyed by requested field ID; each dynamic field contains an _selectOptions object with links, items, count, offset, hasMore, and totalResults |
 |   ↳ `links` | array | Oracle HATEOAS links for the response |
 |     ↳ `rel` | string | Link relationship |
 |     ↳ `href` | string | Link target |
@@ -270,7 +270,7 @@ Attach a contact or file to another NetSuite record.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 204 No Content response |
+| `data` | json (nullable) | Empty for the documented HTTP 204 No Content response |
 
 ### NetSuite Detach Record or File
 
@@ -291,7 +291,7 @@ Detach a contact or file from another NetSuite record.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 204 No Content response |
+| `data` | json (nullable) | Empty for the documented HTTP 204 No Content response |
 
 ### NetSuite Execute Record Action
 
@@ -312,7 +312,7 @@ Execute a supported NetSuite record action such as approve, reject, or confirm.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Documented NetSuite record-action response |
+| `data` | json (nullable) | Documented NetSuite record-action response |
 |   ↳ `result` | boolean | True when NetSuite completed the record action |
 
 ### NetSuite Transform Record
@@ -334,7 +334,7 @@ Transform a supported source record into another NetSuite record type.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 204 No Content response |
+| `data` | json (nullable) | Empty for the documented HTTP 204 No Content response |
 | `location` | string | URL of the transformed record, when NetSuite returns a Location header |
 
 ### NetSuite Batch Get Records
@@ -358,7 +358,7 @@ Submit an asynchronous request to retrieve up to 100 records of one type.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 202 Accepted submission response |
+| `data` | json (nullable) | Empty for the documented HTTP 202 Accepted submission response |
 | `location` | string | Asynchronous job URL from the Location response header |
 | `jobId` | string | Asynchronous job ID parsed from the Location header |
 
@@ -380,7 +380,7 @@ Submit an asynchronous batch that creates up to 100 records of one type.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 202 Accepted submission response |
+| `data` | json (nullable) | Empty for the documented HTTP 202 Accepted submission response |
 | `location` | string | Asynchronous job URL from the Location response header |
 | `jobId` | string | Asynchronous job ID parsed from the Location header |
 
@@ -402,7 +402,7 @@ Submit an asynchronous batch that updates up to 100 records of one type.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 202 Accepted submission response |
+| `data` | json (nullable) | Empty for the documented HTTP 202 Accepted submission response |
 | `location` | string | Asynchronous job URL from the Location response header |
 | `jobId` | string | Asynchronous job ID parsed from the Location header |
 
@@ -424,7 +424,7 @@ Submit an asynchronous batch that creates or updates up to 100 records by extern
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 202 Accepted submission response |
+| `data` | json (nullable) | Empty for the documented HTTP 202 Accepted submission response |
 | `location` | string | Asynchronous job URL from the Location response header |
 | `jobId` | string | Asynchronous job ID parsed from the Location header |
 
@@ -446,7 +446,7 @@ Submit an asynchronous request to delete up to 100 records of one type.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Empty for the documented HTTP 202 Accepted submission response |
+| `data` | json (nullable) | Empty for the documented HTTP 202 Accepted submission response |
 | `location` | string | Asynchronous job URL from the Location response header |
 | `jobId` | string | Asynchronous job ID parsed from the Location header |
 
@@ -468,7 +468,7 @@ Execute one page of a SuiteQL query through SuiteTalk REST web services.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | One documented NetSuite collection page |
+| `data` | json (nullable) | One documented NetSuite collection page |
 |   ↳ `links` | array | Oracle HATEOAS links for the response |
 |     ↳ `rel` | string | Link relationship |
 |     ↳ `href` | string | Link target |
@@ -495,7 +495,7 @@ List one page of SuiteAnalytics Workbook datasets available to the authenticated
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | One documented NetSuite collection page |
+| `data` | json (nullable) | One documented NetSuite collection page |
 |   ↳ `links` | array | Oracle HATEOAS links for the response |
 |     ↳ `rel` | string | Link relationship |
 |     ↳ `href` | string | Link target |
@@ -523,7 +523,7 @@ Execute one page of a standard or custom SuiteAnalytics Workbook dataset.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | One documented NetSuite collection page |
+| `data` | json (nullable) | One documented NetSuite collection page |
 |   ↳ `links` | array | Oracle HATEOAS links for the response |
 |     ↳ `rel` | string | Link relationship |
 |     ↳ `href` | string | Link target |
@@ -548,7 +548,7 @@ List record types exposed to the authenticated role by the REST metadata catalog
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | NetSuite REST metadata catalog |
+| `data` | json (nullable) | NetSuite REST metadata catalog |
 |   ↳ `links` | array | Oracle HATEOAS links for the response |
 |     ↳ `rel` | string | Link relationship |
 |     ↳ `href` | string | Link target |
@@ -576,7 +576,7 @@ Retrieve account-specific metadata for one NetSuite record type.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | NetSuite response body; record fields are account-specific and dynamic |
+| `data` | json (nullable) | NetSuite response body; record fields are account-specific and dynamic |
 
 ### NetSuite Get Async Status
 
@@ -596,7 +596,7 @@ Retrieve job status, list job tasks, or retrieve one task status.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Documented NetSuite asynchronous job, task collection, or task status |
+| `data` | json (nullable) | Documented NetSuite asynchronous job, task collection, or task status |
 |   ↳ `completed` | boolean | Whether processing has completed |
 |   ↳ `endTime` | string | Task completion time |
 |   ↳ `id` | string | Asynchronous job or task ID |
@@ -632,7 +632,7 @@ Retrieve the provider response for one task within a completed asynchronous job.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Result payload for the submitted asynchronous operation; record fields are account-specific and dynamic |
+| `data` | json (nullable) | Result payload for the submitted asynchronous operation; record fields are account-specific and dynamic |
 
 ### NetSuite Get Server Time
 
@@ -649,7 +649,7 @@ Retrieve the current UTC time from the NetSuite server.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | NetSuite server time response |
+| `data` | json (nullable) | NetSuite server time response |
 |   ↳ `serverTime` | string | Current NetSuite server time in UTC |
 
 ### NetSuite Get Governance Limits
@@ -667,10 +667,8 @@ Retrieve REST web-services concurrency limits for the NetSuite account and integ
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status returned by NetSuite |
-| `data` | json | Documented NetSuite governance limits |
+| `data` | json (nullable) | Documented NetSuite governance limits |
 |   ↳ `accountConcurrencyLimit` | number | Account concurrency limit |
 |   ↳ `accountUnallocatedConcurrencyLimit` | number | Account concurrency not allocated to integrations |
 |   ↳ `integrationConcurrencyLimit` | number | Concurrency allocated to this integration |
 |   ↳ `integrationLimitType` | string | Limit assignment: integrationSpecific, accountLimit, or internal |
-
-

--- a/apps/docs/content/docs/integrations/neverbounce.mdx
+++ b/apps/docs/content/docs/integrations/neverbounce.mdx
@@ -5,7 +5,7 @@ description: Verify email deliverability and check account credits
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="neverbounce"
   color="#064AF4"
 />
@@ -62,5 +62,3 @@ Retrieve the remaining paid and free verification credits for the account.
 | --------- | ---- | ----------- |
 | `credits` | number | Remaining paid verification credits |
 | `freeCredits` | number | Remaining free verification credits |
-
-

--- a/apps/docs/content/docs/integrations/new_relic.mdx
+++ b/apps/docs/content/docs/integrations/new_relic.mdx
@@ -5,7 +5,7 @@ description: Query observability data and record deployments in New Relic
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="new_relic"
   color="#000000"
 />
@@ -73,14 +73,14 @@ Search New Relic entities by name, GUID, domain type, tags, or reporting state.
 | `count` | number | Total number of entities matching the query |
 | `query` | string | Entity search query New Relic executed |
 | `entities` | array | Matching New Relic entities |
-|   ↳ `guid` | string | Entity GUID |
-|   ↳ `name` | string | Entity name |
-|   ↳ `entityType` | string | Entity type |
-|   ↳ `domain` | string | Entity domain, e.g. APM, INFRA |
-|   ↳ `reporting` | boolean | Whether the entity is currently reporting data |
-|   ↳ `alertSeverity` | string | Current alert severity for the entity |
+|   ↳ `guid` | string (nullable) | Entity GUID |
+|   ↳ `name` | string (nullable) | Entity name |
+|   ↳ `entityType` | string (nullable) | Entity type |
+|   ↳ `domain` | string (nullable) | Entity domain, e.g. APM, INFRA |
+|   ↳ `reporting` | boolean (nullable) | Whether the entity is currently reporting data |
+|   ↳ `alertSeverity` | string (nullable) | Current alert severity for the entity |
 |   ↳ `tags` | array | Entity tags |
-|     ↳ `key` | string | Tag key |
+|     ↳ `key` | string (nullable) | Tag key |
 |     ↳ `values` | array | Tag values |
 | `nextCursor` | string | Cursor for the next page of results |
 
@@ -101,14 +101,14 @@ Fetch a New Relic entity by GUID.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `entity` | object | New Relic entity details |
-|   ↳ `guid` | string | Entity GUID |
-|   ↳ `name` | string | Entity name |
-|   ↳ `entityType` | string | Entity type |
-|   ↳ `domain` | string | Entity domain, e.g. APM, INFRA |
-|   ↳ `reporting` | boolean | Whether the entity is currently reporting data |
-|   ↳ `alertSeverity` | string | Current alert severity for the entity |
+|   ↳ `guid` | string (nullable) | Entity GUID |
+|   ↳ `name` | string (nullable) | Entity name |
+|   ↳ `entityType` | string (nullable) | Entity type |
+|   ↳ `domain` | string (nullable) | Entity domain, e.g. APM, INFRA |
+|   ↳ `reporting` | boolean (nullable) | Whether the entity is currently reporting data |
+|   ↳ `alertSeverity` | string (nullable) | Current alert severity for the entity |
 |   ↳ `tags` | array | Entity tags |
-|     ↳ `key` | string | Tag key |
+|     ↳ `key` | string (nullable) | Tag key |
 |     ↳ `values` | array | Tag values |
 
 ### New Relic Create Deployment Event
@@ -139,19 +139,17 @@ Record a deployment change event in New Relic change tracking.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `event` | object | Created New Relic change tracking event |
-|   ↳ `changeTrackingId` | string | New Relic change tracking ID |
-|   ↳ `customAttributes` | json | Custom attributes on the change tracking event |
-|   ↳ `category` | string | Change category |
-|   ↳ `categoryAndType` | string | Combined category and type |
-|   ↳ `type` | string | Change type |
-|   ↳ `shortDescription` | string | Short change description |
-|   ↳ `description` | string | Change description |
-|   ↳ `timestamp` | number | Change timestamp in milliseconds |
-|   ↳ `user` | string | User associated with the change |
-|   ↳ `groupId` | string | Change group ID |
-|   ↳ `entity` | object | Entity associated with the change |
-|     ↳ `guid` | string | Entity GUID |
-|     ↳ `name` | string | Entity name |
+|   ↳ `changeTrackingId` | string (nullable) | New Relic change tracking ID |
+|   ↳ `customAttributes` | json (nullable) | Custom attributes on the change tracking event |
+|   ↳ `category` | string (nullable) | Change category |
+|   ↳ `categoryAndType` | string (nullable) | Combined category and type |
+|   ↳ `type` | string (nullable) | Change type |
+|   ↳ `shortDescription` | string (nullable) | Short change description |
+|   ↳ `description` | string (nullable) | Change description |
+|   ↳ `timestamp` | number (nullable) | Change timestamp in milliseconds |
+|   ↳ `user` | string (nullable) | User associated with the change |
+|   ↳ `groupId` | string (nullable) | Change group ID |
+|   ↳ `entity` | object (nullable) | Entity associated with the change |
+|     ↳ `guid` | string (nullable) | Entity GUID |
+|     ↳ `name` | string (nullable) | Entity name |
 | `messages` | array | Messages returned by New Relic for the created change event |
-
-

--- a/apps/docs/content/docs/integrations/notion.mdx
+++ b/apps/docs/content/docs/integrations/notion.mdx
@@ -5,7 +5,7 @@ description: Manage Notion pages
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="notion_v2"
   color="#FFFFFF"
 />
@@ -283,26 +283,30 @@ Append new block children (content) to a Notion page or block
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
+| `results` | array | Array of Notion block objects |
+|   ↳ `object` | string | Always "block" |
+|   ↳ `id` | string | Block UUID |
+|   ↳ `parent` | object | Parent object specifying hierarchical relationship |
+|     ↳ `type` | string | Parent type: "database_id", "data_source_id", "page_id", "workspace", or "block_id" |
+|     ↳ `database_id` | string | Parent database UUID \(if type is database_id\) |
+|     ↳ `data_source_id` | string | Parent data source UUID \(if type is data_source_id\) |
+|     ↳ `page_id` | string | Parent page UUID \(if type is page_id\) |
+|     ↳ `workspace` | boolean | True if parent is workspace \(if type is workspace\) |
+|     ↳ `block_id` | string | Parent block UUID \(if type is block_id\) |
+|   ↳ `type` | string | Block type \(paragraph, heading_1, heading_2, heading_3, image, etc.\) |
+|   ↳ `created_time` | string | ISO 8601 creation timestamp |
+|   ↳ `last_edited_time` | string | ISO 8601 last edit timestamp |
+|   ↳ `created_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `last_edited_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `archived` | boolean | Whether the block is archived |
+|   ↳ `in_trash` | boolean | Whether the block is in trash |
+|   ↳ `has_children` | boolean | Whether the block has nested blocks |
 | `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
-| `has_children` | boolean | Whether the block has nested blocks |
-| `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
-| `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
-| `email` | string | User email address \(person users only\) |
+| `next_cursor` | string | Cursor for next page of results |
 
 ### Notion Retrieve Block
 
@@ -318,26 +322,32 @@ Retrieve a single Notion block by its UUID, including its type-specific content
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
-| `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
+| `id` | string | Block UUID |
+| `type` | string | Block type \(paragraph, heading_1, heading_2, heading_3, image, etc.\) |
 | `has_children` | boolean | Whether the block has nested blocks |
 | `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
-| `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
-| `email` | string | User email address \(person users only\) |
+| `block` | object | The full Notion block object. Includes a type-specific field \(e.g. paragraph, heading_1, image\) whose shape varies by block type and is not enumerated below — read it directly off this object. |
+|   ↳ `object` | string | Always "block" |
+|   ↳ `id` | string | Block UUID |
+|   ↳ `parent` | object | Parent object specifying hierarchical relationship |
+|     ↳ `type` | string | Parent type: "database_id", "data_source_id", "page_id", "workspace", or "block_id" |
+|     ↳ `database_id` | string | Parent database UUID \(if type is database_id\) |
+|     ↳ `data_source_id` | string | Parent data source UUID \(if type is data_source_id\) |
+|     ↳ `page_id` | string | Parent page UUID \(if type is page_id\) |
+|     ↳ `workspace` | boolean | True if parent is workspace \(if type is workspace\) |
+|     ↳ `block_id` | string | Parent block UUID \(if type is block_id\) |
+|   ↳ `type` | string | Block type \(paragraph, heading_1, heading_2, heading_3, image, etc.\) |
+|   ↳ `created_time` | string | ISO 8601 creation timestamp |
+|   ↳ `last_edited_time` | string | ISO 8601 last edit timestamp |
+|   ↳ `created_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `last_edited_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `archived` | boolean | Whether the block is archived |
+|   ↳ `in_trash` | boolean | Whether the block is in trash |
+|   ↳ `has_children` | boolean | Whether the block has nested blocks |
 
 ### Notion Retrieve Block Children
 
@@ -355,26 +365,30 @@ Retrieve the block children (content) of a Notion page or block
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
+| `results` | array | Array of Notion block objects |
+|   ↳ `object` | string | Always "block" |
+|   ↳ `id` | string | Block UUID |
+|   ↳ `parent` | object | Parent object specifying hierarchical relationship |
+|     ↳ `type` | string | Parent type: "database_id", "data_source_id", "page_id", "workspace", or "block_id" |
+|     ↳ `database_id` | string | Parent database UUID \(if type is database_id\) |
+|     ↳ `data_source_id` | string | Parent data source UUID \(if type is data_source_id\) |
+|     ↳ `page_id` | string | Parent page UUID \(if type is page_id\) |
+|     ↳ `workspace` | boolean | True if parent is workspace \(if type is workspace\) |
+|     ↳ `block_id` | string | Parent block UUID \(if type is block_id\) |
+|   ↳ `type` | string | Block type \(paragraph, heading_1, heading_2, heading_3, image, etc.\) |
+|   ↳ `created_time` | string | ISO 8601 creation timestamp |
+|   ↳ `last_edited_time` | string | ISO 8601 last edit timestamp |
+|   ↳ `created_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `last_edited_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `archived` | boolean | Whether the block is archived |
+|   ↳ `in_trash` | boolean | Whether the block is in trash |
+|   ↳ `has_children` | boolean | Whether the block has nested blocks |
 | `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
-| `has_children` | boolean | Whether the block has nested blocks |
-| `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
-| `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
-| `email` | string | User email address \(person users only\) |
+| `next_cursor` | string | Cursor for next page of results |
 
 ### Notion Update Block
 
@@ -392,26 +406,31 @@ Update the content or archived state of a single Notion block
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
-| `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
-| `has_children` | boolean | Whether the block has nested blocks |
+| `id` | string | Block UUID |
+| `type` | string | Block type \(paragraph, heading_1, heading_2, heading_3, image, etc.\) |
 | `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
-| `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
-| `email` | string | User email address \(person users only\) |
+| `block` | object | The full updated Notion block object |
+|   ↳ `object` | string | Always "block" |
+|   ↳ `id` | string | Block UUID |
+|   ↳ `parent` | object | Parent object specifying hierarchical relationship |
+|     ↳ `type` | string | Parent type: "database_id", "data_source_id", "page_id", "workspace", or "block_id" |
+|     ↳ `database_id` | string | Parent database UUID \(if type is database_id\) |
+|     ↳ `data_source_id` | string | Parent data source UUID \(if type is data_source_id\) |
+|     ↳ `page_id` | string | Parent page UUID \(if type is page_id\) |
+|     ↳ `workspace` | boolean | True if parent is workspace \(if type is workspace\) |
+|     ↳ `block_id` | string | Parent block UUID \(if type is block_id\) |
+|   ↳ `type` | string | Block type \(paragraph, heading_1, heading_2, heading_3, image, etc.\) |
+|   ↳ `created_time` | string | ISO 8601 creation timestamp |
+|   ↳ `last_edited_time` | string | ISO 8601 last edit timestamp |
+|   ↳ `created_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `last_edited_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `archived` | boolean | Whether the block is archived |
+|   ↳ `in_trash` | boolean | Whether the block is in trash |
+|   ↳ `has_children` | boolean | Whether the block has nested blocks |
 
 ### Notion Delete Block
 
@@ -427,26 +446,8 @@ Delete (move to trash) a single Notion block
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
-| `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
-| `has_children` | boolean | Whether the block has nested blocks |
-| `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
-| `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
-| `email` | string | User email address \(person users only\) |
+| `id` | string | Block UUID |
+| `archived` | boolean | Whether the block was archived \(moved to trash\) |
 
 ### Notion Create Comment
 
@@ -464,26 +465,21 @@ Create a comment on a Notion page or within an existing discussion thread
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
-| `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
-| `has_children` | boolean | Whether the block has nested blocks |
-| `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
-| `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
-| `email` | string | User email address \(person users only\) |
+| `id` | string | Comment UUID |
+| `discussion_id` | string | UUID of the discussion thread |
+| `created_time` | string | ISO 8601 creation timestamp |
+| `content` | string | Plain text content of the comment |
+| `rich_text` | array | Array of rich text objects |
+|   ↳ `type` | string | Rich text type: "text", "mention", or "equation" |
+|   ↳ `plain_text` | string | Plain text content without annotations |
+|   ↳ `href` | string | URL for links or Notion mentions |
+|   ↳ `annotations` | object | Text styling annotations |
+|     ↳ `bold` | boolean | Bold styling |
+|     ↳ `italic` | boolean | Italic styling |
+|     ↳ `strikethrough` | boolean | Strikethrough styling |
+|     ↳ `underline` | boolean | Underline styling |
+|     ↳ `code` | boolean | Code styling |
+|     ↳ `color` | string | Text color \(default, blue, green, red, purple, orange, pink, gray, brown, yellow, or _background variants\) |
 
 ### Notion List Comments
 
@@ -501,26 +497,35 @@ List unresolved comments on a Notion page or block
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
+| `results` | array | Array of Notion comment objects |
+|   ↳ `object` | string | Always "comment" |
+|   ↳ `id` | string | Comment UUID |
+|   ↳ `parent` | object | Parent object specifying hierarchical relationship |
+|     ↳ `type` | string | Parent type: "database_id", "data_source_id", "page_id", "workspace", or "block_id" |
+|     ↳ `database_id` | string | Parent database UUID \(if type is database_id\) |
+|     ↳ `data_source_id` | string | Parent data source UUID \(if type is data_source_id\) |
+|     ↳ `page_id` | string | Parent page UUID \(if type is page_id\) |
+|     ↳ `workspace` | boolean | True if parent is workspace \(if type is workspace\) |
+|     ↳ `block_id` | string | Parent block UUID \(if type is block_id\) |
+|   ↳ `discussion_id` | string | UUID of the discussion thread |
+|   ↳ `created_time` | string | ISO 8601 creation timestamp |
+|   ↳ `last_edited_time` | string | ISO 8601 last edit timestamp |
+|   ↳ `created_by` | object | Partial user object |
+|     ↳ `object` | string | Always "user" |
+|     ↳ `id` | string | User UUID |
+|   ↳ `rich_text` | array | Array of rich text objects |
+|     ↳ `type` | string | Rich text type: "text", "mention", or "equation" |
+|     ↳ `plain_text` | string | Plain text content without annotations |
+|     ↳ `href` | string | URL for links or Notion mentions |
+|     ↳ `annotations` | object | Text styling annotations |
+|       ↳ `bold` | boolean | Bold styling |
+|       ↳ `italic` | boolean | Italic styling |
+|       ↳ `strikethrough` | boolean | Strikethrough styling |
+|       ↳ `underline` | boolean | Underline styling |
+|       ↳ `code` | boolean | Code styling |
+|       ↳ `color` | string | Text color \(default, blue, green, red, purple, orange, pink, gray, brown, yellow, or _background variants\) |
 | `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
-| `has_children` | boolean | Whether the block has nested blocks |
-| `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
-| `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
-| `email` | string | User email address \(person users only\) |
+| `next_cursor` | string | Cursor for next page of results |
 
 ### Notion List Users
 
@@ -537,26 +542,14 @@ List all users (members and bots) in the Notion workspace
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
+| `results` | array | Array of Notion user objects |
+|   ↳ `object` | string | Always "user" |
+|   ↳ `id` | string | User UUID |
+|   ↳ `type` | string | User type: "person" or "bot" |
+|   ↳ `name` | string | User display name |
+|   ↳ `avatar_url` | string | URL to user avatar image |
 | `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
-| `has_children` | boolean | Whether the block has nested blocks |
-| `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
-| `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
-| `email` | string | User email address \(person users only\) |
+| `next_cursor` | string | Cursor for next page of results |
 
 ### Notion Retrieve User
 
@@ -572,28 +565,11 @@ Retrieve a single Notion user by their UUID
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `content` | string | Page content in markdown format, or comment text for create comment |
-| `title` | string | Page or database title |
-| `url` | string | Notion URL |
-| `id` | string | Page, database, block, comment, or user ID |
-| `created_time` | string | Creation timestamp |
-| `last_edited_time` | string | Last edit timestamp |
-| `results` | array | Array of results \(pages, blocks, comments, or users\) |
-| `has_more` | boolean | Whether more results are available |
-| `next_cursor` | string | Cursor for pagination |
-| `total_results` | number | Number of results returned |
-| `properties` | json | Database properties schema |
-| `appended` | boolean | Whether content was successfully appended |
-| `type` | string | Block type |
-| `block` | json | The full Notion block object |
-| `has_children` | boolean | Whether the block has nested blocks |
-| `archived` | boolean | Whether the block is archived |
-| `discussion_id` | string | Discussion thread ID |
+| `id` | string | User UUID |
+| `type` | string | User type: "person" or "bot" |
 | `name` | string | User display name |
-| `avatar_url` | string | User avatar image URL |
+| `avatar_url` | string | URL to user avatar image |
 | `email` | string | User email address \(person users only\) |
-
-
 
 ## Triggers
 
@@ -937,4 +913,3 @@ Trigger workflow on any Notion webhook event
 |   ↳ `page_id` | string | Page ID related to the event, when present |
 |   ↳ `updated_blocks` | array | Blocks updated as part of the event, when provided by Notion |
 |   ↳ `updated_properties` | array | Updated properties included with the event, when provided by Notion |
-

--- a/apps/docs/content/docs/integrations/obsidian.mdx
+++ b/apps/docs/content/docs/integrations/obsidian.mdx
@@ -5,7 +5,7 @@ description: Interact with your Obsidian vault via the Local REST API
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="obsidian"
   color="#0F0F0F"
 />
@@ -327,5 +327,3 @@ Search for text across notes in your Obsidian vault
 |   ↳ `score` | number | Relevance score |
 |   ↳ `matches` | json | Matching text contexts |
 |     ↳ `context` | string | Text surrounding the match |
-
-

--- a/apps/docs/content/docs/integrations/okta.mdx
+++ b/apps/docs/content/docs/integrations/okta.mdx
@@ -5,7 +5,7 @@ description: Manage users, groups, apps, and MFA in Okta
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="okta"
   color="#191919"
 />
@@ -1266,5 +1266,3 @@ Query the Okta System Log for sign-ins, admin changes, and security events. Supp
 | `nextCursor` | string | Cursor to resume from, or null when Okta advertised no next link. On a polling query it stays set on an empty page so the next scheduled run resumes from here rather than replaying from the start |
 | `hasMore` | boolean | Whether more events are available. A query with no "until" is a polling query, which Okta always answers with a next link even when there are no new events, so this reports false once a page comes back empty |
 | `success` | boolean | Operation success status |
-
-

--- a/apps/docs/content/docs/integrations/onedrive.mdx
+++ b/apps/docs/content/docs/integrations/onedrive.mdx
@@ -5,7 +5,7 @@ description: Create, upload, download, search, move, copy, share, and delete fil
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="onedrive"
   color="#FFFFFF"
 />
@@ -233,5 +233,3 @@ Delete a file or folder from OneDrive
 | `success` | boolean | Whether the file was deleted successfully |
 | `deleted` | boolean | Confirmation that the file was deleted |
 | `fileId` | string | The ID of the deleted file |
-
-

--- a/apps/docs/content/docs/integrations/onepassword.mdx
+++ b/apps/docs/content/docs/integrations/onepassword.mdx
@@ -5,7 +5,7 @@ description: Manage secrets and items in 1Password vaults
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="onepassword"
   color="#FFFFFF"
 />
@@ -136,31 +136,45 @@ Get full details of an item including all fields and secrets
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `response` | json | Deprecated — kept for backward compatibility with workflows saved before per-operation outputs were added below. Never populated; use the operation-specific outputs instead. |
-| `vaults` | json | List of accessible vaults \[\{id, name, description, items, type, createdAt, updatedAt\}\] |
-| `id` | string | Vault or item ID |
-| `name` | string | Vault name |
-| `description` | string | Vault description |
-| `items` | json | Number of items in the vault \(Get Vault\) or item summaries \[\{id, title, category, tags, favorite, version, updatedAt\}\] \(List Items\) |
-| `type` | string | Vault type \(USER_CREATED, PERSONAL, or EVERYONE\) |
+| `id` | string | Item ID |
 | `title` | string | Item title |
+| `vault` | object | Vault reference |
+|   ↳ `id` | string | Vault ID |
 | `category` | string | Item category \(e.g., LOGIN, API_CREDENTIAL, SECURE_NOTE\) |
-| `vault` | json | Vault reference the item belongs to \{id\} |
-| `fields` | json | Item fields including secrets \[\{id, label, type, purpose, value\}\] |
-| `sections` | json | Item sections \[\{id, label\}\] |
-| `files` | json | Files attached to the item \[\{id, name, size, section\}\] — fetch content with Get Item File |
-| `tags` | json | Item tags |
-| `urls` | json | URLs associated with the item \[\{href, label, primary\}\] |
+| `urls` | array | URLs associated with the item |
+|   ↳ `href` | string | URL |
+|   ↳ `label` | string | URL label |
+|   ↳ `primary` | boolean | Whether this is the primary URL |
 | `favorite` | boolean | Whether the item is favorited |
+| `tags` | array | Item tags |
 | `version` | number | Item version number |
 | `state` | string | Item state \(ARCHIVED, or absent/null when active\) |
-| `lastEditedBy` | string | ID of the last editor |
+| `fields` | array | Item fields including secrets |
+|   ↳ `id` | string | Field ID |
+|   ↳ `label` | string | Field label |
+|   ↳ `type` | string | Field type \(STRING, EMAIL, CONCEALED, URL, TOTP, DATE, MONTH_YEAR, MENU\) |
+|   ↳ `purpose` | string | Field purpose \(USERNAME, PASSWORD, NOTES, or empty\) |
+|   ↳ `value` | string | Field value |
+|   ↳ `section` | object | Section reference this field belongs to |
+|     ↳ `id` | string | Section ID |
+|   ↳ `generate` | boolean | Whether the field value should be generated |
+|   ↳ `recipe` | object | Password generation recipe |
+|     ↳ `length` | number | Generated password length |
+|     ↳ `characterSets` | array | Character sets \(LETTERS, DIGITS, SYMBOLS\) |
+|     ↳ `excludeCharacters` | string | Characters to exclude |
+|   ↳ `entropy` | number | Password entropy score |
+| `sections` | array | Item sections |
+|   ↳ `id` | string | Section ID |
+|   ↳ `label` | string | Section label |
+| `files` | array | Files attached to the item \(fetch content with Get Item File\) |
+|   ↳ `id` | string | File ID |
+|   ↳ `name` | string | File name |
+|   ↳ `size` | number | File size in bytes |
+|   ↳ `section` | object | Section reference this file belongs to |
+|     ↳ `id` | string | Section ID |
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last update timestamp |
-| `success` | boolean | Whether the item was successfully deleted |
-| `value` | string | The resolved secret value |
-| `reference` | string | The original secret reference URI |
-| `file` | file | Downloaded file attachment |
+| `lastEditedBy` | string | ID of the last editor |
 
 ### 1Password Get Item File
 
@@ -206,31 +220,45 @@ Create a new item in a vault
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `response` | json | Deprecated — kept for backward compatibility with workflows saved before per-operation outputs were added below. Never populated; use the operation-specific outputs instead. |
-| `vaults` | json | List of accessible vaults \[\{id, name, description, items, type, createdAt, updatedAt\}\] |
-| `id` | string | Vault or item ID |
-| `name` | string | Vault name |
-| `description` | string | Vault description |
-| `items` | json | Number of items in the vault \(Get Vault\) or item summaries \[\{id, title, category, tags, favorite, version, updatedAt\}\] \(List Items\) |
-| `type` | string | Vault type \(USER_CREATED, PERSONAL, or EVERYONE\) |
+| `id` | string | Item ID |
 | `title` | string | Item title |
+| `vault` | object | Vault reference |
+|   ↳ `id` | string | Vault ID |
 | `category` | string | Item category \(e.g., LOGIN, API_CREDENTIAL, SECURE_NOTE\) |
-| `vault` | json | Vault reference the item belongs to \{id\} |
-| `fields` | json | Item fields including secrets \[\{id, label, type, purpose, value\}\] |
-| `sections` | json | Item sections \[\{id, label\}\] |
-| `files` | json | Files attached to the item \[\{id, name, size, section\}\] — fetch content with Get Item File |
-| `tags` | json | Item tags |
-| `urls` | json | URLs associated with the item \[\{href, label, primary\}\] |
+| `urls` | array | URLs associated with the item |
+|   ↳ `href` | string | URL |
+|   ↳ `label` | string | URL label |
+|   ↳ `primary` | boolean | Whether this is the primary URL |
 | `favorite` | boolean | Whether the item is favorited |
+| `tags` | array | Item tags |
 | `version` | number | Item version number |
 | `state` | string | Item state \(ARCHIVED, or absent/null when active\) |
-| `lastEditedBy` | string | ID of the last editor |
+| `fields` | array | Item fields including secrets |
+|   ↳ `id` | string | Field ID |
+|   ↳ `label` | string | Field label |
+|   ↳ `type` | string | Field type \(STRING, EMAIL, CONCEALED, URL, TOTP, DATE, MONTH_YEAR, MENU\) |
+|   ↳ `purpose` | string | Field purpose \(USERNAME, PASSWORD, NOTES, or empty\) |
+|   ↳ `value` | string | Field value |
+|   ↳ `section` | object | Section reference this field belongs to |
+|     ↳ `id` | string | Section ID |
+|   ↳ `generate` | boolean | Whether the field value should be generated |
+|   ↳ `recipe` | object | Password generation recipe |
+|     ↳ `length` | number | Generated password length |
+|     ↳ `characterSets` | array | Character sets \(LETTERS, DIGITS, SYMBOLS\) |
+|     ↳ `excludeCharacters` | string | Characters to exclude |
+|   ↳ `entropy` | number | Password entropy score |
+| `sections` | array | Item sections |
+|   ↳ `id` | string | Section ID |
+|   ↳ `label` | string | Section label |
+| `files` | array | Files attached to the item \(fetch content with Get Item File\) |
+|   ↳ `id` | string | File ID |
+|   ↳ `name` | string | File name |
+|   ↳ `size` | number | File size in bytes |
+|   ↳ `section` | object | Section reference this file belongs to |
+|     ↳ `id` | string | Section ID |
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last update timestamp |
-| `success` | boolean | Whether the item was successfully deleted |
-| `value` | string | The resolved secret value |
-| `reference` | string | The original secret reference URI |
-| `file` | file | Downloaded file attachment |
+| `lastEditedBy` | string | ID of the last editor |
 
 ### 1Password Replace Item
 
@@ -252,31 +280,45 @@ Replace an entire item with new data (full update)
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `response` | json | Deprecated — kept for backward compatibility with workflows saved before per-operation outputs were added below. Never populated; use the operation-specific outputs instead. |
-| `vaults` | json | List of accessible vaults \[\{id, name, description, items, type, createdAt, updatedAt\}\] |
-| `id` | string | Vault or item ID |
-| `name` | string | Vault name |
-| `description` | string | Vault description |
-| `items` | json | Number of items in the vault \(Get Vault\) or item summaries \[\{id, title, category, tags, favorite, version, updatedAt\}\] \(List Items\) |
-| `type` | string | Vault type \(USER_CREATED, PERSONAL, or EVERYONE\) |
+| `id` | string | Item ID |
 | `title` | string | Item title |
+| `vault` | object | Vault reference |
+|   ↳ `id` | string | Vault ID |
 | `category` | string | Item category \(e.g., LOGIN, API_CREDENTIAL, SECURE_NOTE\) |
-| `vault` | json | Vault reference the item belongs to \{id\} |
-| `fields` | json | Item fields including secrets \[\{id, label, type, purpose, value\}\] |
-| `sections` | json | Item sections \[\{id, label\}\] |
-| `files` | json | Files attached to the item \[\{id, name, size, section\}\] — fetch content with Get Item File |
-| `tags` | json | Item tags |
-| `urls` | json | URLs associated with the item \[\{href, label, primary\}\] |
+| `urls` | array | URLs associated with the item |
+|   ↳ `href` | string | URL |
+|   ↳ `label` | string | URL label |
+|   ↳ `primary` | boolean | Whether this is the primary URL |
 | `favorite` | boolean | Whether the item is favorited |
+| `tags` | array | Item tags |
 | `version` | number | Item version number |
 | `state` | string | Item state \(ARCHIVED, or absent/null when active\) |
-| `lastEditedBy` | string | ID of the last editor |
+| `fields` | array | Item fields including secrets |
+|   ↳ `id` | string | Field ID |
+|   ↳ `label` | string | Field label |
+|   ↳ `type` | string | Field type \(STRING, EMAIL, CONCEALED, URL, TOTP, DATE, MONTH_YEAR, MENU\) |
+|   ↳ `purpose` | string | Field purpose \(USERNAME, PASSWORD, NOTES, or empty\) |
+|   ↳ `value` | string | Field value |
+|   ↳ `section` | object | Section reference this field belongs to |
+|     ↳ `id` | string | Section ID |
+|   ↳ `generate` | boolean | Whether the field value should be generated |
+|   ↳ `recipe` | object | Password generation recipe |
+|     ↳ `length` | number | Generated password length |
+|     ↳ `characterSets` | array | Character sets \(LETTERS, DIGITS, SYMBOLS\) |
+|     ↳ `excludeCharacters` | string | Characters to exclude |
+|   ↳ `entropy` | number | Password entropy score |
+| `sections` | array | Item sections |
+|   ↳ `id` | string | Section ID |
+|   ↳ `label` | string | Section label |
+| `files` | array | Files attached to the item \(fetch content with Get Item File\) |
+|   ↳ `id` | string | File ID |
+|   ↳ `name` | string | File name |
+|   ↳ `size` | number | File size in bytes |
+|   ↳ `section` | object | Section reference this file belongs to |
+|     ↳ `id` | string | Section ID |
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last update timestamp |
-| `success` | boolean | Whether the item was successfully deleted |
-| `value` | string | The resolved secret value |
-| `reference` | string | The original secret reference URI |
-| `file` | file | Downloaded file attachment |
+| `lastEditedBy` | string | ID of the last editor |
 
 ### 1Password Update Item
 
@@ -298,31 +340,45 @@ Update an existing item using JSON Patch operations (RFC6902)
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `response` | json | Deprecated — kept for backward compatibility with workflows saved before per-operation outputs were added below. Never populated; use the operation-specific outputs instead. |
-| `vaults` | json | List of accessible vaults \[\{id, name, description, items, type, createdAt, updatedAt\}\] |
-| `id` | string | Vault or item ID |
-| `name` | string | Vault name |
-| `description` | string | Vault description |
-| `items` | json | Number of items in the vault \(Get Vault\) or item summaries \[\{id, title, category, tags, favorite, version, updatedAt\}\] \(List Items\) |
-| `type` | string | Vault type \(USER_CREATED, PERSONAL, or EVERYONE\) |
+| `id` | string | Item ID |
 | `title` | string | Item title |
+| `vault` | object | Vault reference |
+|   ↳ `id` | string | Vault ID |
 | `category` | string | Item category \(e.g., LOGIN, API_CREDENTIAL, SECURE_NOTE\) |
-| `vault` | json | Vault reference the item belongs to \{id\} |
-| `fields` | json | Item fields including secrets \[\{id, label, type, purpose, value\}\] |
-| `sections` | json | Item sections \[\{id, label\}\] |
-| `files` | json | Files attached to the item \[\{id, name, size, section\}\] — fetch content with Get Item File |
-| `tags` | json | Item tags |
-| `urls` | json | URLs associated with the item \[\{href, label, primary\}\] |
+| `urls` | array | URLs associated with the item |
+|   ↳ `href` | string | URL |
+|   ↳ `label` | string | URL label |
+|   ↳ `primary` | boolean | Whether this is the primary URL |
 | `favorite` | boolean | Whether the item is favorited |
+| `tags` | array | Item tags |
 | `version` | number | Item version number |
 | `state` | string | Item state \(ARCHIVED, or absent/null when active\) |
-| `lastEditedBy` | string | ID of the last editor |
+| `fields` | array | Item fields including secrets |
+|   ↳ `id` | string | Field ID |
+|   ↳ `label` | string | Field label |
+|   ↳ `type` | string | Field type \(STRING, EMAIL, CONCEALED, URL, TOTP, DATE, MONTH_YEAR, MENU\) |
+|   ↳ `purpose` | string | Field purpose \(USERNAME, PASSWORD, NOTES, or empty\) |
+|   ↳ `value` | string | Field value |
+|   ↳ `section` | object | Section reference this field belongs to |
+|     ↳ `id` | string | Section ID |
+|   ↳ `generate` | boolean | Whether the field value should be generated |
+|   ↳ `recipe` | object | Password generation recipe |
+|     ↳ `length` | number | Generated password length |
+|     ↳ `characterSets` | array | Character sets \(LETTERS, DIGITS, SYMBOLS\) |
+|     ↳ `excludeCharacters` | string | Characters to exclude |
+|   ↳ `entropy` | number | Password entropy score |
+| `sections` | array | Item sections |
+|   ↳ `id` | string | Section ID |
+|   ↳ `label` | string | Section label |
+| `files` | array | Files attached to the item \(fetch content with Get Item File\) |
+|   ↳ `id` | string | File ID |
+|   ↳ `name` | string | File name |
+|   ↳ `size` | number | File size in bytes |
+|   ↳ `section` | object | Section reference this file belongs to |
+|     ↳ `id` | string | Section ID |
 | `createdAt` | string | Creation timestamp |
 | `updatedAt` | string | Last update timestamp |
-| `success` | boolean | Whether the item was successfully deleted |
-| `value` | string | The resolved secret value |
-| `reference` | string | The original secret reference URI |
-| `file` | file | Downloaded file attachment |
+| `lastEditedBy` | string | ID of the last editor |
 
 ### 1Password Delete Item
 
@@ -363,5 +419,3 @@ Resolve a secret reference (op://vault/item/field) to its value. Service Account
 | --------- | ---- | ----------- |
 | `value` | string | The resolved secret value |
 | `reference` | string | The original secret reference URI |
-
-

--- a/apps/docs/content/docs/integrations/outlook.mdx
+++ b/apps/docs/content/docs/integrations/outlook.mdx
@@ -5,7 +5,7 @@ description: Send, read, search, reply, organize, and manage Outlook email and c
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="outlook"
   color="#FFFFFF"
 />
@@ -679,8 +679,6 @@ Accept, tentatively accept, or decline an Outlook calendar event invitation
 |   ↳ `httpStatus` | number | HTTP status code returned by the API |
 |   ↳ `requestId` | string | Microsoft Graph request-id header for tracing |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -722,4 +720,3 @@ Triggers when new emails are received in Outlook (requires Microsoft credentials
 |   ↳ `messageId` | string | Message ID for threading |
 |   ↳ `threadId` | string | Thread ID for conversation threading |
 | `timestamp` | string | Event timestamp |
-

--- a/apps/docs/content/docs/integrations/pagerduty.mdx
+++ b/apps/docs/content/docs/integrations/pagerduty.mdx
@@ -5,7 +5,7 @@ description: Manage incidents and on-call schedules with PagerDuty
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="pagerduty"
   color="#06AC38"
 />
@@ -456,8 +456,6 @@ Send a trigger, acknowledge, or resolve event to PagerDuty Events API v2 using a
 | `message` | string | Description of the result |
 | `dedupKey` | string | De-duplication key for the alert |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -698,4 +696,3 @@ Trigger workflow when a new incident is triggered in PagerDuty
 |     ↳ `summary` | string | Escalation policy name |
 |     ↳ `html_url` | string | Escalation policy web URL |
 |   ↳ `assignees` | json | Array of assignee references \(\{ id, summary, html_url \}\) |
-

--- a/apps/docs/content/docs/integrations/parallel_ai.mdx
+++ b/apps/docs/content/docs/integrations/parallel_ai.mdx
@@ -5,7 +5,7 @@ description: Web research with Parallel AI
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="parallel_ai"
   color="#1D1C1A"
 />
@@ -124,5 +124,3 @@ Conduct comprehensive deep research across the web using Parallel AI. Synthesize
 |     ↳ `title` | string | Source title |
 |     ↳ `excerpts` | array | Relevant excerpts from the source |
 |   ↳ `confidence` | string | Confidence level \(low, medium, high\) |
-
-

--- a/apps/docs/content/docs/integrations/peopledatalabs.mdx
+++ b/apps/docs/content/docs/integrations/peopledatalabs.mdx
@@ -5,7 +5,7 @@ description: Enrich and search people and companies
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="peopledatalabs"
   color="#4831C3"
 />
@@ -450,5 +450,3 @@ Get autocomplete suggestions for a PDL field (title, skill, company, industry, l
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `suggestions` | array | Autocomplete suggestions ordered by frequency |
-
-

--- a/apps/docs/content/docs/integrations/perplexity.mdx
+++ b/apps/docs/content/docs/integrations/perplexity.mdx
@@ -5,7 +5,7 @@ description: Use Perplexity AI for chat and search
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="perplexity"
   color="#20808D"
 />
@@ -77,5 +77,3 @@ Get ranked search results from Perplexity's continuously refreshed index with ad
 |   ↳ `snippet` | string | Brief excerpt or summary of the content |
 |   ↳ `date` | string | Date the page was crawled and added to Perplexity's index |
 |   ↳ `last_updated` | string | Date the page was last updated in Perplexity's index |
-
-

--- a/apps/docs/content/docs/integrations/persona.mdx
+++ b/apps/docs/content/docs/integrations/persona.mdx
@@ -5,7 +5,7 @@ description: Verify identities with Persona
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="persona"
   color="#FFFFFF"
 />
@@ -523,5 +523,3 @@ List the inquiry templates in your Persona organization, to discover template ID
 | --------- | ---- | ----------- |
 | `inquiryTemplates` | array | Inquiry templates in the organization |
 | `nextCursor` | string | Cursor for the next page \(pass as pageAfter\), or null on the last page |
-
-

--- a/apps/docs/content/docs/integrations/pinecone.mdx
+++ b/apps/docs/content/docs/integrations/pinecone.mdx
@@ -5,7 +5,7 @@ description: Use Pinecone vector database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="pinecone"
   color="#0D1117"
 />
@@ -285,5 +285,3 @@ Get the configuration and status of a Pinecone index by name
 |   ↳ `tags` | object | Custom user tags on the index |
 |   ↳ `spec` | object | Index spec \(serverless or pod configuration\) |
 |   ↳ `status` | object | Index status with ready and state |
-
-

--- a/apps/docs/content/docs/integrations/pipedrive.mdx
+++ b/apps/docs/content/docs/integrations/pipedrive.mdx
@@ -5,7 +5,7 @@ description: Interact with Pipedrive CRM
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="pipedrive"
   color="#2E6936"
 />
@@ -504,5 +504,3 @@ Delete a specific lead from Pipedrive
 | --------- | ---- | ----------- |
 | `data` | object | Deletion confirmation data |
 | `success` | boolean | Operation success status |
-
-

--- a/apps/docs/content/docs/integrations/pitchbook.mdx
+++ b/apps/docs/content/docs/integrations/pitchbook.mdx
@@ -5,7 +5,7 @@ description: Look up private market data on companies, deals, investors, funds, 
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="pitchbook"
   color="#1D5080"
 />
@@ -67,19 +67,19 @@ Search across every PitchBook entity type at once by name, PitchBook ID, website
 |   ↳ `page` | number | Current page number |
 |   ↳ `lastPage` | number | Number of the last available page |
 | `items` | array | Matching entities. Entries carry pbId/name for companies, investors, and service providers, and fundId/fundName for funds, so check which is populated before using an ID. |
-|   ↳ `pbId` | string | PitchBook entity ID, null for fund results |
-|   ↳ `name` | string | Entity name, null for fund results |
-|   ↳ `fundId` | string | PitchBook fund ID, present only on fund results |
-|   ↳ `fundName` | string | Fund name, present only on fund results |
-|   ↳ `website` | string | Entity website, absent on fund results |
-|   ↳ `pitchBookProfileLink` | string | Link to the entity profile in the PitchBook platform |
-|   ↳ `primaryFirmType` | object | Primary type of the entity |
+|   ↳ `pbId` | string (nullable) | PitchBook entity ID, null for fund results |
+|   ↳ `name` | string (nullable) | Entity name, null for fund results |
+|   ↳ `fundId` | string (nullable) | PitchBook fund ID, present only on fund results |
+|   ↳ `fundName` | string (nullable) | Fund name, present only on fund results |
+|   ↳ `website` | string (nullable) | Entity website, absent on fund results |
+|   ↳ `pitchBookProfileLink` | string (nullable) | Link to the entity profile in the PitchBook platform |
+|   ↳ `primaryFirmType` | object (nullable) | Primary type of the entity |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `type` | string | Entity type \(e.g. COMPANY, INVESTOR\) |
 |   ↳ `otherFirmTypes` | array | Additional types the entity is also classified as |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `type` | string | Entity type \(e.g. COMPANY, INVESTOR\) |
-|   ↳ `stockTicker` | string | Stock ticker when the entity is publicly traded |
+|   ↳ `stockTicker` | string (nullable) | Stock ticker when the entity is publicly traded |
 
 ### PitchBook Shared Search
 
@@ -128,26 +128,26 @@ Retrieve the people at an entity: primary contact, current and former team, and 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `entityId` | string | PitchBook entity ID |
-| `primaryContact` | object | Primary contact at the entity |
-|   ↳ `personId` | string | PitchBook person ID |
-|   ↳ `fullName` | string | Full name |
-|   ↳ `title` | string | Job title |
-|   ↳ `phone` | string | Phone number |
-|   ↳ `fax` | string | Fax number |
-|   ↳ `email` | string | Email address |
+| `entityId` | string (nullable) | PitchBook entity ID |
+| `primaryContact` | object (nullable) | Primary contact at the entity |
+|   ↳ `personId` | string (nullable) | PitchBook person ID |
+|   ↳ `fullName` | string (nullable) | Full name |
+|   ↳ `title` | string (nullable) | Job title |
+|   ↳ `phone` | string (nullable) | Phone number |
+|   ↳ `fax` | string (nullable) | Fax number |
+|   ↳ `email` | string (nullable) | Email address |
 | `currentTeam` | array | People currently working at the entity |
 |   ↳ `id` | string | PitchBook person ID |
 |   ↳ `name` | string | Full name |
-|   ↳ `title` | string | Job title |
-|   ↳ `positionStart` | string | Date the position started \(YYYY-MM-DD\) |
+|   ↳ `title` | string (nullable) | Job title |
+|   ↳ `positionStart` | string (nullable) | Date the position started \(YYYY-MM-DD\) |
 |   ↳ `infoAvailable` | boolean | Whether a full person profile is available for them |
 | `formerTeam` | array | People who previously worked at the entity |
 |   ↳ `id` | string | PitchBook person ID |
 |   ↳ `name` | string | Full name |
-|   ↳ `title` | string | Job title |
-|   ↳ `positionStart` | string | Date the position started \(YYYY-MM-DD\) |
-|   ↳ `positionFinish` | string | Date the position ended \(YYYY-MM-DD\) |
+|   ↳ `title` | string (nullable) | Job title |
+|   ↳ `positionStart` | string (nullable) | Date the position started \(YYYY-MM-DD\) |
+|   ↳ `positionFinish` | string (nullable) | Date the position ended \(YYYY-MM-DD\) |
 |   ↳ `infoAvailable` | boolean | Whether a full person profile is available for them |
 | `currentBoardMembersAndObservers` | array | Current board members and observers |
 | `formerBoardMembersAndObservers` | array | Former board members and observers |
@@ -168,34 +168,34 @@ Retrieve the headquarters and every alternate office on record for an entity
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `entityId` | string | PitchBook entity ID |
+| `entityId` | string (nullable) | PitchBook entity ID |
 | `hqOffice` | object | Headquarters office |
 |   ↳ `location` | string | Office label |
 |   ↳ `addressLine1` | string | Address line 1 |
-|   ↳ `addressLine2` | json | Address line 2 |
+|   ↳ `addressLine2` | json (nullable) | Address line 2 |
 |   ↳ `city` | string | City |
 |   ↳ `stateProvince` | string | State or province |
 |   ↳ `postCode` | string | Postal code |
 |   ↳ `country` | string | Country |
 |   ↳ `phone` | string | Phone number |
-|   ↳ `fax` | json | Fax number |
+|   ↳ `fax` | json (nullable) | Fax number |
 |   ↳ `email` | string | Email address |
 |   ↳ `globalRegion` | string | Global region |
 |   ↳ `globalSubRegion` | string | Global sub-region |
 | `alternateOffices` | array | Other offices on record |
 |   ↳ `location` | string | Office label |
-|   ↳ `addressLine1` | string | Address line 1 |
-|   ↳ `addressLine2` | string | Address line 2 |
-|   ↳ `city` | string | City |
-|   ↳ `stateProvince` | string | State or province |
-|   ↳ `postCode` | string | Postal code |
+|   ↳ `addressLine1` | string (nullable) | Address line 1 |
+|   ↳ `addressLine2` | string (nullable) | Address line 2 |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `stateProvince` | string (nullable) | State or province |
+|   ↳ `postCode` | string (nullable) | Postal code |
 |   ↳ `country` | string | Country |
-|   ↳ `phone` | json | Phone number |
-|   ↳ `fax` | json | Fax number |
+|   ↳ `phone` | json (nullable) | Phone number |
+|   ↳ `fax` | json (nullable) | Fax number |
 |   ↳ `email` | string | Email address |
 |   ↳ `globalRegion` | string | Global region |
 |   ↳ `globalSubRegion` | string | Global sub-region |
-| `alternateOfficesCount` | number | How many other offices are on record |
+| `alternateOfficesCount` | number (nullable) | How many other offices are on record |
 
 ### PitchBook Entity Affiliates
 
@@ -240,10 +240,10 @@ Retrieve recent news articles PitchBook has associated with an entity
 | `news` | array | News articles associated with the entity, most recent first |
 |   ↳ `entityId` | string | PitchBook entity ID the article is about |
 |   ↳ `title` | string | Article headline |
-|   ↳ `byline` | string | Article summary or byline |
-|   ↳ `source` | string | Publication the article came from |
-|   ↳ `publishDate` | string | Publication timestamp \(ISO 8601\) |
-|   ↳ `url` | string | Link to the article |
+|   ↳ `byline` | string (nullable) | Article summary or byline |
+|   ↳ `source` | string (nullable) | Publication the article came from |
+|   ↳ `publishDate` | string (nullable) | Publication timestamp \(ISO 8601\) |
+|   ↳ `url` | string (nullable) | Link to the article |
 
 ### PitchBook Entity Updates
 
@@ -263,7 +263,7 @@ Check which entity datasets changed in a window, so a sync only refetches what m
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updates` | json | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
+| `updates` | json (nullable) | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
 
 ### PitchBook Company Search
 
@@ -310,7 +310,7 @@ Search PitchBook for companies by name, location, industry, funding, deal activi
 | `items` | array | Companies matching the search criteria |
 |   ↳ `companyId` | string | PitchBook company ID |
 |   ↳ `companyName` | string | Company name |
-|   ↳ `website` | string | Company website |
+|   ↳ `website` | string (nullable) | Company website |
 
 ### PitchBook Company Bio
 
@@ -328,59 +328,59 @@ Retrieve the core profile of a company: names, description, HQ, status, headcoun
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `companyId` | string | PitchBook company ID |
+| `companyId` | string (nullable) | PitchBook company ID |
 | `companyName` | object | The names the company is known by |
-|   ↳ `formalName` | string | Formal name |
-|   ↳ `alsoKnownAs` | string | Also-known-as name |
-|   ↳ `legalName` | string | Registered legal name |
-|   ↳ `formerlyKnownAs` | string | Previous name |
-| `parentCompanyId` | string | PitchBook ID of the parent company |
-| `parentCompanyName` | string | Name of the parent company |
-| `hqLocation` | object | Headquarters location |
-|   ↳ `city` | string | City |
-|   ↳ `stateProvince` | string | State or province |
-|   ↳ `postCode` | string | Postal code |
-|   ↳ `country` | string | Country |
-| `description` | string | Business description |
-| `financingStatus` | object | How the company is financed |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `businessStatus` | object | Operating status of the business |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `ownershipStatus` | object | Ownership status of the company |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
+|   ↳ `formalName` | string (nullable) | Formal name |
+|   ↳ `alsoKnownAs` | string (nullable) | Also-known-as name |
+|   ↳ `legalName` | string (nullable) | Registered legal name |
+|   ↳ `formerlyKnownAs` | string (nullable) | Previous name |
+| `parentCompanyId` | string (nullable) | PitchBook ID of the parent company |
+| `parentCompanyName` | string (nullable) | Name of the parent company |
+| `hqLocation` | object (nullable) | Headquarters location |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `stateProvince` | string (nullable) | State or province |
+|   ↳ `postCode` | string (nullable) | Postal code |
+|   ↳ `country` | string (nullable) | Country |
+| `description` | string (nullable) | Business description |
+| `financingStatus` | object (nullable) | How the company is financed |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `businessStatus` | object (nullable) | Operating status of the business |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `ownershipStatus` | object (nullable) | Ownership status of the company |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
 | `universe` | array | PitchBook universes the company belongs to |
 |   ↳ `code` | string | Universe code |
 |   ↳ `description` | string | Universe label |
-| `website` | string | Company website |
-| `employees` | number | Current employee count |
+| `website` | string (nullable) | Company website |
+| `employees` | number (nullable) | Current employee count |
 | `employeeHistory` | array | Reported headcount over time |
 |   ↳ `asOfDate` | string | Date the count was reported \(YYYY-MM-DD\) |
 |   ↳ `employeeCount` | number | Headcount on that date |
-| `exchange` | string | Stock exchange the company trades on |
-| `ticker` | string | Stock ticker |
-| `yearFounded` | number | Year the company was founded |
-| `financingStatusNote` | object | Analyst note explaining the financing status |
-|   ↳ `note` | string | Note text |
-|   ↳ `asOfDate` | string | Date of the note \(YYYY-MM-DD\) |
-| `totalMoneyRaised` | object | Total capital raised to date |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `exchange` | string (nullable) | Stock exchange the company trades on |
+| `ticker` | string (nullable) | Stock ticker |
+| `yearFounded` | number (nullable) | Year the company was founded |
+| `financingStatusNote` | object (nullable) | Analyst note explaining the financing status |
+|   ↳ `note` | string (nullable) | Note text |
+|   ↳ `asOfDate` | string (nullable) | Date of the note \(YYYY-MM-DD\) |
+| `totalMoneyRaised` | object (nullable) | Total capital raised to date |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 | `sicCodes` | array | SIC classification codes |
 |   ↳ `code` | string | SIC code |
 |   ↳ `description` | string | SIC code label |
-| `morningstarCode` | string | Morningstar identifier |
-| `cikCode` | string | SEC CIK identifier |
-| `companySocialURLs` | object | Social profile links |
-|   ↳ `facebookProfileUrl` | string | Facebook profile |
-|   ↳ `twitterProfileUrl` | string | X/Twitter profile |
-|   ↳ `linkedInProfileUrl` | string | LinkedIn profile |
-| `pitchBookProfileLink` | string | Link to the company profile in the PitchBook platform |
+| `morningstarCode` | string (nullable) | Morningstar identifier |
+| `cikCode` | string (nullable) | SEC CIK identifier |
+| `companySocialURLs` | object (nullable) | Social profile links |
+|   ↳ `facebookProfileUrl` | string (nullable) | Facebook profile |
+|   ↳ `twitterProfileUrl` | string (nullable) | X/Twitter profile |
+|   ↳ `linkedInProfileUrl` | string (nullable) | LinkedIn profile |
+| `pitchBookProfileLink` | string (nullable) | Link to the company profile in the PitchBook platform |
 
 ### PitchBook Company Industries
 
@@ -442,11 +442,11 @@ Retrieve every investor in a company, current and former, with the type of inves
 |       ↳ `code` | string | Investor type code |
 |       ↳ `description` | string | Investor type label |
 |     ↳ `primary` | boolean | Whether this is the primary type |
-|   ↳ `investorSince` | string | Date the investor first invested \(YYYY-MM-DD\) |
-|   ↳ `investorExit` | string | Date the investor exited \(YYYY-MM-DD\) |
-|   ↳ `investorStatus` | object | Whether the investor is current or former |
-|     ↳ `code` | string | Status code |
-|     ↳ `description` | string | Status label |
+|   ↳ `investorSince` | string (nullable) | Date the investor first invested \(YYYY-MM-DD\) |
+|   ↳ `investorExit` | string (nullable) | Date the investor exited \(YYYY-MM-DD\) |
+|   ↳ `investorStatus` | object (nullable) | Whether the investor is current or former |
+|     ↳ `code` | string (nullable) | Status code |
+|     ↳ `description` | string (nullable) | Status label |
 
 ### PitchBook Company Active Investors
 
@@ -495,16 +495,16 @@ Retrieve every deal a company has been involved in, in chronological order with 
 | `deals` | array | Deals involving the company, oldest first |
 |   ↳ `companyId` | string | PitchBook company ID |
 |   ↳ `dealId` | string | PitchBook deal ID |
-|   ↳ `dealDate` | string | Date of the deal \(YYYY-MM-DD\) |
-|   ↳ `dealType1` | object | Primary deal type |
-|     ↳ `code` | string | Deal type code |
-|     ↳ `description` | string | Deal type label |
-|   ↳ `dealType2` | object | Secondary deal type, such as the round letter |
-|     ↳ `code` | string | Deal type code |
-|     ↳ `description` | string | Deal type label |
-|   ↳ `dealType3` | object | Tertiary deal type |
-|     ↳ `code` | string | Deal type code |
-|     ↳ `description` | string | Deal type label |
+|   ↳ `dealDate` | string (nullable) | Date of the deal \(YYYY-MM-DD\) |
+|   ↳ `dealType1` | object (nullable) | Primary deal type |
+|     ↳ `code` | string (nullable) | Deal type code |
+|     ↳ `description` | string (nullable) | Deal type label |
+|   ↳ `dealType2` | object (nullable) | Secondary deal type, such as the round letter |
+|     ↳ `code` | string (nullable) | Deal type code |
+|     ↳ `description` | string (nullable) | Deal type label |
+|   ↳ `dealType3` | object (nullable) | Tertiary deal type |
+|     ↳ `code` | string (nullable) | Deal type code |
+|     ↳ `description` | string (nullable) | Deal type label |
 |   ↳ `dealNumber` | number | Sequence of this deal in the company financing history |
 
 ### PitchBook Company Most Recent Financing
@@ -523,45 +523,45 @@ Retrieve a company most recent financing round: date, size, type, and last known
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `companyId` | string | PitchBook company ID |
-| `lastFinancingDealId` | string | PitchBook deal ID of the most recent financing |
-| `lastFinancingDate` | string | Date of the most recent financing \(YYYY-MM-DD\) |
-| `lastFinancingSize` | object | Size of the most recent financing |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `companyId` | string (nullable) | PitchBook company ID |
+| `lastFinancingDealId` | string (nullable) | PitchBook deal ID of the most recent financing |
+| `lastFinancingDate` | string (nullable) | Date of the most recent financing \(YYYY-MM-DD\) |
+| `lastFinancingSize` | object (nullable) | Size of the most recent financing |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `lastFinancingSizeStatus` | string | Whether the financing size is actual or estimated |
-| `lastFinancingValuation` | object | Valuation at the most recent financing |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `lastFinancingSizeStatus` | string (nullable) | Whether the financing size is actual or estimated |
+| `lastFinancingValuation` | object (nullable) | Valuation at the most recent financing |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `lastFinancingValuationStatus` | string | Whether the valuation is actual or estimated |
-| `lastFinancingDealType` | object | Primary deal type of the most recent financing |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `lastFinancingDealType2` | object | Secondary deal type of the most recent financing |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `lastFinancingDealType3` | object | Tertiary deal type of the most recent financing |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `lastFinancingDealClass` | object | Deal class of the most recent financing |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `lastKnownValuation` | object | Most recent known valuation of the company |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `lastFinancingValuationStatus` | string (nullable) | Whether the valuation is actual or estimated |
+| `lastFinancingDealType` | object (nullable) | Primary deal type of the most recent financing |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `lastFinancingDealType2` | object (nullable) | Secondary deal type of the most recent financing |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `lastFinancingDealType3` | object (nullable) | Tertiary deal type of the most recent financing |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `lastFinancingDealClass` | object (nullable) | Deal class of the most recent financing |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `lastKnownValuation` | object (nullable) | Most recent known valuation of the company |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `lastKnownValuationDate` | string | Date of the last known valuation \(YYYY-MM-DD\) |
-| `lastKnownValuationDealType` | object | Deal type the last known valuation came from |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
+| `lastKnownValuationDate` | string (nullable) | Date of the last known valuation \(YYYY-MM-DD\) |
+| `lastKnownValuationDealType` | object (nullable) | Deal type the last known valuation came from |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
 
 ### PitchBook Company Most Recent Debt Financing
 
@@ -579,9 +579,9 @@ Retrieve a company most recent debt financing, including each debt instrument ra
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `companyId` | string | PitchBook company ID |
-| `lastDebtFinancingDealId` | string | PitchBook deal ID of the most recent debt financing |
-| `lastDebtFinancingDate` | string | Date of the most recent debt financing \(YYYY-MM-DD\) |
+| `companyId` | string (nullable) | PitchBook company ID |
+| `lastDebtFinancingDealId` | string (nullable) | PitchBook deal ID of the most recent debt financing |
+| `lastDebtFinancingDate` | string (nullable) | Date of the most recent debt financing \(YYYY-MM-DD\) |
 | `lastDebtFinancing` | array | Debt instruments in the most recent debt financing |
 |   ↳ `lastDebtFinancingType` | object | Type of the most recent debt financing |
 |     ↳ `code` | string | PitchBook code |
@@ -592,10 +592,10 @@ Retrieve a company most recent debt financing, including each debt instrument ra
 |     ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-|   ↳ `seniority` | json | Seniority of the debt |
-|   ↳ `security` | json | Security backing the debt |
-|   ↳ `subordination` | json | Subordination terms |
-|   ↳ `term` | json | Term of the debt |
+|   ↳ `seniority` | json (nullable) | Seniority of the debt |
+|   ↳ `security` | json (nullable) | Security backing the debt |
+|   ↳ `subordination` | json (nullable) | Subordination terms |
+|   ↳ `term` | json (nullable) | Term of the debt |
 |   ↳ `additionalDebtCharacteristics` | object | Other characteristics of the debt |
 |     ↳ `unitranche` | boolean | Whether the debt is unitranche |
 |     ↳ `syndicated` | boolean | Whether the debt is syndicated |
@@ -603,7 +603,7 @@ Retrieve a company most recent debt financing, including each debt instrument ra
 |     ↳ `covLite` | boolean | Whether the debt is covenant-lite |
 |     ↳ `warrants` | boolean | Whether warrants are attached |
 |     ↳ `convertible` | boolean | Whether the instrument is convertible |
-|     ↳ `rate` | json | Interest rate |
+|     ↳ `rate` | json (nullable) | Interest rate |
 |   ↳ `lenders` | array | Lenders on the debt |
 
 ### PitchBook Company Most Recent Financials
@@ -622,44 +622,44 @@ Retrieve the most recent reported financials for a private company: revenue, net
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `companyId` | string | PitchBook company ID |
-| `period` | number | Fiscal period the figures cover |
-| `endDate` | string | Period end date \(YYYY-MM-DD\) |
-| `enterpriseValue` | object | Enterprise value |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `companyId` | string (nullable) | PitchBook company ID |
+| `period` | number (nullable) | Fiscal period the figures cover |
+| `endDate` | string (nullable) | Period end date \(YYYY-MM-DD\) |
+| `enterpriseValue` | object (nullable) | Enterprise value |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `revenue` | object | Revenue |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `revenue` | object (nullable) | Revenue |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `netIncome` | object | Net income |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `netIncome` | object (nullable) | Net income |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `ebitda` | object | EBITDA |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `ebitda` | object (nullable) | EBITDA |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `totalAssets` | object | Total assets |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `totalAssets` | object (nullable) | Total assets |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `totalDebt` | object | Total debt |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `totalDebt` | object (nullable) | Total debt |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 
 ### PitchBook Company Financials
@@ -682,13 +682,13 @@ Retrieve reported financials for a private company across every available fiscal
 | `items` | array | Records returned |
 |   ↳ `period` | string | Fiscal period the figures cover |
 |   ↳ `endDate` | string | End date \(YYYY-MM-DD\) |
-|   ↳ `enterpriseValue` | object | Enterprise value |
+|   ↳ `enterpriseValue` | object (nullable) | Enterprise value |
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `currency` | string | Currency of amount |
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 |     ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `revenue` | object | Revenue |
+|   ↳ `revenue` | object (nullable) | Revenue |
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `currency` | string | Currency of amount |
 |     ↳ `amount` | number | Value in the requested currency |
@@ -706,13 +706,13 @@ Retrieve reported financials for a private company across every available fiscal
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 |     ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `totalAssets` | object | Total assets |
+|   ↳ `totalAssets` | object (nullable) | Total assets |
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `currency` | string | Currency of amount |
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 |     ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `totalDebt` | object | Total debt |
+|   ↳ `totalDebt` | object (nullable) | Total debt |
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `currency` | string | Currency of amount |
 |     ↳ `amount` | number | Value in the requested currency |
@@ -758,16 +758,16 @@ Retrieve PitchBook machine-learning exit predictions for a VC-backed company. Re
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `companyId` | string | PitchBook company ID |
-| `predictionDate` | string | Date the prediction was generated \(YYYY-MM-DD\) |
-| `opportunityScore` | number | PitchBook opportunity score |
-| `successClass` | string | Predicted outcome class, such as Success |
-| `successProbability` | number | Probability of a successful outcome, as a percentage |
-| `noexitProbability` | number | Probability of no exit, as a percentage |
-| `exitClass` | string | Most likely exit type, such as IPO or M&A |
-| `ipoProbability` | number | Probability of an IPO exit, as a percentage |
-| `mergeracquisitionProbability` | number | Probability of an M&A exit, as a percentage |
-| `vcDealNumber` | number | Number of VC deals the prediction is based on |
+| `companyId` | string (nullable) | PitchBook company ID |
+| `predictionDate` | string (nullable) | Date the prediction was generated \(YYYY-MM-DD\) |
+| `opportunityScore` | number (nullable) | PitchBook opportunity score |
+| `successClass` | string (nullable) | Predicted outcome class, such as Success |
+| `successProbability` | number (nullable) | Probability of a successful outcome, as a percentage |
+| `noexitProbability` | number (nullable) | Probability of no exit, as a percentage |
+| `exitClass` | string (nullable) | Most likely exit type, such as IPO or M&A |
+| `ipoProbability` | number (nullable) | Probability of an IPO exit, as a percentage |
+| `mergeracquisitionProbability` | number (nullable) | Probability of an M&A exit, as a percentage |
+| `vcDealNumber` | number (nullable) | Number of VC deals the prediction is based on |
 
 ### PitchBook Company Social Analytics
 
@@ -786,26 +786,26 @@ Retrieve web and social growth and size metrics for a company, with percentile r
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `companyId` | string | PitchBook company ID |
-| `growthRate` | number | Overall growth rate |
-| `growthRatePercentile` | number | Percentile of the overall growth rate |
-| `growthRateChange` | number | Change in the overall growth rate |
-| `growthRatePercentChange` | number | Percent change in the overall growth rate |
-| `webGrowthRate` | number | Web traffic growth rate |
-| `webGrowthRatePercentile` | number | Percentile of the web growth rate |
-| `socialGrowthRate` | number | Social following growth rate |
-| `socialGrowthRatePercentile` | number | Percentile of the social growth rate |
-| `sizeMultiple` | number | Overall size multiple |
-| `sizeMultiplePercentile` | number | Percentile of the size multiple |
-| `sizeMultipleChange` | number | Change in the size multiple |
-| `sizeMultiplePercentChange` | number | Percent change in the size multiple |
-| `webSizeMultiple` | number | Web size multiple |
-| `webSizeMultiplePercentile` | number | Percentile of the web size multiple |
-| `socialSizeMultiple` | number | Social size multiple |
-| `socialSizeMultiplePercentile` | number | Percentile of the social size multiple |
-| `twitterFollowers` | number | Twitter/X follower count |
-| `twitterFollowersChange` | number | Change in follower count |
-| `twitterFollowersPercentChange` | number | Percent change in follower count |
+| `companyId` | string (nullable) | PitchBook company ID |
+| `growthRate` | number (nullable) | Overall growth rate |
+| `growthRatePercentile` | number (nullable) | Percentile of the overall growth rate |
+| `growthRateChange` | number (nullable) | Change in the overall growth rate |
+| `growthRatePercentChange` | number (nullable) | Percent change in the overall growth rate |
+| `webGrowthRate` | number (nullable) | Web traffic growth rate |
+| `webGrowthRatePercentile` | number (nullable) | Percentile of the web growth rate |
+| `socialGrowthRate` | number (nullable) | Social following growth rate |
+| `socialGrowthRatePercentile` | number (nullable) | Percentile of the social growth rate |
+| `sizeMultiple` | number (nullable) | Overall size multiple |
+| `sizeMultiplePercentile` | number (nullable) | Percentile of the size multiple |
+| `sizeMultipleChange` | number (nullable) | Change in the size multiple |
+| `sizeMultiplePercentChange` | number (nullable) | Percent change in the size multiple |
+| `webSizeMultiple` | number (nullable) | Web size multiple |
+| `webSizeMultiplePercentile` | number (nullable) | Percentile of the web size multiple |
+| `socialSizeMultiple` | number (nullable) | Social size multiple |
+| `socialSizeMultiplePercentile` | number (nullable) | Percentile of the social size multiple |
+| `twitterFollowers` | number (nullable) | Twitter/X follower count |
+| `twitterFollowersChange` | number (nullable) | Change in follower count |
+| `twitterFollowersPercentChange` | number (nullable) | Percent change in follower count |
 
 ### PitchBook Company General Service Providers
 
@@ -823,7 +823,7 @@ Retrieve the current and former general service providers engaged by a company
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `companyId` | string | PitchBook company ID |
+| `companyId` | string (nullable) | PitchBook company ID |
 | `currentGeneralServices` | array | Current general service relationships |
 |   ↳ `serviceProviderId` | string | PitchBook service provider ID |
 |   ↳ `serviceProviderName` | string | Service provider name |
@@ -894,7 +894,7 @@ Check which company datasets changed in a window, so a sync only refetches what 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updates` | json | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
+| `updates` | json (nullable) | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
 
 ### PitchBook Patent Search
 
@@ -960,13 +960,13 @@ Retrieve the full record for a single patent: title, status, dates, assignees, i
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `patentId` | string | Patent ID |
-| `patentTitle` | string | Patent title |
-| `status` | string | Status |
-| `publicationDate` | string | Publication date \(YYYY-MM-DD\) |
-| `firstFilingDate` | string | First filing date \(YYYY-MM-DD\) |
-| `expirationDate` | json | Expiration date \(YYYY-MM-DD\) |
-| `filingAuthorityLocation` | string | Filing authority location |
+| `patentId` | string (nullable) | Patent ID |
+| `patentTitle` | string (nullable) | Patent title |
+| `status` | string (nullable) | Status |
+| `publicationDate` | string (nullable) | Publication date \(YYYY-MM-DD\) |
+| `firstFilingDate` | string (nullable) | First filing date \(YYYY-MM-DD\) |
+| `expirationDate` | json (nullable) | Expiration date \(YYYY-MM-DD\) |
+| `filingAuthorityLocation` | string (nullable) | Filing authority location |
 | `cpcSection` | object | CPC section |
 |   ↳ `code` | string | PitchBook code |
 |   ↳ `description` | string | Human-readable label for the code |
@@ -978,17 +978,17 @@ Retrieve the full record for a single patent: title, status, dates, assignees, i
 |   ↳ `description` | string | Human-readable label for the code |
 | `currentAssigneeNames` | array | Current assignees |
 | `originalAssigneeNames` | array | Original assignees |
-| `mostRecentLegalStatus` | string | Most recent legal status |
-| `mostRecentLegalStatusDate` | string | Date of the most recent legal status \(YYYY-MM-DD\) |
-| `applicationDate` | string | Application date \(YYYY-MM-DD\) |
-| `grantDate` | string | Grant date \(YYYY-MM-DD\) |
-| `familyId` | string | Patent family ID |
+| `mostRecentLegalStatus` | string (nullable) | Most recent legal status |
+| `mostRecentLegalStatusDate` | string (nullable) | Date of the most recent legal status \(YYYY-MM-DD\) |
+| `applicationDate` | string (nullable) | Application date \(YYYY-MM-DD\) |
+| `grantDate` | string (nullable) | Grant date \(YYYY-MM-DD\) |
+| `familyId` | string (nullable) | Patent family ID |
 | `inventors` | array | Named inventors |
-| `documentForwardCitations` | number | Number of forward citations |
-| `documentBackwardCitations` | number | Number of backward citations |
-| `countOfClaims` | number | Number of claims |
-| `countOfIndependentClaims` | number | Number of independent claims |
-| `patentDownloadUrl` | string | Link to download the patent document |
+| `documentForwardCitations` | number (nullable) | Number of forward citations |
+| `documentBackwardCitations` | number (nullable) | Number of backward citations |
+| `countOfClaims` | number (nullable) | Number of claims |
+| `countOfIndependentClaims` | number (nullable) | Number of independent claims |
+| `patentDownloadUrl` | string (nullable) | Link to download the patent document |
 
 ### PitchBook Deal Search
 
@@ -1048,34 +1048,34 @@ Retrieve the summary of a deal: company, date, size, status, type, and which det
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `dealId` | string | PitchBook deal ID |
-| `dealNumber` | number | Sequence of this deal in the company financing history |
-| `companyId` | string | PitchBook ID of the company in the deal |
-| `companyName` | string | Name of the company in the deal |
-| `dealAnnouncedDate` | string | Date the deal was announced \(YYYY-MM-DD\) |
-| `dealDate` | string | Date the deal closed \(YYYY-MM-DD\) |
-| `dealSize` | object | Size of the deal |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `dealId` | string (nullable) | PitchBook deal ID |
+| `dealNumber` | number (nullable) | Sequence of this deal in the company financing history |
+| `companyId` | string (nullable) | PitchBook ID of the company in the deal |
+| `companyName` | string (nullable) | Name of the company in the deal |
+| `dealAnnouncedDate` | string (nullable) | Date the deal was announced \(YYYY-MM-DD\) |
+| `dealDate` | string (nullable) | Date the deal closed \(YYYY-MM-DD\) |
+| `dealSize` | object (nullable) | Size of the deal |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `dealSizeStatus` | string | Whether the deal size is actual or estimated |
-| `dealStatus` | object | Status of the deal, such as Completed |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `dealType1` | object | Primary deal type |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `dealType2` | object | Secondary deal type, such as the round letter |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `dealType3` | object | Tertiary deal type |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `dealClass` | object | Deal class, such as Venture Capital |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
+| `dealSizeStatus` | string (nullable) | Whether the deal size is actual or estimated |
+| `dealStatus` | object (nullable) | Status of the deal, such as Completed |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `dealType1` | object (nullable) | Primary deal type |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `dealType2` | object (nullable) | Secondary deal type, such as the round letter |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `dealType3` | object (nullable) | Tertiary deal type |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `dealClass` | object (nullable) | Deal class, such as Venture Capital |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
 | `valuationAvailable` | boolean | Whether valuation data exists for this deal |
 | `capTableAvailable` | boolean | Whether cap table history exists for this deal |
 | `trancheInfoAvailable` | boolean | Whether tranche information exists for this deal |
@@ -1097,95 +1097,95 @@ Retrieve the full detail of a deal: synopsis, percent acquired, round, invested 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `dealId` | string | PitchBook deal ID |
-| `dealNumber` | number | Sequence of this deal in the company financing history |
-| `companyId` | string | PitchBook ID of the company in the deal |
-| `companyName` | string | Name of the company in the deal |
-| `dealDate` | string | Date the deal closed \(YYYY-MM-DD\) |
-| `dealSize` | object | Size of the deal |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `dealId` | string (nullable) | PitchBook deal ID |
+| `dealNumber` | number (nullable) | Sequence of this deal in the company financing history |
+| `companyId` | string (nullable) | PitchBook ID of the company in the deal |
+| `companyName` | string (nullable) | Name of the company in the deal |
+| `dealDate` | string (nullable) | Date the deal closed \(YYYY-MM-DD\) |
+| `dealSize` | object (nullable) | Size of the deal |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `dealSizeStatus` | string | Whether the deal size is actual or estimated |
-| `dealStatus` | object | Status of the deal, such as Completed |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `percentAcquired` | number | Percentage of the company acquired in the deal |
-| `raisedToDate` | object | Total the company had raised as of this deal |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `dealSizeStatus` | string (nullable) | Whether the deal size is actual or estimated |
+| `dealStatus` | object (nullable) | Status of the deal, such as Completed |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `percentAcquired` | number (nullable) | Percentage of the company acquired in the deal |
+| `raisedToDate` | object (nullable) | Total the company had raised as of this deal |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `vcRound` | string | Venture round label, such as 1st Round |
-| `vcRoundUpDownFlat` | string | Whether the round was up, down, or flat versus the previous one |
-| `totalInvestedCapital` | object | Total capital invested in the deal |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `vcRound` | string (nullable) | Venture round label, such as 1st Round |
+| `vcRoundUpDownFlat` | string (nullable) | Whether the round was up, down, or flat versus the previous one |
+| `totalInvestedCapital` | object (nullable) | Total capital invested in the deal |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `investorOwnership` | number | Percentage of the company owned by investors after the deal |
-| `stockSplit` | string | Stock split applied at the deal, such as 1:1 |
-| `dealType1` | object | Primary deal type |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `dealType2` | object | Secondary deal type, such as the round letter |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `dealType3` | object | Tertiary deal type |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `dealClass` | object | Deal class, such as Venture Capital |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `dealSynopsis` | string | Narrative summary of the deal |
-| `totalInvestedEquity` | object | Total equity invested in the deal |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `investorOwnership` | number (nullable) | Percentage of the company owned by investors after the deal |
+| `stockSplit` | string (nullable) | Stock split applied at the deal, such as 1:1 |
+| `dealType1` | object (nullable) | Primary deal type |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `dealType2` | object (nullable) | Secondary deal type, such as the round letter |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `dealType3` | object (nullable) | Tertiary deal type |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `dealClass` | object (nullable) | Deal class, such as Venture Capital |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `dealSynopsis` | string (nullable) | Narrative summary of the deal |
+| `totalInvestedEquity` | object (nullable) | Total equity invested in the deal |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `debtType1` | object | Primary debt type raised in the deal |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `debtType2` | object | Secondary debt type raised in the deal |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `debtType3` | object | Tertiary debt type raised in the deal |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
-| `debtAmount1` | object | Amount of the primary debt type |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `debtType1` | object (nullable) | Primary debt type raised in the deal |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `debtType2` | object (nullable) | Secondary debt type raised in the deal |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `debtType3` | object (nullable) | Tertiary debt type raised in the deal |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
+| `debtAmount1` | object (nullable) | Amount of the primary debt type |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `debtAmount2` | object | Amount of the secondary debt type |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `debtAmount2` | object (nullable) | Amount of the secondary debt type |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `debtAmount3` | object | Amount of the tertiary debt type |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `debtAmount3` | object (nullable) | Amount of the tertiary debt type |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `debtRaisedInRound` | object | Total debt raised in the round |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `debtRaisedInRound` | object (nullable) | Total debt raised in the round |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `contingentPayout` | object | Contingent payout attached to the deal |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `contingentPayout` | object (nullable) | Contingent payout attached to the deal |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 | `valuationAvailable` | boolean | Whether valuation data exists for this deal |
 | `capTableAvailable` | boolean | Whether cap table history exists for this deal |
@@ -1208,23 +1208,23 @@ Retrieve the pre-money and post-money valuation recorded for a deal
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `dealId` | string | PitchBook deal ID |
-| `dealNumber` | number | Sequence of this deal in the company financing history |
-| `companyId` | string | PitchBook ID of the company in the deal |
-| `companyName` | string | Name of the company in the deal |
-| `preValuation` | object | Pre-money valuation |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `dealId` | string (nullable) | PitchBook deal ID |
+| `dealNumber` | number (nullable) | Sequence of this deal in the company financing history |
+| `companyId` | string (nullable) | PitchBook ID of the company in the deal |
+| `companyName` | string (nullable) | Name of the company in the deal |
+| `preValuation` | object (nullable) | Pre-money valuation |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `postValuation` | object | Post-money valuation |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `postValuation` | object (nullable) | Post-money valuation |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `postValuationStatus` | string | Whether the post-money valuation is actual or estimated |
+| `postValuationStatus` | string (nullable) | Whether the post-money valuation is actual or estimated |
 
 ### PitchBook Deal Multiples
 
@@ -1242,27 +1242,27 @@ Retrieve the valuation multiples for a deal against revenue, EBITDA, EBIT, cash 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `dealId` | string | PitchBook deal ID |
-| `dealNumber` | number | Sequence of the deal in the company financing history |
-| `companyId` | string | PitchBook company ID |
-| `companyName` | string | Company name |
-| `dealSizeToCashFlow` | number | Deal size to cash flow |
-| `dealSizeToEBIT` | number | Deal size to EBIT |
-| `dealSizeToEBITDA` | number | Deal size to EBITDA |
-| `dealSizeToNetIncome` | json | Deal size to net income |
-| `dealSizeToRevenue` | number | Deal size to revenue |
-| `debtRaisedInRoundToEBITDA` | json | Debt raised in round to EBITDA |
-| `debtRaisedInRoundToEquity` | json | Debt raised in round to equity |
-| `impliedEvToCashFlow` | number | Implied EV to cash flow |
-| `impliedEvToEBIT` | number | Implied EV to EBIT |
-| `impliedEvToEBITDA` | number | Implied EV to EBITDA |
-| `impliedEvToNetIncome` | json | Implied EV to net income |
-| `impliedEvToRevenue` | number | Implied EV to revenue |
-| `valuationToCashFlow` | number | Valuation to cash flow |
-| `valuationToEBIT` | number | Valuation to EBIT |
-| `valuationToEBITDA` | number | Valuation to EBITDA |
-| `valuationToNetIncome` | json | Valuation to net income |
-| `valuationToRevenue` | number | Valuation to revenue |
+| `dealId` | string (nullable) | PitchBook deal ID |
+| `dealNumber` | number (nullable) | Sequence of the deal in the company financing history |
+| `companyId` | string (nullable) | PitchBook company ID |
+| `companyName` | string (nullable) | Company name |
+| `dealSizeToCashFlow` | number (nullable) | Deal size to cash flow |
+| `dealSizeToEBIT` | number (nullable) | Deal size to EBIT |
+| `dealSizeToEBITDA` | number (nullable) | Deal size to EBITDA |
+| `dealSizeToNetIncome` | json (nullable) | Deal size to net income |
+| `dealSizeToRevenue` | number (nullable) | Deal size to revenue |
+| `debtRaisedInRoundToEBITDA` | json (nullable) | Debt raised in round to EBITDA |
+| `debtRaisedInRoundToEquity` | json (nullable) | Debt raised in round to equity |
+| `impliedEvToCashFlow` | number (nullable) | Implied EV to cash flow |
+| `impliedEvToEBIT` | number (nullable) | Implied EV to EBIT |
+| `impliedEvToEBITDA` | number (nullable) | Implied EV to EBITDA |
+| `impliedEvToNetIncome` | json (nullable) | Implied EV to net income |
+| `impliedEvToRevenue` | number (nullable) | Implied EV to revenue |
+| `valuationToCashFlow` | number (nullable) | Valuation to cash flow |
+| `valuationToEBIT` | number (nullable) | Valuation to EBIT |
+| `valuationToEBITDA` | number (nullable) | Valuation to EBITDA |
+| `valuationToNetIncome` | json (nullable) | Valuation to net income |
+| `valuationToRevenue` | number (nullable) | Valuation to revenue |
 
 ### PitchBook Deal Investors
 
@@ -1280,28 +1280,28 @@ Retrieve the investors, sellers, and exiting investors on a deal, including who 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `dealId` | string | PitchBook deal ID |
-| `companyId` | string | PitchBook ID of the company in the deal |
-| `companyName` | string | Name of the company in the deal |
+| `dealId` | string (nullable) | PitchBook deal ID |
+| `companyId` | string (nullable) | PitchBook ID of the company in the deal |
+| `companyName` | string (nullable) | Name of the company in the deal |
 | `investors` | array | Investors participating in the deal |
 |   ↳ `investorId` | string | PitchBook investor ID |
 |   ↳ `investorName` | string | Investor name |
-|   ↳ `investmentStatus` | string | Whether the investor is new or following on |
+|   ↳ `investmentStatus` | string (nullable) | Whether the investor is new or following on |
 |   ↳ `leadSoleInvestor` | boolean | Whether the investor led or solely funded the round |
-|   ↳ `leadPartnerId` | string | PitchBook person ID of the lead partner |
-|   ↳ `leadPartnerName` | string | Name of the lead partner |
+|   ↳ `leadPartnerId` | string (nullable) | PitchBook person ID of the lead partner |
+|   ↳ `leadPartnerName` | string (nullable) | Name of the lead partner |
 |   ↳ `investorFunds` | array | Funds the investor deployed into the deal |
 |     ↳ `fundId` | string | PitchBook fund ID |
 |     ↳ `fundName` | string | Fund name |
-|   ↳ `investmentAmount` | object | Amount this investor put into the deal |
-|     ↳ `amount` | number | Value in the requested currency |
-|     ↳ `currency` | string | Currency of amount |
-|     ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|     ↳ `nativeCurrency` | string | Currency of nativeAmount |
+|   ↳ `investmentAmount` | object (nullable) | Amount this investor put into the deal |
+|     ↳ `amount` | number (nullable) | Value in the requested currency |
+|     ↳ `currency` | string (nullable) | Currency of amount |
+|     ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|     ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-|   ↳ `formOfPayment` | object | How the investment was paid |
-|     ↳ `code` | string | Payment form code |
-|     ↳ `description` | string | Payment form label |
+|   ↳ `formOfPayment` | object (nullable) | How the investment was paid |
+|     ↳ `code` | string (nullable) | Payment form code |
+|     ↳ `description` | string (nullable) | Payment form label |
 | `sellers` | array | Parties selling in the deal |
 | `exiters` | array | Investors exiting through the deal |
 
@@ -1321,29 +1321,29 @@ Retrieve the share terms of a deal: price per share, shares acquired, and the pr
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `dealId` | string | PitchBook deal ID |
-| `dealNumber` | number | Sequence of the deal in the company financing history |
-| `companyId` | string | PitchBook company ID |
-| `companyName` | string | Company name |
-| `series` | string | Stock series |
+| `dealId` | string (nullable) | PitchBook deal ID |
+| `dealNumber` | number (nullable) | Sequence of the deal in the company financing history |
+| `companyId` | string (nullable) | PitchBook company ID |
+| `companyName` | string (nullable) | Company name |
+| `series` | string (nullable) | Stock series |
 | `pricePerShare` | object | Price per share |
 |   ↳ `amount` | number | Value in the requested currency |
 |   ↳ `currency` | string | Currency of amount |
 |   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
 |   ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `stockType` | json | Type of stock |
-| `numberOfSharesAcquired` | number | Shares acquired |
-| `sharesSought` | number | Shares sought |
-| `conversionRatio` | string | Conversion ratio |
-| `liquidationPreferences` | string | Liquidation preference terms |
-| `liquidationParticipating` | string | Whether the preference participates |
-| `dividendRights` | string | Dividend rights terms |
-| `cumulativeness` | string | Whether dividends are cumulative |
-| `antiDilutionProvisions` | string | Anti-dilution provisions |
-| `redemptionRights` | json | Redemption rights terms |
-| `boardVotingRights` | string | Board voting rights terms |
-| `generalVotingRights` | string | General voting rights terms |
+| `stockType` | json (nullable) | Type of stock |
+| `numberOfSharesAcquired` | number (nullable) | Shares acquired |
+| `sharesSought` | number (nullable) | Shares sought |
+| `conversionRatio` | string (nullable) | Conversion ratio |
+| `liquidationPreferences` | string (nullable) | Liquidation preference terms |
+| `liquidationParticipating` | string (nullable) | Whether the preference participates |
+| `dividendRights` | string (nullable) | Dividend rights terms |
+| `cumulativeness` | string (nullable) | Whether dividends are cumulative |
+| `antiDilutionProvisions` | string (nullable) | Anti-dilution provisions |
+| `redemptionRights` | json (nullable) | Redemption rights terms |
+| `boardVotingRights` | string (nullable) | Board voting rights terms |
+| `generalVotingRights` | string (nullable) | General voting rights terms |
 
 ### PitchBook Deal Cap Table History
 
@@ -1375,7 +1375,7 @@ Retrieve the cap table as of a deal, one row per stock series with its terms and
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 |   ↳ `dividendRate` | number | Dividend rate |
-|   ↳ `dividendAmount` | json | Dividend amount |
+|   ↳ `dividendAmount` | json (nullable) | Dividend amount |
 |   ↳ `originalIssuePrice` | object | Original issue price per share |
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `currency` | string | Currency of amount |
@@ -1413,13 +1413,13 @@ Retrieve the tranches a deal was funded in, with each tranche date, size, and in
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `dealId` | string | PitchBook deal ID |
-| `dealNumber` | number | Sequence of the deal in the company financing history |
+| `dealId` | string (nullable) | PitchBook deal ID |
+| `dealNumber` | number (nullable) | Sequence of the deal in the company financing history |
 | `company` | object | Company the record belongs to |
 |   ↳ `id` | string | PitchBook person ID |
 |   ↳ `name` | string | Name |
 | `tranches` | array | Tranches making up the deal |
-|   ↳ `trancheSize` | object | Size of the tranche |
+|   ↳ `trancheSize` | object (nullable) | Size of the tranche |
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `currency` | string | Currency of amount |
 |     ↳ `amount` | number | Value in the requested currency |
@@ -1430,19 +1430,19 @@ Retrieve the tranches a deal was funded in, with each tranche date, size, and in
 |   ↳ `financingType` | object | Type of financing |
 |     ↳ `description` | string | Human-readable label for the code |
 |     ↳ `code` | string | PitchBook code |
-|   ↳ `stockType` | object | Type of stock |
+|   ↳ `stockType` | object (nullable) | Type of stock |
 |     ↳ `description` | string | Human-readable label for the code |
 |     ↳ `code` | string | PitchBook code |
 |   ↳ `stockSeriesType` | string | Type of the stock series |
-|   ↳ `conversionStatus` | json | Conversion status |
-|   ↳ `conversionDate` | json | Conversion date \(YYYY-MM-DD\) |
-|   ↳ `investor` | object | Investor on the record |
+|   ↳ `conversionStatus` | json (nullable) | Conversion status |
+|   ↳ `conversionDate` | json (nullable) | Conversion date \(YYYY-MM-DD\) |
+|   ↳ `investor` | object (nullable) | Investor on the record |
 |     ↳ `name` | string | Name |
 |     ↳ `id` | string | PitchBook person ID |
-|   ↳ `investor2` | object | Second investor on the record |
+|   ↳ `investor2` | object (nullable) | Second investor on the record |
 |     ↳ `id` | string | PitchBook person ID |
 |     ↳ `name` | string | Name |
-|   ↳ `investor3` | object | Third investor on the record |
+|   ↳ `investor3` | object (nullable) | Third investor on the record |
 |     ↳ `id` | string | PitchBook person ID |
 |     ↳ `name` | string | Name |
 
@@ -1462,21 +1462,21 @@ Retrieve the debt raised in a deal and the lenders behind it, with rate, maturit
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `dealId` | string | PitchBook deal ID |
-| `dealNumber` | number | Sequence of the deal in the company financing history |
+| `dealId` | string (nullable) | PitchBook deal ID |
+| `dealNumber` | number (nullable) | Sequence of the deal in the company financing history |
 | `company` | object | Company the record belongs to |
 |   ↳ `id` | string | PitchBook person ID |
 |   ↳ `name` | string | Name |
 | `debts` | array | Debt instruments in the deal |
-|   ↳ `debtSize` | json | Size of the debt instrument |
-|   ↳ `paymentInKind` | json | Whether interest is paid in kind |
+|   ↳ `debtSize` | json (nullable) | Size of the debt instrument |
+|   ↳ `paymentInKind` | json (nullable) | Whether interest is paid in kind |
 |   ↳ `debtType` | object | Type of debt |
 |     ↳ `code` | string | PitchBook code |
 |     ↳ `description` | string | Human-readable label for the code |
-|   ↳ `seniority` | json | Seniority of the debt |
-|   ↳ `security` | json | Security backing the debt |
-|   ↳ `subordination` | json | Subordination terms |
-|   ↳ `term` | json | Term of the debt |
+|   ↳ `seniority` | json (nullable) | Seniority of the debt |
+|   ↳ `security` | json (nullable) | Security backing the debt |
+|   ↳ `subordination` | json (nullable) | Subordination terms |
+|   ↳ `term` | json (nullable) | Term of the debt |
 |   ↳ `additionalDebtCharacteristics` | object | Other characteristics of the debt |
 |     ↳ `unitranche` | boolean | Whether the debt is unitranche |
 |     ↳ `syndicated` | boolean | Whether the debt is syndicated |
@@ -1484,9 +1484,9 @@ Retrieve the debt raised in a deal and the lenders behind it, with rate, maturit
 |     ↳ `covLite` | boolean | Whether the debt is covenant-lite |
 |     ↳ `warrants` | boolean | Whether warrants are attached |
 |     ↳ `convertible` | boolean | Whether the instrument is convertible |
-|     ↳ `rate` | json | Interest rate |
-|   ↳ `maturityDate` | json | Maturity date \(YYYY-MM-DD\) |
-|   ↳ `spreadInterestRate` | json | Spread over the reference interest rate |
+|     ↳ `rate` | json (nullable) | Interest rate |
+|   ↳ `maturityDate` | json (nullable) | Maturity date \(YYYY-MM-DD\) |
+|   ↳ `spreadInterestRate` | json (nullable) | Spread over the reference interest rate |
 |   ↳ `lenders` | array | Lenders on the debt |
 |     ↳ `lenderId` | string | PitchBook ID of the lender |
 |     ↳ `lenderName` | string | Name of the lender |
@@ -1494,7 +1494,7 @@ Retrieve the debt raised in a deal and the lenders behind it, with rate, maturit
 |     ↳ `serviceProviderType` | object | Service provider type |
 |       ↳ `code` | string | PitchBook code |
 |       ↳ `description` | string | Human-readable label for the code |
-|     ↳ `lenderSize` | json | Amount provided by the lender |
+|     ↳ `lenderSize` | json (nullable) | Amount provided by the lender |
 
 ### PitchBook Deal Service Providers
 
@@ -1528,8 +1528,8 @@ Retrieve the service providers that worked on a deal and which party each repres
 |     ↳ `description` | string | Human-readable label for the code |
 |   ↳ `serviceProvidedToId` | string | PitchBook ID of the party the service was provided to |
 |   ↳ `serviceProvidedToName` | string | Name of the party the service was provided to |
-|   ↳ `leadPartnerId` | json | PitchBook person ID of the lead partner |
-|   ↳ `leadPartnerName` | json | Name of the lead partner |
+|   ↳ `leadPartnerId` | json (nullable) | PitchBook person ID of the lead partner |
+|   ↳ `leadPartnerName` | json (nullable) | Name of the lead partner |
 
 ### PitchBook Deal Updates
 
@@ -1549,7 +1549,7 @@ Check which deal datasets changed in a window, so a sync only refetches what mov
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updates` | json | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
+| `updates` | json (nullable) | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
 
 ### PitchBook Investor Search
 
@@ -1594,7 +1594,7 @@ Search PitchBook for investors by type, location, assets under management, fund 
 | `items` | array | Investors matching the search criteria |
 |   ↳ `investorId` | string | PitchBook investor ID |
 |   ↳ `investorName` | string | Investor name |
-|   ↳ `website` | string | Investor website |
+|   ↳ `website` | string (nullable) | Investor website |
 
 ### PitchBook Investor Bio
 
@@ -1612,43 +1612,43 @@ Retrieve the core profile of an investor: names, description, HQ, type, AUM, dry
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `investorId` | string | PitchBook investor ID |
+| `investorId` | string (nullable) | PitchBook investor ID |
 | `investorName` | object | The names the investor is known by |
-|   ↳ `formalName` | string | Formal name |
-|   ↳ `alsoKnownAs` | string | Also-known-as name |
-|   ↳ `legalName` | string | Registered legal name |
-|   ↳ `formerlyKnownAs` | string | Previous name |
-| `hqLocation` | object | Headquarters location |
-|   ↳ `city` | string | City |
-|   ↳ `stateProvince` | string | State or province |
-|   ↳ `postCode` | string | Postal code |
-|   ↳ `country` | string | Country |
-| `description` | object | Investor description in brief and full form |
-|   ↳ `brief` | string | Short description |
-|   ↳ `full` | string | Full description |
-| `investorStatus` | object | Whether the investor is actively investing |
-|   ↳ `code` | string | PitchBook code |
-|   ↳ `description` | string | Human-readable label for the code |
+|   ↳ `formalName` | string (nullable) | Formal name |
+|   ↳ `alsoKnownAs` | string (nullable) | Also-known-as name |
+|   ↳ `legalName` | string (nullable) | Registered legal name |
+|   ↳ `formerlyKnownAs` | string (nullable) | Previous name |
+| `hqLocation` | object (nullable) | Headquarters location |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `stateProvince` | string (nullable) | State or province |
+|   ↳ `postCode` | string (nullable) | Postal code |
+|   ↳ `country` | string (nullable) | Country |
+| `description` | object (nullable) | Investor description in brief and full form |
+|   ↳ `brief` | string (nullable) | Short description |
+|   ↳ `full` | string (nullable) | Full description |
+| `investorStatus` | object (nullable) | Whether the investor is actively investing |
+|   ↳ `code` | string (nullable) | PitchBook code |
+|   ↳ `description` | string (nullable) | Human-readable label for the code |
 | `investorType` | array | Types the investor is classified as, one flagged primary |
 |   ↳ `type` | object | Investor type |
 |     ↳ `code` | string | Investor type code |
 |     ↳ `description` | string | Investor type label |
 |   ↳ `primary` | boolean | Whether this is the primary type |
-| `assetsUnderManagement` | object | Assets under management |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `assetsUnderManagement` | object (nullable) | Assets under management |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `dryPowder` | object | Uncalled capital available to deploy |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `dryPowder` | object (nullable) | Uncalled capital available to deploy |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `yearFounded` | number | Year the investor was founded |
-| `website` | string | Investor website |
-| `countInvestmentProfessionals` | number | Number of investment professionals on staff |
+| `yearFounded` | number (nullable) | Year the investor was founded |
+| `website` | string (nullable) | Investor website |
+| `countInvestmentProfessionals` | number (nullable) | Number of investment professionals on staff |
 | `tradeAssociations` | array | Trade associations the investor belongs to |
 
 ### PitchBook Investor Investments
@@ -1671,11 +1671,11 @@ Retrieve every investment an investor has made, active and exited, with the deal
 |   ↳ `investorId` | string | PitchBook investor ID |
 |   ↳ `companyId` | string | PitchBook ID of the portfolio company |
 |   ↳ `companyName` | string | Name of the portfolio company |
-|   ↳ `investorStatus` | string | Whether the investor is a current or former holder |
-|   ↳ `investmentDate` | string | Date the position was opened \(YYYY-MM-DD\) |
-|   ↳ `investmentDealId` | string | PitchBook deal ID of the investment |
-|   ↳ `exitDate` | string | Date the position was exited \(YYYY-MM-DD\) |
-|   ↳ `exitDealId` | string | PitchBook deal ID of the exit |
+|   ↳ `investorStatus` | string (nullable) | Whether the investor is a current or former holder |
+|   ↳ `investmentDate` | string (nullable) | Date the position was opened \(YYYY-MM-DD\) |
+|   ↳ `investmentDealId` | string (nullable) | PitchBook deal ID of the investment |
+|   ↳ `exitDate` | string (nullable) | Date the position was exited \(YYYY-MM-DD\) |
+|   ↳ `exitDealId` | string (nullable) | PitchBook deal ID of the exit |
 
 ### PitchBook Investor Active Investments
 
@@ -1717,34 +1717,34 @@ Retrieve the funds an investor manages, with open and closed counts and the min,
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `investorId` | string | PitchBook investor ID |
-| `stats` | object | Counts of open and closed funds |
+| `investorId` | string (nullable) | PitchBook investor ID |
+| `stats` | object (nullable) | Counts of open and closed funds |
 |   ↳ `totalFundsOpen` | number | Number of open funds |
 |   ↳ `totalFundsClosed` | number | Number of closed funds |
-| `minFundSize` | object | Smallest fund raised |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `minFundSize` | object (nullable) | Smallest fund raised |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `medianFundSize` | object | Median fund size |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `medianFundSize` | object (nullable) | Median fund size |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `maxFundSize` | object | Largest fund raised |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `maxFundSize` | object (nullable) | Largest fund raised |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 | `fundInfo` | array | Funds the investor manages |
 |   ↳ `fundId` | string | PitchBook fund ID |
 |   ↳ `fundName` | string | Fund name |
-|   ↳ `fundType` | object | Type of the fund |
-|     ↳ `code` | string | Fund type code |
-|     ↳ `description` | string | Fund type label |
+|   ↳ `fundType` | object (nullable) | Type of the fund |
+|     ↳ `code` | string (nullable) | Fund type code |
+|     ↳ `description` | string (nullable) | Fund type label |
 
 ### PitchBook Investor Last Closed Fund
 
@@ -1762,10 +1762,10 @@ Retrieve the most recently closed fund raised by an investor, with its size, typ
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `investorId` | string | PitchBook investor ID |
-| `fundId` | string | PitchBook fund ID |
-| `fundName` | string | Fund name |
-| `fundVintage` | number | Vintage year of the fund |
+| `investorId` | string (nullable) | PitchBook investor ID |
+| `fundId` | string (nullable) | PitchBook fund ID |
+| `fundName` | string (nullable) | Fund name |
+| `fundVintage` | number (nullable) | Vintage year of the fund |
 | `fundSize` | object | Capital raised by the fund |
 |   ↳ `amount` | number | Value in the requested currency |
 |   ↳ `currency` | string | Currency of amount |
@@ -1775,8 +1775,8 @@ Retrieve the most recently closed fund raised by an investor, with its size, typ
 | `fundType` | object | Fund type |
 |   ↳ `code` | string | PitchBook code |
 |   ↳ `description` | string | Human-readable label for the code |
-| `fundCloseDate` | string | Date the fund closed \(YYYY-MM-DD\) |
-| `fundOpenDate` | json | Date the fund opened \(YYYY-MM-DD\) |
+| `fundCloseDate` | string (nullable) | Date the fund closed \(YYYY-MM-DD\) |
+| `fundOpenDate` | json (nullable) | Date the fund opened \(YYYY-MM-DD\) |
 
 ### PitchBook Investor Preferences
 
@@ -1794,29 +1794,29 @@ Retrieve what an investor targets: check size, deal size, valuation, revenue, ge
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `investorId` | string | PitchBook investor ID |
-| `investorName` | string | Investor name |
-| `preferredInvestmentAmount` | object | Preferred check size, as a min and max monetary value |
-|   ↳ `min` | json | Minimum, as a PitchBook monetary value |
-|   ↳ `max` | json | Maximum, as a PitchBook monetary value |
-| `preferredDealSize` | object | Preferred total deal size, as a min and max monetary value |
-|   ↳ `min` | json | Minimum, as a PitchBook monetary value |
-|   ↳ `max` | json | Maximum, as a PitchBook monetary value |
-| `preferredCompanyValuation` | object | Preferred company valuation, as a min and max monetary value |
-|   ↳ `min` | json | Minimum, as a PitchBook monetary value |
-|   ↳ `max` | json | Maximum, as a PitchBook monetary value |
-| `preferredEbitda` | object | Preferred EBITDA, as a min and max monetary value |
-|   ↳ `min` | json | Minimum, as a PitchBook monetary value |
-|   ↳ `max` | json | Maximum, as a PitchBook monetary value |
-| `preferredEbit` | object | Preferred EBIT, as a min and max monetary value |
-|   ↳ `min` | json | Minimum, as a PitchBook monetary value |
-|   ↳ `max` | json | Maximum, as a PitchBook monetary value |
-| `preferredRevenue` | object | Preferred revenue, as a min and max monetary value |
-|   ↳ `min` | json | Minimum, as a PitchBook monetary value |
-|   ↳ `max` | json | Maximum, as a PitchBook monetary value |
-| `preferredInvestmentHorizon` | object | Preferred holding period in years |
-|   ↳ `min` | number | Minimum years |
-|   ↳ `max` | number | Maximum years |
+| `investorId` | string (nullable) | PitchBook investor ID |
+| `investorName` | string (nullable) | Investor name |
+| `preferredInvestmentAmount` | object (nullable) | Preferred check size, as a min and max monetary value |
+|   ↳ `min` | json (nullable) | Minimum, as a PitchBook monetary value |
+|   ↳ `max` | json (nullable) | Maximum, as a PitchBook monetary value |
+| `preferredDealSize` | object (nullable) | Preferred total deal size, as a min and max monetary value |
+|   ↳ `min` | json (nullable) | Minimum, as a PitchBook monetary value |
+|   ↳ `max` | json (nullable) | Maximum, as a PitchBook monetary value |
+| `preferredCompanyValuation` | object (nullable) | Preferred company valuation, as a min and max monetary value |
+|   ↳ `min` | json (nullable) | Minimum, as a PitchBook monetary value |
+|   ↳ `max` | json (nullable) | Maximum, as a PitchBook monetary value |
+| `preferredEbitda` | object (nullable) | Preferred EBITDA, as a min and max monetary value |
+|   ↳ `min` | json (nullable) | Minimum, as a PitchBook monetary value |
+|   ↳ `max` | json (nullable) | Maximum, as a PitchBook monetary value |
+| `preferredEbit` | object (nullable) | Preferred EBIT, as a min and max monetary value |
+|   ↳ `min` | json (nullable) | Minimum, as a PitchBook monetary value |
+|   ↳ `max` | json (nullable) | Maximum, as a PitchBook monetary value |
+| `preferredRevenue` | object (nullable) | Preferred revenue, as a min and max monetary value |
+|   ↳ `min` | json (nullable) | Minimum, as a PitchBook monetary value |
+|   ↳ `max` | json (nullable) | Maximum, as a PitchBook monetary value |
+| `preferredInvestmentHorizon` | object (nullable) | Preferred holding period in years |
+|   ↳ `min` | number (nullable) | Minimum years |
+|   ↳ `max` | number (nullable) | Maximum years |
 | `geographicalPreferences` | array | Regions the investor targets, from broad group down to state |
 |   ↳ `regionGroup` | json | Broad region as a code and description pair |
 |   ↳ `regionSegment` | json | Region segment as a code and description pair |
@@ -1826,7 +1826,7 @@ Retrieve what an investor targets: check size, deal size, valuation, revenue, ge
 |   ↳ `code` | string | Preference code |
 |   ↳ `description` | string | Preference label |
 | `preferredIndustry` | array | Industries the investor targets |
-|   ↳ `industryCode` | json | Most specific industry classification |
+|   ↳ `industryCode` | json (nullable) | Most specific industry classification |
 |   ↳ `industrySector` | object | Top-level sector |
 |     ↳ `code` | string | Sector code |
 |     ↳ `description` | string | Sector label |
@@ -1860,7 +1860,7 @@ Retrieve the board seats an investor holds and previously held across its portfo
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `investorId` | string | PitchBook investor ID |
+| `investorId` | string (nullable) | PitchBook investor ID |
 | `current` | array | Current entries |
 |   ↳ `personId` | string | PitchBook person ID |
 |   ↳ `personName` | string | Full name of the person |
@@ -1868,7 +1868,7 @@ Retrieve the board seats an investor holds and previously held across its portfo
 |   ↳ `boardCompanyName` | string | Name of the company the seat is on |
 |   ↳ `onBoard` | boolean | Whether the person holds a board seat |
 |   ↳ `boardStartDate` | string | Date the seat started \(YYYY-MM-DD\) |
-|   ↳ `boardEndDate` | json | Date the seat ended \(YYYY-MM-DD\) |
+|   ↳ `boardEndDate` | json (nullable) | Date the seat ended \(YYYY-MM-DD\) |
 |   ↳ `role` | string | Role played |
 | `former` | array | Former team members |
 
@@ -1888,7 +1888,7 @@ Retrieve the current and former general service providers engaged by an investor
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `investorId` | string | PitchBook investor ID |
+| `investorId` | string (nullable) | PitchBook investor ID |
 | `currentGeneralServices` | array | Current general service relationships |
 |   ↳ `serviceProviderId` | string | PitchBook service provider ID |
 |   ↳ `serviceProviderName` | string | Service provider name |
@@ -1950,7 +1950,7 @@ Check which investor datasets changed in a window, so a sync only refetches what
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updates` | json | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
+| `updates` | json (nullable) | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
 
 ### PitchBook People Search
 
@@ -1994,7 +1994,7 @@ Search PitchBook for people by name, employer, position, education, and location
 | `items` | array | People matching the search criteria |
 |   ↳ `personId` | string | PitchBook person ID |
 |   ↳ `personName` | string | Full name of the person |
-|   ↳ `firmId` | string | PitchBook ID of the firm the person is associated with |
+|   ↳ `firmId` | string (nullable) | PitchBook ID of the firm the person is associated with |
 
 ### PitchBook Person Bio
 
@@ -2012,35 +2012,35 @@ Retrieve the profile of a person: name, biography, LinkedIn, primary employer, p
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `personId` | string | PitchBook person ID |
+| `personId` | string (nullable) | PitchBook person ID |
 | `personName` | object | Parsed name of the person |
-|   ↳ `full` | string | Full name |
-|   ↳ `first` | string | First name |
-|   ↳ `last` | string | Last name |
-|   ↳ `middle` | string | Middle name |
-|   ↳ `prefix` | string | Name prefix |
-|   ↳ `suffix` | string | Name suffix |
-| `biography` | string | Biography of the person |
-| `linkedInProfileUrl` | string | LinkedIn profile URL |
-| `gender` | string | Gender recorded for the person |
-| `primaryEntityId` | string | PitchBook ID of the primary employer |
-| `primaryEntityName` | string | Name of the primary employer |
-| `primaryEntityType` | string | Type of the primary employer, such as COMPANY or INVESTOR |
-| `primaryEntityWebsite` | string | Website of the primary employer |
-| `primaryPosition` | string | Position the person holds at the primary employer |
-| `primaryOffice` | object | Office the person works out of |
-|   ↳ `location` | string | Office label |
-|   ↳ `addressLine1` | string | Address line 1 |
-|   ↳ `addressLine2` | string | Address line 2 |
-|   ↳ `city` | string | City |
-|   ↳ `stateProvince` | string | State or province |
-|   ↳ `postCode` | string | Postal code |
-|   ↳ `country` | string | Country |
-|   ↳ `phone` | string | Phone number |
-|   ↳ `fax` | string | Fax number |
-|   ↳ `email` | string | Email address |
-|   ↳ `globalRegion` | string | Global region |
-|   ↳ `globalSubRegion` | string | Global sub-region |
+|   ↳ `full` | string (nullable) | Full name |
+|   ↳ `first` | string (nullable) | First name |
+|   ↳ `last` | string (nullable) | Last name |
+|   ↳ `middle` | string (nullable) | Middle name |
+|   ↳ `prefix` | string (nullable) | Name prefix |
+|   ↳ `suffix` | string (nullable) | Name suffix |
+| `biography` | string (nullable) | Biography of the person |
+| `linkedInProfileUrl` | string (nullable) | LinkedIn profile URL |
+| `gender` | string (nullable) | Gender recorded for the person |
+| `primaryEntityId` | string (nullable) | PitchBook ID of the primary employer |
+| `primaryEntityName` | string (nullable) | Name of the primary employer |
+| `primaryEntityType` | string (nullable) | Type of the primary employer, such as COMPANY or INVESTOR |
+| `primaryEntityWebsite` | string (nullable) | Website of the primary employer |
+| `primaryPosition` | string (nullable) | Position the person holds at the primary employer |
+| `primaryOffice` | object (nullable) | Office the person works out of |
+|   ↳ `location` | string (nullable) | Office label |
+|   ↳ `addressLine1` | string (nullable) | Address line 1 |
+|   ↳ `addressLine2` | string (nullable) | Address line 2 |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `stateProvince` | string (nullable) | State or province |
+|   ↳ `postCode` | string (nullable) | Postal code |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `phone` | string (nullable) | Phone number |
+|   ↳ `fax` | string (nullable) | Fax number |
+|   ↳ `email` | string (nullable) | Email address |
+|   ↳ `globalRegion` | string (nullable) | Global region |
+|   ↳ `globalSubRegion` | string (nullable) | Global sub-region |
 
 ### PitchBook Person Contact
 
@@ -2058,11 +2058,11 @@ Retrieve the direct contact details on file for a person
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `personId` | string | PitchBook person ID |
-| `fullName` | string | Full name of the person |
-| `phone` | string | Phone number |
-| `fax` | string | Fax number |
-| `email` | string | Email address |
+| `personId` | string (nullable) | PitchBook person ID |
+| `fullName` | string (nullable) | Full name of the person |
+| `phone` | string (nullable) | Phone number |
+| `fax` | string (nullable) | Fax number |
+| `email` | string (nullable) | Email address |
 
 ### PitchBook Person Education and Work
 
@@ -2080,43 +2080,43 @@ Retrieve a person full history: education, company roles, board seats, deal role
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `personId` | string | PitchBook person ID |
-| `fullName` | string | Full name of the person |
+| `personId` | string (nullable) | PitchBook person ID |
+| `fullName` | string (nullable) | Full name of the person |
 | `education` | array | Institutions the person attended |
 |   ↳ `institution` | string | Institution name |
-|   ↳ `degree` | string | Degree earned |
-|   ↳ `yearOfGraduation` | number | Graduation year |
+|   ↳ `degree` | string (nullable) | Degree earned |
+|   ↳ `yearOfGraduation` | number (nullable) | Graduation year |
 | `companyRoles` | array | Positions the person has held at companies |
 |   ↳ `companyId` | string | PitchBook company ID |
 |   ↳ `companyName` | string | Company name |
-|   ↳ `position` | string | Position title |
-|   ↳ `positionType` | string | Whether the role is an employee or non-employee position |
-|   ↳ `positionStatus` | string | Whether the position is Current or Former |
-|   ↳ `positionStart` | string | Date the position started \(YYYY-MM-DD\) |
-|   ↳ `positionFinish` | string | Date the position ended \(YYYY-MM-DD\) |
+|   ↳ `position` | string (nullable) | Position title |
+|   ↳ `positionType` | string (nullable) | Whether the role is an employee or non-employee position |
+|   ↳ `positionStatus` | string (nullable) | Whether the position is Current or Former |
+|   ↳ `positionStart` | string (nullable) | Date the position started \(YYYY-MM-DD\) |
+|   ↳ `positionFinish` | string (nullable) | Date the position ended \(YYYY-MM-DD\) |
 | `boardSeats` | array | Board seats the person has held |
 |   ↳ `boardCompanyId` | string | PitchBook ID of the company |
 |   ↳ `boardCompanyName` | string | Name of the company |
-|   ↳ `boardRepresentingId` | string | PitchBook ID of the firm the seat represents |
-|   ↳ `boardRepresentingName` | string | Name of the firm the seat represents |
-|   ↳ `positionStatus` | string | Whether the seat is Current or Former |
-|   ↳ `boardStart` | string | Date the seat started \(YYYY-MM-DD\) |
-|   ↳ `boardFinish` | string | Date the seat ended \(YYYY-MM-DD\) |
+|   ↳ `boardRepresentingId` | string (nullable) | PitchBook ID of the firm the seat represents |
+|   ↳ `boardRepresentingName` | string (nullable) | Name of the firm the seat represents |
+|   ↳ `positionStatus` | string (nullable) | Whether the seat is Current or Former |
+|   ↳ `boardStart` | string (nullable) | Date the seat started \(YYYY-MM-DD\) |
+|   ↳ `boardFinish` | string (nullable) | Date the seat ended \(YYYY-MM-DD\) |
 | `currentAdvisoryRoles` | array | Advisory roles the person currently holds |
 | `dealRoles` | array | Deals the person worked on and who they represented |
 |   ↳ `dealId` | string | PitchBook deal ID |
-|   ↳ `dealDate` | string | Date of the deal \(YYYY-MM-DD\) |
+|   ↳ `dealDate` | string (nullable) | Date of the deal \(YYYY-MM-DD\) |
 |   ↳ `companyId` | string | PitchBook ID of the company in the deal |
 |   ↳ `companyName` | string | Name of the company in the deal |
-|   ↳ `representingId` | string | PitchBook ID of the firm the person represented |
-|   ↳ `representingName` | string | Name of the firm the person represented |
+|   ↳ `representingId` | string (nullable) | PitchBook ID of the firm the person represented |
+|   ↳ `representingName` | string (nullable) | Name of the firm the person represented |
 | `fundRoles` | array | Funds the person is associated with |
 |   ↳ `fundId` | string | PitchBook fund ID |
 |   ↳ `fundName` | string | Fund name |
-|   ↳ `investorId` | string | PitchBook ID of the fund manager |
-|   ↳ `investorName` | string | Name of the fund manager |
-|   ↳ `representingId` | string | PitchBook ID of the firm the person represented |
-|   ↳ `representingName` | string | Name of the firm the person represented |
+|   ↳ `investorId` | string (nullable) | PitchBook ID of the fund manager |
+|   ↳ `investorName` | string (nullable) | Name of the fund manager |
+|   ↳ `representingId` | string (nullable) | PitchBook ID of the firm the person represented |
+|   ↳ `representingName` | string (nullable) | Name of the firm the person represented |
 
 ### PitchBook Fund Search
 
@@ -2178,43 +2178,43 @@ Retrieve the profile of a fund: managers, vintage, status, type, size, target, l
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `fundId` | string | PitchBook fund ID |
-| `name` | string | Fund name |
+| `fundId` | string (nullable) | PitchBook fund ID |
+| `name` | string (nullable) | Fund name |
 | `fundInvestors` | array | Managers of the fund, with where it sits in their fund series |
 |   ↳ `investorId` | string | PitchBook investor ID |
 |   ↳ `investorName` | string | Investor name |
-|   ↳ `fundNo` | number | Position in the manager fund series |
+|   ↳ `fundNo` | number (nullable) | Position in the manager fund series |
 |   ↳ `firstFund` | boolean | Whether this is the manager first fund |
-| `vintage` | number | Vintage year of the fund |
-| `fundStatus` | string | Whether the fund is open or closed |
-| `fundType` | string | Type of the fund |
-| `fundSize` | object | Capital raised by the fund |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `vintage` | number (nullable) | Vintage year of the fund |
+| `fundStatus` | string (nullable) | Whether the fund is open or closed |
+| `fundType` | string (nullable) | Type of the fund |
+| `fundSize` | object (nullable) | Capital raised by the fund |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `location` | object | Office the fund is run from |
-|   ↳ `location` | string | Office label |
-|   ↳ `addressLine1` | string | Address line 1 |
-|   ↳ `addressLine2` | string | Address line 2 |
-|   ↳ `city` | string | City |
-|   ↳ `stateProvince` | string | State or province |
-|   ↳ `postCode` | string | Postal code |
-|   ↳ `country` | string | Country |
-|   ↳ `phone` | string | Phone number |
-|   ↳ `fax` | string | Fax number |
-|   ↳ `email` | string | Email address |
-|   ↳ `globalRegion` | string | Global region |
-|   ↳ `globalSubRegion` | string | Global sub-region |
+| `location` | object (nullable) | Office the fund is run from |
+|   ↳ `location` | string (nullable) | Office label |
+|   ↳ `addressLine1` | string (nullable) | Address line 1 |
+|   ↳ `addressLine2` | string (nullable) | Address line 2 |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `stateProvince` | string (nullable) | State or province |
+|   ↳ `postCode` | string (nullable) | Postal code |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `phone` | string (nullable) | Phone number |
+|   ↳ `fax` | string (nullable) | Fax number |
+|   ↳ `email` | string (nullable) | Email address |
+|   ↳ `globalRegion` | string (nullable) | Global region |
+|   ↳ `globalSubRegion` | string (nullable) | Global sub-region |
 | `fundTeam` | array | People on the fund team |
 |   ↳ `personId` | string | PitchBook person ID |
 |   ↳ `personFullName` | string | Full name of the person |
-| `openDate` | string | Date the fund opened \(YYYY-MM-DD\) |
-| `closeDate` | string | Date the fund closed \(YYYY-MM-DD\) |
-| `fundTargetSize` | object | Target raise for the fund, as a min and max monetary value |
-|   ↳ `min` | json | Minimum, as a PitchBook monetary value |
-|   ↳ `max` | json | Maximum, as a PitchBook monetary value |
+| `openDate` | string (nullable) | Date the fund opened \(YYYY-MM-DD\) |
+| `closeDate` | string (nullable) | Date the fund closed \(YYYY-MM-DD\) |
+| `fundTargetSize` | object (nullable) | Target raise for the fund, as a min and max monetary value |
+|   ↳ `min` | json (nullable) | Minimum, as a PitchBook monetary value |
+|   ↳ `max` | json (nullable) | Maximum, as a PitchBook monetary value |
 | `sbic` | boolean | Whether the fund is a Small Business Investment Company |
 | `returnsInfoAvailable` | array | Which returns datasets are available for the fund |
 
@@ -2234,17 +2234,17 @@ Retrieve the most recent reported returns for a fund: IRR, DPI, RVPI, TVPI, NAV,
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `fundId` | string | PitchBook fund ID |
-| `fundName` | string | Fund name |
-| `asOfQuarter` | number | Quarter the figures are reported as of |
-| `asOfYear` | number | Year the figures are reported as of |
-| `irr` | number | Internal rate of return, as a percentage |
-| `dpi` | number | Distributions to paid-in multiple |
-| `rvpi` | number | Residual value to paid-in multiple |
-| `tvpi` | number | Total value to paid-in multiple |
-| `nav` | number | Net asset value |
-| `quartile` | number | Benchmark quartile the fund falls in, 1 being the best |
-| `numberOfFundsInBenchmark` | number | How many funds the benchmark is drawn from |
+| `fundId` | string (nullable) | PitchBook fund ID |
+| `fundName` | string (nullable) | Fund name |
+| `asOfQuarter` | number (nullable) | Quarter the figures are reported as of |
+| `asOfYear` | number (nullable) | Year the figures are reported as of |
+| `irr` | number (nullable) | Internal rate of return, as a percentage |
+| `dpi` | number (nullable) | Distributions to paid-in multiple |
+| `rvpi` | number (nullable) | Residual value to paid-in multiple |
+| `tvpi` | number (nullable) | Total value to paid-in multiple |
+| `nav` | number (nullable) | Net asset value |
+| `quartile` | number (nullable) | Benchmark quartile the fund falls in, 1 being the best |
+| `numberOfFundsInBenchmark` | number (nullable) | How many funds the benchmark is drawn from |
 
 ### PitchBook Fund Benchmark
 
@@ -2262,8 +2262,8 @@ Retrieve the peer benchmark for a fund: benchmark IRR, DPI, TVPI, RVPI, and the 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `fundId` | string | PitchBook fund ID |
-| `fundName` | string | Fund name |
+| `fundId` | string (nullable) | PitchBook fund ID |
+| `fundName` | string (nullable) | Fund name |
 | `benchmarkFundType` | object | Fund type the benchmark is built from |
 |   ↳ `code` | string | PitchBook code |
 |   ↳ `description` | string | Human-readable label for the code |
@@ -2273,12 +2273,12 @@ Retrieve the peer benchmark for a fund: benchmark IRR, DPI, TVPI, RVPI, and the 
 | `benchmarkFundLocation` | object | Location the benchmark is built from |
 |   ↳ `code` | string | PitchBook code |
 |   ↳ `description` | string | Human-readable label for the code |
-| `benchmarkFundVintageYear` | number | Vintage year the benchmark is built from |
-| `irrBenchmark` | number | Benchmark IRR |
-| `dpiBenchmark` | number | Benchmark DPI |
-| `tvpiBenchmark` | number | Benchmark TVPI |
-| `rvpiBenchmark` | number | Benchmark RVPI |
-| `numberOfFundsInBenchmark` | number | How many funds the benchmark is drawn from |
+| `benchmarkFundVintageYear` | number (nullable) | Vintage year the benchmark is built from |
+| `irrBenchmark` | number (nullable) | Benchmark IRR |
+| `dpiBenchmark` | number (nullable) | Benchmark DPI |
+| `tvpiBenchmark` | number (nullable) | Benchmark TVPI |
+| `rvpiBenchmark` | number (nullable) | Benchmark RVPI |
+| `numberOfFundsInBenchmark` | number (nullable) | How many funds the benchmark is drawn from |
 | `benchmarkFunds` | array | Funds making up the benchmark |
 |   ↳ `fundId` | string | PitchBook fund ID |
 |   ↳ `fundName` | string | Fund name |
@@ -2300,24 +2300,24 @@ Retrieve contributed, distributed, and remaining value for a fund as of a specif
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `fundId` | string | PitchBook fund ID |
-| `fundName` | string | Fund name |
-| `asOfQuarter` | number | Quarter the figures are reported as of |
-| `asOfYear` | number | Year the figures are reported as of |
+| `fundId` | string (nullable) | PitchBook fund ID |
+| `fundName` | string (nullable) | Fund name |
+| `asOfQuarter` | number (nullable) | Quarter the figures are reported as of |
+| `asOfYear` | number (nullable) | Year the figures are reported as of |
 | `contributed` | object | Capital contributed by limited partners |
 |   ↳ `amount` | number | Value in the requested currency |
 |   ↳ `currency` | string | Currency of amount |
 |   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
 |   ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `percentCalledDown` | number | Percentage of committed capital called down |
+| `percentCalledDown` | number (nullable) | Percentage of committed capital called down |
 | `dryPowder` | object | Uncalled capital available to deploy |
 |   ↳ `amount` | number | Value in the requested currency |
 |   ↳ `currency` | string | Currency of amount |
 |   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
 |   ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `percentDryPowder` | number | Percentage of committed capital still uncalled |
+| `percentDryPowder` | number (nullable) | Percentage of committed capital still uncalled |
 | `distributed` | object | Capital distributed back to limited partners |
 |   ↳ `amount` | number | Value in the requested currency |
 |   ↳ `currency` | string | Currency of amount |
@@ -2353,16 +2353,16 @@ Retrieve every investment a fund has made, active and exited, with the deals tha
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `fundId` | string | PitchBook fund ID |
-| `fundName` | string | Fund name |
+| `fundId` | string (nullable) | PitchBook fund ID |
+| `fundName` | string (nullable) | Fund name |
 | `investments` | array | Investments held |
 |   ↳ `targetCompanyId` | string | PitchBook ID of the portfolio company |
 |   ↳ `targetCompanyName` | string | Name of the portfolio company |
 |   ↳ `investmentStatus` | string | Whether the position is active or exited |
 |   ↳ `targetCompanyInvestmentDate` | string | Date the position was opened \(YYYY-MM-DD\) |
 |   ↳ `investmentDealId` | string | PitchBook deal ID of the investment |
-|   ↳ `targetCompanyExitDate` | string | Date the position was exited \(YYYY-MM-DD\) |
-|   ↳ `exitDealId` | string | PitchBook deal ID of the exit |
+|   ↳ `targetCompanyExitDate` | string (nullable) | Date the position was exited \(YYYY-MM-DD\) |
+|   ↳ `exitDealId` | string (nullable) | PitchBook deal ID of the exit |
 
 ### PitchBook Fund Active Investments
 
@@ -2407,10 +2407,10 @@ Retrieve the limited partners committed to a fund, with commitment date, size, s
 |   ↳ `fundId` | string | PitchBook fund ID |
 |   ↳ `limitedPartnerId` | string | PitchBook limited partner ID |
 |   ↳ `limitedPartnerName` | string | Limited partner name |
-|   ↳ `commitmentDate` | string | Date of the commitment \(YYYY-MM-DD\) |
-|   ↳ `commitmentSize` | json | Size of the commitment, as a PitchBook monetary value |
-|   ↳ `commitmentStatus` | json | Status of the commitment, as a code and description pair |
-|   ↳ `commitmentType` | json | Type of the commitment, as a code and description pair |
+|   ↳ `commitmentDate` | string (nullable) | Date of the commitment \(YYYY-MM-DD\) |
+|   ↳ `commitmentSize` | json (nullable) | Size of the commitment, as a PitchBook monetary value |
+|   ↳ `commitmentStatus` | json (nullable) | Status of the commitment, as a code and description pair |
+|   ↳ `commitmentType` | json (nullable) | Type of the commitment, as a code and description pair |
 
 ### PitchBook Fund Investment Preferences
 
@@ -2428,14 +2428,14 @@ Retrieve what a fund targets: check size, valuation, geography, industry, vertic
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `fundId` | string | PitchBook fund ID |
-| `preferredInvestmentAmount` | json | Preferred check size |
-| `preferredDealSize` | json | Preferred deal size |
-| `preferredCompanyValuation` | json | Preferred company valuation |
-| `preferredEbitda` | json | Preferred EBITDA |
-| `preferredEbit` | json | Preferred EBIT |
-| `preferredRevenue` | json | Preferred revenue |
-| `preferredInvestmentHorizon` | json | Preferred holding period in years |
+| `fundId` | string (nullable) | PitchBook fund ID |
+| `preferredInvestmentAmount` | json (nullable) | Preferred check size |
+| `preferredDealSize` | json (nullable) | Preferred deal size |
+| `preferredCompanyValuation` | json (nullable) | Preferred company valuation |
+| `preferredEbitda` | json (nullable) | Preferred EBITDA |
+| `preferredEbit` | json (nullable) | Preferred EBIT |
+| `preferredRevenue` | json (nullable) | Preferred revenue |
+| `preferredInvestmentHorizon` | json (nullable) | Preferred holding period in years |
 | `geographicalPreferences` | array | Regions targeted |
 |   ↳ `regionGroup` | object | Broad region as a code and description pair |
 |     ↳ `code` | string | PitchBook code |
@@ -2446,12 +2446,12 @@ Retrieve what a fund targets: check size, valuation, geography, industry, vertic
 |   ↳ `regionCode` | object | Country as a code and description pair |
 |     ↳ `code` | string | PitchBook code |
 |     ↳ `description` | string | Human-readable label for the code |
-|   ↳ `regionState` | json | State or province as a code and description pair |
+|   ↳ `regionState` | json (nullable) | State or province as a code and description pair |
 | `otherInvestmentPreferences` | array | Other stated preferences |
 |   ↳ `code` | string | PitchBook code |
 |   ↳ `description` | string | Human-readable label for the code |
 | `preferredIndustry` | array | Industries targeted |
-|   ↳ `industryCode` | json | Most specific industry classification |
+|   ↳ `industryCode` | json (nullable) | Most specific industry classification |
 |   ↳ `industrySector` | object | Top-level sector |
 |     ↳ `description` | string | Human-readable label for the code |
 |     ↳ `code` | string | PitchBook code |
@@ -2483,9 +2483,9 @@ Retrieve the active and former people on a fund team
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `fundId` | string | PitchBook fund ID |
+| `fundId` | string (nullable) | PitchBook fund ID |
 | `investorIds` | array | PitchBook IDs of the fund managers |
-| `countActiveTeam` | number | Number of active team members |
+| `countActiveTeam` | number (nullable) | Number of active team members |
 | `active` | array | Active team members |
 |   ↳ `id` | string | PitchBook person ID |
 |   ↳ `name` | string | Name |
@@ -2515,7 +2515,7 @@ Check which fund datasets changed in a window, so a sync only refetches what mov
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updates` | json | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
+| `updates` | json (nullable) | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
 
 ### PitchBook Limited Partner Search
 
@@ -2555,7 +2555,7 @@ Search PitchBook for limited partners by type, location, assets under management
 | `items` | array | Limited partners matching the search criteria |
 |   ↳ `limitedPartnerId` | string | PitchBook limited partner ID |
 |   ↳ `limitedPartnerName` | string | Limited partner name |
-|   ↳ `website` | string | Limited partner website |
+|   ↳ `website` | string (nullable) | Limited partner website |
 
 ### PitchBook Limited Partner Bio
 
@@ -2575,25 +2575,25 @@ Retrieve the profile of a limited partner: names, description, type, assets unde
 | --------- | ---- | ----------- |
 | `limitedPartnerId` | string | PitchBook limited partner ID |
 | `limitedPartnerName` | object | The names the limited partner is known by |
-|   ↳ `formalName` | string | Formal name |
-|   ↳ `alsoKnownAs` | string | Also-known-as name |
-|   ↳ `legalName` | string | Registered legal name |
-|   ↳ `formerlyKnownAs` | string | Previous name |
-| `description` | string | Description of the limited partner |
+|   ↳ `formalName` | string (nullable) | Formal name |
+|   ↳ `alsoKnownAs` | string (nullable) | Also-known-as name |
+|   ↳ `legalName` | string (nullable) | Registered legal name |
+|   ↳ `formerlyKnownAs` | string (nullable) | Previous name |
+| `description` | string (nullable) | Description of the limited partner |
 | `limitedPartnerTypes` | array | Types the limited partner is classified as, one flagged primary |
 |   ↳ `type` | object | Limited partner type |
 |     ↳ `code` | string | Type code |
 |     ↳ `description` | string | Type label |
 |   ↳ `primary` | boolean | Whether this is the primary type |
-| `assetsUnderManagement` | object | Assets under management |
-|   ↳ `amount` | number | Value in the requested currency |
-|   ↳ `currency` | string | Currency of amount |
-|   ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `nativeCurrency` | string | Currency of nativeAmount |
+| `assetsUnderManagement` | object (nullable) | Assets under management |
+|   ↳ `amount` | number (nullable) | Value in the requested currency |
+|   ↳ `currency` | string (nullable) | Currency of amount |
+|   ↳ `nativeAmount` | number (nullable) | Value in the currency it was originally reported in |
+|   ↳ `nativeCurrency` | string (nullable) | Currency of nativeAmount |
 |   ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
-| `yearFounded` | number | Year the limited partner was founded |
-| `website` | string | Limited partner website |
-| `managementStaff` | number | Number of management staff |
+| `yearFounded` | number (nullable) | Year the limited partner was founded |
+| `website` | string (nullable) | Limited partner website |
+| `managementStaff` | number (nullable) | Number of management staff |
 
 ### PitchBook Limited Partner Commitments
 
@@ -2618,17 +2618,17 @@ Retrieve every fund commitment a limited partner has made, with date, size, stat
 |   ↳ `committedInvestors` | array | Managers of the fund committed to |
 |     ↳ `committedInvestorName` | string | Name of the fund manager |
 |     ↳ `committedInvestorId` | string | PitchBook ID of the fund manager |
-|   ↳ `commitmentDate` | string | Date of the commitment \(YYYY-MM-DD\) |
-|   ↳ `commitmentSize` | object | Size of the commitment |
+|   ↳ `commitmentDate` | string (nullable) | Date of the commitment \(YYYY-MM-DD\) |
+|   ↳ `commitmentSize` | object (nullable) | Size of the commitment |
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `currency` | string | Currency of amount |
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 |     ↳ `nativeAmount` | number | Value in the currency it was originally reported in |
-|   ↳ `commitmentStatus` | object | Status of the commitment |
+|   ↳ `commitmentStatus` | object (nullable) | Status of the commitment |
 |     ↳ `description` | string | Human-readable label for the code |
 |     ↳ `code` | string | PitchBook code |
-|   ↳ `commitmentType` | object | Type of the commitment |
+|   ↳ `commitmentType` | object (nullable) | Type of the commitment |
 |     ↳ `description` | string | Human-readable label for the code |
 |     ↳ `code` | string | PitchBook code |
 
@@ -2648,26 +2648,26 @@ Retrieve a limited partner commitments rolled up by fund type, both active and a
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `limitedPartnerId` | string | PitchBook limited partner ID |
-| `limitedPartnerName` | string | Limited partner name |
-| `activeCommitmentsInDebtFunds` | json | Number of active commitments to debt funds |
-| `activeCommitmentsInPeFunds` | number | Number of active commitments to PE funds |
-| `activeCommitmentsInReFunds` | number | Number of active commitments to real estate funds |
-| `activeCommitmentsInVcFunds` | number | Number of active commitments to VC funds |
-| `activeCommitmentsInFoFsAnd2nd` | json | Number of active commitments to funds of funds and secondaries |
-| `activeCommitmentsInInfrastructure` | json | Number of active commitments to infrastructure funds |
-| `activeCommitmentsInEnergyFunds` | json | Number of active commitments to energy funds |
-| `activeCommitmentsInOtherFunds` | number | Number of active commitments to other funds |
-| `totalActiveCommitments` | number | Number of active commitments |
-| `totalCommitmentsInDebtFunds` | json | Number of all commitments to debt funds |
-| `totalCommitmentsInPeFunds` | number | Number of all commitments to PE funds |
-| `totalCommitmentsInReFunds` | number | Number of all commitments to real estate funds |
-| `totalCommitmentsInVcFunds` | number | Number of all commitments to VC funds |
-| `totalCommitmentsInFoFsAnd2nd` | json | Number of all commitments to funds of funds and secondaries |
-| `totalCommitmentsInInfrastructure` | json | Number of all commitments to infrastructure funds |
-| `totalCommitmentsInEnergyFunds` | json | Number of all commitments to energy funds |
-| `totalCommitmentsInOtherFunds` | number | Number of all commitments to other funds |
-| `totalCommitments` | number | Number of commitments ever made |
+| `limitedPartnerId` | string (nullable) | PitchBook limited partner ID |
+| `limitedPartnerName` | string (nullable) | Limited partner name |
+| `activeCommitmentsInDebtFunds` | json (nullable) | Number of active commitments to debt funds |
+| `activeCommitmentsInPeFunds` | number (nullable) | Number of active commitments to PE funds |
+| `activeCommitmentsInReFunds` | number (nullable) | Number of active commitments to real estate funds |
+| `activeCommitmentsInVcFunds` | number (nullable) | Number of active commitments to VC funds |
+| `activeCommitmentsInFoFsAnd2nd` | json (nullable) | Number of active commitments to funds of funds and secondaries |
+| `activeCommitmentsInInfrastructure` | json (nullable) | Number of active commitments to infrastructure funds |
+| `activeCommitmentsInEnergyFunds` | json (nullable) | Number of active commitments to energy funds |
+| `activeCommitmentsInOtherFunds` | number (nullable) | Number of active commitments to other funds |
+| `totalActiveCommitments` | number (nullable) | Number of active commitments |
+| `totalCommitmentsInDebtFunds` | json (nullable) | Number of all commitments to debt funds |
+| `totalCommitmentsInPeFunds` | number (nullable) | Number of all commitments to PE funds |
+| `totalCommitmentsInReFunds` | number (nullable) | Number of all commitments to real estate funds |
+| `totalCommitmentsInVcFunds` | number (nullable) | Number of all commitments to VC funds |
+| `totalCommitmentsInFoFsAnd2nd` | json (nullable) | Number of all commitments to funds of funds and secondaries |
+| `totalCommitmentsInInfrastructure` | json (nullable) | Number of all commitments to infrastructure funds |
+| `totalCommitmentsInEnergyFunds` | json (nullable) | Number of all commitments to energy funds |
+| `totalCommitmentsInOtherFunds` | number (nullable) | Number of all commitments to other funds |
+| `totalCommitments` | number (nullable) | Number of commitments ever made |
 
 ### PitchBook Limited Partner Commitment Preferences
 
@@ -2685,16 +2685,16 @@ Retrieve what a limited partner commits to: preferred commitment size, fund type
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `limitedPartnerId` | string | PitchBook limited partner ID |
-| `limitedPartnerName` | string | Limited partner name |
-| `preferredCommitmentSize` | json | Preferred commitment size |
+| `limitedPartnerId` | string (nullable) | PitchBook limited partner ID |
+| `limitedPartnerName` | string (nullable) | Limited partner name |
+| `preferredCommitmentSize` | json (nullable) | Preferred commitment size |
 | `preferredGeography` | array | Regions the limited partner targets |
 |   ↳ `code` | string | PitchBook code |
 |   ↳ `description` | string | Human-readable label for the code |
 | `preferredFundTypes` | array | Fund types the limited partner targets |
 |   ↳ `code` | string | PitchBook code |
 |   ↳ `description` | string | Human-readable label for the code |
-| `preferredDirectInvestmentSize` | json | Preferred direct investment size |
+| `preferredDirectInvestmentSize` | json (nullable) | Preferred direct investment size |
 | `otherInvestmentPreferences` | array | Other stated preferences |
 
 ### PitchBook Limited Partner Actual Allocations
@@ -2713,13 +2713,13 @@ Retrieve a limited partner reported asset allocation across cash, equities, fixe
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `limitedPartnerId` | string | PitchBook limited partner ID |
-| `limitedPartnerName` | string | Limited partner name |
-| `affiliatedFunds` | number | Number of affiliated funds |
-| `affiliatedInvestors` | number | Number of affiliated investors |
+| `limitedPartnerId` | string (nullable) | PitchBook limited partner ID |
+| `limitedPartnerName` | string (nullable) | Limited partner name |
+| `affiliatedFunds` | number (nullable) | Number of affiliated funds |
+| `affiliatedInvestors` | number (nullable) | Number of affiliated investors |
 | `allocations` | array | Reported asset allocations |
-|   ↳ `alternativeInvestments` | json | Amount allocated to alternative investments |
-|   ↳ `alternativeInvestmentsPercent` | json | Percentage of the portfolio allocated to alternative investments |
+|   ↳ `alternativeInvestments` | json (nullable) | Amount allocated to alternative investments |
+|   ↳ `alternativeInvestmentsPercent` | json (nullable) | Percentage of the portfolio allocated to alternative investments |
 |   ↳ `privateEquity` | object | Amount allocated to private equity |
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `currency` | string | Currency of amount |
@@ -2734,8 +2734,8 @@ Retrieve a limited partner reported asset allocation across cash, equities, fixe
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 |   ↳ `realEstatePercent` | number | Percentage of the portfolio allocated to real estate |
-|   ↳ `specialOpportunities` | json | Amount allocated to special opportunities |
-|   ↳ `specialOpportunitiePercent` | json | Percentage of the portfolio allocated to special opportunities |
+|   ↳ `specialOpportunities` | json (nullable) | Amount allocated to special opportunities |
+|   ↳ `specialOpportunitiePercent` | json (nullable) | Percentage of the portfolio allocated to special opportunities |
 |   ↳ `hedgeFunds` | object | Amount allocated to hedge funds |
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `currency` | string | Currency of amount |
@@ -2781,14 +2781,14 @@ Retrieve a limited partner target allocation ranges per asset class, in both val
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `limitedPartnerId` | string | PitchBook limited partner ID |
-| `limitedPartnerName` | string | Limited partner name |
+| `limitedPartnerId` | string (nullable) | PitchBook limited partner ID |
+| `limitedPartnerName` | string (nullable) | Limited partner name |
 | `targetAllocations` | array | Target asset allocations |
 |   ↳ `policyDescription` | string | Allocation policy description |
-|   ↳ `alternativesMin` | json | Alternatives min |
-|   ↳ `alternativesPercentMin` | json | Alternatives percent min |
-|   ↳ `alternativesMax` | json | Alternatives max |
-|   ↳ `alternativesPercentMax` | json | Alternatives percent max |
+|   ↳ `alternativesMin` | json (nullable) | Alternatives min |
+|   ↳ `alternativesPercentMin` | json (nullable) | Alternatives percent min |
+|   ↳ `alternativesMax` | json (nullable) | Alternatives max |
+|   ↳ `alternativesPercentMax` | json (nullable) | Alternatives percent max |
 |   ↳ `privateEquityMin` | object | Minimum target allocation to private equity |
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `currency` | string | Currency of amount |
@@ -2817,14 +2817,14 @@ Retrieve a limited partner target allocation ranges per asset class, in both val
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 |   ↳ `realEstatePercentMax` | number | Maximum target allocation to real estate, as a percentage |
-|   ↳ `specialOpportunitiesMin` | json | Minimum target allocation to special opportunities |
-|   ↳ `specialOpportunitiesPercentMin` | json | Minimum target allocation to special opportunities, as a percentage |
-|   ↳ `specialOpportunitiesMax` | json | Maximum target allocation to special opportunities |
-|   ↳ `specialOpportunitiesPercentMax` | json | Maximum target allocation to special opportunities, as a percentage |
-|   ↳ `hedgeFundsMin` | json | Minimum target allocation to hedge funds |
-|   ↳ `hedgeFundsPercentMin` | json | Minimum target allocation to hedge funds, as a percentage |
-|   ↳ `hedgeFundsMax` | json | Maximum target allocation to hedge funds |
-|   ↳ `hedgeFundsPercentMax` | json | Maximum target allocation to hedge funds, as a percentage |
+|   ↳ `specialOpportunitiesMin` | json (nullable) | Minimum target allocation to special opportunities |
+|   ↳ `specialOpportunitiesPercentMin` | json (nullable) | Minimum target allocation to special opportunities, as a percentage |
+|   ↳ `specialOpportunitiesMax` | json (nullable) | Maximum target allocation to special opportunities |
+|   ↳ `specialOpportunitiesPercentMax` | json (nullable) | Maximum target allocation to special opportunities, as a percentage |
+|   ↳ `hedgeFundsMin` | json (nullable) | Minimum target allocation to hedge funds |
+|   ↳ `hedgeFundsPercentMin` | json (nullable) | Minimum target allocation to hedge funds, as a percentage |
+|   ↳ `hedgeFundsMax` | json (nullable) | Maximum target allocation to hedge funds |
+|   ↳ `hedgeFundsPercentMax` | json (nullable) | Maximum target allocation to hedge funds, as a percentage |
 |   ↳ `equitiesMin` | object | Minimum target allocation to equities |
 |     ↳ `amount` | number | Value in the requested currency |
 |     ↳ `currency` | string | Currency of amount |
@@ -2853,10 +2853,10 @@ Retrieve a limited partner target allocation ranges per asset class, in both val
 |     ↳ `nativeCurrency` | string | Currency of nativeAmount |
 |     ↳ `estimated` | boolean | Whether the value is a PitchBook estimate |
 |   ↳ `fixedIncomePercentMax` | number | Maximum target allocation to fixed income, as a percentage |
-|   ↳ `cashMin` | json | Minimum target allocation to cash |
-|   ↳ `cashPercentMin` | json | Minimum target allocation to cash, as a percentage |
-|   ↳ `cashMax` | json | Maximum target allocation to cash |
-|   ↳ `cashPercentMax` | json | Maximum target allocation to cash, as a percentage |
+|   ↳ `cashMin` | json (nullable) | Minimum target allocation to cash |
+|   ↳ `cashPercentMin` | json (nullable) | Minimum target allocation to cash, as a percentage |
+|   ↳ `cashMax` | json (nullable) | Maximum target allocation to cash |
+|   ↳ `cashPercentMax` | json (nullable) | Maximum target allocation to cash, as a percentage |
 
 ### PitchBook Limited Partner Service Providers
 
@@ -2874,7 +2874,7 @@ Retrieve the current and former service providers engaged by a limited partner
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `limitedPartnerId` | string | PitchBook limited partner ID |
+| `limitedPartnerId` | string (nullable) | PitchBook limited partner ID |
 | `currentGeneralServices` | array | Current general service relationships |
 |   ↳ `serviceProviderId` | string | PitchBook service provider ID |
 |   ↳ `serviceProviderName` | string | Service provider name |
@@ -2916,7 +2916,7 @@ Check which limited partner datasets changed in a window, so a sync only refetch
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updates` | json | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
+| `updates` | json (nullable) | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
 
 ### PitchBook Service Provider Search
 
@@ -2955,7 +2955,7 @@ Search PitchBook for service providers by type, location, and the deals they hav
 | `items` | array | Service providers matching the search criteria |
 |   ↳ `serviceProviderId` | string | PitchBook service provider ID |
 |   ↳ `serviceProviderName` | string | Service provider name |
-|   ↳ `website` | string | Service provider website |
+|   ↳ `website` | string (nullable) | Service provider website |
 
 ### PitchBook Service Provider Bio
 
@@ -2973,25 +2973,25 @@ Retrieve the profile of a service provider: names, types, description, and how m
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `serviceProviderId` | string | PitchBook service provider ID |
+| `serviceProviderId` | string (nullable) | PitchBook service provider ID |
 | `serviceProviderName` | object | The names the service provider is known by |
-|   ↳ `formalName` | string | Formal name |
-|   ↳ `alsoKnownAs` | string | Also-known-as name |
-|   ↳ `legalName` | string | Registered legal name |
-|   ↳ `formerlyKnownAs` | string | Previous name |
+|   ↳ `formalName` | string (nullable) | Formal name |
+|   ↳ `alsoKnownAs` | string (nullable) | Also-known-as name |
+|   ↳ `legalName` | string (nullable) | Registered legal name |
+|   ↳ `formerlyKnownAs` | string (nullable) | Previous name |
 | `serviceProviderTypes` | array | Types the service provider is classified as, one flagged primary |
 |   ↳ `type` | object | Service provider type |
 |     ↳ `code` | string | Type code |
 |     ↳ `description` | string | Type label |
 |   ↳ `primary` | boolean | Whether this is the primary type |
-| `description` | string | Description of the service provider |
-| `website` | string | Service provider website |
-| `employees` | number | Employee count |
-| `servicedCompanies` | number | Number of companies serviced |
-| `servicedDeals` | number | Number of deals serviced |
-| `servicedInvestors` | number | Number of investors serviced |
-| `servicedFunds` | number | Number of funds serviced |
-| `servicedLimitedPartners` | number | Number of limited partners serviced |
+| `description` | string (nullable) | Description of the service provider |
+| `website` | string (nullable) | Service provider website |
+| `employees` | number (nullable) | Employee count |
+| `servicedCompanies` | number (nullable) | Number of companies serviced |
+| `servicedDeals` | number (nullable) | Number of deals serviced |
+| `servicedInvestors` | number (nullable) | Number of investors serviced |
+| `servicedFunds` | number (nullable) | Number of funds serviced |
+| `servicedLimitedPartners` | number (nullable) | Number of limited partners serviced |
 
 ### PitchBook Serviced Companies
 
@@ -3035,7 +3035,7 @@ Retrieve the deals a service provider worked on and what it was hired for on eac
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `serviceProviderName` | string | Service provider name |
+| `serviceProviderName` | string (nullable) | Service provider name |
 | `servicedDealInfo` | array | Deals the service provider worked on |
 |   ↳ `companyId` | string | PitchBook company ID |
 |   ↳ `companyName` | string | Company name |
@@ -3088,8 +3088,8 @@ Retrieve the funds a service provider has worked with and the service provided t
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `serviceProviderId` | string | PitchBook service provider ID |
-| `serviceProviderName` | string | Service provider name |
+| `serviceProviderId` | string (nullable) | PitchBook service provider ID |
+| `serviceProviderName` | string (nullable) | Service provider name |
 | `fundServices` | array | Funds the service provider worked with |
 |   ↳ `fundId` | string | PitchBook fund ID |
 |   ↳ `fundName` | string | Fund name |
@@ -3116,8 +3116,8 @@ Retrieve the limited partners a service provider currently and formerly serves
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `serviceProviderId` | string | PitchBook service provider ID |
-| `serviceProviderName` | string | Service provider name |
+| `serviceProviderId` | string (nullable) | PitchBook service provider ID |
+| `serviceProviderName` | string (nullable) | Service provider name |
 | `currentGeneralServices` | array | Current general service relationships |
 | `formerGeneralServices` | array | Former general service relationships |
 |   ↳ `entityId` | string | PitchBook entity ID |
@@ -3144,7 +3144,7 @@ Check which service provider datasets changed in a window, so a sync only refetc
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `updates` | json | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
+| `updates` | json (nullable) | Map of dataset name to whether it changed in the window. Keys are PitchBook dataset names, so read it as a plain object. |
 
 ### PitchBook Credit News Search
 
@@ -3185,13 +3185,13 @@ Search PitchBook credit analysis news by author, region, asset class, topic, iss
 |   ↳ `publishDate` | string | Publication timestamp \(ISO 8601\) |
 |   ↳ `assetClasses` | array | Asset classes the article covers |
 |   ↳ `topics` | array | Topics the article covers |
-|   ↳ `issuer` | object | Issuer the article is about |
+|   ↳ `issuer` | object (nullable) | Issuer the article is about |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `name` | string | Name |
-|   ↳ `lender` | object | Lender the article is about |
+|   ↳ `lender` | object (nullable) | Lender the article is about |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `name` | string | Name |
-|   ↳ `sponsor` | object | Sponsor the article is about |
+|   ↳ `sponsor` | object (nullable) | Sponsor the article is about |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `name` | string | Name |
 
@@ -3226,13 +3226,13 @@ Retrieve the most recently published credit analysis articles and their descript
 |   ↳ `publishDate` | string | Publication timestamp \(ISO 8601\) |
 |   ↳ `assetClasses` | array | Asset classes the article covers |
 |   ↳ `topics` | array | Topics the article covers |
-|   ↳ `issuer` | object | Issuer the article is about |
+|   ↳ `issuer` | object (nullable) | Issuer the article is about |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `name` | string | Name |
-|   ↳ `lender` | object | Lender the article is about |
+|   ↳ `lender` | object (nullable) | Lender the article is about |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `name` | string | Name |
-|   ↳ `sponsor` | object | Sponsor the article is about |
+|   ↳ `sponsor` | object (nullable) | Sponsor the article is about |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `name` | string | Name |
 
@@ -3252,20 +3252,20 @@ Retrieve one credit analysis article in full, including its body text, authors, 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `articleId` | number | Credit news article ID |
-| `title` | string | Title |
+| `articleId` | number (nullable) | Credit news article ID |
+| `title` | string (nullable) | Title |
 | `authors` | array | Authors of the article |
 |   ↳ `authorName` | string | Author name |
 | `regions` | array | Geographic regions the article covers |
-| `publishDate` | string | Publication timestamp \(ISO 8601\) |
+| `publishDate` | string (nullable) | Publication timestamp \(ISO 8601\) |
 | `assetClasses` | array | Asset classes the article covers |
 | `topics` | array | Topics the article covers |
 | `issuer` | object | Issuer the article is about |
 |   ↳ `pbId` | string | PitchBook entity ID |
 |   ↳ `name` | string | Name |
-| `lender` | json | Lender the article is about |
-| `sponsor` | json | Sponsor the article is about |
-| `articleBody` | string | Full text of the article |
+| `lender` | json (nullable) | Lender the article is about |
+| `sponsor` | json (nullable) | Sponsor the article is about |
+| `articleBody` | string (nullable) | Full text of the article |
 | `attachments` | array | Attachments on the article |
 
 ### PitchBook Credit News Bulk
@@ -3298,14 +3298,14 @@ Retrieve many credit analysis articles in full in a single call, reporting which
 |   ↳ `publishDate` | string | Publication timestamp \(ISO 8601\) |
 |   ↳ `assetClasses` | array | Asset classes the article covers |
 |   ↳ `topics` | array | Topics the article covers |
-|   ↳ `issuer` | object | Issuer the article is about |
+|   ↳ `issuer` | object (nullable) | Issuer the article is about |
 |     ↳ `pbId` | string | PitchBook entity ID |
 |     ↳ `name` | string | Name |
-|   ↳ `lender` | json | Lender the article is about |
-|   ↳ `sponsor` | json | Sponsor the article is about |
+|   ↳ `lender` | json (nullable) | Lender the article is about |
+|   ↳ `sponsor` | json (nullable) | Sponsor the article is about |
 |   ↳ `articleBody` | string | Full text of the article |
 |   ↳ `attachments` | array | Attachments on the article |
-|   ↳ `deal` | object | Deal the record belongs to |
+|   ↳ `deal` | object (nullable) | Deal the record belongs to |
 |     ↳ `dealId` | string | PitchBook deal ID |
 | `notFound` | array | Article IDs that were not found |
 | `duplicates` | array | Article IDs that were requested more than once |
@@ -3331,7 +3331,7 @@ Retrieve the API contracts on the account with their pricing model, term, and cr
 |   ↳ `activeContract` | boolean | Whether the contract is currently active |
 |   ↳ `pricingModel` | string | Pricing model of the contract |
 |   ↳ `startDate` | string | Start date \(YYYY-MM-DD\) |
-|   ↳ `endDate` | string | End date \(YYYY-MM-DD\) |
+|   ↳ `endDate` | string (nullable) | End date \(YYYY-MM-DD\) |
 |   ↳ `creditsUsed` | number | Credits consumed |
 |   ↳ `creditsChanged` | number | Net credits added or removed |
 |   ↳ `creditsExpired` | number | Credits that expired |
@@ -3471,6 +3471,4 @@ List the entities a sandbox API key is allowed to query, so test workflows have 
 | `entities` | array | Entities the sandbox key may query. PitchBook names this array after the requested entity type, so it is surfaced under a stable `entities` key rather than the type-specific one. |
 |   ↳ `companyId` | string | PitchBook ID of the entity, keyed by its own entity type |
 |   ↳ `companyName` | string | Name of the entity, keyed by its own entity type |
-| `entityTypeCounts` | json | Count of available sandbox entities, keyed by entity type |
-
-
+| `entityTypeCounts` | json (nullable) | Count of available sandbox entities, keyed by entity type |

--- a/apps/docs/content/docs/integrations/polymarket.mdx
+++ b/apps/docs/content/docs/integrations/polymarket.mdx
@@ -5,7 +5,7 @@ description: Access prediction markets data from Polymarket
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="polymarket"
   color="#4C82FB"
 />
@@ -623,5 +623,3 @@ Retrieve top holders of a specific market token
 |     ↳ `profileImage` | string | Profile image URL |
 |     ↳ `profileImageOptimized` | string | Optimized profile image URL |
 |     ↳ `verified` | boolean | Whether the holder is verified |
-
-

--- a/apps/docs/content/docs/integrations/postgresql.mdx
+++ b/apps/docs/content/docs/integrations/postgresql.mdx
@@ -5,7 +5,7 @@ description: Connect to PostgreSQL database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="postgresql"
   color="#336791"
 />
@@ -191,5 +191,3 @@ Introspect PostgreSQL database schema to retrieve table structures, columns, and
 |     ↳ `columns` | array | Columns included in the index |
 |     ↳ `unique` | boolean | Whether the index enforces uniqueness |
 | `schemas` | array | List of available schemas in the database |
-
-

--- a/apps/docs/content/docs/integrations/posthog.mdx
+++ b/apps/docs/content/docs/integrations/posthog.mdx
@@ -5,7 +5,7 @@ description: Product analytics and feature management
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="posthog"
   color="#FFFFFF"
 />
@@ -1605,5 +1605,3 @@ Get detailed information about a specific organization by ID. Returns comprehens
 |   ↳ `customer_id` | string | Customer ID for billing |
 |   ↳ `available_features` | array | List of available feature flags for organization |
 |   ↳ `usage` | object | Organization usage statistics |
-
-

--- a/apps/docs/content/docs/integrations/profound.mdx
+++ b/apps/docs/content/docs/integrations/profound.mdx
@@ -5,7 +5,7 @@ description: AI visibility and analytics with Profound
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="profound"
   color="#000000"
 />
@@ -622,5 +622,3 @@ Get prompts that cite a specific domain across AI platforms in Profound
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `data` | json | Citation prompt data for the queried domain |
-
-

--- a/apps/docs/content/docs/integrations/prospeo.mdx
+++ b/apps/docs/content/docs/integrations/prospeo.mdx
@@ -5,7 +5,7 @@ description: Enrich and search B2B contacts and companies
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="prospeo"
   color="#FF1A26"
 />
@@ -214,5 +214,3 @@ Free endpoint to retrieve valid location or job title values for use in Search f
 |   ↳ `name` | string | Formatted location name to use in filters |
 |   ↳ `type` | string | Location type \(COUNTRY, STATE, CITY, or ZONE\) |
 | `job_title_suggestions` | array | Up to 25 job title suggestions ordered by popularity when using job_title_search \(empty when searching locations\) |
-
-

--- a/apps/docs/content/docs/integrations/pulse.mdx
+++ b/apps/docs/content/docs/integrations/pulse.mdx
@@ -5,7 +5,7 @@ description: Extract text from documents using Pulse OCR
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="pulse_v2"
   color="#FFFFFF"
 />
@@ -64,5 +64,3 @@ Parse documents (PDF, images, Office docs) using Pulse OCR API
 | `structured_output` | json | Structured output; Sim exposes no input for supplying a schema, so this is always null |
 | `chunks` | json | Chunked content if chunking was enabled |
 | `figures` | json | Extracted figures; returned only when the hidden extractFigure input is enabled |
-
-

--- a/apps/docs/content/docs/integrations/qdrant.mdx
+++ b/apps/docs/content/docs/integrations/qdrant.mdx
@@ -5,7 +5,7 @@ description: Use Qdrant vector database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="qdrant"
   color="#1A223F"
 />
@@ -104,5 +104,3 @@ Fetch points by ID from a Qdrant collection
 |   ↳ `vector` | json | Point vector\(s\) - single array or named vectors object |
 |   ↳ `shard_key` | string | Shard key for routing |
 |   ↳ `order_value` | number | Order value for sorting |
-
-

--- a/apps/docs/content/docs/integrations/quartr.mdx
+++ b/apps/docs/content/docs/integrations/quartr.mdx
@@ -5,7 +5,7 @@ description: Access earnings calls, transcripts, filings, and slides
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="quartr"
   color="#000000"
 />
@@ -56,13 +56,13 @@ List companies covered by Quartr, filterable by ticker, ISIN, CIK, OpenFIGI, cou
 | `companies` | array | Companies matching the filters |
 |   ↳ `id` | number | Quartr company ID |
 |   ↳ `name` | string | Legal company name |
-|   ↳ `displayName` | string | Display name |
+|   ↳ `displayName` | string (nullable) | Display name |
 |   ↳ `country` | string | ISO 3166-1 alpha-2 country code |
 |   ↳ `tickers` | array | Ticker listings for the company |
 |     ↳ `ticker` | string | Ticker symbol |
 |     ↳ `exchange` | string | Exchange symbol |
 |   ↳ `isins` | array | ISINs for the company |
-|   ↳ `cik` | string | SEC Central Index Key |
+|   ↳ `cik` | string (nullable) | SEC Central Index Key |
 |   ↳ `openfigi` | array | OpenFIGI share class identifiers |
 |   ↳ `backlinkUrl` | string | Quartr backlink URL for the company |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
@@ -87,13 +87,13 @@ Retrieve a single company from Quartr by its company ID.
 | `company` | object | The requested company |
 |   ↳ `id` | number | Quartr company ID |
 |   ↳ `name` | string | Legal company name |
-|   ↳ `displayName` | string | Display name |
+|   ↳ `displayName` | string (nullable) | Display name |
 |   ↳ `country` | string | ISO 3166-1 alpha-2 country code |
 |   ↳ `tickers` | array | Ticker listings for the company |
 |     ↳ `ticker` | string | Ticker symbol |
 |     ↳ `exchange` | string | Exchange symbol |
 |   ↳ `isins` | array | ISINs for the company |
-|   ↳ `cik` | string | SEC Central Index Key |
+|   ↳ `cik` | string (nullable) | SEC Central Index Key |
 |   ↳ `openfigi` | array | OpenFIGI share class identifiers |
 |   ↳ `backlinkUrl` | string | Quartr backlink URL for the company |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
@@ -134,8 +134,8 @@ List corporate events (earnings calls, capital markets days, etc.) from Quartr, 
 |   ↳ `title` | string | Event title \(e.g., "Q1 2024"\) |
 |   ↳ `date` | string | Event date \(ISO 8601\) |
 |   ↳ `typeId` | number | Event type ID |
-|   ↳ `fiscalYear` | number | Fiscal year |
-|   ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
+|   ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|   ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
 |   ↳ `language` | string | Event language code |
 |   ↳ `backlinkUrl` | string | Quartr backlink URL for the event |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
@@ -163,8 +163,8 @@ Retrieve a single corporate event from Quartr by its event ID.
 |   ↳ `title` | string | Event title \(e.g., "Q1 2024"\) |
 |   ↳ `date` | string | Event date \(ISO 8601\) |
 |   ↳ `typeId` | number | Event type ID |
-|   ↳ `fiscalYear` | number | Fiscal year |
-|   ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
+|   ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|   ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
 |   ↳ `language` | string | Event language code |
 |   ↳ `backlinkUrl` | string | Quartr backlink URL for the event |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
@@ -189,10 +189,10 @@ Retrieve the AI-generated summary of a corporate event from Quartr, with selecta
 | --------- | ---- | ----------- |
 | `summary` | string | AI-generated event summary in Markdown \(includes embedded document source tags unless a plain-text summary is requested\) |
 | `sources` | array | Source documents referenced by the summary |
-|   ↳ `sourceId` | string | ID linking the source document to tags embedded in the summary |
+|   ↳ `sourceId` | string (nullable) | ID linking the source document to tags embedded in the summary |
 |   ↳ `documentId` | number | Quartr document ID of the source |
-|   ↳ `page` | number | Page number or timestamp in seconds depending on the document type |
-|   ↳ `timestamp` | number | Timestamp in seconds |
+|   ↳ `page` | number (nullable) | Page number or timestamp in seconds depending on the document type |
+|   ↳ `timestamp` | number (nullable) | Timestamp in seconds |
 |   ↳ `typeId` | number | Document type ID of the source |
 | `summaryId` | number | Quartr summary ID |
 | `summaryCreatedAt` | string | Summary creation timestamp \(ISO 8601\) |
@@ -217,8 +217,8 @@ List the event types available in Quartr (e.g., earnings calls), useful for filt
 | --------- | ---- | ----------- |
 | `eventTypes` | array | Available event types |
 |   ↳ `id` | number | Event type ID |
-|   ↳ `name` | string | Event type name \(e.g., "Q1"\) |
-|   ↳ `parent` | string | Parent event type name \(e.g., "Earnings call"\) |
+|   ↳ `name` | string (nullable) | Event type name \(e.g., "Q1"\) |
+|   ↳ `parent` | string (nullable) | Parent event type name \(e.g., "Earnings call"\) |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
@@ -256,19 +256,19 @@ List documents of all kinds (reports, slide decks, and transcripts) from Quartr,
 | --------- | ---- | ----------- |
 | `documents` | array | Documents matching the filters |
 |   ↳ `id` | number | Quartr document ID |
-|   ↳ `companyId` | number | Quartr company ID |
-|   ↳ `eventId` | number | Quartr event ID |
+|   ↳ `companyId` | number (nullable) | Quartr company ID |
+|   ↳ `eventId` | number (nullable) | Quartr event ID |
 |   ↳ `typeId` | number | Document type ID |
 |   ↳ `fileUrl` | string | URL of the document file |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
 ### Quartr List Document Types
@@ -291,10 +291,10 @@ List the document types available in Quartr (e.g., 10-Q quarterly reports), usef
 | `documentTypes` | array | Available document types |
 |   ↳ `id` | number | Document type ID |
 |   ↳ `name` | string | Document type name \(e.g., "Quarterly Report"\) |
-|   ↳ `description` | string | Document type description |
-|   ↳ `form` | string | Filing form \(e.g., "10-Q"\) |
+|   ↳ `description` | string (nullable) | Document type description |
+|   ↳ `form` | string (nullable) | Filing form \(e.g., "10-Q"\) |
 |   ↳ `category` | string | Document category \(e.g., "Report"\) |
-|   ↳ `documentGroupId` | number | Document group ID |
+|   ↳ `documentGroupId` | number (nullable) | Document group ID |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
@@ -332,19 +332,19 @@ List filings and reports (10-K, 10-Q, earnings releases, etc.) from Quartr, filt
 | --------- | ---- | ----------- |
 | `reports` | array | Reports matching the filters |
 |   ↳ `id` | number | Quartr document ID |
-|   ↳ `companyId` | number | Quartr company ID |
-|   ↳ `eventId` | number | Quartr event ID |
+|   ↳ `companyId` | number (nullable) | Quartr company ID |
+|   ↳ `eventId` | number (nullable) | Quartr event ID |
 |   ↳ `typeId` | number | Document type ID |
 |   ↳ `fileUrl` | string | URL of the document file |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
 ### Quartr Get Report
@@ -364,19 +364,19 @@ Retrieve a filing or report (10-K, 10-Q, earnings release, etc.) from Quartr by 
 | --------- | ---- | ----------- |
 | `document` | object | Report metadata |
 |   ↳ `id` | number | Quartr document ID |
-|   ↳ `companyId` | number | Quartr company ID |
-|   ↳ `eventId` | number | Quartr event ID |
+|   ↳ `companyId` | number (nullable) | Quartr company ID |
+|   ↳ `eventId` | number (nullable) | Quartr event ID |
 |   ↳ `typeId` | number | Document type ID |
 |   ↳ `fileUrl` | string | URL of the document file |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 | `fileUrl` | string | URL of the report PDF |
 | `file` | file | Downloaded report PDF stored in execution files |
 
@@ -413,19 +413,19 @@ List slide presentations from Quartr, filterable by company, event, document typ
 | --------- | ---- | ----------- |
 | `slideDecks` | array | Slide decks matching the filters |
 |   ↳ `id` | number | Quartr document ID |
-|   ↳ `companyId` | number | Quartr company ID |
-|   ↳ `eventId` | number | Quartr event ID |
+|   ↳ `companyId` | number (nullable) | Quartr company ID |
+|   ↳ `eventId` | number (nullable) | Quartr event ID |
 |   ↳ `typeId` | number | Document type ID |
 |   ↳ `fileUrl` | string | URL of the document file |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
 ### Quartr Get Slide Deck
@@ -445,19 +445,19 @@ Retrieve a slide presentation from Quartr by its document ID and download the PD
 | --------- | ---- | ----------- |
 | `document` | object | Slide deck metadata |
 |   ↳ `id` | number | Quartr document ID |
-|   ↳ `companyId` | number | Quartr company ID |
-|   ↳ `eventId` | number | Quartr event ID |
+|   ↳ `companyId` | number (nullable) | Quartr company ID |
+|   ↳ `eventId` | number (nullable) | Quartr event ID |
 |   ↳ `typeId` | number | Document type ID |
 |   ↳ `fileUrl` | string | URL of the document file |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 | `fileUrl` | string | URL of the slide deck PDF |
 | `file` | file | Downloaded slide deck PDF stored in execution files |
 
@@ -494,19 +494,19 @@ List event transcripts from Quartr, filterable by company, event, document type,
 | --------- | ---- | ----------- |
 | `transcripts` | array | Transcripts matching the filters |
 |   ↳ `id` | number | Quartr document ID |
-|   ↳ `companyId` | number | Quartr company ID |
-|   ↳ `eventId` | number | Quartr event ID |
+|   ↳ `companyId` | number (nullable) | Quartr company ID |
+|   ↳ `eventId` | number (nullable) | Quartr event ID |
 |   ↳ `typeId` | number | Document type ID |
 |   ↳ `fileUrl` | string | URL of the document file |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
 ### Quartr Get Transcript
@@ -526,19 +526,19 @@ Retrieve an event transcript from Quartr by its document ID and download the tra
 | --------- | ---- | ----------- |
 | `document` | object | Transcript metadata |
 |   ↳ `id` | number | Quartr document ID |
-|   ↳ `companyId` | number | Quartr company ID |
-|   ↳ `eventId` | number | Quartr event ID |
+|   ↳ `companyId` | number (nullable) | Quartr company ID |
+|   ↳ `eventId` | number (nullable) | Quartr event ID |
 |   ↳ `typeId` | number | Document type ID |
 |   ↳ `fileUrl` | string | URL of the document file |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 | `fileUrl` | string | URL of the transcript JSON file |
 | `file` | file | Downloaded transcript JSON file stored in execution files |
 
@@ -575,23 +575,23 @@ List archived event audio recordings from Quartr, filterable by company, event, 
 |   ↳ `id` | number | Quartr audio ID |
 |   ↳ `companyId` | number | Quartr company ID |
 |   ↳ `eventId` | number | Quartr event ID |
-|   ↳ `fileUrl` | string | Download URL of the audio file \(MPEG\) |
-|   ↳ `streamUrl` | string | Streaming URL of the audio \(M3U8\) |
-|   ↳ `qna` | number | Timestamp in seconds where the Q&A section starts |
-|   ↳ `audioMetadata` | object | Audio file metadata |
-|     ↳ `size` | string | File size \(e.g., "200.00 MB"\) |
-|     ↳ `duration` | number | Duration in seconds |
-|     ↳ `encoding` | string | Audio encoding |
-|     ↳ `mimetype` | string | Audio MIME type |
+|   ↳ `fileUrl` | string (nullable) | Download URL of the audio file \(MPEG\) |
+|   ↳ `streamUrl` | string (nullable) | Streaming URL of the audio \(M3U8\) |
+|   ↳ `qna` | number (nullable) | Timestamp in seconds where the Q&A section starts |
+|   ↳ `audioMetadata` | object (nullable) | Audio file metadata |
+|     ↳ `size` | string (nullable) | File size \(e.g., "200.00 MB"\) |
+|     ↳ `duration` | number (nullable) | Duration in seconds |
+|     ↳ `encoding` | string (nullable) | Audio encoding |
+|     ↳ `mimetype` | string (nullable) | Audio MIME type |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
 
 ### Quartr Get Audio
@@ -613,23 +613,23 @@ Retrieve an archived event audio recording from Quartr by its audio ID. Returns 
 |   ↳ `id` | number | Quartr audio ID |
 |   ↳ `companyId` | number | Quartr company ID |
 |   ↳ `eventId` | number | Quartr event ID |
-|   ↳ `fileUrl` | string | Download URL of the audio file \(MPEG\) |
-|   ↳ `streamUrl` | string | Streaming URL of the audio \(M3U8\) |
-|   ↳ `qna` | number | Timestamp in seconds where the Q&A section starts |
-|   ↳ `audioMetadata` | object | Audio file metadata |
-|     ↳ `size` | string | File size \(e.g., "200.00 MB"\) |
-|     ↳ `duration` | number | Duration in seconds |
-|     ↳ `encoding` | string | Audio encoding |
-|     ↳ `mimetype` | string | Audio MIME type |
+|   ↳ `fileUrl` | string (nullable) | Download URL of the audio file \(MPEG\) |
+|   ↳ `streamUrl` | string (nullable) | Streaming URL of the audio \(M3U8\) |
+|   ↳ `qna` | number (nullable) | Timestamp in seconds where the Q&A section starts |
+|   ↳ `audioMetadata` | object (nullable) | Audio file metadata |
+|     ↳ `size` | string (nullable) | File size \(e.g., "200.00 MB"\) |
+|     ↳ `duration` | number (nullable) | Duration in seconds |
+|     ↳ `encoding` | string (nullable) | Audio encoding |
+|     ↳ `mimetype` | string (nullable) | Audio MIME type |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
-|   ↳ `event` | object | Expanded event details \(present when event expansion is requested\) |
-|     ↳ `title` | string | Event title |
-|     ↳ `typeId` | number | Event type ID |
-|     ↳ `fiscalYear` | number | Fiscal year |
-|     ↳ `fiscalPeriod` | string | Fiscal period \(e.g., "Q1"\) |
-|     ↳ `language` | string | Event language code |
-|     ↳ `date` | string | Event date \(ISO 8601\) |
+|   ↳ `event` | object (nullable) | Expanded event details \(present when event expansion is requested\) |
+|     ↳ `title` | string (nullable) | Event title |
+|     ↳ `typeId` | number (nullable) | Event type ID |
+|     ↳ `fiscalYear` | number (nullable) | Fiscal year |
+|     ↳ `fiscalPeriod` | string (nullable) | Fiscal period \(e.g., "Q1"\) |
+|     ↳ `language` | string (nullable) | Event language code |
+|     ↳ `date` | string (nullable) | Event date \(ISO 8601\) |
 
 ### Quartr List Live Events
 
@@ -666,12 +666,10 @@ List live and upcoming events from Quartr with live audio and transcript stream 
 |   ↳ `eventId` | number | Quartr event ID |
 |   ↳ `companyId` | number | Quartr company ID |
 |   ↳ `date` | string | Scheduled event date \(ISO 8601\) |
-|   ↳ `wentLiveAt` | string | Timestamp when the event went live \(ISO 8601\) |
-|   ↳ `state` | string | Live state \(notLive, willBeLive, live, liveFailedInterrupted, liveFailedNoAccess, liveFailedNotStarted, processingRecording, processingRecordingFailed, recordingAvailable\) |
-|   ↳ `audio` | string | URL of the live audio stream or recording |
-|   ↳ `transcript` | string | URL of the live transcript stream \(JSON Lines\) |
+|   ↳ `wentLiveAt` | string (nullable) | Timestamp when the event went live \(ISO 8601\) |
+|   ↳ `state` | string (nullable) | Live state \(notLive, willBeLive, live, liveFailedInterrupted, liveFailedNoAccess, liveFailedNotStarted, processingRecording, processingRecordingFailed, recordingAvailable\) |
+|   ↳ `audio` | string (nullable) | URL of the live audio stream or recording |
+|   ↳ `transcript` | string (nullable) | URL of the live transcript stream \(JSON Lines\) |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last update timestamp \(ISO 8601\) |
 | `nextCursor` | number | Cursor for fetching the next page of results \(null when no more pages\) |
-
-

--- a/apps/docs/content/docs/integrations/quickbooks.mdx
+++ b/apps/docs/content/docs/integrations/quickbooks.mdx
@@ -5,7 +5,7 @@ description: Manage QuickBooks Online company, transactions, reports, emails, PD
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="quickbooks"
   color="#2CA01C"
 />
@@ -71,7 +71,7 @@ Get information about the connected QuickBooks Online company
 |   ↳ `MetaData` | json | CompanyInfo creation and update timestamps |
 |     ↳ `CreateTime` | string | Entity creation timestamp |
 |     ↳ `LastUpdatedTime` | string | Entity last-updated timestamp |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 
 ### QuickBooks Read Master Data
 
@@ -210,7 +210,7 @@ List or read one account, class, customer, department, employee, item, or vendor
 | `maxResults` | number | Actual number of records returned in this page |
 | `nextStartPosition` | number | Position to use when explicitly requesting the next page |
 | `hasMore` | boolean | Conservative indication that another page may exist |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 
 ### QuickBooks Create Customer
 
@@ -238,7 +238,7 @@ Create a customer in the connected QuickBooks Online company
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created QuickBooks Customer record |
 |   ↳ `Id` | string | QuickBooks entity ID |
 |   ↳ `SyncToken` | string | Entity sync token |
@@ -288,7 +288,7 @@ Sparse-update a customer in the connected QuickBooks Online company
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated QuickBooks Customer record |
 |   ↳ `Id` | string | QuickBooks entity ID |
 |   ↳ `SyncToken` | string | Entity sync token |
@@ -335,7 +335,7 @@ Create a non-payroll employee profile in the connected QuickBooks Online company
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created QuickBooks Employee record |
 |   ↳ `Id` | string | QuickBooks entity ID |
 |   ↳ `SyncToken` | string | Entity sync token |
@@ -381,7 +381,7 @@ Read, merge, and full-update a non-payroll employee profile
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated QuickBooks Employee record |
 |   ↳ `Id` | string | QuickBooks entity ID |
 |   ↳ `SyncToken` | string | Entity sync token |
@@ -427,7 +427,7 @@ Create a vendor in the connected QuickBooks Online company
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created QuickBooks Vendor record |
 |   ↳ `Id` | string | QuickBooks entity ID |
 |   ↳ `SyncToken` | string | Entity sync token |
@@ -479,7 +479,7 @@ Read, merge, and full-update a vendor in QuickBooks Online
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated QuickBooks Vendor record |
 |   ↳ `Id` | string | QuickBooks entity ID |
 |   ↳ `SyncToken` | string | Entity sync token |
@@ -528,7 +528,7 @@ Create a Service or Non-inventory item in QuickBooks Online
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created QuickBooks Item record |
 |   ↳ `Id` | string | QuickBooks entity ID |
 |   ↳ `SyncToken` | string | Entity sync token |
@@ -587,7 +587,7 @@ Read, merge, and full-update a Service or Non-inventory item without changing it
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated QuickBooks Item record |
 |   ↳ `Id` | string | QuickBooks entity ID |
 |   ↳ `SyncToken` | string | Entity sync token |
@@ -710,7 +710,7 @@ List or read one estimate, invoice, sales receipt, payment, credit memo, or refu
 | `maxResults` | number | Actual number of items reported for this response |
 | `nextStartPosition` | number | Position to use when explicitly requesting the next page |
 | `hasMore` | boolean | Conservative indication that another page may exist |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 
 ### QuickBooks Create Estimate
 
@@ -736,7 +736,7 @@ Create an estimate with bounded item and description lines
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks Estimate |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -795,7 +795,7 @@ Sparse-update an estimate using its current sync token
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks Estimate |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -853,7 +853,7 @@ Create an invoice without emailing or collecting payment
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks Invoice |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -912,7 +912,7 @@ Sparse-update an invoice using its current sync token
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks Invoice |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -965,7 +965,7 @@ Void an invoice after explicit confirmation
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `voided` | boolean | Whether QuickBooks voided the transaction |
 | `record` | json | Voided native QuickBooks Invoice |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
@@ -1026,7 +1026,7 @@ Create a sales receipt for a completed customer sale
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks SalesReceipt |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1087,7 +1087,7 @@ Sparse-update a sales receipt using its current sync token
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks SalesReceipt |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1140,7 +1140,7 @@ Void a sales receipt after explicit confirmation
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `voided` | boolean | Whether QuickBooks voided the transaction |
 | `record` | json | Voided native QuickBooks SalesReceipt |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
@@ -1200,7 +1200,7 @@ Record a customer payment with optional bounded invoice allocations
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks Payment |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1261,7 +1261,7 @@ Read, merge, and full-update a customer payment using its current sync token
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks Payment |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1314,7 +1314,7 @@ Void a customer payment after explicit confirmation
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `voided` | boolean | Whether QuickBooks voided the transaction |
 | `record` | json | Voided native QuickBooks Payment |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
@@ -1372,7 +1372,7 @@ Create a customer credit memo with bounded sales lines
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks CreditMemo |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1430,7 +1430,7 @@ Read, merge, and full-update a credit memo using its current sync token
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks CreditMemo |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1490,7 +1490,7 @@ Create a customer refund receipt against a required deposit account
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks RefundReceipt |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1551,7 +1551,7 @@ Sparse-update a refund receipt using its current sync token
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks RefundReceipt |
 |   ↳ `Id` | string | QuickBooks sales transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1712,7 +1712,7 @@ List or read one purchase order, bill, bill payment, vendor credit, or purchase
 | `maxResults` | number | Actual number of items reported for this response |
 | `nextStartPosition` | number | Position to use when explicitly requesting the next page |
 | `hasMore` | boolean | Conservative indication that another page may exist |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 
 ### QuickBooks Create Purchase Order
 
@@ -1740,7 +1740,7 @@ Create a purchase order with bounded expense lines
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks PurchaseOrder |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1816,7 +1816,7 @@ Read, merge, and full-update purchase-order header fields
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks PurchaseOrder |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -1894,9 +1894,9 @@ Create a vendor bill with optional Purchase Order line links without paying it
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `linkingRequested` | boolean | Whether any Purchase Order line links were requested |
-| `linkingSucceeded` | boolean | Whether QuickBooks returned every requested Purchase Order line link |
+| `linkingSucceeded` | boolean (nullable) | Whether QuickBooks returned every requested Purchase Order line link |
 | `linkedLines` | array | Requested Purchase Order line links confirmed by QuickBooks |
 |   ↳ `purchaseOrderId` | string | Requested Purchase Order ID |
 |   ↳ `purchaseOrderLineId` | string | Requested Purchase Order line ID |
@@ -1980,7 +1980,7 @@ Read, merge, and full-update bill header fields using its current sync token
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks Bill |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2059,7 +2059,7 @@ Record a check or credit-card payment allocated to one or more bills
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks BillPayment |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2132,7 +2132,7 @@ Read, merge, and full-update a BillPayment without changing allocations
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks BillPayment |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2203,7 +2203,7 @@ Void a bill payment after explicit confirmation
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `voided` | boolean | Whether QuickBooks voided the transaction |
 | `record` | json | Voided native QuickBooks BillPayment |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
@@ -2281,7 +2281,7 @@ Create a vendor credit without applying it to a bill
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks VendorCredit |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2356,7 +2356,7 @@ Read, merge, and full-update vendor-credit header fields
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks VendorCredit |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2434,7 +2434,7 @@ Record a cash, check, or credit-card purchase with bounded expense lines
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks Purchase |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2508,7 +2508,7 @@ Read, merge, and full-update purchase header fields without changing lines
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks Purchase |
 |   ↳ `Id` | string | QuickBooks purchasing transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2630,7 +2630,7 @@ List or read one journal entry, deposit, or transfer
 | `maxResults` | number | Actual number of items reported for this response |
 | `nextStartPosition` | number | Position to use when explicitly requesting the next page |
 | `hasMore` | boolean | Conservative indication that another page may exist |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 
 ### QuickBooks Create Journal Entry
 
@@ -2656,7 +2656,7 @@ Post a balanced journal entry after explicit confirmation
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks JournalEntry |
 |   ↳ `Id` | string | QuickBooks accounting transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2702,7 +2702,7 @@ Sparse-update journal-entry header fields after explicit confirmation
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks JournalEntry |
 |   ↳ `Id` | string | QuickBooks accounting transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2749,7 +2749,7 @@ Create a deposit with bounded account lines
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Created native QuickBooks Deposit |
 |   ↳ `Id` | string | QuickBooks accounting transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2794,7 +2794,7 @@ Sparse-update deposit header fields using the current sync token and destination
 | `recordId` | string | ID of the created or updated QuickBooks entity |
 | `syncToken` | string | Native QuickBooks SyncToken returned by the mutation |
 | `recordVersion` | string | Latest QuickBooks record version required for a subsequent update; this is the native SyncToken under a display-safe name |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `record` | json | Updated native QuickBooks Deposit |
 |   ↳ `Id` | string | QuickBooks accounting transaction ID |
 |   ↳ `SyncToken` | string | Current transaction sync token |
@@ -2885,7 +2885,7 @@ Run a fixed QuickBooks financial report with verified accountant-focused filters
 |     ↳ `ColData` | array | Row values with optional operational IDs and links |
 |     ↳ `Rows` | json | Nested native QuickBooks report rows |
 |     ↳ `Summary` | json | Section summary column data |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 
 ### QuickBooks Email Transaction
 
@@ -2973,7 +2973,7 @@ Send a supported QuickBooks transaction by email. This causes an external email 
 |   ↳ `PayType` | string | Bill-payment type |
 |   ↳ `CheckPayment` | json | Check payment account details |
 |   ↳ `CreditCardPayment` | json | Credit-card payment account details |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 
 ### QuickBooks Download Transaction PDF
 
@@ -3021,7 +3021,7 @@ List attachment metadata for a fixed QuickBooks entity or read one attachment by
 | `maxResults` | number | Actual number of items reported for this response |
 | `nextStartPosition` | number | Position to use when explicitly requesting the next page |
 | `hasMore` | boolean | Conservative indication that another page may exist |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 | `item` | json | Native QuickBooks attachment metadata |
 |   ↳ `Id` | string | QuickBooks attachment ID |
 |   ↳ `SyncToken` | string | Attachment sync token |
@@ -3096,7 +3096,7 @@ Attach one supported file or one note to a fixed QuickBooks entity
 | `attachmentKind` | string | Created attachment kind |
 | `targetType` | string | QuickBooks target entity type |
 | `targetId` | string | QuickBooks target entity ID |
-| `time` | string | QuickBooks response timestamp |
+| `time` | string (nullable) | QuickBooks response timestamp |
 
 ### QuickBooks Download Attachment
 
@@ -3118,8 +3118,6 @@ Download a QuickBooks file attachment as a stored Sim file
 | `mimeType` | string | Downloaded file MIME type |
 | `size` | number | Downloaded file size in bytes |
 | `attachmentId` | string | Downloaded QuickBooks attachment ID |
-
-
 
 ## Triggers
 
@@ -3990,4 +3988,3 @@ Trigger when selected Vendor events occur in QuickBooks
 | `source` | string | Intuit event source |
 | `contentType` | string | Event content type, when provided |
 | `data` | json | Optional event data supplied by Intuit |
-

--- a/apps/docs/content/docs/integrations/quiver.mdx
+++ b/apps/docs/content/docs/integrations/quiver.mdx
@@ -5,7 +5,7 @@ description: Generate and vectorize SVGs
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="quiver"
   color="#FFFFFF"
 />
@@ -128,5 +128,3 @@ List all available QuiverAI models
 |     ↳ `maxOutputLength` | number | Maximum generation length |
 |     ↳ `supportedOperations` | json | Available operations \(svg_generate, svg_edit, svg_animate, svg_vectorize, chat_completions\) |
 |     ↳ `supportedSamplingParameters` | json | Supported sampling parameters \(temperature, top_p, top_k, repetition_penalty, presence_penalty, stop\) |
-
-

--- a/apps/docs/content/docs/integrations/rabbitmq.mdx
+++ b/apps/docs/content/docs/integrations/rabbitmq.mdx
@@ -5,7 +5,7 @@ description: Publish and read messages and manage queues in RabbitMQ
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="rabbitmq"
   color="#FFFFFF"
 />
@@ -644,5 +644,3 @@ Delete a RabbitMQ policy. Every queue and exchange it matched immediately loses 
 | `policyName` | string | Name of the deleted policy |
 | `vhost` | string | Virtual host the policy applied in |
 | `deleted` | boolean | Whether the policy was deleted |
-
-

--- a/apps/docs/content/docs/integrations/railway.mdx
+++ b/apps/docs/content/docs/integrations/railway.mdx
@@ -5,7 +5,7 @@ description: Manage Railway projects, services, deployments, and variables
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="railway"
   color="#000000"
 />
@@ -488,5 +488,3 @@ Delete a Railway environment variable
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the variable was deleted |
-
-

--- a/apps/docs/content/docs/integrations/rb2b.mdx
+++ b/apps/docs/content/docs/integrations/rb2b.mdx
@@ -5,7 +5,7 @@ description: Identify and enrich website visitors
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="rb2b"
   color="#51FF00"
 />
@@ -341,5 +341,3 @@ Find a LinkedIn profile URL from a first name, last name, and company domain.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `linkedin_url` | string | LinkedIn profile URL for the person |
-
-

--- a/apps/docs/content/docs/integrations/rds.mdx
+++ b/apps/docs/content/docs/integrations/rds.mdx
@@ -5,7 +5,7 @@ description: Connect to Amazon RDS via Data API
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="rds"
   color="linear-gradient(45deg, #2E27AD 0%, #527FFF 100%)"
 />
@@ -172,5 +172,3 @@ Introspect Amazon RDS Aurora database schema to retrieve table structures, colum
 | `engine` | string | Detected database engine type |
 | `tables` | array | Array of table schemas with columns, keys, and indexes |
 | `schemas` | array | List of available schemas in the database |
-
-

--- a/apps/docs/content/docs/integrations/reddit.mdx
+++ b/apps/docs/content/docs/integrations/reddit.mdx
@@ -5,7 +5,7 @@ description: Access Reddit data and content
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="reddit"
   color="#FF5700"
 />
@@ -977,5 +977,3 @@ Sticky or unsticky a Reddit post to the top of a subreddit (moderator action)
 | --------- | ---- | ----------- |
 | `success` | boolean | Whether the sticky action was successful |
 | `message` | string | Success or error message |
-
-

--- a/apps/docs/content/docs/integrations/redis.mdx
+++ b/apps/docs/content/docs/integrations/redis.mdx
@@ -5,7 +5,7 @@ description: Key-value operations with Redis
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="redis"
   color="#FF4438"
 />
@@ -437,5 +437,3 @@ Set the value of a key in Redis only if the key does not already exist.
 | --------- | ---- | ----------- |
 | `key` | string | The key that was set |
 | `wasSet` | boolean | Whether the key was set \(true\) or already existed \(false\) |
-
-

--- a/apps/docs/content/docs/integrations/reducto.mdx
+++ b/apps/docs/content/docs/integrations/reducto.mdx
@@ -5,7 +5,7 @@ description: Extract text from PDF documents
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="reducto_v2"
   color="#5c0c5c"
 />
@@ -46,5 +46,3 @@ Parse PDF documents using Reducto OCR API
 | `result` | json | Parsed document content with chunks and blocks |
 | `pdf_url` | string | Storage URL of converted PDF |
 | `studio_link` | string | Link to Reducto studio interface |
-
-

--- a/apps/docs/content/docs/integrations/resend.mdx
+++ b/apps/docs/content/docs/integrations/resend.mdx
@@ -5,7 +5,7 @@ description: Send emails and manage contacts with Resend.
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="resend"
   color="#181C1E"
 />
@@ -381,8 +381,6 @@ List all verified domains in your Resend account
 |   ↳ `createdAt` | string | Domain creation timestamp |
 | `hasMore` | boolean | Whether there are more domains to retrieve |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -629,4 +627,3 @@ Trigger on Resend webhook events we subscribe to (email lifecycle, contacts, dom
 | `clickLink` | string | URL that was clicked |
 | `clickTimestamp` | string | Click timestamp \(ISO 8601\) |
 | `clickUserAgent` | string | Browser user agent string |
-

--- a/apps/docs/content/docs/integrations/revenuecat.mdx
+++ b/apps/docs/content/docs/integrations/revenuecat.mdx
@@ -5,7 +5,7 @@ description: Manage in-app subscriptions and entitlements
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="revenuecat"
   color="#F25A5A"
 />
@@ -443,8 +443,6 @@ Immediately revoke access to a Google Play subscription and issue a refund (Goog
 |   ↳ `other_purchases` | object | Other purchases attached to the subscriber |
 |   ↳ `subscriber_attributes` | object | Custom attributes set on the subscriber. Only returned when using a secret API key |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -769,4 +767,3 @@ Trigger workflow when a RevenueCat subscription renews
 | `expiration_reason` | string | Reason for expiration \(EXPIRATION events only\) |
 | `api_version` | string | RevenueCat webhook API version |
 | `event` | json | Full RevenueCat event object |
-

--- a/apps/docs/content/docs/integrations/rippling.mdx
+++ b/apps/docs/content/docs/integrations/rippling.mdx
@@ -5,7 +5,7 @@ description: Manage workers, departments, custom objects, and company data in Ri
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="rippling"
   color="#502D3C"
 />
@@ -2285,5 +2285,3 @@ Create bulk draft hires
 | `successfulResults` | json | Successful draft hires |
 | `totalInvalid` | number | Number of failures |
 | `totalSuccessful` | number | Number of successes |
-
-

--- a/apps/docs/content/docs/integrations/rocketlane.mdx
+++ b/apps/docs/content/docs/integrations/rocketlane.mdx
@@ -5,7 +5,7 @@ description: Manage client onboarding projects, tasks, time tracking, and invoic
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="rocketlane"
   color="#000000"
 />
@@ -85,107 +85,107 @@ Create a new Rocketlane project with a customer, owner, dates, team members, tem
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `project` | object | The created project |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 
 ### Rocketlane Get Project
 
@@ -205,107 +205,107 @@ Retrieve a Rocketlane project by its unique identifier
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `project` | object | The requested project |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 
 ### Rocketlane List Projects
 
@@ -343,112 +343,112 @@ List Rocketlane projects with optional filters, sorting, and token-based paginat
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `projects` | array | List of projects |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 | `pagination` | object | Pagination details for fetching further pages |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Update Project
 
@@ -481,107 +481,107 @@ Update a Rocketlane project by ID, including name, dates, visibility, owner, sta
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `project` | object | The updated project |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 
 ### Rocketlane Archive Project
 
@@ -639,107 +639,107 @@ Add team members and customer stakeholders to a Rocketlane project
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `project` | object | The project with its updated team members |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 
 ### Rocketlane Remove Project Members
 
@@ -759,107 +759,107 @@ Remove team members from a Rocketlane project
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `project` | object | The project with its updated team members |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 
 ### Rocketlane Import Template
 
@@ -880,107 +880,107 @@ Import a project template into an existing Rocketlane project
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `project` | object | The project after the template import \(including its sources\) |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 
 ### Rocketlane List Placeholders
 
@@ -998,22 +998,22 @@ List the placeholders of a Rocketlane project
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `placeholders` | array | Placeholders of the project |
-|   ↳ `placeholderId` | number | Unique identifier of the placeholder |
-|   ↳ `placeholderName` | string | Name of the placeholder |
-|   ↳ `project` | object | Project of the placeholder |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `role` | object | Role of the placeholder |
-|     ↳ `roleId` | number | Unique identifier of the role |
-|     ↳ `roleName` | string | Name of the role |
-|   ↳ `placeholderType` | string | Type of the placeholder \(NATIVE or EXTERNAL\) |
-|   ↳ `createdAt` | number | Time when the placeholder was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the placeholder was last updated \(epoch millis\) |
+|   ↳ `placeholderId` | number (nullable) | Unique identifier of the placeholder |
+|   ↳ `placeholderName` | string (nullable) | Name of the placeholder |
+|   ↳ `project` | object (nullable) | Project of the placeholder |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `role` | object (nullable) | Role of the placeholder |
+|     ↳ `roleId` | number (nullable) | Unique identifier of the role |
+|     ↳ `roleName` | string (nullable) | Name of the role |
+|   ↳ `placeholderType` | string (nullable) | Type of the placeholder \(NATIVE or EXTERNAL\) |
+|   ↳ `createdAt` | number (nullable) | Time when the placeholder was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the placeholder was last updated \(epoch millis\) |
 | `pagination` | object | Pagination details for fetching further pages |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Assign Placeholders
 
@@ -1034,122 +1034,122 @@ Assign a placeholder in a Rocketlane project to a user
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `project` | object | The project after the placeholder assignment |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 | `placeholders` | array | Placeholder-to-user mappings on the project |
-|   ↳ `placeholder` | object | Placeholder being mapped |
-|     ↳ `placeholderId` | number | Unique identifier of the placeholder |
-|     ↳ `placeholderName` | string | Name of the placeholder |
-|   ↳ `placeholderStatus` | string | Status of the placeholder \(ASSIGNED or UNASSIGNED\) |
-|   ↳ `user` | object | User assigned to the placeholder |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|     ↳ `role` | string | Role name of the assigned user |
-|   ↳ `hourlyCostRate` | number | Latest hourly cost rate for the placeholder |
-|   ↳ `costRateCurrency` | string | Currency for the cost rate |
-|   ↳ `hourlyBillRate` | number | Latest hourly bill rate for the placeholder |
-|   ↳ `billRateCurrency` | string | Currency for the bill rate |
+|   ↳ `placeholder` | object (nullable) | Placeholder being mapped |
+|     ↳ `placeholderId` | number (nullable) | Unique identifier of the placeholder |
+|     ↳ `placeholderName` | string (nullable) | Name of the placeholder |
+|   ↳ `placeholderStatus` | string (nullable) | Status of the placeholder \(ASSIGNED or UNASSIGNED\) |
+|   ↳ `user` | object (nullable) | User assigned to the placeholder |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `role` | string (nullable) | Role name of the assigned user |
+|   ↳ `hourlyCostRate` | number (nullable) | Latest hourly cost rate for the placeholder |
+|   ↳ `costRateCurrency` | string (nullable) | Currency for the cost rate |
+|   ↳ `hourlyBillRate` | number (nullable) | Latest hourly bill rate for the placeholder |
+|   ↳ `billRateCurrency` | string (nullable) | Currency for the bill rate |
 
 ### Rocketlane Unassign Placeholders
 
@@ -1168,122 +1168,122 @@ Unassign a placeholder from its user in a Rocketlane project
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `project` | object | The project after the placeholder was unassigned |
-|   ↳ `projectId` | number | Unique identifier of the project |
-|   ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Date on which the project execution begins \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time when the project was created \(epoch millis\) |
-|   ↳ `updatedAt` | number | Time when the project was last updated \(epoch millis\) |
-|   ↳ `owner` | object | Project owner |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|   ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Date on which the project execution begins \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date on which the project execution is planned to complete \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time when the project was created \(epoch millis\) |
+|   ↳ `updatedAt` | number (nullable) | Time when the project was last updated \(epoch millis\) |
+|   ↳ `owner` | object (nullable) | Project owner |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `teamMembers` | object | Project members, customers, and customer champion |
 |     ↳ `members` | array | Team members working on the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
 |     ↳ `customers` | array | Customer stakeholders involved in the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|     ↳ `customerChampion` | object | Customer champion of the project |
-|       ↳ `userId` | number | Unique identifier of the user |
-|       ↳ `firstName` | string | First name of the user |
-|       ↳ `lastName` | string | Last name of the user |
-|       ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Project status value and label |
-|     ↳ `value` | number | Unique identifier of the status |
-|     ↳ `label` | string | Name of the status |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `customerChampion` | object (nullable) | Customer champion of the project |
+|       ↳ `userId` | number (nullable) | Unique identifier of the user |
+|       ↳ `firstName` | string (nullable) | First name of the user |
+|       ↳ `lastName` | string (nullable) | Last name of the user |
+|       ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Project status value and label |
+|     ↳ `value` | number (nullable) | Unique identifier of the status |
+|     ↳ `label` | string (nullable) | Name of the status |
 |   ↳ `fields` | array | Custom project field values |
-|     ↳ `fieldId` | number | Unique identifier of the custom field |
-|     ↳ `fieldLabel` | string | Name of the custom project field |
-|     ↳ `fieldValue` | string | Value assigned to the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `customer` | object | Customer company of the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the custom field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom project field |
+|     ↳ `fieldValue` | string (nullable) | Value assigned to the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `customer` | object (nullable) | Customer company of the project |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
 |   ↳ `partnerCompanies` | array | Partner companies on the project |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|     ↳ `companyUrl` | string | Website URL of the company |
-|   ↳ `archived` | boolean | Whether the project is archived |
-|   ↳ `visibility` | string | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
-|   ↳ `createdBy` | object | Team member who created the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the project |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `currency` | string | Currency for the project financials \(ISO code\) |
-|   ↳ `financials` | object | Project financials \(contract type and per-contract-type fields\) |
-|     ↳ `contractType` | string | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
-|     ↳ `revenueRecognitionType` | string | Method used for revenue recognition |
-|     ↳ `fixedFee` | number | Project fee for Fixed fee contract type projects |
-|     ↳ `projectBudget` | number | Budget allocated for Time & Material contract type projects |
-|     ↳ `rateCardId` | number | Unique identifier of the rate card |
-|     ↳ `rateCardName` | string | Name of the rate card |
-|     ↳ `subscriptionFrequency` | string | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
-|     ↳ `subscriptionStartDate` | string | Date when the subscription interval begins \(YYYY-MM-DD\) |
-|     ↳ `periodMinutes` | number | Budgeted minutes for each subscription period |
-|     ↳ `periodBudget` | number | Fixed budget of every subscription period |
-|     ↳ `noOfPeriods` | number | Number of periods in the subscription |
-|   ↳ `startDateActual` | string | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date on which the project status changed to completed \(YYYY-MM-DD\) |
-|   ↳ `annualizedRecurringRevenue` | number | Recurring revenue of the customer subscriptions for a single calendar year |
-|   ↳ `projectFee` | number | Total fee charged for the project |
-|   ↳ `budgetedHours` | number | Total hours allocated for project execution |
-|   ↳ `percentageBudgetedHoursConsumed` | number | Budgeted hours consumed percentage |
-|   ↳ `percentageBudgetConsumed` | number | Budget consumed percentage |
-|   ↳ `trackedHours` | number | Hours tracked as part of submitted time entries |
-|   ↳ `trackedMinutes` | number | Minutes tracked as part of submitted time entries |
-|   ↳ `allocatedHours` | number | Allocated hours against users or placeholders |
-|   ↳ `allocatedMinutes` | number | Allocated minutes against users or placeholders |
-|   ↳ `billableHours` | number | Hours of time entries tracked as billable |
-|   ↳ `billableMinutes` | number | Minutes of time entries tracked as billable |
-|   ↳ `nonBillableHours` | number | Hours of time entries tracked as non-billable |
-|   ↳ `nonBillableMinutes` | number | Minutes of time entries tracked as non-billable |
-|   ↳ `remainingHours` | number | Hours left to complete the project based on tracked and budgeted hours |
-|   ↳ `remainingMinutes` | number | Minutes left to complete the project \(complements remainingHours\) |
-|   ↳ `progressPercentage` | number | Progress based on completed tasks vs total tasks |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|     ↳ `companyUrl` | string (nullable) | Website URL of the company |
+|   ↳ `archived` | boolean (nullable) | Whether the project is archived |
+|   ↳ `visibility` | string (nullable) | Project visibility \(EVERYONE, MEMBERS, or GROUP\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the project |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `currency` | string (nullable) | Currency for the project financials \(ISO code\) |
+|   ↳ `financials` | object (nullable) | Project financials \(contract type and per-contract-type fields\) |
+|     ↳ `contractType` | string (nullable) | Contract type for the project financials \(FIXED_FEE, TIME_AND_MATERIAL, SUBSCRIPTION, or NON_BILLABLE\) |
+|     ↳ `revenueRecognitionType` | string (nullable) | Method used for revenue recognition |
+|     ↳ `fixedFee` | number (nullable) | Project fee for Fixed fee contract type projects |
+|     ↳ `projectBudget` | number (nullable) | Budget allocated for Time & Material contract type projects |
+|     ↳ `rateCardId` | number (nullable) | Unique identifier of the rate card |
+|     ↳ `rateCardName` | string (nullable) | Name of the rate card |
+|     ↳ `subscriptionFrequency` | string (nullable) | Interval at which the subscription renews \(MONTHLY, QUARTERLY, HALF_YEARLY, YEARLY\) |
+|     ↳ `subscriptionStartDate` | string (nullable) | Date when the subscription interval begins \(YYYY-MM-DD\) |
+|     ↳ `periodMinutes` | number (nullable) | Budgeted minutes for each subscription period |
+|     ↳ `periodBudget` | number (nullable) | Fixed budget of every subscription period |
+|     ↳ `noOfPeriods` | number (nullable) | Number of periods in the subscription |
+|   ↳ `startDateActual` | string (nullable) | Date on which the project status changed to in progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date on which the project status changed to completed \(YYYY-MM-DD\) |
+|   ↳ `annualizedRecurringRevenue` | number (nullable) | Recurring revenue of the customer subscriptions for a single calendar year |
+|   ↳ `projectFee` | number (nullable) | Total fee charged for the project |
+|   ↳ `budgetedHours` | number (nullable) | Total hours allocated for project execution |
+|   ↳ `percentageBudgetedHoursConsumed` | number (nullable) | Budgeted hours consumed percentage |
+|   ↳ `percentageBudgetConsumed` | number (nullable) | Budget consumed percentage |
+|   ↳ `trackedHours` | number (nullable) | Hours tracked as part of submitted time entries |
+|   ↳ `trackedMinutes` | number (nullable) | Minutes tracked as part of submitted time entries |
+|   ↳ `allocatedHours` | number (nullable) | Allocated hours against users or placeholders |
+|   ↳ `allocatedMinutes` | number (nullable) | Allocated minutes against users or placeholders |
+|   ↳ `billableHours` | number (nullable) | Hours of time entries tracked as billable |
+|   ↳ `billableMinutes` | number (nullable) | Minutes of time entries tracked as billable |
+|   ↳ `nonBillableHours` | number (nullable) | Hours of time entries tracked as non-billable |
+|   ↳ `nonBillableMinutes` | number (nullable) | Minutes of time entries tracked as non-billable |
+|   ↳ `remainingHours` | number (nullable) | Hours left to complete the project based on tracked and budgeted hours |
+|   ↳ `remainingMinutes` | number (nullable) | Minutes left to complete the project \(complements remainingHours\) |
+|   ↳ `progressPercentage` | number (nullable) | Progress based on completed tasks vs total tasks |
 |   ↳ `currentPhases` | array | Phases currently marked as in progress |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `autoAllocation` | boolean | Whether auto allocation is enabled for the project |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `autoAllocation` | boolean (nullable) | Whether auto allocation is enabled for the project |
 |   ↳ `sources` | array | Project templates imported into the project |
-|     ↳ `prefix` | string | Prefix distinguishing which phase or task corresponds to which template |
-|     ↳ `startDate` | string | Date on which the template goes into effect \(YYYY-MM-DD\) |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `plannedDurationInDays` | number | Difference between startDate and dueDate in days |
-|   ↳ `inferredProgress` | string | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
-|   ↳ `projectAgeInDays` | number | Age of the project in days based on actual dates |
-|   ↳ `customersInvited` | number | Number of customers invited to the project |
-|   ↳ `customersJoined` | number | Number of customers who joined the project |
-|   ↳ `externalReferenceId` | string | Identifier linking the project to an external system |
+|     ↳ `prefix` | string (nullable) | Prefix distinguishing which phase or task corresponds to which template |
+|     ↳ `startDate` | string (nullable) | Date on which the template goes into effect \(YYYY-MM-DD\) |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `plannedDurationInDays` | number (nullable) | Difference between startDate and dueDate in days |
+|   ↳ `inferredProgress` | string (nullable) | Inferred progress \(ON_TRACK, AHEAD_OF_TIME, RUNNING_LATE, or NONE\) |
+|   ↳ `projectAgeInDays` | number (nullable) | Age of the project in days based on actual dates |
+|   ↳ `customersInvited` | number (nullable) | Number of customers invited to the project |
+|   ↳ `customersJoined` | number (nullable) | Number of customers who joined the project |
+|   ↳ `externalReferenceId` | string (nullable) | Identifier linking the project to an external system |
 | `placeholders` | array | Placeholder-to-user mappings on the project |
-|   ↳ `placeholder` | object | Placeholder being mapped |
-|     ↳ `placeholderId` | number | Unique identifier of the placeholder |
-|     ↳ `placeholderName` | string | Name of the placeholder |
-|   ↳ `placeholderStatus` | string | Status of the placeholder \(ASSIGNED or UNASSIGNED\) |
-|   ↳ `user` | object | User assigned to the placeholder |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|     ↳ `role` | string | Role name of the assigned user |
-|   ↳ `hourlyCostRate` | number | Latest hourly cost rate for the placeholder |
-|   ↳ `costRateCurrency` | string | Currency for the cost rate |
-|   ↳ `hourlyBillRate` | number | Latest hourly bill rate for the placeholder |
-|   ↳ `billRateCurrency` | string | Currency for the bill rate |
+|   ↳ `placeholder` | object (nullable) | Placeholder being mapped |
+|     ↳ `placeholderId` | number (nullable) | Unique identifier of the placeholder |
+|     ↳ `placeholderName` | string (nullable) | Name of the placeholder |
+|   ↳ `placeholderStatus` | string (nullable) | Status of the placeholder \(ASSIGNED or UNASSIGNED\) |
+|   ↳ `user` | object (nullable) | User assigned to the placeholder |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|     ↳ `role` | string (nullable) | Role name of the assigned user |
+|   ↳ `hourlyCostRate` | number (nullable) | Latest hourly cost rate for the placeholder |
+|   ↳ `costRateCurrency` | string (nullable) | Currency for the cost rate |
+|   ↳ `hourlyBillRate` | number (nullable) | Latest hourly bill rate for the placeholder |
+|   ↳ `billRateCurrency` | string (nullable) | Currency for the bill rate |
 
 ### Rocketlane Create Task
 
@@ -1321,66 +1321,66 @@ Create a new task in a Rocketlane project
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The created task |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Get Task
 
@@ -1400,66 +1400,66 @@ Retrieve detailed information about a Rocketlane task by its unique identifier
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The requested task |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane List Tasks
 
@@ -1494,71 +1494,71 @@ Retrieve all Rocketlane tasks with optional filters, sorting, and pagination
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `tasks` | array | List of tasks matching the filters |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Update Task
 
@@ -1590,66 +1590,66 @@ Update the properties of an existing Rocketlane task by its unique identifier
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The updated task |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Delete Task
 
@@ -1686,66 +1686,66 @@ Move a Rocketlane task to a given phase, associating the task with that phase
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The task with its updated phase |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Add Task Assignees
 
@@ -1765,66 +1765,66 @@ Add members as assignees to a Rocketlane task
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The task with its updated assignees |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Remove Task Assignees
 
@@ -1844,66 +1844,66 @@ Remove assignees from a Rocketlane task
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The task with its updated assignees |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Add Task Followers
 
@@ -1923,66 +1923,66 @@ Add members as followers to a Rocketlane task
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The task with its updated followers |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Remove Task Followers
 
@@ -2002,66 +2002,66 @@ Remove followers from a Rocketlane task
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The task with its updated followers |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Add Task Dependencies
 
@@ -2080,66 +2080,66 @@ Add finish-to-start dependencies between a Rocketlane task and other tasks
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The task with its updated dependencies |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Remove Task Dependencies
 
@@ -2158,66 +2158,66 @@ Remove dependencies from a Rocketlane task
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `task` | object | The task with its updated dependencies |
-|   ↳ `taskId` | number | Unique identifier of the task |
-|   ↳ `taskName` | string | Name of the task |
-|   ↳ `taskDescription` | string | Description of the task in HTML format |
-|   ↳ `taskPrivateNote` | string | Private note visible only to team members, in HTML format |
-|   ↳ `startDate` | string | Date when the task starts \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Date when the task is due \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Date the task status changed to In Progress \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Date the task status changed to Completed \(YYYY-MM-DD\) |
-|   ↳ `archived` | boolean | Whether the task is archived |
-|   ↳ `effortInMinutes` | number | Expected effort to complete the task, in minutes |
-|   ↳ `progress` | number | Progress of the task \(0-100\) |
-|   ↳ `atRisk` | boolean | Whether the task is marked as At Risk |
-|   ↳ `type` | string | Type of the task: TASK or MILESTONE |
-|   ↳ `createdAt` | number | Time the task was created, in epoch millis |
-|   ↳ `updatedAt` | number | Time the task was last updated, in epoch millis |
-|   ↳ `createdBy` | object | User who created the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `project` | object | Project associated with the task |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `phase` | object | Phase associated with the task |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `status` | object | Status of the task \(value and label\) |
-|   ↳ `priority` | object | Priority of the task \(value and label\) |
+|   ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|   ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `taskDescription` | string (nullable) | Description of the task in HTML format |
+|   ↳ `taskPrivateNote` | string (nullable) | Private note visible only to team members, in HTML format |
+|   ↳ `startDate` | string (nullable) | Date when the task starts \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Date when the task is due \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Date the task status changed to In Progress \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Date the task status changed to Completed \(YYYY-MM-DD\) |
+|   ↳ `archived` | boolean (nullable) | Whether the task is archived |
+|   ↳ `effortInMinutes` | number (nullable) | Expected effort to complete the task, in minutes |
+|   ↳ `progress` | number (nullable) | Progress of the task \(0-100\) |
+|   ↳ `atRisk` | boolean (nullable) | Whether the task is marked as At Risk |
+|   ↳ `type` | string (nullable) | Type of the task: TASK or MILESTONE |
+|   ↳ `createdAt` | number (nullable) | Time the task was created, in epoch millis |
+|   ↳ `updatedAt` | number (nullable) | Time the task was last updated, in epoch millis |
+|   ↳ `createdBy` | object (nullable) | User who created the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `project` | object (nullable) | Project associated with the task |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `phase` | object (nullable) | Phase associated with the task |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `status` | object (nullable) | Status of the task \(value and label\) |
+|   ↳ `priority` | object (nullable) | Priority of the task \(value and label\) |
 |   ↳ `fields` | array | Custom field values set on the task |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `assignees` | object | Assignees of the task \(members and placeholders\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `followers` | object | Followers of the task |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `assignees` | object (nullable) | Assignees of the task \(members and placeholders\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `followers` | object (nullable) | Followers of the task |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 |   ↳ `dependencies` | array | Tasks this task depends on \(finish-to-start dependencies\) |
-|   ↳ `parent` | object | Parent task of the task |
-|   ↳ `externalReferenceId` | string | External reference identifier linking the task to an external system |
-|   ↳ `billable` | boolean | Whether the task is billable |
-|   ↳ `timeEntryCategory` | object | Category in which the task time entries are added |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
+|   ↳ `parent` | object (nullable) | Parent task of the task |
+|   ↳ `externalReferenceId` | string (nullable) | External reference identifier linking the task to an external system |
+|   ↳ `billable` | boolean (nullable) | Whether the task is billable |
+|   ↳ `timeEntryCategory` | object (nullable) | Category in which the task time entries are added |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
 |   ↳ `financialsBudgets` | array | Financials budgets in which the task time entries are added |
-|     ↳ `budgetId` | number | Unique identifier of the budget |
-|     ↳ `budgetName` | string | Name of the budget |
-|   ↳ `csatEnabled` | boolean | Whether a CSAT survey is sent on completion \(milestone tasks\) |
-|   ↳ `private` | boolean | Whether the task is private |
+|     ↳ `budgetId` | number (nullable) | Unique identifier of the budget |
+|     ↳ `budgetName` | string (nullable) | Name of the budget |
+|   ↳ `csatEnabled` | boolean (nullable) | Whether a CSAT survey is sent on completion \(milestone tasks\) |
+|   ↳ `private` | boolean (nullable) | Whether the task is private |
 
 ### Rocketlane Create Phase
 
@@ -2242,31 +2242,31 @@ Create a new phase in a Rocketlane project
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `phase` | object | The created phase |
-|   ↳ `phaseId` | number | Unique identifier of the phase |
-|   ↳ `phaseName` | string | Name of the phase |
-|   ↳ `project` | object | Project the phase belongs to |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Planned start date of the phase \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Planned due date of the phase \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Actual start date of the phase \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Actual due date of the phase \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time the phase was created, in epoch milliseconds |
-|   ↳ `updatedAt` | number | Time the phase was last updated, in epoch milliseconds |
-|   ↳ `createdBy` | object | Team member who created the phase |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the phase |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Status of the phase |
-|     ↳ `value` | number | Numeric status value |
-|     ↳ `label` | string | Display label of the status |
-|   ↳ `private` | boolean | Whether the phase is private |
+|   ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|   ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `project` | object (nullable) | Project the phase belongs to |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Planned start date of the phase \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Planned due date of the phase \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Actual start date of the phase \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Actual due date of the phase \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time the phase was created, in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Time the phase was last updated, in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | Team member who created the phase |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the phase |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Status of the phase |
+|     ↳ `value` | number (nullable) | Numeric status value |
+|     ↳ `label` | string (nullable) | Display label of the status |
+|   ↳ `private` | boolean (nullable) | Whether the phase is private |
 
 ### Rocketlane Get Phase
 
@@ -2286,31 +2286,31 @@ Retrieve a single Rocketlane phase by ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `phase` | object | The requested phase |
-|   ↳ `phaseId` | number | Unique identifier of the phase |
-|   ↳ `phaseName` | string | Name of the phase |
-|   ↳ `project` | object | Project the phase belongs to |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Planned start date of the phase \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Planned due date of the phase \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Actual start date of the phase \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Actual due date of the phase \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time the phase was created, in epoch milliseconds |
-|   ↳ `updatedAt` | number | Time the phase was last updated, in epoch milliseconds |
-|   ↳ `createdBy` | object | Team member who created the phase |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the phase |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Status of the phase |
-|     ↳ `value` | number | Numeric status value |
-|     ↳ `label` | string | Display label of the status |
-|   ↳ `private` | boolean | Whether the phase is private |
+|   ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|   ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `project` | object (nullable) | Project the phase belongs to |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Planned start date of the phase \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Planned due date of the phase \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Actual start date of the phase \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Actual due date of the phase \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time the phase was created, in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Time the phase was last updated, in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | Team member who created the phase |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the phase |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Status of the phase |
+|     ↳ `value` | number (nullable) | Numeric status value |
+|     ↳ `label` | string (nullable) | Display label of the status |
+|   ↳ `private` | boolean (nullable) | Whether the phase is private |
 
 ### Rocketlane List Phases
 
@@ -2336,36 +2336,36 @@ List phases of a Rocketlane project, with optional filters, sorting, and paginat
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `phases` | array | List of phases |
-|   ↳ `phaseId` | number | Unique identifier of the phase |
-|   ↳ `phaseName` | string | Name of the phase |
-|   ↳ `project` | object | Project the phase belongs to |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Planned start date of the phase \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Planned due date of the phase \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Actual start date of the phase \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Actual due date of the phase \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time the phase was created, in epoch milliseconds |
-|   ↳ `updatedAt` | number | Time the phase was last updated, in epoch milliseconds |
-|   ↳ `createdBy` | object | Team member who created the phase |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the phase |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Status of the phase |
-|     ↳ `value` | number | Numeric status value |
-|     ↳ `label` | string | Display label of the status |
-|   ↳ `private` | boolean | Whether the phase is private |
+|   ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|   ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `project` | object (nullable) | Project the phase belongs to |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Planned start date of the phase \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Planned due date of the phase \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Actual start date of the phase \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Actual due date of the phase \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time the phase was created, in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Time the phase was last updated, in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | Team member who created the phase |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the phase |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Status of the phase |
+|     ↳ `value` | number (nullable) | Numeric status value |
+|     ↳ `label` | string (nullable) | Display label of the status |
+|   ↳ `private` | boolean (nullable) | Whether the phase is private |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Update Phase
 
@@ -2390,31 +2390,31 @@ Update the name, dates, status, or privacy of an existing Rocketlane phase
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `phase` | object | The updated phase |
-|   ↳ `phaseId` | number | Unique identifier of the phase |
-|   ↳ `phaseName` | string | Name of the phase |
-|   ↳ `project` | object | Project the phase belongs to |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `startDate` | string | Planned start date of the phase \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Planned due date of the phase \(YYYY-MM-DD\) |
-|   ↳ `startDateActual` | string | Actual start date of the phase \(YYYY-MM-DD\) |
-|   ↳ `dueDateActual` | string | Actual due date of the phase \(YYYY-MM-DD\) |
-|   ↳ `createdAt` | number | Time the phase was created, in epoch milliseconds |
-|   ↳ `updatedAt` | number | Time the phase was last updated, in epoch milliseconds |
-|   ↳ `createdBy` | object | Team member who created the phase |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the phase |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `status` | object | Status of the phase |
-|     ↳ `value` | number | Numeric status value |
-|     ↳ `label` | string | Display label of the status |
-|   ↳ `private` | boolean | Whether the phase is private |
+|   ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|   ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `project` | object (nullable) | Project the phase belongs to |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `startDate` | string (nullable) | Planned start date of the phase \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Planned due date of the phase \(YYYY-MM-DD\) |
+|   ↳ `startDateActual` | string (nullable) | Actual start date of the phase \(YYYY-MM-DD\) |
+|   ↳ `dueDateActual` | string (nullable) | Actual due date of the phase \(YYYY-MM-DD\) |
+|   ↳ `createdAt` | number (nullable) | Time the phase was created, in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Time the phase was last updated, in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | Team member who created the phase |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the phase |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `status` | object (nullable) | Status of the phase |
+|     ↳ `value` | number (nullable) | Numeric status value |
+|     ↳ `label` | string (nullable) | Display label of the status |
+|   ↳ `private` | boolean (nullable) | Whether the phase is private |
 
 ### Rocketlane Delete Phase
 
@@ -2459,30 +2459,30 @@ Create a custom field in your Rocketlane account, with options for SINGLE_CHOICE
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `field` | object | The created field |
-|   ↳ `fieldId` | number | Unique identifier of the field |
-|   ↳ `fieldLabel` | string | Name of the field |
-|   ↳ `fieldDescription` | string | Description of the field |
-|   ↳ `fieldType` | string | Type of the field \(TEXT, MULTI_LINE_TEXT, YES_OR_NO, DATE, SINGLE_CHOICE, MULTIPLE_CHOICE, SINGLE_USER, MULTIPLE_USER, NUMBER, NOTE, RATING\) |
-|   ↳ `objectType` | string | Object the field is associated with \(PROJECT, TASK, or USER\) |
+|   ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|   ↳ `fieldLabel` | string (nullable) | Name of the field |
+|   ↳ `fieldDescription` | string (nullable) | Description of the field |
+|   ↳ `fieldType` | string (nullable) | Type of the field \(TEXT, MULTI_LINE_TEXT, YES_OR_NO, DATE, SINGLE_CHOICE, MULTIPLE_CHOICE, SINGLE_USER, MULTIPLE_USER, NUMBER, NOTE, RATING\) |
+|   ↳ `objectType` | string (nullable) | Object the field is associated with \(PROJECT, TASK, or USER\) |
 |   ↳ `fieldOptions` | array | Options available for SINGLE_CHOICE and MULTIPLE_CHOICE fields |
-|     ↳ `optionValue` | number | Unique identifier of the option within the field |
-|     ↳ `optionLabel` | string | Display label of the option |
-|     ↳ `optionColor` | string | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
-|   ↳ `ratingScale` | string | Rating scale for RATING fields \(THREE, FIVE, SEVEN, TEN\) |
-|   ↳ `createdBy` | object | Team member who created the field |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the field |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `createdAt` | number | Time the field was created, in epoch milliseconds |
-|   ↳ `updatedAt` | number | Time the field was last updated, in epoch milliseconds |
-|   ↳ `enabled` | boolean | Whether the field is enabled |
-|   ↳ `private` | boolean | Whether the field is private |
+|     ↳ `optionValue` | number (nullable) | Unique identifier of the option within the field |
+|     ↳ `optionLabel` | string (nullable) | Display label of the option |
+|     ↳ `optionColor` | string (nullable) | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
+|   ↳ `ratingScale` | string (nullable) | Rating scale for RATING fields \(THREE, FIVE, SEVEN, TEN\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the field |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the field |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `createdAt` | number (nullable) | Time the field was created, in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Time the field was last updated, in epoch milliseconds |
+|   ↳ `enabled` | boolean (nullable) | Whether the field is enabled |
+|   ↳ `private` | boolean (nullable) | Whether the field is private |
 
 ### Rocketlane Get Field
 
@@ -2502,30 +2502,30 @@ Retrieve a single Rocketlane field by ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `field` | object | The requested field |
-|   ↳ `fieldId` | number | Unique identifier of the field |
-|   ↳ `fieldLabel` | string | Name of the field |
-|   ↳ `fieldDescription` | string | Description of the field |
-|   ↳ `fieldType` | string | Type of the field \(TEXT, MULTI_LINE_TEXT, YES_OR_NO, DATE, SINGLE_CHOICE, MULTIPLE_CHOICE, SINGLE_USER, MULTIPLE_USER, NUMBER, NOTE, RATING\) |
-|   ↳ `objectType` | string | Object the field is associated with \(PROJECT, TASK, or USER\) |
+|   ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|   ↳ `fieldLabel` | string (nullable) | Name of the field |
+|   ↳ `fieldDescription` | string (nullable) | Description of the field |
+|   ↳ `fieldType` | string (nullable) | Type of the field \(TEXT, MULTI_LINE_TEXT, YES_OR_NO, DATE, SINGLE_CHOICE, MULTIPLE_CHOICE, SINGLE_USER, MULTIPLE_USER, NUMBER, NOTE, RATING\) |
+|   ↳ `objectType` | string (nullable) | Object the field is associated with \(PROJECT, TASK, or USER\) |
 |   ↳ `fieldOptions` | array | Options available for SINGLE_CHOICE and MULTIPLE_CHOICE fields |
-|     ↳ `optionValue` | number | Unique identifier of the option within the field |
-|     ↳ `optionLabel` | string | Display label of the option |
-|     ↳ `optionColor` | string | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
-|   ↳ `ratingScale` | string | Rating scale for RATING fields \(THREE, FIVE, SEVEN, TEN\) |
-|   ↳ `createdBy` | object | Team member who created the field |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the field |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `createdAt` | number | Time the field was created, in epoch milliseconds |
-|   ↳ `updatedAt` | number | Time the field was last updated, in epoch milliseconds |
-|   ↳ `enabled` | boolean | Whether the field is enabled |
-|   ↳ `private` | boolean | Whether the field is private |
+|     ↳ `optionValue` | number (nullable) | Unique identifier of the option within the field |
+|     ↳ `optionLabel` | string (nullable) | Display label of the option |
+|     ↳ `optionColor` | string (nullable) | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
+|   ↳ `ratingScale` | string (nullable) | Rating scale for RATING fields \(THREE, FIVE, SEVEN, TEN\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the field |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the field |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `createdAt` | number (nullable) | Time the field was created, in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Time the field was last updated, in epoch milliseconds |
+|   ↳ `enabled` | boolean (nullable) | Whether the field is enabled |
+|   ↳ `private` | boolean (nullable) | Whether the field is private |
 
 ### Rocketlane List Fields
 
@@ -2553,35 +2553,35 @@ List fields in your Rocketlane account, with optional filters, sorting, and pagi
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `fields` | array | List of fields |
-|   ↳ `fieldId` | number | Unique identifier of the field |
-|   ↳ `fieldLabel` | string | Name of the field |
-|   ↳ `fieldDescription` | string | Description of the field |
-|   ↳ `fieldType` | string | Type of the field \(TEXT, MULTI_LINE_TEXT, YES_OR_NO, DATE, SINGLE_CHOICE, MULTIPLE_CHOICE, SINGLE_USER, MULTIPLE_USER, NUMBER, NOTE, RATING\) |
-|   ↳ `objectType` | string | Object the field is associated with \(PROJECT, TASK, or USER\) |
+|   ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|   ↳ `fieldLabel` | string (nullable) | Name of the field |
+|   ↳ `fieldDescription` | string (nullable) | Description of the field |
+|   ↳ `fieldType` | string (nullable) | Type of the field \(TEXT, MULTI_LINE_TEXT, YES_OR_NO, DATE, SINGLE_CHOICE, MULTIPLE_CHOICE, SINGLE_USER, MULTIPLE_USER, NUMBER, NOTE, RATING\) |
+|   ↳ `objectType` | string (nullable) | Object the field is associated with \(PROJECT, TASK, or USER\) |
 |   ↳ `fieldOptions` | array | Options available for SINGLE_CHOICE and MULTIPLE_CHOICE fields |
-|     ↳ `optionValue` | number | Unique identifier of the option within the field |
-|     ↳ `optionLabel` | string | Display label of the option |
-|     ↳ `optionColor` | string | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
-|   ↳ `ratingScale` | string | Rating scale for RATING fields \(THREE, FIVE, SEVEN, TEN\) |
-|   ↳ `createdBy` | object | Team member who created the field |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the field |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `createdAt` | number | Time the field was created, in epoch milliseconds |
-|   ↳ `updatedAt` | number | Time the field was last updated, in epoch milliseconds |
-|   ↳ `enabled` | boolean | Whether the field is enabled |
-|   ↳ `private` | boolean | Whether the field is private |
+|     ↳ `optionValue` | number (nullable) | Unique identifier of the option within the field |
+|     ↳ `optionLabel` | string (nullable) | Display label of the option |
+|     ↳ `optionColor` | string (nullable) | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
+|   ↳ `ratingScale` | string (nullable) | Rating scale for RATING fields \(THREE, FIVE, SEVEN, TEN\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the field |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the field |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `createdAt` | number (nullable) | Time the field was created, in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Time the field was last updated, in epoch milliseconds |
+|   ↳ `enabled` | boolean (nullable) | Whether the field is enabled |
+|   ↳ `private` | boolean (nullable) | Whether the field is private |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Update Field
 
@@ -2605,30 +2605,30 @@ Update the label, description, enabled state, or privacy of an existing Rocketla
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `field` | object | The updated field |
-|   ↳ `fieldId` | number | Unique identifier of the field |
-|   ↳ `fieldLabel` | string | Name of the field |
-|   ↳ `fieldDescription` | string | Description of the field |
-|   ↳ `fieldType` | string | Type of the field \(TEXT, MULTI_LINE_TEXT, YES_OR_NO, DATE, SINGLE_CHOICE, MULTIPLE_CHOICE, SINGLE_USER, MULTIPLE_USER, NUMBER, NOTE, RATING\) |
-|   ↳ `objectType` | string | Object the field is associated with \(PROJECT, TASK, or USER\) |
+|   ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|   ↳ `fieldLabel` | string (nullable) | Name of the field |
+|   ↳ `fieldDescription` | string (nullable) | Description of the field |
+|   ↳ `fieldType` | string (nullable) | Type of the field \(TEXT, MULTI_LINE_TEXT, YES_OR_NO, DATE, SINGLE_CHOICE, MULTIPLE_CHOICE, SINGLE_USER, MULTIPLE_USER, NUMBER, NOTE, RATING\) |
+|   ↳ `objectType` | string (nullable) | Object the field is associated with \(PROJECT, TASK, or USER\) |
 |   ↳ `fieldOptions` | array | Options available for SINGLE_CHOICE and MULTIPLE_CHOICE fields |
-|     ↳ `optionValue` | number | Unique identifier of the option within the field |
-|     ↳ `optionLabel` | string | Display label of the option |
-|     ↳ `optionColor` | string | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
-|   ↳ `ratingScale` | string | Rating scale for RATING fields \(THREE, FIVE, SEVEN, TEN\) |
-|   ↳ `createdBy` | object | Team member who created the field |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | Team member who last updated the field |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `createdAt` | number | Time the field was created, in epoch milliseconds |
-|   ↳ `updatedAt` | number | Time the field was last updated, in epoch milliseconds |
-|   ↳ `enabled` | boolean | Whether the field is enabled |
-|   ↳ `private` | boolean | Whether the field is private |
+|     ↳ `optionValue` | number (nullable) | Unique identifier of the option within the field |
+|     ↳ `optionLabel` | string (nullable) | Display label of the option |
+|     ↳ `optionColor` | string (nullable) | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
+|   ↳ `ratingScale` | string (nullable) | Rating scale for RATING fields \(THREE, FIVE, SEVEN, TEN\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the field |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the field |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `createdAt` | number (nullable) | Time the field was created, in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Time the field was last updated, in epoch milliseconds |
+|   ↳ `enabled` | boolean (nullable) | Whether the field is enabled |
+|   ↳ `private` | boolean (nullable) | Whether the field is private |
 
 ### Rocketlane Delete Field
 
@@ -2666,9 +2666,9 @@ Add a new option to an existing SINGLE_CHOICE or MULTIPLE_CHOICE Rocketlane fiel
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `option` | object | The created field option |
-|   ↳ `optionValue` | number | Unique identifier of the option within the field |
-|   ↳ `optionLabel` | string | Display label of the option |
-|   ↳ `optionColor` | string | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
+|   ↳ `optionValue` | number (nullable) | Unique identifier of the option within the field |
+|   ↳ `optionLabel` | string (nullable) | Display label of the option |
+|   ↳ `optionColor` | string (nullable) | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
 
 ### Rocketlane Update Field Option
 
@@ -2689,9 +2689,9 @@ Update the label or color of an existing option on a SINGLE_CHOICE or MULTIPLE_C
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `option` | object | The updated field option |
-|   ↳ `optionValue` | number | Unique identifier of the option within the field |
-|   ↳ `optionLabel` | string | Display label of the option |
-|   ↳ `optionColor` | string | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
+|   ↳ `optionValue` | number (nullable) | Unique identifier of the option within the field |
+|   ↳ `optionLabel` | string (nullable) | Display label of the option |
+|   ↳ `optionColor` | string (nullable) | Color of the option \(RED, YELLOW, GREEN, TEAL, CYAN, BLUE, PURPLE, MAGENTA, GRAY, COOL_GRAY\) |
 
 ### Rocketlane Create Time Entry
 
@@ -2721,69 +2721,69 @@ Create a time entry in Rocketlane against an adhoc activity, task, project phase
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeEntry` | object | The created time entry |
-|   ↳ `timeEntryId` | number | Unique identifier of the time entry |
-|   ↳ `date` | string | Date of the time entry \(YYYY-MM-DD\) |
-|   ↳ `minutes` | number | Duration of the time entry in minutes |
-|   ↳ `activityName` | string | Name of the adhoc activity, when the entry is tracked against an activity |
-|   ↳ `project` | object | Project associated with the time entry |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `task` | object | Task associated with the time entry |
-|     ↳ `taskId` | number | Unique identifier of the task |
-|     ↳ `taskName` | string | Name of the task |
-|   ↳ `projectPhase` | object | Project phase associated with the time entry |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `billable` | boolean | Whether the time entry is billable |
-|   ↳ `user` | object | User the time entry belongs to |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `notes` | string | Notes for the time entry |
-|   ↳ `category` | object | Category associated with the time entry |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
-|   ↳ `sourceType` | string | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
-|   ↳ `status` | string | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
-|   ↳ `createdAt` | number | Creation timestamp in epoch milliseconds |
-|   ↳ `updatedAt` | number | Last-updated timestamp in epoch milliseconds |
-|   ↳ `createdBy` | object | User who created the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedBy` | object | User who submitted the time entry \(may be null even for approved/rejected entries\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedAt` | number | Submission timestamp in epoch milliseconds |
-|   ↳ `approvedBy` | object | User who approved the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `approvedAt` | number | Approval timestamp in epoch milliseconds |
-|   ↳ `rejectedBy` | object | User who rejected the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `rejectedAt` | number | Rejection timestamp in epoch milliseconds |
-|   ↳ `deleted` | boolean | Whether the time entry is deleted |
-|   ↳ `costRate` | object | Hourly cost rate assigned to the user for this entry |
-|   ↳ `billRate` | object | Hourly rate billed to the customer for this entry |
+|   ↳ `timeEntryId` | number (nullable) | Unique identifier of the time entry |
+|   ↳ `date` | string (nullable) | Date of the time entry \(YYYY-MM-DD\) |
+|   ↳ `minutes` | number (nullable) | Duration of the time entry in minutes |
+|   ↳ `activityName` | string (nullable) | Name of the adhoc activity, when the entry is tracked against an activity |
+|   ↳ `project` | object (nullable) | Project associated with the time entry |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `task` | object (nullable) | Task associated with the time entry |
+|     ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|     ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `projectPhase` | object (nullable) | Project phase associated with the time entry |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `billable` | boolean (nullable) | Whether the time entry is billable |
+|   ↳ `user` | object (nullable) | User the time entry belongs to |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `notes` | string (nullable) | Notes for the time entry |
+|   ↳ `category` | object (nullable) | Category associated with the time entry |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
+|   ↳ `sourceType` | string (nullable) | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
+|   ↳ `status` | string (nullable) | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
+|   ↳ `createdAt` | number (nullable) | Creation timestamp in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Last-updated timestamp in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | User who created the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedBy` | object (nullable) | User who submitted the time entry \(may be null even for approved/rejected entries\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedAt` | number (nullable) | Submission timestamp in epoch milliseconds |
+|   ↳ `approvedBy` | object (nullable) | User who approved the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `approvedAt` | number (nullable) | Approval timestamp in epoch milliseconds |
+|   ↳ `rejectedBy` | object (nullable) | User who rejected the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `rejectedAt` | number (nullable) | Rejection timestamp in epoch milliseconds |
+|   ↳ `deleted` | boolean (nullable) | Whether the time entry is deleted |
+|   ↳ `costRate` | object (nullable) | Hourly cost rate assigned to the user for this entry |
+|   ↳ `billRate` | object (nullable) | Hourly rate billed to the customer for this entry |
 |   ↳ `fields` | array | Custom fields associated with the time entry |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
 
 ### Rocketlane Get Time Entry
 
@@ -2803,69 +2803,69 @@ Get a single Rocketlane time entry by ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeEntry` | object | The requested time entry |
-|   ↳ `timeEntryId` | number | Unique identifier of the time entry |
-|   ↳ `date` | string | Date of the time entry \(YYYY-MM-DD\) |
-|   ↳ `minutes` | number | Duration of the time entry in minutes |
-|   ↳ `activityName` | string | Name of the adhoc activity, when the entry is tracked against an activity |
-|   ↳ `project` | object | Project associated with the time entry |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `task` | object | Task associated with the time entry |
-|     ↳ `taskId` | number | Unique identifier of the task |
-|     ↳ `taskName` | string | Name of the task |
-|   ↳ `projectPhase` | object | Project phase associated with the time entry |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `billable` | boolean | Whether the time entry is billable |
-|   ↳ `user` | object | User the time entry belongs to |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `notes` | string | Notes for the time entry |
-|   ↳ `category` | object | Category associated with the time entry |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
-|   ↳ `sourceType` | string | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
-|   ↳ `status` | string | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
-|   ↳ `createdAt` | number | Creation timestamp in epoch milliseconds |
-|   ↳ `updatedAt` | number | Last-updated timestamp in epoch milliseconds |
-|   ↳ `createdBy` | object | User who created the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedBy` | object | User who submitted the time entry \(may be null even for approved/rejected entries\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedAt` | number | Submission timestamp in epoch milliseconds |
-|   ↳ `approvedBy` | object | User who approved the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `approvedAt` | number | Approval timestamp in epoch milliseconds |
-|   ↳ `rejectedBy` | object | User who rejected the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `rejectedAt` | number | Rejection timestamp in epoch milliseconds |
-|   ↳ `deleted` | boolean | Whether the time entry is deleted |
-|   ↳ `costRate` | object | Hourly cost rate assigned to the user for this entry |
-|   ↳ `billRate` | object | Hourly rate billed to the customer for this entry |
+|   ↳ `timeEntryId` | number (nullable) | Unique identifier of the time entry |
+|   ↳ `date` | string (nullable) | Date of the time entry \(YYYY-MM-DD\) |
+|   ↳ `minutes` | number (nullable) | Duration of the time entry in minutes |
+|   ↳ `activityName` | string (nullable) | Name of the adhoc activity, when the entry is tracked against an activity |
+|   ↳ `project` | object (nullable) | Project associated with the time entry |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `task` | object (nullable) | Task associated with the time entry |
+|     ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|     ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `projectPhase` | object (nullable) | Project phase associated with the time entry |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `billable` | boolean (nullable) | Whether the time entry is billable |
+|   ↳ `user` | object (nullable) | User the time entry belongs to |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `notes` | string (nullable) | Notes for the time entry |
+|   ↳ `category` | object (nullable) | Category associated with the time entry |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
+|   ↳ `sourceType` | string (nullable) | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
+|   ↳ `status` | string (nullable) | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
+|   ↳ `createdAt` | number (nullable) | Creation timestamp in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Last-updated timestamp in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | User who created the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedBy` | object (nullable) | User who submitted the time entry \(may be null even for approved/rejected entries\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedAt` | number (nullable) | Submission timestamp in epoch milliseconds |
+|   ↳ `approvedBy` | object (nullable) | User who approved the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `approvedAt` | number (nullable) | Approval timestamp in epoch milliseconds |
+|   ↳ `rejectedBy` | object (nullable) | User who rejected the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `rejectedAt` | number (nullable) | Rejection timestamp in epoch milliseconds |
+|   ↳ `deleted` | boolean (nullable) | Whether the time entry is deleted |
+|   ↳ `costRate` | object (nullable) | Hourly cost rate assigned to the user for this entry |
+|   ↳ `billRate` | object (nullable) | Hourly rate billed to the customer for this entry |
 |   ↳ `fields` | array | Custom fields associated with the time entry |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
 
 ### Rocketlane List Time Entries
 
@@ -2913,74 +2913,74 @@ List Rocketlane time entries with optional filters, sorting, and cursor-based pa
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeEntries` | array | List of time entries matching the filters |
-|   ↳ `timeEntryId` | number | Unique identifier of the time entry |
-|   ↳ `date` | string | Date of the time entry \(YYYY-MM-DD\) |
-|   ↳ `minutes` | number | Duration of the time entry in minutes |
-|   ↳ `activityName` | string | Name of the adhoc activity, when the entry is tracked against an activity |
-|   ↳ `project` | object | Project associated with the time entry |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `task` | object | Task associated with the time entry |
-|     ↳ `taskId` | number | Unique identifier of the task |
-|     ↳ `taskName` | string | Name of the task |
-|   ↳ `projectPhase` | object | Project phase associated with the time entry |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `billable` | boolean | Whether the time entry is billable |
-|   ↳ `user` | object | User the time entry belongs to |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `notes` | string | Notes for the time entry |
-|   ↳ `category` | object | Category associated with the time entry |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
-|   ↳ `sourceType` | string | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
-|   ↳ `status` | string | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
-|   ↳ `createdAt` | number | Creation timestamp in epoch milliseconds |
-|   ↳ `updatedAt` | number | Last-updated timestamp in epoch milliseconds |
-|   ↳ `createdBy` | object | User who created the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedBy` | object | User who submitted the time entry \(may be null even for approved/rejected entries\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedAt` | number | Submission timestamp in epoch milliseconds |
-|   ↳ `approvedBy` | object | User who approved the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `approvedAt` | number | Approval timestamp in epoch milliseconds |
-|   ↳ `rejectedBy` | object | User who rejected the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `rejectedAt` | number | Rejection timestamp in epoch milliseconds |
-|   ↳ `deleted` | boolean | Whether the time entry is deleted |
-|   ↳ `costRate` | object | Hourly cost rate assigned to the user for this entry |
-|   ↳ `billRate` | object | Hourly rate billed to the customer for this entry |
+|   ↳ `timeEntryId` | number (nullable) | Unique identifier of the time entry |
+|   ↳ `date` | string (nullable) | Date of the time entry \(YYYY-MM-DD\) |
+|   ↳ `minutes` | number (nullable) | Duration of the time entry in minutes |
+|   ↳ `activityName` | string (nullable) | Name of the adhoc activity, when the entry is tracked against an activity |
+|   ↳ `project` | object (nullable) | Project associated with the time entry |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `task` | object (nullable) | Task associated with the time entry |
+|     ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|     ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `projectPhase` | object (nullable) | Project phase associated with the time entry |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `billable` | boolean (nullable) | Whether the time entry is billable |
+|   ↳ `user` | object (nullable) | User the time entry belongs to |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `notes` | string (nullable) | Notes for the time entry |
+|   ↳ `category` | object (nullable) | Category associated with the time entry |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
+|   ↳ `sourceType` | string (nullable) | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
+|   ↳ `status` | string (nullable) | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
+|   ↳ `createdAt` | number (nullable) | Creation timestamp in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Last-updated timestamp in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | User who created the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedBy` | object (nullable) | User who submitted the time entry \(may be null even for approved/rejected entries\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedAt` | number (nullable) | Submission timestamp in epoch milliseconds |
+|   ↳ `approvedBy` | object (nullable) | User who approved the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `approvedAt` | number (nullable) | Approval timestamp in epoch milliseconds |
+|   ↳ `rejectedBy` | object (nullable) | User who rejected the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `rejectedAt` | number (nullable) | Rejection timestamp in epoch milliseconds |
+|   ↳ `deleted` | boolean (nullable) | Whether the time entry is deleted |
+|   ↳ `costRate` | object (nullable) | Hourly cost rate assigned to the user for this entry |
+|   ↳ `billRate` | object (nullable) | Hourly rate billed to the customer for this entry |
 |   ↳ `fields` | array | Custom fields associated with the time entry |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Search Time Entries
 
@@ -3018,74 +3018,74 @@ Search Rocketlane time entries with filters, sorting, and pagination (deprecated
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeEntries` | array | List of time entries matching the search filters |
-|   ↳ `timeEntryId` | number | Unique identifier of the time entry |
-|   ↳ `date` | string | Date of the time entry \(YYYY-MM-DD\) |
-|   ↳ `minutes` | number | Duration of the time entry in minutes |
-|   ↳ `activityName` | string | Name of the adhoc activity, when the entry is tracked against an activity |
-|   ↳ `project` | object | Project associated with the time entry |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `task` | object | Task associated with the time entry |
-|     ↳ `taskId` | number | Unique identifier of the task |
-|     ↳ `taskName` | string | Name of the task |
-|   ↳ `projectPhase` | object | Project phase associated with the time entry |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `billable` | boolean | Whether the time entry is billable |
-|   ↳ `user` | object | User the time entry belongs to |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `notes` | string | Notes for the time entry |
-|   ↳ `category` | object | Category associated with the time entry |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
-|   ↳ `sourceType` | string | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
-|   ↳ `status` | string | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
-|   ↳ `createdAt` | number | Creation timestamp in epoch milliseconds |
-|   ↳ `updatedAt` | number | Last-updated timestamp in epoch milliseconds |
-|   ↳ `createdBy` | object | User who created the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedBy` | object | User who submitted the time entry \(may be null even for approved/rejected entries\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedAt` | number | Submission timestamp in epoch milliseconds |
-|   ↳ `approvedBy` | object | User who approved the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `approvedAt` | number | Approval timestamp in epoch milliseconds |
-|   ↳ `rejectedBy` | object | User who rejected the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `rejectedAt` | number | Rejection timestamp in epoch milliseconds |
-|   ↳ `deleted` | boolean | Whether the time entry is deleted |
-|   ↳ `costRate` | object | Hourly cost rate assigned to the user for this entry |
-|   ↳ `billRate` | object | Hourly rate billed to the customer for this entry |
+|   ↳ `timeEntryId` | number (nullable) | Unique identifier of the time entry |
+|   ↳ `date` | string (nullable) | Date of the time entry \(YYYY-MM-DD\) |
+|   ↳ `minutes` | number (nullable) | Duration of the time entry in minutes |
+|   ↳ `activityName` | string (nullable) | Name of the adhoc activity, when the entry is tracked against an activity |
+|   ↳ `project` | object (nullable) | Project associated with the time entry |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `task` | object (nullable) | Task associated with the time entry |
+|     ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|     ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `projectPhase` | object (nullable) | Project phase associated with the time entry |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `billable` | boolean (nullable) | Whether the time entry is billable |
+|   ↳ `user` | object (nullable) | User the time entry belongs to |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `notes` | string (nullable) | Notes for the time entry |
+|   ↳ `category` | object (nullable) | Category associated with the time entry |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
+|   ↳ `sourceType` | string (nullable) | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
+|   ↳ `status` | string (nullable) | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
+|   ↳ `createdAt` | number (nullable) | Creation timestamp in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Last-updated timestamp in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | User who created the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedBy` | object (nullable) | User who submitted the time entry \(may be null even for approved/rejected entries\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedAt` | number (nullable) | Submission timestamp in epoch milliseconds |
+|   ↳ `approvedBy` | object (nullable) | User who approved the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `approvedAt` | number (nullable) | Approval timestamp in epoch milliseconds |
+|   ↳ `rejectedBy` | object (nullable) | User who rejected the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `rejectedAt` | number (nullable) | Rejection timestamp in epoch milliseconds |
+|   ↳ `deleted` | boolean (nullable) | Whether the time entry is deleted |
+|   ↳ `costRate` | object (nullable) | Hourly cost rate assigned to the user for this entry |
+|   ↳ `billRate` | object (nullable) | Hourly rate billed to the customer for this entry |
 |   ↳ `fields` | array | Custom fields associated with the time entry |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Update Time Entry
 
@@ -3111,69 +3111,69 @@ Update a Rocketlane time entry by ID. The activityName, notes, billable, and min
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeEntry` | object | The updated time entry |
-|   ↳ `timeEntryId` | number | Unique identifier of the time entry |
-|   ↳ `date` | string | Date of the time entry \(YYYY-MM-DD\) |
-|   ↳ `minutes` | number | Duration of the time entry in minutes |
-|   ↳ `activityName` | string | Name of the adhoc activity, when the entry is tracked against an activity |
-|   ↳ `project` | object | Project associated with the time entry |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `task` | object | Task associated with the time entry |
-|     ↳ `taskId` | number | Unique identifier of the task |
-|     ↳ `taskName` | string | Name of the task |
-|   ↳ `projectPhase` | object | Project phase associated with the time entry |
-|     ↳ `phaseId` | number | Unique identifier of the phase |
-|     ↳ `phaseName` | string | Name of the phase |
-|   ↳ `billable` | boolean | Whether the time entry is billable |
-|   ↳ `user` | object | User the time entry belongs to |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `notes` | string | Notes for the time entry |
-|   ↳ `category` | object | Category associated with the time entry |
-|     ↳ `categoryId` | number | Unique identifier of the category |
-|     ↳ `categoryName` | string | Name of the category |
-|   ↳ `sourceType` | string | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
-|   ↳ `status` | string | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
-|   ↳ `createdAt` | number | Creation timestamp in epoch milliseconds |
-|   ↳ `updatedAt` | number | Last-updated timestamp in epoch milliseconds |
-|   ↳ `createdBy` | object | User who created the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | User who last updated the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedBy` | object | User who submitted the time entry \(may be null even for approved/rejected entries\) |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `submittedAt` | number | Submission timestamp in epoch milliseconds |
-|   ↳ `approvedBy` | object | User who approved the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `approvedAt` | number | Approval timestamp in epoch milliseconds |
-|   ↳ `rejectedBy` | object | User who rejected the time entry |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `rejectedAt` | number | Rejection timestamp in epoch milliseconds |
-|   ↳ `deleted` | boolean | Whether the time entry is deleted |
-|   ↳ `costRate` | object | Hourly cost rate assigned to the user for this entry |
-|   ↳ `billRate` | object | Hourly rate billed to the customer for this entry |
+|   ↳ `timeEntryId` | number (nullable) | Unique identifier of the time entry |
+|   ↳ `date` | string (nullable) | Date of the time entry \(YYYY-MM-DD\) |
+|   ↳ `minutes` | number (nullable) | Duration of the time entry in minutes |
+|   ↳ `activityName` | string (nullable) | Name of the adhoc activity, when the entry is tracked against an activity |
+|   ↳ `project` | object (nullable) | Project associated with the time entry |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `task` | object (nullable) | Task associated with the time entry |
+|     ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|     ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `projectPhase` | object (nullable) | Project phase associated with the time entry |
+|     ↳ `phaseId` | number (nullable) | Unique identifier of the phase |
+|     ↳ `phaseName` | string (nullable) | Name of the phase |
+|   ↳ `billable` | boolean (nullable) | Whether the time entry is billable |
+|   ↳ `user` | object (nullable) | User the time entry belongs to |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `notes` | string (nullable) | Notes for the time entry |
+|   ↳ `category` | object (nullable) | Category associated with the time entry |
+|     ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|     ↳ `categoryName` | string (nullable) | Name of the category |
+|   ↳ `sourceType` | string (nullable) | Source of the time entry \(GOOGLE_CALENDAR, OUTLOOK_CALENDAR, TASK, PROJECT, PHASE, ADHOC, MILESTONE\) |
+|   ↳ `status` | string (nullable) | Approval status of the time entry \(NOT_SUBMITTED, SUBMITTED, APPROVED, REJECTED\) |
+|   ↳ `createdAt` | number (nullable) | Creation timestamp in epoch milliseconds |
+|   ↳ `updatedAt` | number (nullable) | Last-updated timestamp in epoch milliseconds |
+|   ↳ `createdBy` | object (nullable) | User who created the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | User who last updated the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedBy` | object (nullable) | User who submitted the time entry \(may be null even for approved/rejected entries\) |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `submittedAt` | number (nullable) | Submission timestamp in epoch milliseconds |
+|   ↳ `approvedBy` | object (nullable) | User who approved the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `approvedAt` | number (nullable) | Approval timestamp in epoch milliseconds |
+|   ↳ `rejectedBy` | object (nullable) | User who rejected the time entry |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `rejectedAt` | number (nullable) | Rejection timestamp in epoch milliseconds |
+|   ↳ `deleted` | boolean (nullable) | Whether the time entry is deleted |
+|   ↳ `costRate` | object (nullable) | Hourly cost rate assigned to the user for this entry |
+|   ↳ `billRate` | object (nullable) | Hourly rate billed to the customer for this entry |
 |   ↳ `fields` | array | Custom fields associated with the time entry |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
 
 ### Rocketlane Delete Time Entry
 
@@ -3210,13 +3210,13 @@ List the time entry categories configured in Rocketlane
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `categories` | array | List of time entry categories |
-|   ↳ `categoryId` | number | Unique identifier of the category |
-|   ↳ `categoryName` | string | Name of the category |
+|   ↳ `categoryId` | number (nullable) | Unique identifier of the category |
+|   ↳ `categoryName` | string (nullable) | Name of the category |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Create Time-Off
 
@@ -3245,28 +3245,28 @@ Create a time-off for a team member in Rocketlane. Holidays and weekends within 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeOff` | object | The created time-off |
-|   ↳ `timeOffId` | number | Unique identifier of the time-off |
-|   ↳ `user` | object | The team member the time-off belongs to |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `note` | string | Note or comment about the time-off |
-|   ↳ `startDate` | string | Time-off start date \(YYYY-MM-DD\) |
-|   ↳ `endDate` | string | Time-off end date \(YYYY-MM-DD\) |
-|   ↳ `durationInMinutes` | number | Duration in minutes per day for the time-off interval |
-|   ↳ `type` | string | Type of the time-off \(FULL_DAY, HALF_DAY, or CUSTOM\) |
-|   ↳ `notifyUsers` | object | Users notified about the time-off |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `createdAt` | number | Timestamp when the time-off was created \(epoch milliseconds\) |
-|   ↳ `createdBy` | object | The team member who created the time-off |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `timeOffId` | number (nullable) | Unique identifier of the time-off |
+|   ↳ `user` | object (nullable) | The team member the time-off belongs to |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `note` | string (nullable) | Note or comment about the time-off |
+|   ↳ `startDate` | string (nullable) | Time-off start date \(YYYY-MM-DD\) |
+|   ↳ `endDate` | string (nullable) | Time-off end date \(YYYY-MM-DD\) |
+|   ↳ `durationInMinutes` | number (nullable) | Duration in minutes per day for the time-off interval |
+|   ↳ `type` | string (nullable) | Type of the time-off \(FULL_DAY, HALF_DAY, or CUSTOM\) |
+|   ↳ `notifyUsers` | object (nullable) | Users notified about the time-off |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the time-off was created \(epoch milliseconds\) |
+|   ↳ `createdBy` | object (nullable) | The team member who created the time-off |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 
 ### Rocketlane Get Time-Off
 
@@ -3286,28 +3286,28 @@ Retrieve a Rocketlane time-off by its ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeOff` | object | The requested time-off |
-|   ↳ `timeOffId` | number | Unique identifier of the time-off |
-|   ↳ `user` | object | The team member the time-off belongs to |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `note` | string | Note or comment about the time-off |
-|   ↳ `startDate` | string | Time-off start date \(YYYY-MM-DD\) |
-|   ↳ `endDate` | string | Time-off end date \(YYYY-MM-DD\) |
-|   ↳ `durationInMinutes` | number | Duration in minutes per day for the time-off interval |
-|   ↳ `type` | string | Type of the time-off \(FULL_DAY, HALF_DAY, or CUSTOM\) |
-|   ↳ `notifyUsers` | object | Users notified about the time-off |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `createdAt` | number | Timestamp when the time-off was created \(epoch milliseconds\) |
-|   ↳ `createdBy` | object | The team member who created the time-off |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `timeOffId` | number (nullable) | Unique identifier of the time-off |
+|   ↳ `user` | object (nullable) | The team member the time-off belongs to |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `note` | string (nullable) | Note or comment about the time-off |
+|   ↳ `startDate` | string (nullable) | Time-off start date \(YYYY-MM-DD\) |
+|   ↳ `endDate` | string (nullable) | Time-off end date \(YYYY-MM-DD\) |
+|   ↳ `durationInMinutes` | number (nullable) | Duration in minutes per day for the time-off interval |
+|   ↳ `type` | string (nullable) | Type of the time-off \(FULL_DAY, HALF_DAY, or CUSTOM\) |
+|   ↳ `notifyUsers` | object (nullable) | Users notified about the time-off |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the time-off was created \(epoch milliseconds\) |
+|   ↳ `createdBy` | object (nullable) | The team member who created the time-off |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 
 ### Rocketlane List Time-Offs
 
@@ -3350,33 +3350,33 @@ List time-offs in Rocketlane with optional date, type, and user filters, sorting
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timeOffs` | array | List of time-offs |
-|   ↳ `timeOffId` | number | Unique identifier of the time-off |
-|   ↳ `user` | object | The team member the time-off belongs to |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `note` | string | Note or comment about the time-off |
-|   ↳ `startDate` | string | Time-off start date \(YYYY-MM-DD\) |
-|   ↳ `endDate` | string | Time-off end date \(YYYY-MM-DD\) |
-|   ↳ `durationInMinutes` | number | Duration in minutes per day for the time-off interval |
-|   ↳ `type` | string | Type of the time-off \(FULL_DAY, HALF_DAY, or CUSTOM\) |
-|   ↳ `notifyUsers` | object | Users notified about the time-off |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `createdAt` | number | Timestamp when the time-off was created \(epoch milliseconds\) |
-|   ↳ `createdBy` | object | The team member who created the time-off |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|   ↳ `timeOffId` | number (nullable) | Unique identifier of the time-off |
+|   ↳ `user` | object (nullable) | The team member the time-off belongs to |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `note` | string (nullable) | Note or comment about the time-off |
+|   ↳ `startDate` | string (nullable) | Time-off start date \(YYYY-MM-DD\) |
+|   ↳ `endDate` | string (nullable) | Time-off end date \(YYYY-MM-DD\) |
+|   ↳ `durationInMinutes` | number (nullable) | Duration in minutes per day for the time-off interval |
+|   ↳ `type` | string (nullable) | Type of the time-off \(FULL_DAY, HALF_DAY, or CUSTOM\) |
+|   ↳ `notifyUsers` | object (nullable) | Users notified about the time-off |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the time-off was created \(epoch milliseconds\) |
+|   ↳ `createdBy` | object (nullable) | The team member who created the time-off |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Delete Time-Off
 
@@ -3414,43 +3414,43 @@ Retrieve a Rocketlane user by their ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `user` | object | The requested user |
-|   ↳ `userId` | number | Unique identifier of the user |
-|   ↳ `email` | string | Email address of the user |
-|   ↳ `firstName` | string | First name of the user |
-|   ↳ `lastName` | string | Last name of the user |
-|   ↳ `type` | string | Type of the user \(TEAM_MEMBER, PARTNER, CUSTOMER, or EXTERNAL_PARTNER\) |
-|   ↳ `status` | string | Status of the user \(INACTIVE, INVITED, ACTIVE, or PASSIVE\) |
-|   ↳ `role` | object | Role of the user |
-|     ↳ `roleId` | number | Unique identifier of the role |
-|     ↳ `roleName` | string | Name of the role |
-|   ↳ `company` | object | Company of the user |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|   ↳ `permission` | object | Permission of the user |
-|     ↳ `permissionId` | number | Unique identifier of the permission |
-|     ↳ `permissionName` | string | Name of the permission |
+|   ↳ `userId` | number (nullable) | Unique identifier of the user |
+|   ↳ `email` | string (nullable) | Email address of the user |
+|   ↳ `firstName` | string (nullable) | First name of the user |
+|   ↳ `lastName` | string (nullable) | Last name of the user |
+|   ↳ `type` | string (nullable) | Type of the user \(TEAM_MEMBER, PARTNER, CUSTOMER, or EXTERNAL_PARTNER\) |
+|   ↳ `status` | string (nullable) | Status of the user \(INACTIVE, INVITED, ACTIVE, or PASSIVE\) |
+|   ↳ `role` | object (nullable) | Role of the user |
+|     ↳ `roleId` | number (nullable) | Unique identifier of the role |
+|     ↳ `roleName` | string (nullable) | Name of the role |
+|   ↳ `company` | object (nullable) | Company of the user |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|   ↳ `permission` | object (nullable) | Permission of the user |
+|     ↳ `permissionId` | number (nullable) | Unique identifier of the permission |
+|     ↳ `permissionName` | string (nullable) | Name of the permission |
 |   ↳ `fields` | array | Custom user field values |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Name of the custom user field |
-|     ↳ `fieldValue` | string | Value of the custom user field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `capacityInMinutes` | number | Capacity of the user in minutes |
-|   ↳ `holidayCalendar` | object | Holiday calendar of the user |
-|     ↳ `calenderId` | number | Unique identifier of the holiday calendar |
-|     ↳ `calenderName` | string | Name of the holiday calendar |
-|   ↳ `profilePictureUrl` | string | URL of the user's profile picture |
-|   ↳ `createdAt` | number | Timestamp when the user was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the user |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the user was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the user |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom user field |
+|     ↳ `fieldValue` | string (nullable) | Value of the custom user field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `capacityInMinutes` | number (nullable) | Capacity of the user in minutes |
+|   ↳ `holidayCalendar` | object (nullable) | Holiday calendar of the user |
+|     ↳ `calenderId` | number (nullable) | Unique identifier of the holiday calendar |
+|     ↳ `calenderName` | string (nullable) | Name of the holiday calendar |
+|   ↳ `profilePictureUrl` | string (nullable) | URL of the user's profile picture |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the user was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the user |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the user was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the user |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 
 ### Rocketlane List Users
 
@@ -3509,48 +3509,48 @@ List users in your Rocketlane account, with optional filters, sorting, and pagin
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `users` | array | List of users |
-|   ↳ `userId` | number | Unique identifier of the user |
-|   ↳ `email` | string | Email address of the user |
-|   ↳ `firstName` | string | First name of the user |
-|   ↳ `lastName` | string | Last name of the user |
-|   ↳ `type` | string | Type of the user \(TEAM_MEMBER, PARTNER, CUSTOMER, or EXTERNAL_PARTNER\) |
-|   ↳ `status` | string | Status of the user \(INACTIVE, INVITED, ACTIVE, or PASSIVE\) |
-|   ↳ `role` | object | Role of the user |
-|     ↳ `roleId` | number | Unique identifier of the role |
-|     ↳ `roleName` | string | Name of the role |
-|   ↳ `company` | object | Company of the user |
-|     ↳ `companyId` | number | Unique identifier of the company |
-|     ↳ `companyName` | string | Name of the company |
-|   ↳ `permission` | object | Permission of the user |
-|     ↳ `permissionId` | number | Unique identifier of the permission |
-|     ↳ `permissionName` | string | Name of the permission |
+|   ↳ `userId` | number (nullable) | Unique identifier of the user |
+|   ↳ `email` | string (nullable) | Email address of the user |
+|   ↳ `firstName` | string (nullable) | First name of the user |
+|   ↳ `lastName` | string (nullable) | Last name of the user |
+|   ↳ `type` | string (nullable) | Type of the user \(TEAM_MEMBER, PARTNER, CUSTOMER, or EXTERNAL_PARTNER\) |
+|   ↳ `status` | string (nullable) | Status of the user \(INACTIVE, INVITED, ACTIVE, or PASSIVE\) |
+|   ↳ `role` | object (nullable) | Role of the user |
+|     ↳ `roleId` | number (nullable) | Unique identifier of the role |
+|     ↳ `roleName` | string (nullable) | Name of the role |
+|   ↳ `company` | object (nullable) | Company of the user |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the company |
+|     ↳ `companyName` | string (nullable) | Name of the company |
+|   ↳ `permission` | object (nullable) | Permission of the user |
+|     ↳ `permissionId` | number (nullable) | Unique identifier of the permission |
+|     ↳ `permissionName` | string (nullable) | Name of the permission |
 |   ↳ `fields` | array | Custom user field values |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Name of the custom user field |
-|     ↳ `fieldValue` | string | Value of the custom user field |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
-|   ↳ `capacityInMinutes` | number | Capacity of the user in minutes |
-|   ↳ `holidayCalendar` | object | Holiday calendar of the user |
-|     ↳ `calenderId` | number | Unique identifier of the holiday calendar |
-|     ↳ `calenderName` | string | Name of the holiday calendar |
-|   ↳ `profilePictureUrl` | string | URL of the user's profile picture |
-|   ↳ `createdAt` | number | Timestamp when the user was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the user |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the user was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the user |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Name of the custom user field |
+|     ↳ `fieldValue` | string (nullable) | Value of the custom user field |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
+|   ↳ `capacityInMinutes` | number (nullable) | Capacity of the user in minutes |
+|   ↳ `holidayCalendar` | object (nullable) | Holiday calendar of the user |
+|     ↳ `calenderId` | number (nullable) | Unique identifier of the holiday calendar |
+|     ↳ `calenderName` | string (nullable) | Name of the holiday calendar |
+|   ↳ `profilePictureUrl` | string (nullable) | URL of the user's profile picture |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the user was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the user |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the user was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the user |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 | `pagination` | object | Pagination details |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Create Space
 
@@ -3570,24 +3570,24 @@ Create a new space in a Rocketlane project
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `space` | object | The created space |
-|   ↳ `spaceId` | number | Unique identifier of the space |
-|   ↳ `spaceName` | string | Name of the space |
-|   ↳ `project` | object | Project the space belongs to |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `createdAt` | number | Timestamp when the space was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the space |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the space was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the space |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `private` | boolean | Whether the space is private or shared |
+|   ↳ `spaceId` | number (nullable) | Unique identifier of the space |
+|   ↳ `spaceName` | string (nullable) | Name of the space |
+|   ↳ `project` | object (nullable) | Project the space belongs to |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the space was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the space |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the space was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the space |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `private` | boolean (nullable) | Whether the space is private or shared |
 
 ### Rocketlane Get Space
 
@@ -3605,24 +3605,24 @@ Retrieve a Rocketlane space by its ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `space` | object | The requested space |
-|   ↳ `spaceId` | number | Unique identifier of the space |
-|   ↳ `spaceName` | string | Name of the space |
-|   ↳ `project` | object | Project the space belongs to |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `createdAt` | number | Timestamp when the space was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the space |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the space was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the space |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `private` | boolean | Whether the space is private or shared |
+|   ↳ `spaceId` | number (nullable) | Unique identifier of the space |
+|   ↳ `spaceName` | string (nullable) | Name of the space |
+|   ↳ `project` | object (nullable) | Project the space belongs to |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the space was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the space |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the space was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the space |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `private` | boolean (nullable) | Whether the space is private or shared |
 
 ### Rocketlane List Spaces
 
@@ -3658,29 +3658,29 @@ List spaces in a Rocketlane project, with optional filters, sorting, and paginat
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `spaces` | array | List of spaces |
-|   ↳ `spaceId` | number | Unique identifier of the space |
-|   ↳ `spaceName` | string | Name of the space |
-|   ↳ `project` | object | Project the space belongs to |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `createdAt` | number | Timestamp when the space was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the space |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the space was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the space |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `private` | boolean | Whether the space is private or shared |
+|   ↳ `spaceId` | number (nullable) | Unique identifier of the space |
+|   ↳ `spaceName` | string (nullable) | Name of the space |
+|   ↳ `project` | object (nullable) | Project the space belongs to |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the space was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the space |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the space was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the space |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `private` | boolean (nullable) | Whether the space is private or shared |
 | `pagination` | object | Pagination details |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Update Space
 
@@ -3699,24 +3699,24 @@ Update a Rocketlane space by its ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `space` | object | The updated space |
-|   ↳ `spaceId` | number | Unique identifier of the space |
-|   ↳ `spaceName` | string | Name of the space |
-|   ↳ `project` | object | Project the space belongs to |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
-|   ↳ `createdAt` | number | Timestamp when the space was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the space |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the space was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the space |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `private` | boolean | Whether the space is private or shared |
+|   ↳ `spaceId` | number (nullable) | Unique identifier of the space |
+|   ↳ `spaceName` | string (nullable) | Name of the space |
+|   ↳ `project` | object (nullable) | Project the space belongs to |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the space was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the space |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the space was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the space |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `private` | boolean (nullable) | Whether the space is private or shared |
 
 ### Rocketlane Delete Space
 
@@ -3756,29 +3756,29 @@ Create a new space document in a Rocketlane space
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `spaceDocument` | object | The created space document |
-|   ↳ `spaceDocumentId` | number | Unique identifier of the space document |
-|   ↳ `spaceDocumentName` | string | Name of the space document |
-|   ↳ `space` | object | Space the document belongs to |
-|     ↳ `spaceId` | number | Unique identifier of the space |
-|     ↳ `spaceName` | string | Name of the space |
-|   ↳ `spaceDocumentType` | string | Type of the space document \(ROCKETLANE_DOCUMENT or EMBEDDED_DOCUMENT\) |
-|   ↳ `url` | string | URL embedded in the space document |
-|   ↳ `source` | object | Document template the space document was created from |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `createdAt` | number | Timestamp when the space document was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the space document |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the space document was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the space document |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `private` | boolean | Whether the space document is private or shared |
+|   ↳ `spaceDocumentId` | number (nullable) | Unique identifier of the space document |
+|   ↳ `spaceDocumentName` | string (nullable) | Name of the space document |
+|   ↳ `space` | object (nullable) | Space the document belongs to |
+|     ↳ `spaceId` | number (nullable) | Unique identifier of the space |
+|     ↳ `spaceName` | string (nullable) | Name of the space |
+|   ↳ `spaceDocumentType` | string (nullable) | Type of the space document \(ROCKETLANE_DOCUMENT or EMBEDDED_DOCUMENT\) |
+|   ↳ `url` | string (nullable) | URL embedded in the space document |
+|   ↳ `source` | object (nullable) | Document template the space document was created from |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the space document was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the space document |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the space document was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the space document |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `private` | boolean (nullable) | Whether the space document is private or shared |
 
 ### Rocketlane Get Space Document
 
@@ -3796,29 +3796,29 @@ Retrieve a Rocketlane space document by its ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `spaceDocument` | object | The requested space document |
-|   ↳ `spaceDocumentId` | number | Unique identifier of the space document |
-|   ↳ `spaceDocumentName` | string | Name of the space document |
-|   ↳ `space` | object | Space the document belongs to |
-|     ↳ `spaceId` | number | Unique identifier of the space |
-|     ↳ `spaceName` | string | Name of the space |
-|   ↳ `spaceDocumentType` | string | Type of the space document \(ROCKETLANE_DOCUMENT or EMBEDDED_DOCUMENT\) |
-|   ↳ `url` | string | URL embedded in the space document |
-|   ↳ `source` | object | Document template the space document was created from |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `createdAt` | number | Timestamp when the space document was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the space document |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the space document was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the space document |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `private` | boolean | Whether the space document is private or shared |
+|   ↳ `spaceDocumentId` | number (nullable) | Unique identifier of the space document |
+|   ↳ `spaceDocumentName` | string (nullable) | Name of the space document |
+|   ↳ `space` | object (nullable) | Space the document belongs to |
+|     ↳ `spaceId` | number (nullable) | Unique identifier of the space |
+|     ↳ `spaceName` | string (nullable) | Name of the space |
+|   ↳ `spaceDocumentType` | string (nullable) | Type of the space document \(ROCKETLANE_DOCUMENT or EMBEDDED_DOCUMENT\) |
+|   ↳ `url` | string (nullable) | URL embedded in the space document |
+|   ↳ `source` | object (nullable) | Document template the space document was created from |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the space document was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the space document |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the space document was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the space document |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `private` | boolean (nullable) | Whether the space document is private or shared |
 
 ### Rocketlane List Space Documents
 
@@ -3855,34 +3855,34 @@ List space documents in a Rocketlane project, with optional filters, sorting, an
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `spaceDocuments` | array | List of space documents |
-|   ↳ `spaceDocumentId` | number | Unique identifier of the space document |
-|   ↳ `spaceDocumentName` | string | Name of the space document |
-|   ↳ `space` | object | Space the document belongs to |
-|     ↳ `spaceId` | number | Unique identifier of the space |
-|     ↳ `spaceName` | string | Name of the space |
-|   ↳ `spaceDocumentType` | string | Type of the space document \(ROCKETLANE_DOCUMENT or EMBEDDED_DOCUMENT\) |
-|   ↳ `url` | string | URL embedded in the space document |
-|   ↳ `source` | object | Document template the space document was created from |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `createdAt` | number | Timestamp when the space document was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the space document |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the space document was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the space document |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `private` | boolean | Whether the space document is private or shared |
+|   ↳ `spaceDocumentId` | number (nullable) | Unique identifier of the space document |
+|   ↳ `spaceDocumentName` | string (nullable) | Name of the space document |
+|   ↳ `space` | object (nullable) | Space the document belongs to |
+|     ↳ `spaceId` | number (nullable) | Unique identifier of the space |
+|     ↳ `spaceName` | string (nullable) | Name of the space |
+|   ↳ `spaceDocumentType` | string (nullable) | Type of the space document \(ROCKETLANE_DOCUMENT or EMBEDDED_DOCUMENT\) |
+|   ↳ `url` | string (nullable) | URL embedded in the space document |
+|   ↳ `source` | object (nullable) | Document template the space document was created from |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the space document was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the space document |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the space document was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the space document |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `private` | boolean (nullable) | Whether the space document is private or shared |
 | `pagination` | object | Pagination details |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Update Space Document
 
@@ -3902,29 +3902,29 @@ Update a Rocketlane space document by its ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `spaceDocument` | object | The updated space document |
-|   ↳ `spaceDocumentId` | number | Unique identifier of the space document |
-|   ↳ `spaceDocumentName` | string | Name of the space document |
-|   ↳ `space` | object | Space the document belongs to |
-|     ↳ `spaceId` | number | Unique identifier of the space |
-|     ↳ `spaceName` | string | Name of the space |
-|   ↳ `spaceDocumentType` | string | Type of the space document \(ROCKETLANE_DOCUMENT or EMBEDDED_DOCUMENT\) |
-|   ↳ `url` | string | URL embedded in the space document |
-|   ↳ `source` | object | Document template the space document was created from |
-|     ↳ `templateId` | number | Unique identifier of the template |
-|     ↳ `templateName` | string | Name of the template |
-|   ↳ `createdAt` | number | Timestamp when the space document was created \(epoch millis\) |
-|   ↳ `createdBy` | object | Team member who created the space document |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedAt` | number | Timestamp when the space document was last updated \(epoch millis\) |
-|   ↳ `updatedBy` | object | Team member who last updated the space document |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `private` | boolean | Whether the space document is private or shared |
+|   ↳ `spaceDocumentId` | number (nullable) | Unique identifier of the space document |
+|   ↳ `spaceDocumentName` | string (nullable) | Name of the space document |
+|   ↳ `space` | object (nullable) | Space the document belongs to |
+|     ↳ `spaceId` | number (nullable) | Unique identifier of the space |
+|     ↳ `spaceName` | string (nullable) | Name of the space |
+|   ↳ `spaceDocumentType` | string (nullable) | Type of the space document \(ROCKETLANE_DOCUMENT or EMBEDDED_DOCUMENT\) |
+|   ↳ `url` | string (nullable) | URL embedded in the space document |
+|   ↳ `source` | object (nullable) | Document template the space document was created from |
+|     ↳ `templateId` | number (nullable) | Unique identifier of the template |
+|     ↳ `templateName` | string (nullable) | Name of the template |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the space document was created \(epoch millis\) |
+|   ↳ `createdBy` | object (nullable) | Team member who created the space document |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the space document was last updated \(epoch millis\) |
+|   ↳ `updatedBy` | object (nullable) | Team member who last updated the space document |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `private` | boolean (nullable) | Whether the space document is private or shared |
 
 ### Rocketlane Delete Space Document
 
@@ -3977,43 +3977,43 @@ List resource allocations in Rocketlane within a date range, with optional membe
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `allocations` | array | List of resource allocations |
-|   ↳ `startDate` | string | Allocation start date \(YYYY-MM-DD\) |
-|   ↳ `endDate` | string | Allocation end date \(YYYY-MM-DD\) |
-|   ↳ `secondsPerDay` | number | Allocated seconds per day |
-|   ↳ `minutesPerDay` | number | Allocated minutes per day |
-|   ↳ `hoursPerDay` | number | Allocated hours per day |
-|   ↳ `duration` | object | Total allocation duration between the start and end dates |
-|     ↳ `daysConsider` | number | Number of week days considered for the duration computation |
-|     ↳ `seconds` | number | Total allocation seconds |
-|     ↳ `minutes` | number | Total allocation minutes |
-|     ↳ `hours` | number | Total allocation hours |
-|   ↳ `allocationType` | string | Type of allocation \(SOFT or HARD\) |
-|   ↳ `allocationFor` | string | Who the allocation is for \(TEAM_MEMBER or PLACEHOLDER\) |
-|   ↳ `project` | object | The project associated with the allocation |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
+|   ↳ `startDate` | string (nullable) | Allocation start date \(YYYY-MM-DD\) |
+|   ↳ `endDate` | string (nullable) | Allocation end date \(YYYY-MM-DD\) |
+|   ↳ `secondsPerDay` | number (nullable) | Allocated seconds per day |
+|   ↳ `minutesPerDay` | number (nullable) | Allocated minutes per day |
+|   ↳ `hoursPerDay` | number (nullable) | Allocated hours per day |
+|   ↳ `duration` | object (nullable) | Total allocation duration between the start and end dates |
+|     ↳ `daysConsider` | number (nullable) | Number of week days considered for the duration computation |
+|     ↳ `seconds` | number (nullable) | Total allocation seconds |
+|     ↳ `minutes` | number (nullable) | Total allocation minutes |
+|     ↳ `hours` | number (nullable) | Total allocation hours |
+|   ↳ `allocationType` | string (nullable) | Type of allocation \(SOFT or HARD\) |
+|   ↳ `allocationFor` | string (nullable) | Who the allocation is for \(TEAM_MEMBER or PLACEHOLDER\) |
+|   ↳ `project` | object (nullable) | The project associated with the allocation |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
 |   ↳ `tasks` | array | Tasks associated with the allocation |
-|     ↳ `taskId` | number | Unique identifier of the task |
-|     ↳ `taskName` | string | Name of the task |
-|   ↳ `member` | object | The team member allocated when allocationFor is TEAM_MEMBER |
-|   ↳ `placeholder` | object | The placeholder allocated when allocationFor is PLACEHOLDER |
-|   ↳ `createdAt` | number | Timestamp when the allocation was created \(epoch milliseconds\) |
-|   ↳ `updatedAt` | number | Timestamp when the allocation was last updated \(epoch milliseconds\) |
-|   ↳ `createdBy` | object | The team member who created the allocation |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | The team member who last updated the allocation |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
+|     ↳ `taskId` | number (nullable) | Unique identifier of the task |
+|     ↳ `taskName` | string (nullable) | Name of the task |
+|   ↳ `member` | object (nullable) | The team member allocated when allocationFor is TEAM_MEMBER |
+|   ↳ `placeholder` | object (nullable) | The placeholder allocated when allocationFor is PLACEHOLDER |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the allocation was created \(epoch milliseconds\) |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the allocation was last updated \(epoch milliseconds\) |
+|   ↳ `createdBy` | object (nullable) | The team member who created the allocation |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | The team member who last updated the allocation |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Get Invoice
 
@@ -4033,50 +4033,50 @@ Retrieve a Rocketlane invoice by its ID
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `invoice` | object | The requested invoice |
-|   ↳ `invoiceId` | number | Unique identifier of the invoice |
-|   ↳ `invoiceNumber` | string | Invoice number assigned to this invoice |
-|   ↳ `dateOfIssue` | string | Date when the invoice was issued \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Due date for the invoice payment \(YYYY-MM-DD\) |
-|   ↳ `currency` | string | Currency of the invoice amount \(e.g. USD\) |
-|   ↳ `status` | string | Current status of the invoice |
-|   ↳ `amount` | number | Total amount of the invoice including tax |
-|   ↳ `tax` | number | Tax amount applied to the invoice |
-|   ↳ `subTotal` | number | Total amount of the invoice excluding tax |
-|   ↳ `amountOutstanding` | number | Balance amount remaining to be paid |
-|   ↳ `amountPaid` | number | Total amount paid for this invoice |
-|   ↳ `amountWrittenOff` | number | Total amount written off for this invoice |
-|   ↳ `notes` | string | Notes or additional information about the invoice |
-|   ↳ `createdAt` | number | Timestamp when the invoice was created \(epoch milliseconds\) |
-|   ↳ `updatedAt` | number | Timestamp when the invoice was last updated \(epoch milliseconds\) |
-|   ↳ `createdBy` | object | The team member who created the invoice |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | The team member who last updated the invoice |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `company` | object | Customer company details for the invoice |
-|     ↳ `companyId` | number | Unique identifier of the customer company |
-|     ↳ `companyName` | string | Name of the customer company |
-|     ↳ `companyUrl` | string | URL of the customer company website |
+|   ↳ `invoiceId` | number (nullable) | Unique identifier of the invoice |
+|   ↳ `invoiceNumber` | string (nullable) | Invoice number assigned to this invoice |
+|   ↳ `dateOfIssue` | string (nullable) | Date when the invoice was issued \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Due date for the invoice payment \(YYYY-MM-DD\) |
+|   ↳ `currency` | string (nullable) | Currency of the invoice amount \(e.g. USD\) |
+|   ↳ `status` | string (nullable) | Current status of the invoice |
+|   ↳ `amount` | number (nullable) | Total amount of the invoice including tax |
+|   ↳ `tax` | number (nullable) | Tax amount applied to the invoice |
+|   ↳ `subTotal` | number (nullable) | Total amount of the invoice excluding tax |
+|   ↳ `amountOutstanding` | number (nullable) | Balance amount remaining to be paid |
+|   ↳ `amountPaid` | number (nullable) | Total amount paid for this invoice |
+|   ↳ `amountWrittenOff` | number (nullable) | Total amount written off for this invoice |
+|   ↳ `notes` | string (nullable) | Notes or additional information about the invoice |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the invoice was created \(epoch milliseconds\) |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the invoice was last updated \(epoch milliseconds\) |
+|   ↳ `createdBy` | object (nullable) | The team member who created the invoice |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | The team member who last updated the invoice |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `company` | object (nullable) | Customer company details for the invoice |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the customer company |
+|     ↳ `companyName` | string (nullable) | Name of the customer company |
+|     ↳ `companyUrl` | string (nullable) | URL of the customer company website |
 |   ↳ `projects` | array | Projects mapped to this invoice |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
 |   ↳ `fields` | array | Custom invoice fields with their values |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array depending on field type\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array depending on field type\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
 |   ↳ `attachments` | array | Attachments associated with the invoice |
-|     ↳ `attachmentId` | number | Unique identifier of the attachment |
-|     ↳ `attachmentName` | string | Name of the attachment |
-|     ↳ `createdAt` | number | Timestamp when the attachment was created \(epoch milliseconds\) |
-|     ↳ `location` | string | URL of the attachment |
-|     ↳ `thumbLocation` | string | Thumbnail URL of the attachment |
-|     ↳ `visibility` | boolean | Visibility of the attachment |
+|     ↳ `attachmentId` | number (nullable) | Unique identifier of the attachment |
+|     ↳ `attachmentName` | string (nullable) | Name of the attachment |
+|     ↳ `createdAt` | number (nullable) | Timestamp when the attachment was created \(epoch milliseconds\) |
+|     ↳ `location` | string (nullable) | URL of the attachment |
+|     ↳ `thumbLocation` | string (nullable) | Thumbnail URL of the attachment |
+|     ↳ `visibility` | boolean (nullable) | Visibility of the attachment |
 
 ### Rocketlane List Invoices
 
@@ -4144,55 +4144,55 @@ Search invoices in Rocketlane with date, amount, company, invoice-number, and st
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `invoices` | array | List of invoices |
-|   ↳ `invoiceId` | number | Unique identifier of the invoice |
-|   ↳ `invoiceNumber` | string | Invoice number assigned to this invoice |
-|   ↳ `dateOfIssue` | string | Date when the invoice was issued \(YYYY-MM-DD\) |
-|   ↳ `dueDate` | string | Due date for the invoice payment \(YYYY-MM-DD\) |
-|   ↳ `currency` | string | Currency of the invoice amount \(e.g. USD\) |
-|   ↳ `status` | string | Current status of the invoice |
-|   ↳ `amount` | number | Total amount of the invoice including tax |
-|   ↳ `tax` | number | Tax amount applied to the invoice |
-|   ↳ `subTotal` | number | Total amount of the invoice excluding tax |
-|   ↳ `amountOutstanding` | number | Balance amount remaining to be paid |
-|   ↳ `amountPaid` | number | Total amount paid for this invoice |
-|   ↳ `amountWrittenOff` | number | Total amount written off for this invoice |
-|   ↳ `notes` | string | Notes or additional information about the invoice |
-|   ↳ `createdAt` | number | Timestamp when the invoice was created \(epoch milliseconds\) |
-|   ↳ `updatedAt` | number | Timestamp when the invoice was last updated \(epoch milliseconds\) |
-|   ↳ `createdBy` | object | The team member who created the invoice |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `updatedBy` | object | The team member who last updated the invoice |
-|     ↳ `userId` | number | Unique identifier of the user |
-|     ↳ `firstName` | string | First name of the user |
-|     ↳ `lastName` | string | Last name of the user |
-|     ↳ `emailId` | string | Email address of the user |
-|   ↳ `company` | object | Customer company details for the invoice |
-|     ↳ `companyId` | number | Unique identifier of the customer company |
-|     ↳ `companyName` | string | Name of the customer company |
-|     ↳ `companyUrl` | string | URL of the customer company website |
+|   ↳ `invoiceId` | number (nullable) | Unique identifier of the invoice |
+|   ↳ `invoiceNumber` | string (nullable) | Invoice number assigned to this invoice |
+|   ↳ `dateOfIssue` | string (nullable) | Date when the invoice was issued \(YYYY-MM-DD\) |
+|   ↳ `dueDate` | string (nullable) | Due date for the invoice payment \(YYYY-MM-DD\) |
+|   ↳ `currency` | string (nullable) | Currency of the invoice amount \(e.g. USD\) |
+|   ↳ `status` | string (nullable) | Current status of the invoice |
+|   ↳ `amount` | number (nullable) | Total amount of the invoice including tax |
+|   ↳ `tax` | number (nullable) | Tax amount applied to the invoice |
+|   ↳ `subTotal` | number (nullable) | Total amount of the invoice excluding tax |
+|   ↳ `amountOutstanding` | number (nullable) | Balance amount remaining to be paid |
+|   ↳ `amountPaid` | number (nullable) | Total amount paid for this invoice |
+|   ↳ `amountWrittenOff` | number (nullable) | Total amount written off for this invoice |
+|   ↳ `notes` | string (nullable) | Notes or additional information about the invoice |
+|   ↳ `createdAt` | number (nullable) | Timestamp when the invoice was created \(epoch milliseconds\) |
+|   ↳ `updatedAt` | number (nullable) | Timestamp when the invoice was last updated \(epoch milliseconds\) |
+|   ↳ `createdBy` | object (nullable) | The team member who created the invoice |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `updatedBy` | object (nullable) | The team member who last updated the invoice |
+|     ↳ `userId` | number (nullable) | Unique identifier of the user |
+|     ↳ `firstName` | string (nullable) | First name of the user |
+|     ↳ `lastName` | string (nullable) | Last name of the user |
+|     ↳ `emailId` | string (nullable) | Email address of the user |
+|   ↳ `company` | object (nullable) | Customer company details for the invoice |
+|     ↳ `companyId` | number (nullable) | Unique identifier of the customer company |
+|     ↳ `companyName` | string (nullable) | Name of the customer company |
+|     ↳ `companyUrl` | string (nullable) | URL of the customer company website |
 |   ↳ `projects` | array | Projects mapped to this invoice |
-|     ↳ `projectId` | number | Unique identifier of the project |
-|     ↳ `projectName` | string | Name of the project |
+|     ↳ `projectId` | number (nullable) | Unique identifier of the project |
+|     ↳ `projectName` | string (nullable) | Name of the project |
 |   ↳ `fields` | array | Custom invoice fields with their values |
-|     ↳ `fieldId` | number | Unique identifier of the field |
-|     ↳ `fieldLabel` | string | Label of the field |
-|     ↳ `fieldValue` | json | Value of the field \(string, number, or array depending on field type\) |
-|     ↳ `fieldValueLabel` | string | String representation of the field value |
+|     ↳ `fieldId` | number (nullable) | Unique identifier of the field |
+|     ↳ `fieldLabel` | string (nullable) | Label of the field |
+|     ↳ `fieldValue` | json (nullable) | Value of the field \(string, number, or array depending on field type\) |
+|     ↳ `fieldValueLabel` | string (nullable) | String representation of the field value |
 |   ↳ `attachments` | array | Attachments associated with the invoice |
-|     ↳ `attachmentId` | number | Unique identifier of the attachment |
-|     ↳ `attachmentName` | string | Name of the attachment |
-|     ↳ `createdAt` | number | Timestamp when the attachment was created \(epoch milliseconds\) |
-|     ↳ `location` | string | URL of the attachment |
-|     ↳ `thumbLocation` | string | Thumbnail URL of the attachment |
-|     ↳ `visibility` | boolean | Visibility of the attachment |
+|     ↳ `attachmentId` | number (nullable) | Unique identifier of the attachment |
+|     ↳ `attachmentName` | string (nullable) | Name of the attachment |
+|     ↳ `createdAt` | number (nullable) | Timestamp when the attachment was created \(epoch milliseconds\) |
+|     ↳ `location` | string (nullable) | URL of the attachment |
+|     ↳ `thumbLocation` | string (nullable) | Thumbnail URL of the attachment |
+|     ↳ `visibility` | boolean (nullable) | Visibility of the attachment |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Get Invoice Line Items
 
@@ -4212,29 +4212,29 @@ List line items of a Rocketlane invoice
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `lineItems` | array | List of invoice line items |
-|   ↳ `invoiceLineItemId` | number | Unique identifier of the invoice line item |
-|   ↳ `description` | string | Description of the line item or service provided |
-|   ↳ `quantity` | number | Quantity of the item or service |
-|   ↳ `unitPrice` | number | Unit price for the item or service |
-|   ↳ `amount` | number | Total amount for this line item \(quantity times unit price\) |
-|   ↳ `sourceId` | number | Unique identifier of the source entity \(e.g. project ID\) |
-|   ↳ `sourceType` | string | Type of source entity this line item is associated with \(e.g. PROJECT\) |
-|   ↳ `taxCode` | object | Tax code information for this line item |
-|     ↳ `taxCodeId` | number | Unique identifier of the tax code |
-|     ↳ `taxCodeName` | string | Name of the tax code |
-|     ↳ `taxCodeRate` | number | Tax rate percentage for the tax code |
-|     ↳ `taxCodeAmount` | number | Tax amount calculated for this tax code |
+|   ↳ `invoiceLineItemId` | number (nullable) | Unique identifier of the invoice line item |
+|   ↳ `description` | string (nullable) | Description of the line item or service provided |
+|   ↳ `quantity` | number (nullable) | Quantity of the item or service |
+|   ↳ `unitPrice` | number (nullable) | Unit price for the item or service |
+|   ↳ `amount` | number (nullable) | Total amount for this line item \(quantity times unit price\) |
+|   ↳ `sourceId` | number (nullable) | Unique identifier of the source entity \(e.g. project ID\) |
+|   ↳ `sourceType` | string (nullable) | Type of source entity this line item is associated with \(e.g. PROJECT\) |
+|   ↳ `taxCode` | object (nullable) | Tax code information for this line item |
+|     ↳ `taxCodeId` | number (nullable) | Unique identifier of the tax code |
+|     ↳ `taxCodeName` | string (nullable) | Name of the tax code |
+|     ↳ `taxCodeRate` | number (nullable) | Tax rate percentage for the tax code |
+|     ↳ `taxCodeAmount` | number (nullable) | Tax amount calculated for this tax code |
 |   ↳ `taxComponents` | array | Tax components that make up the tax code |
-|     ↳ `taxComponentId` | number | Unique identifier of the tax component |
-|     ↳ `taxComponentName` | string | Name of the tax component |
-|     ↳ `taxComponentRate` | number | Tax rate percentage for the tax component |
-|     ↳ `taxComponentAmount` | number | Tax amount calculated for this tax component |
-|     ↳ `taxComponentType` | string | Type of the tax component \(e.g. GST, VAT\) |
+|     ↳ `taxComponentId` | number (nullable) | Unique identifier of the tax component |
+|     ↳ `taxComponentName` | string (nullable) | Name of the tax component |
+|     ↳ `taxComponentRate` | number (nullable) | Tax rate percentage for the tax component |
+|     ↳ `taxComponentAmount` | number (nullable) | Tax amount calculated for this tax component |
+|     ↳ `taxComponentType` | string (nullable) | Type of the tax component \(e.g. GST, VAT\) |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |
 
 ### Rocketlane Get Invoice Payments
 
@@ -4254,16 +4254,14 @@ List payments recorded against a Rocketlane invoice
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `payments` | array | List of payments recorded against the invoice |
-|   ↳ `paymentId` | number | Unique identifier of the payment record |
-|   ↳ `paymentRecordType` | string | Type of the payment record \(PAID or WRITE_OFF\) |
-|   ↳ `currency` | string | Currency of the payment amount \(e.g. USD\) |
-|   ↳ `paymentDate` | string | Date when the payment was made \(YYYY-MM-DD\) |
-|   ↳ `amount` | number | Amount of the payment |
-|   ↳ `notes` | string | Additional notes or comments regarding the payment |
+|   ↳ `paymentId` | number (nullable) | Unique identifier of the payment record |
+|   ↳ `paymentRecordType` | string (nullable) | Type of the payment record \(PAID or WRITE_OFF\) |
+|   ↳ `currency` | string (nullable) | Currency of the payment amount \(e.g. USD\) |
+|   ↳ `paymentDate` | string (nullable) | Date when the payment was made \(YYYY-MM-DD\) |
+|   ↳ `amount` | number (nullable) | Amount of the payment |
+|   ↳ `notes` | string (nullable) | Additional notes or comments regarding the payment |
 | `pagination` | object | Pagination details for the result set |
-|   ↳ `pageSize` | number | Page size used for the current request |
-|   ↳ `hasMore` | boolean | Whether more results are available |
-|   ↳ `totalRecordCount` | number | Total number of records matching the request |
-|   ↳ `nextPageToken` | string | Token for fetching the next page \(valid for 15 minutes\) |
-
-
+|   ↳ `pageSize` | number (nullable) | Page size used for the current request |
+|   ↳ `hasMore` | boolean (nullable) | Whether more results are available |
+|   ↳ `totalRecordCount` | number (nullable) | Total number of records matching the request |
+|   ↳ `nextPageToken` | string (nullable) | Token for fetching the next page \(valid for 15 minutes\) |

--- a/apps/docs/content/docs/integrations/rootly.mdx
+++ b/apps/docs/content/docs/integrations/rootly.mdx
@@ -5,7 +5,7 @@ description: Manage incidents, alerts, and on-call with Rootly
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="rootly"
   color="#6C72C8"
 />
@@ -1318,8 +1318,6 @@ List incident roles configured in Rootly (e.g. commander, scribe).
 |   ↳ `updatedAt` | string | Last update date |
 | `totalCount` | number | Total number of incident roles returned |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1547,4 +1545,3 @@ Trigger workflow when an incident is updated in Rootly
 |   ↳ `events` | json | Timeline events |
 |   ↳ `action_items` | json | Action items |
 |   ↳ `incident_post_mortem` | json | Retrospective/post-mortem object |
-

--- a/apps/docs/content/docs/integrations/s3.mdx
+++ b/apps/docs/content/docs/integrations/s3.mdx
@@ -5,7 +5,7 @@ description: Upload, download, list, and manage S3 files and buckets
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="s3"
   color="linear-gradient(45deg, #1B660F 0%, #6CAE3E 100%)"
 />
@@ -282,5 +282,3 @@ Delete multiple objects from an AWS S3 bucket in a single batch request
 |   ↳ `code` | string | Error code |
 |   ↳ `message` | string | Error message |
 | `metadata` | object | Batch deletion summary including counts |
-
-

--- a/apps/docs/content/docs/integrations/sailpoint.mdx
+++ b/apps/docs/content/docs/integrations/sailpoint.mdx
@@ -5,7 +5,7 @@ description: Govern identities and access in SailPoint Identity Security Cloud
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sailpoint"
   color="#FFFFFF"
 />
@@ -177,19 +177,19 @@ List entitlements in one access profile.
 |   ↳ `attribute` | string | Source entitlement attribute |
 |   ↳ `value` | string | Source entitlement value |
 |   ↳ `sourceSchemaObjectType` | string | Source schema object type |
-|   ↳ `description` | string | Entitlement description |
+|   ↳ `description` | string (nullable) | Entitlement description |
 |   ↳ `privileged` | boolean | Whether the entitlement is privileged |
 |   ↳ `cloudGoverned` | boolean | Whether SailPoint governs the entitlement |
 |   ↳ `requestable` | boolean | Whether the entitlement is requestable |
-|   ↳ `owner` | object | Primary owner reference |
+|   ↳ `owner` | object (nullable) | Primary owner reference |
 |     ↳ `id` | string | Identity ID |
 |     ↳ `type` | string | IDENTITY |
 |     ↳ `name` | string | Identity display name |
-|   ↳ `additionalOwners` | array | Additional owner references |
+|   ↳ `additionalOwners` | array (nullable) | Additional owner references |
 |     ↳ `type` | string | IDENTITY or GOVERNANCE_GROUP |
 |     ↳ `id` | string | Identity or governance-group ID |
-|     ↳ `name` | string | Display name |
-|   ↳ `manuallyUpdatedFields` | json | Fields manually updated in SailPoint |
+|     ↳ `name` | string (nullable) | Display name |
+|   ↳ `manuallyUpdatedFields` | json (nullable) | Fields manually updated in SailPoint |
 |   ↳ `accessModelMetadata` | object | Access-model metadata |
 |     ↳ `attributes` | array | Access-model metadata attributes |
 |       ↳ `key` | string | Metadata type identifier |
@@ -210,12 +210,12 @@ List entitlements in one access profile.
 |     ↳ `type` | string | SOURCE |
 |     ↳ `name` | string | Source name |
 |   ↳ `attributes` | json | Source-defined entitlement attributes |
-|   ↳ `segments` | array | Segment IDs |
+|   ↳ `segments` | array (nullable) | Segment IDs |
 |   ↳ `directPermissions` | array | Direct permissions |
 |     ↳ `rights` | array | Rights granted on the target |
 |     ↳ `target` | string | Permission target |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint Get Access Request Config
 
@@ -245,19 +245,19 @@ Get tenant access-request, request-on-behalf-of, and machine-identity configurat
 |     ↳ `accessRequestConfig` | object | Entitlement grant request configuration |
 |       ↳ `approvalSchemes` | array | Ordered approval schemes |
 |         ↳ `approverType` | string | ENTITLEMENT_OWNER, SOURCE_OWNER, MANAGER, GOVERNANCE_GROUP, or WORKFLOW |
-|         ↳ `approverId` | string | Governance group or workflow approver ID |
+|         ↳ `approverId` | string (nullable) | Governance group or workflow approver ID |
 |       ↳ `requestCommentRequired` | boolean | Whether a request comment is required |
 |       ↳ `denialCommentRequired` | boolean | Whether a denial comment is required |
 |       ↳ `reauthorizationRequired` | boolean | Whether reauthorization is required |
 |       ↳ `requireEndDate` | boolean | Whether an end date is required |
-|       ↳ `maxPermittedAccessDuration` | object | Maximum permitted access duration |
+|       ↳ `maxPermittedAccessDuration` | object (nullable) | Maximum permitted access duration |
 |         ↳ `value` | number | Duration value |
 |         ↳ `timeUnit` | string | HOURS, DAYS, WEEKS, or MONTHS |
-|       ↳ `formDefinitionId` | string | Request form definition ID |
+|       ↳ `formDefinitionId` | string (nullable) | Request form definition ID |
 |     ↳ `revocationRequestConfig` | object | Entitlement revocation request configuration |
 |       ↳ `approvalSchemes` | array | Ordered revocation approval schemes |
 |         ↳ `approverType` | string | ENTITLEMENT_OWNER, SOURCE_OWNER, MANAGER, GOVERNANCE_GROUP, or WORKFLOW |
-|         ↳ `approverId` | string | Governance group or workflow approver ID |
+|         ↳ `approverId` | string (nullable) | Governance group or workflow approver ID |
 |   ↳ `govGroupVisibilityEnabled` | boolean | Whether governance group visibility is enabled |
 |   ↳ `machineIdentityAccessRequestEnabled` | boolean | Whether machine identity access requests are enabled |
 
@@ -320,7 +320,7 @@ List requested-item status records for access requests.
 |   ↳ `jitDetails` | array | Just-in-time access details |
 |   ↳ `form` | json | Completed request form |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint Get Account
 
@@ -365,7 +365,7 @@ Get an account from the current /accounts/v1 service by ID.
 |   ↳ `hasEntitlements` | boolean | Whether the account has entitlements |
 |   ↳ `identity` | json | Correlated identity reference |
 |   ↳ `sourceOwner` | json | Source owner reference |
-|   ↳ `features` | string | Account features |
+|   ↳ `features` | string (nullable) | Account features |
 |   ↳ `origin` | string | Account origin |
 |   ↳ `ownerIdentity` | json | Owner identity reference |
 
@@ -428,19 +428,19 @@ List entitlements granted to one account.
 |   ↳ `attribute` | string | Source entitlement attribute |
 |   ↳ `value` | string | Source entitlement value |
 |   ↳ `sourceSchemaObjectType` | string | Source schema object type |
-|   ↳ `description` | string | Entitlement description |
+|   ↳ `description` | string (nullable) | Entitlement description |
 |   ↳ `privileged` | boolean | Whether the entitlement is privileged |
 |   ↳ `cloudGoverned` | boolean | Whether SailPoint governs the entitlement |
 |   ↳ `requestable` | boolean | Whether the entitlement is requestable |
-|   ↳ `owner` | object | Primary owner reference |
+|   ↳ `owner` | object (nullable) | Primary owner reference |
 |     ↳ `id` | string | Identity ID |
 |     ↳ `type` | string | IDENTITY |
 |     ↳ `name` | string | Identity display name |
-|   ↳ `additionalOwners` | array | Additional owner references |
+|   ↳ `additionalOwners` | array (nullable) | Additional owner references |
 |     ↳ `type` | string | IDENTITY or GOVERNANCE_GROUP |
 |     ↳ `id` | string | Identity or governance-group ID |
-|     ↳ `name` | string | Display name |
-|   ↳ `manuallyUpdatedFields` | json | Fields manually updated in SailPoint |
+|     ↳ `name` | string (nullable) | Display name |
+|   ↳ `manuallyUpdatedFields` | json (nullable) | Fields manually updated in SailPoint |
 |   ↳ `accessModelMetadata` | object | Access-model metadata |
 |     ↳ `attributes` | array | Access-model metadata attributes |
 |       ↳ `key` | string | Metadata type identifier |
@@ -461,12 +461,12 @@ List entitlements granted to one account.
 |     ↳ `type` | string | SOURCE |
 |     ↳ `name` | string | Source name |
 |   ↳ `attributes` | json | Source-defined entitlement attributes |
-|   ↳ `segments` | array | Segment IDs |
+|   ↳ `segments` | array (nullable) | Segment IDs |
 |   ↳ `directPermissions` | array | Direct permissions |
 |     ↳ `rights` | array | Rights granted on the target |
 |     ↳ `target` | string | Permission target |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint Get Account Selections
 
@@ -494,7 +494,7 @@ Resolve eligible source accounts before submitting a machine or multi-account ac
 |     ↳ `requestedItems` | array | Requested items and their eligible accounts |
 |       ↳ `description` | string | Requested item description |
 |       ↳ `accountsSelectionBlocked` | boolean | Whether account selection is blocked |
-|       ↳ `accountsSelectionBlockedReason` | string | Provider reason account selection is blocked |
+|       ↳ `accountsSelectionBlockedReason` | string (nullable) | Provider reason account selection is blocked |
 |       ↳ `type` | string | ACCESS_PROFILE, ROLE, or ENTITLEMENT |
 |       ↳ `id` | string | Requested item ID |
 |       ↳ `name` | string | Requested item name |
@@ -615,21 +615,21 @@ Get an entitlement by ID.
 |   ↳ `attribute` | string | Source entitlement attribute |
 |   ↳ `value` | string | Source entitlement value |
 |   ↳ `sourceSchemaObjectType` | string | Source schema object type |
-|   ↳ `description` | string | Entitlement description |
-|   ↳ `privilegeLevel` | object | Privilege-level details |
+|   ↳ `description` | string (nullable) | Entitlement description |
+|   ↳ `privilegeLevel` | object (nullable) | Privilege-level details |
 |     ↳ `direct` | string | Direct privilege level assigned to the entitlement |
 |     ↳ `setBy` | string | User or process that set the privilege level |
-|     ↳ `setByType` | string | Method by which the privilege level was set |
-|     ↳ `inherited` | string | Inherited privilege level on the entitlement |
+|     ↳ `setByType` | string (nullable) | Method by which the privilege level was set |
+|     ↳ `inherited` | string (nullable) | Inherited privilege level on the entitlement |
 |     ↳ `effective` | string | Effective privilege level assigned to the entitlement |
-|   ↳ `tags` | array | Entitlement tags |
+|   ↳ `tags` | array (nullable) | Entitlement tags |
 |   ↳ `cloudGoverned` | boolean | Whether SailPoint governs the entitlement |
 |   ↳ `requestable` | boolean | Whether the entitlement is requestable |
-|   ↳ `owner` | object | Primary owner reference |
+|   ↳ `owner` | object (nullable) | Primary owner reference |
 |     ↳ `id` | string | Identity ID |
 |     ↳ `type` | string | IDENTITY |
 |     ↳ `name` | string | Identity display name |
-|   ↳ `manuallyUpdatedFields` | json | Fields manually updated in SailPoint |
+|   ↳ `manuallyUpdatedFields` | json (nullable) | Fields manually updated in SailPoint |
 |   ↳ `accessModelMetadata` | object | Access-model metadata |
 |     ↳ `attributes` | array | Access-model metadata attributes |
 |       ↳ `key` | string | Metadata type identifier |
@@ -650,7 +650,7 @@ Get an entitlement by ID.
 |     ↳ `type` | string | SOURCE |
 |     ↳ `name` | string | Source name |
 |   ↳ `attributes` | json | Source-defined entitlement attributes |
-|   ↳ `segments` | array | Segment IDs |
+|   ↳ `segments` | array (nullable) | Segment IDs |
 |   ↳ `directPermissions` | array | Direct permissions |
 |     ↳ `rights` | array | Rights granted on the target |
 |     ↳ `target` | string | Permission target |
@@ -676,19 +676,19 @@ Get grant, revocation, duration, approval, and form settings for an entitlement.
 |   ↳ `accessRequestConfig` | object | Entitlement grant request configuration |
 |     ↳ `approvalSchemes` | array | Ordered approval schemes |
 |       ↳ `approverType` | string | ENTITLEMENT_OWNER, SOURCE_OWNER, MANAGER, GOVERNANCE_GROUP, or WORKFLOW |
-|       ↳ `approverId` | string | Governance group or workflow approver ID |
+|       ↳ `approverId` | string (nullable) | Governance group or workflow approver ID |
 |     ↳ `requestCommentRequired` | boolean | Whether a request comment is required |
 |     ↳ `denialCommentRequired` | boolean | Whether a denial comment is required |
 |     ↳ `reauthorizationRequired` | boolean | Whether reauthorization is required |
 |     ↳ `requireEndDate` | boolean | Whether an end date is required |
-|     ↳ `maxPermittedAccessDuration` | object | Maximum permitted access duration |
+|     ↳ `maxPermittedAccessDuration` | object (nullable) | Maximum permitted access duration |
 |       ↳ `value` | number | Duration value |
 |       ↳ `timeUnit` | string | HOURS, DAYS, WEEKS, or MONTHS |
-|     ↳ `formDefinitionId` | string | Request form definition ID |
+|     ↳ `formDefinitionId` | string (nullable) | Request form definition ID |
 |   ↳ `revocationRequestConfig` | object | Entitlement revocation request configuration |
 |     ↳ `approvalSchemes` | array | Ordered revocation approval schemes |
 |       ↳ `approverType` | string | ENTITLEMENT_OWNER, SOURCE_OWNER, MANAGER, GOVERNANCE_GROUP, or WORKFLOW |
-|       ↳ `approverId` | string | Governance group or workflow approver ID |
+|       ↳ `approverId` | string (nullable) | Governance group or workflow approver ID |
 
 ### SailPoint Get Identity
 
@@ -789,19 +789,19 @@ List entitlements in one role using the current non-experimental roles service.
 |   ↳ `attribute` | string | Source entitlement attribute |
 |   ↳ `value` | string | Source entitlement value |
 |   ↳ `sourceSchemaObjectType` | string | Source schema object type |
-|   ↳ `description` | string | Entitlement description |
+|   ↳ `description` | string (nullable) | Entitlement description |
 |   ↳ `privileged` | boolean | Whether the entitlement is privileged |
 |   ↳ `cloudGoverned` | boolean | Whether SailPoint governs the entitlement |
 |   ↳ `requestable` | boolean | Whether the entitlement is requestable |
-|   ↳ `owner` | object | Primary owner reference |
+|   ↳ `owner` | object (nullable) | Primary owner reference |
 |     ↳ `id` | string | Identity ID |
 |     ↳ `type` | string | IDENTITY |
 |     ↳ `name` | string | Identity display name |
-|   ↳ `additionalOwners` | array | Additional owner references |
+|   ↳ `additionalOwners` | array (nullable) | Additional owner references |
 |     ↳ `type` | string | IDENTITY or GOVERNANCE_GROUP |
 |     ↳ `id` | string | Identity or governance-group ID |
-|     ↳ `name` | string | Display name |
-|   ↳ `manuallyUpdatedFields` | json | Fields manually updated in SailPoint |
+|     ↳ `name` | string (nullable) | Display name |
+|   ↳ `manuallyUpdatedFields` | json (nullable) | Fields manually updated in SailPoint |
 |   ↳ `accessModelMetadata` | object | Access-model metadata |
 |     ↳ `attributes` | array | Access-model metadata attributes |
 |       ↳ `key` | string | Metadata type identifier |
@@ -822,12 +822,12 @@ List entitlements in one role using the current non-experimental roles service.
 |     ↳ `type` | string | SOURCE |
 |     ↳ `name` | string | Source name |
 |   ↳ `attributes` | json | Source-defined entitlement attributes |
-|   ↳ `segments` | array | Segment IDs |
+|   ↳ `segments` | array (nullable) | Segment IDs |
 |   ↳ `directPermissions` | array | Direct permissions |
 |     ↳ `rights` | array | Rights granted on the target |
 |     ↳ `target` | string | Permission target |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint Get Source
 
@@ -901,36 +901,36 @@ Get the current status of a SailPoint background task by ID.
 |   ↳ `type` | string | Task type |
 |   ↳ `uniqueName` | string | Task unique name |
 |   ↳ `description` | string | Task description |
-|   ↳ `parentName` | string | Parent task name |
+|   ↳ `parentName` | string (nullable) | Parent task name |
 |   ↳ `launcher` | string | Task launcher |
-|   ↳ `target` | object | Task target |
+|   ↳ `target` | object (nullable) | Task target |
 |     ↳ `id` | string | Target ID |
-|     ↳ `type` | string | APPLICATION or IDENTITY |
+|     ↳ `type` | string (nullable) | APPLICATION or IDENTITY |
 |     ↳ `name` | string | Target name |
 |   ↳ `created` | string | Creation timestamp |
-|   ↳ `modified` | string | Last modification timestamp |
-|   ↳ `launched` | string | Launch timestamp |
-|   ↳ `completed` | string | Completion timestamp |
-|   ↳ `completionStatus` | string | Task completion status |
+|   ↳ `modified` | string (nullable) | Last modification timestamp |
+|   ↳ `launched` | string (nullable) | Launch timestamp |
+|   ↳ `completed` | string (nullable) | Completion timestamp |
+|   ↳ `completionStatus` | string (nullable) | Task completion status |
 |   ↳ `messages` | array | Task messages |
 |     ↳ `type` | string | INFO, WARN, or ERROR |
-|     ↳ `localizedText` | object | Localized task message |
+|     ↳ `localizedText` | object (nullable) | Localized task message |
 |       ↳ `locale` | string | Message locale |
 |       ↳ `message` | string | Message text |
 |     ↳ `key` | string | Message key |
-|     ↳ `parameters` | array | Internationalization parameters |
+|     ↳ `parameters` | array (nullable) | Internationalization parameters |
 |   ↳ `returns` | array | Task return descriptors |
 |     ↳ `name` | string | Return value display name |
 |     ↳ `attributeName` | string | Task attribute name |
 |   ↳ `attributes` | json | Task-specific attributes |
-|   ↳ `progress` | string | Human-readable progress |
+|   ↳ `progress` | string (nullable) | Human-readable progress |
 |   ↳ `percentComplete` | number | Completion percentage |
 |   ↳ `taskDefinitionSummary` | object | Task definition summary |
 |     ↳ `id` | string | Task-definition ID |
 |     ↳ `uniqueName` | string | Task-definition unique name |
-|     ↳ `description` | string | Task-definition description |
+|     ↳ `description` | string (nullable) | Task-definition description |
 |     ↳ `parentName` | string | Parent task-definition name |
-|     ↳ `executor` | string | Task-definition executor |
+|     ↳ `executor` | string (nullable) | Task-definition executor |
 |     ↳ `arguments` | json | Task-definition arguments |
 
 ### SailPoint List Access Profiles
@@ -975,7 +975,7 @@ List access profiles with current visibility and segmentation controls.
 |   ↳ `provisioningCriteria` | json | Multi-account provisioning criteria |
 |   ↳ `additionalOwners` | array | Additional owner references |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Account Activities
 
@@ -1017,7 +1017,7 @@ List provisioning activities with identity, filter, sort, and page controls.
 |   ↳ `executionStatus` | string | Execution status |
 |   ↳ `clientMetadata` | json | Caller-provided string metadata |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Accounts
 
@@ -1067,11 +1067,11 @@ List accounts with documented filtering, sorting, detail, and pagination.
 |   ↳ `hasEntitlements` | boolean | Whether the account has entitlements |
 |   ↳ `identity` | json | Correlated identity reference |
 |   ↳ `sourceOwner` | json | Source owner reference |
-|   ↳ `features` | string | Account features |
+|   ↳ `features` | string (nullable) | Account features |
 |   ↳ `origin` | string | Account origin |
 |   ↳ `ownerIdentity` | json | Owner identity reference |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Campaigns
 
@@ -1120,7 +1120,7 @@ List certification campaigns with detail, filtering, sorting, and pagination.
 |   ↳ `machineAccountCampaignInfo` | json | Machine-account campaign configuration |
 |   ↳ `sourcesWithOrphanEntitlements` | array | Sources containing orphan entitlements |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Certification Review Items
 
@@ -1156,7 +1156,7 @@ List access-review items in one identity certification.
 |   ↳ `decision` | string | Current certification decision |
 |   ↳ `comments` | string | Reviewer comments |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Certifications
 
@@ -1199,7 +1199,7 @@ List identity certifications assigned to a reviewer.
 |   ↳ `errorMessage` | string | Certification error message |
 |   ↳ `phase` | string | Certification phase |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Entitlements
 
@@ -1232,21 +1232,21 @@ List entitlements with current segmentation, cursor, filter, and page controls.
 |   ↳ `attribute` | string | Source entitlement attribute |
 |   ↳ `value` | string | Source entitlement value |
 |   ↳ `sourceSchemaObjectType` | string | Source schema object type |
-|   ↳ `description` | string | Entitlement description |
-|   ↳ `privilegeLevel` | object | Privilege-level details |
+|   ↳ `description` | string (nullable) | Entitlement description |
+|   ↳ `privilegeLevel` | object (nullable) | Privilege-level details |
 |     ↳ `direct` | string | Direct privilege level assigned to the entitlement |
 |     ↳ `setBy` | string | User or process that set the privilege level |
-|     ↳ `setByType` | string | Method by which the privilege level was set |
-|     ↳ `inherited` | string | Inherited privilege level on the entitlement |
+|     ↳ `setByType` | string (nullable) | Method by which the privilege level was set |
+|     ↳ `inherited` | string (nullable) | Inherited privilege level on the entitlement |
 |     ↳ `effective` | string | Effective privilege level assigned to the entitlement |
-|   ↳ `tags` | array | Entitlement tags |
+|   ↳ `tags` | array (nullable) | Entitlement tags |
 |   ↳ `cloudGoverned` | boolean | Whether SailPoint governs the entitlement |
 |   ↳ `requestable` | boolean | Whether the entitlement is requestable |
-|   ↳ `owner` | object | Primary owner reference |
+|   ↳ `owner` | object (nullable) | Primary owner reference |
 |     ↳ `id` | string | Identity ID |
 |     ↳ `type` | string | IDENTITY |
 |     ↳ `name` | string | Identity display name |
-|   ↳ `manuallyUpdatedFields` | json | Fields manually updated in SailPoint |
+|   ↳ `manuallyUpdatedFields` | json (nullable) | Fields manually updated in SailPoint |
 |   ↳ `accessModelMetadata` | object | Access-model metadata |
 |     ↳ `attributes` | array | Access-model metadata attributes |
 |       ↳ `key` | string | Metadata type identifier |
@@ -1267,12 +1267,12 @@ List entitlements with current segmentation, cursor, filter, and page controls.
 |     ↳ `type` | string | SOURCE |
 |     ↳ `name` | string | Source name |
 |   ↳ `attributes` | json | Source-defined entitlement attributes |
-|   ↳ `segments` | array | Segment IDs |
+|   ↳ `segments` | array (nullable) | Segment IDs |
 |   ↳ `directPermissions` | array | Direct permissions |
 |     ↳ `rights` | array | Rights granted on the target |
 |     ↳ `target` | string | Permission target |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Identities
 
@@ -1311,7 +1311,7 @@ List identities with documented filtering, sorting, and pagination.
 |   ↳ `attributes` | json | Tenant-defined identity attributes |
 |   ↳ `lifecycleState` | json | Lifecycle-state reference |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Identity Entitlements
 
@@ -1337,7 +1337,7 @@ List tagged entitlement references held by one identity.
 |   ↳ `objectRef` | json | Tagged entitlement reference |
 |   ↳ `tags` | array | Tags applied to the entitlement |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Pending Access Request Approvals
 
@@ -1393,7 +1393,7 @@ List pending access-request approvals visible to the caller.
 |   ↳ `jitDetails` | array | Just-in-time access details |
 |   ↳ `form` | json | Completed request form |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Roles
 
@@ -1441,7 +1441,7 @@ List roles with current visibility, segmentation, filtering, and pagination cont
 |   ↳ `accessModelMetadata` | json | Access-model metadata |
 |   ↳ `privilegeLevel` | string | Role privilege level |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint List Sources
 
@@ -1499,7 +1499,7 @@ List identity sources with visibility, filtering, sorting, and pagination contro
 |   ↳ `credentialProviderEnabled` | boolean | Whether a credential provider is enabled |
 |   ↳ `category` | string | Source category |
 | `count` | number | Number of records returned in this page |
-| `totalCount` | number | Total matching records when count=true |
+| `totalCount` | number (nullable) | Total matching records when count=true |
 
 ### SailPoint Load Accounts
 
@@ -1528,17 +1528,17 @@ Start account aggregation for a source, optionally using a CSV file.
 |   ↳ `description` | string | Task description |
 |   ↳ `launcher` | string | Task launcher |
 |   ↳ `created` | string | Creation timestamp |
-|   ↳ `launched` | string | Launch timestamp |
-|   ↳ `completed` | string | Completion timestamp |
-|   ↳ `completionStatus` | string | Task completion status |
-|   ↳ `parentName` | string | Parent task name |
+|   ↳ `launched` | string (nullable) | Launch timestamp |
+|   ↳ `completed` | string (nullable) | Completion timestamp |
+|   ↳ `completionStatus` | string (nullable) | Task completion status |
+|   ↳ `parentName` | string (nullable) | Parent task name |
 |   ↳ `messages` | array | Task messages |
 |     ↳ `type` | string | INFO, WARN, or ERROR |
 |     ↳ `error` | boolean | Whether the message is an error |
 |     ↳ `warning` | boolean | Whether the message is a warning |
 |     ↳ `key` | string | Message key |
 |     ↳ `localizedText` | string | Localized message text |
-|   ↳ `progress` | string | Human-readable progress |
+|   ↳ `progress` | string (nullable) | Human-readable progress |
 |   ↳ `attributes` | json | Task-specific attributes |
 |   ↳ `returns` | array | Task return descriptors |
 |     ↳ `displayLabel` | string | Return value display label |
@@ -1669,7 +1669,7 @@ Search current SailPoint indices with every documented search query mode.
 | --------- | ---- | ----------- |
 | `results` | array | Index-dependent search documents |
 | `count` | number | Documents returned in this page |
-| `totalCount` | number | Total matching documents when count=true |
+| `totalCount` | number (nullable) | Total matching documents when count=true |
 
 ### SailPoint Search Aggregate
 
@@ -1708,7 +1708,7 @@ Run an Elasticsearch DSL or SailPoint aggregation over current search indices.
 | --------- | ---- | ----------- |
 | `aggregations` | json | Dynamic Elasticsearch aggregation result document |
 | `hits` | array | Index-dependent aggregation hits |
-| `totalCount` | number | Total matching documents when count=true |
+| `totalCount` | number (nullable) | Total matching documents when count=true |
 
 ### SailPoint Search Count
 
@@ -1779,5 +1779,3 @@ Sign off a completed identity certification.
 |   ↳ `hasErrors` | boolean | Whether the certification has errors |
 |   ↳ `errorMessage` | string | Certification error message |
 |   ↳ `phase` | string | Certification phase |
-
-

--- a/apps/docs/content/docs/integrations/salesforce.mdx
+++ b/apps/docs/content/docs/integrations/salesforce.mdx
@@ -5,7 +5,7 @@ description: Interact with Salesforce CRM
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="salesforce"
   color="#FFFFFF"
 />
@@ -1083,8 +1083,6 @@ Execute a SOQL query against the Tooling API to inspect metadata objects
 |     ↳ `hasMore` | boolean | Whether more records exist \(inverse of done\) |
 |   ↳ `success` | boolean | Salesforce operation success |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1280,4 +1278,3 @@ Trigger workflow on any Salesforce webhook event
 | `timestamp` | string | When the event occurred \(ISO 8601\) |
 | `record` | json | Full record data |
 | `payload` | json | Full webhook payload |
-

--- a/apps/docs/content/docs/integrations/sap_concur.mdx
+++ b/apps/docs/content/docs/integrations/sap_concur.mdx
@@ -5,7 +5,7 @@ description: Manage expense reports, travel requests, cash advances, and more in
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sap_concur"
   color="#FFFFFF"
 />
@@ -2805,5 +2805,3 @@ Upload an image-only receipt (POST /receipts/v4/users/\{userId\}/image-only-rece
 | `data` | json | Image-only receipt upload response \(HTTP 202 Accepted; Location and Link response headers exposed in body\) |
 |   ↳ `location` | string | Location header URL for the new receipt image \(e.g. /receipts/v4/images/\{receiptId\}\) |
 |   ↳ `link` | string | Raw Link header value, forwarded verbatim — it is not a bare URL. Format: &lt;https://\{datacenter\}/receipts/v4/status/\{receiptId\}&gt;; rel="processing-status". Parse the href out of the angle brackets before using it. |
-
-

--- a/apps/docs/content/docs/integrations/sap_s4hana.mdx
+++ b/apps/docs/content/docs/integrations/sap_s4hana.mdx
@@ -5,7 +5,7 @@ description: Read and write SAP S4HANA Cloud business data via OData
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sap_s4hana"
   color="#FFFFFF"
 />
@@ -1799,5 +1799,3 @@ Make an arbitrary OData v2 call against any SAP S/4HANA Cloud whitelisted Commun
 | --------- | ---- | ----------- |
 | `status` | number | HTTP status code returned by SAP |
 | `data` | json | Parsed OData payload \(entity, collection, or null on 204\) |
-
-

--- a/apps/docs/content/docs/integrations/secrets_manager.mdx
+++ b/apps/docs/content/docs/integrations/secrets_manager.mdx
@@ -5,7 +5,7 @@ description: Connect to AWS Secrets Manager
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="secrets_manager"
   color="linear-gradient(45deg, #BD0816 0%, #FF5252 100%)"
 />
@@ -280,5 +280,3 @@ Start or reconfigure rotation for a secret in AWS Secrets Manager
 | `name` | string | Name of the secret |
 | `arn` | string | ARN of the secret |
 | `versionId` | string | ID of the new secret version created by rotation |
-
-

--- a/apps/docs/content/docs/integrations/semrush.mdx
+++ b/apps/docs/content/docs/integrations/semrush.mdx
@@ -5,7 +5,7 @@ description: Research SEO and paid search data with Semrush
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="semrush"
   color="#FFFFFF"
 />
@@ -48,15 +48,15 @@ Get the Semrush rank plus organic and paid search totals for a domain in one reg
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `overview` | json | Organic and paid search overview for the domain |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
+| `overview` | json (nullable) | Organic and paid search overview for the domain |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
 
 ### Semrush Domain Overview (All Databases)
 
@@ -79,17 +79,17 @@ Get organic and paid search totals for a domain across every regional Semrush da
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `databases` | array | One row of domain totals per regional database |
-|   ↳ `database` | string | Regional database the row belongs to |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
-|   ↳ `plaKeywords` | number | Keywords used for product listing ads |
-|   ↳ `plaUniques` | number | Number of unique product listing ads |
+|   ↳ `database` | string (nullable) | Regional database the row belongs to |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
+|   ↳ `plaKeywords` | number (nullable) | Keywords used for product listing ads |
+|   ↳ `plaUniques` | number (nullable) | Number of unique product listing ads |
 
 ### Semrush Domain Overview History
 
@@ -112,14 +112,14 @@ Get the historical trend of a domain rank plus its organic and paid search total
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `history` | array | Historical data points, in the requested sort order |
-|   ↳ `date` | string | Data collection date in YYYYMMDD or YYYYMM format |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
+|   ↳ `date` | string (nullable) | Data collection date in YYYYMMDD or YYYYMM format |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
 
 ### Semrush Domain Organic Keywords
 
@@ -144,19 +144,19 @@ List the keywords a domain ranks for in Google organic search, with position, vo
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Organic keywords the domain ranks for |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `previousPosition` | number | Position held at the previous data collection |
-|   ↳ `positionDifference` | number | Change between the previous and the current position |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `trafficPercent` | number | Share of the traffic to the target driven by this keyword |
-|   ↳ `traffic` | number | Estimated traffic driven by this keyword |
-|   ↳ `trafficCost` | number | Share of the traffic cost of the target attributed to this keyword |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `previousPosition` | number (nullable) | Position held at the previous data collection |
+|   ↳ `positionDifference` | number (nullable) | Change between the previous and the current position |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `trafficPercent` | number (nullable) | Share of the traffic to the target driven by this keyword |
+|   ↳ `traffic` | number (nullable) | Estimated traffic driven by this keyword |
+|   ↳ `trafficCost` | number (nullable) | Share of the traffic cost of the target attributed to this keyword |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
 
@@ -182,21 +182,21 @@ List the keywords a domain buys in Google Ads, with ad position, copy, and traff
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Paid keywords the domain bids on |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `previousPosition` | number | Position held at the previous data collection |
-|   ↳ `positionDifference` | number | Change between the previous and the current position |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `visibleUrl` | string | Display URL shown in the ad |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `description` | string | Ad text |
-|   ↳ `traffic` | number | Estimated traffic driven by this keyword |
-|   ↳ `trafficPercent` | number | Share of the traffic to the target driven by this keyword |
-|   ↳ `trafficCost` | number | Estimated traffic cost attributed to this keyword |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `previousPosition` | number (nullable) | Position held at the previous data collection |
+|   ↳ `positionDifference` | number (nullable) | Change between the previous and the current position |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `visibleUrl` | string (nullable) | Display URL shown in the ad |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `description` | string (nullable) | Ad text |
+|   ↳ `traffic` | number (nullable) | Estimated traffic driven by this keyword |
+|   ↳ `trafficPercent` | number (nullable) | Share of the traffic to the target driven by this keyword |
+|   ↳ `trafficCost` | number (nullable) | Estimated traffic cost attributed to this keyword |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
 
 ### Semrush Domain Ad Copies
 
@@ -219,11 +219,11 @@ List the unique Google Ads creatives a domain runs, with title, description, and
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `ads` | array | Unique ad creatives the domain runs |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `description` | string | Ad text |
-|   ↳ `visibleUrl` | string | Display URL shown in the ad |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `numberOfKeywords` | number | Number of keywords the ad runs on |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `description` | string (nullable) | Ad text |
+|   ↳ `visibleUrl` | string (nullable) | Display URL shown in the ad |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `numberOfKeywords` | number (nullable) | Number of keywords the ad runs on |
 
 ### Semrush Domain Ad History
 
@@ -246,16 +246,16 @@ List a domain past Google Ads placements month by month, with the copy used each
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `ads` | array | Historical ad placements, one row per keyword and month |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `date` | string | Data collection date in YYYYMMDD or YYYYMM format |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `trafficPercent` | number | Share of the traffic to the target driven by this keyword |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `description` | string | Ad text |
-|   ↳ `visibleUrl` | string | Display URL shown in the ad |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `date` | string (nullable) | Data collection date in YYYYMMDD or YYYYMM format |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `trafficPercent` | number (nullable) | Share of the traffic to the target driven by this keyword |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `description` | string (nullable) | Ad text |
+|   ↳ `visibleUrl` | string (nullable) | Display URL shown in the ad |
 
 ### Semrush Organic Competitors
 
@@ -278,13 +278,13 @@ List the domains competing with a target domain in Google organic search results
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `competitors` | array | Competing domains ranked by competitor relevance |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `competitorRelevance` | number | Competition level based on the total keyword count of each domain |
-|   ↳ `commonKeywords` | number | Keywords both domains rank for in the top 100 organic results |
-|   ↳ `organicKeywords` | number | Keywords this competing domain ranks for in the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic this competing domain gets from the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of this competing domain organic keywords |
-|   ↳ `paidKeywords` | number | Keywords this competing domain is buying in Google Ads |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `competitorRelevance` | number (nullable) | Competition level based on the total keyword count of each domain |
+|   ↳ `commonKeywords` | number (nullable) | Keywords both domains rank for in the top 100 organic results |
+|   ↳ `organicKeywords` | number (nullable) | Keywords this competing domain ranks for in the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic this competing domain gets from the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of this competing domain organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords this competing domain is buying in Google Ads |
 
 ### Semrush Paid Competitors
 
@@ -307,13 +307,13 @@ List the domains competing with a target domain in Google paid search results.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `competitors` | array | Competing advertisers ranked by competitor relevance |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `competitorRelevance` | number | Competition level based on the total keyword count of each domain |
-|   ↳ `commonKeywords` | number | Keywords both domains rank for in the top 100 organic results |
-|   ↳ `paidKeywords` | number | Keywords this competing domain is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic this competing domain gets from paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget of this competing domain |
-|   ↳ `organicKeywords` | number | Keywords this competing domain ranks for in the Google top 100 organic results |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `competitorRelevance` | number (nullable) | Competition level based on the total keyword count of each domain |
+|   ↳ `commonKeywords` | number (nullable) | Keywords both domains rank for in the top 100 organic results |
+|   ↳ `paidKeywords` | number (nullable) | Keywords this competing domain is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic this competing domain gets from paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget of this competing domain |
+|   ↳ `organicKeywords` | number (nullable) | Keywords this competing domain ranks for in the Google top 100 organic results |
 
 ### Semrush Domain PLA Keywords
 
@@ -336,16 +336,16 @@ List the keywords that trigger a domain product listing ads, with the promoted p
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Product listing ad keywords for the domain |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `previousPosition` | number | Position held at the previous data collection |
-|   ↳ `positionDifference` | number | Change between the previous and the current position |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `shopName` | string | Name of the shop running the product listing ad |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `productPrice` | number | Price of the promoted product |
-|   ↳ `timestamp` | number | Unix timestamp of the data point |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `previousPosition` | number (nullable) | Position held at the previous data collection |
+|   ↳ `positionDifference` | number (nullable) | Change between the previous and the current position |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `shopName` | string (nullable) | Name of the shop running the product listing ad |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `productPrice` | number (nullable) | Price of the promoted product |
+|   ↳ `timestamp` | number (nullable) | Unix timestamp of the data point |
 
 ### Semrush Domain PLA Copies
 
@@ -366,10 +366,10 @@ List the unique product listing ads a domain runs, with product title, price, an
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `ads` | array | Unique product listing ads the domain runs |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `productPrice` | number | Price of the promoted product |
-|   ↳ `shopName` | string | Name of the shop running the product listing ad |
-|   ↳ `url` | string | URL of the ranking or advertised page |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `productPrice` | number (nullable) | Price of the promoted product |
+|   ↳ `shopName` | string (nullable) | Name of the shop running the product listing ad |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
 
 ### Semrush Domain vs. Domain
 
@@ -394,11 +394,11 @@ Compare up to five domains on the keywords they rank for, returning each domain 
 | --------- | ---- | ----------- |
 | `domains` | array | The compared domains, in the order their positions appear |
 | `keywords` | array | Keywords with each compared domain position |
-|   ↳ `keyword` | string | Keyword phrase |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
 |   ↳ `positions` | json | Position of each compared domain, keyed by domain, where 0 means not ranked |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
 
 ### Semrush Subdomain Overview
 
@@ -417,15 +417,15 @@ Get the organic and paid search totals for a subdomain in one regional database.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `overview` | json | Organic and paid search overview for the subdomain |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
+| `overview` | json (nullable) | Organic and paid search overview for the subdomain |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
 
 ### Semrush Subdomain Overview (All Databases)
 
@@ -448,17 +448,17 @@ Get organic and paid search totals for a subdomain across every regional Semrush
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `databases` | array | One row of subdomain totals per regional database |
-|   ↳ `database` | string | Regional database the row belongs to |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
-|   ↳ `plaKeywords` | number | Keywords used for product listing ads |
-|   ↳ `plaUniques` | number | Number of unique product listing ads |
+|   ↳ `database` | string (nullable) | Regional database the row belongs to |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
+|   ↳ `plaKeywords` | number (nullable) | Keywords used for product listing ads |
+|   ↳ `plaUniques` | number (nullable) | Number of unique product listing ads |
 
 ### Semrush Subdomain Overview History
 
@@ -481,14 +481,14 @@ Get the historical trend of a subdomain organic and paid search totals.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `history` | array | Historical data points, in the requested sort order |
-|   ↳ `date` | string | Data collection date in YYYYMMDD or YYYYMM format |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
+|   ↳ `date` | string (nullable) | Data collection date in YYYYMMDD or YYYYMM format |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
 
 ### Semrush Subdomain Organic Keywords
 
@@ -513,19 +513,19 @@ List the keywords a subdomain ranks for in Google organic search.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Organic keywords the subdomain ranks for |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `previousPosition` | number | Position held at the previous data collection |
-|   ↳ `positionDifference` | number | Change between the previous and the current position |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `trafficPercent` | number | Share of the traffic to the target driven by this keyword |
-|   ↳ `traffic` | number | Estimated traffic driven by this keyword |
-|   ↳ `trafficCost` | number | Share of the traffic cost of the target attributed to this keyword |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `previousPosition` | number (nullable) | Position held at the previous data collection |
+|   ↳ `positionDifference` | number (nullable) | Change between the previous and the current position |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `trafficPercent` | number (nullable) | Share of the traffic to the target driven by this keyword |
+|   ↳ `traffic` | number (nullable) | Estimated traffic driven by this keyword |
+|   ↳ `trafficCost` | number (nullable) | Share of the traffic cost of the target attributed to this keyword |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
 
@@ -551,21 +551,21 @@ List the keywords a subdomain buys in Google Ads.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Paid keywords the subdomain bids on |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `previousPosition` | number | Position held at the previous data collection |
-|   ↳ `positionDifference` | number | Change between the previous and the current position |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `visibleUrl` | string | Display URL shown in the ad |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `description` | string | Ad text |
-|   ↳ `traffic` | number | Estimated traffic driven by this keyword |
-|   ↳ `trafficPercent` | number | Share of the traffic to the target driven by this keyword |
-|   ↳ `trafficCost` | number | Estimated traffic cost attributed to this keyword |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `previousPosition` | number (nullable) | Position held at the previous data collection |
+|   ↳ `positionDifference` | number (nullable) | Change between the previous and the current position |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `visibleUrl` | string (nullable) | Display URL shown in the ad |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `description` | string (nullable) | Ad text |
+|   ↳ `traffic` | number (nullable) | Estimated traffic driven by this keyword |
+|   ↳ `trafficPercent` | number (nullable) | Share of the traffic to the target driven by this keyword |
+|   ↳ `trafficCost` | number (nullable) | Estimated traffic cost attributed to this keyword |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
 
 ### Semrush Subdomain Ad Copies
 
@@ -588,11 +588,11 @@ List the unique Google Ads creatives a subdomain runs.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `ads` | array | Unique ad creatives the subdomain runs |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `description` | string | Ad text |
-|   ↳ `visibleUrl` | string | Display URL shown in the ad |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `numberOfKeywords` | number | Number of keywords the ad runs on |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `description` | string (nullable) | Ad text |
+|   ↳ `visibleUrl` | string (nullable) | Display URL shown in the ad |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `numberOfKeywords` | number (nullable) | Number of keywords the ad runs on |
 
 ### Semrush URL Overview
 
@@ -611,15 +611,15 @@ Get the organic and paid search totals for a single URL in one regional database
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `overview` | json | Organic and paid search overview for the URL |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
+| `overview` | json (nullable) | Organic and paid search overview for the URL |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
 
 ### Semrush URL Overview (All Databases)
 
@@ -642,17 +642,17 @@ Get organic and paid search totals for a single URL across every regional Semrus
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `databases` | array | One row of URL totals per regional database |
-|   ↳ `database` | string | Regional database the row belongs to |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
-|   ↳ `plaKeywords` | number | Keywords used for product listing ads |
-|   ↳ `plaUniques` | number | Number of unique product listing ads |
+|   ↳ `database` | string (nullable) | Regional database the row belongs to |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
+|   ↳ `plaKeywords` | number (nullable) | Keywords used for product listing ads |
+|   ↳ `plaUniques` | number (nullable) | Number of unique product listing ads |
 
 ### Semrush URL Overview History
 
@@ -675,14 +675,14 @@ Get the historical trend of a URL organic and paid search totals.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `history` | array | Historical data points, in the requested sort order |
-|   ↳ `date` | string | Data collection date in YYYYMMDD or YYYYMM format |
-|   ↳ `rank` | number | Semrush popularity rating of the target, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords bringing users via the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic brought via the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of the organic keywords |
-|   ↳ `paidKeywords` | number | Keywords the target is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic brought via paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget |
+|   ↳ `date` | string (nullable) | Data collection date in YYYYMMDD or YYYYMM format |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of the target, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords bringing users via the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic brought via the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of the organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords the target is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic brought via paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget |
 
 ### Semrush URL Organic Keywords
 
@@ -706,17 +706,17 @@ List the keywords a single URL ranks for in Google organic search.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Organic keywords the URL ranks for |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `previousPosition` | number | Position held at the previous data collection |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
-|   ↳ `trafficPercent` | number | Share of the traffic to the target driven by this keyword |
-|   ↳ `traffic` | number | Estimated traffic driven by this keyword |
-|   ↳ `trafficCost` | number | Estimated traffic cost attributed to this keyword |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `previousPosition` | number (nullable) | Position held at the previous data collection |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `trafficPercent` | number (nullable) | Share of the traffic to the target driven by this keyword |
+|   ↳ `traffic` | number (nullable) | Estimated traffic driven by this keyword |
+|   ↳ `trafficCost` | number (nullable) | Estimated traffic cost attributed to this keyword |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
 
@@ -742,18 +742,18 @@ List the keywords a single URL is advertised on in Google Ads, with the ad copy 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Paid keywords the URL is advertised on |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `traffic` | number | Estimated traffic driven by this keyword |
-|   ↳ `trafficPercent` | number | Share of the traffic to the target driven by this keyword |
-|   ↳ `trafficCost` | number | Estimated traffic cost attributed to this keyword |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `traffic` | number (nullable) | Estimated traffic driven by this keyword |
+|   ↳ `trafficPercent` | number (nullable) | Share of the traffic to the target driven by this keyword |
+|   ↳ `trafficCost` | number (nullable) | Estimated traffic cost attributed to this keyword |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `description` | string | Ad text |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `description` | string (nullable) | Ad text |
 
 ### Semrush Keyword Overview
 
@@ -772,13 +772,13 @@ Get search volume, CPC, competition, difficulty, and intent for a single keyword
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `overview` | json | Keyword metrics in the selected database |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
+| `overview` | json (nullable) | Keyword metrics in the selected database |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
 
@@ -799,15 +799,15 @@ Get search volume, CPC, and competition for a keyword across every regional Semr
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `databases` | array | One row of keyword metrics per regional database |
-|   ↳ `date` | string | Data collection date in YYYYMMDD or YYYYMM format |
-|   ↳ `database` | string | Regional database the row belongs to |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
+|   ↳ `date` | string (nullable) | Data collection date in YYYYMMDD or YYYYMM format |
+|   ↳ `database` | string (nullable) | Regional database the row belongs to |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
 
 ### Semrush Batch Keyword Overview
 
@@ -827,12 +827,12 @@ Get search volume, CPC, competition, difficulty, and intent for up to 100 keywor
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Keyword metrics, one row per submitted keyword |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
 
@@ -853,8 +853,8 @@ Get the Keyword Difficulty Index for up to 100 keywords at once.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Keyword difficulty scores, one row per submitted keyword |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
 
 ### Semrush Related Keywords
 
@@ -877,13 +877,13 @@ Find keywords semantically related to a seed keyword, with volume, difficulty, a
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Related keyword ideas for the seed keyword |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
-|   ↳ `relatedRelevance` | number | Relevance of the result keyword to the seed keyword |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `relatedRelevance` | number (nullable) | Relevance of the result keyword to the seed keyword |
 |   ↳ `keywordSerpFeatures` | array | IDs of all SERP features triggered by the keyword |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
@@ -909,12 +909,12 @@ Find broad-match and phrase-match variations of a seed keyword, with volume and 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Broad match keyword variations of the seed keyword |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
 |   ↳ `keywordSerpFeatures` | array | IDs of all SERP features triggered by the keyword |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
@@ -940,12 +940,12 @@ Find question-form keywords containing a seed keyword, with volume and difficult
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `keywords` | array | Question keywords containing the seed keyword |
-|   ↳ `keyword` | string | Keyword phrase |
-|   ↳ `searchVolume` | number | Average monthly searches for the keyword |
-|   ↳ `cpc` | number | Average cost per click in USD \(Google Ads\) |
-|   ↳ `competition` | number | Competitive density of advertisers bidding on the keyword \(0-1\) |
-|   ↳ `numberOfResults` | number | Total organic results returned for the keyword |
-|   ↳ `keywordDifficulty` | number | Estimated difficulty of ranking for the keyword \(0-100\) |
+|   ↳ `keyword` | string (nullable) | Keyword phrase |
+|   ↳ `searchVolume` | number (nullable) | Average monthly searches for the keyword |
+|   ↳ `cpc` | number (nullable) | Average cost per click in USD \(Google Ads\) |
+|   ↳ `competition` | number (nullable) | Competitive density of advertisers bidding on the keyword \(0-1\) |
+|   ↳ `numberOfResults` | number (nullable) | Total organic results returned for the keyword |
+|   ↳ `keywordDifficulty` | number (nullable) | Estimated difficulty of ranking for the keyword \(0-100\) |
 |   ↳ `intents` | array | Keyword intents: 0 commercial, 1 informational, 2 navigational, 3 transactional |
 |   ↳ `trends` | array | Relative search interest over the last 12 months |
 
@@ -969,10 +969,10 @@ List the domains and URLs ranking in Google organic search results for a keyword
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `results` | array | Ranking pages for the keyword, in SERP order |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `positionType` | string | Whether the position is a regular organic result or a SERP feature |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `url` | string | URL of the ranking or advertised page |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `positionType` | string (nullable) | Whether the position is a regular organic result or a SERP feature |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
 |   ↳ `keywordSerpFeatures` | array | IDs of all SERP features triggered by the keyword |
 |   ↳ `serpFeatures` | array | IDs of the SERP features the domain appears in for the keyword |
 
@@ -996,9 +996,9 @@ List the domains and URLs advertising on a keyword in Google paid search results
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `results` | array | Advertisers appearing for the keyword |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `visibleUrl` | string | Display URL shown in the ad |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `visibleUrl` | string (nullable) | Display URL shown in the ad |
 
 ### Semrush Keyword Ad History
 
@@ -1019,13 +1019,13 @@ List which domains advertised on a keyword month by month, with the copy each on
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `ads` | array | Historical advertisers for the keyword, one row per domain and month |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `date` | string | Data collection date in YYYYMMDD or YYYYMM format |
-|   ↳ `position` | number | Position in the Google top 100 results, where 0 means not ranked |
-|   ↳ `url` | string | URL of the ranking or advertised page |
-|   ↳ `title` | string | Ad or product title |
-|   ↳ `description` | string | Ad text |
-|   ↳ `visibleUrl` | string | Display URL shown in the ad |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `date` | string (nullable) | Data collection date in YYYYMMDD or YYYYMM format |
+|   ↳ `position` | number (nullable) | Position in the Google top 100 results, where 0 means not ranked |
+|   ↳ `url` | string (nullable) | URL of the ranking or advertised page |
+|   ↳ `title` | string (nullable) | Ad or product title |
+|   ↳ `description` | string (nullable) | Ad text |
+|   ↳ `visibleUrl` | string (nullable) | Display URL shown in the ad |
 
 ### Semrush Winners and Losers
 
@@ -1047,20 +1047,20 @@ List the domains that gained or lost the most organic and paid search visibility
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `domains` | array | Domains ranked by change in search visibility |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `rank` | number | Semrush popularity rating of this domain, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords this domain ranks for in the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic this domain gets from the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of this domain organic keywords |
-|   ↳ `paidKeywords` | number | Keywords this domain is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic this domain gets from paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget of this domain |
-|   ↳ `organicKeywordsDifference` | number | Change in organic keyword count since the previous month |
-|   ↳ `organicTrafficDifference` | number | Change in organic traffic since the previous month |
-|   ↳ `organicCostDifference` | number | Change in organic cost since the previous month |
-|   ↳ `paidKeywordsDifference` | number | Change in paid keyword count since the previous month |
-|   ↳ `paidTrafficDifference` | number | Change in paid traffic since the previous month |
-|   ↳ `paidCostDifference` | number | Change in paid cost since the previous month |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of this domain, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords this domain ranks for in the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic this domain gets from the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of this domain organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords this domain is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic this domain gets from paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget of this domain |
+|   ↳ `organicKeywordsDifference` | number (nullable) | Change in organic keyword count since the previous month |
+|   ↳ `organicTrafficDifference` | number (nullable) | Change in organic traffic since the previous month |
+|   ↳ `organicCostDifference` | number (nullable) | Change in organic cost since the previous month |
+|   ↳ `paidKeywordsDifference` | number (nullable) | Change in paid keyword count since the previous month |
+|   ↳ `paidTrafficDifference` | number (nullable) | Change in paid traffic since the previous month |
+|   ↳ `paidCostDifference` | number (nullable) | Change in paid cost since the previous month |
 
 ### Semrush Top Domains
 
@@ -1082,14 +1082,14 @@ List the highest-ranked domains in a regional database by Semrush rank.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `domains` | array | Top-ranked domains in the database |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `rank` | number | Semrush popularity rating of this domain, based on organic traffic |
-|   ↳ `organicKeywords` | number | Keywords this domain ranks for in the Google top 100 organic results |
-|   ↳ `organicTraffic` | number | Traffic this domain gets from the Google top 100 organic results |
-|   ↳ `organicCost` | number | Estimated Google Ads price of this domain organic keywords |
-|   ↳ `paidKeywords` | number | Keywords this domain is buying in Google Ads |
-|   ↳ `paidTraffic` | number | Traffic this domain gets from paid search results |
-|   ↳ `paidCost` | number | Estimated monthly Google Ads budget of this domain |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `rank` | number (nullable) | Semrush popularity rating of this domain, based on organic traffic |
+|   ↳ `organicKeywords` | number (nullable) | Keywords this domain ranks for in the Google top 100 organic results |
+|   ↳ `organicTraffic` | number (nullable) | Traffic this domain gets from the Google top 100 organic results |
+|   ↳ `organicCost` | number (nullable) | Estimated Google Ads price of this domain organic keywords |
+|   ↳ `paidKeywords` | number (nullable) | Keywords this domain is buying in Google Ads |
+|   ↳ `paidTraffic` | number (nullable) | Traffic this domain gets from paid search results |
+|   ↳ `paidCost` | number (nullable) | Estimated monthly Google Ads budget of this domain |
 
 ### Semrush Backlinks Overview
 
@@ -1107,21 +1107,21 @@ Get the Authority Score and backlink profile totals for a domain, subdomain, or 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `overview` | json | Backlink profile totals for the target |
-|   ↳ `authorityScore` | number | Semrush Authority Score \(0-100\) |
-|   ↳ `total` | number | Total number of backlinks |
-|   ↳ `domainsNum` | number | Number of referring domains |
-|   ↳ `urlsNum` | number | Number of referring URLs |
-|   ↳ `ipsNum` | number | Number of referring IPs |
-|   ↳ `ipClassCNum` | number | Number of referring class C subnets |
-|   ↳ `followsNum` | number | Number of followed backlinks |
-|   ↳ `nofollowsNum` | number | Number of nofollow backlinks |
-|   ↳ `sponsoredNum` | number | Number of backlinks marked rel="sponsored" |
-|   ↳ `ugcNum` | number | Number of backlinks marked rel="ugc" |
-|   ↳ `textsNum` | number | Number of text backlinks |
-|   ↳ `imagesNum` | number | Number of image backlinks |
-|   ↳ `formsNum` | number | Number of form backlinks |
-|   ↳ `framesNum` | number | Number of frame backlinks |
+| `overview` | json (nullable) | Backlink profile totals for the target |
+|   ↳ `authorityScore` | number (nullable) | Semrush Authority Score \(0-100\) |
+|   ↳ `total` | number (nullable) | Total number of backlinks |
+|   ↳ `domainsNum` | number (nullable) | Number of referring domains |
+|   ↳ `urlsNum` | number (nullable) | Number of referring URLs |
+|   ↳ `ipsNum` | number (nullable) | Number of referring IPs |
+|   ↳ `ipClassCNum` | number (nullable) | Number of referring class C subnets |
+|   ↳ `followsNum` | number (nullable) | Number of followed backlinks |
+|   ↳ `nofollowsNum` | number (nullable) | Number of nofollow backlinks |
+|   ↳ `sponsoredNum` | number (nullable) | Number of backlinks marked rel="sponsored" |
+|   ↳ `ugcNum` | number (nullable) | Number of backlinks marked rel="ugc" |
+|   ↳ `textsNum` | number (nullable) | Number of text backlinks |
+|   ↳ `imagesNum` | number (nullable) | Number of image backlinks |
+|   ↳ `formsNum` | number (nullable) | Number of form backlinks |
+|   ↳ `framesNum` | number (nullable) | Number of frame backlinks |
 
 ### Semrush Backlinks
 
@@ -1144,16 +1144,16 @@ List the backlinks pointing at a domain, subdomain, or URL, with source page, an
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `backlinks` | array | Backlinks pointing at the target |
-|   ↳ `pageAuthorityScore` | number | Authority Score of the source page |
-|   ↳ `sourceTitle` | string | Title of the linking page |
-|   ↳ `sourceUrl` | string | URL of the linking page |
-|   ↳ `targetUrl` | string | URL the backlink points to |
-|   ↳ `anchor` | string | Anchor text of the backlink |
-|   ↳ `nofollow` | string | Raw rel="nofollow" flag as returned by the API |
-|   ↳ `externalLinksNum` | number | External links on the source page |
-|   ↳ `internalLinksNum` | number | Internal links on the source page |
-|   ↳ `firstSeen` | number | Unix timestamp when the link was first seen |
-|   ↳ `lastSeen` | number | Unix timestamp when the link was last seen |
+|   ↳ `pageAuthorityScore` | number (nullable) | Authority Score of the source page |
+|   ↳ `sourceTitle` | string (nullable) | Title of the linking page |
+|   ↳ `sourceUrl` | string (nullable) | URL of the linking page |
+|   ↳ `targetUrl` | string (nullable) | URL the backlink points to |
+|   ↳ `anchor` | string (nullable) | Anchor text of the backlink |
+|   ↳ `nofollow` | string (nullable) | Raw rel="nofollow" flag as returned by the API |
+|   ↳ `externalLinksNum` | number (nullable) | External links on the source page |
+|   ↳ `internalLinksNum` | number (nullable) | Internal links on the source page |
+|   ↳ `firstSeen` | number (nullable) | Unix timestamp when the link was first seen |
+|   ↳ `lastSeen` | number (nullable) | Unix timestamp when the link was last seen |
 
 ### Semrush Referring Domains
 
@@ -1176,13 +1176,13 @@ List the domains linking to a target, with Authority Score, backlink count, and 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `domains` | array | Domains linking to the target |
-|   ↳ `domainAuthorityScore` | number | Authority Score of the referring domain |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `backlinksNum` | number | Number of backlinks |
-|   ↳ `ip` | string | IP address |
-|   ↳ `country` | string | Country of the referring domain |
-|   ↳ `firstSeen` | number | Unix timestamp when the link was first seen |
-|   ↳ `lastSeen` | number | Unix timestamp when the link was last seen |
+|   ↳ `domainAuthorityScore` | number (nullable) | Authority Score of the referring domain |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `backlinksNum` | number (nullable) | Number of backlinks |
+|   ↳ `ip` | string (nullable) | IP address |
+|   ↳ `country` | string (nullable) | Country of the referring domain |
+|   ↳ `firstSeen` | number (nullable) | Unix timestamp when the link was first seen |
+|   ↳ `lastSeen` | number (nullable) | Unix timestamp when the link was last seen |
 
 ### Semrush Referring IPs
 
@@ -1204,12 +1204,12 @@ List the IP addresses linking to a target, with the domain and backlink counts b
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `ips` | array | IP addresses linking to the target |
-|   ↳ `ip` | string | IP address |
-|   ↳ `country` | string | Country of the referring domain |
-|   ↳ `domainsNum` | number | Number of referring domains |
-|   ↳ `backlinksNum` | number | Number of backlinks |
-|   ↳ `firstSeen` | number | Unix timestamp when the link was first seen |
-|   ↳ `lastSeen` | number | Unix timestamp when the link was last seen |
+|   ↳ `ip` | string (nullable) | IP address |
+|   ↳ `country` | string (nullable) | Country of the referring domain |
+|   ↳ `domainsNum` | number (nullable) | Number of referring domains |
+|   ↳ `backlinksNum` | number (nullable) | Number of backlinks |
+|   ↳ `firstSeen` | number (nullable) | Unix timestamp when the link was first seen |
+|   ↳ `lastSeen` | number (nullable) | Unix timestamp when the link was last seen |
 
 ### Semrush Backlink TLD Distribution
 
@@ -1231,9 +1231,9 @@ Break a target backlink profile down by the top-level domain of its referring do
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `zones` | array | Referring domain and backlink counts per top-level domain |
-|   ↳ `zone` | string | Top-level domain zone |
-|   ↳ `domainsNum` | number | Number of referring domains |
-|   ↳ `backlinksNum` | number | Number of backlinks |
+|   ↳ `zone` | string (nullable) | Top-level domain zone |
+|   ↳ `domainsNum` | number (nullable) | Number of referring domains |
+|   ↳ `backlinksNum` | number (nullable) | Number of backlinks |
 
 ### Semrush Backlink Country Distribution
 
@@ -1255,9 +1255,9 @@ Break a target backlink profile down by the country of its referring domains.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `countries` | array | Referring domain and backlink counts per country |
-|   ↳ `country` | string | Country of the referring domain |
-|   ↳ `domainsNum` | number | Number of referring domains |
-|   ↳ `backlinksNum` | number | Number of backlinks |
+|   ↳ `country` | string (nullable) | Country of the referring domain |
+|   ↳ `domainsNum` | number (nullable) | Number of referring domains |
+|   ↳ `backlinksNum` | number (nullable) | Number of backlinks |
 
 ### Semrush Backlink Anchors
 
@@ -1279,11 +1279,11 @@ List the anchor texts used in backlinks to a target, with domain and backlink co
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `anchors` | array | Anchor text distribution for the backlink profile |
-|   ↳ `anchor` | string | Anchor text of the backlink |
-|   ↳ `domainsNum` | number | Number of referring domains |
-|   ↳ `backlinksNum` | number | Number of backlinks |
-|   ↳ `firstSeen` | number | Unix timestamp when the link was first seen |
-|   ↳ `lastSeen` | number | Unix timestamp when the link was last seen |
+|   ↳ `anchor` | string (nullable) | Anchor text of the backlink |
+|   ↳ `domainsNum` | number (nullable) | Number of referring domains |
+|   ↳ `backlinksNum` | number (nullable) | Number of backlinks |
+|   ↳ `firstSeen` | number (nullable) | Unix timestamp when the link was first seen |
+|   ↳ `lastSeen` | number (nullable) | Unix timestamp when the link was last seen |
 
 ### Semrush Indexed Pages
 
@@ -1305,14 +1305,14 @@ List the pages of a target that attract backlinks, with response code and link c
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `pages` | array | Indexed pages of the target and the links they attract |
-|   ↳ `sourceUrl` | string | URL of the linking page |
-|   ↳ `sourceTitle` | string | Title of the linking page |
-|   ↳ `responseCode` | number | HTTP status code the page returned when last crawled |
-|   ↳ `backlinksNum` | number | Number of backlinks |
-|   ↳ `domainsNum` | number | Number of referring domains |
-|   ↳ `lastSeen` | number | Unix timestamp when the link was last seen |
-|   ↳ `externalLinksNum` | number | External links on the source page |
-|   ↳ `internalLinksNum` | number | Internal links on the source page |
+|   ↳ `sourceUrl` | string (nullable) | URL of the linking page |
+|   ↳ `sourceTitle` | string (nullable) | Title of the linking page |
+|   ↳ `responseCode` | number (nullable) | HTTP status code the page returned when last crawled |
+|   ↳ `backlinksNum` | number (nullable) | Number of backlinks |
+|   ↳ `domainsNum` | number (nullable) | Number of referring domains |
+|   ↳ `lastSeen` | number (nullable) | Unix timestamp when the link was last seen |
+|   ↳ `externalLinksNum` | number (nullable) | External links on the source page |
+|   ↳ `internalLinksNum` | number (nullable) | Internal links on the source page |
 
 ### Semrush Backlink Competitors
 
@@ -1333,11 +1333,9 @@ List domains with a backlink profile similar to the target, ranked by shared ref
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `competitors` | array | Domains with backlink profiles similar to the target |
-|   ↳ `authorityScore` | number | Semrush Authority Score \(0-100\) |
-|   ↳ `domain` | string | Domain name |
-|   ↳ `similarity` | number | Backlink profile similarity to the target |
-|   ↳ `commonRefdomains` | number | Referring domains shared with the target |
-|   ↳ `domainsNum` | number | Number of referring domains |
-|   ↳ `backlinksNum` | number | Number of backlinks |
-
-
+|   ↳ `authorityScore` | number (nullable) | Semrush Authority Score \(0-100\) |
+|   ↳ `domain` | string (nullable) | Domain name |
+|   ↳ `similarity` | number (nullable) | Backlink profile similarity to the target |
+|   ↳ `commonRefdomains` | number (nullable) | Referring domains shared with the target |
+|   ↳ `domainsNum` | number (nullable) | Number of referring domains |
+|   ↳ `backlinksNum` | number (nullable) | Number of backlinks |

--- a/apps/docs/content/docs/integrations/sendblue.mdx
+++ b/apps/docs/content/docs/integrations/sendblue.mdx
@@ -5,7 +5,7 @@ description: Send and receive iMessage and SMS
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sendblue"
   color="#008BFF"
 />
@@ -206,8 +206,6 @@ Retrieve a single message and its current status by message handle/ID.
 | `date_sent` | string | ISO 8601 creation timestamp |
 | `date_updated` | string | ISO 8601 last-update timestamp |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -288,4 +286,3 @@ Trigger when an outbound message status changes (SENT, DELIVERED, ERROR) in Send
 | `sender_email` | string | Email of the user who sent the message |
 | `seat_id` | string | Seat UUID, null if absent |
 | `raw` | string | Complete raw webhook payload from Sendblue as a JSON string |
-

--- a/apps/docs/content/docs/integrations/sendgrid.mdx
+++ b/apps/docs/content/docs/integrations/sendgrid.mdx
@@ -5,7 +5,7 @@ description: Send emails and manage contacts, lists, and templates with SendGrid
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sendgrid"
   color="#1A82E2"
 />
@@ -384,5 +384,3 @@ Create a new version of an email template in SendGrid
 | `htmlContent` | string | HTML content |
 | `plainContent` | string | Plain text content |
 | `updatedAt` | string | Last update timestamp |
-
-

--- a/apps/docs/content/docs/integrations/sentry.mdx
+++ b/apps/docs/content/docs/integrations/sentry.mdx
@@ -5,7 +5,7 @@ description: Manage Sentry issues, projects, events, and releases
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sentry"
   color="#362D59"
 />
@@ -664,8 +664,6 @@ List all teams in a Sentry organization. Useful for discovering the team slug re
 |   ↳ `nextCursor` | string | Cursor for the next page of results \(if available\) |
 |   ↳ `hasMore` | boolean | Whether there are more results available |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -884,4 +882,3 @@ Trigger workflow when a Sentry metric alert changes state (critical, warning, re
 | `description_text` | string | Human-friendly description of the alert |
 | `description_title` | string | Human-friendly title of the alert |
 | `web_url` | string | API URL for the incident |
-

--- a/apps/docs/content/docs/integrations/serper.mdx
+++ b/apps/docs/content/docs/integrations/serper.mdx
@@ -5,7 +5,7 @@ description: Search the web using Serper
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="serper"
   color="#2B3543"
 />
@@ -55,5 +55,3 @@ A powerful web search tool that provides access to Google search results through
 |   ↳ `address` | string | Address \(places\) |
 |   ↳ `price` | string | Price \(shopping\) |
 |   ↳ `duration` | string | Duration \(videos\) |
-
-

--- a/apps/docs/content/docs/integrations/servicenow.mdx
+++ b/apps/docs/content/docs/integrations/servicenow.mdx
@@ -5,7 +5,7 @@ description: Create, read, update, and delete ServiceNow records
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="servicenow"
   color="#032D42"
 />
@@ -250,33 +250,9 @@ Create an incident in ServiceNow. Reference fields (caller, assignment group, as
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### Get ServiceNow Incident
 
@@ -298,33 +274,9 @@ Retrieve a single ServiceNow incident by number (e.g., INC0010001) or sys_id. Re
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### List ServiceNow Incidents
 
@@ -354,33 +306,9 @@ Search ServiceNow incidents by state, priority, assignment, caller, or text. All
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `records` | array | Matching ServiceNow records. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned |
 
 ### Update ServiceNow Incident
 
@@ -416,33 +344,9 @@ Update fields on an existing ServiceNow incident. Only the fields you supply are
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### Resolve ServiceNow Incident
 
@@ -468,33 +372,9 @@ Move a ServiceNow incident to Resolved (state 6) with a resolution code and reso
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### Close ServiceNow Incident
 
@@ -520,33 +400,9 @@ Move a ServiceNow incident to Closed (state 7) with a resolution code and resolu
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### Add ServiceNow Incident Comment
 
@@ -570,33 +426,9 @@ Append an internal work note or a customer-visible additional comment to a Servi
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### Create ServiceNow Change Request
 
@@ -635,33 +467,9 @@ Create a change request in ServiceNow. Reference fields (assignment group, assig
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### Get ServiceNow Change Request
 
@@ -683,33 +491,9 @@ Retrieve a single ServiceNow change request by number (e.g., CHG0030001) or sys_
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### List ServiceNow Change Requests
 
@@ -739,33 +523,9 @@ Search ServiceNow change requests by state, type, risk, assignment, or text. All
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `records` | array | Matching ServiceNow records. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned |
 
 ### Update ServiceNow Change Request
 
@@ -801,33 +561,9 @@ Update fields on an existing ServiceNow change request. Only the fields you supp
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### Move ServiceNow Change State
 
@@ -854,33 +590,9 @@ Move a ServiceNow change request to another state. Base-system change model stat
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### List ServiceNow Change Tasks
 
@@ -964,11 +676,11 @@ Browse or search the ServiceNow service catalog. Returns each item with its sys_
 | `items` | array | Catalog items |
 |   ↳ `sys_id` | string | Catalog item sys_id, used to order the item |
 |   ↳ `name` | string | Catalog item name |
-|   ↳ `short_description` | string | Short description |
+|   ↳ `short_description` | string (nullable) | Short description |
 |   ↳ `description` | string | HTML description |
 |   ↳ `type` | string | Item type, e.g., record_producer or catalog_item |
 |   ↳ `sys_class_name` | string | Item table |
-|   ↳ `category` | json | Category \{sys_id, title\} |
+|   ↳ `category` | json (nullable) | Category \{sys_id, title\} |
 |   ↳ `catalogs` | json | Catalogs the item belongs to, each \{sys_id, title\} |
 |   ↳ `picture` | string | Item picture reference |
 |   ↳ `icon` | string | Item icon reference |
@@ -1002,11 +714,11 @@ Submit a service catalog request for a catalog item using the Service Catalog AP
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `sysId` | string | Sys_id of the order |
-| `number` | string | Number of the generated request |
-| `requestNumber` | string | Request number |
-| `requestId` | string | Sys_id of the order request |
-| `table` | string | Table name of the request |
+| `sysId` | string (nullable) | Sys_id of the order |
+| `number` | string (nullable) | Number of the generated request |
+| `requestNumber` | string (nullable) | Request number |
+| `requestId` | string (nullable) | Sys_id of the order request |
+| `table` | string (nullable) | Table name of the request |
 
 ### List ServiceNow Requested Items
 
@@ -1032,33 +744,9 @@ List requested items (RITMs) from the ServiceNow Requested Item [sc_req_item] ta
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `records` | array | Matching ServiceNow records. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned |
 
 ### Get ServiceNow Requested Item
 
@@ -1080,33 +768,9 @@ Retrieve a single ServiceNow requested item (RITM) by number (e.g., RITM0010001)
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### List ServiceNow Approvals
 
@@ -1132,33 +796,9 @@ List approval records from the ServiceNow Approval [sysapproval_approver] table.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `records` | array | Matching ServiceNow records. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned |
 
 ### Approve or Reject ServiceNow Approval
 
@@ -1182,33 +822,9 @@ Approve or reject a ServiceNow approval record by setting its state on the Appro
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `record` | json (nullable) | The ServiceNow record. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned \(0 or 1\) |
 
 ### Search ServiceNow Configuration Items
 
@@ -1234,33 +850,9 @@ Search the ServiceNow CMDB for configuration items. Defaults to the base cmdb_ci
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `records` | array | Matching ServiceNow records. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned |
 
 ### Get ServiceNow Configuration Item
 
@@ -1280,7 +872,7 @@ Retrieve a configuration item and its CMDB relationships through the CMDB Instan
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `attributes` | json | Data attributes on the CI record. The available attributes depend on the class. |
+| `attributes` | json (nullable) | Data attributes on the CI record. The available attributes depend on the class. |
 | `inboundRelations` | array | Inbound CI relationships |
 |   ↳ `sys_id` | string | Sys_id of the relationship record on cmdb_rel_ci |
 |   ↳ `target` | json | Related CI as \{value \(sys_id\), display_value, link\} |
@@ -1316,33 +908,9 @@ List rows from the CI Relationship [cmdb_rel_ci] table for a configuration item.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `records` | array | Matching ServiceNow records. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned |
 
 ### Search ServiceNow Knowledge
 
@@ -1378,7 +946,7 @@ Search ServiceNow knowledge base articles through the Knowledge Management API. 
 |   ↳ `fields` | json | Requested kb_knowledge fields, each \{name, label, type, value, display_value\} |
 | `metadata` | json | Operation metadata |
 |   ↳ `recordCount` | number | Number of articles returned |
-|   ↳ `totalCount` | number | Total number of available articles reported by ServiceNow |
+|   ↳ `totalCount` | number (nullable) | Total number of available articles reported by ServiceNow |
 
 ### Get ServiceNow Knowledge Article
 
@@ -1400,11 +968,11 @@ Retrieve the full content of a ServiceNow knowledge article by sys_id or KB numb
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `sysId` | string | Article sys_id on kb_knowledge |
-| `number` | string | Knowledge article number |
-| `title` | string | Article title \(short description\) |
-| `content` | string | Full HTML content of the article |
-| `fields` | json | Requested kb_knowledge fields, each \{name, label, type, value, display_value\} |
+| `sysId` | string (nullable) | Article sys_id on kb_knowledge |
+| `number` | string (nullable) | Knowledge article number |
+| `title` | string (nullable) | Article title \(short description\) |
+| `content` | string (nullable) | Full HTML content of the article |
+| `fields` | json (nullable) | Requested kb_knowledge fields, each \{name, label, type, value, display_value\} |
 | `attachments` | array | Article attachments, returned only when display_attachments is active on the article |
 |   ↳ `sys_id` | string | Attachment sys_id |
 |   ↳ `file_name` | string | Attachment file name |
@@ -1436,33 +1004,9 @@ Look up ServiceNow users by email, user name, or display name. Use this to resol
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `records` | array | Matching ServiceNow records. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
+|   ↳ `recordCount` | number | Number of records returned |
 
 ### List ServiceNow Group Members
 
@@ -1487,35 +1031,9 @@ List the members of a ServiceNow group from the Group Member [sys_user_grmember]
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `record` | json | Single ServiceNow record |
-| `records` | json | Array of ServiceNow records |
-| `success` | boolean | Operation success status |
+| `records` | array | Matching ServiceNow records. With the default display value mode "all", every field is an object of the form \{value, display_value\}. |
 | `metadata` | json | Operation metadata |
-| `result` | json | Aggregate result \(stats or grouped array\) |
-| `count` | number | Aggregate matching record count |
-| `attachments` | json | Attachment metadata list — record attachments \(sys_id, file_name, content_type, download_link\) or knowledge article attachments \(sys_id, file_name, size_bytes, state\) |
-| `file` | file | Downloaded attachment file |
-| `content` | string | Base64-encoded downloaded file content, or the HTML body of a knowledge article |
-| `attachment` | json | Uploaded attachment metadata |
-| `tasks` | json | Change tasks belonging to a change request. Unlike the Table API operations, the Change Management API always returns every field as \{value, display_value\} regardless of the display value setting |
-| `items` | json | Service catalog items |
-| `articles` | json | Knowledge article search results |
-| `attributes` | json | Configuration item attributes |
-| `inboundRelations` | json | Inbound CI relationships |
-| `outboundRelations` | json | Outbound CI relationships |
-| `sysId` | string | sys_id returned by the operation |
-| `number` | string | Record number returned by the operation |
-| `requestNumber` | string | Catalog request number |
-| `requestId` | string | sys_id of the catalog request |
-| `table` | string | Table the catalog request was created on |
-| `availableStates` | json | State coded values a change request can reach, including its current state |
-| `allowedStates` | json | State coded values whose transition conditions the change request already meets |
-| `stateLabels` | json | This instance's own map of state coded value to label, e.g. \{'0': 'Review'\} |
-| `stateTransitions` | json | \[\{sys_id, display_value, from_state, to_state, transition_available, automatic_transition, conditions\}\] |
-| `title` | string | Knowledge article title |
-| `fields` | json | Requested knowledge article field values |
-
-
+|   ↳ `recordCount` | number | Number of records returned |
 
 ## Triggers
 
@@ -1714,4 +1232,3 @@ Trigger workflow on any ServiceNow webhook event
 | `eventType` | string | The type of event that triggered this workflow \(e.g., insert, update, delete\) |
 | `category` | string | Record category |
 | `record` | json | Full record data from the webhook payload |
-

--- a/apps/docs/content/docs/integrations/ses.mdx
+++ b/apps/docs/content/docs/integrations/ses.mdx
@@ -5,7 +5,7 @@ description: Send emails and manage templates with AWS Simple Email Service
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="ses"
   color="linear-gradient(45deg, #BD0816 0%, #FF5252 100%)"
 />
@@ -455,5 +455,3 @@ Send a branded custom verification email to an address using a custom verificati
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `messageId` | string | SES message ID for the sent verification email |
-
-

--- a/apps/docs/content/docs/integrations/sftp.mdx
+++ b/apps/docs/content/docs/integrations/sftp.mdx
@@ -5,7 +5,7 @@ description: Transfer files via SFTP (SSH File Transfer Protocol)
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sftp"
   color="#2D3748"
 />
@@ -167,5 +167,3 @@ Create a directory on a remote SFTP server
 | `success` | boolean | Whether the directory was created successfully |
 | `createdPath` | string | Path of the created directory |
 | `message` | string | Operation status message |
-
-

--- a/apps/docs/content/docs/integrations/sharepoint.mdx
+++ b/apps/docs/content/docs/integrations/sharepoint.mdx
@@ -5,7 +5,7 @@ description: Work with pages and lists
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sharepoint_v2"
   color="#FFFFFF"
 />
@@ -448,5 +448,3 @@ Delete a file (or folder) from a SharePoint document library
 | --------- | ---- | ----------- |
 | `deleted` | boolean | Whether the file was deleted |
 | `itemId` | string | The ID of the deleted file |
-
-

--- a/apps/docs/content/docs/integrations/shopify.mdx
+++ b/apps/docs/content/docs/integrations/shopify.mdx
@@ -5,7 +5,7 @@ description: Manage products, orders, customers, and inventory in your Shopify s
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="shopify"
   color="#FFFFFF"
 />
@@ -682,5 +682,3 @@ Get a specific collection by ID, including its products. Use this to retrieve pr
 |   ↳ `updatedAt` | string | Last modification timestamp \(ISO 8601\) |
 |   ↳ `image` | object | Collection image |
 |   ↳ `products` | array | Products in the collection |
-
-

--- a/apps/docs/content/docs/integrations/similarweb.mdx
+++ b/apps/docs/content/docs/integrations/similarweb.mdx
@@ -5,7 +5,7 @@ description: Website traffic and analytics data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="similarweb"
   color="#000922"
 />
@@ -207,5 +207,3 @@ Get total page views over time (desktop and mobile combined)
 | `pageViews` | array | Page view data over time |
 |   ↳ `date` | string | Date \(YYYY-MM-DD\) |
 |   ↳ `pageViews` | number | Total page views |
-
-

--- a/apps/docs/content/docs/integrations/sixtyfour.mdx
+++ b/apps/docs/content/docs/integrations/sixtyfour.mdx
@@ -5,7 +5,7 @@ description: Enrich leads and companies with AI-powered research
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sixtyfour"
   color="#000000"
 />
@@ -130,5 +130,3 @@ Enrich company data with additional information and find associated people using
 | `references` | json | Source URLs and descriptions used for enrichment |
 | `confidenceScore` | number | Quality score for the returned data \(0-10\) |
 | `orgChart` | json | Org chart returned when fullOrgChart is enabled |
-
-

--- a/apps/docs/content/docs/integrations/slack.mdx
+++ b/apps/docs/content/docs/integrations/slack.mdx
@@ -5,7 +5,7 @@ description: Send and manage Slack messages, Agent Sessions, streamed replies, v
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="slack_v2"
   color="#611f69"
 />
@@ -914,7 +914,7 @@ Create or update the state of a Slack agent session associated with a thread.
 | `ok` | boolean | Whether Slack updated the agent session |
 | `status` | string | Requested agent session status |
 | `agentStatus` | string | Agent status recorded by Slack |
-| `title` | string | Current agent session title, or null when the session has no title |
+| `title` | string (nullable) | Current agent session title, or null when the session has no title |
 
 ### Slack Rename Agent Session
 
@@ -1940,8 +1940,6 @@ Set the purpose (description) for a Slack channel (max 250 characters).
 | --------- | ---- | ----------- |
 | `purpose` | string | The purpose/description that was set on the channel |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -2017,4 +2015,3 @@ Trigger from Slack events, interactions, and slash commands
 |   ↳ `state` | json | Current values of all stateful elements in the surface \(state.values\) at the time of a block action — e.g. inputs read on a button click. Present for block_actions; null otherwise |
 |   ↳ `hasFiles` | boolean | Whether the message has file attachments |
 |   ↳ `files` | file[] | File attachments downloaded from the message \(if includeFiles is enabled and bot token is provided\) |
-

--- a/apps/docs/content/docs/integrations/smartlead.mdx
+++ b/apps/docs/content/docs/integrations/smartlead.mdx
@@ -5,7 +5,7 @@ description: Manage Smartlead cold email campaigns, sequences, and leads
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="smartlead"
   color="#000000"
 />
@@ -54,99 +54,30 @@ Retrieves all Smartlead campaigns for the authenticated account.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+|   ↳ `id` | number | Campaign ID |
+|   ↳ `user_id` | number | Owning Smartlead user ID |
+|   ↳ `name` | string | Campaign name |
+|   ↳ `status` | string | Campaign status \(DRAFTED, ACTIVE, PAUSED, STOPPED, COMPLETED\) |
+|   ↳ `created_at` | string | Creation timestamp |
+|   ↳ `updated_at` | string | Last update timestamp |
+|   ↳ `track_settings` | array | Disabled tracking settings |
+|   ↳ `scheduler_cron_value` | object | Sending schedule, or null when no schedule is set |
+|     ↳ `tz` | string | Scheduler timezone |
+|     ↳ `days` | array | Sending days as ISO weekday numbers |
+|     ↳ `startHour` | string | Sending window start \(HH:MM\) |
+|     ↳ `endHour` | string | Sending window end \(HH:MM\) |
+|   ↳ `min_time_btwn_emails` | number | Minimum minutes between emails |
+|   ↳ `max_leads_per_day` | number | Maximum new leads per day |
+|   ↳ `stop_lead_settings` | string | Activity that stops a lead sequence |
+|   ↳ `schedule_start_time` | string | Scheduled start time |
+|   ↳ `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
+|   ↳ `send_as_plain_text` | boolean | Whether emails send as plain text |
+|   ↳ `follow_up_percentage` | number | Follow-up percentage |
+|   ↳ `unsubscribe_text` | string | Unsubscribe text |
+|   ↳ `parent_campaign_id` | number | Parent campaign ID |
+|   ↳ `client_id` | number | Client ID for agency accounts |
+|   ↳ `tags` | array | Campaign tags \(only returned when tags are requested\) |
+| `count` | number | Number of campaigns returned |
 
 ### Smartlead Get Campaign
 
@@ -163,85 +94,18 @@ Retrieves a single Smartlead campaign by ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
+| `id` | number | Campaign ID |
+| `user_id` | number | Owning Smartlead user ID |
+| `name` | string | Campaign name |
+| `status` | string | Campaign status \(DRAFTED, ACTIVE, PAUSED, STOPPED, COMPLETED\) |
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
 | `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
+| `scheduler_cron_value` | object | Sending schedule, or null when no schedule is set |
+|   ↳ `tz` | string | Scheduler timezone |
+|   ↳ `days` | array | Sending days as ISO weekday numbers |
+|   ↳ `startHour` | string | Sending window start \(HH:MM\) |
+|   ↳ `endHour` | string | Sending window end \(HH:MM\) |
 | `min_time_btwn_emails` | number | Minimum minutes between emails |
 | `max_leads_per_day` | number | Maximum new leads per day |
 | `stop_lead_settings` | string | Activity that stops a lead sequence |
@@ -252,11 +116,7 @@ Retrieves a single Smartlead campaign by ID.
 | `unsubscribe_text` | string | Unsubscribe text |
 | `parent_campaign_id` | number | Parent campaign ID |
 | `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `tags` | array | Campaign tags \(only returned when tags are requested\) |
 
 ### Smartlead Create Campaign
 
@@ -274,100 +134,9 @@ Creates a Smartlead campaign. The campaign starts in DRAFTED status; add sequenc
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
+| `id` | number | Created campaign ID |
+| `name` | string | Created campaign name |
 | `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Update Campaign Status
 
@@ -385,100 +154,7 @@ Starts, pauses, or stops a Smartlead campaign. START requires the campaign to al
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Update Campaign Schedule
 
@@ -502,100 +178,7 @@ Sets the sending window, timezone, and throughput limits for a Smartlead campaig
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Update Campaign Settings
 
@@ -618,100 +201,7 @@ Updates tracking, stop-on-activity, and sending settings for a Smartlead campaig
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Get Campaign Analytics
 
@@ -728,100 +218,40 @@ Retrieves lifetime performance totals for a Smartlead campaign — sends, opens,
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
+| `id` | number | Campaign ID |
+| `user_id` | number | Owning Smartlead user ID |
+| `name` | string | Campaign name |
 | `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
+| `created_at` | string | Creation timestamp |
 | `sent_count` | number | Emails sent |
+| `unique_sent_count` | number | Unique leads emailed |
 | `open_count` | number | Email opens |
+| `unique_open_count` | number | Unique opens |
 | `click_count` | number | Link clicks |
+| `unique_click_count` | number | Unique clicks |
 | `reply_count` | number | Replies |
 | `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
+| `block_count` | number | Blocked sends |
 | `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
+| `total_count` | number | Total emails in the campaign |
 | `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
+| `sequence_count` | number | Number of sequence steps |
+| `campaign_lead_stats` | object | Lead counts by state |
+|   ↳ `total` | number | Total leads |
+|   ↳ `notStarted` | number | Leads not yet started |
+|   ↳ `inprogress` | number | Leads in progress |
+|   ↳ `completed` | number | Leads completed |
+|   ↳ `paused` | number | Leads paused |
+|   ↳ `stopped` | number | Leads stopped |
+|   ↳ `blocked` | number | Leads blocked |
+|   ↳ `interested` | number | Leads marked interested |
+|   ↳ `revenue` | number | Revenue attributed to the campaign |
+| `client_id` | number | Client ID |
 | `client_name` | string | Client name |
 | `client_email` | string | Client email |
 | `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `parent_campaign_id` | number | Parent campaign ID |
+| `send_as_plain_text` | boolean | Whether emails send as plain text |
 
 ### Smartlead Get Campaign Analytics By Date
 
@@ -840,100 +270,25 @@ Retrieves Smartlead campaign performance totals for a date range. Smartlead reje
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
+| `id` | number | Campaign ID |
+| `user_id` | number | Owning Smartlead user ID |
+| `name` | string | Campaign name |
 | `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
+| `created_at` | string | Creation timestamp |
 | `start_date` | string | Start of the reported range |
 | `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
+| `sent_count` | number | Emails sent |
 | `unique_sent_count` | number | Unique leads emailed |
+| `open_count` | number | Email opens |
 | `unique_open_count` | number | Unique opens |
+| `click_count` | number | Link clicks |
 | `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
+| `reply_count` | number | Replies |
+| `bounce_count` | number | Bounces |
+| `block_count` | number | Blocked sends |
+| `unsubscribed_count` | number | Unsubscribes |
+| `total_count` | number | Total emails in the campaign |
 | `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Get Campaign Sequences
 
@@ -950,100 +305,17 @@ Retrieves the email sequence steps for a Smartlead campaign, including subjects,
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `sequences` | array | Campaign email sequence steps |
+|   ↳ `id` | number | Sequence step ID |
+|   ↳ `created_at` | string | Creation timestamp |
+|   ↳ `updated_at` | string | Last update timestamp |
+|   ↳ `email_campaign_id` | number | Campaign ID |
+|   ↳ `seq_number` | number | Step position in the sequence |
+|   ↳ `delay_in_days` | number | Days to wait before sending this step |
+|   ↳ `subject` | string | Email subject \(empty string continues the previous thread\) |
+|   ↳ `email_body` | string | Email body HTML |
+|   ↳ `sequence_variants` | array | A/B variants for this step |
+| `count` | number | Number of sequence steps returned |
 
 ### Smartlead Save Campaign Sequences
 
@@ -1061,100 +333,11 @@ Replaces the email sequence for a Smartlead campaign. Send every step in one cal
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead saved the sequence |
+| `sequences` | array | Saved sequence steps |
+|   ↳ `id` | number | Sequence step ID |
+|   ↳ `seq_number` | number | Step position in the sequence |
+| `count` | number | Number of sequence steps saved |
 
 ### Smartlead Get Campaign Statistics
 
@@ -1177,100 +360,10 @@ Retrieves per-email statistics rows for a Smartlead campaign, filterable by sequ
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
+| `stats` | array | Per-email statistics rows returned by Smartlead. Row fields are passed through unchanged. |
+| `total_stats` | number | Total rows matching the filters |
 | `offset` | number | Pagination offset used |
 | `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Add Leads to Campaign
 
@@ -1292,100 +385,17 @@ Adds leads to a Smartlead campaign, up to 400 per call. Returns per-reason count
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
 | `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
+| `total_leads` | number | Leads newly added to the campaign |
+| `already_added_to_campaign` | number | Leads already present in the campaign |
+| `duplicate_count` | number | Duplicate leads skipped |
 | `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
+| `block_count` | number | Leads skipped by the block list |
+| `bounce_count` | number | Leads skipped for prior bounces |
 | `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was reached |
+| `invalid_emails` | array | Emails rejected as invalid |
+| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
 
 ### Smartlead List Campaign Leads
 
@@ -1404,100 +414,28 @@ Retrieves the leads in a Smartlead campaign with their per-campaign status.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
+| `leads` | array | Leads in the campaign |
+|   ↳ `campaign_lead_map_id` | number | Campaign-lead association ID |
+|   ↳ `lead_category_id` | number | Lead category ID |
+|   ↳ `status` | string | Lead status in the campaign |
+|   ↳ `created_at` | string | When the lead joined the campaign |
+|   ↳ `lead` | object | Lead record |
+|     ↳ `id` | number | Lead ID |
+|     ↳ `first_name` | string | Lead first name |
+|     ↳ `last_name` | string | Lead last name |
+|     ↳ `email` | string | Lead email address |
+|     ↳ `phone_number` | string | Lead phone number |
+|     ↳ `company_name` | string | Lead company name |
+|     ↳ `website` | string | Lead website |
+|     ↳ `location` | string | Lead location |
+|     ↳ `linkedin_profile` | string | Lead LinkedIn profile URL |
+|     ↳ `company_url` | string | Lead company URL |
+|     ↳ `custom_fields` | object | Lead custom fields |
+|     ↳ `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
+| `total_leads` | number | Total leads in the campaign |
 | `offset` | number | Pagination offset used |
 | `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `count` | number | Number of leads returned in this page |
 
 ### Smartlead Get Lead by Email
 
@@ -1514,100 +452,29 @@ Looks up a Smartlead lead by email address and returns the lead record plus ever
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
+| `id` | number | Lead ID |
 | `first_name` | string | Lead first name |
 | `last_name` | string | Lead last name |
+| `email` | string | Lead email address |
 | `phone_number` | string | Lead phone number |
 | `company_name` | string | Lead company name |
 | `website` | string | Lead website |
 | `location` | string | Lead location |
 | `linkedin_profile` | string | Lead LinkedIn profile URL |
 | `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
+| `custom_fields` | object | Lead custom fields |
 | `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `created_at` | string | Lead creation timestamp |
+| `lead_campaign_data` | array | Campaigns this lead belongs to |
+|   ↳ `campaign_id` | number | Campaign ID |
+|   ↳ `campaign_name` | string | Campaign name |
+|   ↳ `campaign_lead_map_id` | number | Campaign-lead association ID |
+|   ↳ `lead_category_id` | number | Lead category ID |
+|   ↳ `last_sent_at` | string | Last send timestamp |
+|   ↳ `last_reply_at` | string | Last reply timestamp |
+|   ↳ `last_activity_at` | string | Last activity timestamp |
+|   ↳ `client_id` | number | Client ID |
+|   ↳ `client_email` | string | Client email |
 
 ### Smartlead Update Lead
 
@@ -1635,100 +502,7 @@ Updates a lead in a Smartlead campaign. Smartlead requires the email field even 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Update Lead Category
 
@@ -1748,100 +522,7 @@ Sets the category of a lead in a Smartlead campaign, such as Interested or Not I
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Pause Lead
 
@@ -1859,100 +540,7 @@ Pauses a lead in a Smartlead campaign so it stops receiving sequence emails.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Resume Lead
 
@@ -1971,100 +559,7 @@ Resumes a paused lead in a Smartlead campaign, optionally after a delay.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead List Lead Categories
 
@@ -2080,100 +575,12 @@ Retrieves the lead categories configured on the Smartlead account, with the cate
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `categories` | array | Lead categories configured on the account |
+|   ↳ `id` | number | Category ID |
+|   ↳ `name` | string | Category name |
+|   ↳ `sentiment_type` | string | Category sentiment \(positive, negative, neutral\) |
+|   ↳ `created_at` | string | Creation timestamp |
+| `count` | number | Number of categories returned |
 
 ### Smartlead Get Lead Message History
 
@@ -2191,100 +598,8 @@ Retrieves the sent-and-received message history for a lead in a Smartlead campai
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `history` | array | Message history entries for the lead. Entry fields are passed through unchanged. |
+| `count` | number | Number of history entries returned |
 
 ### Smartlead List Campaign Webhooks
 
@@ -2301,100 +616,16 @@ Retrieves the webhooks registered on a Smartlead campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `webhooks` | array | Webhooks registered on the campaign |
+|   ↳ `id` | number | Webhook ID |
+|   ↳ `name` | string | Webhook name |
+|   ↳ `webhook_url` | string | Destination URL |
+|   ↳ `email_campaign_id` | number | Campaign ID |
+|   ↳ `event_types` | array | Subscribed event types |
+|   ↳ `categories` | array | Lead categories the webhook is scoped to |
+|   ↳ `created_at` | string | Creation timestamp |
+|   ↳ `updated_at` | string | Last update timestamp |
+| `count` | number | Number of webhooks returned |
 
 ### Smartlead Create or Update Campaign Webhook
 
@@ -2416,100 +647,12 @@ Creates a webhook on a Smartlead campaign, or updates an existing one when a web
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `id` | number | Webhook ID |
+| `name` | string | Webhook name |
+| `webhook_url` | string | Destination URL |
+| `email_campaign_id` | number | Campaign ID |
+| `event_types` | array | Subscribed event types |
+| `categories` | array | Lead categories the webhook is scoped to |
 
 ### Smartlead Delete Campaign Webhook
 
@@ -2527,100 +670,7 @@ Deletes a webhook from a Smartlead campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Get Campaign Webhook Summary
 
@@ -2639,100 +689,10 @@ Retrieves webhook delivery counts for a Smartlead campaign over a time window, f
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
+| `summary` | array | Per-webhook delivery summary rows, passed through unchanged |
+| `count` | number | Number of summary rows returned |
 | `from` | string | Start of the reported window |
 | `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Duplicate Campaign
 
@@ -2749,100 +709,8 @@ Copies a Smartlead campaign, including its sequences and settings. The copy is n
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead duplicated the campaign |
+| `id` | number | ID of the newly created campaign |
 
 ### Smartlead Delete Campaign
 
@@ -2859,100 +727,7 @@ Permanently deletes a Smartlead campaign along with its sequences, leads, and we
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Export Campaign Leads
 
@@ -2969,100 +744,8 @@ Exports every lead in a Smartlead campaign as CSV, including engagement counts a
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `csv` | string | Campaign leads as CSV. Columns: id, campaign_lead_map_id, status, category, is_interested, created_at, first_name, last_name, email, phone_number, company_name, website, location, custom_fields, linkedin_profile, company_url, is_unsubscribed, unsubscribed_client_id_map, last_email_sequence_sent, open_count, click_count, reply_count. |
+| `row_count` | number | Number of data rows in the CSV |
 
 ### Smartlead List Campaign Email Accounts
 
@@ -3079,100 +762,36 @@ Retrieves the sending email accounts attached to a Smartlead campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `accounts` | array | Email accounts, excluding their stored mailbox credentials |
+|   ↳ `id` | number | Email account ID, used to attach it to a campaign |
+|   ↳ `from_name` | string | Sender display name |
+|   ↳ `from_email` | string | Sender email address |
+|   ↳ `username` | string | Mailbox username |
+|   ↳ `type` | string | Account type \(GMAIL, OUTLOOK, SMTP\) |
+|   ↳ `smtp_host` | string | SMTP host |
+|   ↳ `smtp_port` | number | SMTP port |
+|   ↳ `smtp_port_type` | string | SMTP encryption type |
+|   ↳ `imap_host` | string | IMAP host |
+|   ↳ `imap_port` | number | IMAP port |
+|   ↳ `imap_port_type` | string | IMAP encryption type |
+|   ↳ `is_smtp_success` | boolean | Whether SMTP verification succeeded |
+|   ↳ `is_imap_success` | boolean | Whether IMAP verification succeeded |
+|   ↳ `smtp_failure_error` | string | Last SMTP error |
+|   ↳ `imap_failure_error` | string | Last IMAP error |
+|   ↳ `message_per_day` | number | Daily sending cap |
+|   ↳ `daily_sent_count` | number | Messages sent today |
+|   ↳ `campaign_count` | number | Campaigns using this account |
+|   ↳ `signature` | string | Email signature HTML |
+|   ↳ `custom_tracking_domain` | string | Custom tracking domain |
+|   ↳ `bcc_email` | string | BCC address |
+|   ↳ `different_reply_to_address` | string | Reply-to address |
+|   ↳ `client_id` | number | Owning client ID |
+|   ↳ `is_suspended` | boolean | Whether the account is suspended |
+|   ↳ `warmup_status` | string | Warmup status |
+|   ↳ `tags` | array | Tags applied to the account |
+|   ↳ `created_at` | string | Creation timestamp |
+|   ↳ `updated_at` | string | Last update timestamp |
+| `count` | number | Number of accounts returned |
 
 ### Smartlead Add Email Accounts to Campaign
 
@@ -3190,100 +809,7 @@ Attaches sending email accounts to a Smartlead campaign. A campaign needs at lea
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Remove Email Accounts from Campaign
 
@@ -3301,100 +827,7 @@ Detaches sending email accounts from a Smartlead campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead List Email Accounts
 
@@ -3413,100 +846,36 @@ Retrieves the sending email accounts on the Smartlead account, including their I
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `accounts` | array | Email accounts, excluding their stored mailbox credentials |
+|   ↳ `id` | number | Email account ID, used to attach it to a campaign |
+|   ↳ `from_name` | string | Sender display name |
+|   ↳ `from_email` | string | Sender email address |
+|   ↳ `username` | string | Mailbox username |
+|   ↳ `type` | string | Account type \(GMAIL, OUTLOOK, SMTP\) |
+|   ↳ `smtp_host` | string | SMTP host |
+|   ↳ `smtp_port` | number | SMTP port |
+|   ↳ `smtp_port_type` | string | SMTP encryption type |
+|   ↳ `imap_host` | string | IMAP host |
+|   ↳ `imap_port` | number | IMAP port |
+|   ↳ `imap_port_type` | string | IMAP encryption type |
+|   ↳ `is_smtp_success` | boolean | Whether SMTP verification succeeded |
+|   ↳ `is_imap_success` | boolean | Whether IMAP verification succeeded |
+|   ↳ `smtp_failure_error` | string | Last SMTP error |
+|   ↳ `imap_failure_error` | string | Last IMAP error |
+|   ↳ `message_per_day` | number | Daily sending cap |
+|   ↳ `daily_sent_count` | number | Messages sent today |
+|   ↳ `campaign_count` | number | Campaigns using this account |
+|   ↳ `signature` | string | Email signature HTML |
+|   ↳ `custom_tracking_domain` | string | Custom tracking domain |
+|   ↳ `bcc_email` | string | BCC address |
+|   ↳ `different_reply_to_address` | string | Reply-to address |
+|   ↳ `client_id` | number | Owning client ID |
+|   ↳ `is_suspended` | boolean | Whether the account is suspended |
+|   ↳ `warmup_status` | string | Warmup status |
+|   ↳ `tags` | array | Tags applied to the account |
+|   ↳ `created_at` | string | Creation timestamp |
+|   ↳ `updated_at` | string | Last update timestamp |
+| `count` | number | Number of accounts returned |
 
 ### Smartlead Get Campaign Lead Statistics
 
@@ -3525,100 +894,11 @@ Retrieves per-lead engagement statistics for a Smartlead campaign.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
+| `rows` | array | Rows returned by Smartlead, passed through unchanged |
+| `count` | number | Number of rows returned in this page |
 | `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
 | `offset` | number | Pagination offset used |
 | `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Get Campaign Mailbox Statistics
 
@@ -3635,100 +915,8 @@ Retrieves per-mailbox sending statistics for a Smartlead campaign, for spotting 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
+| `items` | array | Records returned by Smartlead, passed through unchanged |
 | `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Get Campaign Top-Level Analytics By Date
 
@@ -3747,100 +935,22 @@ Retrieves top-level Smartlead campaign counts for a date range, including positi
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
+| `id` | number | Campaign ID |
+| `name` | string | Campaign name |
 | `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
+| `start_date` | string | Start of the reported range |
+| `end_date` | string | End of the reported range |
+| `total_count` | number | Total emails in the range |
 | `sent_count` | number | Emails sent |
+| `skipped_count` | number | Emails skipped |
 | `open_count` | number | Email opens |
 | `click_count` | number | Link clicks |
 | `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
 | `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
+| `bounce_count` | number | Bounces |
 | `failed_count` | number | Failed sends |
 | `stopped_count` | number | Stopped leads |
 | `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead List Lead Activities
 
@@ -3858,100 +968,11 @@ Retrieves recent lead activity across all Smartlead campaigns — opens, clicks,
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
+| `rows` | array | Rows returned by Smartlead, passed through unchanged |
+| `count` | number | Number of rows returned in this page |
 | `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
 | `offset` | number | Pagination offset used |
 | `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Get Lead by ID
 
@@ -3968,100 +989,19 @@ Looks up a Smartlead lead by its ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
+| `id` | number | Lead ID |
 | `first_name` | string | Lead first name |
 | `last_name` | string | Lead last name |
+| `email` | string | Lead email address |
 | `phone_number` | string | Lead phone number |
 | `company_name` | string | Lead company name |
 | `website` | string | Lead website |
 | `location` | string | Lead location |
 | `linkedin_profile` | string | Lead LinkedIn profile URL |
 | `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
+| `custom_fields` | object | Lead custom fields |
 | `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `created_at` | string | Lead creation timestamp |
 
 ### Smartlead Unsubscribe Lead from Campaign
 
@@ -4079,100 +1019,7 @@ Unsubscribes a lead from a single Smartlead campaign, leaving it active in other
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Unsubscribe Lead Globally
 
@@ -4189,100 +1036,7 @@ Unsubscribes a lead across every Smartlead campaign and adds it to the account-w
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead Mark Lead Complete
 
@@ -4300,100 +1054,10 @@ Marks a lead as completed in a Smartlead campaign so it stops receiving further 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether the lead was marked complete |
+| `is_last_sequence` | boolean | Whether the lead was on the final sequence step |
+| `next_sequence_id` | number | ID of the next sequence step, or null when none remains |
+| `next_sequence_delay_in_days` | number | Days before the next sequence step would have sent |
 
 ### Smartlead Delete Lead from Campaign
 
@@ -4411,100 +1075,7 @@ Removes a lead from a Smartlead campaign. The lead record itself remains on the 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead List Inbox Replies
 
@@ -4523,100 +1094,11 @@ Retrieves replies from the Smartlead master inbox across all campaigns, optional
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
+| `rows` | array | Rows returned by Smartlead, passed through unchanged |
+| `count` | number | Number of rows returned in this page |
 | `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
 | `offset` | number | Pagination offset used |
 | `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead List Lead Lists
 
@@ -4634,100 +1116,15 @@ Retrieves the lead lists on the Smartlead account with their lead counts.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `lists` | array | Lead lists on the account |
+|   ↳ `id` | number | Lead list ID |
+|   ↳ `list_name` | string | Lead list name |
+|   ↳ `created_at` | string | Creation timestamp |
+|   ↳ `updated_at` | string | Last update timestamp |
+|   ↳ `leads_count` | number | Leads in the list |
+|   ↳ `active_leads_count` | number | Active leads in the list |
+| `total_count` | number | Total lead lists on the account |
+| `count` | number | Number of lead lists returned |
 
 ### Smartlead Get Lead List
 
@@ -4744,100 +1141,12 @@ Retrieves a single Smartlead lead list by ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
+| `id` | number | Lead list ID |
 | `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 | `leads_count` | number | Leads in the list |
 | `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Create Lead List
 
@@ -4854,100 +1163,12 @@ Creates a lead list on the Smartlead account.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
+| `id` | number | Lead list ID |
 | `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 | `leads_count` | number | Leads in the list |
 | `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Update Lead List
 
@@ -4965,100 +1186,12 @@ Renames a Smartlead lead list.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
+| `id` | number | Lead list ID |
 | `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
 | `created_at` | string | Creation timestamp |
 | `updated_at` | string | Last update timestamp |
 | `leads_count` | number | Leads in the list |
 | `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
 
 ### Smartlead Delete Lead List
 
@@ -5075,100 +1208,7 @@ Deletes a Smartlead lead list.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
-| `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
+| `success` | boolean | Whether Smartlead confirmed the change |
 
 ### Smartlead List Clients
 
@@ -5184,99 +1224,5 @@ Retrieves the clients on a Smartlead agency account, including the client IDs us
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `campaigns` | array | List of campaigns |
-| `leads` | array | List of leads |
-| `sequences` | array | Email sequence steps |
-| `categories` | array | Lead categories |
-| `webhooks` | array | Campaign webhooks |
-| `stats` | array | Per-email statistics rows |
-| `history` | array | Lead message history |
+| `items` | array | Records returned by Smartlead, passed through unchanged |
 | `count` | number | Number of records returned |
-| `total_leads` | number | Total leads in the campaign, or leads newly added when importing |
-| `total_stats` | number | Total statistics rows matching the filters |
-| `id` | number | Record ID |
-| `name` | string | Record name |
-| `status` | string | Campaign status |
-| `email` | string | Lead email address |
-| `webhook_url` | string | Webhook destination URL |
-| `event_types` | array | Webhook event types |
-| `sent_count` | number | Emails sent |
-| `open_count` | number | Email opens |
-| `click_count` | number | Link clicks |
-| `reply_count` | number | Replies |
-| `bounce_count` | number | Bounces |
-| `campaign_lead_stats` | json | Lead counts by state |
-| `upload_count` | number | Leads submitted in the request |
-| `success` | boolean | Whether the action succeeded |
-| `items` | array | Records returned by Smartlead |
-| `rows` | array | Rows returned by Smartlead |
-| `lists` | array | Lead lists |
-| `summary` | array | Webhook delivery summary rows |
-| `csv` | string | Exported leads as CSV |
-| `row_count` | number | Rows in the exported CSV |
-| `has_more` | boolean | Whether more rows are available |
-| `list_name` | string | Lead list name |
-| `positive_reply_count` | number | Replies categorized as positive |
-| `offset` | number | Pagination offset used |
-| `limit` | number | Pagination limit used |
-| `total_count` | number | Total records matching the request |
-| `from` | string | Start of the reported window |
-| `to` | string | End of the reported window |
-| `start_date` | string | Start of the reported range |
-| `end_date` | string | End of the reported range |
-| `skipped_count` | number | Emails skipped |
-| `failed_count` | number | Failed sends |
-| `stopped_count` | number | Stopped leads |
-| `unsubscribed_count` | number | Unsubscribes |
-| `unique_sent_count` | number | Unique leads emailed |
-| `unique_open_count` | number | Unique opens |
-| `unique_click_count` | number | Unique clicks |
-| `block_count` | number | Blocked sends, or leads skipped by the block list |
-| `drafted_count` | number | Drafted emails |
-| `sequence_count` | number | Sequence steps in the campaign |
-| `duplicate_count` | number | Duplicate leads skipped on import |
-| `invalid_email_count` | number | Leads skipped for an invalid email |
-| `invalid_emails` | array | Emails rejected as invalid |
-| `already_added_to_campaign` | number | Leads already in the campaign |
-| `unsubscribed_leads` | array | Leads skipped because they unsubscribed |
-| `lead_import_stopped_count` | number | Leads whose import was stopped |
-| `is_lead_limit_exhausted` | boolean | Whether the plan lead limit was hit |
-| `is_last_sequence` | boolean | Whether the lead was on the final step |
-| `next_sequence_id` | number | ID of the next sequence step |
-| `next_sequence_delay_in_days` | number | Days before the next step |
-| `first_name` | string | Lead first name |
-| `last_name` | string | Lead last name |
-| `phone_number` | string | Lead phone number |
-| `company_name` | string | Lead company name |
-| `website` | string | Lead website |
-| `location` | string | Lead location |
-| `linkedin_profile` | string | Lead LinkedIn profile URL |
-| `company_url` | string | Lead company URL |
-| `custom_fields` | json | Lead custom fields |
-| `is_unsubscribed` | boolean | Whether the lead is unsubscribed |
-| `lead_campaign_data` | array | Campaigns the lead belongs to |
-| `created_at` | string | Creation timestamp |
-| `updated_at` | string | Last update timestamp |
-| `leads_count` | number | Leads in the list |
-| `active_leads_count` | number | Active leads in the list |
-| `track_settings` | array | Disabled tracking settings |
-| `scheduler_cron_value` | json | Campaign sending schedule |
-| `accounts` | array | Sending email accounts, excluding their stored mailbox credentials |
-| `user_id` | number | Owning Smartlead user ID |
-| `min_time_btwn_emails` | number | Minimum minutes between emails |
-| `max_leads_per_day` | number | Maximum new leads per day |
-| `stop_lead_settings` | string | Activity that stops a lead sequence |
-| `schedule_start_time` | string | Scheduled start time |
-| `enable_ai_esp_matching` | boolean | Whether AI ESP matching is enabled |
-| `send_as_plain_text` | boolean | Whether emails send as plain text |
-| `follow_up_percentage` | number | Follow-up percentage |
-| `unsubscribe_text` | string | Unsubscribe text |
-| `parent_campaign_id` | number | Parent campaign ID |
-| `client_id` | number | Client ID for agency accounts |
-| `client_name` | string | Client name |
-| `client_email` | string | Client email |
-| `client_company_name` | string | Client company name |
-| `tags` | array | Tags on the record |
-| `email_campaign_id` | number | Campaign the webhook belongs to |
-
-

--- a/apps/docs/content/docs/integrations/smtp.mdx
+++ b/apps/docs/content/docs/integrations/smtp.mdx
@@ -5,7 +5,7 @@ description: Send emails via any SMTP mail server
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="smtp"
   color="#2D3748"
 />
@@ -56,5 +56,3 @@ Send emails via SMTP server
 | `to` | string | Recipient email address |
 | `subject` | string | Email subject |
 | `error` | string | Error message if sending failed |
-
-

--- a/apps/docs/content/docs/integrations/snowflake.mdx
+++ b/apps/docs/content/docs/integrations/snowflake.mdx
@@ -5,7 +5,7 @@ description: Query data and manage warehouses and tasks in Snowflake
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="snowflake"
   color="#FFFFFF"
 />
@@ -50,22 +50,22 @@ Execute one parameterized SQL statement through the Snowflake SQL API.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -91,22 +91,22 @@ Check a running or completed statement and retrieve exactly one result partition
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -130,22 +130,22 @@ Cancel a running Snowflake SQL API statement.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -175,22 +175,22 @@ Insert structured JSON rows using bound values.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -221,22 +221,22 @@ Update matching rows with a bound MERGE statement without inserting new rows.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -267,22 +267,22 @@ Update matching rows and insert unmatched rows with a bound MERGE statement.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -312,22 +312,22 @@ Delete rows matching a required set of bound column filters.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -364,22 +364,22 @@ Load files from an existing Snowflake stage with COPY INTO.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -415,22 +415,22 @@ Export a Snowflake table to files in a stage with COPY INTO.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -457,22 +457,22 @@ List the databases the credential can access.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -500,22 +500,22 @@ List the schemas in a Snowflake database.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -544,22 +544,22 @@ List the tables in a Snowflake schema.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -586,22 +586,22 @@ List warehouses visible to the active Snowflake role.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -627,22 +627,22 @@ Get the full details for a Snowflake virtual warehouse.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -668,22 +668,22 @@ Resume a Snowflake virtual warehouse if it is suspended.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -709,22 +709,22 @@ Suspend a Snowflake virtual warehouse.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -753,22 +753,22 @@ Resize a Snowflake warehouse or change its auto-suspend and auto-resume settings
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -797,22 +797,22 @@ List tasks in a Snowflake schema.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -840,22 +840,22 @@ Describe a Snowflake task.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -884,22 +884,22 @@ Run a Snowflake task immediately, optionally retrying its last failed graph.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -927,22 +927,22 @@ Resume a suspended Snowflake task so its schedule runs again.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -970,22 +970,22 @@ Suspend a Snowflake task so its schedule stops triggering runs.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -1016,22 +1016,22 @@ Query up to seven days of Snowflake task history, capped at 10000 rows.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -1061,22 +1061,22 @@ Find one task history record by query ID within Snowflake’s seven-day window a
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -1103,22 +1103,22 @@ Cancel one running task query by query ID with SYSTEM$CANCEL_QUERY. Task runs al
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -1146,22 +1146,22 @@ Read a task query result with RESULT_SCAN during Snowflake’s 24-hour retention
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -1193,22 +1193,22 @@ List queries that completed in the last seven days, optionally filtered.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -1240,22 +1240,22 @@ List staged-file load results for a table over the last fourteen days.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -1286,22 +1286,22 @@ Inspect table and column metadata through Snowflake INFORMATION_SCHEMA views.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
@@ -1332,26 +1332,24 @@ Call a stored procedure with explicitly typed Snowflake bindings.
 | --------- | ---- | ----------- |
 | `statementHandle` | string | Snowflake statement handle |
 | `status` | string | Statement status: SUCCEEDED, RUNNING, or CANCELED |
-| `message` | string | Snowflake response message |
-| `result` | object | Completed result partition, or null while running or when no result is available |
-|   ↳ `columns` | array | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
+| `message` | string (nullable) | Snowflake response message |
+| `result` | object (nullable) | Completed result partition, or null while running or when no result is available |
+|   ↳ `columns` | array (nullable) | Documented Snowflake result column metadata, or null when Snowflake returned a metadata-less partition response |
 |     ↳ `name` | string | Column name |
 |     ↳ `type` | string | Snowflake data type |
-|     ↳ `length` | number | Column length |
-|     ↳ `precision` | number | Numeric precision |
-|     ↳ `scale` | number | Numeric scale |
+|     ↳ `length` | number (nullable) | Column length |
+|     ↳ `precision` | number (nullable) | Numeric precision |
+|     ↳ `scale` | number (nullable) | Numeric scale |
 |     ↳ `nullable` | boolean | Whether the column is nullable |
 |   ↳ `rows` | array | One complete Snowflake result partition as string or null arrays |
-|   ↳ `totalRows` | number | Total result rows |
+|   ↳ `totalRows` | number (nullable) | Total result rows |
 |   ↳ `currentPartition` | number | Zero-based partition returned |
-|   ↳ `partitionCount` | number | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
-|   ↳ `nextPartition` | number | Next partition to request with Get Statement, if one exists |
-|   ↳ `truncated` | boolean | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
-| `dml` | object | Completed DML statistics, or null when the statement has no DML statistics |
+|   ↳ `partitionCount` | number (nullable) | Total partitions in the result set. Snowflake reports this only on the first partition, so pass it back to Get Statement when fetching later partitions |
+|   ↳ `nextPartition` | number (nullable) | Next partition to request with Get Statement, if one exists |
+|   ↳ `truncated` | boolean (nullable) | Whether more result partitions remain to fetch with Get Statement, or null when Snowflake returned a metadata-less partition response and partitionCount was not supplied. Snowflake does not report when the requested row limit capped the result set, so that cap is never reflected here |
+| `dml` | object (nullable) | Completed DML statistics, or null when the statement has no DML statistics |
 |   ↳ `rowsInserted` | number | Rows inserted by the statement |
 |   ↳ `rowsUpdated` | number | Rows updated by the statement |
 |   ↳ `rowsDeleted` | number | Rows deleted by the statement |
 |   ↳ `duplicateRowsUpdated` | number | Duplicate rows updated by the statement |
 |   ↳ `rowsAffected` | number | Total inserted, updated, and deleted rows |
-
-

--- a/apps/docs/content/docs/integrations/splunk.mdx
+++ b/apps/docs/content/docs/integrations/splunk.mdx
@@ -5,7 +5,7 @@ description: Run SPL searches and manage saved searches and alerts in Splunk
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="splunk"
   color="#FFFFFF"
 />
@@ -449,5 +449,3 @@ List the apps installed on the Splunk instance with their label, version, author
 |   ↳ `stateChangeRequiresRestart` | boolean | Whether changing the app state requires a restart |
 | `total` | number | Total number of entries matching the request, from the response paging envelope. Compare with offset to decide whether another page remains. |
 | `offset` | number | Offset of the first entry in this page, echoed from the response paging envelope |
-
-

--- a/apps/docs/content/docs/integrations/sportmonks.mdx
+++ b/apps/docs/content/docs/integrations/sportmonks.mdx
@@ -5,7 +5,7 @@ description: Access Sportmonks football, motorsport, odds, and reference data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sportmonks"
   color="#171534"
 />
@@ -55,8 +55,8 @@ Retrieve lineup-level expected goals (xG) values per player from Sportmonks
 |   ↳ `id` | number | Unique id of the expected value |
 |   ↳ `fixture_id` | number | Fixture related to the value |
 |   ↳ `player_id` | number | Player related to the value |
-|   ↳ `team_id` | number | Team related to the value |
-|   ↳ `lineup_id` | number | Lineup record the player relates to |
+|   ↳ `team_id` | number (nullable) | Team related to the value |
+|   ↳ `lineup_id` | number (nullable) | Lineup record the player relates to |
 |   ↳ `type_id` | number | Type of the expected value |
 |   ↳ `data` | object | The expected value payload |
 |     ↳ `value` | number | The xG value |
@@ -87,7 +87,7 @@ Retrieve fixture-level expected goals (xG) values per team from Sportmonks
 |   ↳ `participant_id` | number | Team related to the expected value |
 |   ↳ `data` | object | The expected value payload |
 |     ↳ `value` | number | The xG value |
-|   ↳ `location` | string | Home or away |
+|   ↳ `location` | string (nullable) | Home or away |
 
 ### Get All Commentaries
 
@@ -112,8 +112,8 @@ Retrieve all textual commentaries available within your Sportmonks subscription
 |   ↳ `id` | number | Unique id of the commentary |
 |   ↳ `fixture_id` | number | Fixture related to the commentary |
 |   ↳ `comment` | string | The commentary text |
-|   ↳ `minute` | number | Match minute of the comment |
-|   ↳ `extra_minute` | number | Extra \(injury\) minute of the comment |
+|   ↳ `minute` | number (nullable) | Match minute of the comment |
+|   ↳ `extra_minute` | number (nullable) | Extra \(injury\) minute of the comment |
 |   ↳ `is_goal` | boolean | Whether the comment is a goal |
 |   ↳ `is_important` | boolean | Whether the comment is important |
 |   ↳ `order` | number | Order of the comment |
@@ -143,17 +143,17 @@ Retrieve all football fixtures available within your Sportmonks subscription
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -181,21 +181,21 @@ Retrieve all football players available within your Sportmonks subscription
 | `players` | array | Array of player objects |
 |   ↳ `id` | number | Unique id of the player |
 |   ↳ `sport_id` | number | Sport of the player |
-|   ↳ `country_id` | number | Country of birth of the player |
-|   ↳ `nationality_id` | number | Nationality of the player |
-|   ↳ `city_id` | number | City of birth of the player |
-|   ↳ `position_id` | number | Position of the player |
-|   ↳ `detailed_position_id` | number | Detailed position of the player |
-|   ↳ `type_id` | number | Type of the player |
+|   ↳ `country_id` | number (nullable) | Country of birth of the player |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the player |
+|   ↳ `city_id` | number (nullable) | City of birth of the player |
+|   ↳ `position_id` | number (nullable) | Position of the player |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position of the player |
+|   ↳ `type_id` | number (nullable) | Type of the player |
 |   ↳ `common_name` | string | Name the player is known for |
 |   ↳ `firstname` | string | First name of the player |
 |   ↳ `lastname` | string | Last name of the player |
 |   ↳ `name` | string | Name of the player |
 |   ↳ `display_name` | string | Display name of the player |
 |   ↳ `image_path` | string | URL to the player headshot |
-|   ↳ `height` | number | Height of the player in cm |
-|   ↳ `weight` | number | Weight of the player in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the player |
+|   ↳ `height` | number (nullable) | Height of the player in cm |
+|   ↳ `weight` | number (nullable) | Weight of the player in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
 ### Get All Rivals
@@ -245,15 +245,15 @@ Retrieve all football teams available within your Sportmonks subscription
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Home venue of the team |
+|   ↳ `venue_id` | number (nullable) | Home venue of the team |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the last played match |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the last played match |
 
 ### Get All Transfer Rumours
 
@@ -278,16 +278,16 @@ Retrieve all transfer rumours available within your Sportmonks subscription
 |   ↳ `id` | number | Unique id of the transfer rumour |
 |   ↳ `sport_id` | number | Sport of the transfer rumour |
 |   ↳ `player_id` | number | Player the rumour relates to |
-|   ↳ `position_id` | number | Position id of the player |
-|   ↳ `from_team_id` | number | Team the player would transfer from |
-|   ↳ `to_team_id` | number | Team the player would transfer to |
-|   ↳ `transfer_fee_id` | number | Transfer fee id of the rumour |
+|   ↳ `position_id` | number (nullable) | Position id of the player |
+|   ↳ `from_team_id` | number (nullable) | Team the player would transfer from |
+|   ↳ `to_team_id` | number (nullable) | Team the player would transfer to |
+|   ↳ `transfer_fee_id` | number (nullable) | Transfer fee id of the rumour |
 |   ↳ `probability` | string | Probability of the rumour \(e.g. LOW\) |
-|   ↳ `source_name` | string | Name of the source of the rumour |
-|   ↳ `source_url` | string | URL of the source of the rumour |
-|   ↳ `amount` | number | Estimated transfer fee amount |
-|   ↳ `currency` | string | Currency of the amount |
-|   ↳ `date` | string | Date of the rumour |
+|   ↳ `source_name` | string (nullable) | Name of the source of the rumour |
+|   ↳ `source_url` | string (nullable) | URL of the source of the rumour |
+|   ↳ `amount` | number (nullable) | Estimated transfer fee amount |
+|   ↳ `currency` | string (nullable) | Currency of the amount |
+|   ↳ `date` | string (nullable) | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
 ### Get All Transfers
@@ -314,14 +314,14 @@ Retrieve all transfers available within your Sportmonks subscription
 |   ↳ `sport_id` | number | Sport of the transfer |
 |   ↳ `player_id` | number | Player who transferred |
 |   ↳ `type_id` | number | Type of the transfer |
-|   ↳ `from_team_id` | number | Team the player transferred from |
-|   ↳ `to_team_id` | number | Team the player transferred to |
-|   ↳ `position_id` | number | Position id of the transfer |
-|   ↳ `detailed_position_id` | number | Detailed position id of the transfer |
-|   ↳ `date` | string | Date of the transfer |
+|   ↳ `from_team_id` | number (nullable) | Team the player transferred from |
+|   ↳ `to_team_id` | number (nullable) | Team the player transferred to |
+|   ↳ `position_id` | number (nullable) | Position id of the transfer |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position id of the transfer |
+|   ↳ `date` | string (nullable) | Date of the transfer |
 |   ↳ `career_ended` | boolean | Whether the transfer ended the career |
 |   ↳ `completed` | boolean | Whether the transfer is completed |
-|   ↳ `amount` | number | Transfer fee amount |
+|   ↳ `amount` | number (nullable) | Transfer fee amount |
 
 ### Get Brackets by Season
 
@@ -360,21 +360,21 @@ Retrieve a single football coach by their ID from Sportmonks
 | --------- | ---- | ----------- |
 | `coach` | object | The requested coach object |
 |   ↳ `id` | number | Unique id of the coach |
-|   ↳ `player_id` | number | Player related to the coach |
+|   ↳ `player_id` | number (nullable) | Player related to the coach |
 |   ↳ `sport_id` | number | Sport of the coach |
-|   ↳ `country_id` | number | Country of the coach |
-|   ↳ `nationality_id` | number | Nationality of the coach |
-|   ↳ `city_id` | number | Birth city of the coach |
+|   ↳ `country_id` | number (nullable) | Country of the coach |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the coach |
+|   ↳ `city_id` | number (nullable) | Birth city of the coach |
 |   ↳ `common_name` | string | Common name of the coach |
-|   ↳ `firstname` | string | First name of the coach |
-|   ↳ `lastname` | string | Last name of the coach |
+|   ↳ `firstname` | string (nullable) | First name of the coach |
+|   ↳ `lastname` | string (nullable) | Last name of the coach |
 |   ↳ `name` | string | Name of the coach |
 |   ↳ `display_name` | string | Display name of the coach |
 |   ↳ `image_path` | string | URL to the coach headshot |
-|   ↳ `height` | number | Height of the coach in cm |
-|   ↳ `weight` | number | Weight of the coach in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the coach |
-|   ↳ `gender` | string | Gender of the coach |
+|   ↳ `height` | number (nullable) | Height of the coach in cm |
+|   ↳ `weight` | number (nullable) | Weight of the coach in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the coach |
+|   ↳ `gender` | string (nullable) | Gender of the coach |
 
 ### Get Coaches
 
@@ -397,21 +397,21 @@ Retrieve all football coaches available within your Sportmonks subscription
 | --------- | ---- | ----------- |
 | `coaches` | array | Array of coach objects |
 |   ↳ `id` | number | Unique id of the coach |
-|   ↳ `player_id` | number | Player related to the coach |
+|   ↳ `player_id` | number (nullable) | Player related to the coach |
 |   ↳ `sport_id` | number | Sport of the coach |
-|   ↳ `country_id` | number | Country of the coach |
-|   ↳ `nationality_id` | number | Nationality of the coach |
-|   ↳ `city_id` | number | Birth city of the coach |
+|   ↳ `country_id` | number (nullable) | Country of the coach |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the coach |
+|   ↳ `city_id` | number (nullable) | Birth city of the coach |
 |   ↳ `common_name` | string | Common name of the coach |
-|   ↳ `firstname` | string | First name of the coach |
-|   ↳ `lastname` | string | Last name of the coach |
+|   ↳ `firstname` | string (nullable) | First name of the coach |
+|   ↳ `lastname` | string (nullable) | Last name of the coach |
 |   ↳ `name` | string | Name of the coach |
 |   ↳ `display_name` | string | Display name of the coach |
 |   ↳ `image_path` | string | URL to the coach headshot |
-|   ↳ `height` | number | Height of the coach in cm |
-|   ↳ `weight` | number | Weight of the coach in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the coach |
-|   ↳ `gender` | string | Gender of the coach |
+|   ↳ `height` | number (nullable) | Height of the coach in cm |
+|   ↳ `weight` | number (nullable) | Weight of the coach in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the coach |
+|   ↳ `gender` | string (nullable) | Gender of the coach |
 
 ### Get Coaches by Country
 
@@ -435,21 +435,21 @@ Retrieve all coaches for a country ID from Sportmonks
 | --------- | ---- | ----------- |
 | `coaches` | array | Array of coach objects for the country |
 |   ↳ `id` | number | Unique id of the coach |
-|   ↳ `player_id` | number | Player related to the coach |
+|   ↳ `player_id` | number (nullable) | Player related to the coach |
 |   ↳ `sport_id` | number | Sport of the coach |
-|   ↳ `country_id` | number | Country of the coach |
-|   ↳ `nationality_id` | number | Nationality of the coach |
-|   ↳ `city_id` | number | Birth city of the coach |
+|   ↳ `country_id` | number (nullable) | Country of the coach |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the coach |
+|   ↳ `city_id` | number (nullable) | Birth city of the coach |
 |   ↳ `common_name` | string | Common name of the coach |
-|   ↳ `firstname` | string | First name of the coach |
-|   ↳ `lastname` | string | Last name of the coach |
+|   ↳ `firstname` | string (nullable) | First name of the coach |
+|   ↳ `lastname` | string (nullable) | Last name of the coach |
 |   ↳ `name` | string | Name of the coach |
 |   ↳ `display_name` | string | Display name of the coach |
 |   ↳ `image_path` | string | URL to the coach headshot |
-|   ↳ `height` | number | Height of the coach in cm |
-|   ↳ `weight` | number | Weight of the coach in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the coach |
-|   ↳ `gender` | string | Gender of the coach |
+|   ↳ `height` | number (nullable) | Height of the coach in cm |
+|   ↳ `weight` | number (nullable) | Weight of the coach in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the coach |
+|   ↳ `gender` | string (nullable) | Gender of the coach |
 
 ### Get Commentaries by Fixture
 
@@ -471,8 +471,8 @@ Retrieve textual commentary for a fixture by fixture ID from Sportmonks
 |   ↳ `id` | number | Unique id of the commentary |
 |   ↳ `fixture_id` | number | Fixture related to the commentary |
 |   ↳ `comment` | string | The commentary text |
-|   ↳ `minute` | number | Match minute of the comment |
-|   ↳ `extra_minute` | number | Extra \(injury\) minute of the comment |
+|   ↳ `minute` | number (nullable) | Match minute of the comment |
+|   ↳ `extra_minute` | number (nullable) | Extra \(injury\) minute of the comment |
 |   ↳ `is_goal` | boolean | Whether the comment is a goal |
 |   ↳ `is_important` | boolean | Whether the comment is important |
 |   ↳ `order` | number | Order of the comment |
@@ -503,11 +503,11 @@ Retrieve all current leagues for a team ID from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | number | Whether the league is active \(1\) or inactive \(0\) |
-|   ↳ `short_code` | string | Short code of the league |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
 |   ↳ `image_path` | string | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
 |   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date the last fixture was played |
+|   ↳ `last_played_at` | string (nullable) | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
 ### Get Expected Lineups by Player
@@ -536,13 +536,13 @@ Retrieve the premium expected lineups for a player ID from Sportmonks
 |   ↳ `fixture_id` | number | Fixture the expected lineup relates to |
 |   ↳ `player_id` | number | Player in the expected lineup |
 |   ↳ `team_id` | number | Team of the expected lineup player |
-|   ↳ `formation_field` | string | Formation field of the player |
-|   ↳ `position_id` | number | Position id of the player |
-|   ↳ `detailed_position_id` | number | Detailed position id of the player |
+|   ↳ `formation_field` | string (nullable) | Formation field of the player |
+|   ↳ `position_id` | number (nullable) | Position id of the player |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position id of the player |
 |   ↳ `type_id` | number | Type of the expected lineup record |
-|   ↳ `formation_position` | number | Position of the player in the formation |
+|   ↳ `formation_position` | number (nullable) | Position of the player in the formation |
 |   ↳ `player_name` | string | Name of the player |
-|   ↳ `jersey_number` | number | Jersey number of the player |
+|   ↳ `jersey_number` | number (nullable) | Jersey number of the player |
 
 ### Get Expected Lineups by Team
 
@@ -570,13 +570,13 @@ Retrieve the premium expected lineups for a team ID from Sportmonks
 |   ↳ `fixture_id` | number | Fixture the expected lineup relates to |
 |   ↳ `player_id` | number | Player in the expected lineup |
 |   ↳ `team_id` | number | Team of the expected lineup player |
-|   ↳ `formation_field` | string | Formation field of the player |
-|   ↳ `position_id` | number | Position id of the player |
-|   ↳ `detailed_position_id` | number | Detailed position id of the player |
+|   ↳ `formation_field` | string (nullable) | Formation field of the player |
+|   ↳ `position_id` | number (nullable) | Position id of the player |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position id of the player |
 |   ↳ `type_id` | number | Type of the expected lineup record |
-|   ↳ `formation_position` | number | Position of the player in the formation |
+|   ↳ `formation_position` | number (nullable) | Position of the player in the formation |
 |   ↳ `player_name` | string | Name of the player |
-|   ↳ `jersey_number` | number | Jersey number of the player |
+|   ↳ `jersey_number` | number (nullable) | Jersey number of the player |
 
 ### Get Extended Team Squad
 
@@ -597,14 +597,14 @@ Retrieve all squad entries for a team (based on current seasons) by team ID
 | --------- | ---- | ----------- |
 | `squad` | array | Array of extended squad entries for the team |
 |   ↳ `id` | number | Unique id of the squad record |
-|   ↳ `transfer_id` | number | Transfer id of the squad record |
+|   ↳ `transfer_id` | number (nullable) | Transfer id of the squad record |
 |   ↳ `player_id` | number | Player in the squad |
 |   ↳ `team_id` | number | Team of the squad |
-|   ↳ `position_id` | number | Position of the player in the squad |
-|   ↳ `detailed_position_id` | number | Detailed position of the player in the squad |
-|   ↳ `jersey_number` | number | Jersey number of the player |
-|   ↳ `start` | string | Start contract date of the player |
-|   ↳ `end` | string | End contract date of the player |
+|   ↳ `position_id` | number (nullable) | Position of the player in the squad |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position of the player in the squad |
+|   ↳ `jersey_number` | number (nullable) | Jersey number of the player |
+|   ↳ `start` | string (nullable) | Start contract date of the player |
+|   ↳ `end` | string (nullable) | End contract date of the player |
 
 ### Get Fixture by ID
 
@@ -629,17 +629,17 @@ Retrieve a single football fixture by its ID from Sportmonks
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -671,17 +671,17 @@ Retrieve all football fixtures on a specific date (YYYY-MM-DD) from Sportmonks
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -714,17 +714,17 @@ Retrieve football fixtures between two dates (YYYY-MM-DD) from Sportmonks. Max r
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -758,17 +758,17 @@ Retrieve fixtures for a team within a date range (YYYY-MM-DD) from Sportmonks
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -797,17 +797,17 @@ Retrieve multiple football fixtures by a comma-separated list of IDs (max 50)
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -859,17 +859,17 @@ Retrieve the head-to-head fixtures between two teams from Sportmonks
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -897,17 +897,17 @@ Retrieve all fixtures that are currently being played (in-play) from Sportmonks
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -934,21 +934,21 @@ Retrieve all coaches that have received updates in the past two hours
 | --------- | ---- | ----------- |
 | `coaches` | array | Array of recently updated coach objects |
 |   ↳ `id` | number | Unique id of the coach |
-|   ↳ `player_id` | number | Player related to the coach |
+|   ↳ `player_id` | number (nullable) | Player related to the coach |
 |   ↳ `sport_id` | number | Sport of the coach |
-|   ↳ `country_id` | number | Country of the coach |
-|   ↳ `nationality_id` | number | Nationality of the coach |
-|   ↳ `city_id` | number | Birth city of the coach |
+|   ↳ `country_id` | number (nullable) | Country of the coach |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the coach |
+|   ↳ `city_id` | number (nullable) | Birth city of the coach |
 |   ↳ `common_name` | string | Common name of the coach |
-|   ↳ `firstname` | string | First name of the coach |
-|   ↳ `lastname` | string | Last name of the coach |
+|   ↳ `firstname` | string (nullable) | First name of the coach |
+|   ↳ `lastname` | string (nullable) | Last name of the coach |
 |   ↳ `name` | string | Name of the coach |
 |   ↳ `display_name` | string | Display name of the coach |
 |   ↳ `image_path` | string | URL to the coach headshot |
-|   ↳ `height` | number | Height of the coach in cm |
-|   ↳ `weight` | number | Weight of the coach in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the coach |
-|   ↳ `gender` | string | Gender of the coach |
+|   ↳ `height` | number (nullable) | Height of the coach in cm |
+|   ↳ `weight` | number (nullable) | Weight of the coach in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the coach |
+|   ↳ `gender` | string (nullable) | Gender of the coach |
 
 ### Get Latest Updated Fixtures
 
@@ -972,17 +972,17 @@ Retrieve all fixtures that have received updates within the last 10 seconds
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -1010,17 +1010,17 @@ Retrieve all livescores that have received updates within the last 10 seconds
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -1045,21 +1045,21 @@ Retrieve all players that have received updates in the past two hours
 | `players` | array | Array of recently updated player objects |
 |   ↳ `id` | number | Unique id of the player |
 |   ↳ `sport_id` | number | Sport of the player |
-|   ↳ `country_id` | number | Country of birth of the player |
-|   ↳ `nationality_id` | number | Nationality of the player |
-|   ↳ `city_id` | number | City of birth of the player |
-|   ↳ `position_id` | number | Position of the player |
-|   ↳ `detailed_position_id` | number | Detailed position of the player |
-|   ↳ `type_id` | number | Type of the player |
+|   ↳ `country_id` | number (nullable) | Country of birth of the player |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the player |
+|   ↳ `city_id` | number (nullable) | City of birth of the player |
+|   ↳ `position_id` | number (nullable) | Position of the player |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position of the player |
+|   ↳ `type_id` | number (nullable) | Type of the player |
 |   ↳ `common_name` | string | Name the player is known for |
 |   ↳ `firstname` | string | First name of the player |
 |   ↳ `lastname` | string | Last name of the player |
 |   ↳ `name` | string | Name of the player |
 |   ↳ `display_name` | string | Display name of the player |
 |   ↳ `image_path` | string | URL to the player headshot |
-|   ↳ `height` | number | Height of the player in cm |
-|   ↳ `weight` | number | Weight of the player in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the player |
+|   ↳ `height` | number (nullable) | Height of the player in cm |
+|   ↳ `weight` | number (nullable) | Weight of the player in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
 ### Get Latest Team of the Week
@@ -1112,14 +1112,14 @@ Retrieve the latest transfers available within your Sportmonks subscription
 |   ↳ `sport_id` | number | Sport of the transfer |
 |   ↳ `player_id` | number | Player who transferred |
 |   ↳ `type_id` | number | Type of the transfer |
-|   ↳ `from_team_id` | number | Team the player transferred from |
-|   ↳ `to_team_id` | number | Team the player transferred to |
-|   ↳ `position_id` | number | Position id of the transfer |
-|   ↳ `detailed_position_id` | number | Detailed position id of the transfer |
-|   ↳ `date` | string | Date of the transfer |
+|   ↳ `from_team_id` | number (nullable) | Team the player transferred from |
+|   ↳ `to_team_id` | number (nullable) | Team the player transferred to |
+|   ↳ `position_id` | number (nullable) | Position id of the transfer |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position id of the transfer |
+|   ↳ `date` | string (nullable) | Date of the transfer |
 |   ↳ `career_ended` | boolean | Whether the transfer ended the career |
 |   ↳ `completed` | boolean | Whether the transfer is completed |
-|   ↳ `amount` | number | Transfer fee amount |
+|   ↳ `amount` | number (nullable) | Transfer fee amount |
 
 ### Get League by ID
 
@@ -1144,11 +1144,11 @@ Retrieve a single football league by its ID from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | number | Whether the league is active \(1\) or inactive \(0\) |
-|   ↳ `short_code` | string | Short code of the league |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
 |   ↳ `image_path` | string | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
 |   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date the last fixture was played |
+|   ↳ `last_played_at` | string (nullable) | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
 ### Get Leagues
@@ -1176,11 +1176,11 @@ Retrieve all football leagues available within your Sportmonks subscription
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | number | Whether the league is active \(1\) or inactive \(0\) |
-|   ↳ `short_code` | string | Short code of the league |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
 |   ↳ `image_path` | string | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
 |   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date the last fixture was played |
+|   ↳ `last_played_at` | string (nullable) | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
 ### Get Leagues by Country
@@ -1209,11 +1209,11 @@ Retrieve all leagues for a country ID from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | number | Whether the league is active \(1\) or inactive \(0\) |
-|   ↳ `short_code` | string | Short code of the league |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
 |   ↳ `image_path` | string | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
 |   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date the last fixture was played |
+|   ↳ `last_played_at` | string (nullable) | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
 ### Get Leagues by Date
@@ -1242,11 +1242,11 @@ Retrieve all leagues with fixtures on a given date (YYYY-MM-DD) from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | number | Whether the league is active \(1\) or inactive \(0\) |
-|   ↳ `short_code` | string | Short code of the league |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
 |   ↳ `image_path` | string | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
 |   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date the last fixture was played |
+|   ↳ `last_played_at` | string (nullable) | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
 ### Get Leagues by Team
@@ -1275,11 +1275,11 @@ Retrieve all current and historical leagues for a team ID from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | number | Whether the league is active \(1\) or inactive \(0\) |
-|   ↳ `short_code` | string | Short code of the league |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
 |   ↳ `image_path` | string | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
 |   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date the last fixture was played |
+|   ↳ `last_played_at` | string (nullable) | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
 ### Get Live Leagues
@@ -1307,11 +1307,11 @@ Retrieve all leagues that have fixtures currently being played from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | number | Whether the league is active \(1\) or inactive \(0\) |
-|   ↳ `short_code` | string | Short code of the league |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
 |   ↳ `image_path` | string | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
 |   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date the last fixture was played |
+|   ↳ `last_played_at` | string (nullable) | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
 ### Get Live Probabilities
@@ -1391,8 +1391,8 @@ Retrieve the live standing table for a league ID from Sportmonks
 |   ↳ `league_id` | number | League related to the standing |
 |   ↳ `season_id` | number | Season related to the standing |
 |   ↳ `stage_id` | number | Stage related to the standing |
-|   ↳ `group_id` | number | Group related to the standing |
-|   ↳ `round_id` | number | Round related to the standing |
+|   ↳ `group_id` | number (nullable) | Group related to the standing |
+|   ↳ `round_id` | number (nullable) | Round related to the standing |
 |   ↳ `standing_rule_id` | number | Standing rule related to the standing |
 |   ↳ `position` | number | Position of the team in the standing |
 |   ↳ `result` | string | Movement of the team in the standing |
@@ -1420,17 +1420,17 @@ Retrieve fixtures starting within 15 minutes and currently in progress from Spor
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -1590,17 +1590,17 @@ Retrieve all past fixtures that were available for a TV station ID from Sportmon
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -1626,21 +1626,21 @@ Retrieve a single football player by their ID from Sportmonks
 | `player` | object | The requested player object |
 |   ↳ `id` | number | Unique id of the player |
 |   ↳ `sport_id` | number | Sport of the player |
-|   ↳ `country_id` | number | Country of birth of the player |
-|   ↳ `nationality_id` | number | Nationality of the player |
-|   ↳ `city_id` | number | City of birth of the player |
-|   ↳ `position_id` | number | Position of the player |
-|   ↳ `detailed_position_id` | number | Detailed position of the player |
-|   ↳ `type_id` | number | Type of the player |
+|   ↳ `country_id` | number (nullable) | Country of birth of the player |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the player |
+|   ↳ `city_id` | number (nullable) | City of birth of the player |
+|   ↳ `position_id` | number (nullable) | Position of the player |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position of the player |
+|   ↳ `type_id` | number (nullable) | Type of the player |
 |   ↳ `common_name` | string | Name the player is known for |
 |   ↳ `firstname` | string | First name of the player |
 |   ↳ `lastname` | string | Last name of the player |
 |   ↳ `name` | string | Name of the player |
 |   ↳ `display_name` | string | Display name of the player |
 |   ↳ `image_path` | string | URL to the player headshot |
-|   ↳ `height` | number | Height of the player in cm |
-|   ↳ `weight` | number | Weight of the player in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the player |
+|   ↳ `height` | number (nullable) | Height of the player in cm |
+|   ↳ `weight` | number (nullable) | Weight of the player in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
 ### Get Players by Country
@@ -1666,21 +1666,21 @@ Retrieve all players for a country ID from Sportmonks
 | `players` | array | Array of player objects for the country |
 |   ↳ `id` | number | Unique id of the player |
 |   ↳ `sport_id` | number | Sport of the player |
-|   ↳ `country_id` | number | Country of birth of the player |
-|   ↳ `nationality_id` | number | Nationality of the player |
-|   ↳ `city_id` | number | City of birth of the player |
-|   ↳ `position_id` | number | Position of the player |
-|   ↳ `detailed_position_id` | number | Detailed position of the player |
-|   ↳ `type_id` | number | Type of the player |
+|   ↳ `country_id` | number (nullable) | Country of birth of the player |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the player |
+|   ↳ `city_id` | number (nullable) | City of birth of the player |
+|   ↳ `position_id` | number (nullable) | Position of the player |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position of the player |
+|   ↳ `type_id` | number (nullable) | Type of the player |
 |   ↳ `common_name` | string | Name the player is known for |
 |   ↳ `firstname` | string | First name of the player |
 |   ↳ `lastname` | string | Last name of the player |
 |   ↳ `name` | string | Name of the player |
 |   ↳ `display_name` | string | Display name of the player |
 |   ↳ `image_path` | string | URL to the player headshot |
-|   ↳ `height` | number | Height of the player in cm |
-|   ↳ `weight` | number | Weight of the player in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the player |
+|   ↳ `height` | number (nullable) | Height of the player in cm |
+|   ↳ `weight` | number (nullable) | Weight of the player in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
 ### Get Post-Match News
@@ -1912,19 +1912,19 @@ Retrieve a single football referee by their ID from Sportmonks
 | `referee` | object | The requested referee object |
 |   ↳ `id` | number | Unique id of the referee |
 |   ↳ `sport_id` | number | Sport of the referee |
-|   ↳ `country_id` | number | Country of the referee |
-|   ↳ `nationality_id` | number | Nationality of the referee |
-|   ↳ `city_id` | number | Birth city of the referee |
+|   ↳ `country_id` | number (nullable) | Country of the referee |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the referee |
+|   ↳ `city_id` | number (nullable) | Birth city of the referee |
 |   ↳ `common_name` | string | Common name of the referee |
-|   ↳ `firstname` | string | First name of the referee |
-|   ↳ `lastname` | string | Last name of the referee |
+|   ↳ `firstname` | string (nullable) | First name of the referee |
+|   ↳ `lastname` | string (nullable) | Last name of the referee |
 |   ↳ `name` | string | Name of the referee |
 |   ↳ `display_name` | string | Display name of the referee |
 |   ↳ `image_path` | string | URL to the referee headshot |
-|   ↳ `height` | number | Height of the referee in cm |
-|   ↳ `weight` | number | Weight of the referee in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the referee |
-|   ↳ `gender` | string | Gender of the referee |
+|   ↳ `height` | number (nullable) | Height of the referee in cm |
+|   ↳ `weight` | number (nullable) | Weight of the referee in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the referee |
+|   ↳ `gender` | string (nullable) | Gender of the referee |
 
 ### Get Referees
 
@@ -1948,19 +1948,19 @@ Retrieve all football referees available within your Sportmonks subscription
 | `referees` | array | Array of referee objects |
 |   ↳ `id` | number | Unique id of the referee |
 |   ↳ `sport_id` | number | Sport of the referee |
-|   ↳ `country_id` | number | Country of the referee |
-|   ↳ `nationality_id` | number | Nationality of the referee |
-|   ↳ `city_id` | number | Birth city of the referee |
+|   ↳ `country_id` | number (nullable) | Country of the referee |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the referee |
+|   ↳ `city_id` | number (nullable) | Birth city of the referee |
 |   ↳ `common_name` | string | Common name of the referee |
-|   ↳ `firstname` | string | First name of the referee |
-|   ↳ `lastname` | string | Last name of the referee |
+|   ↳ `firstname` | string (nullable) | First name of the referee |
+|   ↳ `lastname` | string (nullable) | Last name of the referee |
 |   ↳ `name` | string | Name of the referee |
 |   ↳ `display_name` | string | Display name of the referee |
 |   ↳ `image_path` | string | URL to the referee headshot |
-|   ↳ `height` | number | Height of the referee in cm |
-|   ↳ `weight` | number | Weight of the referee in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the referee |
-|   ↳ `gender` | string | Gender of the referee |
+|   ↳ `height` | number (nullable) | Height of the referee in cm |
+|   ↳ `weight` | number (nullable) | Weight of the referee in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the referee |
+|   ↳ `gender` | string (nullable) | Gender of the referee |
 
 ### Get Referees by Country
 
@@ -1985,19 +1985,19 @@ Retrieve all referees for a country ID from Sportmonks
 | `referees` | array | Array of referee objects for the country |
 |   ↳ `id` | number | Unique id of the referee |
 |   ↳ `sport_id` | number | Sport of the referee |
-|   ↳ `country_id` | number | Country of the referee |
-|   ↳ `nationality_id` | number | Nationality of the referee |
-|   ↳ `city_id` | number | Birth city of the referee |
+|   ↳ `country_id` | number (nullable) | Country of the referee |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the referee |
+|   ↳ `city_id` | number (nullable) | Birth city of the referee |
 |   ↳ `common_name` | string | Common name of the referee |
-|   ↳ `firstname` | string | First name of the referee |
-|   ↳ `lastname` | string | Last name of the referee |
+|   ↳ `firstname` | string (nullable) | First name of the referee |
+|   ↳ `lastname` | string (nullable) | Last name of the referee |
 |   ↳ `name` | string | Name of the referee |
 |   ↳ `display_name` | string | Display name of the referee |
 |   ↳ `image_path` | string | URL to the referee headshot |
-|   ↳ `height` | number | Height of the referee in cm |
-|   ↳ `weight` | number | Weight of the referee in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the referee |
-|   ↳ `gender` | string | Gender of the referee |
+|   ↳ `height` | number (nullable) | Height of the referee in cm |
+|   ↳ `weight` | number (nullable) | Weight of the referee in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the referee |
+|   ↳ `gender` | string (nullable) | Gender of the referee |
 
 ### Get Referees by Season
 
@@ -2022,19 +2022,19 @@ Retrieve all referees for a season ID from Sportmonks
 | `referees` | array | Array of referee objects for the season |
 |   ↳ `id` | number | Unique id of the referee |
 |   ↳ `sport_id` | number | Sport of the referee |
-|   ↳ `country_id` | number | Country of the referee |
-|   ↳ `nationality_id` | number | Nationality of the referee |
-|   ↳ `city_id` | number | Birth city of the referee |
+|   ↳ `country_id` | number (nullable) | Country of the referee |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the referee |
+|   ↳ `city_id` | number (nullable) | Birth city of the referee |
 |   ↳ `common_name` | string | Common name of the referee |
-|   ↳ `firstname` | string | First name of the referee |
-|   ↳ `lastname` | string | Last name of the referee |
+|   ↳ `firstname` | string (nullable) | First name of the referee |
+|   ↳ `lastname` | string (nullable) | Last name of the referee |
 |   ↳ `name` | string | Name of the referee |
 |   ↳ `display_name` | string | Display name of the referee |
 |   ↳ `image_path` | string | URL to the referee headshot |
-|   ↳ `height` | number | Height of the referee in cm |
-|   ↳ `weight` | number | Weight of the referee in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the referee |
-|   ↳ `gender` | string | Gender of the referee |
+|   ↳ `height` | number (nullable) | Height of the referee in cm |
+|   ↳ `weight` | number (nullable) | Weight of the referee in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the referee |
+|   ↳ `gender` | string (nullable) | Gender of the referee |
 
 ### Get Rivals by Team
 
@@ -2079,12 +2079,12 @@ Retrieve a single football round by its ID from Sportmonks
 |   ↳ `sport_id` | number | Sport of the round |
 |   ↳ `league_id` | number | League of the round |
 |   ↳ `season_id` | number | Season of the round |
-|   ↳ `stage_id` | number | Stage of the round |
+|   ↳ `stage_id` | number (nullable) | Stage of the round |
 |   ↳ `name` | string | Name of the round |
 |   ↳ `finished` | boolean | Whether the round is finished |
 |   ↳ `is_current` | boolean | Whether the round is the current round |
-|   ↳ `starting_at` | string | Start date of the round |
-|   ↳ `ending_at` | string | End date of the round |
+|   ↳ `starting_at` | string (nullable) | Start date of the round |
+|   ↳ `ending_at` | string (nullable) | End date of the round |
 |   ↳ `games_in_current_week` | boolean | Whether the round has fixtures this week |
 
 ### Get Round Statistics
@@ -2111,7 +2111,7 @@ Retrieve all available statistics for a round ID from Sportmonks
 |   ↳ `id` | number | Unique id of the statistic record |
 |   ↳ `model_id` | number | Id of the entity the statistic belongs to |
 |   ↳ `type_id` | number | Type of the statistic |
-|   ↳ `relation_id` | number | Related entity id \(e.g. participant\) when applicable |
+|   ↳ `relation_id` | number (nullable) | Related entity id \(e.g. participant\) when applicable |
 |   ↳ `value` | json | Statistic value payload \(varies by type\) |
 
 ### Get Rounds
@@ -2138,12 +2138,12 @@ Retrieve all football rounds available within your Sportmonks subscription
 |   ↳ `sport_id` | number | Sport of the round |
 |   ↳ `league_id` | number | League of the round |
 |   ↳ `season_id` | number | Season of the round |
-|   ↳ `stage_id` | number | Stage of the round |
+|   ↳ `stage_id` | number (nullable) | Stage of the round |
 |   ↳ `name` | string | Name of the round |
 |   ↳ `finished` | boolean | Whether the round is finished |
 |   ↳ `is_current` | boolean | Whether the round is the current round |
-|   ↳ `starting_at` | string | Start date of the round |
-|   ↳ `ending_at` | string | End date of the round |
+|   ↳ `starting_at` | string (nullable) | Start date of the round |
+|   ↳ `ending_at` | string (nullable) | End date of the round |
 |   ↳ `games_in_current_week` | boolean | Whether the round has fixtures this week |
 
 ### Get Rounds by Season
@@ -2168,12 +2168,12 @@ Retrieve all rounds for a season ID from Sportmonks
 |   ↳ `sport_id` | number | Sport of the round |
 |   ↳ `league_id` | number | League of the round |
 |   ↳ `season_id` | number | Season of the round |
-|   ↳ `stage_id` | number | Stage of the round |
+|   ↳ `stage_id` | number (nullable) | Stage of the round |
 |   ↳ `name` | string | Name of the round |
 |   ↳ `finished` | boolean | Whether the round is finished |
 |   ↳ `is_current` | boolean | Whether the round is the current round |
-|   ↳ `starting_at` | string | Start date of the round |
-|   ↳ `ending_at` | string | End date of the round |
+|   ↳ `starting_at` | string (nullable) | Start date of the round |
+|   ↳ `ending_at` | string (nullable) | End date of the round |
 |   ↳ `games_in_current_week` | boolean | Whether the round has fixtures this week |
 
 ### Get Schedules by Season
@@ -2249,15 +2249,15 @@ Retrieve a single football season by its ID from Sportmonks
 |   ↳ `id` | number | Unique id of the season |
 |   ↳ `sport_id` | number | Sport of the season |
 |   ↳ `league_id` | number | League of the season |
-|   ↳ `tie_breaker_rule_id` | number | Tie-breaker rule of the season |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Tie-breaker rule of the season |
 |   ↳ `name` | string | Name of the season \(e.g. 2023/2024\) |
 |   ↳ `finished` | boolean | Whether the season is finished |
 |   ↳ `pending` | boolean | Whether the season is pending |
 |   ↳ `is_current` | boolean | Whether the season is the current season |
-|   ↳ `standing_method` | string | Standing calculation method |
-|   ↳ `starting_at` | string | Start date of the season |
-|   ↳ `ending_at` | string | End date of the season |
-|   ↳ `standings_recalculated_at` | string | Last standings recalculation time |
+|   ↳ `standing_method` | string (nullable) | Standing calculation method |
+|   ↳ `starting_at` | string (nullable) | Start date of the season |
+|   ↳ `ending_at` | string (nullable) | End date of the season |
+|   ↳ `standings_recalculated_at` | string (nullable) | Last standings recalculation time |
 |   ↳ `games_in_current_week` | boolean | Whether the season has fixtures this week |
 
 ### Get Seasons
@@ -2283,15 +2283,15 @@ Retrieve all football seasons available within your Sportmonks subscription
 |   ↳ `id` | number | Unique id of the season |
 |   ↳ `sport_id` | number | Sport of the season |
 |   ↳ `league_id` | number | League of the season |
-|   ↳ `tie_breaker_rule_id` | number | Tie-breaker rule of the season |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Tie-breaker rule of the season |
 |   ↳ `name` | string | Name of the season \(e.g. 2023/2024\) |
 |   ↳ `finished` | boolean | Whether the season is finished |
 |   ↳ `pending` | boolean | Whether the season is pending |
 |   ↳ `is_current` | boolean | Whether the season is the current season |
-|   ↳ `standing_method` | string | Standing calculation method |
-|   ↳ `starting_at` | string | Start date of the season |
-|   ↳ `ending_at` | string | End date of the season |
-|   ↳ `standings_recalculated_at` | string | Last standings recalculation time |
+|   ↳ `standing_method` | string (nullable) | Standing calculation method |
+|   ↳ `starting_at` | string (nullable) | Start date of the season |
+|   ↳ `ending_at` | string (nullable) | End date of the season |
+|   ↳ `standings_recalculated_at` | string (nullable) | Last standings recalculation time |
 |   ↳ `games_in_current_week` | boolean | Whether the season has fixtures this week |
 
 ### Get Seasons by Team
@@ -2315,15 +2315,15 @@ Retrieve all seasons for a team ID from Sportmonks
 |   ↳ `id` | number | Unique id of the season |
 |   ↳ `sport_id` | number | Sport of the season |
 |   ↳ `league_id` | number | League of the season |
-|   ↳ `tie_breaker_rule_id` | number | Tie-breaker rule of the season |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Tie-breaker rule of the season |
 |   ↳ `name` | string | Name of the season \(e.g. 2023/2024\) |
 |   ↳ `finished` | boolean | Whether the season is finished |
 |   ↳ `pending` | boolean | Whether the season is pending |
 |   ↳ `is_current` | boolean | Whether the season is the current season |
-|   ↳ `standing_method` | string | Standing calculation method |
-|   ↳ `starting_at` | string | Start date of the season |
-|   ↳ `ending_at` | string | End date of the season |
-|   ↳ `standings_recalculated_at` | string | Last standings recalculation time |
+|   ↳ `standing_method` | string (nullable) | Standing calculation method |
+|   ↳ `starting_at` | string (nullable) | Start date of the season |
+|   ↳ `ending_at` | string (nullable) | End date of the season |
+|   ↳ `standings_recalculated_at` | string (nullable) | Last standings recalculation time |
 |   ↳ `games_in_current_week` | boolean | Whether the season has fixtures this week |
 
 ### Get Stage by ID
@@ -2353,8 +2353,8 @@ Retrieve a single football stage by its ID from Sportmonks
 |   ↳ `sort_order` | number | Sort order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Start date of the stage |
-|   ↳ `ending_at` | string | End date of the stage |
+|   ↳ `starting_at` | string (nullable) | Start date of the stage |
+|   ↳ `ending_at` | string (nullable) | End date of the stage |
 |   ↳ `games_in_current_week` | boolean | Whether the stage has fixtures this week |
 
 ### Get Stage Statistics
@@ -2381,7 +2381,7 @@ Retrieve all available statistics for a stage ID from Sportmonks
 |   ↳ `id` | number | Unique id of the statistic record |
 |   ↳ `model_id` | number | Id of the entity the statistic belongs to |
 |   ↳ `type_id` | number | Type of the statistic |
-|   ↳ `relation_id` | number | Related entity id \(e.g. participant\) when applicable |
+|   ↳ `relation_id` | number (nullable) | Related entity id \(e.g. participant\) when applicable |
 |   ↳ `value` | json | Statistic value payload \(varies by type\) |
 
 ### Get Stages
@@ -2413,8 +2413,8 @@ Retrieve all football stages available within your Sportmonks subscription
 |   ↳ `sort_order` | number | Sort order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Start date of the stage |
-|   ↳ `ending_at` | string | End date of the stage |
+|   ↳ `starting_at` | string (nullable) | Start date of the stage |
+|   ↳ `ending_at` | string (nullable) | End date of the stage |
 |   ↳ `games_in_current_week` | boolean | Whether the stage has fixtures this week |
 
 ### Get Stages by Season
@@ -2444,8 +2444,8 @@ Retrieve all stages for a season ID from Sportmonks
 |   ↳ `sort_order` | number | Sort order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Start date of the stage |
-|   ↳ `ending_at` | string | End date of the stage |
+|   ↳ `starting_at` | string (nullable) | Start date of the stage |
+|   ↳ `ending_at` | string (nullable) | End date of the stage |
 |   ↳ `games_in_current_week` | boolean | Whether the stage has fixtures this week |
 
 ### Get Standing Corrections by Season
@@ -2468,8 +2468,8 @@ Retrieve point corrections (awarded or deducted) for a season ID from Sportmonks
 | `corrections` | array | Array of standing correction entries for the season |
 |   ↳ `id` | number | Unique id of the standing correction |
 |   ↳ `season_id` | number | Season related to the correction |
-|   ↳ `stage_id` | number | Stage related to the correction |
-|   ↳ `group_id` | number | Group related to the correction |
+|   ↳ `stage_id` | number (nullable) | Stage related to the correction |
+|   ↳ `group_id` | number (nullable) | Group related to the correction |
 |   ↳ `type_id` | number | Type of the correction |
 |   ↳ `value` | number | Amount of points awarded or deducted |
 |   ↳ `calc_type` | string | Calculation type applied \(e.g. + or -\) |
@@ -2503,8 +2503,8 @@ Retrieve all standings available within your Sportmonks subscription
 |   ↳ `league_id` | number | League related to the standing |
 |   ↳ `season_id` | number | Season related to the standing |
 |   ↳ `stage_id` | number | Stage related to the standing |
-|   ↳ `group_id` | number | Group related to the standing |
-|   ↳ `round_id` | number | Round related to the standing |
+|   ↳ `group_id` | number (nullable) | Group related to the standing |
+|   ↳ `round_id` | number (nullable) | Round related to the standing |
 |   ↳ `standing_rule_id` | number | Standing rule related to the standing |
 |   ↳ `position` | number | Position of the team in the standing |
 |   ↳ `result` | string | Movement of the team in the standing |
@@ -2534,8 +2534,8 @@ Retrieve the full standing table for a round ID from Sportmonks
 |   ↳ `league_id` | number | League related to the standing |
 |   ↳ `season_id` | number | Season related to the standing |
 |   ↳ `stage_id` | number | Stage related to the standing |
-|   ↳ `group_id` | number | Group related to the standing |
-|   ↳ `round_id` | number | Round related to the standing |
+|   ↳ `group_id` | number (nullable) | Group related to the standing |
+|   ↳ `round_id` | number (nullable) | Round related to the standing |
 |   ↳ `standing_rule_id` | number | Standing rule related to the standing |
 |   ↳ `position` | number | Position of the team in the standing |
 |   ↳ `result` | string | Movement of the team in the standing |
@@ -2565,8 +2565,8 @@ Retrieve the full league standings table for a season by season ID from Sportmon
 |   ↳ `league_id` | number | League related to the standing |
 |   ↳ `season_id` | number | Season related to the standing |
 |   ↳ `stage_id` | number | Stage related to the standing |
-|   ↳ `group_id` | number | Group related to the standing |
-|   ↳ `round_id` | number | Round related to the standing |
+|   ↳ `group_id` | number (nullable) | Group related to the standing |
+|   ↳ `round_id` | number (nullable) | Round related to the standing |
 |   ↳ `standing_rule_id` | number | Standing rule related to the standing |
 |   ↳ `position` | number | Position of the team in the standing |
 |   ↳ `result` | string | Movement of the team in the standing |
@@ -2591,7 +2591,7 @@ Retrieve a single fixture state by its ID from Sportmonks
 |   ↳ `id` | number | Unique id of the state |
 |   ↳ `state` | string | State code \(e.g. NS, INPLAY_1ST_HALF\) |
 |   ↳ `name` | string | Full name of the state \(e.g. Not Started\) |
-|   ↳ `short_name` | string | Short name of the state \(e.g. NS\) |
+|   ↳ `short_name` | string (nullable) | Short name of the state \(e.g. NS\) |
 |   ↳ `developer_name` | string | Developer name of the state |
 
 ### Get States
@@ -2615,7 +2615,7 @@ Retrieve all fixture states (e.g. Not Started, 1st Half, Full Time) from Sportmo
 |   ↳ `id` | number | Unique id of the state |
 |   ↳ `state` | string | State code \(e.g. NS, INPLAY_1ST_HALF\) |
 |   ↳ `name` | string | Full name of the state \(e.g. Not Started\) |
-|   ↳ `short_name` | string | Short name of the state \(e.g. NS\) |
+|   ↳ `short_name` | string (nullable) | Short name of the state \(e.g. NS\) |
 |   ↳ `developer_name` | string | Developer name of the state |
 
 ### Get Team by ID
@@ -2639,15 +2639,15 @@ Retrieve a single football team by its ID from Sportmonks
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Home venue of the team |
+|   ↳ `venue_id` | number (nullable) | Home venue of the team |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the last played match |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the last played match |
 
 ### Get All Team Rankings
 
@@ -2745,14 +2745,14 @@ Retrieve the current domestic squad for a team by team ID from Sportmonks
 | --------- | ---- | ----------- |
 | `squad` | array | Array of squad entries for the team |
 |   ↳ `id` | number | Unique id of the squad record |
-|   ↳ `transfer_id` | number | Transfer id of the squad record |
+|   ↳ `transfer_id` | number (nullable) | Transfer id of the squad record |
 |   ↳ `player_id` | number | Player in the squad |
 |   ↳ `team_id` | number | Team of the squad |
-|   ↳ `position_id` | number | Position of the player in the squad |
-|   ↳ `detailed_position_id` | number | Detailed position of the player in the squad |
-|   ↳ `jersey_number` | number | Jersey number of the player |
-|   ↳ `start` | string | Start contract date of the player |
-|   ↳ `end` | string | End contract date of the player |
+|   ↳ `position_id` | number (nullable) | Position of the player in the squad |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position of the player in the squad |
+|   ↳ `jersey_number` | number (nullable) | Jersey number of the player |
+|   ↳ `start` | string (nullable) | Start contract date of the player |
+|   ↳ `end` | string (nullable) | End contract date of the player |
 
 ### Get Team Squad by Season
 
@@ -2774,14 +2774,14 @@ Retrieve the (historical) squad for a team in a specific season from Sportmonks
 | --------- | ---- | ----------- |
 | `squad` | array | Array of squad entries for the team in the season |
 |   ↳ `id` | number | Unique id of the squad record |
-|   ↳ `transfer_id` | number | Transfer id of the squad record |
+|   ↳ `transfer_id` | number (nullable) | Transfer id of the squad record |
 |   ↳ `player_id` | number | Player in the squad |
 |   ↳ `team_id` | number | Team of the squad |
-|   ↳ `position_id` | number | Position of the player in the squad |
-|   ↳ `detailed_position_id` | number | Detailed position of the player in the squad |
-|   ↳ `jersey_number` | number | Jersey number of the player |
-|   ↳ `start` | string | Start contract date of the player |
-|   ↳ `end` | string | End contract date of the player |
+|   ↳ `position_id` | number (nullable) | Position of the player in the squad |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position of the player in the squad |
+|   ↳ `jersey_number` | number (nullable) | Jersey number of the player |
+|   ↳ `start` | string (nullable) | Start contract date of the player |
+|   ↳ `end` | string (nullable) | End contract date of the player |
 
 ### Get Teams by Country
 
@@ -2807,15 +2807,15 @@ Retrieve all teams for a country ID from Sportmonks
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Home venue of the team |
+|   ↳ `venue_id` | number (nullable) | Home venue of the team |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the last played match |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the last played match |
 
 ### Get Teams by Season
 
@@ -2841,15 +2841,15 @@ Retrieve all teams for a season ID from Sportmonks
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Home venue of the team |
+|   ↳ `venue_id` | number (nullable) | Home venue of the team |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the last played match |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the last played match |
 
 ### Get Topscorers by Season
 
@@ -2989,14 +2989,14 @@ Retrieve a single transfer by its ID from Sportmonks
 |   ↳ `sport_id` | number | Sport of the transfer |
 |   ↳ `player_id` | number | Player who transferred |
 |   ↳ `type_id` | number | Type of the transfer |
-|   ↳ `from_team_id` | number | Team the player transferred from |
-|   ↳ `to_team_id` | number | Team the player transferred to |
-|   ↳ `position_id` | number | Position id of the transfer |
-|   ↳ `detailed_position_id` | number | Detailed position id of the transfer |
-|   ↳ `date` | string | Date of the transfer |
+|   ↳ `from_team_id` | number (nullable) | Team the player transferred from |
+|   ↳ `to_team_id` | number (nullable) | Team the player transferred to |
+|   ↳ `position_id` | number (nullable) | Position id of the transfer |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position id of the transfer |
+|   ↳ `date` | string (nullable) | Date of the transfer |
 |   ↳ `career_ended` | boolean | Whether the transfer ended the career |
 |   ↳ `completed` | boolean | Whether the transfer is completed |
-|   ↳ `amount` | number | Transfer fee amount |
+|   ↳ `amount` | number (nullable) | Transfer fee amount |
 
 ### Get Transfer Rumour by ID
 
@@ -3019,16 +3019,16 @@ Retrieve a single transfer rumour by its ID from Sportmonks
 |   ↳ `id` | number | Unique id of the transfer rumour |
 |   ↳ `sport_id` | number | Sport of the transfer rumour |
 |   ↳ `player_id` | number | Player the rumour relates to |
-|   ↳ `position_id` | number | Position id of the player |
-|   ↳ `from_team_id` | number | Team the player would transfer from |
-|   ↳ `to_team_id` | number | Team the player would transfer to |
-|   ↳ `transfer_fee_id` | number | Transfer fee id of the rumour |
+|   ↳ `position_id` | number (nullable) | Position id of the player |
+|   ↳ `from_team_id` | number (nullable) | Team the player would transfer from |
+|   ↳ `to_team_id` | number (nullable) | Team the player would transfer to |
+|   ↳ `transfer_fee_id` | number (nullable) | Transfer fee id of the rumour |
 |   ↳ `probability` | string | Probability of the rumour \(e.g. LOW\) |
-|   ↳ `source_name` | string | Name of the source of the rumour |
-|   ↳ `source_url` | string | URL of the source of the rumour |
-|   ↳ `amount` | number | Estimated transfer fee amount |
-|   ↳ `currency` | string | Currency of the amount |
-|   ↳ `date` | string | Date of the rumour |
+|   ↳ `source_name` | string (nullable) | Name of the source of the rumour |
+|   ↳ `source_url` | string (nullable) | URL of the source of the rumour |
+|   ↳ `amount` | number (nullable) | Estimated transfer fee amount |
+|   ↳ `currency` | string (nullable) | Currency of the amount |
+|   ↳ `date` | string (nullable) | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
 ### Get Transfer Rumours Between Dates
@@ -3056,16 +3056,16 @@ Retrieve transfer rumours within a date range (YYYY-MM-DD) from Sportmonks
 |   ↳ `id` | number | Unique id of the transfer rumour |
 |   ↳ `sport_id` | number | Sport of the transfer rumour |
 |   ↳ `player_id` | number | Player the rumour relates to |
-|   ↳ `position_id` | number | Position id of the player |
-|   ↳ `from_team_id` | number | Team the player would transfer from |
-|   ↳ `to_team_id` | number | Team the player would transfer to |
-|   ↳ `transfer_fee_id` | number | Transfer fee id of the rumour |
+|   ↳ `position_id` | number (nullable) | Position id of the player |
+|   ↳ `from_team_id` | number (nullable) | Team the player would transfer from |
+|   ↳ `to_team_id` | number (nullable) | Team the player would transfer to |
+|   ↳ `transfer_fee_id` | number (nullable) | Transfer fee id of the rumour |
 |   ↳ `probability` | string | Probability of the rumour \(e.g. LOW\) |
-|   ↳ `source_name` | string | Name of the source of the rumour |
-|   ↳ `source_url` | string | URL of the source of the rumour |
-|   ↳ `amount` | number | Estimated transfer fee amount |
-|   ↳ `currency` | string | Currency of the amount |
-|   ↳ `date` | string | Date of the rumour |
+|   ↳ `source_name` | string (nullable) | Name of the source of the rumour |
+|   ↳ `source_url` | string (nullable) | URL of the source of the rumour |
+|   ↳ `amount` | number (nullable) | Estimated transfer fee amount |
+|   ↳ `currency` | string (nullable) | Currency of the amount |
+|   ↳ `date` | string (nullable) | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
 ### Get Transfer Rumours by Player
@@ -3092,16 +3092,16 @@ Retrieve transfer rumours for a player ID from Sportmonks
 |   ↳ `id` | number | Unique id of the transfer rumour |
 |   ↳ `sport_id` | number | Sport of the transfer rumour |
 |   ↳ `player_id` | number | Player the rumour relates to |
-|   ↳ `position_id` | number | Position id of the player |
-|   ↳ `from_team_id` | number | Team the player would transfer from |
-|   ↳ `to_team_id` | number | Team the player would transfer to |
-|   ↳ `transfer_fee_id` | number | Transfer fee id of the rumour |
+|   ↳ `position_id` | number (nullable) | Position id of the player |
+|   ↳ `from_team_id` | number (nullable) | Team the player would transfer from |
+|   ↳ `to_team_id` | number (nullable) | Team the player would transfer to |
+|   ↳ `transfer_fee_id` | number (nullable) | Transfer fee id of the rumour |
 |   ↳ `probability` | string | Probability of the rumour \(e.g. LOW\) |
-|   ↳ `source_name` | string | Name of the source of the rumour |
-|   ↳ `source_url` | string | URL of the source of the rumour |
-|   ↳ `amount` | number | Estimated transfer fee amount |
-|   ↳ `currency` | string | Currency of the amount |
-|   ↳ `date` | string | Date of the rumour |
+|   ↳ `source_name` | string (nullable) | Name of the source of the rumour |
+|   ↳ `source_url` | string (nullable) | URL of the source of the rumour |
+|   ↳ `amount` | number (nullable) | Estimated transfer fee amount |
+|   ↳ `currency` | string (nullable) | Currency of the amount |
+|   ↳ `date` | string (nullable) | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
 ### Get Transfer Rumours by Team
@@ -3128,16 +3128,16 @@ Retrieve transfer rumours for a team ID from Sportmonks
 |   ↳ `id` | number | Unique id of the transfer rumour |
 |   ↳ `sport_id` | number | Sport of the transfer rumour |
 |   ↳ `player_id` | number | Player the rumour relates to |
-|   ↳ `position_id` | number | Position id of the player |
-|   ↳ `from_team_id` | number | Team the player would transfer from |
-|   ↳ `to_team_id` | number | Team the player would transfer to |
-|   ↳ `transfer_fee_id` | number | Transfer fee id of the rumour |
+|   ↳ `position_id` | number (nullable) | Position id of the player |
+|   ↳ `from_team_id` | number (nullable) | Team the player would transfer from |
+|   ↳ `to_team_id` | number (nullable) | Team the player would transfer to |
+|   ↳ `transfer_fee_id` | number (nullable) | Transfer fee id of the rumour |
 |   ↳ `probability` | string | Probability of the rumour \(e.g. LOW\) |
-|   ↳ `source_name` | string | Name of the source of the rumour |
-|   ↳ `source_url` | string | URL of the source of the rumour |
-|   ↳ `amount` | number | Estimated transfer fee amount |
-|   ↳ `currency` | string | Currency of the amount |
-|   ↳ `date` | string | Date of the rumour |
+|   ↳ `source_name` | string (nullable) | Name of the source of the rumour |
+|   ↳ `source_url` | string (nullable) | URL of the source of the rumour |
+|   ↳ `amount` | number (nullable) | Estimated transfer fee amount |
+|   ↳ `currency` | string (nullable) | Currency of the amount |
+|   ↳ `date` | string (nullable) | Date of the rumour |
 |   ↳ `type_id` | number | Type of the transfer rumour |
 
 ### Get Transfers Between Dates
@@ -3166,14 +3166,14 @@ Retrieve transfers within a date range (YYYY-MM-DD) from Sportmonks
 |   ↳ `sport_id` | number | Sport of the transfer |
 |   ↳ `player_id` | number | Player who transferred |
 |   ↳ `type_id` | number | Type of the transfer |
-|   ↳ `from_team_id` | number | Team the player transferred from |
-|   ↳ `to_team_id` | number | Team the player transferred to |
-|   ↳ `position_id` | number | Position id of the transfer |
-|   ↳ `detailed_position_id` | number | Detailed position id of the transfer |
-|   ↳ `date` | string | Date of the transfer |
+|   ↳ `from_team_id` | number (nullable) | Team the player transferred from |
+|   ↳ `to_team_id` | number (nullable) | Team the player transferred to |
+|   ↳ `position_id` | number (nullable) | Position id of the transfer |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position id of the transfer |
+|   ↳ `date` | string (nullable) | Date of the transfer |
 |   ↳ `career_ended` | boolean | Whether the transfer ended the career |
 |   ↳ `completed` | boolean | Whether the transfer is completed |
-|   ↳ `amount` | number | Transfer fee amount |
+|   ↳ `amount` | number (nullable) | Transfer fee amount |
 
 ### Get Transfers by Player
 
@@ -3200,14 +3200,14 @@ Retrieve transfers for a player by player ID from Sportmonks
 |   ↳ `sport_id` | number | Sport of the transfer |
 |   ↳ `player_id` | number | Player who transferred |
 |   ↳ `type_id` | number | Type of the transfer |
-|   ↳ `from_team_id` | number | Team the player transferred from |
-|   ↳ `to_team_id` | number | Team the player transferred to |
-|   ↳ `position_id` | number | Position id of the transfer |
-|   ↳ `detailed_position_id` | number | Detailed position id of the transfer |
-|   ↳ `date` | string | Date of the transfer |
+|   ↳ `from_team_id` | number (nullable) | Team the player transferred from |
+|   ↳ `to_team_id` | number (nullable) | Team the player transferred to |
+|   ↳ `position_id` | number (nullable) | Position id of the transfer |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position id of the transfer |
+|   ↳ `date` | string (nullable) | Date of the transfer |
 |   ↳ `career_ended` | boolean | Whether the transfer ended the career |
 |   ↳ `completed` | boolean | Whether the transfer is completed |
-|   ↳ `amount` | number | Transfer fee amount |
+|   ↳ `amount` | number (nullable) | Transfer fee amount |
 
 ### Get Transfers by Team
 
@@ -3234,14 +3234,14 @@ Retrieve transfers for a team by team ID from Sportmonks
 |   ↳ `sport_id` | number | Sport of the transfer |
 |   ↳ `player_id` | number | Player who transferred |
 |   ↳ `type_id` | number | Type of the transfer |
-|   ↳ `from_team_id` | number | Team the player transferred from |
-|   ↳ `to_team_id` | number | Team the player transferred to |
-|   ↳ `position_id` | number | Position id of the transfer |
-|   ↳ `detailed_position_id` | number | Detailed position id of the transfer |
-|   ↳ `date` | string | Date of the transfer |
+|   ↳ `from_team_id` | number (nullable) | Team the player transferred from |
+|   ↳ `to_team_id` | number (nullable) | Team the player transferred to |
+|   ↳ `position_id` | number (nullable) | Position id of the transfer |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position id of the transfer |
+|   ↳ `date` | string (nullable) | Date of the transfer |
 |   ↳ `career_ended` | boolean | Whether the transfer ended the career |
 |   ↳ `completed` | boolean | Whether the transfer is completed |
-|   ↳ `amount` | number | Transfer fee amount |
+|   ↳ `amount` | number (nullable) | Transfer fee amount |
 
 ### Get TV Station by ID
 
@@ -3263,10 +3263,10 @@ Retrieve a single TV station by its ID from Sportmonks
 | `tvStation` | object | The requested TV station object |
 |   ↳ `id` | number | Unique id of the TV station |
 |   ↳ `name` | string | Name of the TV station |
-|   ↳ `url` | string | URL of the TV station |
-|   ↳ `image_path` | string | Image path of the TV station |
+|   ↳ `url` | string (nullable) | URL of the TV station |
+|   ↳ `image_path` | string (nullable) | Image path of the TV station |
 |   ↳ `type` | string | Type of the TV station \(tv, channel\) |
-|   ↳ `related_id` | number | Related id of the TV station |
+|   ↳ `related_id` | number (nullable) | Related id of the TV station |
 
 ### Get TV Stations
 
@@ -3290,10 +3290,10 @@ Retrieve all TV stations available within your Sportmonks subscription
 | `tvStations` | array | Array of TV station objects |
 |   ↳ `id` | number | Unique id of the TV station |
 |   ↳ `name` | string | Name of the TV station |
-|   ↳ `url` | string | URL of the TV station |
-|   ↳ `image_path` | string | Image path of the TV station |
+|   ↳ `url` | string (nullable) | URL of the TV station |
+|   ↳ `image_path` | string (nullable) | Image path of the TV station |
 |   ↳ `type` | string | Type of the TV station \(tv, channel\) |
-|   ↳ `related_id` | number | Related id of the TV station |
+|   ↳ `related_id` | number (nullable) | Related id of the TV station |
 
 ### Get TV Stations by Fixture
 
@@ -3318,10 +3318,10 @@ Retrieve broadcasting TV stations for a fixture by fixture ID from Sportmonks
 | `tvStations` | array | Array of TV station objects broadcasting the fixture |
 |   ↳ `id` | number | Unique id of the TV station |
 |   ↳ `name` | string | Name of the TV station |
-|   ↳ `url` | string | URL of the TV station |
-|   ↳ `image_path` | string | Image path of the TV station |
+|   ↳ `url` | string (nullable) | URL of the TV station |
+|   ↳ `image_path` | string (nullable) | Image path of the TV station |
 |   ↳ `type` | string | Type of the TV station \(tv, channel\) |
-|   ↳ `related_id` | number | Related id of the TV station |
+|   ↳ `related_id` | number (nullable) | Related id of the TV station |
 
 ### Get Upcoming Fixtures by Market
 
@@ -3349,17 +3349,17 @@ Retrieve all upcoming fixtures for a market ID from Sportmonks
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -3391,17 +3391,17 @@ Retrieve all upcoming fixtures available for a TV station ID from Sportmonks
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -3475,17 +3475,17 @@ Retrieve a single football venue by its ID from Sportmonks
 | --------- | ---- | ----------- |
 | `venue` | object | The requested venue object |
 |   ↳ `id` | number | Unique id of the venue |
-|   ↳ `country_id` | number | Country of the venue |
-|   ↳ `city_id` | number | City of the venue |
+|   ↳ `country_id` | number (nullable) | Country of the venue |
+|   ↳ `city_id` | number (nullable) | City of the venue |
 |   ↳ `name` | string | Name of the venue |
-|   ↳ `address` | string | Address of the venue |
-|   ↳ `zipcode` | string | Zipcode of the venue |
-|   ↳ `latitude` | string | Latitude of the venue |
-|   ↳ `longitude` | string | Longitude of the venue |
-|   ↳ `capacity` | number | Seating capacity of the venue |
-|   ↳ `image_path` | string | Image path of the venue |
-|   ↳ `city_name` | string | Name of the city the venue is in |
-|   ↳ `surface` | string | Surface type of the venue |
+|   ↳ `address` | string (nullable) | Address of the venue |
+|   ↳ `zipcode` | string (nullable) | Zipcode of the venue |
+|   ↳ `latitude` | string (nullable) | Latitude of the venue |
+|   ↳ `longitude` | string (nullable) | Longitude of the venue |
+|   ↳ `capacity` | number (nullable) | Seating capacity of the venue |
+|   ↳ `image_path` | string (nullable) | Image path of the venue |
+|   ↳ `city_name` | string (nullable) | Name of the city the venue is in |
+|   ↳ `surface` | string (nullable) | Surface type of the venue |
 |   ↳ `national_team` | boolean | Whether the venue is used by the national team |
 
 ### Get Venues
@@ -3509,17 +3509,17 @@ Retrieve all football venues available within your Sportmonks subscription
 | --------- | ---- | ----------- |
 | `venues` | array | Array of venue objects |
 |   ↳ `id` | number | Unique id of the venue |
-|   ↳ `country_id` | number | Country of the venue |
-|   ↳ `city_id` | number | City of the venue |
+|   ↳ `country_id` | number (nullable) | Country of the venue |
+|   ↳ `city_id` | number (nullable) | City of the venue |
 |   ↳ `name` | string | Name of the venue |
-|   ↳ `address` | string | Address of the venue |
-|   ↳ `zipcode` | string | Zipcode of the venue |
-|   ↳ `latitude` | string | Latitude of the venue |
-|   ↳ `longitude` | string | Longitude of the venue |
-|   ↳ `capacity` | number | Seating capacity of the venue |
-|   ↳ `image_path` | string | Image path of the venue |
-|   ↳ `city_name` | string | Name of the city the venue is in |
-|   ↳ `surface` | string | Surface type of the venue |
+|   ↳ `address` | string (nullable) | Address of the venue |
+|   ↳ `zipcode` | string (nullable) | Zipcode of the venue |
+|   ↳ `latitude` | string (nullable) | Latitude of the venue |
+|   ↳ `longitude` | string (nullable) | Longitude of the venue |
+|   ↳ `capacity` | number (nullable) | Seating capacity of the venue |
+|   ↳ `image_path` | string (nullable) | Image path of the venue |
+|   ↳ `city_name` | string (nullable) | Name of the city the venue is in |
+|   ↳ `surface` | string (nullable) | Surface type of the venue |
 |   ↳ `national_team` | boolean | Whether the venue is used by the national team |
 
 ### Get Venues by Season
@@ -3541,17 +3541,17 @@ Retrieve all venues for a season ID from Sportmonks
 | --------- | ---- | ----------- |
 | `venues` | array | Array of venue objects for the season |
 |   ↳ `id` | number | Unique id of the venue |
-|   ↳ `country_id` | number | Country of the venue |
-|   ↳ `city_id` | number | City of the venue |
+|   ↳ `country_id` | number (nullable) | Country of the venue |
+|   ↳ `city_id` | number (nullable) | City of the venue |
 |   ↳ `name` | string | Name of the venue |
-|   ↳ `address` | string | Address of the venue |
-|   ↳ `zipcode` | string | Zipcode of the venue |
-|   ↳ `latitude` | string | Latitude of the venue |
-|   ↳ `longitude` | string | Longitude of the venue |
-|   ↳ `capacity` | number | Seating capacity of the venue |
-|   ↳ `image_path` | string | Image path of the venue |
-|   ↳ `city_name` | string | Name of the city the venue is in |
-|   ↳ `surface` | string | Surface type of the venue |
+|   ↳ `address` | string (nullable) | Address of the venue |
+|   ↳ `zipcode` | string (nullable) | Zipcode of the venue |
+|   ↳ `latitude` | string (nullable) | Latitude of the venue |
+|   ↳ `longitude` | string (nullable) | Longitude of the venue |
+|   ↳ `capacity` | number (nullable) | Seating capacity of the venue |
+|   ↳ `image_path` | string (nullable) | Image path of the venue |
+|   ↳ `city_name` | string (nullable) | Name of the city the venue is in |
+|   ↳ `surface` | string (nullable) | Surface type of the venue |
 |   ↳ `national_team` | boolean | Whether the venue is used by the national team |
 
 ### Search Coaches
@@ -3576,21 +3576,21 @@ Search for football coaches by name from Sportmonks
 | --------- | ---- | ----------- |
 | `coaches` | array | Array of coach objects matching the search query |
 |   ↳ `id` | number | Unique id of the coach |
-|   ↳ `player_id` | number | Player related to the coach |
+|   ↳ `player_id` | number (nullable) | Player related to the coach |
 |   ↳ `sport_id` | number | Sport of the coach |
-|   ↳ `country_id` | number | Country of the coach |
-|   ↳ `nationality_id` | number | Nationality of the coach |
-|   ↳ `city_id` | number | Birth city of the coach |
+|   ↳ `country_id` | number (nullable) | Country of the coach |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the coach |
+|   ↳ `city_id` | number (nullable) | Birth city of the coach |
 |   ↳ `common_name` | string | Common name of the coach |
-|   ↳ `firstname` | string | First name of the coach |
-|   ↳ `lastname` | string | Last name of the coach |
+|   ↳ `firstname` | string (nullable) | First name of the coach |
+|   ↳ `lastname` | string (nullable) | Last name of the coach |
 |   ↳ `name` | string | Name of the coach |
 |   ↳ `display_name` | string | Display name of the coach |
 |   ↳ `image_path` | string | URL to the coach headshot |
-|   ↳ `height` | number | Height of the coach in cm |
-|   ↳ `weight` | number | Weight of the coach in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the coach |
-|   ↳ `gender` | string | Gender of the coach |
+|   ↳ `height` | number (nullable) | Height of the coach in cm |
+|   ↳ `weight` | number (nullable) | Weight of the coach in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the coach |
+|   ↳ `gender` | string (nullable) | Gender of the coach |
 
 ### Search Fixtures
 
@@ -3618,17 +3618,17 @@ Search for football fixtures by name (participants) from Sportmonks
 |   ↳ `league_id` | number | League the fixture is played in |
 |   ↳ `season_id` | number | Season the fixture is played in |
 |   ↳ `stage_id` | number | Stage the fixture is played in |
-|   ↳ `group_id` | number | Group the fixture is played in |
-|   ↳ `aggregate_id` | number | Aggregate the fixture belongs to |
-|   ↳ `round_id` | number | Round the fixture is played in |
+|   ↳ `group_id` | number (nullable) | Group the fixture is played in |
+|   ↳ `aggregate_id` | number (nullable) | Aggregate the fixture belongs to |
+|   ↳ `round_id` | number (nullable) | Round the fixture is played in |
 |   ↳ `state_id` | number | State \(status\) of the fixture |
-|   ↳ `venue_id` | number | Venue the fixture is played at |
-|   ↳ `name` | string | Name of the fixture \(participants\) |
-|   ↳ `starting_at` | string | Datetime the fixture starts |
-|   ↳ `result_info` | string | Final result summary |
+|   ↳ `venue_id` | number (nullable) | Venue the fixture is played at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(participants\) |
+|   ↳ `starting_at` | string (nullable) | Datetime the fixture starts |
+|   ↳ `result_info` | string (nullable) | Final result summary |
 |   ↳ `leg` | string | Leg of the fixture \(e.g. 1/1\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Length of the fixture in minutes |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Length of the fixture in minutes |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Whether odds are available |
 |   ↳ `has_premium_odds` | boolean | Whether premium odds are available |
@@ -3660,11 +3660,11 @@ Search for football leagues by name from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | number | Whether the league is active \(1\) or inactive \(0\) |
-|   ↳ `short_code` | string | Short code of the league |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
 |   ↳ `image_path` | string | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
 |   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date the last fixture was played |
+|   ↳ `last_played_at` | string (nullable) | Date the last fixture was played |
 |   ↳ `category` | number | Importance category of the league \(1-4\) |
 
 ### Search Players
@@ -3690,21 +3690,21 @@ Search for football players by name from Sportmonks
 | `players` | array | Array of player objects matching the search query |
 |   ↳ `id` | number | Unique id of the player |
 |   ↳ `sport_id` | number | Sport of the player |
-|   ↳ `country_id` | number | Country of birth of the player |
-|   ↳ `nationality_id` | number | Nationality of the player |
-|   ↳ `city_id` | number | City of birth of the player |
-|   ↳ `position_id` | number | Position of the player |
-|   ↳ `detailed_position_id` | number | Detailed position of the player |
-|   ↳ `type_id` | number | Type of the player |
+|   ↳ `country_id` | number (nullable) | Country of birth of the player |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the player |
+|   ↳ `city_id` | number (nullable) | City of birth of the player |
+|   ↳ `position_id` | number (nullable) | Position of the player |
+|   ↳ `detailed_position_id` | number (nullable) | Detailed position of the player |
+|   ↳ `type_id` | number (nullable) | Type of the player |
 |   ↳ `common_name` | string | Name the player is known for |
 |   ↳ `firstname` | string | First name of the player |
 |   ↳ `lastname` | string | Last name of the player |
 |   ↳ `name` | string | Name of the player |
 |   ↳ `display_name` | string | Display name of the player |
 |   ↳ `image_path` | string | URL to the player headshot |
-|   ↳ `height` | number | Height of the player in cm |
-|   ↳ `weight` | number | Weight of the player in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the player |
+|   ↳ `height` | number (nullable) | Height of the player in cm |
+|   ↳ `weight` | number (nullable) | Weight of the player in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the player |
 |   ↳ `gender` | string | Gender of the player |
 
 ### Search Referees
@@ -3730,19 +3730,19 @@ Search for football referees by name from Sportmonks
 | `referees` | array | Array of referee objects matching the search query |
 |   ↳ `id` | number | Unique id of the referee |
 |   ↳ `sport_id` | number | Sport of the referee |
-|   ↳ `country_id` | number | Country of the referee |
-|   ↳ `nationality_id` | number | Nationality of the referee |
-|   ↳ `city_id` | number | Birth city of the referee |
+|   ↳ `country_id` | number (nullable) | Country of the referee |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the referee |
+|   ↳ `city_id` | number (nullable) | Birth city of the referee |
 |   ↳ `common_name` | string | Common name of the referee |
-|   ↳ `firstname` | string | First name of the referee |
-|   ↳ `lastname` | string | Last name of the referee |
+|   ↳ `firstname` | string (nullable) | First name of the referee |
+|   ↳ `lastname` | string (nullable) | Last name of the referee |
 |   ↳ `name` | string | Name of the referee |
 |   ↳ `display_name` | string | Display name of the referee |
 |   ↳ `image_path` | string | URL to the referee headshot |
-|   ↳ `height` | number | Height of the referee in cm |
-|   ↳ `weight` | number | Weight of the referee in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the referee |
-|   ↳ `gender` | string | Gender of the referee |
+|   ↳ `height` | number (nullable) | Height of the referee in cm |
+|   ↳ `weight` | number (nullable) | Weight of the referee in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the referee |
+|   ↳ `gender` | string (nullable) | Gender of the referee |
 
 ### Search Rounds
 
@@ -3769,12 +3769,12 @@ Search for football rounds by name from Sportmonks
 |   ↳ `sport_id` | number | Sport of the round |
 |   ↳ `league_id` | number | League of the round |
 |   ↳ `season_id` | number | Season of the round |
-|   ↳ `stage_id` | number | Stage of the round |
+|   ↳ `stage_id` | number (nullable) | Stage of the round |
 |   ↳ `name` | string | Name of the round |
 |   ↳ `finished` | boolean | Whether the round is finished |
 |   ↳ `is_current` | boolean | Whether the round is the current round |
-|   ↳ `starting_at` | string | Start date of the round |
-|   ↳ `ending_at` | string | End date of the round |
+|   ↳ `starting_at` | string (nullable) | Start date of the round |
+|   ↳ `ending_at` | string (nullable) | End date of the round |
 |   ↳ `games_in_current_week` | boolean | Whether the round has fixtures this week |
 
 ### Search Seasons
@@ -3801,15 +3801,15 @@ Search for football seasons by name from Sportmonks
 |   ↳ `id` | number | Unique id of the season |
 |   ↳ `sport_id` | number | Sport of the season |
 |   ↳ `league_id` | number | League of the season |
-|   ↳ `tie_breaker_rule_id` | number | Tie-breaker rule of the season |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Tie-breaker rule of the season |
 |   ↳ `name` | string | Name of the season \(e.g. 2023/2024\) |
 |   ↳ `finished` | boolean | Whether the season is finished |
 |   ↳ `pending` | boolean | Whether the season is pending |
 |   ↳ `is_current` | boolean | Whether the season is the current season |
-|   ↳ `standing_method` | string | Standing calculation method |
-|   ↳ `starting_at` | string | Start date of the season |
-|   ↳ `ending_at` | string | End date of the season |
-|   ↳ `standings_recalculated_at` | string | Last standings recalculation time |
+|   ↳ `standing_method` | string (nullable) | Standing calculation method |
+|   ↳ `starting_at` | string (nullable) | Start date of the season |
+|   ↳ `ending_at` | string (nullable) | End date of the season |
+|   ↳ `standings_recalculated_at` | string (nullable) | Last standings recalculation time |
 |   ↳ `games_in_current_week` | boolean | Whether the season has fixtures this week |
 
 ### Search Stages
@@ -3842,8 +3842,8 @@ Search for football stages by name from Sportmonks
 |   ↳ `sort_order` | number | Sort order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Start date of the stage |
-|   ↳ `ending_at` | string | End date of the stage |
+|   ↳ `starting_at` | string (nullable) | Start date of the stage |
+|   ↳ `ending_at` | string (nullable) | End date of the stage |
 |   ↳ `games_in_current_week` | boolean | Whether the stage has fixtures this week |
 
 ### Search Teams
@@ -3870,15 +3870,15 @@ Search for football teams by name from Sportmonks
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Home venue of the team |
+|   ↳ `venue_id` | number (nullable) | Home venue of the team |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the last played match |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the last played match |
 
 ### Search Venues
 
@@ -3902,17 +3902,17 @@ Search for football venues by name from Sportmonks
 | --------- | ---- | ----------- |
 | `venues` | array | Array of venue objects matching the search query |
 |   ↳ `id` | number | Unique id of the venue |
-|   ↳ `country_id` | number | Country of the venue |
-|   ↳ `city_id` | number | City of the venue |
+|   ↳ `country_id` | number (nullable) | Country of the venue |
+|   ↳ `city_id` | number (nullable) | City of the venue |
 |   ↳ `name` | string | Name of the venue |
-|   ↳ `address` | string | Address of the venue |
-|   ↳ `zipcode` | string | Zipcode of the venue |
-|   ↳ `latitude` | string | Latitude of the venue |
-|   ↳ `longitude` | string | Longitude of the venue |
-|   ↳ `capacity` | number | Seating capacity of the venue |
-|   ↳ `image_path` | string | Image path of the venue |
-|   ↳ `city_name` | string | Name of the city the venue is in |
-|   ↳ `surface` | string | Surface type of the venue |
+|   ↳ `address` | string (nullable) | Address of the venue |
+|   ↳ `zipcode` | string (nullable) | Zipcode of the venue |
+|   ↳ `latitude` | string (nullable) | Latitude of the venue |
+|   ↳ `longitude` | string (nullable) | Longitude of the venue |
+|   ↳ `capacity` | number (nullable) | Seating capacity of the venue |
+|   ↳ `image_path` | string (nullable) | Image path of the venue |
+|   ↳ `city_name` | string (nullable) | Name of the city the venue is in |
+|   ↳ `surface` | string (nullable) | Surface type of the venue |
 |   ↳ `national_team` | boolean | Whether the venue is used by the national team |
 
 ### Get All Motorsport Fixtures
@@ -3940,17 +3940,17 @@ Retrieve all motorsport fixtures (sessions) from Sportmonks
 |   ↳ `league_id` | number | League the fixture is held in |
 |   ↳ `season_id` | number | Season the fixture is held in |
 |   ↳ `stage_id` | number | Stage \(race weekend\) the fixture is held in |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `aggregate_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `aggregate_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `state_id` | number | State the fixture is currently in |
-|   ↳ `venue_id` | number | Venue \(track\) the fixture is held at |
-|   ↳ `name` | string | Name of the fixture \(e.g. Practice 1, Race\) |
-|   ↳ `starting_at` | string | Start date and time |
-|   ↳ `result_info` | string | Final result info |
+|   ↳ `venue_id` | number (nullable) | Venue \(track\) the fixture is held at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(e.g. Practice 1, Race\) |
+|   ↳ `starting_at` | string (nullable) | Start date and time |
+|   ↳ `result_info` | string (nullable) | Final result info |
 |   ↳ `leg` | string | Stage of the fixture \(e.g. 2/3 for Practice 2\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Session length in minutes or total laps |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Session length in minutes or total laps |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
@@ -3982,12 +3982,12 @@ Retrieve the current motorsport leagues for a team by team ID from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | boolean | Whether the league is active |
-|   ↳ `short_code` | string | Short code of the league |
-|   ↳ `image_path` | string | URL to the league logo |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
+|   ↳ `image_path` | string (nullable) | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
-|   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date of the last fixture held in the league |
-|   ↳ `category` | number | Category of the league |
+|   ↳ `sub_type` | string (nullable) | Subtype of the league |
+|   ↳ `last_played_at` | string (nullable) | Date of the last fixture held in the league |
+|   ↳ `category` | number (nullable) | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
 ### Get Driver by ID
@@ -4010,21 +4010,21 @@ Retrieve a single motorsport driver by their ID from Sportmonks
 | `driver` | object | The requested driver object |
 |   ↳ `id` | number | Unique id of the driver \(player_id in responses\) |
 |   ↳ `sport_id` | number | Sport of the driver |
-|   ↳ `country_id` | number | Country of birth of the driver |
-|   ↳ `nationality_id` | number | Nationality of the driver |
-|   ↳ `city_id` | number | City of birth of the driver |
-|   ↳ `position_id` | number | Position of the driver within the team |
-|   ↳ `detailed_position_id` | number | Not used in the Motorsport API |
-|   ↳ `type_id` | number | Not used in the Motorsport API |
+|   ↳ `country_id` | number (nullable) | Country of birth of the driver |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the driver |
+|   ↳ `city_id` | number (nullable) | City of birth of the driver |
+|   ↳ `position_id` | number (nullable) | Position of the driver within the team |
+|   ↳ `detailed_position_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `type_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `common_name` | string | Name the driver is known for |
 |   ↳ `firstname` | string | First name of the driver |
 |   ↳ `lastname` | string | Last name of the driver |
 |   ↳ `name` | string | Name of the driver |
 |   ↳ `display_name` | string | Display name of the driver |
 |   ↳ `image_path` | string | URL to the driver headshot |
-|   ↳ `height` | number | Height of the driver in cm |
-|   ↳ `weight` | number | Weight of the driver in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the driver |
+|   ↳ `height` | number (nullable) | Height of the driver in cm |
+|   ↳ `weight` | number (nullable) | Weight of the driver in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
 ### Get All Driver Standings
@@ -4053,11 +4053,11 @@ Retrieve all driver championship standings from Sportmonks
 |   ↳ `league_id` | number | League related to the standing |
 |   ↳ `season_id` | number | Season related to the standing |
 |   ↳ `stage_id` | number | Stage related to the standing |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
-|   ↳ `standing_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `standing_rule_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `position` | number | Position of the participant in the standing |
-|   ↳ `result` | string | Not used in the Motorsport API |
+|   ↳ `result` | string (nullable) | Not used in the Motorsport API |
 |   ↳ `points` | number | Points the participant has gathered |
 
 ### Get Driver Standings by Season
@@ -4087,11 +4087,11 @@ Retrieve the drivers championship standings for a season by season ID from Sport
 |   ↳ `league_id` | number | League related to the standing |
 |   ↳ `season_id` | number | Season related to the standing |
 |   ↳ `stage_id` | number | Stage related to the standing |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
-|   ↳ `standing_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `standing_rule_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `position` | number | Position of the participant in the standing |
-|   ↳ `result` | string | Not used in the Motorsport API |
+|   ↳ `result` | string (nullable) | Not used in the Motorsport API |
 |   ↳ `points` | number | Points the participant has gathered |
 
 ### Get Drivers
@@ -4116,21 +4116,21 @@ Retrieve all motorsport drivers from Sportmonks
 | `drivers` | array | Array of driver objects |
 |   ↳ `id` | number | Unique id of the driver \(player_id in responses\) |
 |   ↳ `sport_id` | number | Sport of the driver |
-|   ↳ `country_id` | number | Country of birth of the driver |
-|   ↳ `nationality_id` | number | Nationality of the driver |
-|   ↳ `city_id` | number | City of birth of the driver |
-|   ↳ `position_id` | number | Position of the driver within the team |
-|   ↳ `detailed_position_id` | number | Not used in the Motorsport API |
-|   ↳ `type_id` | number | Not used in the Motorsport API |
+|   ↳ `country_id` | number (nullable) | Country of birth of the driver |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the driver |
+|   ↳ `city_id` | number (nullable) | City of birth of the driver |
+|   ↳ `position_id` | number (nullable) | Position of the driver within the team |
+|   ↳ `detailed_position_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `type_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `common_name` | string | Name the driver is known for |
 |   ↳ `firstname` | string | First name of the driver |
 |   ↳ `lastname` | string | Last name of the driver |
 |   ↳ `name` | string | Name of the driver |
 |   ↳ `display_name` | string | Display name of the driver |
 |   ↳ `image_path` | string | URL to the driver headshot |
-|   ↳ `height` | number | Height of the driver in cm |
-|   ↳ `weight` | number | Weight of the driver in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the driver |
+|   ↳ `height` | number (nullable) | Height of the driver in cm |
+|   ↳ `weight` | number (nullable) | Weight of the driver in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
 ### Get Drivers by Country
@@ -4156,21 +4156,21 @@ Retrieve all motorsport drivers for a country by country ID from Sportmonks
 | `drivers` | array | Array of driver objects for the country |
 |   ↳ `id` | number | Unique id of the driver \(player_id in responses\) |
 |   ↳ `sport_id` | number | Sport of the driver |
-|   ↳ `country_id` | number | Country of birth of the driver |
-|   ↳ `nationality_id` | number | Nationality of the driver |
-|   ↳ `city_id` | number | City of birth of the driver |
-|   ↳ `position_id` | number | Position of the driver within the team |
-|   ↳ `detailed_position_id` | number | Not used in the Motorsport API |
-|   ↳ `type_id` | number | Not used in the Motorsport API |
+|   ↳ `country_id` | number (nullable) | Country of birth of the driver |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the driver |
+|   ↳ `city_id` | number (nullable) | City of birth of the driver |
+|   ↳ `position_id` | number (nullable) | Position of the driver within the team |
+|   ↳ `detailed_position_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `type_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `common_name` | string | Name the driver is known for |
 |   ↳ `firstname` | string | First name of the driver |
 |   ↳ `lastname` | string | Last name of the driver |
 |   ↳ `name` | string | Name of the driver |
 |   ↳ `display_name` | string | Display name of the driver |
 |   ↳ `image_path` | string | URL to the driver headshot |
-|   ↳ `height` | number | Height of the driver in cm |
-|   ↳ `weight` | number | Weight of the driver in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the driver |
+|   ↳ `height` | number (nullable) | Height of the driver in cm |
+|   ↳ `weight` | number (nullable) | Weight of the driver in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
 ### Get Drivers by Season
@@ -4196,21 +4196,21 @@ Retrieve all motorsport drivers for a season by season ID from Sportmonks
 | `drivers` | array | Array of driver objects for the season |
 |   ↳ `id` | number | Unique id of the driver \(player_id in responses\) |
 |   ↳ `sport_id` | number | Sport of the driver |
-|   ↳ `country_id` | number | Country of birth of the driver |
-|   ↳ `nationality_id` | number | Nationality of the driver |
-|   ↳ `city_id` | number | City of birth of the driver |
-|   ↳ `position_id` | number | Position of the driver within the team |
-|   ↳ `detailed_position_id` | number | Not used in the Motorsport API |
-|   ↳ `type_id` | number | Not used in the Motorsport API |
+|   ↳ `country_id` | number (nullable) | Country of birth of the driver |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the driver |
+|   ↳ `city_id` | number (nullable) | City of birth of the driver |
+|   ↳ `position_id` | number (nullable) | Position of the driver within the team |
+|   ↳ `detailed_position_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `type_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `common_name` | string | Name the driver is known for |
 |   ↳ `firstname` | string | First name of the driver |
 |   ↳ `lastname` | string | Last name of the driver |
 |   ↳ `name` | string | Name of the driver |
 |   ↳ `display_name` | string | Display name of the driver |
 |   ↳ `image_path` | string | URL to the driver headshot |
-|   ↳ `height` | number | Height of the driver in cm |
-|   ↳ `weight` | number | Weight of the driver in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the driver |
+|   ↳ `height` | number (nullable) | Height of the driver in cm |
+|   ↳ `weight` | number (nullable) | Weight of the driver in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
 ### Get Motorsport Fixture by ID
@@ -4236,17 +4236,17 @@ Retrieve a single motorsport fixture (session) by its ID from Sportmonks
 |   ↳ `league_id` | number | League the fixture is held in |
 |   ↳ `season_id` | number | Season the fixture is held in |
 |   ↳ `stage_id` | number | Stage \(race weekend\) the fixture is held in |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `aggregate_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `aggregate_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `state_id` | number | State the fixture is currently in |
-|   ↳ `venue_id` | number | Venue \(track\) the fixture is held at |
-|   ↳ `name` | string | Name of the fixture \(e.g. Practice 1, Race\) |
-|   ↳ `starting_at` | string | Start date and time |
-|   ↳ `result_info` | string | Final result info |
+|   ↳ `venue_id` | number (nullable) | Venue \(track\) the fixture is held at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(e.g. Practice 1, Race\) |
+|   ↳ `starting_at` | string (nullable) | Start date and time |
+|   ↳ `result_info` | string (nullable) | Final result info |
 |   ↳ `leg` | string | Stage of the fixture \(e.g. 2/3 for Practice 2\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Session length in minutes or total laps |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Session length in minutes or total laps |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
@@ -4278,17 +4278,17 @@ Retrieve motorsport fixtures (sessions) on a specific date (YYYY-MM-DD) from Spo
 |   ↳ `league_id` | number | League the fixture is held in |
 |   ↳ `season_id` | number | Season the fixture is held in |
 |   ↳ `stage_id` | number | Stage \(race weekend\) the fixture is held in |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `aggregate_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `aggregate_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `state_id` | number | State the fixture is currently in |
-|   ↳ `venue_id` | number | Venue \(track\) the fixture is held at |
-|   ↳ `name` | string | Name of the fixture \(e.g. Practice 1, Race\) |
-|   ↳ `starting_at` | string | Start date and time |
-|   ↳ `result_info` | string | Final result info |
+|   ↳ `venue_id` | number (nullable) | Venue \(track\) the fixture is held at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(e.g. Practice 1, Race\) |
+|   ↳ `starting_at` | string (nullable) | Start date and time |
+|   ↳ `result_info` | string (nullable) | Final result info |
 |   ↳ `leg` | string | Stage of the fixture \(e.g. 2/3 for Practice 2\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Session length in minutes or total laps |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Session length in minutes or total laps |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
@@ -4321,17 +4321,17 @@ Retrieve motorsport fixtures (sessions) between two dates (YYYY-MM-DD, max 100 d
 |   ↳ `league_id` | number | League the fixture is held in |
 |   ↳ `season_id` | number | Season the fixture is held in |
 |   ↳ `stage_id` | number | Stage \(race weekend\) the fixture is held in |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `aggregate_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `aggregate_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `state_id` | number | State the fixture is currently in |
-|   ↳ `venue_id` | number | Venue \(track\) the fixture is held at |
-|   ↳ `name` | string | Name of the fixture \(e.g. Practice 1, Race\) |
-|   ↳ `starting_at` | string | Start date and time |
-|   ↳ `result_info` | string | Final result info |
+|   ↳ `venue_id` | number (nullable) | Venue \(track\) the fixture is held at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(e.g. Practice 1, Race\) |
+|   ↳ `starting_at` | string (nullable) | Start date and time |
+|   ↳ `result_info` | string (nullable) | Final result info |
 |   ↳ `leg` | string | Stage of the fixture \(e.g. 2/3 for Practice 2\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Session length in minutes or total laps |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Session length in minutes or total laps |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
@@ -4363,17 +4363,17 @@ Retrieve multiple motorsport fixtures (sessions) by their IDs (max 50) from Spor
 |   ↳ `league_id` | number | League the fixture is held in |
 |   ↳ `season_id` | number | Season the fixture is held in |
 |   ↳ `stage_id` | number | Stage \(race weekend\) the fixture is held in |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `aggregate_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `aggregate_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `state_id` | number | State the fixture is currently in |
-|   ↳ `venue_id` | number | Venue \(track\) the fixture is held at |
-|   ↳ `name` | string | Name of the fixture \(e.g. Practice 1, Race\) |
-|   ↳ `starting_at` | string | Start date and time |
-|   ↳ `result_info` | string | Final result info |
+|   ↳ `venue_id` | number (nullable) | Venue \(track\) the fixture is held at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(e.g. Practice 1, Race\) |
+|   ↳ `starting_at` | string (nullable) | Start date and time |
+|   ↳ `result_info` | string (nullable) | Final result info |
 |   ↳ `leg` | string | Stage of the fixture \(e.g. 2/3 for Practice 2\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Session length in minutes or total laps |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Session length in minutes or total laps |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
@@ -4553,21 +4553,21 @@ Retrieve the most recently updated motorsport drivers from Sportmonks
 | `drivers` | array | Array of recently updated driver objects |
 |   ↳ `id` | number | Unique id of the driver \(player_id in responses\) |
 |   ↳ `sport_id` | number | Sport of the driver |
-|   ↳ `country_id` | number | Country of birth of the driver |
-|   ↳ `nationality_id` | number | Nationality of the driver |
-|   ↳ `city_id` | number | City of birth of the driver |
-|   ↳ `position_id` | number | Position of the driver within the team |
-|   ↳ `detailed_position_id` | number | Not used in the Motorsport API |
-|   ↳ `type_id` | number | Not used in the Motorsport API |
+|   ↳ `country_id` | number (nullable) | Country of birth of the driver |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the driver |
+|   ↳ `city_id` | number (nullable) | City of birth of the driver |
+|   ↳ `position_id` | number (nullable) | Position of the driver within the team |
+|   ↳ `detailed_position_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `type_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `common_name` | string | Name the driver is known for |
 |   ↳ `firstname` | string | First name of the driver |
 |   ↳ `lastname` | string | Last name of the driver |
 |   ↳ `name` | string | Name of the driver |
 |   ↳ `display_name` | string | Display name of the driver |
 |   ↳ `image_path` | string | URL to the driver headshot |
-|   ↳ `height` | number | Height of the driver in cm |
-|   ↳ `weight` | number | Weight of the driver in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the driver |
+|   ↳ `height` | number (nullable) | Height of the driver in cm |
+|   ↳ `weight` | number (nullable) | Weight of the driver in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
 ### Get Latest Updated Motorsport Fixtures
@@ -4595,17 +4595,17 @@ Retrieve the most recently updated motorsport fixtures (sessions) from Sportmonk
 |   ↳ `league_id` | number | League the fixture is held in |
 |   ↳ `season_id` | number | Season the fixture is held in |
 |   ↳ `stage_id` | number | Stage \(race weekend\) the fixture is held in |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `aggregate_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `aggregate_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `state_id` | number | State the fixture is currently in |
-|   ↳ `venue_id` | number | Venue \(track\) the fixture is held at |
-|   ↳ `name` | string | Name of the fixture \(e.g. Practice 1, Race\) |
-|   ↳ `starting_at` | string | Start date and time |
-|   ↳ `result_info` | string | Final result info |
+|   ↳ `venue_id` | number (nullable) | Venue \(track\) the fixture is held at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(e.g. Practice 1, Race\) |
+|   ↳ `starting_at` | string (nullable) | Start date and time |
+|   ↳ `result_info` | string (nullable) | Final result info |
 |   ↳ `leg` | string | Stage of the fixture \(e.g. 2/3 for Practice 2\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Session length in minutes or total laps |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Session length in minutes or total laps |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
@@ -4634,12 +4634,12 @@ Retrieve a single motorsport league by its ID from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | boolean | Whether the league is active |
-|   ↳ `short_code` | string | Short code of the league |
-|   ↳ `image_path` | string | URL to the league logo |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
+|   ↳ `image_path` | string (nullable) | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
-|   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date of the last fixture held in the league |
-|   ↳ `category` | number | Category of the league |
+|   ↳ `sub_type` | string (nullable) | Subtype of the league |
+|   ↳ `last_played_at` | string (nullable) | Date of the last fixture held in the league |
+|   ↳ `category` | number (nullable) | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
 ### Get All Leagues
@@ -4667,12 +4667,12 @@ Retrieve all motorsport leagues from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | boolean | Whether the league is active |
-|   ↳ `short_code` | string | Short code of the league |
-|   ↳ `image_path` | string | URL to the league logo |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
+|   ↳ `image_path` | string (nullable) | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
-|   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date of the last fixture held in the league |
-|   ↳ `category` | number | Category of the league |
+|   ↳ `sub_type` | string (nullable) | Subtype of the league |
+|   ↳ `last_played_at` | string (nullable) | Date of the last fixture held in the league |
+|   ↳ `category` | number (nullable) | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
 ### Get Leagues by Country
@@ -4701,12 +4701,12 @@ Retrieve all motorsport leagues for a country by country ID from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | boolean | Whether the league is active |
-|   ↳ `short_code` | string | Short code of the league |
-|   ↳ `image_path` | string | URL to the league logo |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
+|   ↳ `image_path` | string (nullable) | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
-|   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date of the last fixture held in the league |
-|   ↳ `category` | number | Category of the league |
+|   ↳ `sub_type` | string (nullable) | Subtype of the league |
+|   ↳ `last_played_at` | string (nullable) | Date of the last fixture held in the league |
+|   ↳ `category` | number (nullable) | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
 ### Get Leagues by Fixture Date
@@ -4735,12 +4735,12 @@ Retrieve all motorsport leagues with fixtures on a specific date (YYYY-MM-DD) fr
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | boolean | Whether the league is active |
-|   ↳ `short_code` | string | Short code of the league |
-|   ↳ `image_path` | string | URL to the league logo |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
+|   ↳ `image_path` | string (nullable) | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
-|   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date of the last fixture held in the league |
-|   ↳ `category` | number | Category of the league |
+|   ↳ `sub_type` | string (nullable) | Subtype of the league |
+|   ↳ `last_played_at` | string (nullable) | Date of the last fixture held in the league |
+|   ↳ `category` | number (nullable) | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
 ### Get Leagues by Live
@@ -4768,12 +4768,12 @@ Retrieve all motorsport leagues that currently have live fixtures from Sportmonk
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | boolean | Whether the league is active |
-|   ↳ `short_code` | string | Short code of the league |
-|   ↳ `image_path` | string | URL to the league logo |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
+|   ↳ `image_path` | string (nullable) | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
-|   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date of the last fixture held in the league |
-|   ↳ `category` | number | Category of the league |
+|   ↳ `sub_type` | string (nullable) | Subtype of the league |
+|   ↳ `last_played_at` | string (nullable) | Date of the last fixture held in the league |
+|   ↳ `category` | number (nullable) | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
 ### Get Leagues by Team
@@ -4802,12 +4802,12 @@ Retrieve all current and historical motorsport leagues for a team by team ID fro
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | boolean | Whether the league is active |
-|   ↳ `short_code` | string | Short code of the league |
-|   ↳ `image_path` | string | URL to the league logo |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
+|   ↳ `image_path` | string (nullable) | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
-|   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date of the last fixture held in the league |
-|   ↳ `category` | number | Category of the league |
+|   ↳ `sub_type` | string (nullable) | Subtype of the league |
+|   ↳ `last_played_at` | string (nullable) | Date of the last fixture held in the league |
+|   ↳ `category` | number (nullable) | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
 ### Get Motorsport Livescores
@@ -4835,17 +4835,17 @@ Retrieve all live motorsport fixtures (sessions) from Sportmonks
 |   ↳ `league_id` | number | League the fixture is held in |
 |   ↳ `season_id` | number | Season the fixture is held in |
 |   ↳ `stage_id` | number | Stage \(race weekend\) the fixture is held in |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `aggregate_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `aggregate_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `state_id` | number | State the fixture is currently in |
-|   ↳ `venue_id` | number | Venue \(track\) the fixture is held at |
-|   ↳ `name` | string | Name of the fixture \(e.g. Practice 1, Race\) |
-|   ↳ `starting_at` | string | Start date and time |
-|   ↳ `result_info` | string | Final result info |
+|   ↳ `venue_id` | number (nullable) | Venue \(track\) the fixture is held at |
+|   ↳ `name` | string (nullable) | Name of the fixture \(e.g. Practice 1, Race\) |
+|   ↳ `starting_at` | string (nullable) | Start date and time |
+|   ↳ `result_info` | string (nullable) | Final result info |
 |   ↳ `leg` | string | Stage of the fixture \(e.g. 2/3 for Practice 2\) |
-|   ↳ `details` | string | Details about the fixture |
-|   ↳ `length` | number | Session length in minutes or total laps |
+|   ↳ `details` | string (nullable) | Details about the fixture |
+|   ↳ `length` | number (nullable) | Session length in minutes or total laps |
 |   ↳ `placeholder` | boolean | Whether the fixture is a placeholder |
 |   ↳ `has_odds` | boolean | Not used in the Motorsport API |
 |   ↳ `has_premium_odds` | boolean | Not used in the Motorsport API |
@@ -4954,15 +4954,15 @@ Retrieve race results (stages with fixtures, lineups and lineup details) for a s
 |   ↳ `sport_id` | number | Sport of the stage |
 |   ↳ `league_id` | number | League related to the stage |
 |   ↳ `season_id` | number | Season related to the stage |
-|   ↳ `type_id` | number | Type of the stage |
+|   ↳ `type_id` | number (nullable) | Type of the stage |
 |   ↳ `name` | string | Name of the stage |
-|   ↳ `sort_order` | number | Order of the stage |
+|   ↳ `sort_order` | number (nullable) | Order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Starting date of the stage |
-|   ↳ `ending_at` | string | Ending date of the stage |
+|   ↳ `starting_at` | string (nullable) | Starting date of the stage |
+|   ↳ `ending_at` | string (nullable) | Ending date of the stage |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 
 ### Get Race Results by Season and Team
 
@@ -4990,15 +4990,15 @@ Retrieve race results (stages with fixtures, lineups and lineup details) for a s
 |   ↳ `sport_id` | number | Sport of the stage |
 |   ↳ `league_id` | number | League related to the stage |
 |   ↳ `season_id` | number | Season related to the stage |
-|   ↳ `type_id` | number | Type of the stage |
+|   ↳ `type_id` | number (nullable) | Type of the stage |
 |   ↳ `name` | string | Name of the stage |
-|   ↳ `sort_order` | number | Order of the stage |
+|   ↳ `sort_order` | number (nullable) | Order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Starting date of the stage |
-|   ↳ `ending_at` | string | Ending date of the stage |
+|   ↳ `starting_at` | string (nullable) | Starting date of the stage |
+|   ↳ `ending_at` | string (nullable) | Ending date of the stage |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 
 ### Get Schedules by Season
 
@@ -5025,15 +5025,15 @@ Retrieve the full schedule (stages with nested fixtures and venues) for a season
 |   ↳ `sport_id` | number | Sport of the stage |
 |   ↳ `league_id` | number | League related to the stage |
 |   ↳ `season_id` | number | Season related to the stage |
-|   ↳ `type_id` | number | Type of the stage |
+|   ↳ `type_id` | number (nullable) | Type of the stage |
 |   ↳ `name` | string | Name of the stage |
-|   ↳ `sort_order` | number | Order of the stage |
+|   ↳ `sort_order` | number (nullable) | Order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Starting date of the stage |
-|   ↳ `ending_at` | string | Ending date of the stage |
+|   ↳ `starting_at` | string (nullable) | Starting date of the stage |
+|   ↳ `ending_at` | string (nullable) | Ending date of the stage |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 
 ### Get Season by ID
 
@@ -5056,14 +5056,14 @@ Retrieve a single motorsport season by its ID from Sportmonks
 |   ↳ `id` | number | Unique id of the season |
 |   ↳ `sport_id` | number | Sport of the season |
 |   ↳ `league_id` | number | League of the season |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `name` | string | Name of the season |
 |   ↳ `finished` | boolean | Whether the season is finished |
 |   ↳ `pending` | boolean | Whether the season is pending |
 |   ↳ `is_current` | boolean | Whether the season is the current season |
-|   ↳ `starting_at` | string | Starting date of the season |
-|   ↳ `ending_at` | string | Ending date of the season |
-|   ↳ `standings_recalculated_at` | string | Timestamp when standings were last updated |
+|   ↳ `starting_at` | string (nullable) | Starting date of the season |
+|   ↳ `ending_at` | string (nullable) | Ending date of the season |
+|   ↳ `standings_recalculated_at` | string (nullable) | Timestamp when standings were last updated |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 
 ### Get All Seasons
@@ -5089,14 +5089,14 @@ Retrieve all motorsport seasons from Sportmonks
 |   ↳ `id` | number | Unique id of the season |
 |   ↳ `sport_id` | number | Sport of the season |
 |   ↳ `league_id` | number | League of the season |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `name` | string | Name of the season |
 |   ↳ `finished` | boolean | Whether the season is finished |
 |   ↳ `pending` | boolean | Whether the season is pending |
 |   ↳ `is_current` | boolean | Whether the season is the current season |
-|   ↳ `starting_at` | string | Starting date of the season |
-|   ↳ `ending_at` | string | Ending date of the season |
-|   ↳ `standings_recalculated_at` | string | Timestamp when standings were last updated |
+|   ↳ `starting_at` | string (nullable) | Starting date of the season |
+|   ↳ `ending_at` | string (nullable) | Ending date of the season |
+|   ↳ `standings_recalculated_at` | string (nullable) | Timestamp when standings were last updated |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
 
 ### Get Stage by ID
@@ -5121,15 +5121,15 @@ Retrieve a single motorsport stage (race weekend) by its ID from Sportmonks
 |   ↳ `sport_id` | number | Sport of the stage |
 |   ↳ `league_id` | number | League related to the stage |
 |   ↳ `season_id` | number | Season related to the stage |
-|   ↳ `type_id` | number | Type of the stage |
+|   ↳ `type_id` | number (nullable) | Type of the stage |
 |   ↳ `name` | string | Name of the stage |
-|   ↳ `sort_order` | number | Order of the stage |
+|   ↳ `sort_order` | number (nullable) | Order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Starting date of the stage |
-|   ↳ `ending_at` | string | Ending date of the stage |
+|   ↳ `starting_at` | string (nullable) | Starting date of the stage |
+|   ↳ `ending_at` | string (nullable) | Ending date of the stage |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 
 ### Get All Stages
 
@@ -5155,15 +5155,15 @@ Retrieve all motorsport stages (race weekends) from Sportmonks
 |   ↳ `sport_id` | number | Sport of the stage |
 |   ↳ `league_id` | number | League related to the stage |
 |   ↳ `season_id` | number | Season related to the stage |
-|   ↳ `type_id` | number | Type of the stage |
+|   ↳ `type_id` | number (nullable) | Type of the stage |
 |   ↳ `name` | string | Name of the stage |
-|   ↳ `sort_order` | number | Order of the stage |
+|   ↳ `sort_order` | number (nullable) | Order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Starting date of the stage |
-|   ↳ `ending_at` | string | Ending date of the stage |
+|   ↳ `starting_at` | string (nullable) | Starting date of the stage |
+|   ↳ `ending_at` | string (nullable) | Ending date of the stage |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 
 ### Get Stages by Season
 
@@ -5190,15 +5190,15 @@ Retrieve all motorsport stages (race weekends) for a season by season ID from Sp
 |   ↳ `sport_id` | number | Sport of the stage |
 |   ↳ `league_id` | number | League related to the stage |
 |   ↳ `season_id` | number | Season related to the stage |
-|   ↳ `type_id` | number | Type of the stage |
+|   ↳ `type_id` | number (nullable) | Type of the stage |
 |   ↳ `name` | string | Name of the stage |
-|   ↳ `sort_order` | number | Order of the stage |
+|   ↳ `sort_order` | number (nullable) | Order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Starting date of the stage |
-|   ↳ `ending_at` | string | Ending date of the stage |
+|   ↳ `starting_at` | string (nullable) | Starting date of the stage |
+|   ↳ `ending_at` | string (nullable) | Ending date of the stage |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 
 ### Get State by ID
 
@@ -5221,7 +5221,7 @@ Retrieve a single motorsport fixture state by its ID from Sportmonks
 |   ↳ `id` | number | Unique id of the state |
 |   ↳ `state` | string | Abbreviation of the state |
 |   ↳ `name` | string | Full name of the state |
-|   ↳ `short_name` | string | Short name of the state |
+|   ↳ `short_name` | string (nullable) | Short name of the state |
 |   ↳ `developer_name` | string | Name recommended for developers to use |
 
 ### Get All States
@@ -5247,7 +5247,7 @@ Retrieve all possible motorsport fixture states from Sportmonks
 |   ↳ `id` | number | Unique id of the state |
 |   ↳ `state` | string | Abbreviation of the state |
 |   ↳ `name` | string | Full name of the state |
-|   ↳ `short_name` | string | Short name of the state |
+|   ↳ `short_name` | string (nullable) | Short name of the state |
 |   ↳ `developer_name` | string | Name recommended for developers to use |
 
 ### Get Stints by Fixture
@@ -5348,15 +5348,15 @@ Retrieve a single motorsport team (constructor) by its ID from Sportmonks
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Not used in the Motorsport API |
+|   ↳ `venue_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team \(constructor\) |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the team's last session |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the team's last session |
 
 ### Get All Team Standings
 
@@ -5384,11 +5384,11 @@ Retrieve all team (constructor) championship standings from Sportmonks
 |   ↳ `league_id` | number | League related to the standing |
 |   ↳ `season_id` | number | Season related to the standing |
 |   ↳ `stage_id` | number | Stage related to the standing |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
-|   ↳ `standing_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `standing_rule_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `position` | number | Position of the participant in the standing |
-|   ↳ `result` | string | Not used in the Motorsport API |
+|   ↳ `result` | string (nullable) | Not used in the Motorsport API |
 |   ↳ `points` | number | Points the participant has gathered |
 
 ### Get Team Standings by Season
@@ -5418,11 +5418,11 @@ Retrieve the constructors championship standings for a season by season ID from 
 |   ↳ `league_id` | number | League related to the standing |
 |   ↳ `season_id` | number | Season related to the standing |
 |   ↳ `stage_id` | number | Stage related to the standing |
-|   ↳ `group_id` | number | Not used in the Motorsport API |
-|   ↳ `round_id` | number | Not used in the Motorsport API |
-|   ↳ `standing_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `group_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `round_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `standing_rule_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `position` | number | Position of the participant in the standing |
-|   ↳ `result` | string | Not used in the Motorsport API |
+|   ↳ `result` | string (nullable) | Not used in the Motorsport API |
 |   ↳ `points` | number | Points the participant has gathered |
 
 ### Get Teams
@@ -5448,15 +5448,15 @@ Retrieve all motorsport teams (constructors) from Sportmonks
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Not used in the Motorsport API |
+|   ↳ `venue_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team \(constructor\) |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the team's last session |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the team's last session |
 
 ### Get Teams by Country
 
@@ -5482,15 +5482,15 @@ Retrieve all motorsport teams (constructors) for a country by country ID from Sp
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Not used in the Motorsport API |
+|   ↳ `venue_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team \(constructor\) |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the team's last session |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the team's last session |
 
 ### Get Teams by Season
 
@@ -5516,15 +5516,15 @@ Retrieve all motorsport teams (constructors) for a season by season ID from Spor
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Not used in the Motorsport API |
+|   ↳ `venue_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team \(constructor\) |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the team's last session |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the team's last session |
 
 ### Get Venue by ID
 
@@ -5546,16 +5546,16 @@ Retrieve a single motorsport venue (racing track) by its ID from Sportmonks
 | `venue` | object | The requested venue \(racing track\) object |
 |   ↳ `id` | number | Unique id of the venue \(track\) |
 |   ↳ `country_id` | number | Country the venue is in |
-|   ↳ `city_id` | number | City the venue is in |
+|   ↳ `city_id` | number (nullable) | City the venue is in |
 |   ↳ `name` | string | Name of the venue/track |
-|   ↳ `address` | string | Address of the venue |
-|   ↳ `zipcode` | string | Zipcode of the venue |
-|   ↳ `latitude` | string | Latitude of the venue |
-|   ↳ `longitude` | string | Longitude of the venue |
-|   ↳ `capacity` | number | Capacity of the venue |
-|   ↳ `image_path` | string | URL to the track layout image |
-|   ↳ `city_name` | string | Name of the city the venue is in |
-|   ↳ `surface` | string | Surface of the venue |
+|   ↳ `address` | string (nullable) | Address of the venue |
+|   ↳ `zipcode` | string (nullable) | Zipcode of the venue |
+|   ↳ `latitude` | string (nullable) | Latitude of the venue |
+|   ↳ `longitude` | string (nullable) | Longitude of the venue |
+|   ↳ `capacity` | number (nullable) | Capacity of the venue |
+|   ↳ `image_path` | string (nullable) | URL to the track layout image |
+|   ↳ `city_name` | string (nullable) | Name of the city the venue is in |
+|   ↳ `surface` | string (nullable) | Surface of the venue |
 |   ↳ `national_team` | boolean | Not used in the Motorsport API |
 
 ### Get Venues
@@ -5580,16 +5580,16 @@ Retrieve all motorsport venues (racing tracks) from Sportmonks
 | `venues` | array | Array of venue \(racing track\) objects |
 |   ↳ `id` | number | Unique id of the venue \(track\) |
 |   ↳ `country_id` | number | Country the venue is in |
-|   ↳ `city_id` | number | City the venue is in |
+|   ↳ `city_id` | number (nullable) | City the venue is in |
 |   ↳ `name` | string | Name of the venue/track |
-|   ↳ `address` | string | Address of the venue |
-|   ↳ `zipcode` | string | Zipcode of the venue |
-|   ↳ `latitude` | string | Latitude of the venue |
-|   ↳ `longitude` | string | Longitude of the venue |
-|   ↳ `capacity` | number | Capacity of the venue |
-|   ↳ `image_path` | string | URL to the track layout image |
-|   ↳ `city_name` | string | Name of the city the venue is in |
-|   ↳ `surface` | string | Surface of the venue |
+|   ↳ `address` | string (nullable) | Address of the venue |
+|   ↳ `zipcode` | string (nullable) | Zipcode of the venue |
+|   ↳ `latitude` | string (nullable) | Latitude of the venue |
+|   ↳ `longitude` | string (nullable) | Longitude of the venue |
+|   ↳ `capacity` | number (nullable) | Capacity of the venue |
+|   ↳ `image_path` | string (nullable) | URL to the track layout image |
+|   ↳ `city_name` | string (nullable) | Name of the city the venue is in |
+|   ↳ `surface` | string (nullable) | Surface of the venue |
 |   ↳ `national_team` | boolean | Not used in the Motorsport API |
 
 ### Get Venues by Season
@@ -5615,16 +5615,16 @@ Retrieve all motorsport venues (racing tracks) for a season by season ID from Sp
 | `venues` | array | Array of venue \(racing track\) objects for the season |
 |   ↳ `id` | number | Unique id of the venue \(track\) |
 |   ↳ `country_id` | number | Country the venue is in |
-|   ↳ `city_id` | number | City the venue is in |
+|   ↳ `city_id` | number (nullable) | City the venue is in |
 |   ↳ `name` | string | Name of the venue/track |
-|   ↳ `address` | string | Address of the venue |
-|   ↳ `zipcode` | string | Zipcode of the venue |
-|   ↳ `latitude` | string | Latitude of the venue |
-|   ↳ `longitude` | string | Longitude of the venue |
-|   ↳ `capacity` | number | Capacity of the venue |
-|   ↳ `image_path` | string | URL to the track layout image |
-|   ↳ `city_name` | string | Name of the city the venue is in |
-|   ↳ `surface` | string | Surface of the venue |
+|   ↳ `address` | string (nullable) | Address of the venue |
+|   ↳ `zipcode` | string (nullable) | Zipcode of the venue |
+|   ↳ `latitude` | string (nullable) | Latitude of the venue |
+|   ↳ `longitude` | string (nullable) | Longitude of the venue |
+|   ↳ `capacity` | number (nullable) | Capacity of the venue |
+|   ↳ `image_path` | string (nullable) | URL to the track layout image |
+|   ↳ `city_name` | string (nullable) | Name of the city the venue is in |
+|   ↳ `surface` | string (nullable) | Surface of the venue |
 |   ↳ `national_team` | boolean | Not used in the Motorsport API |
 
 ### Search Drivers
@@ -5650,21 +5650,21 @@ Search for motorsport drivers by name from Sportmonks
 | `drivers` | array | Array of driver objects matching the search query |
 |   ↳ `id` | number | Unique id of the driver \(player_id in responses\) |
 |   ↳ `sport_id` | number | Sport of the driver |
-|   ↳ `country_id` | number | Country of birth of the driver |
-|   ↳ `nationality_id` | number | Nationality of the driver |
-|   ↳ `city_id` | number | City of birth of the driver |
-|   ↳ `position_id` | number | Position of the driver within the team |
-|   ↳ `detailed_position_id` | number | Not used in the Motorsport API |
-|   ↳ `type_id` | number | Not used in the Motorsport API |
+|   ↳ `country_id` | number (nullable) | Country of birth of the driver |
+|   ↳ `nationality_id` | number (nullable) | Nationality of the driver |
+|   ↳ `city_id` | number (nullable) | City of birth of the driver |
+|   ↳ `position_id` | number (nullable) | Position of the driver within the team |
+|   ↳ `detailed_position_id` | number (nullable) | Not used in the Motorsport API |
+|   ↳ `type_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `common_name` | string | Name the driver is known for |
 |   ↳ `firstname` | string | First name of the driver |
 |   ↳ `lastname` | string | Last name of the driver |
 |   ↳ `name` | string | Name of the driver |
 |   ↳ `display_name` | string | Display name of the driver |
 |   ↳ `image_path` | string | URL to the driver headshot |
-|   ↳ `height` | number | Height of the driver in cm |
-|   ↳ `weight` | number | Weight of the driver in kg |
-|   ↳ `date_of_birth` | string | Date of birth of the driver |
+|   ↳ `height` | number (nullable) | Height of the driver in cm |
+|   ↳ `weight` | number (nullable) | Weight of the driver in kg |
+|   ↳ `date_of_birth` | string (nullable) | Date of birth of the driver |
 |   ↳ `gender` | string | Gender of the driver |
 
 ### Search Leagues
@@ -5693,12 +5693,12 @@ Search for motorsport leagues by name from Sportmonks
 |   ↳ `country_id` | number | Country of the league |
 |   ↳ `name` | string | Name of the league |
 |   ↳ `active` | boolean | Whether the league is active |
-|   ↳ `short_code` | string | Short code of the league |
-|   ↳ `image_path` | string | URL to the league logo |
+|   ↳ `short_code` | string (nullable) | Short code of the league |
+|   ↳ `image_path` | string (nullable) | URL to the league logo |
 |   ↳ `type` | string | Type of the league |
-|   ↳ `sub_type` | string | Subtype of the league |
-|   ↳ `last_played_at` | string | Date of the last fixture held in the league |
-|   ↳ `category` | number | Category of the league |
+|   ↳ `sub_type` | string (nullable) | Subtype of the league |
+|   ↳ `last_played_at` | string (nullable) | Date of the last fixture held in the league |
+|   ↳ `category` | number (nullable) | Category of the league |
 |   ↳ `has_jerseys` | boolean | Not used in the Motorsport API |
 
 ### Search Stages
@@ -5726,15 +5726,15 @@ Search for motorsport stages (race weekends) by name from Sportmonks
 |   ↳ `sport_id` | number | Sport of the stage |
 |   ↳ `league_id` | number | League related to the stage |
 |   ↳ `season_id` | number | Season related to the stage |
-|   ↳ `type_id` | number | Type of the stage |
+|   ↳ `type_id` | number (nullable) | Type of the stage |
 |   ↳ `name` | string | Name of the stage |
-|   ↳ `sort_order` | number | Order of the stage |
+|   ↳ `sort_order` | number (nullable) | Order of the stage |
 |   ↳ `finished` | boolean | Whether the stage is finished |
 |   ↳ `is_current` | boolean | Whether the stage is the current stage |
-|   ↳ `starting_at` | string | Starting date of the stage |
-|   ↳ `ending_at` | string | Ending date of the stage |
+|   ↳ `starting_at` | string (nullable) | Starting date of the stage |
+|   ↳ `ending_at` | string (nullable) | Ending date of the stage |
 |   ↳ `games_in_current_week` | boolean | Not used in the Motorsport API |
-|   ↳ `tie_breaker_rule_id` | number | Not used in the Motorsport API |
+|   ↳ `tie_breaker_rule_id` | number (nullable) | Not used in the Motorsport API |
 
 ### Search Teams
 
@@ -5760,15 +5760,15 @@ Search for motorsport teams (constructors) by name from Sportmonks
 |   ↳ `id` | number | Unique id of the team |
 |   ↳ `sport_id` | number | Sport of the team |
 |   ↳ `country_id` | number | Country of the team |
-|   ↳ `venue_id` | number | Not used in the Motorsport API |
+|   ↳ `venue_id` | number (nullable) | Not used in the Motorsport API |
 |   ↳ `gender` | string | Gender of the team |
 |   ↳ `name` | string | Name of the team \(constructor\) |
-|   ↳ `short_code` | string | Short code of the team |
+|   ↳ `short_code` | string (nullable) | Short code of the team |
 |   ↳ `image_path` | string | URL to the team logo |
-|   ↳ `founded` | number | Founding year of the team |
+|   ↳ `founded` | number (nullable) | Founding year of the team |
 |   ↳ `type` | string | Type of the team |
 |   ↳ `placeholder` | boolean | Whether the team is a placeholder |
-|   ↳ `last_played_at` | string | Date and time of the team's last session |
+|   ↳ `last_played_at` | string (nullable) | Date and time of the team's last session |
 
 ### Search Venues
 
@@ -5793,16 +5793,16 @@ Search for motorsport venues (racing tracks) by name from Sportmonks
 | `venues` | array | Array of venue \(racing track\) objects matching the search query |
 |   ↳ `id` | number | Unique id of the venue \(track\) |
 |   ↳ `country_id` | number | Country the venue is in |
-|   ↳ `city_id` | number | City the venue is in |
+|   ↳ `city_id` | number (nullable) | City the venue is in |
 |   ↳ `name` | string | Name of the venue/track |
-|   ↳ `address` | string | Address of the venue |
-|   ↳ `zipcode` | string | Zipcode of the venue |
-|   ↳ `latitude` | string | Latitude of the venue |
-|   ↳ `longitude` | string | Longitude of the venue |
-|   ↳ `capacity` | number | Capacity of the venue |
-|   ↳ `image_path` | string | URL to the track layout image |
-|   ↳ `city_name` | string | Name of the city the venue is in |
-|   ↳ `surface` | string | Surface of the venue |
+|   ↳ `address` | string (nullable) | Address of the venue |
+|   ↳ `zipcode` | string (nullable) | Zipcode of the venue |
+|   ↳ `latitude` | string (nullable) | Latitude of the venue |
+|   ↳ `longitude` | string (nullable) | Longitude of the venue |
+|   ↳ `capacity` | number (nullable) | Capacity of the venue |
+|   ↳ `image_path` | string (nullable) | URL to the track layout image |
+|   ↳ `city_name` | string (nullable) | Name of the city the venue is in |
+|   ↳ `surface` | string (nullable) | Surface of the venue |
 |   ↳ `national_team` | boolean | Not used in the Motorsport API |
 
 ### Get All Historical Odds
@@ -5827,12 +5827,12 @@ Retrieve all available historical (premium) pre-match odd values from the Sportm
 | `historicalOdds` | array | Array of historical premium odd value records |
 |   ↳ `id` | number | Unique id of the history record |
 |   ↳ `odd_id` | number | Premium odd this history record belongs to |
-|   ↳ `value` | string | Historical decimal odds value |
-|   ↳ `probability` | string | Implied probability at this point in time |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `bookmaker_update` | string | Bookmaker's update timestamp for this record \(UTC\) |
+|   ↳ `value` | string (nullable) | Historical decimal odds value |
+|   ↳ `probability` | string (nullable) | Implied probability at this point in time |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `bookmaker_update` | string (nullable) | Bookmaker's update timestamp for this record \(UTC\) |
 
 ### Get All In-play Odds
 
@@ -5856,24 +5856,24 @@ Retrieve all available live (in-play) odds from the Sportmonks Odds API
 | `odds` | array | Array of in-play odd objects |
 |   ↳ `id` | number | Unique id of the odd |
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
-|   ↳ `external_id` | number | External id of the odd |
+|   ↳ `external_id` | number (nullable) | External id of the odd |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `suspended` | boolean | Whether the odd is suspended |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `suspended` | boolean (nullable) | Whether the odd is suspended |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
 
 ### Get All Pre-match Odds
 
@@ -5899,21 +5899,21 @@ Retrieve all available pre-match odds from the Sportmonks Odds API
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name \(e.g. Home, Draw, Away\) |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 48.78%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds \(e.g. 31/15\) |
-|   ↳ `american` | string | American/moneyline odds \(e.g. +104\) |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
-|   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name \(e.g. Home, Draw, Away\) |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 48.78%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds \(e.g. 31/15\) |
+|   ↳ `american` | string (nullable) | American/moneyline odds \(e.g. +104\) |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
+|   ↳ `original_label` | string (nullable) | Original handicap value of the odd \(handicap markets\) |
 
 ### Get All Premium Odds
 
@@ -5939,21 +5939,21 @@ Retrieve all available premium (historical) pre-match odds from the Sportmonks O
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 29.85%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `created_at` | string | Timestamp the odd was created \(UTC\) |
-|   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
-|   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
+|   ↳ `label` | string (nullable) | Outcome label |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 29.85%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `created_at` | string (nullable) | Timestamp the odd was created \(UTC\) |
+|   ↳ `updated_at` | string (nullable) | Timestamp the odd was last updated \(UTC\) |
+|   ↳ `latest_bookmaker_update` | string (nullable) | Bookmaker's own last-update timestamp \(UTC\) |
 
 ### Get Bookmaker by ID
 
@@ -5973,7 +5973,7 @@ Retrieve a single bookmaker by its ID from the Sportmonks Odds API
 | `bookmaker` | object | The requested bookmaker object |
 |   ↳ `id` | number | Unique id of the bookmaker |
 |   ↳ `name` | string | Name of the bookmaker |
-|   ↳ `logo` | string | Logo of the bookmaker |
+|   ↳ `logo` | string (nullable) | Logo of the bookmaker |
 
 ### Get Bookmaker Event IDs by Fixture
 
@@ -5996,8 +5996,8 @@ Retrieve bookmakers' own event ids mapped to a Sportmonks fixture via the Sportm
 | `bookmakerEvents` | array | Array of bookmaker event mapping records for the fixture |
 |   ↳ `fixture_id` | number | Sportmonks fixture id |
 |   ↳ `bookmaker_id` | number | Id of the bookmaker |
-|   ↳ `bookmaker_name` | string | Name of the bookmaker |
-|   ↳ `bookmaker_event_id` | string | The fixture's event id at the bookmaker |
+|   ↳ `bookmaker_name` | string (nullable) | Name of the bookmaker |
+|   ↳ `bookmaker_event_id` | string (nullable) | The fixture's event id at the bookmaker |
 
 ### Get Bookmakers
 
@@ -6020,7 +6020,7 @@ Retrieve all bookmakers from the Sportmonks Odds API
 | `bookmakers` | array | Array of bookmaker objects |
 |   ↳ `id` | number | Unique id of the bookmaker |
 |   ↳ `name` | string | Name of the bookmaker |
-|   ↳ `logo` | string | Logo of the bookmaker |
+|   ↳ `logo` | string (nullable) | Logo of the bookmaker |
 
 ### Get Bookmakers by Fixture
 
@@ -6043,7 +6043,7 @@ Retrieve all bookmakers available for a fixture from the Sportmonks Odds API
 | `bookmakers` | array | Array of bookmaker objects available for the fixture |
 |   ↳ `id` | number | Unique id of the bookmaker |
 |   ↳ `name` | string | Name of the bookmaker |
-|   ↳ `logo` | string | Logo of the bookmaker |
+|   ↳ `logo` | string (nullable) | Logo of the bookmaker |
 
 ### Get In-play Odds by Fixture
 
@@ -6068,24 +6068,24 @@ Retrieve live (in-play) odds for a fixture by fixture ID from the Sportmonks Odd
 | `odds` | array | Array of in-play odd objects for the fixture |
 |   ↳ `id` | number | Unique id of the odd |
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
-|   ↳ `external_id` | number | External id of the odd |
+|   ↳ `external_id` | number (nullable) | External id of the odd |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `suspended` | boolean | Whether the odd is suspended |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `suspended` | boolean (nullable) | Whether the odd is suspended |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
 
 ### Get In-play Odds by Fixture and Bookmaker
 
@@ -6108,24 +6108,24 @@ Retrieve live (in-play) odds for a fixture from a specific bookmaker via the Spo
 | `odds` | array | Array of in-play odd objects for the fixture and bookmaker |
 |   ↳ `id` | number | Unique id of the odd |
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
-|   ↳ `external_id` | number | External id of the odd |
+|   ↳ `external_id` | number (nullable) | External id of the odd |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `suspended` | boolean | Whether the odd is suspended |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `suspended` | boolean (nullable) | Whether the odd is suspended |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
 
 ### Get In-play Odds by Fixture and Market
 
@@ -6148,24 +6148,24 @@ Retrieve live (in-play) odds for a fixture on a specific market via the Sportmon
 | `odds` | array | Array of in-play odd objects for the fixture and market |
 |   ↳ `id` | number | Unique id of the odd |
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
-|   ↳ `external_id` | number | External id of the odd |
+|   ↳ `external_id` | number (nullable) | External id of the odd |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `suspended` | boolean | Whether the odd is suspended |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `suspended` | boolean (nullable) | Whether the odd is suspended |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
 
 ### Get Last Updated In-play Odds
 
@@ -6186,24 +6186,24 @@ Retrieve in-play odds updated in the last 10 seconds from the Sportmonks Odds AP
 | `odds` | array | Array of in-play odd objects updated in the last 10 seconds |
 |   ↳ `id` | number | Unique id of the odd |
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
-|   ↳ `external_id` | number | External id of the odd |
+|   ↳ `external_id` | number (nullable) | External id of the odd |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `suspended` | boolean | Whether the odd is suspended |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `suspended` | boolean (nullable) | Whether the odd is suspended |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
 
 ### Get Last Updated Pre-match Odds
 
@@ -6226,21 +6226,21 @@ Retrieve pre-match odds updated in the last 10 seconds from the Sportmonks Odds 
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name \(e.g. Home, Draw, Away\) |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 48.78%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds \(e.g. 31/15\) |
-|   ↳ `american` | string | American/moneyline odds \(e.g. +104\) |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
-|   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name \(e.g. Home, Draw, Away\) |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 48.78%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds \(e.g. 31/15\) |
+|   ↳ `american` | string (nullable) | American/moneyline odds \(e.g. +104\) |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
+|   ↳ `original_label` | string (nullable) | Original handicap value of the odd \(handicap markets\) |
 
 ### Get Market by ID
 
@@ -6260,7 +6260,7 @@ Retrieve a single betting market by its ID from the Sportmonks Odds API
 | `market` | object | The requested market object |
 |   ↳ `id` | number | Unique id of the market |
 |   ↳ `name` | string | Name of the market |
-|   ↳ `developer_name` | string | Developer \(machine-readable\) name of the market |
+|   ↳ `developer_name` | string (nullable) | Developer \(machine-readable\) name of the market |
 
 ### Get Markets
 
@@ -6283,7 +6283,7 @@ Retrieve all betting markets from the Sportmonks Odds API
 | `markets` | array | Array of market objects |
 |   ↳ `id` | number | Unique id of the market |
 |   ↳ `name` | string | Name of the market |
-|   ↳ `developer_name` | string | Developer \(machine-readable\) name of the market |
+|   ↳ `developer_name` | string (nullable) | Developer \(machine-readable\) name of the market |
 
 ### Get Pre-match Odds by Fixture
 
@@ -6310,21 +6310,21 @@ Retrieve pre-match odds for a fixture by fixture ID from the Sportmonks Odds API
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name \(e.g. Home, Draw, Away\) |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 48.78%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds \(e.g. 31/15\) |
-|   ↳ `american` | string | American/moneyline odds \(e.g. +104\) |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
-|   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name \(e.g. Home, Draw, Away\) |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 48.78%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds \(e.g. 31/15\) |
+|   ↳ `american` | string (nullable) | American/moneyline odds \(e.g. +104\) |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
+|   ↳ `original_label` | string (nullable) | Original handicap value of the odd \(handicap markets\) |
 
 ### Get Pre-match Odds by Fixture and Bookmaker
 
@@ -6349,21 +6349,21 @@ Retrieve pre-match odds for a fixture from a specific bookmaker via the Sportmon
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name \(e.g. Home, Draw, Away\) |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 48.78%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds \(e.g. 31/15\) |
-|   ↳ `american` | string | American/moneyline odds \(e.g. +104\) |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
-|   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name \(e.g. Home, Draw, Away\) |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 48.78%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds \(e.g. 31/15\) |
+|   ↳ `american` | string (nullable) | American/moneyline odds \(e.g. +104\) |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
+|   ↳ `original_label` | string (nullable) | Original handicap value of the odd \(handicap markets\) |
 
 ### Get Pre-match Odds by Fixture and Market
 
@@ -6388,21 +6388,21 @@ Retrieve pre-match odds for a fixture on a specific market via the Sportmonks Od
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label \(e.g. 1, X, 2\) |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name \(e.g. Home, Draw, Away\) |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 48.78%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds \(e.g. 31/15\) |
-|   ↳ `american` | string | American/moneyline odds \(e.g. +104\) |
-|   ↳ `winning` | boolean | Whether this is the winning outcome |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `participants` | string | Participant ids related to the outcome |
-|   ↳ `original_label` | string | Original handicap value of the odd \(handicap markets\) |
+|   ↳ `label` | string (nullable) | Outcome label \(e.g. 1, X, 2\) |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name \(e.g. Home, Draw, Away\) |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 48.78%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds \(e.g. 31/15\) |
+|   ↳ `american` | string (nullable) | American/moneyline odds \(e.g. +104\) |
+|   ↳ `winning` | boolean (nullable) | Whether this is the winning outcome |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `participants` | string (nullable) | Participant ids related to the outcome |
+|   ↳ `original_label` | string (nullable) | Original handicap value of the odd \(handicap markets\) |
 
 ### Get Premium Odds by Fixture
 
@@ -6426,21 +6426,21 @@ Retrieve premium (historical) pre-match odds for a fixture from the Sportmonks O
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 29.85%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `created_at` | string | Timestamp the odd was created \(UTC\) |
-|   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
-|   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
+|   ↳ `label` | string (nullable) | Outcome label |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 29.85%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `created_at` | string (nullable) | Timestamp the odd was created \(UTC\) |
+|   ↳ `updated_at` | string (nullable) | Timestamp the odd was last updated \(UTC\) |
+|   ↳ `latest_bookmaker_update` | string (nullable) | Bookmaker's own last-update timestamp \(UTC\) |
 
 ### Get Premium Odds by Fixture and Bookmaker
 
@@ -6465,21 +6465,21 @@ Retrieve premium pre-match odds for a fixture from a specific bookmaker via the 
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 29.85%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `created_at` | string | Timestamp the odd was created \(UTC\) |
-|   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
-|   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
+|   ↳ `label` | string (nullable) | Outcome label |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 29.85%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `created_at` | string (nullable) | Timestamp the odd was created \(UTC\) |
+|   ↳ `updated_at` | string (nullable) | Timestamp the odd was last updated \(UTC\) |
+|   ↳ `latest_bookmaker_update` | string (nullable) | Bookmaker's own last-update timestamp \(UTC\) |
 
 ### Get Premium Odds by Fixture and Market
 
@@ -6504,21 +6504,21 @@ Retrieve premium pre-match odds for a fixture on a specific market via the Sport
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 29.85%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `created_at` | string | Timestamp the odd was created \(UTC\) |
-|   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
-|   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
+|   ↳ `label` | string (nullable) | Outcome label |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 29.85%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `created_at` | string (nullable) | Timestamp the odd was created \(UTC\) |
+|   ↳ `updated_at` | string (nullable) | Timestamp the odd was last updated \(UTC\) |
+|   ↳ `latest_bookmaker_update` | string (nullable) | Bookmaker's own last-update timestamp \(UTC\) |
 
 ### Get Updated Historical Odds Between Time Range
 
@@ -6544,12 +6544,12 @@ Retrieve historical (premium) odds updated between two UNIX timestamps (max 5 mi
 | `historicalOdds` | array | Array of historical premium odd value records updated within the time range |
 |   ↳ `id` | number | Unique id of the history record |
 |   ↳ `odd_id` | number | Premium odd this history record belongs to |
-|   ↳ `value` | string | Historical decimal odds value |
-|   ↳ `probability` | string | Implied probability at this point in time |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `bookmaker_update` | string | Bookmaker's update timestamp for this record \(UTC\) |
+|   ↳ `value` | string (nullable) | Historical decimal odds value |
+|   ↳ `probability` | string (nullable) | Implied probability at this point in time |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `bookmaker_update` | string (nullable) | Bookmaker's update timestamp for this record \(UTC\) |
 
 ### Get Updated Premium Odds Between Time Range
 
@@ -6577,21 +6577,21 @@ Retrieve premium odds updated between two UNIX timestamps (max 5 minutes) from t
 |   ↳ `fixture_id` | number | Fixture the odd belongs to |
 |   ↳ `market_id` | number | Market the odd belongs to |
 |   ↳ `bookmaker_id` | number | Bookmaker offering the odd |
-|   ↳ `label` | string | Outcome label |
-|   ↳ `value` | string | Decimal odds value |
-|   ↳ `name` | string | Outcome name |
-|   ↳ `sort_order` | number | Sort order of the odd |
-|   ↳ `market_description` | string | Description of the market |
-|   ↳ `probability` | string | Implied probability \(e.g. 29.85%\) |
-|   ↳ `dp3` | string | Decimal odds to 3 decimal places |
-|   ↳ `fractional` | string | Fractional odds |
-|   ↳ `american` | string | American/moneyline odds |
-|   ↳ `stopped` | boolean | Whether the odd is stopped |
-|   ↳ `total` | string | Total line for over/under markets |
-|   ↳ `handicap` | string | Handicap line for handicap markets |
-|   ↳ `created_at` | string | Timestamp the odd was created \(UTC\) |
-|   ↳ `updated_at` | string | Timestamp the odd was last updated \(UTC\) |
-|   ↳ `latest_bookmaker_update` | string | Bookmaker's own last-update timestamp \(UTC\) |
+|   ↳ `label` | string (nullable) | Outcome label |
+|   ↳ `value` | string (nullable) | Decimal odds value |
+|   ↳ `name` | string (nullable) | Outcome name |
+|   ↳ `sort_order` | number (nullable) | Sort order of the odd |
+|   ↳ `market_description` | string (nullable) | Description of the market |
+|   ↳ `probability` | string (nullable) | Implied probability \(e.g. 29.85%\) |
+|   ↳ `dp3` | string (nullable) | Decimal odds to 3 decimal places |
+|   ↳ `fractional` | string (nullable) | Fractional odds |
+|   ↳ `american` | string (nullable) | American/moneyline odds |
+|   ↳ `stopped` | boolean (nullable) | Whether the odd is stopped |
+|   ↳ `total` | string (nullable) | Total line for over/under markets |
+|   ↳ `handicap` | string (nullable) | Handicap line for handicap markets |
+|   ↳ `created_at` | string (nullable) | Timestamp the odd was created \(UTC\) |
+|   ↳ `updated_at` | string (nullable) | Timestamp the odd was last updated \(UTC\) |
+|   ↳ `latest_bookmaker_update` | string (nullable) | Bookmaker's own last-update timestamp \(UTC\) |
 
 ### Search Bookmakers
 
@@ -6614,7 +6614,7 @@ Search for bookmakers by name from the Sportmonks Odds API
 | `bookmakers` | array | Array of bookmaker objects matching the search query |
 |   ↳ `id` | number | Unique id of the bookmaker |
 |   ↳ `name` | string | Name of the bookmaker |
-|   ↳ `logo` | string | Logo of the bookmaker |
+|   ↳ `logo` | string (nullable) | Logo of the bookmaker |
 
 ### Search Markets
 
@@ -6637,7 +6637,7 @@ Search for betting markets by name from the Sportmonks Odds API
 | `markets` | array | Array of market objects matching the search query |
 |   ↳ `id` | number | Unique id of the market |
 |   ↳ `name` | string | Name of the market |
-|   ↳ `developer_name` | string | Developer \(machine-readable\) name of the market |
+|   ↳ `developer_name` | string (nullable) | Developer \(machine-readable\) name of the market |
 
 ### Get Cities
 
@@ -6661,11 +6661,11 @@ Retrieve all cities from the Sportmonks Core API
 | `cities` | array | Array of city objects |
 |   ↳ `id` | number | Unique id of the city |
 |   ↳ `country_id` | number | Country of the city |
-|   ↳ `region_id` | number | Region id of the city |
+|   ↳ `region_id` | number (nullable) | Region id of the city |
 |   ↳ `name` | string | Name of the city |
-|   ↳ `latitude` | string | Latitude of the city |
-|   ↳ `longitude` | string | Longitude of the city |
-|   ↳ `geonameid` | number | Official geonameid of the city |
+|   ↳ `latitude` | string (nullable) | Latitude of the city |
+|   ↳ `longitude` | string (nullable) | Longitude of the city |
+|   ↳ `geonameid` | number (nullable) | Official geonameid of the city |
 
 ### Get City by ID
 
@@ -6686,11 +6686,11 @@ Retrieve a single city by its ID from the Sportmonks Core API
 | `city` | object | The requested city object |
 |   ↳ `id` | number | Unique id of the city |
 |   ↳ `country_id` | number | Country of the city |
-|   ↳ `region_id` | number | Region id of the city |
+|   ↳ `region_id` | number (nullable) | Region id of the city |
 |   ↳ `name` | string | Name of the city |
-|   ↳ `latitude` | string | Latitude of the city |
-|   ↳ `longitude` | string | Longitude of the city |
-|   ↳ `geonameid` | number | Official geonameid of the city |
+|   ↳ `latitude` | string (nullable) | Latitude of the city |
+|   ↳ `longitude` | string (nullable) | Longitude of the city |
+|   ↳ `geonameid` | number (nullable) | Official geonameid of the city |
 
 ### Get Continent by ID
 
@@ -6757,16 +6757,16 @@ Retrieve all countries from the Sportmonks Core API
 | --------- | ---- | ----------- |
 | `countries` | array | Array of country objects |
 |   ↳ `id` | number | Unique id of the country |
-|   ↳ `continent_id` | number | Continent of the country |
+|   ↳ `continent_id` | number (nullable) | Continent of the country |
 |   ↳ `name` | string | Name of the country |
 |   ↳ `official_name` | string | Official name of the country |
-|   ↳ `fifa_name` | string | Official FIFA short code name |
-|   ↳ `iso2` | string | Two letter country code |
-|   ↳ `iso3` | string | Three letter country code |
-|   ↳ `latitude` | string | Latitude position of the country |
-|   ↳ `longitude` | string | Longitude position of the country |
-|   ↳ `geonameid` | number | Official geonameid |
-|   ↳ `borders` | array | Neighbouring countries \(ISO3 codes\) |
+|   ↳ `fifa_name` | string (nullable) | Official FIFA short code name |
+|   ↳ `iso2` | string (nullable) | Two letter country code |
+|   ↳ `iso3` | string (nullable) | Three letter country code |
+|   ↳ `latitude` | string (nullable) | Latitude position of the country |
+|   ↳ `longitude` | string (nullable) | Longitude position of the country |
+|   ↳ `geonameid` | number (nullable) | Official geonameid |
+|   ↳ `borders` | array (nullable) | Neighbouring countries \(ISO3 codes\) |
 |   ↳ `image_path` | string | Image path to the country flag |
 
 ### Get Country by ID
@@ -6787,16 +6787,16 @@ Retrieve a single country by its ID from the Sportmonks Core API
 | --------- | ---- | ----------- |
 | `country` | object | The requested country object |
 |   ↳ `id` | number | Unique id of the country |
-|   ↳ `continent_id` | number | Continent of the country |
+|   ↳ `continent_id` | number (nullable) | Continent of the country |
 |   ↳ `name` | string | Name of the country |
 |   ↳ `official_name` | string | Official name of the country |
-|   ↳ `fifa_name` | string | Official FIFA short code name |
-|   ↳ `iso2` | string | Two letter country code |
-|   ↳ `iso3` | string | Three letter country code |
-|   ↳ `latitude` | string | Latitude position of the country |
-|   ↳ `longitude` | string | Longitude position of the country |
-|   ↳ `geonameid` | number | Official geonameid |
-|   ↳ `borders` | array | Neighbouring countries \(ISO3 codes\) |
+|   ↳ `fifa_name` | string (nullable) | Official FIFA short code name |
+|   ↳ `iso2` | string (nullable) | Two letter country code |
+|   ↳ `iso3` | string (nullable) | Three letter country code |
+|   ↳ `latitude` | string (nullable) | Latitude position of the country |
+|   ↳ `longitude` | string (nullable) | Longitude position of the country |
+|   ↳ `geonameid` | number (nullable) | Official geonameid |
+|   ↳ `borders` | array (nullable) | Neighbouring countries \(ISO3 codes\) |
 |   ↳ `image_path` | string | Image path to the country flag |
 
 ### Get All Entity Filters
@@ -6919,12 +6919,12 @@ Retrieve a single type by its ID from the Sportmonks Core API
 | --------- | ---- | ----------- |
 | `type` | object | The requested type object |
 |   ↳ `id` | number | Unique id of the type |
-|   ↳ `parent_id` | number | Parent type of the type |
+|   ↳ `parent_id` | number (nullable) | Parent type of the type |
 |   ↳ `name` | string | Name of the type |
-|   ↳ `code` | string | Code of the type |
-|   ↳ `developer_name` | string | Developer name of the type |
-|   ↳ `group` | string | Group the type falls under |
-|   ↳ `description` | string | Description of the type |
+|   ↳ `code` | string (nullable) | Code of the type |
+|   ↳ `developer_name` | string (nullable) | Developer name of the type |
+|   ↳ `group` | string (nullable) | Group the type falls under |
+|   ↳ `description` | string (nullable) | Description of the type |
 
 ### Get Type by Entity
 
@@ -6961,12 +6961,12 @@ Retrieve all types (reference data describing events, statistics, positions, etc
 | --------- | ---- | ----------- |
 | `types` | array | Array of type objects |
 |   ↳ `id` | number | Unique id of the type |
-|   ↳ `parent_id` | number | Parent type of the type |
+|   ↳ `parent_id` | number (nullable) | Parent type of the type |
 |   ↳ `name` | string | Name of the type |
-|   ↳ `code` | string | Code of the type |
-|   ↳ `developer_name` | string | Developer name of the type |
-|   ↳ `group` | string | Group the type falls under |
-|   ↳ `description` | string | Description of the type |
+|   ↳ `code` | string (nullable) | Code of the type |
+|   ↳ `developer_name` | string (nullable) | Developer name of the type |
+|   ↳ `group` | string (nullable) | Group the type falls under |
+|   ↳ `description` | string (nullable) | Description of the type |
 
 ### Search Cities
 
@@ -6991,11 +6991,11 @@ Search for cities by name from the Sportmonks Core API
 | `cities` | array | Array of city objects matching the search query |
 |   ↳ `id` | number | Unique id of the city |
 |   ↳ `country_id` | number | Country of the city |
-|   ↳ `region_id` | number | Region id of the city |
+|   ↳ `region_id` | number (nullable) | Region id of the city |
 |   ↳ `name` | string | Name of the city |
-|   ↳ `latitude` | string | Latitude of the city |
-|   ↳ `longitude` | string | Longitude of the city |
-|   ↳ `geonameid` | number | Official geonameid of the city |
+|   ↳ `latitude` | string (nullable) | Latitude of the city |
+|   ↳ `longitude` | string (nullable) | Longitude of the city |
+|   ↳ `geonameid` | number (nullable) | Official geonameid of the city |
 
 ### Search Countries
 
@@ -7019,16 +7019,16 @@ Search for countries by name from the Sportmonks Core API
 | --------- | ---- | ----------- |
 | `countries` | array | Array of country objects matching the search query |
 |   ↳ `id` | number | Unique id of the country |
-|   ↳ `continent_id` | number | Continent of the country |
+|   ↳ `continent_id` | number (nullable) | Continent of the country |
 |   ↳ `name` | string | Name of the country |
 |   ↳ `official_name` | string | Official name of the country |
-|   ↳ `fifa_name` | string | Official FIFA short code name |
-|   ↳ `iso2` | string | Two letter country code |
-|   ↳ `iso3` | string | Three letter country code |
-|   ↳ `latitude` | string | Latitude position of the country |
-|   ↳ `longitude` | string | Longitude position of the country |
-|   ↳ `geonameid` | number | Official geonameid |
-|   ↳ `borders` | array | Neighbouring countries \(ISO3 codes\) |
+|   ↳ `fifa_name` | string (nullable) | Official FIFA short code name |
+|   ↳ `iso2` | string (nullable) | Two letter country code |
+|   ↳ `iso3` | string (nullable) | Three letter country code |
+|   ↳ `latitude` | string (nullable) | Latitude position of the country |
+|   ↳ `longitude` | string (nullable) | Longitude position of the country |
+|   ↳ `geonameid` | number (nullable) | Official geonameid |
+|   ↳ `borders` | array (nullable) | Neighbouring countries \(ISO3 codes\) |
 |   ↳ `image_path` | string | Image path to the country flag |
 
 ### Search Regions
@@ -7055,5 +7055,3 @@ Search for regions by name from the Sportmonks Core API
 |   ↳ `id` | number | Unique id of the region |
 |   ↳ `country_id` | number | Country of the region |
 |   ↳ `name` | string | Name of the region |
-
-

--- a/apps/docs/content/docs/integrations/sqs.mdx
+++ b/apps/docs/content/docs/integrations/sqs.mdx
@@ -5,7 +5,7 @@ description: Connect to Amazon SQS
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sqs"
   color="linear-gradient(45deg, #2E27AD 0%, #527FFF 100%)"
 />
@@ -56,9 +56,9 @@ Send a message to an Amazon SQS queue
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
 | `id` | string | Message ID |
-| `md5OfMessageBody` | string | MD5 digest of the message body, for verifying SQS received it intact |
-| `md5OfMessageAttributes` | string | MD5 digest of the message attributes |
-| `sequenceNumber` | string | Large, non-consecutive sequence number assigned by a FIFO queue |
+| `md5OfMessageBody` | string (nullable) | MD5 digest of the message body, for verifying SQS received it intact |
+| `md5OfMessageAttributes` | string (nullable) | MD5 digest of the message attributes |
+| `sequenceNumber` | string (nullable) | Large, non-consecutive sequence number assigned by a FIFO queue |
 
 ### SQS Send Message Batch
 
@@ -491,15 +491,15 @@ List the most recent message move tasks for an Amazon SQS source queue
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `results` | array | Move tasks for the source queue |
-|   ↳ `taskHandle` | string | Handle of the task, populated only while its status is RUNNING |
-|   ↳ `status` | string | RUNNING, COMPLETED, CANCELLING, CANCELLED, or FAILED |
-|   ↳ `sourceArn` | string | ARN of the source queue |
-|   ↳ `destinationArn` | string | ARN of the destination queue, absent when redriving to source queues |
-|   ↳ `maxNumberOfMessagesPerSecond` | number | Per-second throttle applied to the move |
-|   ↳ `approximateNumberOfMessagesMoved` | number | Approximate number of messages moved so far |
-|   ↳ `approximateNumberOfMessagesToMove` | number | Approximate number of messages still to move |
-|   ↳ `failureReason` | string | Why the task failed, set only when the status is FAILED |
-|   ↳ `startedTimestamp` | number | Epoch milliseconds when the task started |
+|   ↳ `taskHandle` | string (nullable) | Handle of the task, populated only while its status is RUNNING |
+|   ↳ `status` | string (nullable) | RUNNING, COMPLETED, CANCELLING, CANCELLED, or FAILED |
+|   ↳ `sourceArn` | string (nullable) | ARN of the source queue |
+|   ↳ `destinationArn` | string (nullable) | ARN of the destination queue, absent when redriving to source queues |
+|   ↳ `maxNumberOfMessagesPerSecond` | number (nullable) | Per-second throttle applied to the move |
+|   ↳ `approximateNumberOfMessagesMoved` | number (nullable) | Approximate number of messages moved so far |
+|   ↳ `approximateNumberOfMessagesToMove` | number (nullable) | Approximate number of messages still to move |
+|   ↳ `failureReason` | string (nullable) | Why the task failed, set only when the status is FAILED |
+|   ↳ `startedTimestamp` | number (nullable) | Epoch milliseconds when the task started |
 | `count` | number | Number of move tasks returned |
 
 ### SQS Cancel Message Move Task
@@ -520,6 +520,4 @@ Cancel an in-progress Amazon SQS message move task
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `message` | string | Operation status message |
-| `approximateNumberOfMessagesMoved` | number | Approximate number of messages already moved before the task was cancelled |
-
-
+| `approximateNumberOfMessagesMoved` | number (nullable) | Approximate number of messages already moved before the task was cancelled |

--- a/apps/docs/content/docs/integrations/square.mdx
+++ b/apps/docs/content/docs/integrations/square.mdx
@@ -5,7 +5,7 @@ description: Process payments and manage Square commerce data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="square"
   color="#000000"
 />
@@ -1489,5 +1489,3 @@ Retrieve current inventory counts for catalog items across locations
 | `metadata` | json | List pagination metadata |
 |   ↳ `count` | number | Number of items returned in this page |
 |   ↳ `cursor` | string | Pagination cursor to fetch the next page, if more results exist |
-
-

--- a/apps/docs/content/docs/integrations/ssh.mdx
+++ b/apps/docs/content/docs/integrations/ssh.mdx
@@ -5,7 +5,7 @@ description: Connect to remote servers via SSH
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="ssh"
   color="#000000"
 />
@@ -391,5 +391,3 @@ Write or append content to a remote file
 | `remotePath` | string | File path |
 | `size` | number | Final file size in bytes |
 | `message` | string | Operation status message |
-
-

--- a/apps/docs/content/docs/integrations/ssm.mdx
+++ b/apps/docs/content/docs/integrations/ssm.mdx
@@ -5,7 +5,7 @@ description: Run commands, manage parameters, and audit managed nodes
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="ssm"
   color="#E7157B"
 />
@@ -623,5 +623,3 @@ Read the content of an SSM document or Automation runbook
 | `documentType` | string | Type of the document \(Command, Automation, Policy, Session, and related values\) |
 | `documentFormat` | string | Format the content is returned in |
 | `reviewStatus` | string | Review status of the document \(APPROVED, NOT_REVIEWED, PENDING, REJECTED\) |
-
-

--- a/apps/docs/content/docs/integrations/stagehand.mdx
+++ b/apps/docs/content/docs/integrations/stagehand.mdx
@@ -5,7 +5,7 @@ description: Web automation and data extraction
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="stagehand"
   color="#FFC83C"
 />
@@ -81,5 +81,3 @@ Run an autonomous web agent to complete tasks and extract structured data
 | `structuredOutput` | object | Extracted data matching the provided output schema |
 | `liveViewUrl` | string | Embeddable Browserbase live view URL \(active only while the session is running\) |
 | `sessionId` | string | Browserbase session identifier |
-
-

--- a/apps/docs/content/docs/integrations/stripe.mdx
+++ b/apps/docs/content/docs/integrations/stripe.mdx
@@ -5,7 +5,7 @@ description: Process payments and manage Stripe data
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="stripe"
   color="#635BFF"
 />
@@ -2892,8 +2892,6 @@ List all Events
 |   ↳ `count` | number | Number of items returned |
 |   ↳ `has_more` | boolean | Whether more items exist beyond this page |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -2922,4 +2920,3 @@ Triggers when Stripe events occur (payments, subscriptions, invoices, etc.)
 | `livemode` | boolean | Whether this event occurred in live mode \(true\) or test mode \(false\) |
 | `pending_webhooks` | number | Number of webhooks yet to be delivered for this event |
 | `request` | json | Information about the API request that triggered this event \(id, idempotency_key\) |
-

--- a/apps/docs/content/docs/integrations/sts.mdx
+++ b/apps/docs/content/docs/integrations/sts.mdx
@@ -5,7 +5,7 @@ description: Connect to AWS Security Token Service
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="sts"
   color="linear-gradient(45deg, #BD0816 0%, #FF5252 100%)"
 />
@@ -187,5 +187,3 @@ Get the AWS account ID associated with an access key
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `account` | string | AWS account ID that owns the access key |
-
-

--- a/apps/docs/content/docs/integrations/supabase.mdx
+++ b/apps/docs/content/docs/integrations/supabase.mdx
@@ -5,7 +5,7 @@ description: Use Supabase database
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="supabase"
   color="#1C1C1C"
 />
@@ -647,5 +647,3 @@ Create a temporary signed URL a client can use to upload directly to a Supabase 
 | `signedUrl` | string | The temporary signed URL a client can PUT the file to |
 | `path` | string | The destination object path |
 | `token` | string | The upload token embedded in the signed URL |
-
-

--- a/apps/docs/content/docs/integrations/table.mdx
+++ b/apps/docs/content/docs/integrations/table.mdx
@@ -5,7 +5,7 @@ description: User-defined data tables
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="table_v2"
   color="#10B981"
 />

--- a/apps/docs/content/docs/integrations/tailscale.mdx
+++ b/apps/docs/content/docs/integrations/tailscale.mdx
@@ -5,7 +5,7 @@ description: Manage devices and network settings in your Tailscale tailnet
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="tailscale"
   color="#2E2D2D"
 />
@@ -563,5 +563,3 @@ Replace the ACL policy file for the tailnet
 | --------- | ---- | ----------- |
 | `acl` | string | Updated ACL policy as JSON string |
 | `etag` | string | ETag for the new ACL version \(use with If-Match header for future updates\) |
-
-

--- a/apps/docs/content/docs/integrations/tavily.mdx
+++ b/apps/docs/content/docs/integrations/tavily.mdx
@@ -5,7 +5,7 @@ description: Search and extract information
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="tavily"
   color="#FFFFFF"
 />
@@ -163,5 +163,3 @@ Discover and visualize website structure using Tavily's map API. Maps out all ac
 |   ↳ `url` | string | Discovered URL |
 | `response_time` | number | Time taken for the map request in seconds |
 | `request_id` | string | Unique identifier for support reference |
-
-

--- a/apps/docs/content/docs/integrations/telegram.mdx
+++ b/apps/docs/content/docs/integrations/telegram.mdx
@@ -5,7 +5,7 @@ description: Interact with Telegram
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="telegram"
   color="#FFFFFF"
 />
@@ -661,8 +661,6 @@ Get information about a member of a Telegram chat through the Telegram Bot API.
 |     ↳ `last_name` | string | User's last name |
 |     ↳ `username` | string | User's username |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -715,4 +713,3 @@ Trigger workflow from Telegram bot messages and events
 |   ↳ `isBot` | boolean | Whether the sender is a bot |
 | `updateId` | number | Update ID for this webhook delivery |
 | `updateType` | string | Type of update: message, edited_message, channel_post, edited_channel_post, unknown |
-

--- a/apps/docs/content/docs/integrations/temporal.mdx
+++ b/apps/docs/content/docs/integrations/temporal.mdx
@@ -5,7 +5,7 @@ description: Start, signal, query, and manage Temporal workflow executions
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="temporal"
   color="#141414"
 />
@@ -538,5 +538,3 @@ Delete a Temporal schedule. Workflows already started by the schedule keep runni
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `scheduleId` | string | ID of the deleted schedule |
-
-

--- a/apps/docs/content/docs/integrations/textract.mdx
+++ b/apps/docs/content/docs/integrations/textract.mdx
@@ -5,7 +5,7 @@ description: Extract text, tables, and forms from documents
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="textract_v2"
   color="linear-gradient(135deg, #055F4E 0%, #56C0A7 100%)"
 />
@@ -150,5 +150,3 @@ Extract identity document fields using AWS Textract AnalyzeID
 | `documentMetadata` | object | Metadata about the analyzed document |
 |   ↳ `pages` | number | Number of pages analyzed |
 | `modelVersion` | string | Version of the AnalyzeID model used for processing |
-
-

--- a/apps/docs/content/docs/integrations/thrive.mdx
+++ b/apps/docs/content/docs/integrations/thrive.mdx
@@ -5,7 +5,7 @@ description: Manage users, audiences, learning and CPD on Thrive
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="thrive"
   color="#FFFFFF"
 />
@@ -63,17 +63,17 @@ Create a new user in Thrive.
 |   ↳ `lastName` | string | The family name of the individual |
 |   ↳ `role` | string | Role assigned to this individual |
 |   ↳ `jobTitle` | string | Name of this individual's role |
-|   ↳ `managerRef` | string | The line manager's ref |
-|   ↳ `startDate` | string | Date started with the organisation |
-|   ↳ `endDate` | string | Date left the organisation |
+|   ↳ `managerRef` | string (nullable) | The line manager's ref |
+|   ↳ `startDate` | string (nullable) | Date started with the organisation |
+|   ↳ `endDate` | string (nullable) | Date left the organisation |
 |   ↳ `timeZone` | string | The user's preferred timezone |
 |   ↳ `languageCode` | string | The user's preferred language |
 |   ↳ `active` | boolean | Whether the account is active or suspended |
 |   ↳ `createdAt` | string | Date/time the user was created |
 |   ↳ `updatedAt` | string | Date/time the user was last modified |
 |   ↳ `sso` | boolean | Whether the account is managed by an auth provider |
-|   ↳ `domain` | string | Domain this individual is associated with |
-|   ↳ `additionalFields` | json | Custom field values for this user |
+|   ↳ `domain` | string (nullable) | Domain this individual is associated with |
+|   ↳ `additionalFields` | json (nullable) | Custom field values for this user |
 
 ### Thrive Update User
 
@@ -115,17 +115,17 @@ Update an existing user in Thrive by ref. Only the fields provided are changed.
 |   ↳ `lastName` | string | The family name of the individual |
 |   ↳ `role` | string | Role assigned to this individual |
 |   ↳ `jobTitle` | string | Name of this individual's role |
-|   ↳ `managerRef` | string | The line manager's ref |
-|   ↳ `startDate` | string | Date started with the organisation |
-|   ↳ `endDate` | string | Date left the organisation |
+|   ↳ `managerRef` | string (nullable) | The line manager's ref |
+|   ↳ `startDate` | string (nullable) | Date started with the organisation |
+|   ↳ `endDate` | string (nullable) | Date left the organisation |
 |   ↳ `timeZone` | string | The user's preferred timezone |
 |   ↳ `languageCode` | string | The user's preferred language |
 |   ↳ `active` | boolean | Whether the account is active or suspended |
 |   ↳ `createdAt` | string | Date/time the user was created |
 |   ↳ `updatedAt` | string | Date/time the user was last modified |
 |   ↳ `sso` | boolean | Whether the account is managed by an auth provider |
-|   ↳ `domain` | string | Domain this individual is associated with |
-|   ↳ `additionalFields` | json | Custom field values for this user |
+|   ↳ `domain` | string (nullable) | Domain this individual is associated with |
+|   ↳ `additionalFields` | json (nullable) | Custom field values for this user |
 
 ### Thrive Delete User
 
@@ -173,17 +173,17 @@ Suspend a user in Thrive by ref, marking the account inactive.
 |   ↳ `lastName` | string | The family name of the individual |
 |   ↳ `role` | string | Role assigned to this individual |
 |   ↳ `jobTitle` | string | Name of this individual's role |
-|   ↳ `managerRef` | string | The line manager's ref |
-|   ↳ `startDate` | string | Date started with the organisation |
-|   ↳ `endDate` | string | Date left the organisation |
+|   ↳ `managerRef` | string (nullable) | The line manager's ref |
+|   ↳ `startDate` | string (nullable) | Date started with the organisation |
+|   ↳ `endDate` | string (nullable) | Date left the organisation |
 |   ↳ `timeZone` | string | The user's preferred timezone |
 |   ↳ `languageCode` | string | The user's preferred language |
 |   ↳ `active` | boolean | Whether the account is active or suspended |
 |   ↳ `createdAt` | string | Date/time the user was created |
 |   ↳ `updatedAt` | string | Date/time the user was last modified |
 |   ↳ `sso` | boolean | Whether the account is managed by an auth provider |
-|   ↳ `domain` | string | Domain this individual is associated with |
-|   ↳ `additionalFields` | json | Custom field values for this user |
+|   ↳ `domain` | string (nullable) | Domain this individual is associated with |
+|   ↳ `additionalFields` | json (nullable) | Custom field values for this user |
 
 ### Thrive Search Users
 
@@ -209,32 +209,32 @@ Search users in Thrive and return basic user information with pagination.
 | --------- | ---- | ----------- |
 | `results` | array | The matching users |
 |   ↳ `id` | string | The user's ID |
-|   ↳ `ref` | string | The user's ref |
-|   ↳ `firstName` | string | The user's first name |
-|   ↳ `lastName` | string | The user's last name |
-|   ↳ `email` | string | The user's email |
-|   ↳ `role` | string | The user's role |
-|   ↳ `status` | string | The user's status |
+|   ↳ `ref` | string (nullable) | The user's ref |
+|   ↳ `firstName` | string (nullable) | The user's first name |
+|   ↳ `lastName` | string (nullable) | The user's last name |
+|   ↳ `email` | string (nullable) | The user's email |
+|   ↳ `role` | string (nullable) | The user's role |
+|   ↳ `status` | string (nullable) | The user's status |
 |   ↳ `positions` | array | The user's positions |
-|   ↳ `additionalFields` | json | Custom field values |
-|   ↳ `languageCode` | string | The user's language code |
+|   ↳ `additionalFields` | json (nullable) | Custom field values |
+|   ↳ `languageCode` | string (nullable) | The user's language code |
 |   ↳ `deleted` | boolean | Whether the user has been deleted |
 |   ↳ `compliance` | number | The user's compliance score |
 |   ↳ `level` | number | The user's level |
-|   ↳ `firstLogin` | string | First login timestamp \(ISO 8601\) |
-|   ↳ `lastLogin` | string | Last login timestamp \(ISO 8601\) |
+|   ↳ `firstLogin` | string (nullable) | First login timestamp \(ISO 8601\) |
+|   ↳ `lastLogin` | string (nullable) | Last login timestamp \(ISO 8601\) |
 |   ↳ `tags` | json | Tag membership \(e.g. skills\) |
 |   ↳ `usersFollowing` | array | IDs of users this user follows |
 |   ↳ `tagsFollowing` | array | Tags this user follows |
-|   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
-|   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
+|   ↳ `createdAt` | string (nullable) | Creation timestamp \(ISO 8601\) |
+|   ↳ `updatedAt` | string (nullable) | Last-update timestamp \(ISO 8601\) |
 |   ↳ `hasPicture` | boolean | Whether the user has a profile picture |
-|   ↳ `timeZone` | string | The user's time zone |
-|   ↳ `summary` | string | The user's summary |
+|   ↳ `timeZone` | string (nullable) | The user's time zone |
+|   ↳ `summary` | string (nullable) | The user's summary |
 |   ↳ `relevancy` | number | The user's relevancy score |
 |   ↳ `rank` | json | The user's rank details |
-|   ↳ `agreedTerms` | boolean | Whether the user agreed to the terms |
-|   ↳ `onboarded` | boolean | Whether the user has been onboarded |
+|   ↳ `agreedTerms` | boolean (nullable) | Whether the user agreed to the terms |
+|   ↳ `onboarded` | boolean (nullable) | Whether the user has been onboarded |
 |   ↳ `audiences` | array | Audience IDs the user belongs to |
 |   ↳ `singleSignOn` | boolean | Whether the user uses single sign-on |
 | `pagination` | object | Pagination details |
@@ -262,32 +262,32 @@ Get a single user in Thrive by their ID and return basic user information.
 | --------- | ---- | ----------- |
 | `user` | object | The user |
 |   ↳ `id` | string | The user's ID |
-|   ↳ `ref` | string | The user's ref |
-|   ↳ `firstName` | string | The user's first name |
-|   ↳ `lastName` | string | The user's last name |
-|   ↳ `email` | string | The user's email |
-|   ↳ `role` | string | The user's role |
-|   ↳ `status` | string | The user's status |
+|   ↳ `ref` | string (nullable) | The user's ref |
+|   ↳ `firstName` | string (nullable) | The user's first name |
+|   ↳ `lastName` | string (nullable) | The user's last name |
+|   ↳ `email` | string (nullable) | The user's email |
+|   ↳ `role` | string (nullable) | The user's role |
+|   ↳ `status` | string (nullable) | The user's status |
 |   ↳ `positions` | array | The user's positions |
-|   ↳ `additionalFields` | json | Custom field values |
-|   ↳ `languageCode` | string | The user's language code |
+|   ↳ `additionalFields` | json (nullable) | Custom field values |
+|   ↳ `languageCode` | string (nullable) | The user's language code |
 |   ↳ `deleted` | boolean | Whether the user has been deleted |
 |   ↳ `compliance` | number | The user's compliance score |
 |   ↳ `level` | number | The user's level |
-|   ↳ `firstLogin` | string | First login timestamp \(ISO 8601\) |
-|   ↳ `lastLogin` | string | Last login timestamp \(ISO 8601\) |
+|   ↳ `firstLogin` | string (nullable) | First login timestamp \(ISO 8601\) |
+|   ↳ `lastLogin` | string (nullable) | Last login timestamp \(ISO 8601\) |
 |   ↳ `tags` | json | Tag membership \(e.g. skills\) |
 |   ↳ `usersFollowing` | array | IDs of users this user follows |
 |   ↳ `tagsFollowing` | array | Tags this user follows |
-|   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
-|   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
+|   ↳ `createdAt` | string (nullable) | Creation timestamp \(ISO 8601\) |
+|   ↳ `updatedAt` | string (nullable) | Last-update timestamp \(ISO 8601\) |
 |   ↳ `hasPicture` | boolean | Whether the user has a profile picture |
-|   ↳ `timeZone` | string | The user's time zone |
-|   ↳ `summary` | string | The user's summary |
+|   ↳ `timeZone` | string (nullable) | The user's time zone |
+|   ↳ `summary` | string (nullable) | The user's summary |
 |   ↳ `relevancy` | number | The user's relevancy score |
 |   ↳ `rank` | json | The user's rank details |
-|   ↳ `agreedTerms` | boolean | Whether the user agreed to the terms |
-|   ↳ `onboarded` | boolean | Whether the user has been onboarded |
+|   ↳ `agreedTerms` | boolean (nullable) | Whether the user agreed to the terms |
+|   ↳ `onboarded` | boolean (nullable) | Whether the user has been onboarded |
 |   ↳ `audiences` | array | Audience IDs the user belongs to |
 |   ↳ `singleSignOn` | boolean | Whether the user uses single sign-on |
 
@@ -310,15 +310,15 @@ Get a single user in Thrive by their ref and return basic user information.
 | --------- | ---- | ----------- |
 | `user` | object | The user \(basic information\) |
 |   ↳ `id` | string | The user's ID |
-|   ↳ `ref` | string | The user's ref |
-|   ↳ `firstName` | string | The user's first name |
-|   ↳ `lastName` | string | The user's last name |
-|   ↳ `email` | string | The user's email |
-|   ↳ `role` | string | The user's role |
-|   ↳ `status` | string | The user's status |
+|   ↳ `ref` | string (nullable) | The user's ref |
+|   ↳ `firstName` | string (nullable) | The user's first name |
+|   ↳ `lastName` | string (nullable) | The user's last name |
+|   ↳ `email` | string (nullable) | The user's email |
+|   ↳ `role` | string (nullable) | The user's role |
+|   ↳ `status` | string (nullable) | The user's status |
 |   ↳ `positions` | array | The user's positions |
-|   ↳ `additionalFields` | json | Custom field values |
-|   ↳ `languageCode` | string | The user's language code |
+|   ↳ `additionalFields` | json (nullable) | Custom field values |
+|   ↳ `languageCode` | string (nullable) | The user's language code |
 
 ### Thrive List Audiences
 
@@ -347,7 +347,7 @@ List audiences and structures in Thrive with pagination.
 |   ↳ `apiControlled` | boolean | Whether the audience is API controlled |
 |   ↳ `category` | string | Either "audience" or "structure" |
 |   ↳ `type` | string | Either "manual" or "smart" |
-|   ↳ `parent` | object | Parent audience/structure information |
+|   ↳ `parent` | object (nullable) | Parent audience/structure information |
 |     ↳ `name` | string | The name of the parent audience |
 |     ↳ `reference` | string | The external reference for the parent |
 |     ↳ `id` | string | The id of the parent audience/structure |
@@ -386,7 +386,7 @@ Create a new audience or structure in Thrive.
 |   ↳ `apiControlled` | boolean | Whether the audience is API controlled |
 |   ↳ `category` | string | Either "audience" or "structure" |
 |   ↳ `type` | string | Either "manual" or "smart" |
-|   ↳ `parent` | object | Parent audience/structure information |
+|   ↳ `parent` | object (nullable) | Parent audience/structure information |
 |     ↳ `name` | string | The name of the parent audience |
 |     ↳ `reference` | string | The external reference for the parent |
 |     ↳ `id` | string | The id of the parent audience/structure |
@@ -417,7 +417,7 @@ Get a single audience or structure in Thrive by id or reference.
 |   ↳ `apiControlled` | boolean | Whether the audience is API controlled |
 |   ↳ `category` | string | Either "audience" or "structure" |
 |   ↳ `type` | string | Either "manual" or "smart" |
-|   ↳ `parent` | object | Parent audience/structure information |
+|   ↳ `parent` | object (nullable) | Parent audience/structure information |
 |     ↳ `name` | string | The name of the parent audience |
 |     ↳ `reference` | string | The external reference for the parent |
 |     ↳ `id` | string | The id of the parent audience/structure |
@@ -451,7 +451,7 @@ Update an audience in Thrive, optionally moving it to a new parent.
 |   ↳ `apiControlled` | boolean | Whether the audience is API controlled |
 |   ↳ `category` | string | Either "audience" or "structure" |
 |   ↳ `type` | string | Either "manual" or "smart" |
-|   ↳ `parent` | object | Parent audience/structure information |
+|   ↳ `parent` | object (nullable) | Parent audience/structure information |
 |     ↳ `name` | string | The name of the parent audience |
 |     ↳ `reference` | string | The external reference for the parent |
 |     ↳ `id` | string | The id of the parent audience/structure |
@@ -608,7 +608,7 @@ List the managers of a Thrive audience.
 |   ↳ `permissions` | object | The manager permissions |
 |     ↳ `audienceManager` | json | Audience manager permissions |
 |     ↳ `peopleManager` | json | People manager permissions |
-|     ↳ `administrator` | json | Administrator permissions \(structures only\) |
+|     ↳ `administrator` | json (nullable) | Administrator permissions \(structures only\) |
 
 ### Thrive Add Audience Managers
 
@@ -715,12 +715,12 @@ List compliance assignments in Thrive, optionally filtered by audience.
 |   ↳ `alternativeContentIds` | array | Content IDs that can also complete the assignment |
 |   ↳ `hideAlternativeContent` | boolean | Whether to hide the alternative content |
 |   ↳ `completionPeriod` | number | Number of days required to complete the assignment |
-|   ↳ `recurrence` | number | Number of days until the assignment reoccurs |
+|   ↳ `recurrence` | number (nullable) | Number of days until the assignment reoccurs |
 |   ↳ `isActive` | boolean | Whether the assignment is active |
 |   ↳ `isDeleted` | boolean | Whether the assignment is deleted |
-|   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
-|   ↳ `deletedAt` | string | Deletion timestamp \(ISO 8601\) |
-|   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
+|   ↳ `createdAt` | string (nullable) | Creation timestamp \(ISO 8601\) |
+|   ↳ `deletedAt` | string (nullable) | Deletion timestamp \(ISO 8601\) |
+|   ↳ `updatedAt` | string (nullable) | Last-update timestamp \(ISO 8601\) |
 
 ### Thrive Create Assignment
 
@@ -751,12 +751,12 @@ Create a compliance assignment in Thrive for an audience and content item.
 |   ↳ `alternativeContentIds` | array | Content IDs that can also complete the assignment |
 |   ↳ `hideAlternativeContent` | boolean | Whether to hide the alternative content |
 |   ↳ `completionPeriod` | number | Number of days required to complete the assignment |
-|   ↳ `recurrence` | number | Number of days until the assignment reoccurs |
+|   ↳ `recurrence` | number (nullable) | Number of days until the assignment reoccurs |
 |   ↳ `isActive` | boolean | Whether the assignment is active |
 |   ↳ `isDeleted` | boolean | Whether the assignment is deleted |
-|   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
-|   ↳ `deletedAt` | string | Deletion timestamp \(ISO 8601\) |
-|   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
+|   ↳ `createdAt` | string (nullable) | Creation timestamp \(ISO 8601\) |
+|   ↳ `deletedAt` | string (nullable) | Deletion timestamp \(ISO 8601\) |
+|   ↳ `updatedAt` | string (nullable) | Last-update timestamp \(ISO 8601\) |
 
 ### Thrive Get Assignment
 
@@ -782,12 +782,12 @@ Get a single compliance assignment in Thrive by its ID.
 |   ↳ `alternativeContentIds` | array | Content IDs that can also complete the assignment |
 |   ↳ `hideAlternativeContent` | boolean | Whether to hide the alternative content |
 |   ↳ `completionPeriod` | number | Number of days required to complete the assignment |
-|   ↳ `recurrence` | number | Number of days until the assignment reoccurs |
+|   ↳ `recurrence` | number (nullable) | Number of days until the assignment reoccurs |
 |   ↳ `isActive` | boolean | Whether the assignment is active |
 |   ↳ `isDeleted` | boolean | Whether the assignment is deleted |
-|   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
-|   ↳ `deletedAt` | string | Deletion timestamp \(ISO 8601\) |
-|   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
+|   ↳ `createdAt` | string (nullable) | Creation timestamp \(ISO 8601\) |
+|   ↳ `deletedAt` | string (nullable) | Deletion timestamp \(ISO 8601\) |
+|   ↳ `updatedAt` | string (nullable) | Last-update timestamp \(ISO 8601\) |
 
 ### Thrive Update Assignment
 
@@ -818,12 +818,12 @@ Update a compliance assignment in Thrive.
 |   ↳ `alternativeContentIds` | array | Content IDs that can also complete the assignment |
 |   ↳ `hideAlternativeContent` | boolean | Whether to hide the alternative content |
 |   ↳ `completionPeriod` | number | Number of days required to complete the assignment |
-|   ↳ `recurrence` | number | Number of days until the assignment reoccurs |
+|   ↳ `recurrence` | number (nullable) | Number of days until the assignment reoccurs |
 |   ↳ `isActive` | boolean | Whether the assignment is active |
 |   ↳ `isDeleted` | boolean | Whether the assignment is deleted |
-|   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
-|   ↳ `deletedAt` | string | Deletion timestamp \(ISO 8601\) |
-|   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
+|   ↳ `createdAt` | string (nullable) | Creation timestamp \(ISO 8601\) |
+|   ↳ `deletedAt` | string (nullable) | Deletion timestamp \(ISO 8601\) |
+|   ↳ `updatedAt` | string (nullable) | Last-update timestamp \(ISO 8601\) |
 
 ### Thrive Delete Assignment
 
@@ -1033,10 +1033,10 @@ Get a single content record in Thrive by its ID.
 |   ↳ `type` | string | The kind of artifact associated with this content |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
-|   ↳ `author` | string | User ID who authored the content |
+|   ↳ `author` | string (nullable) | User ID who authored the content |
 |   ↳ `isOfficial` | boolean | Whether the content is recognised as official |
-|   ↳ `duration` | object | Expected time to complete the content |
-|     ↳ `value` | number | Duration value |
+|   ↳ `duration` | object (nullable) | Expected time to complete the content |
+|     ↳ `value` | number (nullable) | Duration value |
 |     ↳ `unit` | string | The unit of the duration \(always 'minutes'\) |
 |   ↳ `contentHistory` | array | Chronological history of actions on this content |
 
@@ -1069,10 +1069,10 @@ Query content records in Thrive with pagination and filtering options.
 |   ↳ `type` | string | The kind of artifact associated with this content |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
 |   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
-|   ↳ `author` | string | User ID who authored the content |
+|   ↳ `author` | string (nullable) | User ID who authored the content |
 |   ↳ `isOfficial` | boolean | Whether the content is recognised as official |
-|   ↳ `duration` | object | Expected time to complete the content |
-|     ↳ `value` | number | Duration value |
+|   ↳ `duration` | object (nullable) | Expected time to complete the content |
+|     ↳ `value` | number (nullable) | Duration value |
 |     ↳ `unit` | string | The unit of the duration \(always 'minutes'\) |
 |   ↳ `contentHistory` | array | Chronological history of actions on this content |
 | `pagination` | object | Pagination details |
@@ -1107,7 +1107,7 @@ Get a single activity record in Thrive by its ID.
 |   ↳ `contextId` | string | Identifier for the context item |
 |   ↳ `contextType` | string | What this activity was in relation to |
 |   ↳ `data` | json | Unstructured activity data; shape varies by type |
-|   ↳ `with` | json | Additional context information |
+|   ↳ `with` | json (nullable) | Additional context information |
 
 ### Thrive Query Activities
 
@@ -1142,7 +1142,7 @@ Query activity records in Thrive with pagination and filtering options.
 |   ↳ `contextId` | string | Identifier for the context item |
 |   ↳ `contextType` | string | What this activity was in relation to |
 |   ↳ `data` | json | Unstructured activity data; shape varies by type |
-|   ↳ `with` | json | Additional context information |
+|   ↳ `with` | json (nullable) | Additional context information |
 | `pagination` | object | Pagination details |
 |   ↳ `totalResults` | number | Total number of results matching the query |
 |   ↳ `totalPages` | number | Total number of pages available |
@@ -1226,7 +1226,7 @@ Get a single CPD log entry in Thrive by its ID.
 |     ↳ `name` | string | Name of the category of CPD activity |
 |   ↳ `entryDate` | string | The date and time the CPD entry was logged \(ISO 8601\) |
 |   ↳ `durationMinutes` | number | Minutes logged as CPD from this activity |
-|   ↳ `description` | string | Summary or reflective statement |
+|   ↳ `description` | string (nullable) | Summary or reflective statement |
 |   ↳ `isVerified` | boolean | Whether the activity was generated from verified system activity |
 
 ### Thrive Query CPD Entries
@@ -1260,7 +1260,7 @@ Query CPD log entries in Thrive and return results with pagination.
 |     ↳ `name` | string | Name of the category of CPD activity |
 |   ↳ `entryDate` | string | The date and time the CPD entry was logged \(ISO 8601\) |
 |   ↳ `durationMinutes` | number | Minutes logged as CPD from this activity |
-|   ↳ `description` | string | Summary or reflective statement |
+|   ↳ `description` | string (nullable) | Summary or reflective statement |
 |   ↳ `isVerified` | boolean | Whether the activity was generated from verified system activity |
 | `pagination` | object | Pagination details |
 |   ↳ `totalResults` | number | Total number of results matching the query |
@@ -1290,7 +1290,7 @@ Get a single CPD requirement summary in Thrive by its ID.
 |   ↳ `audienceId` | string | ID of the audience this requirement applies to |
 |   ↳ `requiredMinutes` | number | Number of minutes required for CPD completion |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
-|   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
+|   ↳ `updatedAt` | string (nullable) | Last-update timestamp \(ISO 8601\) |
 
 ### Thrive Query CPD Requirements
 
@@ -1316,7 +1316,7 @@ Query CPD requirement summaries in Thrive and return results with pagination.
 |   ↳ `audienceId` | string | ID of the audience this requirement applies to |
 |   ↳ `requiredMinutes` | number | Number of minutes required for CPD completion |
 |   ↳ `createdAt` | string | Creation timestamp \(ISO 8601\) |
-|   ↳ `updatedAt` | string | Last-update timestamp \(ISO 8601\) |
+|   ↳ `updatedAt` | string (nullable) | Last-update timestamp \(ISO 8601\) |
 | `pagination` | object | Pagination details |
 |   ↳ `totalResults` | number | Total number of results matching the query |
 |   ↳ `totalPages` | number | Total number of pages available |
@@ -1493,5 +1493,3 @@ Get the available skill levels configured in Thrive.
 |   ↳ `name` | string | The name of the skill level |
 |   ↳ `isEnabled` | boolean | Whether the skill level is enabled |
 |   ↳ `value` | number | The numeric value of the skill level |
-
-

--- a/apps/docs/content/docs/integrations/tiktok.mdx
+++ b/apps/docs/content/docs/integrations/tiktok.mdx
@@ -5,7 +5,7 @@ description: Access TikTok profiles and videos, and upload inbox drafts
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="tiktok"
   color="#000000"
 />
@@ -150,8 +150,6 @@ Check the status of a video draft upload. Use the publishId returned from Upload
 | `publiclyAvailablePostId` | array | Array of public post IDs \(as strings\) once the content is published and publicly viewable. Can be used to construct the TikTok post URL. |
 | `uploadedBytes` | number | Number of bytes uploaded to TikTok for FILE_UPLOAD posts |
 | `downloadedBytes` | number | Number of bytes TikTok reports as downloaded |
-
-
 
 ## Triggers
 
@@ -299,4 +297,3 @@ Trigger when a TikTok Content Posting publish fails
 | `publishId` | string | Content Posting API publish_id |
 | `publishType` | string | Publish type \(e.g. DIRECT_POST, INBOX_SHARE\) |
 | `failReason` | string | Failure reason enum from TikTok when publishing fails |
-

--- a/apps/docs/content/docs/integrations/tinybird.mdx
+++ b/apps/docs/content/docs/integrations/tinybird.mdx
@@ -5,7 +5,7 @@ description: Send events, query data, and manage Data Sources with Tinybird
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="tinybird"
   color="#2EF598"
 />
@@ -197,5 +197,3 @@ Check the status of an asynchronous Tinybird job (import, delete, etc.) by ID.
 | `is_cancellable` | boolean | Whether the job can still be cancelled |
 | `error` | string | Error message, present only when status is "error" |
 | `job` | json | Full raw job details, including kind-specific fields \(statistics, datasource, delete_condition, etc.\) |
-
-

--- a/apps/docs/content/docs/integrations/tinyfish.mdx
+++ b/apps/docs/content/docs/integrations/tinyfish.mdx
@@ -5,7 +5,7 @@ description: Automate and read the live web
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="tinyfish"
   color="#FFFFFF"
 />
@@ -113,7 +113,7 @@ Run a TinyFish web agent against a website and wait for it to finish, returning 
 |   ↳ `retryAfter` | number | Suggested retry delay in seconds, null when not retryable |
 |   ↳ `helpUrl` | string | Troubleshooting documentation URL |
 |   ↳ `helpMessage` | string | Human-readable guidance |
-| `profileHint` | object | Present when TinyFish believes a Browser Context Profile would fix this failed run, such as one that stopped at a login wall |
+| `profileHint` | object (nullable) | Present when TinyFish believes a Browser Context Profile would fix this failed run, such as one that stopped at a login wall |
 |   ↳ `message` | string | Why a Browser Context Profile would help this run |
 |   ↳ `setupUrl` | string | Path on the TinyFish dashboard that sets up a profile for the blocked domain |
 |   ↳ `reason` | string | auth_wall \(the run hit a login\) or bot_challenge \(the site blocked automation\) |
@@ -190,9 +190,9 @@ Get the status, extracted result, and step history of a TinyFish automation run 
 | `browserConfig` | object | Proxy settings the run executed with |
 |   ↳ `proxyEnabled` | boolean | Whether a proxy was used |
 |   ↳ `proxyCountryCode` | string | Proxy country code |
-| `profileAttached` | boolean | Whether the run actually started from a Browser Context Profile, null when the API omits it — treat null as unknown rather than as false |
-| `profileId` | string | Browser Context Profile the run attached. Null covers both no profile and a payload that omitted the field, so read profileAttached alongside it rather than reading null as proof |
-| `profileHint` | object | Present when TinyFish believes a Browser Context Profile would fix this failed run |
+| `profileAttached` | boolean (nullable) | Whether the run actually started from a Browser Context Profile, null when the API omits it — treat null as unknown rather than as false |
+| `profileId` | string (nullable) | Browser Context Profile the run attached. Null covers both no profile and a payload that omitted the field, so read profileAttached alongside it rather than reading null as proof |
+| `profileHint` | object (nullable) | Present when TinyFish believes a Browser Context Profile would fix this failed run |
 |   ↳ `message` | string | Why a Browser Context Profile would help this run |
 |   ↳ `setupUrl` | string | Path on the TinyFish dashboard that sets up a profile for the blocked domain |
 |   ↳ `reason` | string | auth_wall \(the run hit a login\) or bot_challenge \(the site blocked automation\) |
@@ -273,9 +273,9 @@ List TinyFish automation runs, optionally filtered by status, goal text, or crea
 |   ↳ `browserConfig` | object | Proxy settings the run executed with |
 |     ↳ `proxyEnabled` | boolean | Whether a proxy was used |
 |     ↳ `proxyCountryCode` | string | Proxy country code |
-|   ↳ `profileAttached` | boolean | Whether the run actually started from a Browser Context Profile, null when the API omits it — treat null as unknown rather than as false |
-|   ↳ `profileId` | string | Browser Context Profile the run attached. Null covers both no profile and a payload that omitted the field, so read profileAttached alongside it rather than reading null as proof |
-|   ↳ `profileHint` | object | Present when TinyFish believes a Browser Context Profile would fix this failed run |
+|   ↳ `profileAttached` | boolean (nullable) | Whether the run actually started from a Browser Context Profile, null when the API omits it — treat null as unknown rather than as false |
+|   ↳ `profileId` | string (nullable) | Browser Context Profile the run attached. Null covers both no profile and a payload that omitted the field, so read profileAttached alongside it rather than reading null as proof |
+|   ↳ `profileHint` | object (nullable) | Present when TinyFish believes a Browser Context Profile would fix this failed run |
 |     ↳ `message` | string | Why a Browser Context Profile would help this run |
 |     ↳ `setupUrl` | string | Path on the TinyFish dashboard that sets up a profile for the blocked domain |
 |     ↳ `reason` | string | auth_wall \(the run hit a login\) or bot_challenge \(the site blocked automation\) |
@@ -387,11 +387,9 @@ List the Browser Context Profiles saved on the TinyFish account, with the ids an
 | `profiles` | array | Browser Context Profiles an agent run can start from |
 |   ↳ `profileId` | string | Profile identifier, used as the Browser Profile ID on a run |
 |   ↳ `name` | string | Profile name, such as "Salesforce Production" |
-|   ↳ `proxyCountryCode` | string | Country the profile proxies through, null when it has no proxy |
-|   ↳ `fingerprintSeed` | string | Seed for the browser fingerprint the profile replays, null when the API omits it |
-|   ↳ `domainCount` | number | How many domains the profile holds saved state for, null when the API omits it. Zero means it was created but never logged into |
-|   ↳ `createdAt` | string | ISO 8601 timestamp when the profile was created, null when the API omits it |
-|   ↳ `updatedAt` | string | ISO 8601 timestamp when the profile was last saved, null when the API omits it |
-|   ↳ `isDefault` | boolean | Whether runs with no Browser Profile ID use this one, null when the API omits it |
-
-
+|   ↳ `proxyCountryCode` | string (nullable) | Country the profile proxies through, null when it has no proxy |
+|   ↳ `fingerprintSeed` | string (nullable) | Seed for the browser fingerprint the profile replays, null when the API omits it |
+|   ↳ `domainCount` | number (nullable) | How many domains the profile holds saved state for, null when the API omits it. Zero means it was created but never logged into |
+|   ↳ `createdAt` | string (nullable) | ISO 8601 timestamp when the profile was created, null when the API omits it |
+|   ↳ `updatedAt` | string (nullable) | ISO 8601 timestamp when the profile was last saved, null when the API omits it |
+|   ↳ `isDefault` | boolean (nullable) | Whether runs with no Browser Profile ID use this one, null when the API omits it |

--- a/apps/docs/content/docs/integrations/trello.mdx
+++ b/apps/docs/content/docs/integrations/trello.mdx
@@ -5,7 +5,7 @@ description: Manage Trello lists, cards, checklists, and activity
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="trello"
   color="#0052CC"
 />
@@ -578,5 +578,3 @@ List members of a Trello board
 |   ↳ `fullName` | string | Member full name |
 |   ↳ `username` | string | Member username |
 | `count` | number | Number of members returned |
-
-

--- a/apps/docs/content/docs/integrations/trigger_dev.mdx
+++ b/apps/docs/content/docs/integrations/trigger_dev.mdx
@@ -5,7 +5,7 @@ description: Trigger tasks and manage runs and schedules
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="trigger_dev"
   color="#000000"
 />
@@ -96,10 +96,10 @@ Retrieve a Trigger.dev batch by its ID, including its status, run IDs, and succe
 | `successfulRunCount` | number | Number of successful runs, populated after completion |
 | `failedRunCount` | number | Number of failed runs, populated after completion |
 | `errors` | array | Error details for failed items, present for PARTIAL_FAILED batches |
-|   ↳ `index` | number | Index of the failed item |
-|   ↳ `taskIdentifier` | string | Task identifier of the failed item |
-|   ↳ `error` | json | Error details |
-|   ↳ `errorCode` | string | Optional error code |
+|   ↳ `index` | number (nullable) | Index of the failed item |
+|   ↳ `taskIdentifier` | string (nullable) | Task identifier of the failed item |
+|   ↳ `error` | json (nullable) | Error details |
+|   ↳ `errorCode` | string (nullable) | Optional error code |
 
 ### Trigger.dev Get Batch Results
 
@@ -134,67 +134,121 @@ Retrieve a Trigger.dev run by its ID, including status, payload, output, attempt
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the run \(starts with run_\) |
+| `status` | string | Run status \(PENDING_VERSION, DELAYED, QUEUED, EXECUTING, REATTEMPTING, FROZEN, COMPLETED, CANCELED, FAILED, CRASHED, INTERRUPTED, or SYSTEM_FAILURE\) |
+| `taskIdentifier` | string | Identifier of the task the run executes |
+| `version` | string (nullable) | Worker version the run executes on |
+| `idempotencyKey` | string (nullable) | Idempotency key the run was triggered with |
+| `isTest` | boolean | Whether the run is a test run |
+| `createdAt` | string (nullable) | ISO timestamp when the run was created |
+| `updatedAt` | string (nullable) | ISO timestamp when the run was last updated |
+| `startedAt` | string (nullable) | ISO timestamp when the run started executing |
+| `finishedAt` | string (nullable) | ISO timestamp when the run finished |
+| `delayedUntil` | string (nullable) | ISO timestamp the run is delayed until |
+| `ttl` | string (nullable) | Time-to-live before an unstarted run expires |
+| `expiredAt` | string (nullable) | ISO timestamp when the run expired |
+| `tags` | array | Tags attached to the run |
+| `costInCents` | number (nullable) | Compute cost of the run in cents |
+| `baseCostInCents` | number (nullable) | Base invocation cost of the run in cents |
+| `durationMs` | number (nullable) | Compute duration of the run in milliseconds |
+| `env` | object (nullable) | Environment the run executes in |
+|   ↳ `id` | string (nullable) | Environment ID |
+|   ↳ `name` | string (nullable) | Environment name |
+|   ↳ `user` | string (nullable) | Username for dev environments |
+| `metadata` | json | Metadata attached to the run |
+| `depth` | number | Depth of the run in a parent-child run hierarchy |
+| `batchId` | string | ID of the batch the run belongs to, if batch-triggered |
+| `triggerFunction` | string | Function used to trigger the run \(trigger, triggerAndWait, batchTrigger, or batchTriggerAndWait\) |
+| `payload` | json | Payload the run was triggered with |
+| `payloadPresignedUrl` | string | Presigned URL to download the payload when it is too large to inline |
+| `output` | json | Output returned by the run |
+| `outputPresignedUrl` | string | Presigned URL to download the output when it is too large to inline |
+| `schedule` | object | Schedule that triggered the run, if any |
+|   ↳ `id` | string (nullable) | Schedule ID |
+|   ↳ `externalId` | string (nullable) | External ID of the schedule |
+|   ↳ `deduplicationKey` | string (nullable) | Deduplication key of the schedule |
+|   ↳ `generator` | object (nullable) | Schedule generator details |
+|     ↳ `type` | string (nullable) | Generator type \(e.g., CRON\) |
+|     ↳ `expression` | string (nullable) | Cron expression |
+|     ↳ `description` | string (nullable) | Human-readable description of the cron expression |
+| `attempts` | array | Attempts made for the run |
+|   ↳ `id` | string | Attempt ID \(starts with attempt_\) |
+|   ↳ `status` | string | Attempt status \(PENDING, EXECUTING, PAUSED, COMPLETED, FAILED, or CANCELED\) |
+|   ↳ `createdAt` | string (nullable) | ISO timestamp when the attempt was created |
+|   ↳ `updatedAt` | string (nullable) | ISO timestamp when the attempt was last updated |
+|   ↳ `startedAt` | string (nullable) | ISO timestamp when the attempt started |
+|   ↳ `completedAt` | string (nullable) | ISO timestamp when the attempt completed |
+|   ↳ `error` | object (nullable) | Error details when the attempt failed |
+|     ↳ `message` | string (nullable) | Error message |
+|     ↳ `name` | string (nullable) | Error name |
+|     ↳ `stackTrace` | string (nullable) | Error stack trace |
+| `relatedRuns` | object | Root, parent, and child runs related to this run |
+|   ↳ `root` | object (nullable) | Root run of the hierarchy |
+|     ↳ `id` | string | Unique ID of the run \(starts with run_\) |
+|     ↳ `status` | string | Run status \(PENDING_VERSION, DELAYED, QUEUED, EXECUTING, REATTEMPTING, FROZEN, COMPLETED, CANCELED, FAILED, CRASHED, INTERRUPTED, or SYSTEM_FAILURE\) |
+|     ↳ `taskIdentifier` | string | Identifier of the task the run executes |
+|     ↳ `version` | string (nullable) | Worker version the run executes on |
+|     ↳ `idempotencyKey` | string (nullable) | Idempotency key the run was triggered with |
+|     ↳ `isTest` | boolean | Whether the run is a test run |
+|     ↳ `createdAt` | string (nullable) | ISO timestamp when the run was created |
+|     ↳ `updatedAt` | string (nullable) | ISO timestamp when the run was last updated |
+|     ↳ `startedAt` | string (nullable) | ISO timestamp when the run started executing |
+|     ↳ `finishedAt` | string (nullable) | ISO timestamp when the run finished |
+|     ↳ `delayedUntil` | string (nullable) | ISO timestamp the run is delayed until |
+|     ↳ `ttl` | string (nullable) | Time-to-live before an unstarted run expires |
+|     ↳ `expiredAt` | string (nullable) | ISO timestamp when the run expired |
+|     ↳ `tags` | array | Tags attached to the run |
+|     ↳ `costInCents` | number (nullable) | Compute cost of the run in cents |
+|     ↳ `baseCostInCents` | number (nullable) | Base invocation cost of the run in cents |
+|     ↳ `durationMs` | number (nullable) | Compute duration of the run in milliseconds |
+|     ↳ `env` | object (nullable) | Environment the run executes in |
+|       ↳ `id` | string (nullable) | Environment ID |
+|       ↳ `name` | string (nullable) | Environment name |
+|       ↳ `user` | string (nullable) | Username for dev environments |
+|   ↳ `parent` | object (nullable) | Parent run of this run |
+|     ↳ `id` | string | Unique ID of the run \(starts with run_\) |
+|     ↳ `status` | string | Run status \(PENDING_VERSION, DELAYED, QUEUED, EXECUTING, REATTEMPTING, FROZEN, COMPLETED, CANCELED, FAILED, CRASHED, INTERRUPTED, or SYSTEM_FAILURE\) |
+|     ↳ `taskIdentifier` | string | Identifier of the task the run executes |
+|     ↳ `version` | string (nullable) | Worker version the run executes on |
+|     ↳ `idempotencyKey` | string (nullable) | Idempotency key the run was triggered with |
+|     ↳ `isTest` | boolean | Whether the run is a test run |
+|     ↳ `createdAt` | string (nullable) | ISO timestamp when the run was created |
+|     ↳ `updatedAt` | string (nullable) | ISO timestamp when the run was last updated |
+|     ↳ `startedAt` | string (nullable) | ISO timestamp when the run started executing |
+|     ↳ `finishedAt` | string (nullable) | ISO timestamp when the run finished |
+|     ↳ `delayedUntil` | string (nullable) | ISO timestamp the run is delayed until |
+|     ↳ `ttl` | string (nullable) | Time-to-live before an unstarted run expires |
+|     ↳ `expiredAt` | string (nullable) | ISO timestamp when the run expired |
+|     ↳ `tags` | array | Tags attached to the run |
+|     ↳ `costInCents` | number (nullable) | Compute cost of the run in cents |
+|     ↳ `baseCostInCents` | number (nullable) | Base invocation cost of the run in cents |
+|     ↳ `durationMs` | number (nullable) | Compute duration of the run in milliseconds |
+|     ↳ `env` | object (nullable) | Environment the run executes in |
+|       ↳ `id` | string (nullable) | Environment ID |
+|       ↳ `name` | string (nullable) | Environment name |
+|       ↳ `user` | string (nullable) | Username for dev environments |
+|   ↳ `children` | array | Child runs of this run |
+|     ↳ `id` | string | Unique ID of the run \(starts with run_\) |
+|     ↳ `status` | string | Run status \(PENDING_VERSION, DELAYED, QUEUED, EXECUTING, REATTEMPTING, FROZEN, COMPLETED, CANCELED, FAILED, CRASHED, INTERRUPTED, or SYSTEM_FAILURE\) |
+|     ↳ `taskIdentifier` | string | Identifier of the task the run executes |
+|     ↳ `version` | string (nullable) | Worker version the run executes on |
+|     ↳ `idempotencyKey` | string (nullable) | Idempotency key the run was triggered with |
+|     ↳ `isTest` | boolean | Whether the run is a test run |
+|     ↳ `createdAt` | string (nullable) | ISO timestamp when the run was created |
+|     ↳ `updatedAt` | string (nullable) | ISO timestamp when the run was last updated |
+|     ↳ `startedAt` | string (nullable) | ISO timestamp when the run started executing |
+|     ↳ `finishedAt` | string (nullable) | ISO timestamp when the run finished |
+|     ↳ `delayedUntil` | string (nullable) | ISO timestamp the run is delayed until |
+|     ↳ `ttl` | string (nullable) | Time-to-live before an unstarted run expires |
+|     ↳ `expiredAt` | string (nullable) | ISO timestamp when the run expired |
+|     ↳ `tags` | array | Tags attached to the run |
+|     ↳ `costInCents` | number (nullable) | Compute cost of the run in cents |
+|     ↳ `baseCostInCents` | number (nullable) | Base invocation cost of the run in cents |
+|     ↳ `durationMs` | number (nullable) | Compute duration of the run in milliseconds |
+|     ↳ `env` | object (nullable) | Environment the run executes in |
+|       ↳ `id` | string (nullable) | Environment ID |
+|       ↳ `name` | string (nullable) | Environment name |
+|       ↳ `user` | string (nullable) | Username for dev environments |
 
 ### Trigger.dev Get Run Result
 
@@ -211,67 +265,13 @@ Retrieve the result of a Trigger.dev run: whether it succeeded, its output, and 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `ok` | boolean | Whether the run completed successfully |
+| `id` | string | ID of the run \(starts with run_\) |
+| `taskIdentifier` | string (nullable) | Identifier of the task the run executed |
+| `output` | json (nullable) | Output returned by the run, parsed when the output type is JSON |
+| `outputType` | string (nullable) | Content type of the serialized output \(e.g., application/json\) |
+| `error` | json (nullable) | Error details when the run failed |
+| `durationMs` | number (nullable) | Duration of the run in milliseconds |
 
 ### Trigger.dev Get Run Events
 
@@ -289,22 +289,22 @@ Retrieve the log and span events of a Trigger.dev run, including messages, level
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `events` | array | Log and span events recorded during the run |
-|   ↳ `spanId` | string | Span ID of the event |
-|   ↳ `parentId` | string | Parent span ID |
-|   ↳ `runId` | string | Run ID associated with the event |
-|   ↳ `message` | string | Event message |
-|   ↳ `startTime` | string | Start time as a bigint string \(nanoseconds since epoch\) |
-|   ↳ `duration` | number | Duration of the event in nanoseconds |
+|   ↳ `spanId` | string (nullable) | Span ID of the event |
+|   ↳ `parentId` | string (nullable) | Parent span ID |
+|   ↳ `runId` | string (nullable) | Run ID associated with the event |
+|   ↳ `message` | string (nullable) | Event message |
+|   ↳ `startTime` | string (nullable) | Start time as a bigint string \(nanoseconds since epoch\) |
+|   ↳ `duration` | number (nullable) | Duration of the event in nanoseconds |
 |   ↳ `isError` | boolean | Whether the event represents an error |
 |   ↳ `isPartial` | boolean | Whether the event is still in progress |
 |   ↳ `isCancelled` | boolean | Whether the event was cancelled |
-|   ↳ `level` | string | Log level \(TRACE, DEBUG, LOG, INFO, WARN, or ERROR\) |
-|   ↳ `kind` | string | Kind of span event |
-|   ↳ `attemptNumber` | number | Attempt number the event belongs to |
-|   ↳ `taskSlug` | string | Task identifier |
+|   ↳ `level` | string (nullable) | Log level \(TRACE, DEBUG, LOG, INFO, WARN, or ERROR\) |
+|   ↳ `kind` | string (nullable) | Kind of span event |
+|   ↳ `attemptNumber` | number (nullable) | Attempt number the event belongs to |
+|   ↳ `taskSlug` | string (nullable) | Task identifier |
 |   ↳ `events` | array | Span events \(e.g., exceptions\) that occurred during this event |
-|     ↳ `name` | string | Event name |
-|     ↳ `time` | string | When the event occurred |
+|     ↳ `name` | string (nullable) | Event name |
+|     ↳ `time` | string (nullable) | When the event occurred |
 
 ### Trigger.dev Get Run Trace
 
@@ -352,8 +352,8 @@ List Trigger.dev runs in the environment of the API key, with optional filters f
 | --------- | ---- | ----------- |
 | `runs` | array | Runs matching the filters |
 | `pagination` | object | Cursor pagination details |
-|   ↳ `next` | string | Run ID to start the next page after |
-|   ↳ `previous` | string | Run ID to start the previous page before |
+|   ↳ `next` | string (nullable) | Run ID to start the next page after |
+|   ↳ `previous` | string (nullable) | Run ID to start the previous page before |
 
 ### Trigger.dev Cancel Run
 
@@ -405,67 +405,121 @@ Reschedule a delayed Trigger.dev run with a new delay. Only valid while the run 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the run \(starts with run_\) |
+| `status` | string | Run status \(PENDING_VERSION, DELAYED, QUEUED, EXECUTING, REATTEMPTING, FROZEN, COMPLETED, CANCELED, FAILED, CRASHED, INTERRUPTED, or SYSTEM_FAILURE\) |
+| `taskIdentifier` | string | Identifier of the task the run executes |
+| `version` | string (nullable) | Worker version the run executes on |
+| `idempotencyKey` | string (nullable) | Idempotency key the run was triggered with |
+| `isTest` | boolean | Whether the run is a test run |
+| `createdAt` | string (nullable) | ISO timestamp when the run was created |
+| `updatedAt` | string (nullable) | ISO timestamp when the run was last updated |
+| `startedAt` | string (nullable) | ISO timestamp when the run started executing |
+| `finishedAt` | string (nullable) | ISO timestamp when the run finished |
+| `delayedUntil` | string (nullable) | ISO timestamp the run is delayed until |
+| `ttl` | string (nullable) | Time-to-live before an unstarted run expires |
+| `expiredAt` | string (nullable) | ISO timestamp when the run expired |
+| `tags` | array | Tags attached to the run |
+| `costInCents` | number (nullable) | Compute cost of the run in cents |
+| `baseCostInCents` | number (nullable) | Base invocation cost of the run in cents |
+| `durationMs` | number (nullable) | Compute duration of the run in milliseconds |
+| `env` | object (nullable) | Environment the run executes in |
+|   ↳ `id` | string (nullable) | Environment ID |
+|   ↳ `name` | string (nullable) | Environment name |
+|   ↳ `user` | string (nullable) | Username for dev environments |
+| `metadata` | json | Metadata attached to the run |
+| `depth` | number | Depth of the run in a parent-child run hierarchy |
+| `batchId` | string | ID of the batch the run belongs to, if batch-triggered |
+| `triggerFunction` | string | Function used to trigger the run \(trigger, triggerAndWait, batchTrigger, or batchTriggerAndWait\) |
+| `payload` | json | Payload the run was triggered with |
+| `payloadPresignedUrl` | string | Presigned URL to download the payload when it is too large to inline |
+| `output` | json | Output returned by the run |
+| `outputPresignedUrl` | string | Presigned URL to download the output when it is too large to inline |
+| `schedule` | object | Schedule that triggered the run, if any |
+|   ↳ `id` | string (nullable) | Schedule ID |
+|   ↳ `externalId` | string (nullable) | External ID of the schedule |
+|   ↳ `deduplicationKey` | string (nullable) | Deduplication key of the schedule |
+|   ↳ `generator` | object (nullable) | Schedule generator details |
+|     ↳ `type` | string (nullable) | Generator type \(e.g., CRON\) |
+|     ↳ `expression` | string (nullable) | Cron expression |
+|     ↳ `description` | string (nullable) | Human-readable description of the cron expression |
+| `attempts` | array | Attempts made for the run |
+|   ↳ `id` | string | Attempt ID \(starts with attempt_\) |
+|   ↳ `status` | string | Attempt status \(PENDING, EXECUTING, PAUSED, COMPLETED, FAILED, or CANCELED\) |
+|   ↳ `createdAt` | string (nullable) | ISO timestamp when the attempt was created |
+|   ↳ `updatedAt` | string (nullable) | ISO timestamp when the attempt was last updated |
+|   ↳ `startedAt` | string (nullable) | ISO timestamp when the attempt started |
+|   ↳ `completedAt` | string (nullable) | ISO timestamp when the attempt completed |
+|   ↳ `error` | object (nullable) | Error details when the attempt failed |
+|     ↳ `message` | string (nullable) | Error message |
+|     ↳ `name` | string (nullable) | Error name |
+|     ↳ `stackTrace` | string (nullable) | Error stack trace |
+| `relatedRuns` | object | Root, parent, and child runs related to this run |
+|   ↳ `root` | object (nullable) | Root run of the hierarchy |
+|     ↳ `id` | string | Unique ID of the run \(starts with run_\) |
+|     ↳ `status` | string | Run status \(PENDING_VERSION, DELAYED, QUEUED, EXECUTING, REATTEMPTING, FROZEN, COMPLETED, CANCELED, FAILED, CRASHED, INTERRUPTED, or SYSTEM_FAILURE\) |
+|     ↳ `taskIdentifier` | string | Identifier of the task the run executes |
+|     ↳ `version` | string (nullable) | Worker version the run executes on |
+|     ↳ `idempotencyKey` | string (nullable) | Idempotency key the run was triggered with |
+|     ↳ `isTest` | boolean | Whether the run is a test run |
+|     ↳ `createdAt` | string (nullable) | ISO timestamp when the run was created |
+|     ↳ `updatedAt` | string (nullable) | ISO timestamp when the run was last updated |
+|     ↳ `startedAt` | string (nullable) | ISO timestamp when the run started executing |
+|     ↳ `finishedAt` | string (nullable) | ISO timestamp when the run finished |
+|     ↳ `delayedUntil` | string (nullable) | ISO timestamp the run is delayed until |
+|     ↳ `ttl` | string (nullable) | Time-to-live before an unstarted run expires |
+|     ↳ `expiredAt` | string (nullable) | ISO timestamp when the run expired |
+|     ↳ `tags` | array | Tags attached to the run |
+|     ↳ `costInCents` | number (nullable) | Compute cost of the run in cents |
+|     ↳ `baseCostInCents` | number (nullable) | Base invocation cost of the run in cents |
+|     ↳ `durationMs` | number (nullable) | Compute duration of the run in milliseconds |
+|     ↳ `env` | object (nullable) | Environment the run executes in |
+|       ↳ `id` | string (nullable) | Environment ID |
+|       ↳ `name` | string (nullable) | Environment name |
+|       ↳ `user` | string (nullable) | Username for dev environments |
+|   ↳ `parent` | object (nullable) | Parent run of this run |
+|     ↳ `id` | string | Unique ID of the run \(starts with run_\) |
+|     ↳ `status` | string | Run status \(PENDING_VERSION, DELAYED, QUEUED, EXECUTING, REATTEMPTING, FROZEN, COMPLETED, CANCELED, FAILED, CRASHED, INTERRUPTED, or SYSTEM_FAILURE\) |
+|     ↳ `taskIdentifier` | string | Identifier of the task the run executes |
+|     ↳ `version` | string (nullable) | Worker version the run executes on |
+|     ↳ `idempotencyKey` | string (nullable) | Idempotency key the run was triggered with |
+|     ↳ `isTest` | boolean | Whether the run is a test run |
+|     ↳ `createdAt` | string (nullable) | ISO timestamp when the run was created |
+|     ↳ `updatedAt` | string (nullable) | ISO timestamp when the run was last updated |
+|     ↳ `startedAt` | string (nullable) | ISO timestamp when the run started executing |
+|     ↳ `finishedAt` | string (nullable) | ISO timestamp when the run finished |
+|     ↳ `delayedUntil` | string (nullable) | ISO timestamp the run is delayed until |
+|     ↳ `ttl` | string (nullable) | Time-to-live before an unstarted run expires |
+|     ↳ `expiredAt` | string (nullable) | ISO timestamp when the run expired |
+|     ↳ `tags` | array | Tags attached to the run |
+|     ↳ `costInCents` | number (nullable) | Compute cost of the run in cents |
+|     ↳ `baseCostInCents` | number (nullable) | Base invocation cost of the run in cents |
+|     ↳ `durationMs` | number (nullable) | Compute duration of the run in milliseconds |
+|     ↳ `env` | object (nullable) | Environment the run executes in |
+|       ↳ `id` | string (nullable) | Environment ID |
+|       ↳ `name` | string (nullable) | Environment name |
+|       ↳ `user` | string (nullable) | Username for dev environments |
+|   ↳ `children` | array | Child runs of this run |
+|     ↳ `id` | string | Unique ID of the run \(starts with run_\) |
+|     ↳ `status` | string | Run status \(PENDING_VERSION, DELAYED, QUEUED, EXECUTING, REATTEMPTING, FROZEN, COMPLETED, CANCELED, FAILED, CRASHED, INTERRUPTED, or SYSTEM_FAILURE\) |
+|     ↳ `taskIdentifier` | string | Identifier of the task the run executes |
+|     ↳ `version` | string (nullable) | Worker version the run executes on |
+|     ↳ `idempotencyKey` | string (nullable) | Idempotency key the run was triggered with |
+|     ↳ `isTest` | boolean | Whether the run is a test run |
+|     ↳ `createdAt` | string (nullable) | ISO timestamp when the run was created |
+|     ↳ `updatedAt` | string (nullable) | ISO timestamp when the run was last updated |
+|     ↳ `startedAt` | string (nullable) | ISO timestamp when the run started executing |
+|     ↳ `finishedAt` | string (nullable) | ISO timestamp when the run finished |
+|     ↳ `delayedUntil` | string (nullable) | ISO timestamp the run is delayed until |
+|     ↳ `ttl` | string (nullable) | Time-to-live before an unstarted run expires |
+|     ↳ `expiredAt` | string (nullable) | ISO timestamp when the run expired |
+|     ↳ `tags` | array | Tags attached to the run |
+|     ↳ `costInCents` | number (nullable) | Compute cost of the run in cents |
+|     ↳ `baseCostInCents` | number (nullable) | Base invocation cost of the run in cents |
+|     ↳ `durationMs` | number (nullable) | Compute duration of the run in milliseconds |
+|     ↳ `env` | object (nullable) | Environment the run executes in |
+|       ↳ `id` | string (nullable) | Environment ID |
+|       ↳ `name` | string (nullable) | Environment name |
+|       ↳ `user` | string (nullable) | Username for dev environments |
 
 ### Trigger.dev Add Run Tags
 
@@ -522,67 +576,20 @@ Create an imperative cron schedule that triggers a Trigger.dev task on a recurri
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the schedule \(starts with sched_\) |
+| `task` | string | Identifier of the task the schedule triggers |
+| `type` | string | Schedule type \(DECLARATIVE or IMPERATIVE\) |
+| `active` | boolean | Whether the schedule is active |
+| `deduplicationKey` | string | Deduplication key of the schedule |
+| `externalId` | string | External ID associated with the schedule |
+| `cron` | string | Cron expression of the schedule |
+| `cronDescription` | string | Human-readable description of the cron expression |
+| `timezone` | string | IANA timezone of the schedule |
+| `nextRun` | string | ISO timestamp of the next scheduled run |
+| `environments` | array | Environments the schedule runs in |
+|   ↳ `id` | string (nullable) | Environment ID |
+|   ↳ `type` | string (nullable) | Environment type |
+|   ↳ `userName` | string (nullable) | Username for dev environments |
 
 ### Trigger.dev Get Schedule
 
@@ -599,67 +606,20 @@ Retrieve a Trigger.dev schedule by its ID.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the schedule \(starts with sched_\) |
+| `task` | string | Identifier of the task the schedule triggers |
+| `type` | string | Schedule type \(DECLARATIVE or IMPERATIVE\) |
+| `active` | boolean | Whether the schedule is active |
+| `deduplicationKey` | string | Deduplication key of the schedule |
+| `externalId` | string | External ID associated with the schedule |
+| `cron` | string | Cron expression of the schedule |
+| `cronDescription` | string | Human-readable description of the cron expression |
+| `timezone` | string | IANA timezone of the schedule |
+| `nextRun` | string | ISO timestamp of the next scheduled run |
+| `environments` | array | Environments the schedule runs in |
+|   ↳ `id` | string (nullable) | Environment ID |
+|   ↳ `type` | string (nullable) | Environment type |
+|   ↳ `userName` | string (nullable) | Username for dev environments |
 
 ### Trigger.dev List Schedules
 
@@ -680,22 +640,22 @@ List Trigger.dev schedules in the project, with page-based pagination.
 | `schedules` | array | Schedules in the project |
 |   ↳ `id` | string | Unique ID of the schedule \(starts with sched_\) |
 |   ↳ `task` | string | Identifier of the task the schedule triggers |
-|   ↳ `type` | string | Schedule type \(DECLARATIVE or IMPERATIVE\) |
+|   ↳ `type` | string (nullable) | Schedule type \(DECLARATIVE or IMPERATIVE\) |
 |   ↳ `active` | boolean | Whether the schedule is active |
-|   ↳ `deduplicationKey` | string | Deduplication key of the schedule |
-|   ↳ `externalId` | string | External ID associated with the schedule |
-|   ↳ `cron` | string | Cron expression of the schedule |
-|   ↳ `cronDescription` | string | Human-readable description of the cron expression |
-|   ↳ `timezone` | string | IANA timezone of the schedule |
-|   ↳ `nextRun` | string | ISO timestamp of the next scheduled run |
+|   ↳ `deduplicationKey` | string (nullable) | Deduplication key of the schedule |
+|   ↳ `externalId` | string (nullable) | External ID associated with the schedule |
+|   ↳ `cron` | string (nullable) | Cron expression of the schedule |
+|   ↳ `cronDescription` | string (nullable) | Human-readable description of the cron expression |
+|   ↳ `timezone` | string (nullable) | IANA timezone of the schedule |
+|   ↳ `nextRun` | string (nullable) | ISO timestamp of the next scheduled run |
 |   ↳ `environments` | array | Environments the schedule runs in |
-|     ↳ `id` | string | Environment ID |
-|     ↳ `type` | string | Environment type |
-|     ↳ `userName` | string | Username for dev environments |
+|     ↳ `id` | string (nullable) | Environment ID |
+|     ↳ `type` | string (nullable) | Environment type |
+|     ↳ `userName` | string (nullable) | Username for dev environments |
 | `pagination` | object | Page-based pagination details |
-|   ↳ `currentPage` | number | Current page number |
-|   ↳ `totalPages` | number | Total number of pages |
-|   ↳ `count` | number | Total number of schedules |
+|   ↳ `currentPage` | number (nullable) | Current page number |
+|   ↳ `totalPages` | number (nullable) | Total number of pages |
+|   ↳ `count` | number (nullable) | Total number of schedules |
 
 ### Trigger.dev Update Schedule
 
@@ -716,67 +676,20 @@ Update an imperative Trigger.dev schedule by its ID, replacing its task, cron ex
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the schedule \(starts with sched_\) |
+| `task` | string | Identifier of the task the schedule triggers |
+| `type` | string | Schedule type \(DECLARATIVE or IMPERATIVE\) |
+| `active` | boolean | Whether the schedule is active |
+| `deduplicationKey` | string | Deduplication key of the schedule |
+| `externalId` | string | External ID associated with the schedule |
+| `cron` | string | Cron expression of the schedule |
+| `cronDescription` | string | Human-readable description of the cron expression |
+| `timezone` | string | IANA timezone of the schedule |
+| `nextRun` | string | ISO timestamp of the next scheduled run |
+| `environments` | array | Environments the schedule runs in |
+|   ↳ `id` | string (nullable) | Environment ID |
+|   ↳ `type` | string (nullable) | Environment type |
+|   ↳ `userName` | string (nullable) | Username for dev environments |
 
 ### Trigger.dev Delete Schedule
 
@@ -811,67 +724,20 @@ Activate an imperative Trigger.dev schedule so it resumes triggering its task.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the schedule \(starts with sched_\) |
+| `task` | string | Identifier of the task the schedule triggers |
+| `type` | string | Schedule type \(DECLARATIVE or IMPERATIVE\) |
+| `active` | boolean | Whether the schedule is active |
+| `deduplicationKey` | string | Deduplication key of the schedule |
+| `externalId` | string | External ID associated with the schedule |
+| `cron` | string | Cron expression of the schedule |
+| `cronDescription` | string | Human-readable description of the cron expression |
+| `timezone` | string | IANA timezone of the schedule |
+| `nextRun` | string | ISO timestamp of the next scheduled run |
+| `environments` | array | Environments the schedule runs in |
+|   ↳ `id` | string (nullable) | Environment ID |
+|   ↳ `type` | string (nullable) | Environment type |
+|   ↳ `userName` | string (nullable) | Username for dev environments |
 
 ### Trigger.dev Deactivate Schedule
 
@@ -888,67 +754,20 @@ Deactivate an imperative Trigger.dev schedule so it stops triggering its task.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the schedule \(starts with sched_\) |
+| `task` | string | Identifier of the task the schedule triggers |
+| `type` | string | Schedule type \(DECLARATIVE or IMPERATIVE\) |
+| `active` | boolean | Whether the schedule is active |
+| `deduplicationKey` | string | Deduplication key of the schedule |
+| `externalId` | string | External ID associated with the schedule |
+| `cron` | string | Cron expression of the schedule |
+| `cronDescription` | string | Human-readable description of the cron expression |
+| `timezone` | string | IANA timezone of the schedule |
+| `nextRun` | string | ISO timestamp of the next scheduled run |
+| `environments` | array | Environments the schedule runs in |
+|   ↳ `id` | string (nullable) | Environment ID |
+|   ↳ `type` | string (nullable) | Environment type |
+|   ↳ `userName` | string (nullable) | Username for dev environments |
 
 ### Trigger.dev List Env Vars
 
@@ -1089,67 +908,18 @@ Retrieve a Trigger.dev queue by ID, task identifier, or custom queue name, inclu
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the queue \(starts with queue_\) |
+| `name` | string | Name of the queue |
+| `type` | string | Queue type \(task for task-default queues, custom for named queues\) |
+| `running` | number | Number of runs currently executing |
+| `queued` | number | Number of runs waiting in the queue |
+| `paused` | boolean | Whether the queue is paused |
+| `concurrencyLimit` | number | Maximum number of runs that can execute concurrently |
+| `concurrency` | object | Concurrency details for the queue |
+|   ↳ `current` | number (nullable) | Current concurrency limit |
+|   ↳ `base` | number (nullable) | Base concurrency limit |
+|   ↳ `override` | number (nullable) | Overridden concurrency limit |
+|   ↳ `overriddenAt` | string (nullable) | ISO timestamp when the concurrency limit was overridden |
 
 ### Trigger.dev List Queues
 
@@ -1170,20 +940,20 @@ List the queues in the environment of the API key, including running and queued 
 | `queues` | array | Queues in the environment |
 |   ↳ `id` | string | Unique ID of the queue \(starts with queue_\) |
 |   ↳ `name` | string | Name of the queue |
-|   ↳ `type` | string | Queue type \(task for task-default queues, custom for named queues\) |
-|   ↳ `running` | number | Number of runs currently executing |
-|   ↳ `queued` | number | Number of runs waiting in the queue |
+|   ↳ `type` | string (nullable) | Queue type \(task for task-default queues, custom for named queues\) |
+|   ↳ `running` | number (nullable) | Number of runs currently executing |
+|   ↳ `queued` | number (nullable) | Number of runs waiting in the queue |
 |   ↳ `paused` | boolean | Whether the queue is paused |
-|   ↳ `concurrencyLimit` | number | Maximum number of runs that can execute concurrently |
-|   ↳ `concurrency` | object | Concurrency details for the queue |
-|     ↳ `current` | number | Current concurrency limit |
-|     ↳ `base` | number | Base concurrency limit |
-|     ↳ `override` | number | Overridden concurrency limit |
-|     ↳ `overriddenAt` | string | ISO timestamp when the concurrency limit was overridden |
+|   ↳ `concurrencyLimit` | number (nullable) | Maximum number of runs that can execute concurrently |
+|   ↳ `concurrency` | object (nullable) | Concurrency details for the queue |
+|     ↳ `current` | number (nullable) | Current concurrency limit |
+|     ↳ `base` | number (nullable) | Base concurrency limit |
+|     ↳ `override` | number (nullable) | Overridden concurrency limit |
+|     ↳ `overriddenAt` | string (nullable) | ISO timestamp when the concurrency limit was overridden |
 | `pagination` | object | Page-based pagination details |
-|   ↳ `currentPage` | number | Current page number |
-|   ↳ `totalPages` | number | Total number of pages |
-|   ↳ `count` | number | Total number of queues |
+|   ↳ `currentPage` | number (nullable) | Current page number |
+|   ↳ `totalPages` | number (nullable) | Total number of pages |
+|   ↳ `count` | number (nullable) | Total number of queues |
 
 ### Trigger.dev Pause Queue
 
@@ -1201,67 +971,18 @@ Pause a Trigger.dev queue so no new runs start. Runs that are currently executin
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the queue \(starts with queue_\) |
+| `name` | string | Name of the queue |
+| `type` | string | Queue type \(task for task-default queues, custom for named queues\) |
+| `running` | number | Number of runs currently executing |
+| `queued` | number | Number of runs waiting in the queue |
+| `paused` | boolean | Whether the queue is paused |
+| `concurrencyLimit` | number | Maximum number of runs that can execute concurrently |
+| `concurrency` | object | Concurrency details for the queue |
+|   ↳ `current` | number (nullable) | Current concurrency limit |
+|   ↳ `base` | number (nullable) | Base concurrency limit |
+|   ↳ `override` | number (nullable) | Overridden concurrency limit |
+|   ↳ `overriddenAt` | string (nullable) | ISO timestamp when the concurrency limit was overridden |
 
 ### Trigger.dev Resume Queue
 
@@ -1279,67 +1000,18 @@ Resume a paused Trigger.dev queue so new runs can start again.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the queue \(starts with queue_\) |
+| `name` | string | Name of the queue |
+| `type` | string | Queue type \(task for task-default queues, custom for named queues\) |
+| `running` | number | Number of runs currently executing |
+| `queued` | number | Number of runs waiting in the queue |
+| `paused` | boolean | Whether the queue is paused |
+| `concurrencyLimit` | number | Maximum number of runs that can execute concurrently |
+| `concurrency` | object | Concurrency details for the queue |
+|   ↳ `current` | number (nullable) | Current concurrency limit |
+|   ↳ `base` | number (nullable) | Base concurrency limit |
+|   ↳ `override` | number (nullable) | Overridden concurrency limit |
+|   ↳ `overriddenAt` | string (nullable) | ISO timestamp when the concurrency limit was overridden |
 
 ### Trigger.dev Override Queue Concurrency
 
@@ -1358,67 +1030,18 @@ Override the concurrency limit of a Trigger.dev queue with a new value.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the queue \(starts with queue_\) |
+| `name` | string | Name of the queue |
+| `type` | string | Queue type \(task for task-default queues, custom for named queues\) |
+| `running` | number | Number of runs currently executing |
+| `queued` | number | Number of runs waiting in the queue |
+| `paused` | boolean | Whether the queue is paused |
+| `concurrencyLimit` | number | Maximum number of runs that can execute concurrently |
+| `concurrency` | object | Concurrency details for the queue |
+|   ↳ `current` | number (nullable) | Current concurrency limit |
+|   ↳ `base` | number (nullable) | Base concurrency limit |
+|   ↳ `override` | number (nullable) | Overridden concurrency limit |
+|   ↳ `overriddenAt` | string (nullable) | ISO timestamp when the concurrency limit was overridden |
 
 ### Trigger.dev Reset Queue Concurrency
 
@@ -1436,67 +1059,18 @@ Reset the concurrency limit of a Trigger.dev queue back to its base value, remov
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the queue \(starts with queue_\) |
+| `name` | string | Name of the queue |
+| `type` | string | Queue type \(task for task-default queues, custom for named queues\) |
+| `running` | number | Number of runs currently executing |
+| `queued` | number | Number of runs waiting in the queue |
+| `paused` | boolean | Whether the queue is paused |
+| `concurrencyLimit` | number | Maximum number of runs that can execute concurrently |
+| `concurrency` | object | Concurrency details for the queue |
+|   ↳ `current` | number (nullable) | Current concurrency limit |
+|   ↳ `base` | number (nullable) | Base concurrency limit |
+|   ↳ `override` | number (nullable) | Overridden concurrency limit |
+|   ↳ `overriddenAt` | string (nullable) | ISO timestamp when the concurrency limit was overridden |
 
 ### Trigger.dev List Deployments
 
@@ -1520,7 +1094,7 @@ List Trigger.dev deployments in the environment of the API key, with optional st
 | --------- | ---- | ----------- |
 | `deployments` | array | Deployments matching the filters |
 | `pagination` | object | Cursor pagination details |
-|   ↳ `next` | string | Cursor to pass as the page-after parameter for the next page |
+|   ↳ `next` | string (nullable) | Cursor to pass as the page-after parameter for the next page |
 
 ### Trigger.dev Get Deployment
 
@@ -1537,67 +1111,20 @@ Retrieve a Trigger.dev deployment by its ID, including its status, version, and 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the deployment |
+| `status` | string | Deployment status \(PENDING, INSTALLING, BUILDING, DEPLOYING, DEPLOYED, FAILED, CANCELED, or TIMED_OUT\) |
+| `version` | string (nullable) | Deployment version \(e.g., "20250228.1"\) |
+| `shortCode` | string (nullable) | Short code of the deployment |
+| `createdAt` | string (nullable) | ISO timestamp when the deployment was created |
+| `deployedAt` | string (nullable) | ISO timestamp when the deployment was promoted to DEPLOYED |
+| `runtime` | string (nullable) | Runtime used by the deployment \(e.g., "node"\) |
+| `runtimeVersion` | string (nullable) | Runtime version of the deployment |
+| `git` | json (nullable) | Git metadata associated with the deployment |
+| `error` | json (nullable) | Error details when the deployment failed |
+| `tasks` | array | Tasks registered by the deployed worker |
+|   ↳ `id` | string (nullable) | Task ID |
+|   ↳ `slug` | string (nullable) | Task identifier |
+|   ↳ `filePath` | string (nullable) | File path of the task in the project |
 
 ### Trigger.dev Get Latest Deployment
 
@@ -1613,67 +1140,20 @@ Retrieve the latest Trigger.dev deployment in the environment of the API key.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the deployment |
+| `status` | string | Deployment status \(PENDING, INSTALLING, BUILDING, DEPLOYING, DEPLOYED, FAILED, CANCELED, or TIMED_OUT\) |
+| `version` | string (nullable) | Deployment version \(e.g., "20250228.1"\) |
+| `shortCode` | string (nullable) | Short code of the deployment |
+| `createdAt` | string (nullable) | ISO timestamp when the deployment was created |
+| `deployedAt` | string (nullable) | ISO timestamp when the deployment was promoted to DEPLOYED |
+| `runtime` | string (nullable) | Runtime used by the deployment \(e.g., "node"\) |
+| `runtimeVersion` | string (nullable) | Runtime version of the deployment |
+| `git` | json (nullable) | Git metadata associated with the deployment |
+| `error` | json (nullable) | Error details when the deployment failed |
+| `tasks` | array | Tasks registered by the deployed worker |
+|   ↳ `id` | string (nullable) | Task ID |
+|   ↳ `slug` | string (nullable) | Task identifier |
+|   ↳ `filePath` | string (nullable) | File path of the task in the project |
 
 ### Trigger.dev Promote Deployment
 
@@ -1732,14 +1212,14 @@ Retrieve the TRQL query schema: the tables and columns available for Execute Que
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `tables` | array | Tables that can be queried with TRQL |
-|   ↳ `name` | string | Table name used in TRQL queries |
-|   ↳ `description` | string | Description of the table |
-|   ↳ `timeColumn` | string | Primary time column for the table |
+|   ↳ `name` | string (nullable) | Table name used in TRQL queries |
+|   ↳ `description` | string (nullable) | Description of the table |
+|   ↳ `timeColumn` | string (nullable) | Primary time column for the table |
 |   ↳ `columns` | array | Columns of the table |
-|     ↳ `name` | string | Column name |
-|     ↳ `type` | string | ClickHouse data type |
-|     ↳ `description` | string | Column description |
-|     ↳ `example` | string | Example value |
+|     ↳ `name` | string (nullable) | Column name |
+|     ↳ `type` | string (nullable) | ClickHouse data type |
+|     ↳ `description` | string (nullable) | Column description |
+|     ↳ `example` | string (nullable) | Example value |
 |     ↳ `allowedValues` | array | Allowed values for enum-like columns |
 |     ↳ `coreColumn` | boolean | Whether the column is included in default queries |
 
@@ -1798,67 +1278,18 @@ Retrieve a Trigger.dev waitpoint token by its ID, including its status, timeout,
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `id` | string | Run, schedule, or queue ID |
-| `batchId` | string | Batch ID \(Batch Trigger Task\) |
-| `runIds` | json | Run IDs in the batch \(batch operations\) |
-| `runCount` | number | Total number of runs in the batch \(Get Batch\) |
-| `successfulRunCount` | number | Number of successful runs in the batch \(Get Batch\) |
-| `failedRunCount` | number | Number of failed runs in the batch \(Get Batch\) |
-| `errors` | json | Error details for failed batch items \(Get Batch\) |
-| `items` | json | Execution results for each run in the batch \(Get Batch Results\) |
-| `status` | string | Run status \(Get Run\) |
-| `taskIdentifier` | string | Task identifier of the run \(Get Run\) |
-| `createdAt` | string | When the run was created \(Get Run\) |
-| `startedAt` | string | When the run started \(Get Run\) |
-| `finishedAt` | string | When the run finished \(Get Run\) |
-| `durationMs` | number | Compute duration in milliseconds \(Get Run\) |
-| `costInCents` | number | Compute cost in cents \(Get Run\) |
-| `isTest` | boolean | Whether the run is a test run \(Get Run\) |
-| `tags` | json | Tags attached to the run \(Get Run\) |
-| `payload` | json | Payload the run was triggered with \(Get Run\) |
-| `output` | json | Output returned by the run \(Get Run\) |
-| `attempts` | json | Attempts made for the run \(Get Run\) |
-| `metadata` | json | Run metadata \(Get Run, Update Run Metadata\) |
-| `ok` | boolean | Whether the run succeeded \(Get Run Result\) |
-| `outputType` | string | Content type of the run output \(Get Run Result\) |
-| `error` | json | Error details for a failed run \(Get Run Result\) |
-| `message` | string | Confirmation message \(Add Run Tags\) |
-| `events` | json | Log and span events of the run \(Get Run Events\) |
-| `traceId` | string | OpenTelemetry trace ID \(Get Run Trace\) |
-| `rootSpan` | json | Root span of the run trace \(Get Run Trace\) |
-| `runs` | json | Runs matching the filters \(List Runs\) |
-| `schedules` | json | Schedules in the project \(List Schedules\) |
-| `pagination` | json | Pagination details \(list operations\) |
-| `task` | string | Task the schedule triggers \(schedule operations\) |
-| `active` | boolean | Whether the schedule is active \(schedule operations\) |
-| `cron` | string | Cron expression \(schedule operations\) |
-| `cronDescription` | string | Human-readable cron description \(schedule operations\) |
-| `timezone` | string | Timezone of the schedule \(schedule operations\) |
-| `nextRun` | string | Next scheduled run time \(schedule operations\) |
-| `environments` | json | Environments the schedule runs in \(schedule operations\) |
-| `deleted` | boolean | Whether the schedule was deleted \(Delete Schedule\) |
-| `variables` | json | Environment variables in the project environment \(List Env Vars\) |
-| `name` | string | Environment variable or queue name \(env var and queue operations\) |
-| `value` | string | Value of the environment variable \(Get Env Var\) |
-| `success` | boolean | Whether the operation succeeded \(env var operations, Complete Waitpoint Token\) |
-| `count` | number | Number of environment variables submitted \(Import Env Vars\) |
-| `queues` | json | Queues in the environment \(List Queues\) |
-| `running` | number | Runs currently executing \(queue operations\) |
-| `queued` | number | Runs waiting in the queue \(queue operations\) |
-| `paused` | boolean | Whether the queue is paused \(queue operations\) |
-| `concurrencyLimit` | number | Concurrency limit of the queue \(queue operations\) |
-| `concurrency` | json | Concurrency details of the queue \(queue operations\) |
-| `deployments` | json | Deployments matching the filters \(List Deployments\) |
-| `version` | string | Deployment version \(deployment operations\) |
-| `shortCode` | string | Deployment short code \(deployment operations\) |
-| `tasks` | json | Tasks registered by the deployed worker \(deployment operations\) |
-| `format` | string | Format of the query results \(Execute Query\) |
-| `results` | json | Query results \(Execute Query\) |
-| `tables` | json | Queryable TRQL tables and columns \(Get Query Schema\) |
-| `tokens` | json | Waitpoint tokens \(List Waitpoint Tokens\) |
-| `url` | string | Waitpoint callback URL \(waitpoint operations\) |
-| `isCached` | boolean | Whether an existing token was returned \(Create Waitpoint Token\) |
-| `timezones` | json | Supported IANA timezones \(List Timezones\) |
+| `id` | string | Unique ID of the waitpoint token \(starts with waitpoint_\) |
+| `url` | string | HTTP callback URL; a POST request to this URL completes the waitpoint without an API key |
+| `status` | string | Status of the waitpoint token \(WAITING, COMPLETED, or TIMED_OUT\) |
+| `idempotencyKey` | string (nullable) | Idempotency key used when creating the token |
+| `idempotencyKeyExpiresAt` | string (nullable) | ISO timestamp when the idempotency key expires |
+| `timeoutAt` | string (nullable) | ISO timestamp when the token times out |
+| `completedAt` | string (nullable) | ISO timestamp when the token was completed |
+| `output` | json (nullable) | Data passed when completing the token, parsed when the output type is JSON |
+| `outputType` | string (nullable) | Content type of the serialized output \(e.g., application/json\) |
+| `outputIsError` | boolean | Whether the output represents an error \(e.g., a timeout\) |
+| `tags` | array | Tags attached to the waitpoint |
+| `createdAt` | string (nullable) | ISO timestamp when the token was created |
 
 ### Trigger.dev List Waitpoint Tokens
 
@@ -1885,8 +1316,8 @@ List Trigger.dev waitpoint tokens in the environment of the API key, with option
 | --------- | ---- | ----------- |
 | `tokens` | array | Waitpoint tokens matching the filters |
 | `pagination` | object | Cursor pagination details |
-|   ↳ `next` | string | Waitpoint ID to start the next page after |
-|   ↳ `previous` | string | Waitpoint ID to start the previous page before |
+|   ↳ `next` | string (nullable) | Waitpoint ID to start the next page after |
+|   ↳ `previous` | string (nullable) | Waitpoint ID to start the previous page before |
 
 ### Trigger.dev List Timezones
 
@@ -1904,5 +1335,3 @@ List the IANA timezones supported by Trigger.dev schedules, for use as the timez
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `timezones` | array | IANA timezones supported by schedules |
-
-

--- a/apps/docs/content/docs/integrations/twilio.mdx
+++ b/apps/docs/content/docs/integrations/twilio.mdx
@@ -97,4 +97,3 @@ Trigger workflow when an inbound SMS or MMS message is received via Twilio
 | `toZip` | string | Zip/postal code of the recipient, when available |
 | `toCountry` | string | Country of the recipient, when available |
 | `raw` | string | Complete raw webhook payload from Twilio as a JSON string |
-

--- a/apps/docs/content/docs/integrations/twilio_sms.mdx
+++ b/apps/docs/content/docs/integrations/twilio_sms.mdx
@@ -5,7 +5,7 @@ description: Send SMS messages
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="twilio_sms"
   color="#F22F46"
 />
@@ -46,5 +46,3 @@ Send text messages to single or multiple recipients using the Twilio API.
 | `status` | string | Message delivery status from Twilio |
 | `fromNumber` | string | Phone number message was sent from |
 | `toNumber` | string | Phone number message was sent to |
-
-

--- a/apps/docs/content/docs/integrations/twilio_voice.mdx
+++ b/apps/docs/content/docs/integrations/twilio_voice.mdx
@@ -5,7 +5,7 @@ description: Make and manage phone calls
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="twilio_voice"
   color="#F22F46"
 />
@@ -121,8 +121,6 @@ Retrieve call recording information and transcription (if enabled via TwiML).
 | `transcriptionPriceUnit` | string | Currency of the transcription price |
 | `error` | string | Error message if retrieval failed |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -176,4 +174,3 @@ Trigger workflow when phone calls are received via Twilio Voice
 | `callerCountry` | string | Country of the caller \(same as fromCountry\) |
 | `callToken` | string | Twilio call token for authentication |
 | `raw` | string | Complete raw webhook payload from Twilio as JSON string |
-

--- a/apps/docs/content/docs/integrations/typeform.mdx
+++ b/apps/docs/content/docs/integrations/typeform.mdx
@@ -5,7 +5,7 @@ description: Interact with Typeform
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="typeform"
   color="#262627"
 />
@@ -228,8 +228,6 @@ Permanently delete a form and all its responses
 | `deleted` | boolean | Whether the form was successfully deleted |
 | `message` | string | Deletion confirmation message |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -295,4 +293,3 @@ Trigger workflow when a Typeform submission is received
 |   ↳ `id` | string | Ending screen ID |
 |   ↳ `ref` | string | Ending screen reference |
 | `raw` | object | Complete original webhook payload from Typeform |
-

--- a/apps/docs/content/docs/integrations/upstash.mdx
+++ b/apps/docs/content/docs/integrations/upstash.mdx
@@ -5,7 +5,7 @@ description: Serverless Redis with Upstash
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="upstash"
   color="#181C1E"
 />
@@ -342,5 +342,3 @@ Increment the integer value of a key by a given amount. Use a negative value to 
 | --------- | ---- | ----------- |
 | `key` | string | The key that was incremented |
 | `value` | number | The new value after incrementing |
-
-

--- a/apps/docs/content/docs/integrations/uptimerobot.mdx
+++ b/apps/docs/content/docs/integrations/uptimerobot.mdx
@@ -5,7 +5,7 @@ description: Monitor uptime, manage incidents, maintenance windows, and status p
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="uptimerobot"
   color="#111921"
 />
@@ -57,41 +57,41 @@ List monitors in your UptimeRobot account, with optional filters and pagination
 | `monitors` | array | List of monitors |
 |   ↳ `id` | number | Monitor ID |
 |   ↳ `friendlyName` | string | Friendly name of the monitor |
-|   ↳ `url` | string | Monitored URL or host |
-|   ↳ `type` | string | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
-|   ↳ `status` | string | Current status \(UP, DOWN, PAUSED, etc.\) |
-|   ↳ `interval` | number | Check interval in seconds |
-|   ↳ `timeout` | number | Check timeout in seconds |
-|   ↳ `port` | number | Port for Port/UDP monitors |
-|   ↳ `keywordType` | string | Keyword match type for Keyword monitors |
-|   ↳ `keywordValue` | string | Keyword to match for Keyword monitors |
-|   ↳ `httpMethodType` | string | HTTP method used for the check |
-|   ↳ `authType` | string | HTTP authentication method |
+|   ↳ `url` | string (nullable) | Monitored URL or host |
+|   ↳ `type` | string (nullable) | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
+|   ↳ `status` | string (nullable) | Current status \(UP, DOWN, PAUSED, etc.\) |
+|   ↳ `interval` | number (nullable) | Check interval in seconds |
+|   ↳ `timeout` | number (nullable) | Check timeout in seconds |
+|   ↳ `port` | number (nullable) | Port for Port/UDP monitors |
+|   ↳ `keywordType` | string (nullable) | Keyword match type for Keyword monitors |
+|   ↳ `keywordValue` | string (nullable) | Keyword to match for Keyword monitors |
+|   ↳ `httpMethodType` | string (nullable) | HTTP method used for the check |
+|   ↳ `authType` | string (nullable) | HTTP authentication method |
 |   ↳ `successHttpResponseCodes` | array | HTTP response codes treated as success |
-|   ↳ `checkSSLErrors` | boolean | Whether SSL/domain expiration errors are checked |
-|   ↳ `followRedirections` | boolean | Whether redirects are followed |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
-|   ↳ `domainExpirationReminder` | boolean | Whether domain expiration reminders are enabled |
-|   ↳ `responseTimeThreshold` | number | Response time threshold in milliseconds |
-|   ↳ `currentStateDuration` | number | Seconds spent in the current state |
-|   ↳ `lastIncidentId` | string | ID of the most recent incident |
-|   ↳ `groupId` | number | Monitor group ID \(0 if ungrouped\) |
-|   ↳ `createDateTime` | string | When the monitor was created |
+|   ↳ `checkSSLErrors` | boolean (nullable) | Whether SSL/domain expiration errors are checked |
+|   ↳ `followRedirections` | boolean (nullable) | Whether redirects are followed |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
+|   ↳ `domainExpirationReminder` | boolean (nullable) | Whether domain expiration reminders are enabled |
+|   ↳ `responseTimeThreshold` | number (nullable) | Response time threshold in milliseconds |
+|   ↳ `currentStateDuration` | number (nullable) | Seconds spent in the current state |
+|   ↳ `lastIncidentId` | string (nullable) | ID of the most recent incident |
+|   ↳ `groupId` | number (nullable) | Monitor group ID \(0 if ungrouped\) |
+|   ↳ `createDateTime` | string (nullable) | When the monitor was created |
 |   ↳ `tags` | array | Tags assigned to the monitor |
 |     ↳ `id` | number | Tag ID |
 |     ↳ `name` | string | Tag name |
-|     ↳ `color` | string | Tag color |
+|     ↳ `color` | string (nullable) | Tag color |
 |   ↳ `assignedAlertContacts` | array | Alert contacts assigned to the monitor |
 |     ↳ `alertContactId` | number | Alert contact ID |
 |     ↳ `threshold` | number | Notification delay threshold in minutes |
 |     ↳ `recurrence` | number | Repeat notification interval in minutes |
-|   ↳ `lastIncident` | object | Details of the most recent incident |
+|   ↳ `lastIncident` | object (nullable) | Details of the most recent incident |
 |     ↳ `id` | string | Incident ID |
-|     ↳ `status` | string | Incident status |
-|     ↳ `cause` | number | Incident cause code |
-|     ↳ `reason` | string | Incident reason |
-|     ↳ `startedAt` | string | When the incident started |
-|     ↳ `duration` | number | Incident duration in seconds |
+|     ↳ `status` | string (nullable) | Incident status |
+|     ↳ `cause` | number (nullable) | Incident cause code |
+|     ↳ `reason` | string (nullable) | Incident reason |
+|     ↳ `startedAt` | string (nullable) | When the incident started |
+|     ↳ `duration` | number (nullable) | Incident duration in seconds |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
 ### UptimeRobot Get Monitor
@@ -112,41 +112,41 @@ Get the details of a single UptimeRobot monitor by ID
 | `monitor` | object | The monitor details |
 |   ↳ `id` | number | Monitor ID |
 |   ↳ `friendlyName` | string | Friendly name of the monitor |
-|   ↳ `url` | string | Monitored URL or host |
-|   ↳ `type` | string | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
-|   ↳ `status` | string | Current status \(UP, DOWN, PAUSED, etc.\) |
-|   ↳ `interval` | number | Check interval in seconds |
-|   ↳ `timeout` | number | Check timeout in seconds |
-|   ↳ `port` | number | Port for Port/UDP monitors |
-|   ↳ `keywordType` | string | Keyword match type for Keyword monitors |
-|   ↳ `keywordValue` | string | Keyword to match for Keyword monitors |
-|   ↳ `httpMethodType` | string | HTTP method used for the check |
-|   ↳ `authType` | string | HTTP authentication method |
+|   ↳ `url` | string (nullable) | Monitored URL or host |
+|   ↳ `type` | string (nullable) | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
+|   ↳ `status` | string (nullable) | Current status \(UP, DOWN, PAUSED, etc.\) |
+|   ↳ `interval` | number (nullable) | Check interval in seconds |
+|   ↳ `timeout` | number (nullable) | Check timeout in seconds |
+|   ↳ `port` | number (nullable) | Port for Port/UDP monitors |
+|   ↳ `keywordType` | string (nullable) | Keyword match type for Keyword monitors |
+|   ↳ `keywordValue` | string (nullable) | Keyword to match for Keyword monitors |
+|   ↳ `httpMethodType` | string (nullable) | HTTP method used for the check |
+|   ↳ `authType` | string (nullable) | HTTP authentication method |
 |   ↳ `successHttpResponseCodes` | array | HTTP response codes treated as success |
-|   ↳ `checkSSLErrors` | boolean | Whether SSL/domain expiration errors are checked |
-|   ↳ `followRedirections` | boolean | Whether redirects are followed |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
-|   ↳ `domainExpirationReminder` | boolean | Whether domain expiration reminders are enabled |
-|   ↳ `responseTimeThreshold` | number | Response time threshold in milliseconds |
-|   ↳ `currentStateDuration` | number | Seconds spent in the current state |
-|   ↳ `lastIncidentId` | string | ID of the most recent incident |
-|   ↳ `groupId` | number | Monitor group ID \(0 if ungrouped\) |
-|   ↳ `createDateTime` | string | When the monitor was created |
+|   ↳ `checkSSLErrors` | boolean (nullable) | Whether SSL/domain expiration errors are checked |
+|   ↳ `followRedirections` | boolean (nullable) | Whether redirects are followed |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
+|   ↳ `domainExpirationReminder` | boolean (nullable) | Whether domain expiration reminders are enabled |
+|   ↳ `responseTimeThreshold` | number (nullable) | Response time threshold in milliseconds |
+|   ↳ `currentStateDuration` | number (nullable) | Seconds spent in the current state |
+|   ↳ `lastIncidentId` | string (nullable) | ID of the most recent incident |
+|   ↳ `groupId` | number (nullable) | Monitor group ID \(0 if ungrouped\) |
+|   ↳ `createDateTime` | string (nullable) | When the monitor was created |
 |   ↳ `tags` | array | Tags assigned to the monitor |
 |     ↳ `id` | number | Tag ID |
 |     ↳ `name` | string | Tag name |
-|     ↳ `color` | string | Tag color |
+|     ↳ `color` | string (nullable) | Tag color |
 |   ↳ `assignedAlertContacts` | array | Alert contacts assigned to the monitor |
 |     ↳ `alertContactId` | number | Alert contact ID |
 |     ↳ `threshold` | number | Notification delay threshold in minutes |
 |     ↳ `recurrence` | number | Repeat notification interval in minutes |
-|   ↳ `lastIncident` | object | Details of the most recent incident |
+|   ↳ `lastIncident` | object (nullable) | Details of the most recent incident |
 |     ↳ `id` | string | Incident ID |
-|     ↳ `status` | string | Incident status |
-|     ↳ `cause` | number | Incident cause code |
-|     ↳ `reason` | string | Incident reason |
-|     ↳ `startedAt` | string | When the incident started |
-|     ↳ `duration` | number | Incident duration in seconds |
+|     ↳ `status` | string (nullable) | Incident status |
+|     ↳ `cause` | number (nullable) | Incident cause code |
+|     ↳ `reason` | string (nullable) | Incident reason |
+|     ↳ `startedAt` | string (nullable) | When the incident started |
+|     ↳ `duration` | number (nullable) | Incident duration in seconds |
 
 ### UptimeRobot Create Monitor
 
@@ -189,41 +189,41 @@ Create a new monitor in UptimeRobot
 | `monitor` | object | The created monitor |
 |   ↳ `id` | number | Monitor ID |
 |   ↳ `friendlyName` | string | Friendly name of the monitor |
-|   ↳ `url` | string | Monitored URL or host |
-|   ↳ `type` | string | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
-|   ↳ `status` | string | Current status \(UP, DOWN, PAUSED, etc.\) |
-|   ↳ `interval` | number | Check interval in seconds |
-|   ↳ `timeout` | number | Check timeout in seconds |
-|   ↳ `port` | number | Port for Port/UDP monitors |
-|   ↳ `keywordType` | string | Keyword match type for Keyword monitors |
-|   ↳ `keywordValue` | string | Keyword to match for Keyword monitors |
-|   ↳ `httpMethodType` | string | HTTP method used for the check |
-|   ↳ `authType` | string | HTTP authentication method |
+|   ↳ `url` | string (nullable) | Monitored URL or host |
+|   ↳ `type` | string (nullable) | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
+|   ↳ `status` | string (nullable) | Current status \(UP, DOWN, PAUSED, etc.\) |
+|   ↳ `interval` | number (nullable) | Check interval in seconds |
+|   ↳ `timeout` | number (nullable) | Check timeout in seconds |
+|   ↳ `port` | number (nullable) | Port for Port/UDP monitors |
+|   ↳ `keywordType` | string (nullable) | Keyword match type for Keyword monitors |
+|   ↳ `keywordValue` | string (nullable) | Keyword to match for Keyword monitors |
+|   ↳ `httpMethodType` | string (nullable) | HTTP method used for the check |
+|   ↳ `authType` | string (nullable) | HTTP authentication method |
 |   ↳ `successHttpResponseCodes` | array | HTTP response codes treated as success |
-|   ↳ `checkSSLErrors` | boolean | Whether SSL/domain expiration errors are checked |
-|   ↳ `followRedirections` | boolean | Whether redirects are followed |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
-|   ↳ `domainExpirationReminder` | boolean | Whether domain expiration reminders are enabled |
-|   ↳ `responseTimeThreshold` | number | Response time threshold in milliseconds |
-|   ↳ `currentStateDuration` | number | Seconds spent in the current state |
-|   ↳ `lastIncidentId` | string | ID of the most recent incident |
-|   ↳ `groupId` | number | Monitor group ID \(0 if ungrouped\) |
-|   ↳ `createDateTime` | string | When the monitor was created |
+|   ↳ `checkSSLErrors` | boolean (nullable) | Whether SSL/domain expiration errors are checked |
+|   ↳ `followRedirections` | boolean (nullable) | Whether redirects are followed |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
+|   ↳ `domainExpirationReminder` | boolean (nullable) | Whether domain expiration reminders are enabled |
+|   ↳ `responseTimeThreshold` | number (nullable) | Response time threshold in milliseconds |
+|   ↳ `currentStateDuration` | number (nullable) | Seconds spent in the current state |
+|   ↳ `lastIncidentId` | string (nullable) | ID of the most recent incident |
+|   ↳ `groupId` | number (nullable) | Monitor group ID \(0 if ungrouped\) |
+|   ↳ `createDateTime` | string (nullable) | When the monitor was created |
 |   ↳ `tags` | array | Tags assigned to the monitor |
 |     ↳ `id` | number | Tag ID |
 |     ↳ `name` | string | Tag name |
-|     ↳ `color` | string | Tag color |
+|     ↳ `color` | string (nullable) | Tag color |
 |   ↳ `assignedAlertContacts` | array | Alert contacts assigned to the monitor |
 |     ↳ `alertContactId` | number | Alert contact ID |
 |     ↳ `threshold` | number | Notification delay threshold in minutes |
 |     ↳ `recurrence` | number | Repeat notification interval in minutes |
-|   ↳ `lastIncident` | object | Details of the most recent incident |
+|   ↳ `lastIncident` | object (nullable) | Details of the most recent incident |
 |     ↳ `id` | string | Incident ID |
-|     ↳ `status` | string | Incident status |
-|     ↳ `cause` | number | Incident cause code |
-|     ↳ `reason` | string | Incident reason |
-|     ↳ `startedAt` | string | When the incident started |
-|     ↳ `duration` | number | Incident duration in seconds |
+|     ↳ `status` | string (nullable) | Incident status |
+|     ↳ `cause` | number (nullable) | Incident cause code |
+|     ↳ `reason` | string (nullable) | Incident reason |
+|     ↳ `startedAt` | string (nullable) | When the incident started |
+|     ↳ `duration` | number (nullable) | Incident duration in seconds |
 
 ### UptimeRobot Update Monitor
 
@@ -264,41 +264,41 @@ Update an existing UptimeRobot monitor. Only the provided fields are changed.
 | `monitor` | object | The updated monitor |
 |   ↳ `id` | number | Monitor ID |
 |   ↳ `friendlyName` | string | Friendly name of the monitor |
-|   ↳ `url` | string | Monitored URL or host |
-|   ↳ `type` | string | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
-|   ↳ `status` | string | Current status \(UP, DOWN, PAUSED, etc.\) |
-|   ↳ `interval` | number | Check interval in seconds |
-|   ↳ `timeout` | number | Check timeout in seconds |
-|   ↳ `port` | number | Port for Port/UDP monitors |
-|   ↳ `keywordType` | string | Keyword match type for Keyword monitors |
-|   ↳ `keywordValue` | string | Keyword to match for Keyword monitors |
-|   ↳ `httpMethodType` | string | HTTP method used for the check |
-|   ↳ `authType` | string | HTTP authentication method |
+|   ↳ `url` | string (nullable) | Monitored URL or host |
+|   ↳ `type` | string (nullable) | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
+|   ↳ `status` | string (nullable) | Current status \(UP, DOWN, PAUSED, etc.\) |
+|   ↳ `interval` | number (nullable) | Check interval in seconds |
+|   ↳ `timeout` | number (nullable) | Check timeout in seconds |
+|   ↳ `port` | number (nullable) | Port for Port/UDP monitors |
+|   ↳ `keywordType` | string (nullable) | Keyword match type for Keyword monitors |
+|   ↳ `keywordValue` | string (nullable) | Keyword to match for Keyword monitors |
+|   ↳ `httpMethodType` | string (nullable) | HTTP method used for the check |
+|   ↳ `authType` | string (nullable) | HTTP authentication method |
 |   ↳ `successHttpResponseCodes` | array | HTTP response codes treated as success |
-|   ↳ `checkSSLErrors` | boolean | Whether SSL/domain expiration errors are checked |
-|   ↳ `followRedirections` | boolean | Whether redirects are followed |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
-|   ↳ `domainExpirationReminder` | boolean | Whether domain expiration reminders are enabled |
-|   ↳ `responseTimeThreshold` | number | Response time threshold in milliseconds |
-|   ↳ `currentStateDuration` | number | Seconds spent in the current state |
-|   ↳ `lastIncidentId` | string | ID of the most recent incident |
-|   ↳ `groupId` | number | Monitor group ID \(0 if ungrouped\) |
-|   ↳ `createDateTime` | string | When the monitor was created |
+|   ↳ `checkSSLErrors` | boolean (nullable) | Whether SSL/domain expiration errors are checked |
+|   ↳ `followRedirections` | boolean (nullable) | Whether redirects are followed |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
+|   ↳ `domainExpirationReminder` | boolean (nullable) | Whether domain expiration reminders are enabled |
+|   ↳ `responseTimeThreshold` | number (nullable) | Response time threshold in milliseconds |
+|   ↳ `currentStateDuration` | number (nullable) | Seconds spent in the current state |
+|   ↳ `lastIncidentId` | string (nullable) | ID of the most recent incident |
+|   ↳ `groupId` | number (nullable) | Monitor group ID \(0 if ungrouped\) |
+|   ↳ `createDateTime` | string (nullable) | When the monitor was created |
 |   ↳ `tags` | array | Tags assigned to the monitor |
 |     ↳ `id` | number | Tag ID |
 |     ↳ `name` | string | Tag name |
-|     ↳ `color` | string | Tag color |
+|     ↳ `color` | string (nullable) | Tag color |
 |   ↳ `assignedAlertContacts` | array | Alert contacts assigned to the monitor |
 |     ↳ `alertContactId` | number | Alert contact ID |
 |     ↳ `threshold` | number | Notification delay threshold in minutes |
 |     ↳ `recurrence` | number | Repeat notification interval in minutes |
-|   ↳ `lastIncident` | object | Details of the most recent incident |
+|   ↳ `lastIncident` | object (nullable) | Details of the most recent incident |
 |     ↳ `id` | string | Incident ID |
-|     ↳ `status` | string | Incident status |
-|     ↳ `cause` | number | Incident cause code |
-|     ↳ `reason` | string | Incident reason |
-|     ↳ `startedAt` | string | When the incident started |
-|     ↳ `duration` | number | Incident duration in seconds |
+|     ↳ `status` | string (nullable) | Incident status |
+|     ↳ `cause` | number (nullable) | Incident cause code |
+|     ↳ `reason` | string (nullable) | Incident reason |
+|     ↳ `startedAt` | string (nullable) | When the incident started |
+|     ↳ `duration` | number (nullable) | Incident duration in seconds |
 
 ### UptimeRobot Delete Monitor
 
@@ -336,41 +336,41 @@ Pause an UptimeRobot monitor so it stops running checks
 | `monitor` | object | The paused monitor |
 |   ↳ `id` | number | Monitor ID |
 |   ↳ `friendlyName` | string | Friendly name of the monitor |
-|   ↳ `url` | string | Monitored URL or host |
-|   ↳ `type` | string | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
-|   ↳ `status` | string | Current status \(UP, DOWN, PAUSED, etc.\) |
-|   ↳ `interval` | number | Check interval in seconds |
-|   ↳ `timeout` | number | Check timeout in seconds |
-|   ↳ `port` | number | Port for Port/UDP monitors |
-|   ↳ `keywordType` | string | Keyword match type for Keyword monitors |
-|   ↳ `keywordValue` | string | Keyword to match for Keyword monitors |
-|   ↳ `httpMethodType` | string | HTTP method used for the check |
-|   ↳ `authType` | string | HTTP authentication method |
+|   ↳ `url` | string (nullable) | Monitored URL or host |
+|   ↳ `type` | string (nullable) | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
+|   ↳ `status` | string (nullable) | Current status \(UP, DOWN, PAUSED, etc.\) |
+|   ↳ `interval` | number (nullable) | Check interval in seconds |
+|   ↳ `timeout` | number (nullable) | Check timeout in seconds |
+|   ↳ `port` | number (nullable) | Port for Port/UDP monitors |
+|   ↳ `keywordType` | string (nullable) | Keyword match type for Keyword monitors |
+|   ↳ `keywordValue` | string (nullable) | Keyword to match for Keyword monitors |
+|   ↳ `httpMethodType` | string (nullable) | HTTP method used for the check |
+|   ↳ `authType` | string (nullable) | HTTP authentication method |
 |   ↳ `successHttpResponseCodes` | array | HTTP response codes treated as success |
-|   ↳ `checkSSLErrors` | boolean | Whether SSL/domain expiration errors are checked |
-|   ↳ `followRedirections` | boolean | Whether redirects are followed |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
-|   ↳ `domainExpirationReminder` | boolean | Whether domain expiration reminders are enabled |
-|   ↳ `responseTimeThreshold` | number | Response time threshold in milliseconds |
-|   ↳ `currentStateDuration` | number | Seconds spent in the current state |
-|   ↳ `lastIncidentId` | string | ID of the most recent incident |
-|   ↳ `groupId` | number | Monitor group ID \(0 if ungrouped\) |
-|   ↳ `createDateTime` | string | When the monitor was created |
+|   ↳ `checkSSLErrors` | boolean (nullable) | Whether SSL/domain expiration errors are checked |
+|   ↳ `followRedirections` | boolean (nullable) | Whether redirects are followed |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
+|   ↳ `domainExpirationReminder` | boolean (nullable) | Whether domain expiration reminders are enabled |
+|   ↳ `responseTimeThreshold` | number (nullable) | Response time threshold in milliseconds |
+|   ↳ `currentStateDuration` | number (nullable) | Seconds spent in the current state |
+|   ↳ `lastIncidentId` | string (nullable) | ID of the most recent incident |
+|   ↳ `groupId` | number (nullable) | Monitor group ID \(0 if ungrouped\) |
+|   ↳ `createDateTime` | string (nullable) | When the monitor was created |
 |   ↳ `tags` | array | Tags assigned to the monitor |
 |     ↳ `id` | number | Tag ID |
 |     ↳ `name` | string | Tag name |
-|     ↳ `color` | string | Tag color |
+|     ↳ `color` | string (nullable) | Tag color |
 |   ↳ `assignedAlertContacts` | array | Alert contacts assigned to the monitor |
 |     ↳ `alertContactId` | number | Alert contact ID |
 |     ↳ `threshold` | number | Notification delay threshold in minutes |
 |     ↳ `recurrence` | number | Repeat notification interval in minutes |
-|   ↳ `lastIncident` | object | Details of the most recent incident |
+|   ↳ `lastIncident` | object (nullable) | Details of the most recent incident |
 |     ↳ `id` | string | Incident ID |
-|     ↳ `status` | string | Incident status |
-|     ↳ `cause` | number | Incident cause code |
-|     ↳ `reason` | string | Incident reason |
-|     ↳ `startedAt` | string | When the incident started |
-|     ↳ `duration` | number | Incident duration in seconds |
+|     ↳ `status` | string (nullable) | Incident status |
+|     ↳ `cause` | number (nullable) | Incident cause code |
+|     ↳ `reason` | string (nullable) | Incident reason |
+|     ↳ `startedAt` | string (nullable) | When the incident started |
+|     ↳ `duration` | number (nullable) | Incident duration in seconds |
 
 ### UptimeRobot Start Monitor
 
@@ -390,41 +390,41 @@ Resume a paused UptimeRobot monitor so it starts running checks again
 | `monitor` | object | The started monitor |
 |   ↳ `id` | number | Monitor ID |
 |   ↳ `friendlyName` | string | Friendly name of the monitor |
-|   ↳ `url` | string | Monitored URL or host |
-|   ↳ `type` | string | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
-|   ↳ `status` | string | Current status \(UP, DOWN, PAUSED, etc.\) |
-|   ↳ `interval` | number | Check interval in seconds |
-|   ↳ `timeout` | number | Check timeout in seconds |
-|   ↳ `port` | number | Port for Port/UDP monitors |
-|   ↳ `keywordType` | string | Keyword match type for Keyword monitors |
-|   ↳ `keywordValue` | string | Keyword to match for Keyword monitors |
-|   ↳ `httpMethodType` | string | HTTP method used for the check |
-|   ↳ `authType` | string | HTTP authentication method |
+|   ↳ `url` | string (nullable) | Monitored URL or host |
+|   ↳ `type` | string (nullable) | Monitor type \(HTTP, KEYWORD, PING, PORT, HEARTBEAT, DNS, API, UDP\) |
+|   ↳ `status` | string (nullable) | Current status \(UP, DOWN, PAUSED, etc.\) |
+|   ↳ `interval` | number (nullable) | Check interval in seconds |
+|   ↳ `timeout` | number (nullable) | Check timeout in seconds |
+|   ↳ `port` | number (nullable) | Port for Port/UDP monitors |
+|   ↳ `keywordType` | string (nullable) | Keyword match type for Keyword monitors |
+|   ↳ `keywordValue` | string (nullable) | Keyword to match for Keyword monitors |
+|   ↳ `httpMethodType` | string (nullable) | HTTP method used for the check |
+|   ↳ `authType` | string (nullable) | HTTP authentication method |
 |   ↳ `successHttpResponseCodes` | array | HTTP response codes treated as success |
-|   ↳ `checkSSLErrors` | boolean | Whether SSL/domain expiration errors are checked |
-|   ↳ `followRedirections` | boolean | Whether redirects are followed |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
-|   ↳ `domainExpirationReminder` | boolean | Whether domain expiration reminders are enabled |
-|   ↳ `responseTimeThreshold` | number | Response time threshold in milliseconds |
-|   ↳ `currentStateDuration` | number | Seconds spent in the current state |
-|   ↳ `lastIncidentId` | string | ID of the most recent incident |
-|   ↳ `groupId` | number | Monitor group ID \(0 if ungrouped\) |
-|   ↳ `createDateTime` | string | When the monitor was created |
+|   ↳ `checkSSLErrors` | boolean (nullable) | Whether SSL/domain expiration errors are checked |
+|   ↳ `followRedirections` | boolean (nullable) | Whether redirects are followed |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
+|   ↳ `domainExpirationReminder` | boolean (nullable) | Whether domain expiration reminders are enabled |
+|   ↳ `responseTimeThreshold` | number (nullable) | Response time threshold in milliseconds |
+|   ↳ `currentStateDuration` | number (nullable) | Seconds spent in the current state |
+|   ↳ `lastIncidentId` | string (nullable) | ID of the most recent incident |
+|   ↳ `groupId` | number (nullable) | Monitor group ID \(0 if ungrouped\) |
+|   ↳ `createDateTime` | string (nullable) | When the monitor was created |
 |   ↳ `tags` | array | Tags assigned to the monitor |
 |     ↳ `id` | number | Tag ID |
 |     ↳ `name` | string | Tag name |
-|     ↳ `color` | string | Tag color |
+|     ↳ `color` | string (nullable) | Tag color |
 |   ↳ `assignedAlertContacts` | array | Alert contacts assigned to the monitor |
 |     ↳ `alertContactId` | number | Alert contact ID |
 |     ↳ `threshold` | number | Notification delay threshold in minutes |
 |     ↳ `recurrence` | number | Repeat notification interval in minutes |
-|   ↳ `lastIncident` | object | Details of the most recent incident |
+|   ↳ `lastIncident` | object (nullable) | Details of the most recent incident |
 |     ↳ `id` | string | Incident ID |
-|     ↳ `status` | string | Incident status |
-|     ↳ `cause` | number | Incident cause code |
-|     ↳ `reason` | string | Incident reason |
-|     ↳ `startedAt` | string | When the incident started |
-|     ↳ `duration` | number | Incident duration in seconds |
+|     ↳ `status` | string (nullable) | Incident status |
+|     ↳ `cause` | number (nullable) | Incident cause code |
+|     ↳ `reason` | string (nullable) | Incident reason |
+|     ↳ `startedAt` | string (nullable) | When the incident started |
+|     ↳ `duration` | number (nullable) | Incident duration in seconds |
 
 ### UptimeRobot List Incidents
 
@@ -447,17 +447,17 @@ List incidents across your UptimeRobot account (last 24 hours by default), with 
 | --------- | ---- | ----------- |
 | `incidents` | array | List of incidents |
 |   ↳ `id` | string | Incident ID |
-|   ↳ `status` | string | Incident status |
-|   ↳ `type` | string | Incident type |
-|   ↳ `cause` | number | Incident cause code |
-|   ↳ `reason` | string | Incident reason |
-|   ↳ `monitorId` | number | Affected monitor ID |
-|   ↳ `monitorName` | string | Affected monitor name |
-|   ↳ `commentsCount` | number | Number of comments |
-|   ↳ `startedAt` | string | When the incident started |
-|   ↳ `resolvedAt` | string | When the incident resolved |
-|   ↳ `duration` | number | Incident duration in seconds |
-|   ↳ `includeInReports` | boolean | Whether the incident is included in reports |
+|   ↳ `status` | string (nullable) | Incident status |
+|   ↳ `type` | string (nullable) | Incident type |
+|   ↳ `cause` | number (nullable) | Incident cause code |
+|   ↳ `reason` | string (nullable) | Incident reason |
+|   ↳ `monitorId` | number (nullable) | Affected monitor ID |
+|   ↳ `monitorName` | string (nullable) | Affected monitor name |
+|   ↳ `commentsCount` | number (nullable) | Number of comments |
+|   ↳ `startedAt` | string (nullable) | When the incident started |
+|   ↳ `resolvedAt` | string (nullable) | When the incident resolved |
+|   ↳ `duration` | number (nullable) | Incident duration in seconds |
+|   ↳ `includeInReports` | boolean (nullable) | Whether the incident is included in reports |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
 ### UptimeRobot Get Incident
@@ -477,16 +477,16 @@ Get the details of a single UptimeRobot incident by ID
 | --------- | ---- | ----------- |
 | `incident` | object | The incident details |
 |   ↳ `id` | string | Incident ID |
-|   ↳ `status` | string | Incident status |
-|   ↳ `cause` | number | Incident cause code |
-|   ↳ `reason` | string | Incident reason |
-|   ↳ `duration` | number | Incident duration in seconds |
-|   ↳ `startedAt` | string | When the incident started |
-|   ↳ `resolvedAt` | string | When the incident resolved |
-|   ↳ `rootCause` | object | Root cause details for the incident |
-|     ↳ `url` | string | Checked URL |
-|     ↳ `httpResponseCode` | number | HTTP response code observed |
-|     ↳ `responseDownloadUrl` | string | URL to download the captured response body |
+|   ↳ `status` | string (nullable) | Incident status |
+|   ↳ `cause` | number (nullable) | Incident cause code |
+|   ↳ `reason` | string (nullable) | Incident reason |
+|   ↳ `duration` | number (nullable) | Incident duration in seconds |
+|   ↳ `startedAt` | string (nullable) | When the incident started |
+|   ↳ `resolvedAt` | string (nullable) | When the incident resolved |
+|   ↳ `rootCause` | object (nullable) | Root cause details for the incident |
+|     ↳ `url` | string (nullable) | Checked URL |
+|     ↳ `httpResponseCode` | number (nullable) | HTTP response code observed |
+|     ↳ `responseDownloadUrl` | string (nullable) | URL to download the captured response body |
 
 ### UptimeRobot List Maintenance Windows
 
@@ -505,17 +505,17 @@ List maintenance windows in your UptimeRobot account
 | --------- | ---- | ----------- |
 | `maintenanceWindows` | array | List of maintenance windows |
 |   ↳ `id` | number | Maintenance window ID |
-|   ↳ `userId` | number | Owner user ID |
+|   ↳ `userId` | number (nullable) | Owner user ID |
 |   ↳ `name` | string | Maintenance window name |
-|   ↳ `interval` | string | Recurrence interval \(once, daily, weekly, monthly\) |
-|   ↳ `date` | string | Start date \(YYYY-MM-DD\) |
-|   ↳ `time` | string | Start time \(HH:mm:ss\) |
-|   ↳ `duration` | number | Duration in minutes |
-|   ↳ `autoAddMonitors` | boolean | Whether all monitors are auto-added |
+|   ↳ `interval` | string (nullable) | Recurrence interval \(once, daily, weekly, monthly\) |
+|   ↳ `date` | string (nullable) | Start date \(YYYY-MM-DD\) |
+|   ↳ `time` | string (nullable) | Start time \(HH:mm:ss\) |
+|   ↳ `duration` | number (nullable) | Duration in minutes |
+|   ↳ `autoAddMonitors` | boolean (nullable) | Whether all monitors are auto-added |
 |   ↳ `monitorIds` | array | Assigned monitor IDs |
 |   ↳ `days` | array | Days for weekly/monthly recurrence |
-|   ↳ `status` | string | Status \(active or paused\) |
-|   ↳ `created` | string | When the maintenance window was created |
+|   ↳ `status` | string (nullable) | Status \(active or paused\) |
+|   ↳ `created` | string (nullable) | When the maintenance window was created |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
 ### UptimeRobot Get Maintenance Window
@@ -535,17 +535,17 @@ Get the details of a single UptimeRobot maintenance window by ID
 | --------- | ---- | ----------- |
 | `maintenanceWindow` | object | The maintenance window details |
 |   ↳ `id` | number | Maintenance window ID |
-|   ↳ `userId` | number | Owner user ID |
+|   ↳ `userId` | number (nullable) | Owner user ID |
 |   ↳ `name` | string | Maintenance window name |
-|   ↳ `interval` | string | Recurrence interval \(once, daily, weekly, monthly\) |
-|   ↳ `date` | string | Start date \(YYYY-MM-DD\) |
-|   ↳ `time` | string | Start time \(HH:mm:ss\) |
-|   ↳ `duration` | number | Duration in minutes |
-|   ↳ `autoAddMonitors` | boolean | Whether all monitors are auto-added |
+|   ↳ `interval` | string (nullable) | Recurrence interval \(once, daily, weekly, monthly\) |
+|   ↳ `date` | string (nullable) | Start date \(YYYY-MM-DD\) |
+|   ↳ `time` | string (nullable) | Start time \(HH:mm:ss\) |
+|   ↳ `duration` | number (nullable) | Duration in minutes |
+|   ↳ `autoAddMonitors` | boolean (nullable) | Whether all monitors are auto-added |
 |   ↳ `monitorIds` | array | Assigned monitor IDs |
 |   ↳ `days` | array | Days for weekly/monthly recurrence |
-|   ↳ `status` | string | Status \(active or paused\) |
-|   ↳ `created` | string | When the maintenance window was created |
+|   ↳ `status` | string (nullable) | Status \(active or paused\) |
+|   ↳ `created` | string (nullable) | When the maintenance window was created |
 
 ### UptimeRobot Create Maintenance Window
 
@@ -571,17 +571,17 @@ Create a new maintenance window to suppress alerts during planned downtime
 | --------- | ---- | ----------- |
 | `maintenanceWindow` | object | The created maintenance window |
 |   ↳ `id` | number | Maintenance window ID |
-|   ↳ `userId` | number | Owner user ID |
+|   ↳ `userId` | number (nullable) | Owner user ID |
 |   ↳ `name` | string | Maintenance window name |
-|   ↳ `interval` | string | Recurrence interval \(once, daily, weekly, monthly\) |
-|   ↳ `date` | string | Start date \(YYYY-MM-DD\) |
-|   ↳ `time` | string | Start time \(HH:mm:ss\) |
-|   ↳ `duration` | number | Duration in minutes |
-|   ↳ `autoAddMonitors` | boolean | Whether all monitors are auto-added |
+|   ↳ `interval` | string (nullable) | Recurrence interval \(once, daily, weekly, monthly\) |
+|   ↳ `date` | string (nullable) | Start date \(YYYY-MM-DD\) |
+|   ↳ `time` | string (nullable) | Start time \(HH:mm:ss\) |
+|   ↳ `duration` | number (nullable) | Duration in minutes |
+|   ↳ `autoAddMonitors` | boolean (nullable) | Whether all monitors are auto-added |
 |   ↳ `monitorIds` | array | Assigned monitor IDs |
 |   ↳ `days` | array | Days for weekly/monthly recurrence |
-|   ↳ `status` | string | Status \(active or paused\) |
-|   ↳ `created` | string | When the maintenance window was created |
+|   ↳ `status` | string (nullable) | Status \(active or paused\) |
+|   ↳ `created` | string (nullable) | When the maintenance window was created |
 
 ### UptimeRobot Update Maintenance Window
 
@@ -608,17 +608,17 @@ Update an existing maintenance window. Only the provided fields are changed.
 | --------- | ---- | ----------- |
 | `maintenanceWindow` | object | The updated maintenance window |
 |   ↳ `id` | number | Maintenance window ID |
-|   ↳ `userId` | number | Owner user ID |
+|   ↳ `userId` | number (nullable) | Owner user ID |
 |   ↳ `name` | string | Maintenance window name |
-|   ↳ `interval` | string | Recurrence interval \(once, daily, weekly, monthly\) |
-|   ↳ `date` | string | Start date \(YYYY-MM-DD\) |
-|   ↳ `time` | string | Start time \(HH:mm:ss\) |
-|   ↳ `duration` | number | Duration in minutes |
-|   ↳ `autoAddMonitors` | boolean | Whether all monitors are auto-added |
+|   ↳ `interval` | string (nullable) | Recurrence interval \(once, daily, weekly, monthly\) |
+|   ↳ `date` | string (nullable) | Start date \(YYYY-MM-DD\) |
+|   ↳ `time` | string (nullable) | Start time \(HH:mm:ss\) |
+|   ↳ `duration` | number (nullable) | Duration in minutes |
+|   ↳ `autoAddMonitors` | boolean (nullable) | Whether all monitors are auto-added |
 |   ↳ `monitorIds` | array | Assigned monitor IDs |
 |   ↳ `days` | array | Days for weekly/monthly recurrence |
-|   ↳ `status` | string | Status \(active or paused\) |
-|   ↳ `created` | string | When the maintenance window was created |
+|   ↳ `status` | string (nullable) | Status \(active or paused\) |
+|   ↳ `created` | string (nullable) | When the maintenance window was created |
 
 ### UptimeRobot Delete Maintenance Window
 
@@ -655,13 +655,13 @@ List the personal alert contacts in your UptimeRobot account
 | --------- | ---- | ----------- |
 | `alertContacts` | array | List of alert contacts |
 |   ↳ `id` | number | Alert contact ID |
-|   ↳ `friendlyName` | string | Display name |
-|   ↳ `type` | string | Alert contact type |
-|   ↳ `value` | string | Contact value \(e.g. email address\) |
-|   ↳ `customValue` | string | Custom value for webhook-style contacts |
-|   ↳ `status` | string | Activation status |
-|   ↳ `enableNotificationsFor` | string | Which monitor events trigger notifications |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
+|   ↳ `friendlyName` | string (nullable) | Display name |
+|   ↳ `type` | string (nullable) | Alert contact type |
+|   ↳ `value` | string (nullable) | Contact value \(e.g. email address\) |
+|   ↳ `customValue` | string (nullable) | Custom value for webhook-style contacts |
+|   ↳ `status` | string (nullable) | Activation status |
+|   ↳ `enableNotificationsFor` | string (nullable) | Which monitor events trigger notifications |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
 ### UptimeRobot Get Alert Contact
@@ -681,13 +681,13 @@ Get the details of a single UptimeRobot alert contact by ID
 | --------- | ---- | ----------- |
 | `alertContact` | object | The alert contact details |
 |   ↳ `id` | number | Alert contact ID |
-|   ↳ `friendlyName` | string | Display name |
-|   ↳ `type` | string | Alert contact type |
-|   ↳ `value` | string | Contact value \(e.g. email address\) |
-|   ↳ `customValue` | string | Custom value for webhook-style contacts |
-|   ↳ `status` | string | Activation status |
-|   ↳ `enableNotificationsFor` | string | Which monitor events trigger notifications |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
+|   ↳ `friendlyName` | string (nullable) | Display name |
+|   ↳ `type` | string (nullable) | Alert contact type |
+|   ↳ `value` | string (nullable) | Contact value \(e.g. email address\) |
+|   ↳ `customValue` | string (nullable) | Custom value for webhook-style contacts |
+|   ↳ `status` | string (nullable) | Activation status |
+|   ↳ `enableNotificationsFor` | string (nullable) | Which monitor events trigger notifications |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
 
 ### UptimeRobot Create Alert Contact
 
@@ -708,13 +708,13 @@ Create an email alert contact in UptimeRobot. The contact must be confirmed via 
 | --------- | ---- | ----------- |
 | `alertContact` | object | The created alert contact |
 |   ↳ `id` | number | Alert contact ID |
-|   ↳ `friendlyName` | string | Display name |
-|   ↳ `type` | string | Alert contact type |
-|   ↳ `value` | string | Contact value \(e.g. email address\) |
-|   ↳ `customValue` | string | Custom value for webhook-style contacts |
-|   ↳ `status` | string | Activation status |
-|   ↳ `enableNotificationsFor` | string | Which monitor events trigger notifications |
-|   ↳ `sslExpirationReminder` | boolean | Whether SSL expiration reminders are enabled |
+|   ↳ `friendlyName` | string (nullable) | Display name |
+|   ↳ `type` | string (nullable) | Alert contact type |
+|   ↳ `value` | string (nullable) | Contact value \(e.g. email address\) |
+|   ↳ `customValue` | string (nullable) | Custom value for webhook-style contacts |
+|   ↳ `status` | string (nullable) | Activation status |
+|   ↳ `enableNotificationsFor` | string (nullable) | Which monitor events trigger notifications |
+|   ↳ `sslExpirationReminder` | boolean (nullable) | Whether SSL expiration reminders are enabled |
 
 ### UptimeRobot Delete Alert Contact
 
@@ -752,20 +752,20 @@ List the public status pages in your UptimeRobot account
 | `psps` | array | List of public status pages |
 |   ↳ `id` | number | Public status page ID |
 |   ↳ `friendlyName` | string | Status page name |
-|   ↳ `customDomain` | string | Custom domain |
-|   ↳ `isPasswordSet` | boolean | Whether the page is password protected |
+|   ↳ `customDomain` | string (nullable) | Custom domain |
+|   ↳ `isPasswordSet` | boolean (nullable) | Whether the page is password protected |
 |   ↳ `monitorIds` | array | Monitor IDs shown on the page |
 |   ↳ `tagIds` | array | Tag IDs shown on the page |
-|   ↳ `monitorsCount` | number | Number of monitors on the page |
-|   ↳ `status` | string | Status \(ENABLED or PAUSED\) |
-|   ↳ `urlKey` | string | Public URL key |
-|   ↳ `homepageLink` | string | Homepage link target |
-|   ↳ `gaCode` | string | Google Analytics code |
-|   ↳ `icon` | string | Icon URL |
-|   ↳ `logo` | string | Logo URL |
-|   ↳ `noIndex` | boolean | Whether search engine indexing is disabled |
-|   ↳ `hideUrlLinks` | boolean | Whether the "Powered by" footer link is hidden |
-|   ↳ `subscription` | boolean | Whether the subscribe feature is enabled |
+|   ↳ `monitorsCount` | number (nullable) | Number of monitors on the page |
+|   ↳ `status` | string (nullable) | Status \(ENABLED or PAUSED\) |
+|   ↳ `urlKey` | string (nullable) | Public URL key |
+|   ↳ `homepageLink` | string (nullable) | Homepage link target |
+|   ↳ `gaCode` | string (nullable) | Google Analytics code |
+|   ↳ `icon` | string (nullable) | Icon URL |
+|   ↳ `logo` | string (nullable) | Logo URL |
+|   ↳ `noIndex` | boolean (nullable) | Whether search engine indexing is disabled |
+|   ↳ `hideUrlLinks` | boolean (nullable) | Whether the "Powered by" footer link is hidden |
+|   ↳ `subscription` | boolean (nullable) | Whether the subscribe feature is enabled |
 | `nextLink` | string | URL for the next page of results, or null on the last page |
 
 ### UptimeRobot Get Status Page
@@ -786,20 +786,20 @@ Get the details of a single UptimeRobot public status page by ID
 | `psp` | object | The status page details |
 |   ↳ `id` | number | Public status page ID |
 |   ↳ `friendlyName` | string | Status page name |
-|   ↳ `customDomain` | string | Custom domain |
-|   ↳ `isPasswordSet` | boolean | Whether the page is password protected |
+|   ↳ `customDomain` | string (nullable) | Custom domain |
+|   ↳ `isPasswordSet` | boolean (nullable) | Whether the page is password protected |
 |   ↳ `monitorIds` | array | Monitor IDs shown on the page |
 |   ↳ `tagIds` | array | Tag IDs shown on the page |
-|   ↳ `monitorsCount` | number | Number of monitors on the page |
-|   ↳ `status` | string | Status \(ENABLED or PAUSED\) |
-|   ↳ `urlKey` | string | Public URL key |
-|   ↳ `homepageLink` | string | Homepage link target |
-|   ↳ `gaCode` | string | Google Analytics code |
-|   ↳ `icon` | string | Icon URL |
-|   ↳ `logo` | string | Logo URL |
-|   ↳ `noIndex` | boolean | Whether search engine indexing is disabled |
-|   ↳ `hideUrlLinks` | boolean | Whether the "Powered by" footer link is hidden |
-|   ↳ `subscription` | boolean | Whether the subscribe feature is enabled |
+|   ↳ `monitorsCount` | number (nullable) | Number of monitors on the page |
+|   ↳ `status` | string (nullable) | Status \(ENABLED or PAUSED\) |
+|   ↳ `urlKey` | string (nullable) | Public URL key |
+|   ↳ `homepageLink` | string (nullable) | Homepage link target |
+|   ↳ `gaCode` | string (nullable) | Google Analytics code |
+|   ↳ `icon` | string (nullable) | Icon URL |
+|   ↳ `logo` | string (nullable) | Logo URL |
+|   ↳ `noIndex` | boolean (nullable) | Whether search engine indexing is disabled |
+|   ↳ `hideUrlLinks` | boolean (nullable) | Whether the "Powered by" footer link is hidden |
+|   ↳ `subscription` | boolean (nullable) | Whether the subscribe feature is enabled |
 
 ### UptimeRobot Create Status Page
 
@@ -827,20 +827,20 @@ Create a public status page in UptimeRobot, optionally with a logo and icon imag
 | `psp` | object | The created status page |
 |   ↳ `id` | number | Public status page ID |
 |   ↳ `friendlyName` | string | Status page name |
-|   ↳ `customDomain` | string | Custom domain |
-|   ↳ `isPasswordSet` | boolean | Whether the page is password protected |
+|   ↳ `customDomain` | string (nullable) | Custom domain |
+|   ↳ `isPasswordSet` | boolean (nullable) | Whether the page is password protected |
 |   ↳ `monitorIds` | array | Monitor IDs shown on the page |
 |   ↳ `tagIds` | array | Tag IDs shown on the page |
-|   ↳ `monitorsCount` | number | Number of monitors on the page |
-|   ↳ `status` | string | Status \(ENABLED or PAUSED\) |
-|   ↳ `urlKey` | string | Public URL key |
-|   ↳ `homepageLink` | string | Homepage link target |
-|   ↳ `gaCode` | string | Google Analytics code |
-|   ↳ `icon` | string | Icon URL |
-|   ↳ `logo` | string | Logo URL |
-|   ↳ `noIndex` | boolean | Whether search engine indexing is disabled |
-|   ↳ `hideUrlLinks` | boolean | Whether the "Powered by" footer link is hidden |
-|   ↳ `subscription` | boolean | Whether the subscribe feature is enabled |
+|   ↳ `monitorsCount` | number (nullable) | Number of monitors on the page |
+|   ↳ `status` | string (nullable) | Status \(ENABLED or PAUSED\) |
+|   ↳ `urlKey` | string (nullable) | Public URL key |
+|   ↳ `homepageLink` | string (nullable) | Homepage link target |
+|   ↳ `gaCode` | string (nullable) | Google Analytics code |
+|   ↳ `icon` | string (nullable) | Icon URL |
+|   ↳ `logo` | string (nullable) | Logo URL |
+|   ↳ `noIndex` | boolean (nullable) | Whether search engine indexing is disabled |
+|   ↳ `hideUrlLinks` | boolean (nullable) | Whether the "Powered by" footer link is hidden |
+|   ↳ `subscription` | boolean (nullable) | Whether the subscribe feature is enabled |
 
 ### UptimeRobot Update Status Page
 
@@ -869,20 +869,20 @@ Update a public status page in UptimeRobot. Only the provided fields are changed
 | `psp` | object | The updated status page |
 |   ↳ `id` | number | Public status page ID |
 |   ↳ `friendlyName` | string | Status page name |
-|   ↳ `customDomain` | string | Custom domain |
-|   ↳ `isPasswordSet` | boolean | Whether the page is password protected |
+|   ↳ `customDomain` | string (nullable) | Custom domain |
+|   ↳ `isPasswordSet` | boolean (nullable) | Whether the page is password protected |
 |   ↳ `monitorIds` | array | Monitor IDs shown on the page |
 |   ↳ `tagIds` | array | Tag IDs shown on the page |
-|   ↳ `monitorsCount` | number | Number of monitors on the page |
-|   ↳ `status` | string | Status \(ENABLED or PAUSED\) |
-|   ↳ `urlKey` | string | Public URL key |
-|   ↳ `homepageLink` | string | Homepage link target |
-|   ↳ `gaCode` | string | Google Analytics code |
-|   ↳ `icon` | string | Icon URL |
-|   ↳ `logo` | string | Logo URL |
-|   ↳ `noIndex` | boolean | Whether search engine indexing is disabled |
-|   ↳ `hideUrlLinks` | boolean | Whether the "Powered by" footer link is hidden |
-|   ↳ `subscription` | boolean | Whether the subscribe feature is enabled |
+|   ↳ `monitorsCount` | number (nullable) | Number of monitors on the page |
+|   ↳ `status` | string (nullable) | Status \(ENABLED or PAUSED\) |
+|   ↳ `urlKey` | string (nullable) | Public URL key |
+|   ↳ `homepageLink` | string (nullable) | Homepage link target |
+|   ↳ `gaCode` | string (nullable) | Google Analytics code |
+|   ↳ `icon` | string (nullable) | Icon URL |
+|   ↳ `logo` | string (nullable) | Logo URL |
+|   ↳ `noIndex` | boolean (nullable) | Whether search engine indexing is disabled |
+|   ↳ `hideUrlLinks` | boolean (nullable) | Whether the "Powered by" footer link is hidden |
+|   ↳ `subscription` | boolean (nullable) | Whether the subscribe feature is enabled |
 
 ### UptimeRobot Delete Status Page
 
@@ -917,13 +917,11 @@ Get details about the authenticated UptimeRobot account, including plan and limi
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `account` | object | The account details |
-|   ↳ `email` | string | Account email |
-|   ↳ `fullName` | string | Account holder name |
-|   ↳ `monitorsCount` | number | Number of monitors in the account |
-|   ↳ `monitorLimit` | number | Maximum number of monitors allowed |
-|   ↳ `smsCredits` | number | Remaining SMS credits |
-|   ↳ `plan` | string | Subscription plan name |
-|   ↳ `subscriptionStatus` | string | Subscription status |
-|   ↳ `subscriptionExpiresAt` | string | Subscription expiration date |
-
-
+|   ↳ `email` | string (nullable) | Account email |
+|   ↳ `fullName` | string (nullable) | Account holder name |
+|   ↳ `monitorsCount` | number (nullable) | Number of monitors in the account |
+|   ↳ `monitorLimit` | number (nullable) | Maximum number of monitors allowed |
+|   ↳ `smsCredits` | number (nullable) | Remaining SMS credits |
+|   ↳ `plan` | string (nullable) | Subscription plan name |
+|   ↳ `subscriptionStatus` | string (nullable) | Subscription status |
+|   ↳ `subscriptionExpiresAt` | string (nullable) | Subscription expiration date |

--- a/apps/docs/content/docs/integrations/vanta.mdx
+++ b/apps/docs/content/docs/integrations/vanta.mdx
@@ -5,7 +5,7 @@ description: Query compliance status and manage evidence in Vanta
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="vanta"
   color="#F8F4F3"
 />
@@ -686,5 +686,3 @@ Get a Vanta risk scenario by ID, including its scores, treatment decision, and r
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `riskScenario` | json | The requested risk scenario |
-
-

--- a/apps/docs/content/docs/integrations/vercel.mdx
+++ b/apps/docs/content/docs/integrations/vercel.mdx
@@ -5,7 +5,7 @@ description: Manage Vercel deployments, projects, and infrastructure
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="vercel"
   color="#171717"
 />
@@ -1682,8 +1682,6 @@ Get information about the authenticated Vercel user
 |   ↳ `reason` | string | Reason for the block |
 | `hasTrialAvailable` | boolean | Whether a trial is available |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -2051,4 +2049,3 @@ Trigger on a curated set of common Vercel events (deployments, projects, domains
 | `domain` | object | domain output from the tool |
 |   ↳ `name` | string | Domain name |
 |   ↳ `delegated` | boolean | Whether the domain was delegated/shared when present on the payload |
-

--- a/apps/docs/content/docs/integrations/wealthbox.mdx
+++ b/apps/docs/content/docs/integrations/wealthbox.mdx
@@ -5,7 +5,7 @@ description: Interact with Wealthbox
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="wealthbox"
   color="#FFFFFF"
 />
@@ -178,5 +178,3 @@ Create or update a Wealthbox task
 |     ↳ `itemId` | string | ID of the created/updated task |
 |     ↳ `taskId` | string | ID of the created/updated task |
 |     ↳ `itemType` | string | Type of item \(task\) |
-
-

--- a/apps/docs/content/docs/integrations/webflow.mdx
+++ b/apps/docs/content/docs/integrations/webflow.mdx
@@ -5,7 +5,7 @@ description: Manage Webflow CMS collections
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="webflow"
   color="#FFFFFF"
 />
@@ -132,8 +132,6 @@ Delete an item from a Webflow CMS collection
 | `success` | boolean | Whether the deletion was successful |
 | `metadata` | json | Metadata about the deletion |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -252,4 +250,3 @@ Trigger workflow when a form is submitted on a Webflow site (requires Webflow cr
 |   ↳ `fieldType` | string | Type of input \(e.g., FormTextInput, FormEmail\) |
 |   ↳ `fieldElementId` | string | Unique identifier for the form element \(UUID\) |
 | `formElementId` | string | The form element ID |
-

--- a/apps/docs/content/docs/integrations/whatsapp.mdx
+++ b/apps/docs/content/docs/integrations/whatsapp.mdx
@@ -5,7 +5,7 @@ description: Send WhatsApp messages
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="whatsapp"
   color="#25D366"
 />
@@ -40,39 +40,15 @@ Send a free-form text message through the WhatsApp Cloud API. Only works inside 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `success` | boolean | Send success status |
-| `messageId` | string | WhatsApp message identifier |
-| `messageStatus` | string | Pacing status from the send API: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — use the webhook trigger for delivery status. |
-| `messagingProduct` | string | Messaging product returned by the send API |
-| `inputPhoneNumber` | string | Recipient phone number echoed by the send API |
-| `whatsappUserId` | string | Resolved WhatsApp user ID for the recipient |
-| `contacts` | array | Recipient contacts returned by the send API \(each item includes input and wa_id\) |
-| `mediaId` | string | Media asset ID from Upload Media, or the ID downloaded by Download Media |
-| `file` | file | Media downloaded by Download Media, stored as a workflow file |
-| `fileName` | string | Name of the file uploaded by Upload Media |
-| `mimeType` | string | MIME type of the uploaded or downloaded media |
-| `size` | number | Size in bytes of the file uploaded by Upload Media |
-| `fileSize` | number | Size in bytes of the downloaded media |
-| `sha256` | string | SHA-256 hash WhatsApp reported for the downloaded media |
-| `eventType` | string | Webhook classification such as incoming_message, message_status, or mixed |
-| `from` | string | Sender phone number from the first incoming message |
-| `recipientId` | string | Recipient phone number from the first status update in the batch |
-| `phoneNumberId` | string | Business phone number ID from the first message or status item in the batch |
-| `displayPhoneNumber` | string | Business display phone number from the first message or status item in the batch |
-| `text` | string | Text body from the first incoming text message |
-| `timestamp` | string | Timestamp from the first message or status item in the batch |
-| `messageType` | string | Type of the first incoming message in the batch, such as text, image, or system |
-| `mediaMimeType` | string | MIME type of the first incoming media message in the webhook batch |
-| `caption` | string | Caption on the first incoming image, video, or document message |
-| `status` | string | First outgoing message status in the batch, such as sent, delivered, or read |
-| `contact` | json | First sender contact in the webhook batch \(wa_id, profile.name\) |
-| `messages` | json | All incoming message objects from the webhook batch, flattened across entries/changes |
-| `statuses` | json | All message status objects from the webhook batch, flattened across entries/changes |
-| `webhookContacts` | json | All sender contact profiles from the webhook batch |
-| `conversation` | json | Conversation metadata from the first status update in the batch \(id, expiration_timestamp, origin.type\) |
-| `pricing` | json | Pricing metadata from the first status update in the batch \(billable, pricing_model, category\) |
-| `raw` | json | Full structured WhatsApp webhook payload |
-| `error` | string | Error information if sending fails |
+| `success` | boolean | WhatsApp message send success status |
+| `messageId` | string | Unique WhatsApp message identifier |
+| `messageStatus` | string | Message pacing status when WhatsApp returns one: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — subscribe to the webhook trigger for delivery status. |
+| `messagingProduct` | string | Messaging product returned by the API |
+| `inputPhoneNumber` | string | Recipient phone number echoed back by WhatsApp |
+| `whatsappUserId` | string | WhatsApp user ID resolved for the recipient |
+| `contacts` | array | Recipient contact records returned by WhatsApp |
+|   ↳ `input` | string | Input phone number sent to the API |
+|   ↳ `wa_id` | string | WhatsApp user ID associated with the recipient |
 
 ### WhatsApp Send Template
 
@@ -92,39 +68,15 @@ Send a pre-approved WhatsApp template message. Required to start a conversation 
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `success` | boolean | Send success status |
-| `messageId` | string | WhatsApp message identifier |
-| `messageStatus` | string | Pacing status from the send API: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — use the webhook trigger for delivery status. |
-| `messagingProduct` | string | Messaging product returned by the send API |
-| `inputPhoneNumber` | string | Recipient phone number echoed by the send API |
-| `whatsappUserId` | string | Resolved WhatsApp user ID for the recipient |
-| `contacts` | array | Recipient contacts returned by the send API \(each item includes input and wa_id\) |
-| `mediaId` | string | Media asset ID from Upload Media, or the ID downloaded by Download Media |
-| `file` | file | Media downloaded by Download Media, stored as a workflow file |
-| `fileName` | string | Name of the file uploaded by Upload Media |
-| `mimeType` | string | MIME type of the uploaded or downloaded media |
-| `size` | number | Size in bytes of the file uploaded by Upload Media |
-| `fileSize` | number | Size in bytes of the downloaded media |
-| `sha256` | string | SHA-256 hash WhatsApp reported for the downloaded media |
-| `eventType` | string | Webhook classification such as incoming_message, message_status, or mixed |
-| `from` | string | Sender phone number from the first incoming message |
-| `recipientId` | string | Recipient phone number from the first status update in the batch |
-| `phoneNumberId` | string | Business phone number ID from the first message or status item in the batch |
-| `displayPhoneNumber` | string | Business display phone number from the first message or status item in the batch |
-| `text` | string | Text body from the first incoming text message |
-| `timestamp` | string | Timestamp from the first message or status item in the batch |
-| `messageType` | string | Type of the first incoming message in the batch, such as text, image, or system |
-| `mediaMimeType` | string | MIME type of the first incoming media message in the webhook batch |
-| `caption` | string | Caption on the first incoming image, video, or document message |
-| `status` | string | First outgoing message status in the batch, such as sent, delivered, or read |
-| `contact` | json | First sender contact in the webhook batch \(wa_id, profile.name\) |
-| `messages` | json | All incoming message objects from the webhook batch, flattened across entries/changes |
-| `statuses` | json | All message status objects from the webhook batch, flattened across entries/changes |
-| `webhookContacts` | json | All sender contact profiles from the webhook batch |
-| `conversation` | json | Conversation metadata from the first status update in the batch \(id, expiration_timestamp, origin.type\) |
-| `pricing` | json | Pricing metadata from the first status update in the batch \(billable, pricing_model, category\) |
-| `raw` | json | Full structured WhatsApp webhook payload |
-| `error` | string | Error information if sending fails |
+| `success` | boolean | WhatsApp message send success status |
+| `messageId` | string | Unique WhatsApp message identifier |
+| `messageStatus` | string | Message pacing status when WhatsApp returns one: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — subscribe to the webhook trigger for delivery status. |
+| `messagingProduct` | string | Messaging product returned by the API |
+| `inputPhoneNumber` | string | Recipient phone number echoed back by WhatsApp |
+| `whatsappUserId` | string | WhatsApp user ID resolved for the recipient |
+| `contacts` | array | Recipient contact records returned by WhatsApp |
+|   ↳ `input` | string | Input phone number sent to the API |
+|   ↳ `wa_id` | string | WhatsApp user ID associated with the recipient |
 
 ### WhatsApp Send Media
 
@@ -147,39 +99,15 @@ Send an image, document, video, audio, or sticker message. Accepts an uploaded f
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `success` | boolean | Send success status |
-| `messageId` | string | WhatsApp message identifier |
-| `messageStatus` | string | Pacing status from the send API: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — use the webhook trigger for delivery status. |
-| `messagingProduct` | string | Messaging product returned by the send API |
-| `inputPhoneNumber` | string | Recipient phone number echoed by the send API |
-| `whatsappUserId` | string | Resolved WhatsApp user ID for the recipient |
-| `contacts` | array | Recipient contacts returned by the send API \(each item includes input and wa_id\) |
-| `mediaId` | string | Media asset ID from Upload Media, or the ID downloaded by Download Media |
-| `file` | file | Media downloaded by Download Media, stored as a workflow file |
-| `fileName` | string | Name of the file uploaded by Upload Media |
-| `mimeType` | string | MIME type of the uploaded or downloaded media |
-| `size` | number | Size in bytes of the file uploaded by Upload Media |
-| `fileSize` | number | Size in bytes of the downloaded media |
-| `sha256` | string | SHA-256 hash WhatsApp reported for the downloaded media |
-| `eventType` | string | Webhook classification such as incoming_message, message_status, or mixed |
-| `from` | string | Sender phone number from the first incoming message |
-| `recipientId` | string | Recipient phone number from the first status update in the batch |
-| `phoneNumberId` | string | Business phone number ID from the first message or status item in the batch |
-| `displayPhoneNumber` | string | Business display phone number from the first message or status item in the batch |
-| `text` | string | Text body from the first incoming text message |
-| `timestamp` | string | Timestamp from the first message or status item in the batch |
-| `messageType` | string | Type of the first incoming message in the batch, such as text, image, or system |
-| `mediaMimeType` | string | MIME type of the first incoming media message in the webhook batch |
-| `caption` | string | Caption on the first incoming image, video, or document message |
-| `status` | string | First outgoing message status in the batch, such as sent, delivered, or read |
-| `contact` | json | First sender contact in the webhook batch \(wa_id, profile.name\) |
-| `messages` | json | All incoming message objects from the webhook batch, flattened across entries/changes |
-| `statuses` | json | All message status objects from the webhook batch, flattened across entries/changes |
-| `webhookContacts` | json | All sender contact profiles from the webhook batch |
-| `conversation` | json | Conversation metadata from the first status update in the batch \(id, expiration_timestamp, origin.type\) |
-| `pricing` | json | Pricing metadata from the first status update in the batch \(billable, pricing_model, category\) |
-| `raw` | json | Full structured WhatsApp webhook payload |
-| `error` | string | Error information if sending fails |
+| `success` | boolean | WhatsApp message send success status |
+| `messageId` | string | Unique WhatsApp message identifier |
+| `messageStatus` | string | Message pacing status when WhatsApp returns one: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — subscribe to the webhook trigger for delivery status. |
+| `messagingProduct` | string | Messaging product returned by the API |
+| `inputPhoneNumber` | string | Recipient phone number echoed back by WhatsApp |
+| `whatsappUserId` | string | WhatsApp user ID resolved for the recipient |
+| `contacts` | array | Recipient contact records returned by WhatsApp |
+|   ↳ `input` | string | Input phone number sent to the API |
+|   ↳ `wa_id` | string | WhatsApp user ID associated with the recipient |
 
 ### WhatsApp Send Interactive
 
@@ -202,39 +130,15 @@ Send an interactive WhatsApp message with reply buttons or a selectable list.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `success` | boolean | Send success status |
-| `messageId` | string | WhatsApp message identifier |
-| `messageStatus` | string | Pacing status from the send API: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — use the webhook trigger for delivery status. |
-| `messagingProduct` | string | Messaging product returned by the send API |
-| `inputPhoneNumber` | string | Recipient phone number echoed by the send API |
-| `whatsappUserId` | string | Resolved WhatsApp user ID for the recipient |
-| `contacts` | array | Recipient contacts returned by the send API \(each item includes input and wa_id\) |
-| `mediaId` | string | Media asset ID from Upload Media, or the ID downloaded by Download Media |
-| `file` | file | Media downloaded by Download Media, stored as a workflow file |
-| `fileName` | string | Name of the file uploaded by Upload Media |
-| `mimeType` | string | MIME type of the uploaded or downloaded media |
-| `size` | number | Size in bytes of the file uploaded by Upload Media |
-| `fileSize` | number | Size in bytes of the downloaded media |
-| `sha256` | string | SHA-256 hash WhatsApp reported for the downloaded media |
-| `eventType` | string | Webhook classification such as incoming_message, message_status, or mixed |
-| `from` | string | Sender phone number from the first incoming message |
-| `recipientId` | string | Recipient phone number from the first status update in the batch |
-| `phoneNumberId` | string | Business phone number ID from the first message or status item in the batch |
-| `displayPhoneNumber` | string | Business display phone number from the first message or status item in the batch |
-| `text` | string | Text body from the first incoming text message |
-| `timestamp` | string | Timestamp from the first message or status item in the batch |
-| `messageType` | string | Type of the first incoming message in the batch, such as text, image, or system |
-| `mediaMimeType` | string | MIME type of the first incoming media message in the webhook batch |
-| `caption` | string | Caption on the first incoming image, video, or document message |
-| `status` | string | First outgoing message status in the batch, such as sent, delivered, or read |
-| `contact` | json | First sender contact in the webhook batch \(wa_id, profile.name\) |
-| `messages` | json | All incoming message objects from the webhook batch, flattened across entries/changes |
-| `statuses` | json | All message status objects from the webhook batch, flattened across entries/changes |
-| `webhookContacts` | json | All sender contact profiles from the webhook batch |
-| `conversation` | json | Conversation metadata from the first status update in the batch \(id, expiration_timestamp, origin.type\) |
-| `pricing` | json | Pricing metadata from the first status update in the batch \(billable, pricing_model, category\) |
-| `raw` | json | Full structured WhatsApp webhook payload |
-| `error` | string | Error information if sending fails |
+| `success` | boolean | WhatsApp message send success status |
+| `messageId` | string | Unique WhatsApp message identifier |
+| `messageStatus` | string | Message pacing status when WhatsApp returns one: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — subscribe to the webhook trigger for delivery status. |
+| `messagingProduct` | string | Messaging product returned by the API |
+| `inputPhoneNumber` | string | Recipient phone number echoed back by WhatsApp |
+| `whatsappUserId` | string | WhatsApp user ID resolved for the recipient |
+| `contacts` | array | Recipient contact records returned by WhatsApp |
+|   ↳ `input` | string | Input phone number sent to the API |
+|   ↳ `wa_id` | string | WhatsApp user ID associated with the recipient |
 
 ### WhatsApp Send Reaction
 
@@ -253,39 +157,15 @@ React to a WhatsApp message with an emoji. Send an empty emoji to remove an exis
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| `success` | boolean | Send success status |
-| `messageId` | string | WhatsApp message identifier |
-| `messageStatus` | string | Pacing status from the send API: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — use the webhook trigger for delivery status. |
-| `messagingProduct` | string | Messaging product returned by the send API |
-| `inputPhoneNumber` | string | Recipient phone number echoed by the send API |
-| `whatsappUserId` | string | Resolved WhatsApp user ID for the recipient |
-| `contacts` | array | Recipient contacts returned by the send API \(each item includes input and wa_id\) |
-| `mediaId` | string | Media asset ID from Upload Media, or the ID downloaded by Download Media |
-| `file` | file | Media downloaded by Download Media, stored as a workflow file |
-| `fileName` | string | Name of the file uploaded by Upload Media |
-| `mimeType` | string | MIME type of the uploaded or downloaded media |
-| `size` | number | Size in bytes of the file uploaded by Upload Media |
-| `fileSize` | number | Size in bytes of the downloaded media |
-| `sha256` | string | SHA-256 hash WhatsApp reported for the downloaded media |
-| `eventType` | string | Webhook classification such as incoming_message, message_status, or mixed |
-| `from` | string | Sender phone number from the first incoming message |
-| `recipientId` | string | Recipient phone number from the first status update in the batch |
-| `phoneNumberId` | string | Business phone number ID from the first message or status item in the batch |
-| `displayPhoneNumber` | string | Business display phone number from the first message or status item in the batch |
-| `text` | string | Text body from the first incoming text message |
-| `timestamp` | string | Timestamp from the first message or status item in the batch |
-| `messageType` | string | Type of the first incoming message in the batch, such as text, image, or system |
-| `mediaMimeType` | string | MIME type of the first incoming media message in the webhook batch |
-| `caption` | string | Caption on the first incoming image, video, or document message |
-| `status` | string | First outgoing message status in the batch, such as sent, delivered, or read |
-| `contact` | json | First sender contact in the webhook batch \(wa_id, profile.name\) |
-| `messages` | json | All incoming message objects from the webhook batch, flattened across entries/changes |
-| `statuses` | json | All message status objects from the webhook batch, flattened across entries/changes |
-| `webhookContacts` | json | All sender contact profiles from the webhook batch |
-| `conversation` | json | Conversation metadata from the first status update in the batch \(id, expiration_timestamp, origin.type\) |
-| `pricing` | json | Pricing metadata from the first status update in the batch \(billable, pricing_model, category\) |
-| `raw` | json | Full structured WhatsApp webhook payload |
-| `error` | string | Error information if sending fails |
+| `success` | boolean | WhatsApp message send success status |
+| `messageId` | string | Unique WhatsApp message identifier |
+| `messageStatus` | string | Message pacing status when WhatsApp returns one: accepted, held_for_quality_assessment, or paused. Acceptance is not delivery — subscribe to the webhook trigger for delivery status. |
+| `messagingProduct` | string | Messaging product returned by the API |
+| `inputPhoneNumber` | string | Recipient phone number echoed back by WhatsApp |
+| `whatsappUserId` | string | WhatsApp user ID resolved for the recipient |
+| `contacts` | array | Recipient contact records returned by WhatsApp |
+|   ↳ `input` | string | Input phone number sent to the API |
+|   ↳ `wa_id` | string | WhatsApp user ID associated with the recipient |
 
 ### WhatsApp Mark As Read
 
@@ -346,8 +226,6 @@ Download media a customer sent you. Takes the media ID from an incoming WhatsApp
 | `fileSize` | number | Size of the downloaded media in bytes |
 | `sha256` | string | SHA-256 hash WhatsApp reported for the media, for integrity checks |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -387,4 +265,3 @@ Trigger workflow from WhatsApp incoming messages and message status webhooks
 | `conversation` | json | Conversation metadata from the first status update in the batch \(id, expiration_timestamp, origin.type\) |
 | `pricing` | json | Pricing metadata from the first status update in the batch \(billable, pricing_model, category\) |
 | `raw` | json | Complete structured webhook payload from WhatsApp |
-

--- a/apps/docs/content/docs/integrations/wikipedia.mdx
+++ b/apps/docs/content/docs/integrations/wikipedia.mdx
@@ -5,7 +5,7 @@ description: Search and retrieve content from Wikipedia
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="wikipedia"
   color="#000000"
 />
@@ -160,5 +160,3 @@ Get a random Wikipedia page.
 |   ↳ `lang` | string | Language code |
 |   ↳ `timestamp` | string | Timestamp |
 |   ↳ `pageid` | number | Page ID |
-
-

--- a/apps/docs/content/docs/integrations/windchill.mdx
+++ b/apps/docs/content/docs/integrations/windchill.mdx
@@ -5,7 +5,7 @@ description: Manage documents, revisions, and content in PTC Windchill
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="windchill"
   color="#FFFFFF"
 />
@@ -60,24 +60,24 @@ List documents with an OData query, sorting, and pagination
 | --------- | ---- | ----------- |
 | `operation` | string | Windchill operation that was executed |
 | `documents` | array | Windchill documents |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 | `pageInfo` | object | OData pagination information |
 |   ↳ `count` | number | Number of items returned in this page |
-|   ↳ `totalCount` | number | Total matching items |
-|   ↳ `nextLink` | string | URL returned by Windchill for the next page |
+|   ↳ `totalCount` | number (nullable) | Total matching items |
+|   ↳ `nextLink` | string (nullable) | URL returned by Windchill for the next page |
 
 ### Windchill Get Document
 
@@ -99,20 +99,20 @@ Get a WT.Document by OID
 | --------- | ---- | ----------- |
 | `operation` | string | Windchill operation that was executed |
 | `document` | object | Windchill document |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Get Document Structure
 
@@ -135,42 +135,42 @@ Retrieve recursive document usage links and their parent and child documents
 | --------- | ---- | ----------- |
 | `operation` | string | Windchill operation that was executed |
 | `structure` | array | Document usage links, including recursively expanded child links |
-|   ↳ `id` | string | Document usage link OID |
-|   ↳ `parent` | object | Parent document |
-|     ↳ `id` | string | Windchill object identifier |
-|     ↳ `name` | string | Document name |
-|     ↳ `number` | string | Document number |
-|     ↳ `title` | string | Document title |
-|     ↳ `description` | string | Document description |
-|     ↳ `state` | string | Internal life cycle state value |
-|     ↳ `stateDisplay` | string | Displayed life cycle state value |
-|     ↳ `versionId` | string | Version identifier |
-|     ↳ `revision` | string | Revision identifier |
-|     ↳ `version` | string | Version and iteration |
-|     ↳ `latest` | boolean | Whether this is the latest version |
-|     ↳ `checkoutState` | string | Checkout state |
-|     ↳ `folderName` | string | Folder name |
-|     ↳ `folderLocation` | string | Folder path |
-|   ↳ `child` | object | Child document |
-|     ↳ `id` | string | Windchill object identifier |
-|     ↳ `name` | string | Document name |
-|     ↳ `number` | string | Document number |
-|     ↳ `title` | string | Document title |
-|     ↳ `description` | string | Document description |
-|     ↳ `state` | string | Internal life cycle state value |
-|     ↳ `stateDisplay` | string | Displayed life cycle state value |
-|     ↳ `versionId` | string | Version identifier |
-|     ↳ `revision` | string | Revision identifier |
-|     ↳ `version` | string | Version and iteration |
-|     ↳ `latest` | boolean | Whether this is the latest version |
-|     ↳ `checkoutState` | string | Checkout state |
-|     ↳ `folderName` | string | Folder name |
-|     ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Document usage link OID |
+|   ↳ `parent` | object (nullable) | Parent document |
+|     ↳ `id` | string (nullable) | Windchill object identifier |
+|     ↳ `name` | string (nullable) | Document name |
+|     ↳ `number` | string (nullable) | Document number |
+|     ↳ `title` | string (nullable) | Document title |
+|     ↳ `description` | string (nullable) | Document description |
+|     ↳ `state` | string (nullable) | Internal life cycle state value |
+|     ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|     ↳ `versionId` | string (nullable) | Version identifier |
+|     ↳ `revision` | string (nullable) | Revision identifier |
+|     ↳ `version` | string (nullable) | Version and iteration |
+|     ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|     ↳ `checkoutState` | string (nullable) | Checkout state |
+|     ↳ `folderName` | string (nullable) | Folder name |
+|     ↳ `folderLocation` | string (nullable) | Folder path |
+|   ↳ `child` | object (nullable) | Child document |
+|     ↳ `id` | string (nullable) | Windchill object identifier |
+|     ↳ `name` | string (nullable) | Document name |
+|     ↳ `number` | string (nullable) | Document number |
+|     ↳ `title` | string (nullable) | Document title |
+|     ↳ `description` | string (nullable) | Document description |
+|     ↳ `state` | string (nullable) | Internal life cycle state value |
+|     ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|     ↳ `versionId` | string (nullable) | Version identifier |
+|     ↳ `revision` | string (nullable) | Revision identifier |
+|     ↳ `version` | string (nullable) | Version and iteration |
+|     ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|     ↳ `checkoutState` | string (nullable) | Checkout state |
+|     ↳ `folderName` | string (nullable) | Folder name |
+|     ↳ `folderLocation` | string (nullable) | Folder path |
 |   ↳ `children` | array | Nested child usage links with the same recursive shape |
 | `pageInfo` | object | OData pagination information |
 |   ↳ `count` | number | Number of items returned in this page |
-|   ↳ `totalCount` | number | Total matching items |
-|   ↳ `nextLink` | string | URL returned by Windchill for the next page |
+|   ↳ `totalCount` | number (nullable) | Total matching items |
+|   ↳ `nextLink` | string (nullable) | URL returned by Windchill for the next page |
 
 ### Windchill Get Valid State Transitions
 
@@ -191,8 +191,8 @@ Get lifecycle states a document can transition to from its current state
 | --------- | ---- | ----------- |
 | `operation` | string | Windchill operation that was executed |
 | `states` | array | Valid lifecycle transitions |
-|   ↳ `value` | string | Internal state value |
-|   ↳ `display` | string | Displayed state value |
+|   ↳ `value` | string (nullable) | Internal state value |
+|   ↳ `display` | string (nullable) | Displayed state value |
 
 ### Windchill Get Primary Content
 
@@ -212,17 +212,17 @@ Get primary-content metadata for a document
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `operation` | string | Windchill operation that was executed |
-| `content` | object | Primary-content metadata |
-|   ↳ `id` | string | Content object identifier |
-|   ↳ `fileName` | string | Content file name |
-|   ↳ `description` | string | Content description |
-|   ↳ `format` | string | Windchill content format |
-|   ↳ `mimeType` | string | Content MIME type |
-|   ↳ `fileSize` | number | Content size in bytes |
-|   ↳ `contentType` | string | Windchill OData content entity type |
-|   ↳ `displayName` | string | Displayed content name |
-|   ↳ `urlLocation` | string | URL-data location |
-|   ↳ `externalLocation` | string | External-storage location |
+| `content` | object (nullable) | Primary-content metadata |
+|   ↳ `id` | string (nullable) | Content object identifier |
+|   ↳ `fileName` | string (nullable) | Content file name |
+|   ↳ `description` | string (nullable) | Content description |
+|   ↳ `format` | string (nullable) | Windchill content format |
+|   ↳ `mimeType` | string (nullable) | Content MIME type |
+|   ↳ `fileSize` | number (nullable) | Content size in bytes |
+|   ↳ `contentType` | string (nullable) | Windchill OData content entity type |
+|   ↳ `displayName` | string (nullable) | Displayed content name |
+|   ↳ `urlLocation` | string (nullable) | URL-data location |
+|   ↳ `externalLocation` | string (nullable) | External-storage location |
 
 ### Windchill List Attachments
 
@@ -244,20 +244,20 @@ List attachment metadata for a document
 | --------- | ---- | ----------- |
 | `operation` | string | Windchill operation that was executed |
 | `attachments` | array | Document attachments |
-|   ↳ `id` | string | Content object identifier |
-|   ↳ `fileName` | string | Content file name |
-|   ↳ `description` | string | Content description |
-|   ↳ `format` | string | Windchill content format |
-|   ↳ `mimeType` | string | Content MIME type |
-|   ↳ `fileSize` | number | Content size in bytes |
-|   ↳ `contentType` | string | Windchill OData content entity type |
-|   ↳ `displayName` | string | Displayed content name |
-|   ↳ `urlLocation` | string | URL-data location |
-|   ↳ `externalLocation` | string | External-storage location |
+|   ↳ `id` | string (nullable) | Content object identifier |
+|   ↳ `fileName` | string (nullable) | Content file name |
+|   ↳ `description` | string (nullable) | Content description |
+|   ↳ `format` | string (nullable) | Windchill content format |
+|   ↳ `mimeType` | string (nullable) | Content MIME type |
+|   ↳ `fileSize` | number (nullable) | Content size in bytes |
+|   ↳ `contentType` | string (nullable) | Windchill OData content entity type |
+|   ↳ `displayName` | string (nullable) | Displayed content name |
+|   ↳ `urlLocation` | string (nullable) | URL-data location |
+|   ↳ `externalLocation` | string (nullable) | External-storage location |
 | `pageInfo` | object | OData pagination information |
 |   ↳ `count` | number | Number of items returned in this page |
-|   ↳ `totalCount` | number | Total matching items |
-|   ↳ `nextLink` | string | URL returned by Windchill for the next page |
+|   ↳ `totalCount` | number (nullable) | Total matching items |
+|   ↳ `nextLink` | string (nullable) | URL returned by Windchill for the next page |
 
 ### Windchill Create Document
 
@@ -285,20 +285,20 @@ Create one WT.Document
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `document` | object | Document returned by Windchill when the operation returns one |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Create Documents
 
@@ -320,20 +320,20 @@ Create several documents in one atomic Windchill request
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `documents` | array | Documents returned by Windchill when the operation returns them |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Update Document
 
@@ -356,20 +356,20 @@ Update one document's editable attributes
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `document` | object | Document returned by Windchill when the operation returns one |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Update Common Properties
 
@@ -392,20 +392,20 @@ Update a document's Name, Number, and other common properties
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `document` | object | Document returned by Windchill when the operation returns one |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Update Documents
 
@@ -427,20 +427,20 @@ Update several documents' editable attributes in one atomic request
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `documents` | array | Documents returned by Windchill when the operation returns them |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Delete Document
 
@@ -503,20 +503,20 @@ Check out one document
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `document` | object | Document returned by Windchill when the operation returns one |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Check Out Documents
 
@@ -539,20 +539,20 @@ Check out multiple documents atomically
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `documents` | array | Documents returned by Windchill when the operation returns them |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Check In Document
 
@@ -577,20 +577,20 @@ Check in one document
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `document` | object | Document returned by Windchill when the operation returns one |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Check In Documents
 
@@ -615,20 +615,20 @@ Check in multiple documents atomically
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `documents` | array | Documents returned by Windchill when the operation returns them |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Undo Check Out Document
 
@@ -650,20 +650,20 @@ Undo checkout for one document
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `document` | object | Document returned by Windchill when the operation returns one |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Undo Check Out Documents
 
@@ -685,20 +685,20 @@ Undo checkout for multiple documents atomically
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `documents` | array | Documents returned by Windchill when the operation returns them |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Revise Document
 
@@ -721,20 +721,20 @@ Create a new revision of one document
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `document` | object | Document returned by Windchill when the operation returns one |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Revise Documents
 
@@ -756,20 +756,20 @@ Create new revisions of multiple documents atomically
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `documents` | array | Documents returned by Windchill when the operation returns them |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Set Lifecycle State
 
@@ -793,20 +793,20 @@ Transition a document to a valid lifecycle state
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `document` | object | Document returned by Windchill when the operation returns one |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Update Document Security Labels
 
@@ -828,20 +828,20 @@ Update installed security-label attributes for one or more documents
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the operation |
 | `documents` | array | Documents returned by Windchill when the operation returns them |
-|   ↳ `id` | string | Windchill object identifier |
-|   ↳ `name` | string | Document name |
-|   ↳ `number` | string | Document number |
-|   ↳ `title` | string | Document title |
-|   ↳ `description` | string | Document description |
-|   ↳ `state` | string | Internal life cycle state value |
-|   ↳ `stateDisplay` | string | Displayed life cycle state value |
-|   ↳ `versionId` | string | Version identifier |
-|   ↳ `revision` | string | Revision identifier |
-|   ↳ `version` | string | Version and iteration |
-|   ↳ `latest` | boolean | Whether this is the latest version |
-|   ↳ `checkoutState` | string | Checkout state |
-|   ↳ `folderName` | string | Folder name |
-|   ↳ `folderLocation` | string | Folder path |
+|   ↳ `id` | string (nullable) | Windchill object identifier |
+|   ↳ `name` | string (nullable) | Document name |
+|   ↳ `number` | string (nullable) | Document number |
+|   ↳ `title` | string (nullable) | Document title |
+|   ↳ `description` | string (nullable) | Document description |
+|   ↳ `state` | string (nullable) | Internal life cycle state value |
+|   ↳ `stateDisplay` | string (nullable) | Displayed life cycle state value |
+|   ↳ `versionId` | string (nullable) | Version identifier |
+|   ↳ `revision` | string (nullable) | Revision identifier |
+|   ↳ `version` | string (nullable) | Version and iteration |
+|   ↳ `latest` | boolean (nullable) | Whether this is the latest version |
+|   ↳ `checkoutState` | string (nullable) | Checkout state |
+|   ↳ `folderName` | string (nullable) | Folder name |
+|   ↳ `folderLocation` | string (nullable) | Folder path |
 
 ### Windchill Download Primary Content
 
@@ -933,5 +933,3 @@ Upload one or more files as document attachments
 | `operation` | string | Windchill operation that was executed |
 | `affectedIds` | array | Document identifiers affected by the upload |
 | `uploadedFileNames` | array | Names of files accepted by Windchill |
-
-

--- a/apps/docs/content/docs/integrations/wiza.mdx
+++ b/apps/docs/content/docs/integrations/wiza.mdx
@@ -5,7 +5,7 @@ description: Find, enrich, and verify B2B contact data with Wiza
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="wiza"
   color="#9284BC"
 />
@@ -208,5 +208,3 @@ Retrieve the remaining credits on your Wiza account
 | `phone_credits` | json | Remaining phone credits \(number or "unlimited"\) |
 | `export_credits` | number | Remaining export credits |
 | `api_credits` | number | Remaining API credits |
-
-

--- a/apps/docs/content/docs/integrations/wordpress.mdx
+++ b/apps/docs/content/docs/integrations/wordpress.mdx
@@ -5,7 +5,7 @@ description: Manage WordPress content
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="wordpress"
   color="#21759B"
 />
@@ -1032,5 +1032,3 @@ Search across all content types in WordPress.com (posts, pages, media)
 |   ↳ `subtype` | string | Subtype within the content type \(e.g., post, page\) |
 | `total` | number | Total number of results |
 | `totalPages` | number | Total number of result pages |
-
-

--- a/apps/docs/content/docs/integrations/workday.mdx
+++ b/apps/docs/content/docs/integrations/workday.mdx
@@ -5,7 +5,7 @@ description: Manage workers, hiring, onboarding, and HR operations in Workday
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="workday"
   color="#F5F0EB"
 />
@@ -274,5 +274,3 @@ Initiate a worker termination in Workday. Triggers the Terminate Employee busine
 | `eventId` | string | Termination event ID |
 | `workerId` | string | Worker ID that was terminated |
 | `terminationDate` | string | Effective termination date |
-
-

--- a/apps/docs/content/docs/integrations/x.mdx
+++ b/apps/docs/content/docs/integrations/x.mdx
@@ -5,7 +5,7 @@ description: Interact with X
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="x"
   color="#000000"
 />
@@ -826,5 +826,3 @@ Get the API usage data for your X project
 |   ↳ `usage` | array | Daily usage entries for this app |
 |     ↳ `date` | string | Usage date in ISO 8601 format |
 |     ↳ `usage` | number | Number of tweets consumed |
-
-

--- a/apps/docs/content/docs/integrations/youtube.mdx
+++ b/apps/docs/content/docs/integrations/youtube.mdx
@@ -5,7 +5,7 @@ description: Interact with YouTube videos, channels, and playlists
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="youtube"
   color="#FF0000"
 />
@@ -318,5 +318,3 @@ Get detailed information about a specific YouTube video including statistics, co
 | `actualEndTime` | string | When the live stream ended \(ISO 8601\) |
 | `concurrentViewers` | number | Current number of viewers \(only for active live streams\) |
 | `activeLiveChatId` | string | Live chat ID for the stream \(only for active live streams\) |
-
-

--- a/apps/docs/content/docs/integrations/zendesk.mdx
+++ b/apps/docs/content/docs/integrations/zendesk.mdx
@@ -5,7 +5,7 @@ description: Manage support tickets, users, and organizations in Zendesk
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="zendesk"
   color="#03363D"
 />
@@ -1256,8 +1256,6 @@ Count the number of search results matching a query in Zendesk
 | --------- | ---- | ----------- |
 | `count` | number | Number of matching results |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -1463,4 +1461,3 @@ Trigger workflow when a ticket status changes in Zendesk
 |   ↳ `created_at` | string | Ticket creation timestamp |
 |   ↳ `updated_at` | string | Ticket last update timestamp |
 | `event` | json | Event-specific changed data \(e.g. status/priority diff\) |
-

--- a/apps/docs/content/docs/integrations/zep.mdx
+++ b/apps/docs/content/docs/integrations/zep.mdx
@@ -5,7 +5,7 @@ description: Long-term memory for AI agents
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="zep"
   color="#E8E8E8"
 />
@@ -236,5 +236,3 @@ List all conversation threads for a specific user
 |   ↳ `projectUuid` | string | Project UUID |
 |   ↳ `metadata` | object | Custom metadata \(dynamic key-value pairs\) |
 | `totalCount` | number | Total number of items available |
-
-

--- a/apps/docs/content/docs/integrations/zerobounce.mdx
+++ b/apps/docs/content/docs/integrations/zerobounce.mdx
@@ -5,7 +5,7 @@ description: Validate email deliverability and check account credits
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="zerobounce"
   color="#FFFFFF"
 />
@@ -60,5 +60,3 @@ Retrieve the remaining validation credits for the authenticated account.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `credits` | number | Remaining validation credits \(-1 if unavailable\) |
-
-

--- a/apps/docs/content/docs/integrations/zoho_desk.mdx
+++ b/apps/docs/content/docs/integrations/zoho_desk.mdx
@@ -5,7 +5,7 @@ description: Manage Zoho Desk tickets, comments, threads, and contacts
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="zoho_desk"
   color="#FFFFFF"
 />
@@ -71,28 +71,28 @@ List tickets from a Zoho Desk organization with optional filters. Returns a list
 |   ↳ `id` | string | Ticket ID |
 |   ↳ `ticketNumber` | string | Human-readable ticket number |
 |   ↳ `subject` | string | Ticket subject |
-|   ↳ `description` | string | Ticket description \(raw; may be HTML\) |
-|   ↳ `descriptionText` | string | Plain-text rendering of the description: HTML stripped when the body contains markup, otherwise the description verbatim |
+|   ↳ `description` | string (nullable) | Ticket description \(raw; may be HTML\) |
+|   ↳ `descriptionText` | string (nullable) | Plain-text rendering of the description: HTML stripped when the body contains markup, otherwise the description verbatim |
 |   ↳ `status` | string | Ticket status |
 |   ↳ `statusType` | string | Status category \(Open/Closed/On Hold\) |
-|   ↳ `priority` | string | Ticket priority |
-|   ↳ `category` | string | Ticket category |
-|   ↳ `subCategory` | string | Ticket sub-category |
-|   ↳ `classification` | string | Ticket classification |
+|   ↳ `priority` | string (nullable) | Ticket priority |
+|   ↳ `category` | string (nullable) | Ticket category |
+|   ↳ `subCategory` | string (nullable) | Ticket sub-category |
+|   ↳ `classification` | string (nullable) | Ticket classification |
 |   ↳ `channel` | string | Origin channel |
 |   ↳ `departmentId` | string | Department ID |
-|   ↳ `contactId` | string | Contact ID |
-|   ↳ `accountId` | string | Account ID |
-|   ↳ `assigneeId` | string | Assignee ID |
-|   ↳ `email` | string | Contact email |
-|   ↳ `phone` | string | Contact phone |
-|   ↳ `dueDate` | string | Due date |
-|   ↳ `responseDueDate` | string | Response due date |
+|   ↳ `contactId` | string (nullable) | Contact ID |
+|   ↳ `accountId` | string (nullable) | Account ID |
+|   ↳ `assigneeId` | string (nullable) | Assignee ID |
+|   ↳ `email` | string (nullable) | Contact email |
+|   ↳ `phone` | string (nullable) | Contact phone |
+|   ↳ `dueDate` | string (nullable) | Due date |
+|   ↳ `responseDueDate` | string (nullable) | Response due date |
 |   ↳ `createdTime` | string | Created timestamp |
 |   ↳ `modifiedTime` | string | Last modified timestamp |
-|   ↳ `customerResponseTime` | string | Time the last customer response was received |
-|   ↳ `closedTime` | string | Closed timestamp |
-|   ↳ `resolution` | string | Resolution text |
+|   ↳ `customerResponseTime` | string (nullable) | Time the last customer response was received |
+|   ↳ `closedTime` | string (nullable) | Closed timestamp |
+|   ↳ `resolution` | string (nullable) | Resolution text |
 |   ↳ `threadCount` | string | Number of threads |
 |   ↳ `commentCount` | string | Number of comments |
 |   ↳ `webUrl` | string | Web URL to the ticket |
@@ -122,28 +122,28 @@ Retrieve a single Zoho Desk ticket by ID.
 |   ↳ `id` | string | Ticket ID |
 |   ↳ `ticketNumber` | string | Human-readable ticket number |
 |   ↳ `subject` | string | Ticket subject |
-|   ↳ `description` | string | Ticket description \(raw; may be HTML\) |
-|   ↳ `descriptionText` | string | Plain-text rendering of the description: HTML stripped when the body contains markup, otherwise the description verbatim |
+|   ↳ `description` | string (nullable) | Ticket description \(raw; may be HTML\) |
+|   ↳ `descriptionText` | string (nullable) | Plain-text rendering of the description: HTML stripped when the body contains markup, otherwise the description verbatim |
 |   ↳ `status` | string | Ticket status |
 |   ↳ `statusType` | string | Status category \(Open/Closed/On Hold\) |
-|   ↳ `priority` | string | Ticket priority |
-|   ↳ `category` | string | Ticket category |
-|   ↳ `subCategory` | string | Ticket sub-category |
-|   ↳ `classification` | string | Ticket classification |
+|   ↳ `priority` | string (nullable) | Ticket priority |
+|   ↳ `category` | string (nullable) | Ticket category |
+|   ↳ `subCategory` | string (nullable) | Ticket sub-category |
+|   ↳ `classification` | string (nullable) | Ticket classification |
 |   ↳ `channel` | string | Origin channel |
 |   ↳ `departmentId` | string | Department ID |
-|   ↳ `contactId` | string | Contact ID |
-|   ↳ `accountId` | string | Account ID |
-|   ↳ `assigneeId` | string | Assignee ID |
-|   ↳ `email` | string | Contact email |
-|   ↳ `phone` | string | Contact phone |
-|   ↳ `dueDate` | string | Due date |
-|   ↳ `responseDueDate` | string | Response due date |
+|   ↳ `contactId` | string (nullable) | Contact ID |
+|   ↳ `accountId` | string (nullable) | Account ID |
+|   ↳ `assigneeId` | string (nullable) | Assignee ID |
+|   ↳ `email` | string (nullable) | Contact email |
+|   ↳ `phone` | string (nullable) | Contact phone |
+|   ↳ `dueDate` | string (nullable) | Due date |
+|   ↳ `responseDueDate` | string (nullable) | Response due date |
 |   ↳ `createdTime` | string | Created timestamp |
 |   ↳ `modifiedTime` | string | Last modified timestamp |
-|   ↳ `customerResponseTime` | string | Time the last customer response was received |
-|   ↳ `closedTime` | string | Closed timestamp |
-|   ↳ `resolution` | string | Resolution text |
+|   ↳ `customerResponseTime` | string (nullable) | Time the last customer response was received |
+|   ↳ `closedTime` | string (nullable) | Closed timestamp |
+|   ↳ `resolution` | string (nullable) | Resolution text |
 |   ↳ `threadCount` | string | Number of threads |
 |   ↳ `commentCount` | string | Number of comments |
 |   ↳ `webUrl` | string | Web URL to the ticket |
@@ -183,28 +183,28 @@ Update fields on an existing Zoho Desk ticket.
 |   ↳ `id` | string | Ticket ID |
 |   ↳ `ticketNumber` | string | Human-readable ticket number |
 |   ↳ `subject` | string | Ticket subject |
-|   ↳ `description` | string | Ticket description \(raw; may be HTML\) |
-|   ↳ `descriptionText` | string | Plain-text rendering of the description: HTML stripped when the body contains markup, otherwise the description verbatim |
+|   ↳ `description` | string (nullable) | Ticket description \(raw; may be HTML\) |
+|   ↳ `descriptionText` | string (nullable) | Plain-text rendering of the description: HTML stripped when the body contains markup, otherwise the description verbatim |
 |   ↳ `status` | string | Ticket status |
 |   ↳ `statusType` | string | Status category \(Open/Closed/On Hold\) |
-|   ↳ `priority` | string | Ticket priority |
-|   ↳ `category` | string | Ticket category |
-|   ↳ `subCategory` | string | Ticket sub-category |
-|   ↳ `classification` | string | Ticket classification |
+|   ↳ `priority` | string (nullable) | Ticket priority |
+|   ↳ `category` | string (nullable) | Ticket category |
+|   ↳ `subCategory` | string (nullable) | Ticket sub-category |
+|   ↳ `classification` | string (nullable) | Ticket classification |
 |   ↳ `channel` | string | Origin channel |
 |   ↳ `departmentId` | string | Department ID |
-|   ↳ `contactId` | string | Contact ID |
-|   ↳ `accountId` | string | Account ID |
-|   ↳ `assigneeId` | string | Assignee ID |
-|   ↳ `email` | string | Contact email |
-|   ↳ `phone` | string | Contact phone |
-|   ↳ `dueDate` | string | Due date |
-|   ↳ `responseDueDate` | string | Response due date |
+|   ↳ `contactId` | string (nullable) | Contact ID |
+|   ↳ `accountId` | string (nullable) | Account ID |
+|   ↳ `assigneeId` | string (nullable) | Assignee ID |
+|   ↳ `email` | string (nullable) | Contact email |
+|   ↳ `phone` | string (nullable) | Contact phone |
+|   ↳ `dueDate` | string (nullable) | Due date |
+|   ↳ `responseDueDate` | string (nullable) | Response due date |
 |   ↳ `createdTime` | string | Created timestamp |
 |   ↳ `modifiedTime` | string | Last modified timestamp |
-|   ↳ `customerResponseTime` | string | Time the last customer response was received |
-|   ↳ `closedTime` | string | Closed timestamp |
-|   ↳ `resolution` | string | Resolution text |
+|   ↳ `customerResponseTime` | string (nullable) | Time the last customer response was received |
+|   ↳ `closedTime` | string (nullable) | Closed timestamp |
+|   ↳ `resolution` | string (nullable) | Resolution text |
 |   ↳ `threadCount` | string | Number of threads |
 |   ↳ `commentCount` | string | Number of comments |
 |   ↳ `webUrl` | string | Web URL to the ticket |
@@ -245,9 +245,9 @@ List comments on a Zoho Desk ticket.
 |     ↳ `email` | string | Email address |
 |     ↳ `type` | string | Commenter type \(AGENT/END_USER\) |
 |     ↳ `roleName` | string | Role name |
-|     ↳ `photoURL` | string | Avatar URL |
+|     ↳ `photoURL` | string (nullable) | Avatar URL |
 |   ↳ `commentedTime` | string | Commented timestamp |
-|   ↳ `modifiedTime` | string | Modified timestamp |
+|   ↳ `modifiedTime` | string (nullable) | Modified timestamp |
 |   ↳ `attachments` | array | Comment attachments |
 |     ↳ `id` | string | Attachment ID |
 |     ↳ `name` | string | File name |
@@ -287,9 +287,9 @@ Add a comment to a Zoho Desk ticket.
 |     ↳ `email` | string | Email address |
 |     ↳ `type` | string | Commenter type \(AGENT/END_USER\) |
 |     ↳ `roleName` | string | Role name |
-|     ↳ `photoURL` | string | Avatar URL |
+|     ↳ `photoURL` | string (nullable) | Avatar URL |
 |   ↳ `commentedTime` | string | Commented timestamp |
-|   ↳ `modifiedTime` | string | Modified timestamp |
+|   ↳ `modifiedTime` | string (nullable) | Modified timestamp |
 |   ↳ `attachments` | array | Comment attachments |
 |     ↳ `id` | string | Attachment ID |
 |     ↳ `name` | string | File name |
@@ -318,23 +318,23 @@ List conversation threads on a Zoho Desk ticket, newest first (Zoho sorts by sen
 |   ↳ `id` | string | Thread ID |
 |   ↳ `channel` | string | Thread channel |
 |   ↳ `direction` | string | Direction \(in/out\) |
-|   ↳ `content` | string | Thread content \(raw; may be HTML\) |
+|   ↳ `content` | string (nullable) | Thread content \(raw; may be HTML\) |
 |   ↳ `contentType` | string | Content type |
-|   ↳ `contentText` | string | Plain-text rendering of content \(HTML stripped when contentType is html\) |
-|   ↳ `summary` | string | Thread summary |
-|   ↳ `responderId` | string | Responder ID |
+|   ↳ `contentText` | string (nullable) | Plain-text rendering of content \(HTML stripped when contentType is html\) |
+|   ↳ `summary` | string (nullable) | Thread summary |
+|   ↳ `responderId` | string (nullable) | Responder ID |
 |   ↳ `createdTime` | string | Created timestamp |
 |   ↳ `hasAttach` | boolean | Whether the thread has attachments |
 |   ↳ `attachmentCount` | string | Number of attachments |
-|   ↳ `fromEmailAddress` | string | From email address |
-|   ↳ `to` | string | To email address |
-|   ↳ `cc` | string | CC email address |
-|   ↳ `bcc` | string | BCC email address |
-|   ↳ `replyTo` | string | Reply-to email address |
+|   ↳ `fromEmailAddress` | string (nullable) | From email address |
+|   ↳ `to` | string (nullable) | To email address |
+|   ↳ `cc` | string (nullable) | CC email address |
+|   ↳ `bcc` | string (nullable) | BCC email address |
+|   ↳ `replyTo` | string (nullable) | Reply-to email address |
 |   ↳ `isForward` | boolean | Whether the thread is a forward |
 |   ↳ `isContentTruncated` | boolean | Whether Zoho truncated the thread content; fetch fullContentURL for the rest |
-|   ↳ `fullContentURL` | string | URL returning the untruncated thread content |
-|   ↳ `plainText` | string | Zoho's own plain-text rendering of the thread, when it supplies one |
+|   ↳ `fullContentURL` | string (nullable) | URL returning the untruncated thread content |
+|   ↳ `plainText` | string (nullable) | Zoho's own plain-text rendering of the thread, when it supplies one |
 |   ↳ `status` | string | Delivery status of the thread \(e.g. SUCCESS, PENDING, FAILED, DRAFT\) |
 |   ↳ `isDescriptionThread` | boolean | Whether this thread is the ticket's original description |
 |   ↳ `visibility` | string | Thread visibility \(e.g. public\) |
@@ -345,7 +345,7 @@ List conversation threads on a Zoho Desk ticket, newest first (Zoho sorts by sen
 |     ↳ `lastName` | string | Last name |
 |     ↳ `email` | string | Email address |
 |     ↳ `type` | string | Author type \(AGENT/END_USER\) |
-|     ↳ `photoURL` | string | Avatar URL |
+|     ↳ `photoURL` | string (nullable) | Avatar URL |
 |   ↳ `attachments` | array | Thread attachments |
 |     ↳ `id` | string | Attachment ID |
 |     ↳ `name` | string | File name |
@@ -374,23 +374,23 @@ Retrieve the full content of a single Zoho Desk ticket thread.
 |   ↳ `id` | string | Thread ID |
 |   ↳ `channel` | string | Thread channel |
 |   ↳ `direction` | string | Direction \(in/out\) |
-|   ↳ `content` | string | Thread content \(raw; may be HTML\) |
+|   ↳ `content` | string (nullable) | Thread content \(raw; may be HTML\) |
 |   ↳ `contentType` | string | Content type |
-|   ↳ `contentText` | string | Plain-text rendering of content \(HTML stripped when contentType is html\) |
-|   ↳ `summary` | string | Thread summary |
-|   ↳ `responderId` | string | Responder ID |
+|   ↳ `contentText` | string (nullable) | Plain-text rendering of content \(HTML stripped when contentType is html\) |
+|   ↳ `summary` | string (nullable) | Thread summary |
+|   ↳ `responderId` | string (nullable) | Responder ID |
 |   ↳ `createdTime` | string | Created timestamp |
 |   ↳ `hasAttach` | boolean | Whether the thread has attachments |
 |   ↳ `attachmentCount` | string | Number of attachments |
-|   ↳ `fromEmailAddress` | string | From email address |
-|   ↳ `to` | string | To email address |
-|   ↳ `cc` | string | CC email address |
-|   ↳ `bcc` | string | BCC email address |
-|   ↳ `replyTo` | string | Reply-to email address |
+|   ↳ `fromEmailAddress` | string (nullable) | From email address |
+|   ↳ `to` | string (nullable) | To email address |
+|   ↳ `cc` | string (nullable) | CC email address |
+|   ↳ `bcc` | string (nullable) | BCC email address |
+|   ↳ `replyTo` | string (nullable) | Reply-to email address |
 |   ↳ `isForward` | boolean | Whether the thread is a forward |
 |   ↳ `isContentTruncated` | boolean | Whether Zoho truncated the thread content; fetch fullContentURL for the rest |
-|   ↳ `fullContentURL` | string | URL returning the untruncated thread content |
-|   ↳ `plainText` | string | Zoho's own plain-text rendering of the thread, when it supplies one |
+|   ↳ `fullContentURL` | string (nullable) | URL returning the untruncated thread content |
+|   ↳ `plainText` | string (nullable) | Zoho's own plain-text rendering of the thread, when it supplies one |
 |   ↳ `status` | string | Delivery status of the thread \(e.g. SUCCESS, PENDING, FAILED, DRAFT\) |
 |   ↳ `isDescriptionThread` | boolean | Whether this thread is the ticket's original description |
 |   ↳ `visibility` | string | Thread visibility \(e.g. public\) |
@@ -401,7 +401,7 @@ Retrieve the full content of a single Zoho Desk ticket thread.
 |     ↳ `lastName` | string | Last name |
 |     ↳ `email` | string | Email address |
 |     ↳ `type` | string | Author type \(AGENT/END_USER\) |
-|     ↳ `photoURL` | string | Avatar URL |
+|     ↳ `photoURL` | string (nullable) | Avatar URL |
 |   ↳ `attachments` | array | Thread attachments |
 |     ↳ `id` | string | Attachment ID |
 |     ↳ `name` | string | File name |
@@ -426,22 +426,22 @@ Retrieve a Zoho Desk contact by ID.
 | --------- | ---- | ----------- |
 | `contact` | object | The contact |
 |   ↳ `id` | string | Contact ID |
-|   ↳ `firstName` | string | First name |
+|   ↳ `firstName` | string (nullable) | First name |
 |   ↳ `lastName` | string | Last name |
-|   ↳ `email` | string | Primary email |
-|   ↳ `secondaryEmail` | string | Secondary email |
-|   ↳ `phone` | string | Phone number |
-|   ↳ `mobile` | string | Mobile number |
-|   ↳ `accountId` | string | Associated account ID |
-|   ↳ `ownerId` | string | Owner ID |
-|   ↳ `type` | string | Contact type |
-|   ↳ `title` | string | Job title |
-|   ↳ `street` | string | Street |
-|   ↳ `city` | string | City |
-|   ↳ `state` | string | State |
-|   ↳ `country` | string | Country |
-|   ↳ `zip` | string | ZIP / postal code |
-|   ↳ `description` | string | Description |
+|   ↳ `email` | string (nullable) | Primary email |
+|   ↳ `secondaryEmail` | string (nullable) | Secondary email |
+|   ↳ `phone` | string (nullable) | Phone number |
+|   ↳ `mobile` | string (nullable) | Mobile number |
+|   ↳ `accountId` | string (nullable) | Associated account ID |
+|   ↳ `ownerId` | string (nullable) | Owner ID |
+|   ↳ `type` | string (nullable) | Contact type |
+|   ↳ `title` | string (nullable) | Job title |
+|   ↳ `street` | string (nullable) | Street |
+|   ↳ `city` | string (nullable) | City |
+|   ↳ `state` | string (nullable) | State |
+|   ↳ `country` | string (nullable) | Country |
+|   ↳ `zip` | string (nullable) | ZIP / postal code |
+|   ↳ `description` | string (nullable) | Description |
 |   ↳ `cf` | json | Custom field values, keyed by custom field API name |
 
 ### Zoho Desk Get Attachment
@@ -481,8 +481,6 @@ List the Zoho Desk organizations (portals) the connected account can access.
 |   ↳ `portalName` | string | Portal name |
 | `count` | number | Number of organizations returned |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -512,4 +510,3 @@ Trigger a workflow when a Zoho Desk event occurs (ticket, comment, thread, conta
 | `orgId` | string | Zoho Desk organization ID |
 | `payload` | json | The full resource that changed \(ticket, comment, thread, etc.\). Comment and thread events gain a derived plain-text `contentText` alongside the raw `content` + `contentType`; ticket events gain `descriptionText` alongside `description`. |
 | `prevState` | json | Previous state of the resource \(update events only\) |
-

--- a/apps/docs/content/docs/integrations/zoom.mdx
+++ b/apps/docs/content/docs/integrations/zoom.mdx
@@ -5,7 +5,7 @@ description: Create and manage Zoom meetings and recordings
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="zoom"
   color="#2D8CFF"
 />
@@ -401,8 +401,6 @@ List participants from a past Zoom meeting
 |   ↳ `totalRecords` | number | Total number of records |
 |   ↳ `nextPageToken` | string | Token for next page of results |
 
-
-
 ## Triggers
 
 A **Trigger** is a block that starts a workflow when an event happens in this service.
@@ -609,4 +607,3 @@ Trigger workflow on any Zoom webhook event
 | `event` | string | The webhook event type \(e.g., meeting.started, recording.completed\) |
 | `event_ts` | number | Unix timestamp in milliseconds when the event occurred |
 | `payload` | json | Complete webhook payload \(structure varies by event type\) |
-

--- a/apps/docs/content/docs/integrations/zoominfo.mdx
+++ b/apps/docs/content/docs/integrations/zoominfo.mdx
@@ -5,7 +5,7 @@ description: Search and enrich B2B company and contact data with ZoomInfo.
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="zoominfo"
   color="#EA1B15"
 />
@@ -191,5 +191,3 @@ Search ZoomInfo news articles by category, URL, or date range.
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | `articles` | array | News articles matching the filters |
-
-

--- a/scripts/generate-docs.test.ts
+++ b/scripts/generate-docs.test.ts
@@ -11,8 +11,11 @@ import {
   extractInheritedBlockCategory,
   extractToolInfo,
   extractUserSettableParamIds,
+  finalizeGeneratedMarkdown,
   generateIconMappings,
+  generateMarkdownForBlock,
   getToolInfo,
+  mergeWithManualContent,
   parseConstProperties,
   parsePropertiesContent,
 } from './generate-docs'
@@ -50,6 +53,36 @@ describe('documentation editor icon metadata', () => {
 })
 
 describe('documentation tool metadata', () => {
+  it('renders evaluated tool outputs when the source constant cannot be resolved', async () => {
+    const [block] = extractAllBlockConfigs(
+      fs.readFileSync(path.resolve('apps/sim/blocks/blocks/ashby.ts'), 'utf-8')
+    )
+    const markdown = await generateMarkdownForBlock({
+      ...block,
+      tools: { access: ['ashby_get_candidate'] },
+    })
+
+    expect(markdown).toContain('| `primaryEmailAddress` |')
+    expect(markdown).not.toContain('| `candidates` |')
+    expect(markdown).not.toContain('| `jobs` |')
+    expect(markdown).not.toContain('| `applications` |')
+  })
+
+  it('renders nullable fields without making their parents or siblings nullable', async () => {
+    const [block] = extractAllBlockConfigs(
+      fs.readFileSync(path.resolve('apps/sim/blocks/blocks/affinity.ts'), 'utf-8')
+    )
+    const markdown = await generateMarkdownForBlock({
+      ...block,
+      tools: { access: ['affinity_get_current_user', 'affinity_list_calls'] },
+    })
+
+    expect(markdown).toContain('|   ↳ `lastName` | string (nullable) |')
+    expect(markdown).toContain('| `nextCursor` | string (nullable) |')
+    expect(markdown).toContain('| `user` | object |')
+    expect(markdown).toContain('| `count` | number |')
+  })
+
   it('uses evaluated outputs for factory-defined tools', async () => {
     const approve = await getToolInfo('sailpoint_approve_access_request')
     const identity = await getToolInfo('sailpoint_get_identity')
@@ -239,6 +272,26 @@ describe('documentation input parameter parsing', () => {
 })
 
 describe('documentation output property parsing', () => {
+  it('preserves nullable fields in constant schemas without reading nested flags or prose', () => {
+    const properties = parseConstProperties(
+      `record: {
+        type: 'object',
+        description: 'A record with nullable: true in its description',
+        properties: {
+          name: { type: 'string', nullable: true },
+          id: { type: 'string', nullable: false },
+        },
+      }`,
+      'test',
+      '',
+      0
+    )
+
+    expect(properties.record).not.toHaveProperty('nullable')
+    expect(properties.record.properties.name).toMatchObject({ type: 'string', nullable: true })
+    expect(properties.record.properties.id).not.toHaveProperty('nullable')
+  })
+
   it('keeps a response field named items inside an array element', () => {
     const properties = parsePropertiesContent(`
       vaults: {
@@ -983,6 +1036,23 @@ describe('template interpolation is lexed rather than brace-counted', () => {
 })
 
 describe('generated reference Markdown', () => {
+  it('cleans template whitespace and EOF while preserving manual Markdown hard breaks', async () => {
+    const markdown = await generateMarkdownForBlock({
+      type: 'test',
+      name: 'Test',
+      description: 'Test documentation',
+      category: 'tools',
+    })
+    expect(markdown).not.toMatch(/[\t ]+$/m)
+
+    const manual = 'First line  \nSecond line'
+    const merged = mergeWithManualContent(markdown, 'existing page', { intro: manual })
+    const final = finalizeGeneratedMarkdown(merged)
+    expect(final).toContain(manual)
+    expect(final).toMatch(/[^\n]\n$/)
+    expect(finalizeGeneratedMarkdown(final)).toBe(final)
+  })
+
   it('renders example URLs without adding punctuation or escape characters to their destinations', () => {
     const description = escapeMdxCell(
       'Use a URL (e.g., https://example.com/file) or [https://example.com/other].'

--- a/scripts/generate-docs.test.ts
+++ b/scripts/generate-docs.test.ts
@@ -83,6 +83,20 @@ describe('documentation tool metadata', () => {
     expect(markdown).toContain('| `count` | number |')
   })
 
+  it('renders nullable overrides on spread-based output definitions', async () => {
+    const [block] = extractAllBlockConfigs(
+      fs.readFileSync(path.resolve('apps/sim/blocks/blocks/github.ts'), 'utf-8')
+    )
+    const markdown = await generateMarkdownForBlock({
+      ...block,
+      tools: { access: ['github_create_pr_review_v2'] },
+    })
+    expect(markdown).toContain('| `user` | object (nullable) |')
+
+    const outputs = parsePropertiesContent('user: { ...USER_OUTPUT, nullable: false },', 'github')
+    expect(outputs.user).toMatchObject({ type: 'object', nullable: false })
+  })
+
   it('uses evaluated outputs for factory-defined tools', async () => {
     const approve = await getToolInfo('sailpoint_approve_access_request')
     const identity = await getToolInfo('sailpoint_get_identity')

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -4104,6 +4104,7 @@ function extractManualContent(existingContent: string): Record<string, string> {
   return manualSections
 }
 
+/** Re-inserts preserved manual sections at their supported locations in generated block Markdown. */
 export function mergeWithManualContent(
   generatedMarkdown: string,
   existingContent: string | null,
@@ -4224,6 +4225,7 @@ async function generateBlockDoc(blockPath: string) {
   }
 }
 
+/** Renders a block's integration reference, including tool metadata and output schemas. */
 export async function generateMarkdownForBlock(
   blockConfig: BlockConfig,
   displayType?: string

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -3628,6 +3628,11 @@ function parseFieldContent(fieldContent: string, toolPrefix?: string, propertyNa
       if (description) {
         result.description = description
       }
+      const nullableOverride = findTopLevelMatch(
+        blankStringsAndComments(fieldContent) ?? '',
+        /\bnullable\s*:\s*(true|false)\b/
+      )
+      if (nullableOverride) result.nullable = nullableOverride[1] === 'true'
       return result
     }
   }

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -457,11 +457,17 @@ const wouldDeletePaths: string[] = []
 
 /** Writes a generated artifact, or in check mode records its final content for the end-of-run comparison. */
 function emitGeneratedFile(filePath: string, content: string): void {
+  if (filePath.endsWith('.mdx')) content = finalizeGeneratedMarkdown(content)
   if (CHECK_ONLY) {
     emittedByPath.set(filePath, content)
     return
   }
   fs.writeFileSync(filePath, content)
+}
+
+/** Keeps one final newline without stripping Markdown hard-break spaces from authored content. */
+export function finalizeGeneratedMarkdown(content: string): string {
+  return content.replace(/\n*$/, '\n')
 }
 
 /** Reads a generated artifact as the pipeline would see it mid-run: overlay first in check mode, then disk. */
@@ -2859,6 +2865,9 @@ function parseConstFieldContent(
   const result: any = {
     type: fieldType,
     description: description || '',
+    ...(findTopLevelMatch(blankStringsAndComments(fieldContent) ?? '', /\bnullable\s*:\s*true\b/)
+      ? { nullable: true }
+      : {}),
   }
 
   if (fieldType === 'object' || fieldType === 'json') {
@@ -3370,6 +3379,9 @@ function formatOutputStructure(outputs: Record<string, any>, indentLevel = 0): s
       if (output.type) {
         type = output.type
       }
+      if (output.nullable === true) {
+        type += ' (nullable)'
+      }
 
       if (output.description) {
         description = output.description
@@ -3640,6 +3652,9 @@ function parseFieldContent(fieldContent: string, toolPrefix?: string, propertyNa
   const result: any = {
     type: fieldType,
     description: description || '',
+    ...(findTopLevelMatch(blankStringsAndComments(fieldContent) ?? '', /\bnullable\s*:\s*true\b/)
+      ? { nullable: true }
+      : {}),
   }
 
   if (fieldType === 'object' || fieldType === 'json') {
@@ -4059,7 +4074,9 @@ export async function getToolInfo(
       outputs:
         toolPrefix === 'sailpoint' || toolName === 'file_edit'
           ? (generatedOutputs ?? sourceInfo?.outputs ?? {})
-          : (sourceInfo?.outputs ?? generatedOutputs ?? {}),
+          : sourceInfo && Object.keys(sourceInfo.outputs).length > 0
+            ? sourceInfo.outputs
+            : (generatedOutputs ?? {}),
     }
   } catch (error) {
     console.error(`Error getting info for tool ${toolName}:`, error)
@@ -4082,7 +4099,7 @@ function extractManualContent(existingContent: string): Record<string, string> {
   return manualSections
 }
 
-function mergeWithManualContent(
+export function mergeWithManualContent(
   generatedMarkdown: string,
   existingContent: string | null,
   manualSections: Record<string, string>
@@ -4202,7 +4219,7 @@ async function generateBlockDoc(blockPath: string) {
   }
 }
 
-async function generateMarkdownForBlock(
+export async function generateMarkdownForBlock(
   blockConfig: BlockConfig,
   displayType?: string
 ): Promise<string> {
@@ -4350,7 +4367,7 @@ description: ${description}
 
 import { BlockInfoCard } from "@/components/ui/block-info-card"
 
-<BlockInfoCard 
+<BlockInfoCard
   type="${type}"
   color="${bgColor || '#F5F5F5'}"
 />
@@ -5011,11 +5028,7 @@ async function generateAllTriggerDocs(): Promise<void> {
       if (existing?.includes('\n## Actions')) {
         // Actions page generated this run by the block pass — append the Triggers section.
         if (!existing.includes('\n## Triggers')) {
-          if (CHECK_ONLY) {
-            emittedByPath.set(outputFilePath, `${existing}\n${buildTriggersSection(triggers)}`)
-          } else {
-            fs.appendFileSync(outputFilePath, `\n${buildTriggersSection(triggers)}`)
-          }
+          emitGeneratedFile(outputFilePath, `${existing}\n${buildTriggersSection(triggers)}`)
         }
       } else {
         // Trigger-only service (no actions block) — (re)write the standalone page,


### PR DESCRIPTION
## Summary
- Use evaluated tool outputs when source extraction is empty, preserving existing nonempty-source precedence.
- Preserve nullable output types and clean generated template/EOF whitespace without changing manual Markdown.
- Regenerate 271 integration pages: 218 whitespace-only, 40 nullable-only, and 13 with corrected output schemas. Generator logic and tests are the only handwritten changes.

## Type of Change
- [x] Bug fix

## Testing
- 84 documentation-generator tests pass, including actual tool-to-rendered-table regressions and manual hard-break preservation.
- App type-check, repository lint, all 46 audits, block-registry/migration checks, docs-manifest check, and diff check pass.
- Confirmed all existing manual-content sections remain byte-identical. No new lint warnings; three existing parser-fixture warnings remain.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)


