### PR TITLE
test(ci): temporary stacked PR trigger verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+# Temporary stacked-PR trigger validation; this branch will not be merged.
 
 # Runner provider toggle, read from the CI_PROVIDER repo variable:
 #


### PR DESCRIPTION
Temporary, non-mergeable validation fixture for #7662. This comment-only workflow change verifies automatic validation against a nonstandard same-repository PR base. No deployment is intended. This PR and remote branch will be closed/deleted after the run is inspected.