### PR TITLE
fix(lint): check the generated integration catalog

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -142,6 +142,10 @@
   },
   "overrides": [
     {
+      "includes": ["packages/deployment-config/src/integrations.json"],
+      "files": { "maxSize": 2097152 }
+    },
+    {
       "includes": ["apps/sim/app/_styles/tailwind.css"],
       "linter": { "enabled": false },
       "formatter": { "enabled": false }


### PR DESCRIPTION
## Summary

- Keep the generated integration catalog within Biome's checked files with a bounded, exact-path 2 MiB override.
- Preserve the global file-size limit and existing catalog generation and semantic audits.

## Type of Change

- [x] Bug fix

## Testing

Targeted catalog/config Biome check, full repository lint, all 46 repository audits, block-registry audit, docs-manifest check, and git diff whitespace check passed. No new tests are needed for this configuration-only change.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing (configuration-only; existing checks passed)
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
