### PR TITLE
fix(executor): remove quadratic backtracking in env var reference patterns

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/settings/components/mcp/components/mcp-server-form-modal/mcp-server-form-modal.tsx
@@ -67,7 +67,7 @@ export interface McpServerFormModalProps {
   domainPolicyError?: string
 }
 
-const ENV_VAR_PATTERN = /\{\{[^}]+\}\}/
+const ENV_VAR_PATTERN = /\{\{[^{}]+\}\}/
 
 function hasEnvVarInHostname(url: string): boolean {
   const globalPattern = new RegExp(ENV_VAR_PATTERN.source, 'g')

--- a/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-editor/preview-editor.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/w/components/preview/components/preview-editor/preview-editor.tsx
@@ -128,7 +128,7 @@ function extractAllReferencesFromSubBlocks(
         }
       }
 
-      const envMatches = value.match(/\{\{([^}]+)\}\}/g)
+      const envMatches = value.match(/\{\{([^{}]+)\}\}/g)
       if (envMatches) {
         envMatches.forEach((match) => envVars.add(match))
       }

--- a/apps/sim/executor/utils/reference-validation.differential.test.ts
+++ b/apps/sim/executor/utils/reference-validation.differential.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment node
+ *
+ * Differential test: narrowing the `{{ENV_VAR}}` body from `[^}]` to `[^{}]`
+ * must not change resolution for any name the product can represent.
+ *
+ * The narrowing exists to remove polynomial backtracking — a class admitting
+ * its own opening delimiter lets every offset in a run of `{` restart a full
+ * scan. That is a real change to the accepted language, not a refactor, and it
+ * runs on the execution path, so the divergence is pinned down here rather than
+ * argued in a review comment.
+ *
+ * The one accepted divergence is enumerated below: a reference whose name
+ * contains `{`. `PATTERNS.ENV_VAR_NAME` forbids that character, so no such name
+ * can be stored through the secrets manager, and the divergence is unreachable.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { PATTERNS, REFERENCE } from '@/executor/constants'
+import { createEnvVarPattern, resolveEnvVarReferences } from '@/executor/utils/reference-validation'
+
+/** The pattern as it stood before the narrowing. */
+function createLegacyEnvVarPattern(): RegExp {
+  return new RegExp(`\\${REFERENCE.ENV_VAR_START}([^}]+)\\${REFERENCE.ENV_VAR_END}`, 'g')
+}
+
+function matchesOf(pattern: RegExp, text: string): string[] {
+  pattern.lastIndex = 0
+  const found: string[] = []
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(text)) !== null) found.push(`${match.index}:${match[0]}`)
+  return found
+}
+
+/**
+ * Complete up to character equivalence: `{`, `}`, `<`, `>` are the delimiters,
+ * and every other character behaves identically in both bodies. `_`, `A` and
+ * the space cover the name, trim and separator cases.
+ */
+const ALPHABET = ['{', '}', '<', '>', 'A', '_', ' ']
+const MAX_LEN = 6
+
+function* corpus(): Generator<string> {
+  let level = ['']
+  yield ''
+  for (let length = 1; length <= MAX_LEN; length++) {
+    const next: string[] = []
+    for (const prefix of level) {
+      for (const character of ALPHABET) {
+        const candidate = prefix + character
+        next.push(candidate)
+        yield candidate
+      }
+    }
+    level = next
+  }
+}
+
+/** The enumerated divergence: a `{{` whose body reaches a `{` before any `}`. */
+const NAME_CONTAINS_BRACE = /\{\{[^}]*\{/
+
+describe('env var pattern narrowing', () => {
+  it('diverges only where the reference name contains an opening brace', () => {
+    const legacy = createLegacyEnvVarPattern()
+    const current = createEnvVarPattern()
+    const unexplained: string[] = []
+    let differed = 0
+
+    for (const text of corpus()) {
+      const before = matchesOf(legacy, text)
+      const after = matchesOf(current, text)
+      if (before.join('|') === after.join('|')) continue
+      differed++
+      if (!NAME_CONTAINS_BRACE.test(text) && unexplained.length < 20) unexplained.push(text)
+    }
+
+    expect(unexplained).toEqual([])
+    expect(differed).toBeGreaterThan(0)
+  })
+
+  it('never diverges on a representable environment-variable name', () => {
+    const legacy = createLegacyEnvVarPattern()
+    const current = createEnvVarPattern()
+    const names = ['A', '_', 'API_KEY', 'a1', '_x9', 'X'.repeat(64)]
+    const surroundings = ['%s', 'a%sb', '%s%s', 'x {{%s}} y', '{{%s}} {{%s}}']
+
+    for (const name of names) {
+      expect(PATTERNS.ENV_VAR_NAME.test(name)).toBe(true)
+      for (const shape of surroundings) {
+        const text = shape.replaceAll('%s', `{{${name}}}`).replaceAll('{{{{', '{{')
+        expect(matchesOf(current, text)).toEqual(matchesOf(legacy, text))
+      }
+    }
+  })
+
+  it('still resolves references, including padded and embedded ones', () => {
+    const envVars = { API_KEY: 'secret', OTHER: 'value' }
+    expect(resolveEnvVarReferences('{{API_KEY}}', envVars)).toBe('secret')
+    expect(resolveEnvVarReferences('{{ API_KEY }}', envVars)).toBe('secret')
+    expect(resolveEnvVarReferences('a-{{API_KEY}}-b', envVars)).toBe('a-secret-b')
+    expect(resolveEnvVarReferences('{{API_KEY}}/{{OTHER}}', envVars)).toBe('secret/value')
+  })
+
+  it('scans an unterminated brace run in linear time', () => {
+    const started = performance.now()
+    resolveEnvVarReferences('{'.repeat(100_000), { API_KEY: 'secret' })
+    expect(performance.now() - started).toBeLessThan(1_000)
+  })
+})

--- a/apps/sim/executor/utils/reference-validation.ts
+++ b/apps/sim/executor/utils/reference-validation.ts
@@ -1,6 +1,16 @@
 import { REFERENCE } from '@/executor/constants'
 
 /**
+ * Body of an `{{ENV_VAR}}` reference. Excludes both braces for the same reason
+ * `createReferencePattern` excludes both angle brackets: a class that admits its
+ * own opening delimiter lets every offset in a run of `{` restart a full
+ * backtracking scan, which is quadratic in the length of the run. Env var names
+ * are `PATTERNS.ENV_VAR_NAME` (`[A-Za-z_][A-Za-z0-9_]*`), so no representable
+ * name is excluded by this.
+ */
+const ENV_VAR_BODY = '[^{}]+'
+
+/**
  * Creates a regex pattern for matching variable references.
  * Uses [^<>]+ to prevent matching across nested brackets (e.g., "<3 <real.ref>" matches separately).
  */
@@ -15,7 +25,7 @@ export function createReferencePattern(): RegExp {
  * Creates a regex pattern for matching environment variables {{variable}}
  */
 export function createEnvVarPattern(): RegExp {
-  return new RegExp(`\\${REFERENCE.ENV_VAR_START}([^}]+)\\${REFERENCE.ENV_VAR_END}`, 'g')
+  return new RegExp(`\\${REFERENCE.ENV_VAR_START}(${ENV_VAR_BODY})\\${REFERENCE.ENV_VAR_END}`, 'g')
 }
 
 export interface EnvVarResolveOptions {
@@ -66,7 +76,7 @@ export function resolveEnvVarReferences(
   if (typeof value === 'string') {
     if (resolveExactMatch) {
       const exactMatchPattern = new RegExp(
-        `^\\${REFERENCE.ENV_VAR_START}([^}]+)\\${REFERENCE.ENV_VAR_END}$`
+        `^\\${REFERENCE.ENV_VAR_START}(${ENV_VAR_BODY})\\${REFERENCE.ENV_VAR_END}$`
       )
       const exactMatch = exactMatchPattern.exec(value)
       if (exactMatch) {
@@ -140,7 +150,7 @@ export function createWorkflowVariablePattern(): RegExp {
 export function createCombinedPattern(): RegExp {
   return new RegExp(
     `${REFERENCE.START}[^${REFERENCE.START}${REFERENCE.END}]+${REFERENCE.END}|` +
-      `\\${REFERENCE.ENV_VAR_START}[^}]+\\${REFERENCE.ENV_VAR_END}`,
+      `\\${REFERENCE.ENV_VAR_START}${ENV_VAR_BODY}\\${REFERENCE.ENV_VAR_END}`,
     'g'
   )
 }

--- a/apps/sim/lib/execution/code-placeholders/scan.differential.test.ts
+++ b/apps/sim/lib/execution/code-placeholders/scan.differential.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment node
+ *
+ * Differential test: the placeholder scan must accept exactly what the regex it
+ * replaced accepted.
+ *
+ * `collectCodePlaceholderOccurrences` used `/\{\{([^}]+)\}\}/g`, which is quadratic
+ * because the body class admits `{`. Narrowing the class would have been the cheap
+ * fix, but parameter keys are arbitrary strings — they bind to opaque indexed names,
+ * not to identifiers — so a name containing `{` is representable and dropping it
+ * would silently leave a literal placeholder in compiled user code.
+ *
+ * The scan therefore keeps the old language and drops only the backtracking. That is
+ * only safe if it is exactly equivalent, so the equivalence is pinned here rather
+ * than argued: any divergence from the regex is a bug, with no exceptions enumerated.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { collectCodePlaceholderOccurrences } from '@/lib/execution/code-placeholders/shared'
+import type { CodePlaceholderOccurrence } from '@/lib/execution/code-placeholders/types'
+
+/** The regex the scan replaced, applied with the same skip-blank-name rule. */
+function collectWithLegacyRegex(code: string): CodePlaceholderOccurrence[] {
+  const pattern = /\{\{([^}]+)\}\}/g
+  const occurrences: CodePlaceholderOccurrence[] = []
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(code)) !== null) {
+    const name = match[1].trim()
+    if (!name) continue
+    occurrences.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      raw: match[0],
+      name,
+    })
+  }
+  return occurrences
+}
+
+/**
+ * Complete up to character equivalence: `{` and `}` are the delimiters and every
+ * other character behaves identically in the body. `A` and the space cover the
+ * name and the trim-to-blank case.
+ */
+const ALPHABET = ['{', '}', 'A', ' ']
+const MAX_LEN = 12
+
+function* corpus(): Generator<string> {
+  let level = ['']
+  yield ''
+  for (let length = 1; length <= MAX_LEN; length++) {
+    const next: string[] = []
+    for (const prefix of level) {
+      for (const character of ALPHABET) {
+        const candidate = prefix + character
+        next.push(candidate)
+        yield candidate
+      }
+    }
+    level = next
+  }
+}
+
+describe('code placeholder scan', () => {
+  it('is exactly equivalent to the regex it replaced', () => {
+    let compared = 0
+    const divergent: string[] = []
+
+    for (const code of corpus()) {
+      compared++
+      const scanned = JSON.stringify(collectCodePlaceholderOccurrences(code))
+      const expected = JSON.stringify(collectWithLegacyRegex(code))
+      if (scanned !== expected && divergent.length < 20) divergent.push(code)
+    }
+
+    expect(divergent).toEqual([])
+    expect(compared).toBeGreaterThan(20_000_000)
+  }, 900_000)
+
+  it('keeps names that contain an opening brace', () => {
+    expect(collectCodePlaceholderOccurrences('{{a{b}}').map((o) => o.name)).toEqual(['a{b'])
+    expect(collectCodePlaceholderOccurrences('x {{ A }} y').map((o) => o.name)).toEqual(['A'])
+  })
+
+  it('scans an unterminated brace run in linear time', () => {
+    const started = performance.now()
+    collectCodePlaceholderOccurrences('{'.repeat(200_000))
+    expect(performance.now() - started).toBeLessThan(1_000)
+  })
+})

--- a/apps/sim/lib/execution/code-placeholders/shared.ts
+++ b/apps/sim/lib/execution/code-placeholders/shared.ts
@@ -11,7 +11,6 @@ import type {
 } from '@/lib/execution/code-placeholders/types'
 
 const MAX_PLACEHOLDERS = 10_000
-const PLACEHOLDER_PATTERN = /\{\{([^{}]+)\}\}/g
 
 export class CodePlaceholderCompileError extends Error {
   readonly line?: number
@@ -28,17 +27,43 @@ export class CodePlaceholderCompileError extends Error {
   }
 }
 
+/**
+ * Scans `{{name}}` placeholders, accepting exactly what `/\{\{([^}]+)\}\}/g` accepts —
+ * a name may contain `{`, because parameter keys are arbitrary strings rather than
+ * identifiers.
+ *
+ * Written as a scan rather than that regex because the regex is quadratic: `[^}]`
+ * admits `{`, so every offset in a run of `{` restarts a full backtracking scan, and
+ * this runs on user-authored code during execution. No regex is both linear and this
+ * permissive. The scan is linear because a failure at one `{{` predicts failure for
+ * every `{{` before the same closing brace: they share a body run and therefore the
+ * same terminator check, so the cursor jumps past them instead of retrying each.
+ */
 export function collectCodePlaceholderOccurrences(code: string): CodePlaceholderOccurrence[] {
   const occurrences: CodePlaceholderOccurrence[] = []
-  let match: RegExpExecArray | null
-  PLACEHOLDER_PATTERN.lastIndex = 0
-  while ((match = PLACEHOLDER_PATTERN.exec(code)) !== null) {
-    const name = match[1].trim()
+  let cursor = 0
+  while (cursor < code.length) {
+    const start = code.indexOf('{{', cursor)
+    if (start === -1) break
+
+    const bodyStart = start + 2
+    const bodyEnd = code.indexOf('}', bodyStart)
+    if (bodyEnd === -1) break
+
+    if (bodyEnd === bodyStart || code[bodyEnd + 1] !== '}') {
+      cursor = bodyEnd - 1
+      continue
+    }
+
+    const raw = code.slice(start, bodyEnd + 2)
+    cursor = bodyEnd + 2
+
+    const name = code.slice(bodyStart, bodyEnd).trim()
     if (!name) continue
     occurrences.push({
-      start: match.index,
-      end: match.index + match[0].length,
-      raw: match[0],
+      start,
+      end: start + raw.length,
+      raw,
       name,
     })
     if (occurrences.length > MAX_PLACEHOLDERS) {

--- a/apps/sim/lib/execution/code-placeholders/shared.ts
+++ b/apps/sim/lib/execution/code-placeholders/shared.ts
@@ -11,7 +11,7 @@ import type {
 } from '@/lib/execution/code-placeholders/types'
 
 const MAX_PLACEHOLDERS = 10_000
-const PLACEHOLDER_PATTERN = /\{\{([^}]+)\}\}/g
+const PLACEHOLDER_PATTERN = /\{\{([^{}]+)\}\}/g
 
 export class CodePlaceholderCompileError extends Error {
   readonly line?: number

--- a/apps/sim/lib/mcp/domain-check.test.ts
+++ b/apps/sim/lib/mcp/domain-check.test.ts
@@ -13,7 +13,7 @@ vi.mock('dns/promises', () => ({
 }))
 
 vi.mock('@/executor/utils/reference-validation', () => ({
-  createEnvVarPattern: () => /\{\{([^}]+)\}\}/g,
+  createEnvVarPattern: () => /\{\{([^{}]+)\}\}/g,
 }))
 
 import {


### PR DESCRIPTION
## Summary
- Follow-up to #7672, which fixed the renderer. This fixes the same defect where it actually costs a worker's CPU rather than a browser tab's
- The `{{ENV_VAR}}` body was `[^}]+` in `createEnvVarPattern`, the exact-match path and `createCombinedPattern` (`executor/utils/reference-validation.ts`), in `code-placeholders/shared.ts`, and in two client surfaces. The class admits `{`, so a run of unmatched braces restarts a full backtracking scan at every offset
- Measured end to end through `resolveEnvVarReferences`: 100k braces took **12.1s**. `code-placeholders` is reached from `function-execution/execute-request.ts` on user-authored Function block code
- **Environment-variable paths** narrow the body to `[^{}]+` — the same reason `createReferencePattern` already documents for excluding both angle brackets. The three executor sites now share one constant so they can't drift apart
- **The code-placeholder compiler keeps its grammar** and drops only the backtracking. Narrowing was wrong there (caught in review): parameter keys are `Record<string, unknown>` and bind to opaque indexed names rather than identifiers, so a key containing `{` is representable, and dropping it would silently leave a literal placeholder in compiled JavaScript, Python or shell source. `collectCodePlaceholderOccurrences` is now a scan — linear because a failure at one `{{` predicts failure for every `{{` before the same closing brace, so the cursor jumps past them instead of retrying each

## Why this can't affect a running workflow
Two different arguments, because the two paths have different key spaces.

**Environment variables** are `PATTERNS.ENV_VAR_NAME` — `/^[A-Za-z_][A-Za-z0-9_]*$/` (`executor/constants.ts:440`) — enforced by the secrets manager on every key, typed or pasted. `{` is not representable in a name, so the narrowed class excludes nothing that can be stored.

**Code placeholders** have no such constraint, so nothing is excluded there at all: the accepted language is unchanged and the equivalence is proven rather than argued.

Deliberately narrowed to `[^{}]+` rather than reusing the editor-side `[^{}\r\n]+` from `@sim/utils/workflow-references`: excluding CR/LF would additionally stop a placeholder split across lines in Function block code from resolving. The two patterns legitimately differ — the editor one also forbids newlines because a token shouldn't span lines — so they are not unified.

## Type of Change
- [x] Bug fix

## Testing
- Two differential tests added. `executor/utils/reference-validation.differential.test.ts`, in the style of the existing `linear-regex.differential.test.ts`: pins the accepted divergence rather than arguing it in review. Exhaustive over every string up to length 6 across `{ } < > A _ ␠` (complete up to character equivalence), asserting every divergence is a name containing `{`, that no representable `ENV_VAR_NAME` diverges, and that a 100k brace run scans in under 1s
- `lib/execution/code-placeholders/scan.differential.test.ts` compares the scan against the exact regex it replaced over every string up to length 12 across `{ } A ␠` — **22.4M inputs, zero divergence, no enumerated exceptions**. Harness verified to have teeth by mutating the scan
- Guards verified to fail against the old code (`expected 12103ms to be less than 1000`, the divergence-set assertion, and the mutated scan) and pass after
- **Full `apps/sim` suite: 3,374 files / 47,496 tests passing** (one unrelated copilot test timed out under parallel load and passes in isolation — it has no reference to the changed code)
- `bun run lint`, `bun run check:audits` (46 audits), `docs-manifest:check`, `type-check` all clean

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139x4ngJzcoYrjwsS9B2ZG4
