### PR TITLE
fix(workflow-renderer): remove quadratic backtracking in reference highlighting

### DIFF
--- a/packages/workflow-renderer/src/formatted-text.test.tsx
+++ b/packages/workflow-renderer/src/formatted-text.test.tsx
@@ -104,3 +104,21 @@ describe('shared reference formatting', () => {
     expect((html.match(/class=/g) ?? []).length).toBe(2)
   })
 })
+
+describe('brace scanning', () => {
+  it('highlights the innermost environment reference inside repeated braces', () => {
+    const html = renderToStaticMarkup(
+      <>{formatDisplayText('{{{{KEY}}', { availableEnvVars: new Set(['KEY']) })}</>
+    )
+
+    expect(html).toContain('<span>{{</span>')
+    expect(html).toContain('text-[var(--brand-secondary)]')
+    expect(html).toContain('{{KEY}}')
+  })
+
+  it('scans unterminated brace runs in linear time', () => {
+    const started = performance.now()
+    formatDisplayText('{'.repeat(100_000))
+    expect(performance.now() - started).toBeLessThan(1_000)
+  })
+})

--- a/packages/workflow-renderer/src/formatted-text.tsx
+++ b/packages/workflow-renderer/src/formatted-text.tsx
@@ -107,7 +107,7 @@ function formatDisplayTextInternal(
   }
 
   const nodes: ReactNode[] = []
-  const regex = /<[^<>]+>|\{\{[^}]+\}\}/g
+  const regex = /<[^<>]+>|\{\{[^{}]+\}\}/g
   let lastIndex = 0
   let key = 0
 


### PR DESCRIPTION
## Summary
- Fixes CodeQL alert 492 (`js/polynomial-redos`) in `formatDisplayText`
- The env-var branch of the scanner was `\{\{[^}]+\}\}`. The class admits `{`, so a run of unmatched braces restarts a full backtracking scan at every offset — quadratic. Measured on the real pattern: 5k braces 25ms, 10k 93ms, 20k 341ms, 40k 1.4s, 100k 8.3s
- Excluding `{` from the class makes it linear (100k braces now ~1ms)

## Behavior change
Narrowing the class is a real, deliberate narrowing: a reference whose **name contains `{`** (e.g. `{{FOO{BAR}}`) no longer highlights, while `resolveEnvVars` would still resolve it at runtime.

This is accepted rather than worked around, because there is no formulation that is both linear and permissive — allowing `{` in the body is precisely what lets overlapping `{{` starts each rescan the same brace-free region. Bounding the body length (`[^}]{1,N}`) only trades this divergence for a different one. `{` is not a legitimate character in an environment-variable name; the BYOK path already enforces `^[A-Za-z0-9_]+$`.

The divergence is cosmetic — it changes only whether a span carries the highlight class, never the rendered characters (see Testing).

## Type of Change
- [x] Bug fix

## Testing
- Two regression tests added, both verified to fail against the old regex (`expected 8301ms to be less than 1000`, and the nested-brace assertion) and pass after
- Exhaustive differential run of the old vs new module (scratch, not committed): every string up to length 7 over `{ } < > K . ␠` across 7 highlight contexts including the search-highlight recursion — **6,725,600 comparisons, 2,133 differences, 0 outside the `/\{\{[^}]*\{/` class, 0 where the rendered text changed**. Plus 300k randomized strings of length 8–40: same result
- `@sim/workflow-renderer` suite: 15 files / 143 tests passing; consumer tests in `apps/sim` (formatted-text, dropdown, selector-combobox) passing
- `bun run lint`, `bun run check:audits` (46 audits), `docs-manifest:check`, package `type-check` all clean

## Follow-up (not in this PR)
The same quadratic pattern exists in two server-side spots, where the CPU burned is a worker's rather than a browser tab's — `executor/utils/reference-validation.ts` (`createEnvVarPattern`, 40k braces → 613ms) and `lib/execution/code-placeholders/shared.ts`. Tightening those to `[^{}]+` would also close the divergence noted above from the other side.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139x4ngJzcoYrjwsS9B2ZG4
