### PR TITLE
fix(slack): use runtime origin for onboarding links

### DIFF
--- a/apps/sim/lib/slack-search/onboarding.test.ts
+++ b/apps/sim/lib/slack-search/onboarding.test.ts
@@ -1,0 +1,37 @@
+/** @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getEnv } = vi.hoisted(() => ({ getEnv: vi.fn() }))
+
+vi.unmock('@/lib/core/utils/urls')
+vi.mock('@/lib/core/config/env', () => ({
+  env: { NEXT_PUBLIC_APP_URL: 'http://localhost:3000' },
+  getEnv,
+}))
+vi.mock('@/lib/core/config/env-flags', () => ({ isProd: true }))
+
+import { slackSearchOnboardingUrl } from '@/lib/slack-search/onboarding'
+
+describe('Slack onboarding URL', () => {
+  beforeEach(() => {
+    getEnv.mockReset()
+  })
+
+  it.each(['https://staging.example.com', 'https://app.example.com', 'https://search.example.org'])(
+    'uses the runtime origin %s instead of the build-time localhost value',
+    (origin) => {
+      getEnv.mockImplementation((key: string) =>
+        key === 'NEXT_PUBLIC_APP_URL' ? origin : undefined
+      )
+      expect(slackSearchOnboardingUrl('opaque-token')).toBe(
+        `${origin}/slack-search/connect/opaque-token`
+      )
+    }
+  )
+
+  it('fails when the runtime public URL is missing instead of using the build-time value', () => {
+    expect(() => slackSearchOnboardingUrl('opaque-token')).toThrow(
+      'NEXT_PUBLIC_APP_URL must be configured'
+    )
+  })
+})

--- a/apps/sim/lib/slack-search/onboarding.ts
+++ b/apps/sim/lib/slack-search/onboarding.ts
@@ -1,4 +1,4 @@
-import { env } from '@/lib/core/config/env'
+import { getBaseUrl } from '@/lib/core/utils/urls'
 import { organizationRoutes } from '@/lib/navigation/paths'
 
 export function slackSearchOnboardingPath(token: string) {
@@ -12,7 +12,7 @@ export function slackSearchIntegrationsPath(organizationId: string, token: strin
 
 /** The destination is application-authored; model-generated links never enter onboarding. */
 export function slackSearchOnboardingUrl(token: string) {
-  return new URL(slackSearchOnboardingPath(token), env.NEXT_PUBLIC_APP_URL).href
+  return new URL(slackSearchOnboardingPath(token), getBaseUrl()).href
 }
 
 export const SLACK_SEARCH_CONNECT_ACCOUNT =


### PR DESCRIPTION
## Summary

- Use the runtime public URL for Slack onboarding buttons and the matching links saved in Sim chat history. Shared builds now use the deployment origin instead of retaining the build-time localhost default.
- Add regression coverage for different runtime origins and missing configuration. Previously sent messages keep their saved links.

## Type of Change

- [x] Bug fix

## Testing

- Reproduced the incorrect URL with regression tests before applying the fix.
- 266 focused tests across 23 suites passed, along with app/auth typechecks, lint, all 46 repository audits, block-registry and docs-manifest checks.
- No live Slack smoke test or deployment performed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
