### PR TITLE
fix(ci): validate stacked PRs against explicit audit bases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ on:
   push:
     branches: [main, staging, dev]
   pull_request:
-    branches: [main, staging, dev]
     # Docs content and markdown don't affect the app build or images; push
     # runs stay unfiltered because they feed the deploy pipeline.
     paths-ignore:
@@ -36,9 +35,12 @@ permissions:
 jobs:
   test-build:
     name: Test and Build
-    if: github.ref != 'refs/heads/dev' || github.event_name == 'pull_request'
+    if: >-
+      (github.ref != 'refs/heads/dev' || github.event_name == 'pull_request') &&
+      (github.event_name != 'pull_request' ||
+       contains(fromJSON('["main", "staging", "dev"]'), github.base_ref) ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/test-build.yml
-    secrets: inherit
 
   # Detect if this is a version release commit (e.g., "v0.5.24: ...")
   # Smallest runner on purpose: a few seconds of pure shell over the commit

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -3,6 +3,11 @@ name: Test and Build
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      comparison_base:
+        description: 'Full commit SHA to compare against the selected branch'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -171,7 +176,7 @@ jobs:
       # The diff-based audits below need a base commit to read, and the default
       # depth of 1 clones a single commit with no parent. They normally fetch
       # their base by SHA (see "Resolve base ref"), so this depth only covers the
-      # `HEAD~1` fallback — but without it that fallback resolves to nothing.
+      # new-branch push's `HEAD~1` fallback — without it that resolves to nothing.
       #
       # Worth stating because the failure was invisible for so long: the migration
       # audit read the resulting `git diff` failure as "no migrations changed" and
@@ -286,19 +291,33 @@ jobs:
       # It is fetched by SHA at depth 1; the audits diff two tips and need no
       # common ancestry. An all-zero `before` means the branch is new and has no
       # predecessor to diff, so `HEAD~1` remains the fallback there.
+      # PRs use the event's base SHA, not a branch that can advance while queued.
+      # Manual runs require an explicit base so earlier commits are audited too.
       - name: Resolve base ref for diff-based audits
         id: audit_base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          COMPARISON_BASE: ${{ inputs.comparison_base }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --depth=1 origin "${{ github.base_ref }}"
-            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ github.event.before }}" ] &&
-               [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            git fetch --depth=1 origin "${{ github.event.before }}"
-            echo "ref=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base_sha="$PR_BASE_SHA"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            base_sha="$COMPARISON_BASE"
+          elif [ -n "$PUSH_BEFORE_SHA" ] &&
+               [ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            base_sha="$PUSH_BEFORE_SHA"
           else
-            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
+            base_sha="$(git rev-parse --verify 'HEAD~1^{commit}')"
           fi
+          if ! [[ "$base_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo 'Comparison base must be a full commit SHA.' >&2
+            exit 1
+          fi
+          git fetch --no-tags --depth=1 origin "$base_sha"
+          resolved_base="$(git rev-parse --verify "$base_sha^{commit}")"
+          echo "ref=$resolved_base" >> "$GITHUB_OUTPUT"
 
       - name: Check block registry invariants
         run: bun run apps/sim/scripts/check-block-registry.ts "${{ steps.audit_base.outputs.ref }}"


### PR DESCRIPTION
## Summary

- Run the existing non-deploying validation for same-repository stacked PRs, while retaining primary-base fork PR coverage and existing push/deployment gates.
- Pin PR audits to the event base SHA and require an explicit full comparison SHA for manual runs. Preserve the new-branch push fallback.
- Remove unused secret inheritance from the validation-only workflow call.

## Type of Change
- [x] Bug fix

## Testing

- actionlint 1.7.12 passed for both workflows.
- Exercised six event-gating cases and eight executions of the actual audit-base shell against a shallow Git fixture.
- Verified the real block-registry and migration audits detect an earlier change that a HEAD~1 comparison misses; existing migration-audit tests pass.
- Repository lint, all 46 audits, block-registry and docs-manifest checks pass. Required generators produce no changes.
- [Normal PR CI](https://github.com/simstudioai/sim/actions/runs/34386803404) passed.
- [Manual dispatch with an explicit comparison SHA](https://github.com/simstudioai/sim/actions/runs/34386820254) passed.
- [Actual same-repository stacked PR CI](https://github.com/simstudioai/sim/actions/runs/34386871173) passed, including both diff-based audits; deployment jobs stayed skipped. Temporary fixture PR #7663 was closed without merging.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
