### PR TITLE
fix(table): reclaim a cascade lock a timed-out acquire may have taken

### DIFF
--- a/apps/sim/lib/table/cascade-lock.test.ts
+++ b/apps/sim/lib/table/cascade-lock.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment node
+ */
+import { redisConfigMockFns } from '@sim/testing'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cascadeLockKey, withCascadeLock } from '@/lib/table/cascade-lock'
+
+const TABLE_ID = 'tbl_1'
+const ROW_ID = 'row_1'
+const OWNER_ID = 'exec-1'
+
+describe('withCascadeLock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    redisConfigMockFns.mockAcquireLock.mockResolvedValue(true)
+    redisConfigMockFns.mockReleaseLock.mockResolvedValue(true)
+    redisConfigMockFns.mockExtendLock.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('runs the work and releases under the owner that took the lock', async () => {
+    const fn = vi.fn().mockResolvedValue('done')
+
+    await expect(withCascadeLock(TABLE_ID, ROW_ID, OWNER_ID, fn)).resolves.toEqual({
+      status: 'acquired',
+      result: 'done',
+    })
+    expect(fn).toHaveBeenCalledOnce()
+    expect(redisConfigMockFns.mockReleaseLock).toHaveBeenCalledWith(
+      cascadeLockKey(TABLE_ID, ROW_ID),
+      OWNER_ID
+    )
+  })
+
+  it('skips the work when another task holds the row', async () => {
+    redisConfigMockFns.mockAcquireLock.mockResolvedValue(false)
+    const fn = vi.fn()
+
+    await expect(withCascadeLock(TABLE_ID, ROW_ID, OWNER_ID, fn)).resolves.toEqual({
+      status: 'contended',
+    })
+    expect(fn).not.toHaveBeenCalled()
+    // Nothing was taken, so nothing may be deleted — the holder still owns it.
+    expect(redisConfigMockFns.mockReleaseLock).not.toHaveBeenCalled()
+  })
+
+  it('reclaims a lock a timed-out acquire may have taken', async () => {
+    // A client-side timeout does not mean Redis declined the SET: the command
+    // can still land and hold the row for the full TTL under an owner that
+    // already threw, silently starving every later cell task for that row.
+    redisConfigMockFns.mockAcquireLock.mockRejectedValue(new Error('Command timed out'))
+    const fn = vi.fn()
+
+    await expect(withCascadeLock(TABLE_ID, ROW_ID, OWNER_ID, fn)).rejects.toThrow(
+      'Command timed out'
+    )
+    expect(fn).not.toHaveBeenCalled()
+    expect(redisConfigMockFns.mockAcquireLock).toHaveBeenCalledWith(
+      cascadeLockKey(TABLE_ID, ROW_ID),
+      OWNER_ID,
+      expect.any(Number),
+      { reclaimOnFailure: true }
+    )
+  })
+
+  it('releases the lock when the work throws', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('boom'))
+
+    await expect(withCascadeLock(TABLE_ID, ROW_ID, OWNER_ID, fn)).rejects.toThrow('boom')
+    expect(redisConfigMockFns.mockReleaseLock).toHaveBeenCalledWith(
+      cascadeLockKey(TABLE_ID, ROW_ID),
+      OWNER_ID
+    )
+  })
+
+  it('stops the heartbeat once the work settles', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockResolvedValue(undefined)
+
+    await withCascadeLock(TABLE_ID, ROW_ID, OWNER_ID, fn)
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    // A heartbeat outliving the work would keep extending a lock nobody holds.
+    expect(redisConfigMockFns.mockExtendLock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/sim/lib/table/cascade-lock.ts
+++ b/apps/sim/lib/table/cascade-lock.ts
@@ -40,7 +40,21 @@ export async function withCascadeLock<T>(
   fn: () => Promise<T>
 ): Promise<{ status: 'acquired'; result: T } | { status: 'contended' }> {
   const key = cascadeLockKey(tableId, rowId)
-  const acquired = await acquireLock(key, ownerId, LOCK_TTL_SECONDS)
+  const acquired = await acquireLock(key, ownerId, LOCK_TTL_SECONDS, {
+    /**
+     * A client-side timeout does not mean Redis declined the SET — the command
+     * can still be sitting in the offline queue and take the lock once the
+     * connection completes, leaving the row's cascade held for the full TTL by
+     * an owner that already threw, with no heartbeat and no release. Every other
+     * cell task for that row then reads `contended` and bails on the silent
+     * path, so one stalled connection quietly drops later cells too.
+     *
+     * Both preconditions hold here: `ownerId` is the cell task's `executionId`,
+     * unique to this holder, and a throw means `fn` never runs, so freeing a
+     * lock this call may have taken cannot cut under a caller still working.
+     */
+    reclaimOnFailure: true,
+  })
   if (!acquired) return { status: 'contended' }
 
   const heartbeat = setInterval(() => {


### PR DESCRIPTION
## Summary
- A client-side timeout does not mean Redis declined the `SET`. The command can still be parked in the offline queue and take the lock once the connection completes, leaving the row's cascade held for the full 30s TTL by an owner that already threw — no heartbeat, no release
- Every other cell task for that row then reads `contended` and bails on the *silent* path, so one stalled connection quietly drops later cells rather than just failing the one run
- Releasing after a failed acquire is what [Redlock](https://redis.io/docs/latest/develop/clients/patterns/distributed-locks/) prescribes: a client that fails to acquire "will try to unlock all the instances (even the instances it believed it was not able to lock)", and the docs stress releasing ASAP so nobody waits out the TTL
- Both preconditions the option documents hold here — `ownerId` is the cell task's unique `executionId`, and a throw means `fn` never runs, so the reclaim cannot cut under a caller still doing work

Verified against a local ioredis harness: at the moment the caller sees the timeout the server has only seen the handshake, and the `SET` arrives afterwards — so the lock really is taken by a caller that gave up. With the reclaim, the compare-and-delete lands behind it and frees the key.

The option stays opt-in rather than becoming the default: `withLeaderLock` and the MCP OAuth refresh mutex both `return fn()` when acquisition throws, so freeing a lock under them would admit a second concurrent runner.

## Type of Change
- [x] Bug fix

## Testing
Adds the cascade lock's first tests — acquire, contention, reclaim, release on throw, and heartbeat teardown. The reclaim test was verified to fail when the option is flipped off.

`bun run type-check` clean. 1,775 tests pass across `lib/table` and `background`. `bun run lint`, `docs-manifest:check`, and all 46 audits in `check:audits` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)