### PR TITLE
fix(billing): stop transient read failures from reading as plan downgrades

### DIFF
--- a/apps/sim/app/api/v1/middleware.ts
+++ b/apps/sim/app/api/v1/middleware.ts
@@ -11,6 +11,7 @@ import type { ForbiddenDetailCode } from '@/lib/core/application/forbidden'
 import type { SubscriptionPlan } from '@/lib/core/rate-limiter'
 import { getRateLimit, RateLimiter } from '@/lib/core/rate-limiter'
 import { generateRequestId } from '@/lib/core/utils/request'
+import { withDatabaseReadRetry } from '@/lib/db/read-retry'
 import {
   CAPABILITY_RULES,
   type StaticPermissionGroupCapability,
@@ -163,7 +164,17 @@ export async function checkRateLimit(
     }
 
     const userId = auth.userId!
-    const subscription = await getHighestPrioritySubscription(userId)
+    /**
+     * `onError: 'throw'` rather than the default `'return-null'`: the plan here
+     * selects the rate-limit tier, and a swallowed read is indistinguishable
+     * from a genuine absence of plan, so a dropped connection would quietly
+     * apply free-tier limits to a paying user. The catch below already fails
+     * closed, which is where the thrown read lands.
+     */
+    const subscription = await withDatabaseReadRetry(
+      () => getHighestPrioritySubscription(userId, { onError: 'throw' }),
+      { label: 'getHighestPrioritySubscription' }
+    )
 
     const result = await rateLimiter.checkRateLimitWithSubscription(
       userId,

--- a/apps/sim/lib/billing/calculations/usage-monitor.test.ts
+++ b/apps/sim/lib/billing/calculations/usage-monitor.test.ts
@@ -131,6 +131,26 @@ describe('checkUsageStatus', () => {
     expect(mockGetBillingPeriodUsageCost).not.toHaveBeenCalled()
   })
 
+  it('marks the fail-closed block as indeterminate when usage cannot be read', async () => {
+    const subscription = {
+      referenceId: 'user-1',
+      plan: 'pro',
+      status: 'active',
+      seats: 1,
+      periodStart: new Date('2026-06-01T00:00:00.000Z'),
+      periodEnd: new Date('2026-07-01T00:00:00.000Z'),
+    }
+    mockComputeBillingPeriodUsageWithWeeklyRefresh.mockRejectedValueOnce(
+      Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' })
+    )
+
+    /** Still blocks — failing open would admit unmetered work — but says why. */
+    await expect(checkUsageStatus('user-1', subscription)).resolves.toMatchObject({
+      isExceeded: true,
+      indeterminate: true,
+    })
+  })
+
   it('preserves the paid weekly-refresh clamp for negative effective usage', async () => {
     const periodStart = new Date('2026-06-01T00:00:00.000Z')
     const periodEnd = new Date('2026-07-01T00:00:00.000Z')

--- a/apps/sim/lib/billing/calculations/usage-monitor.ts
+++ b/apps/sim/lib/billing/calculations/usage-monitor.ts
@@ -42,6 +42,13 @@ interface UsageData {
   scope: 'user' | 'organization'
   /** Present only when `scope === 'organization'`. */
   organizationId: string | null
+  /**
+   * Set when the gate blocked because usage could not be read at all, rather
+   * than because a real limit was reached. Blocking is deliberate — failing
+   * open would admit unmetered work — but the two are not the same failure and
+   * must not be reported to the caller identically.
+   */
+  indeterminate?: boolean
 }
 
 async function computePooledOrgUsage(
@@ -177,6 +184,7 @@ export async function checkUsageStatus(
       limit: 0,
       scope: 'user',
       organizationId: null,
+      indeterminate: true,
     }
   }
 }

--- a/apps/sim/lib/billing/core/billing-attribution.ts
+++ b/apps/sim/lib/billing/core/billing-attribution.ts
@@ -109,6 +109,8 @@ export interface ResolveWorkspaceBillingPayerOptions {
 
 export interface AttributedUsageLimitsResult {
   isExceeded: boolean
+  /** The block came from an unreadable usage figure, not a real limit. */
+  indeterminate?: boolean
   message?: string
   scope?: 'actor' | 'payer' | 'member'
   payerUsage?: {
@@ -926,6 +928,16 @@ export async function checkAttributedUsageLimits(
   const payerSnapshot = {
     currentUsage: payerUsage.currentUsage,
     limit: payerUsage.limit,
+  }
+
+  if (payerUsage.indeterminate) {
+    return {
+      isExceeded: true,
+      indeterminate: true,
+      message: 'Unable to determine current usage. Please retry.',
+      scope: 'payer',
+      payerUsage: payerSnapshot,
+    }
   }
 
   if (payerUsage.isExceeded) {

--- a/apps/sim/lib/db/read-retry.ts
+++ b/apps/sim/lib/db/read-retry.ts
@@ -38,14 +38,20 @@ export function isTransientDatabaseReadError(error: unknown): boolean {
  * rebuild the query outside any transaction and must have no side effects or locks.
  * A failed connection cannot establish whether a write committed, so writes and
  * transactions must never use this helper.
+ *
+ * `label` names the read in the retry log line so callers that wrap several can tell which flapped.
  */
-export async function withDatabaseReadRetry<T>(read: () => Promise<T>): Promise<T> {
+export async function withDatabaseReadRetry<T>(
+  read: () => Promise<T>,
+  options: { label?: string } = {}
+): Promise<T> {
   for (let attempt = 1; ; attempt++) {
     try {
       return await read()
     } catch (error) {
       if (attempt >= 3 || !isTransientDatabaseReadError(error)) throw error
       logger.warn('Retrying transient database read', {
+        label: options.label,
         attempt,
         code: getPostgresErrorCode(error),
       })

--- a/apps/sim/lib/execution/preprocessing.test.ts
+++ b/apps/sim/lib/execution/preprocessing.test.ts
@@ -5,6 +5,7 @@
 import { loggingSessionMock, workflowAuthzMockFns } from '@sim/testing'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ADMISSION_ERROR_CODE } from '@/lib/core/admission/transient-failure'
+import type { LoggingSession } from '@/lib/logs/execution/logging-session'
 
 const {
   mockSleep,
@@ -275,6 +276,11 @@ describe('preprocessExecution suppressRetryableFailureLogs option', () => {
     }
   }
 
+  /** Preprocessing only reaches `safeStart`/`safeCompleteWithError`, so the mock stands in for the full session. */
+  function asLoggingSession(session: ReturnType<typeof makeLoggingSession>): LoggingSession {
+    return session as unknown as LoggingSession
+  }
+
   it('skips the failure row for a retryable infrastructure failure', async () => {
     workflowAuthzMockFns.mockGetActiveWorkflowRecord.mockRejectedValue(
       Object.assign(new Error('write CONNECT_TIMEOUT'), { code: 'CONNECT_TIMEOUT' })
@@ -284,7 +290,7 @@ describe('preprocessExecution suppressRetryableFailureLogs option', () => {
     const result = await preprocessExecution({
       ...baseOptions,
       suppressRetryableFailureLogs: true,
-      loggingSession: loggingSession as any,
+      loggingSession: asLoggingSession(loggingSession),
     })
 
     expect(result).toMatchObject({
@@ -307,7 +313,7 @@ describe('preprocessExecution suppressRetryableFailureLogs option', () => {
     const result = await preprocessExecution({
       ...baseOptions,
       suppressRetryableFailureLogs: true,
-      loggingSession: loggingSession as any,
+      loggingSession: asLoggingSession(loggingSession),
     })
 
     expect(result).toMatchObject({
@@ -324,7 +330,7 @@ describe('preprocessExecution suppressRetryableFailureLogs option', () => {
 
     const result = await preprocessExecution({
       ...baseOptions,
-      loggingSession: makeLoggingSession() as any,
+      loggingSession: asLoggingSession(makeLoggingSession()),
     })
 
     expect(workflowAuthzMockFns.mockGetActiveWorkflowRecord).toHaveBeenCalledTimes(3)
@@ -342,7 +348,7 @@ describe('preprocessExecution suppressRetryableFailureLogs option', () => {
 
     const result = await preprocessExecution({
       ...baseOptions,
-      loggingSession: loggingSession as any,
+      loggingSession: asLoggingSession(loggingSession),
     })
 
     expect(result).toMatchObject({

--- a/apps/sim/lib/execution/preprocessing.test.ts
+++ b/apps/sim/lib/execution/preprocessing.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ADMISSION_ERROR_CODE } from '@/lib/core/admission/transient-failure'
 
 const {
+  mockSleep,
   mockCheckAttributedUsageLimits,
   mockCheckRateLimit,
   mockGetActivelyBannedUserIds,
@@ -14,6 +15,7 @@ const {
   mockResolveBillingAttribution,
   mockResolveSystemBillingAttribution,
 } = vi.hoisted(() => ({
+  mockSleep: vi.fn().mockResolvedValue(undefined),
   mockCheckAttributedUsageLimits: vi.fn(),
   mockCheckRateLimit: vi.fn(),
   mockGetActivelyBannedUserIds: vi.fn().mockResolvedValue([]),
@@ -22,6 +24,9 @@ const {
   mockResolveSystemBillingAttribution: vi.fn(),
 }))
 
+vi.mock('@sim/utils/helpers', () => ({
+  sleep: mockSleep,
+}))
 vi.mock('@/lib/auth/ban', () => ({
   getActivelyBannedUserIds: mockGetActivelyBannedUserIds,
 }))
@@ -248,6 +253,10 @@ describe('preprocessExecution logPreprocessingErrors option', () => {
 })
 
 describe('preprocessExecution suppressRetryableFailureLogs option', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   const baseOptions = {
     workflowId: 'workflow-1',
     userId: 'owner-1',
@@ -267,7 +276,7 @@ describe('preprocessExecution suppressRetryableFailureLogs option', () => {
   }
 
   it('skips the failure row for a retryable infrastructure failure', async () => {
-    workflowAuthzMockFns.mockGetActiveWorkflowRecord.mockRejectedValueOnce(
+    workflowAuthzMockFns.mockGetActiveWorkflowRecord.mockRejectedValue(
       Object.assign(new Error('write CONNECT_TIMEOUT'), { code: 'CONNECT_TIMEOUT' })
     )
     const loggingSession = makeLoggingSession()
@@ -308,8 +317,25 @@ describe('preprocessExecution suppressRetryableFailureLogs option', () => {
     expect(loggingSession.safeStart).toHaveBeenCalled()
   })
 
+  it('retries the workflow fetch before surfacing a transient failure', async () => {
+    workflowAuthzMockFns.mockGetActiveWorkflowRecord.mockRejectedValue(
+      Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' })
+    )
+
+    const result = await preprocessExecution({
+      ...baseOptions,
+      loggingSession: makeLoggingSession() as any,
+    })
+
+    expect(workflowAuthzMockFns.mockGetActiveWorkflowRecord).toHaveBeenCalledTimes(3)
+    expect(result).toMatchObject({
+      success: false,
+      error: { message: 'Internal error while fetching workflow', retryable: true },
+    })
+  })
+
   it('records retryable failures when the option is absent', async () => {
-    workflowAuthzMockFns.mockGetActiveWorkflowRecord.mockRejectedValueOnce(
+    workflowAuthzMockFns.mockGetActiveWorkflowRecord.mockRejectedValue(
       Object.assign(new Error('write CONNECT_TIMEOUT'), { code: 'CONNECT_TIMEOUT' })
     )
     const loggingSession = makeLoggingSession()

--- a/apps/sim/lib/execution/preprocessing.test.ts
+++ b/apps/sim/lib/execution/preprocessing.test.ts
@@ -96,6 +96,18 @@ afterAll(() => {
   workflowAuthzMockFns.mockGetActiveWorkflowRecord.mockReset()
 })
 
+function makeLoggingSession() {
+  return {
+    safeStart: vi.fn().mockResolvedValue(true),
+    safeCompleteWithError: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+/** Preprocessing only reaches `safeStart`/`safeCompleteWithError`, so the mock stands in for the full session. */
+function asLoggingSession(session: ReturnType<typeof makeLoggingSession>): LoggingSession {
+  return session as unknown as LoggingSession
+}
+
 beforeEach(() => {
   workflowAuthzMockFns.mockGetActiveWorkflowRecord.mockResolvedValue({
     id: 'workflow-1',
@@ -267,18 +279,6 @@ describe('preprocessExecution suppressRetryableFailureLogs option', () => {
     checkDeployment: false,
     checkRateLimit: false,
     workspaceId: 'workspace-1',
-  }
-
-  function makeLoggingSession() {
-    return {
-      safeStart: vi.fn().mockResolvedValue(true),
-      safeCompleteWithError: vi.fn().mockResolvedValue(undefined),
-    }
-  }
-
-  /** Preprocessing only reaches `safeStart`/`safeCompleteWithError`, so the mock stands in for the full session. */
-  function asLoggingSession(session: ReturnType<typeof makeLoggingSession>): LoggingSession {
-    return session as unknown as LoggingSession
   }
 
   it('skips the failure row for a retryable infrastructure failure', async () => {
@@ -596,6 +596,56 @@ describe('preprocessExecution ban gate', () => {
     expect(result.success).toBe(true)
     expect(mockGetActivelyBannedUserIds).toHaveBeenCalledWith(['billed-account-1'])
     expect(mockGetActivelyBannedUserIds.mock.calls[0][0]).not.toContain('creator-1')
+  })
+
+  it('fails closed when the actor subscription cannot be read', async () => {
+    vi.mocked(getHighestPrioritySubscription).mockRejectedValue(
+      Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' })
+    )
+
+    const result = await preprocessExecution({
+      ...baseOptions,
+      loggingSession: asLoggingSession(makeLoggingSession()),
+    })
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { statusCode: 500, retryable: true },
+    })
+  })
+
+  it('asks for the subscription in a form that surfaces read failures', async () => {
+    vi.mocked(getHighestPrioritySubscription).mockResolvedValue({ plan: 'team' } as any)
+
+    await preprocessExecution({
+      ...baseOptions,
+      loggingSession: asLoggingSession(makeLoggingSession()),
+    })
+
+    expect(getHighestPrioritySubscription).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ onError: 'throw' })
+    )
+  })
+
+  it('reports an unreadable usage figure as retryable rather than a billing failure', async () => {
+    mockCheckAttributedUsageLimits.mockResolvedValue({
+      isExceeded: true,
+      indeterminate: true,
+      message: 'Unable to determine current usage. Please retry.',
+      scope: 'payer',
+      payerUsage: { currentUsage: 0, limit: 0 },
+    })
+
+    const result = await preprocessExecution({
+      ...baseOptions,
+      loggingSession: asLoggingSession(makeLoggingSession()),
+    })
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { statusCode: 503, retryable: true },
+    })
   })
 
   it('fails closed with 500 when the ban check errors', async () => {

--- a/apps/sim/lib/execution/preprocessing.ts
+++ b/apps/sim/lib/execution/preprocessing.ts
@@ -560,7 +560,53 @@ export async function preprocessExecution(
     }
   })()
 
-  const subscriptionFetch = getHighestPrioritySubscription(actorUserId)
+  /**
+   * `onError: 'throw'` rather than the default `'return-null'`: this value only
+   * ever feeds the rate limiter, and a swallowed read is indistinguishable from
+   * a genuine absence of plan, so a dropped connection would quietly apply
+   * free-tier limits to a paying actor. Matches the v2 API key auth path, which
+   * resolves the same rate-limit subscription the same way.
+   */
+  const subscriptionFetch = (async (): Promise<{
+    failure: GateFailure | null
+    subscription: SubscriptionInfo | null
+  }> => {
+    try {
+      const subscription = await withDatabaseReadRetry(
+        () => getHighestPrioritySubscription(actorUserId, { onError: 'throw' }),
+        { label: 'getHighestPrioritySubscription' }
+      )
+      return { failure: null, subscription }
+    } catch (error) {
+      logger.error(`[${requestId}] Error resolving actor subscription`, { error, actorUserId })
+
+      return {
+        failure: {
+          response: {
+            success: false,
+            error: {
+              message: 'Unable to determine plan entitlements. Execution blocked.',
+              statusCode: 500,
+              retryable: isRetryableInfrastructureError(error),
+              cause: describeRetryableInfrastructureError(error),
+            },
+          },
+          recordError: {
+            workflowId,
+            executionId,
+            triggerType,
+            requestId,
+            userId: actorUserId,
+            workspaceId,
+            errorMessage: 'Unable to determine plan entitlements. Execution blocked.',
+            loggingSession: providedLoggingSession,
+            triggerData,
+          },
+        },
+        subscription: null,
+      }
+    }
+  })()
 
   /**
    * Returns the usage failure and reservation snapshot together so concurrent
@@ -591,6 +637,46 @@ export async function preprocessExecution(
               : {}),
           }
         : null
+      /**
+       * The usage gate fails closed on an unreadable figure, which is correct —
+       * failing open would admit unmetered work. But that block is an
+       * infrastructure outcome, not a billing one: reporting it as a 402 tells
+       * a customer who is under their limit to upgrade, and marks a retryable
+       * condition permanent.
+       */
+      if (usageCheck.indeterminate) {
+        logger.error(`[${requestId}] Usage gate blocked on an unreadable usage figure.`, {
+          actorUserId,
+          workflowId,
+          triggerType,
+        })
+
+        return {
+          failure: {
+            response: {
+              success: false,
+              error: {
+                message: usageCheck.message || 'Unable to determine current usage. Please retry.',
+                statusCode: 503,
+                retryable: true,
+              },
+            },
+            recordError: {
+              workflowId,
+              executionId,
+              triggerType,
+              requestId,
+              userId: actorUserId,
+              workspaceId,
+              errorMessage: 'Unable to determine current usage. Execution blocked.',
+              loggingSession: providedLoggingSession,
+              triggerData,
+            },
+          },
+          snapshot,
+        }
+      }
+
       if (usageCheck.isExceeded) {
         logger.warn(`[${requestId}] Attributed usage gate blocked actor ${actorUserId}.`, {
           currentUsage: snapshot?.currentUsage,
@@ -668,11 +754,12 @@ export async function preprocessExecution(
    * Ban, subscription, and usage checks are read-only and start together. Their
    * completion order must not affect the fixed ban → usage rejection precedence.
    */
-  const [banFailure, actorSubscription, usageResult] = await Promise.all([
+  const [banFailure, subscriptionResult, usageResult] = await Promise.all([
     banCheck,
     subscriptionFetch,
     usageCheckTask,
   ])
+  const actorSubscription = subscriptionResult.subscription
 
   /**
    * Rate limiting consumes a token, so it remains sequential and runs only after
@@ -755,7 +842,7 @@ export async function preprocessExecution(
 
   const usageSnapshot = usageResult.snapshot
 
-  const readGateFailure = banFailure ?? usageResult.failure
+  const readGateFailure = banFailure ?? subscriptionResult.failure ?? usageResult.failure
   if (readGateFailure) {
     if (readGateFailure.recordError && !isFailureLogSuppressed(readGateFailure.response.error)) {
       await recordPreprocessingError(readGateFailure.recordError)

--- a/apps/sim/lib/execution/preprocessing.ts
+++ b/apps/sim/lib/execution/preprocessing.ts
@@ -35,6 +35,7 @@ import {
 } from '@/lib/core/execution-limits/metrics'
 import { RateLimiter } from '@/lib/core/rate-limiter/rate-limiter'
 import type { SubscriptionPlan } from '@/lib/core/rate-limiter/types'
+import { withDatabaseReadRetry } from '@/lib/db/read-retry'
 import { LoggingSession, type SessionStartParams } from '@/lib/logs/execution/logging-session'
 import type { CoreTriggerType } from '@/stores/logs/filters/types'
 
@@ -236,7 +237,9 @@ export async function preprocessExecution(
   let workflowRecord: WorkflowRecord | null = prefetchedWorkflowRecord ?? null
   if (!workflowRecord) {
     try {
-      workflowRecord = await getActiveWorkflowRecord(workflowId)
+      workflowRecord = await withDatabaseReadRetry(() => getActiveWorkflowRecord(workflowId), {
+        label: 'getActiveWorkflowRecord',
+      })
 
       if (!workflowRecord) {
         logger.warn(`[${requestId}] Workflow not found: ${workflowId}`)
@@ -297,7 +300,9 @@ export async function preprocessExecution(
       },
     }
   } else {
-    const activeWorkflow = await getActiveWorkflowRecord(workflowId)
+    const activeWorkflow = await withDatabaseReadRetry(() => getActiveWorkflowRecord(workflowId), {
+      label: 'getActiveWorkflowRecord',
+    })
     if (!activeWorkflow) {
       logger.warn(`[${requestId}] Workflow archived before execution started: ${workflowId}`)
       return {
@@ -365,7 +370,10 @@ export async function preprocessExecution(
     }
 
     if (!actorUserId) {
-      billingAttribution = await resolveSystemBillingAttribution(workspaceId)
+      billingAttribution = await withDatabaseReadRetry(
+        () => resolveSystemBillingAttribution(workspaceId),
+        { label: 'resolveSystemBillingAttribution' }
+      )
       actorUserId = billingAttribution.actorUserId
       logger.info(`[${requestId}] Using atomically resolved system actor and payer`, {
         actorUserId,
@@ -402,7 +410,11 @@ export async function preprocessExecution(
     }
 
     if (!billingAttribution) {
-      billingAttribution = await resolveBillingAttribution({ actorUserId, workspaceId })
+      const attributionInput = { actorUserId, workspaceId }
+      billingAttribution = await withDatabaseReadRetry(
+        () => resolveBillingAttribution(attributionInput),
+        { label: 'resolveBillingAttribution' }
+      )
     }
   } catch (error) {
     logger.error(`[${requestId}] Error resolving billing attribution`, { error, workflowId })
@@ -487,7 +499,10 @@ export async function preprocessExecution(
       banCandidateIds.push(userId)
     }
     try {
-      const bannedUserIds = await getActivelyBannedUserIds(banCandidateIds)
+      const bannedUserIds = await withDatabaseReadRetry(
+        () => getActivelyBannedUserIds(banCandidateIds),
+        { label: 'getActivelyBannedUserIds' }
+      )
       if (bannedUserIds.length > 0) {
         logger.warn(`[${requestId}] Execution blocked: banned account`, {
           workflowId,
@@ -558,7 +573,10 @@ export async function preprocessExecution(
     if (skipUsageLimits) return { failure: null, snapshot: null }
     let snapshot: UsageSnapshot | null = null
     try {
-      const usageCheck = await checkAttributedUsageLimits(billingAttribution)
+      const usageCheck = await withDatabaseReadRetry(
+        () => checkAttributedUsageLimits(billingAttribution),
+        { label: 'checkAttributedUsageLimits' }
+      )
       snapshot = usageCheck.payerUsage
         ? {
             ...usageCheck.payerUsage,

--- a/apps/sim/lib/workflows/executor/execution-core.test.ts
+++ b/apps/sim/lib/workflows/executor/execution-core.test.ts
@@ -318,7 +318,8 @@ describe('executeWorkflowCore terminal finalization sequencing', () => {
       loggingSession: loggingSession as any,
     })
 
-    await Promise.resolve()
+    // setImmediate, not a fixed hop count: the assertion is about ordering, not how many microtasks precede the loads
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(callOrder).toContain('load-workflow:start')
     expect(callOrder).toContain('load-env:start')

--- a/apps/sim/lib/workflows/executor/execution-core.ts
+++ b/apps/sim/lib/workflows/executor/execution-core.ts
@@ -19,6 +19,7 @@ import {
   getTimeoutErrorMessage,
   isTimeoutAbortReason,
 } from '@/lib/core/execution-limits'
+import { withDatabaseReadRetry } from '@/lib/db/read-retry'
 import { getExecutionEnvironment } from '@/lib/environment/utils'
 import { clearExecutionCancellation } from '@/lib/execution/cancellation'
 import { warmLargeValueRefs } from '@/lib/execution/payloads/hydration'
@@ -381,7 +382,11 @@ export async function executeWorkflowCore(
   options: ExecuteWorkflowCoreOptions
 ): Promise<ExecutionResult> {
   const workspaceId = options.snapshot.metadata.workspaceId
-  const rows = workspaceId ? await getCustomBlockRowsForWorkspace(workspaceId) : []
+  const rows = workspaceId
+    ? await withDatabaseReadRetry(() => getCustomBlockRowsForWorkspace(workspaceId), {
+        label: 'getCustomBlockRowsForWorkspace',
+      })
+    : []
   return withCustomBlockOverlay(rows, () => executeWorkflowCoreImpl(options))
 }
 
@@ -560,8 +565,11 @@ async function executeWorkflowCoreImpl(
     }
 
     const [workflowState, env] = await Promise.all([
-      loadWorkflowState(),
-      getExecutionEnvironment(personalEnvUserId, workspaceEnvUserId, providedWorkspaceId),
+      withDatabaseReadRetry(loadWorkflowState, { label: 'loadWorkflowState' }),
+      withDatabaseReadRetry(
+        () => getExecutionEnvironment(personalEnvUserId, workspaceEnvUserId, providedWorkspaceId),
+        { label: 'getExecutionEnvironment' }
+      ),
     ])
 
     const { blocks, loops, parallels } = workflowState
@@ -847,12 +855,16 @@ async function executeWorkflowCoreImpl(
     // stage (below) and the block-outputs stage (threaded into the executor).
     // Stored rules are the source of truth; absence yields the disabled default
     // with one indexed lookup and no masking cost for non-PII organizations.
-    const [row] = await db
-      .select({ orgSettings: organization.dataRetentionSettings })
-      .from(workspace)
-      .leftJoin(organization, eq(organization.id, workspace.organizationId))
-      .where(eq(workspace.id, providedWorkspaceId))
-      .limit(1)
+    const [row] = await withDatabaseReadRetry(
+      () =>
+        db
+          .select({ orgSettings: organization.dataRetentionSettings })
+          .from(workspace)
+          .leftJoin(organization, eq(organization.id, workspace.organizationId))
+          .where(eq(workspace.id, providedWorkspaceId))
+          .limit(1),
+      { label: 'resolvePiiRedactionPolicy' }
+    )
     const piiRedaction: EffectivePiiRedaction = resolveEffectivePiiRedaction({
       orgSettings: row?.orgSettings,
       workspaceId: providedWorkspaceId,
@@ -933,7 +945,10 @@ async function executeWorkflowCoreImpl(
         (block) => block.id === resolvedTriggerBlockId
       )
       if (entryBlock && isRunMetadataEnabled(entryBlock)) {
-        const runIdentity = await resolveStartBlockRunIdentity(metadata.principal)
+        const runIdentity = await withDatabaseReadRetry(
+          () => resolveStartBlockRunIdentity(metadata.principal),
+          { label: 'resolveStartBlockRunIdentity' }
+        )
         startRunMetadata = {
           ...runIdentity,
           workspaceId: providedWorkspaceId,


### PR DESCRIPTION
Stacked on #7681 — it adds the `withDatabaseReadRetry` usage in `preprocessing.ts` that these fixes build on. Retarget to `staging` once #7681 merges.

## Summary

Two findings from reviewing the retry work in #7681. They look alike but are not the same kind of problem.

**The subscription gate was a real bug.** The subscription that selects an actor's rate-limit tier was read with the default `onError: 'return-null'`, which swallows failures. A dropped connection was therefore indistinguishable from a genuine absence of plan, and a paying actor silently got free-tier rate limits. This repo already names that hazard and has a remedy for it:

> `onError: 'throw'` rather than the default `'return-null'`: a failed subscription read would otherwise read as "no plan" — `lib/users/account-deletion.ts`

> keeps a momentary outage from being recorded as a plan lapse: the resolver otherwise maps a failed read to `false` exactly like a real one — `lib/execution/remote-sandbox/entitlement.ts`

`lib/api/server/routes/v2-api-key-auth.ts` already resolves the *same* rate-limit subscription with `onError: 'throw'`. `preprocessing.ts` and `app/api/v1/middleware.ts` did not. Both now do, retry the read, and fail closed with a retryable error instead of degrading the tier. `actorSubscription` feeds nothing but the rate limiter, so the blast radius is contained.

**The usage gate was intentional, but mis-surfaced.** `checkUsageStatus` fail-closes on an unreadable figure — deliberate, and correct, since failing open would admit unmetered work. But it returned `{ isExceeded: true, currentUsage: 0, limit: 0 }`, indistinguishable from a real overage, so preprocessing rendered it as a **402** reading `Usage limit exceeded: $0.00 used of $0.00 limit. Please upgrade your plan.` A customer well under their limit was told to upgrade because a connection dropped, and 402 marked a retryable condition permanent. The block is unchanged; it now carries `indeterminate` and surfaces as a retryable **503**.

## Type of Change
- [x] Bug fix

## Testing
Four tests added, each verified able to fail by reverting the specific branch it exercises:
- the subscription gate fails closed when the read throws
- the subscription is requested with `onError: 'throw'`
- an unreadable usage figure surfaces as a retryable 503, not a 402
- `checkUsageStatus` marks its fail-closed block `indeterminate`

`type-check`, `lint`, all 46 `check:audits` and `docs-manifest:check` pass. 2,350 tests across `lib/execution`, `lib/billing`, `app/api/v1`, `lib/db`, `lib/workflows/executor` and `background` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYi7yz8qo98ziQWZmRpqb8