### PR TITLE
fix(navigation): land on workspaces from the app entry, not settings

### DIFF
--- a/apps/sim/app/home/page.test.tsx
+++ b/apps/sim/app/home/page.test.tsx
@@ -28,10 +28,16 @@ describe('AppEntryPage', () => {
     vi.clearAllMocks()
   })
 
-  it('sends a signed-out visitor to login without resolving an entry', async () => {
+  /**
+   * The proxy sends cookie-less requests to /login before this route renders, so a
+   * null session here is always a stale cookie. Redirecting to /login would be
+   * bounced back by the proxy's presence-only cookie check, looping forever.
+   */
+  it('sends a stale-cookie viewer to the recovery surface, never back to login', async () => {
     mockGetSession.mockResolvedValue(null)
 
-    await expect(AppEntryPage()).rejects.toThrow('NEXT_REDIRECT:/login')
+    await expect(AppEntryPage()).rejects.toThrow('NEXT_REDIRECT:/workspace')
+    expect(mockRedirect).not.toHaveBeenCalledWith('/login')
     expect(mockResolveAppEntryPath).not.toHaveBeenCalled()
   })
 

--- a/apps/sim/app/home/page.tsx
+++ b/apps/sim/app/home/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 import { getSession } from '@/lib/auth'
+import { WORKSPACES_PATH } from '@/lib/navigation/paths'
 import { resolveAppEntryPath } from '@/lib/navigation/resolve-app-entry'
 
 /**
@@ -10,8 +11,20 @@ import { resolveAppEntryPath } from '@/lib/navigation/resolve-app-entry'
  */
 export default async function AppEntryPage() {
   const session = await getSession()
+
+  /**
+   * A missing session here is never a signed-out visitor: the proxy treats `/home`
+   * as an app surface and sends cookie-less requests to `/login` before this
+   * renders, and auth-disabled deployments always resolve an anonymous session. So
+   * this branch means the cookie is present but its session is gone — and
+   * redirecting to `/login` would be bounced straight back by the proxy, which
+   * reads cookie presence rather than validity, looping until the browser gives up.
+   * Hand off to the workspace loader instead: it is the app's one identity-recovery
+   * surface, and it clears the stale cookies through `recoverFromStaleSession`
+   * before navigating to `/login`.
+   */
   if (!session?.user) {
-    redirect('/login')
+    redirect(WORKSPACES_PATH)
   }
 
   redirect(await resolveAppEntryPath(session))

--- a/apps/sim/lib/navigation/organization-rollout.test.ts
+++ b/apps/sim/lib/navigation/organization-rollout.test.ts
@@ -66,7 +66,7 @@ describe('organization rollout during impersonation', () => {
       session: { impersonatedBy: 'platform-admin', activeOrganizationId: 'customer-org' },
     }
     await expect(resolveAppEntryPath(impersonatedSession)).resolves.toBe(
-      knowledge && groups ? '/o/customer-org/home' : '/workspace?redirect=settings'
+      knowledge && groups ? '/o/customer-org/home' : '/workspace'
     )
     expect(mocks.landing).toHaveBeenLastCalledWith('customer-member', 'customer-org')
     expect(mocks.platformAdmin).not.toHaveBeenCalled()

--- a/apps/sim/lib/navigation/resolve-app-entry.test.ts
+++ b/apps/sim/lib/navigation/resolve-app-entry.test.ts
@@ -37,12 +37,10 @@ describe('resolveAppEntryPath', () => {
     expect(mockSearchAvailable).toHaveBeenCalledWith({ organizationId: 'org-2' })
   })
 
-  it('opens full workspace settings when Search is disabled', async () => {
+  it('lands an organization member on the workspace picker when Search is disabled', async () => {
     mockResolveOrganizationLanding.mockResolvedValue('org-2')
     mockSearchAvailable.mockResolvedValue(false)
-    await expect(resolveAppEntryPath({ user: { id: 'viewer' } })).resolves.toBe(
-      '/workspace?redirect=settings'
-    )
+    await expect(resolveAppEntryPath({ user: { id: 'viewer' } })).resolves.toBe('/workspace')
   })
 
   it('lands a viewer with no organization on the workspace picker', async () => {

--- a/apps/sim/lib/navigation/resolve-app-entry.ts
+++ b/apps/sim/lib/navigation/resolve-app-entry.ts
@@ -1,10 +1,6 @@
 import { getActiveOrganizationId } from '@/lib/auth/session-response'
 import { isKnowledgeMemberAccessAvailable } from '@/lib/knowledge/access/availability'
-import {
-  organizationRoutes,
-  WORKSPACE_SETTINGS_PATH,
-  WORKSPACES_PATH,
-} from '@/lib/navigation/paths'
+import { organizationRoutes, WORKSPACES_PATH } from '@/lib/navigation/paths'
 import { resolveOrganizationLanding } from '@/lib/organizations/surface'
 
 interface EntrySession {
@@ -12,8 +8,12 @@ interface EntrySession {
 }
 
 /**
- * Routes organization members to Home when Search is enabled and workspace settings otherwise.
- * Viewers without an organization land on the workspace picker.
+ * Routes organization members to Home when the organization surface is enabled for
+ * them. Everyone else — viewers without an organization, and members whose
+ * organization has not been rolled out — lands on the workspace picker, which is
+ * where the signed-in app's front door pointed before the organization surface
+ * existed. The default landing never opens settings: a viewer who did not ask for
+ * settings must not be dropped into them.
  */
 export async function resolveAppEntryPath(session: EntrySession): Promise<string> {
   const organizationId = await resolveOrganizationLanding(
@@ -21,8 +21,7 @@ export async function resolveAppEntryPath(session: EntrySession): Promise<string
     getActiveOrganizationId(session)
   )
   if (!organizationId) return WORKSPACES_PATH
-  const routes = organizationRoutes(organizationId)
   return (await isKnowledgeMemberAccessAvailable({ organizationId }))
-    ? routes.home
-    : WORKSPACE_SETTINGS_PATH
+    ? organizationRoutes(organizationId).home
+    : WORKSPACES_PATH
 }


### PR DESCRIPTION
## Summary
- Opening the app as an organization member whose organization has not been rolled out landed on the General settings form instead of a workspace. Send them to the workspace picker, which is where the entry pointed before the organization surface existed.
- The default landing never opens settings. The `/o` guards still fall back to settings for viewers who explicitly asked for the organization surface — that case is unchanged.
- Fixed an infinite `/home` ↔ `/login` redirect loop on a stale session cookie. The proxy treats `/home` as an app surface and redirects cookie-less requests to `/login` before the route renders, and auth-disabled deployments always resolve an anonymous session — so a null session inside `/home` always means a present-but-invalid cookie. Redirecting that to `/login` was bounced straight back by the proxy's presence-only cookie check, looping until the browser gave up and leaving the viewer unable to reach the login page at all. It now hands off to the workspace loader, the one identity-recovery surface, which clears the stale cookies before navigating.

## Type of Change
- [x] Bug fix

## Testing
- 22 tests pass across `app/home` and `lib/navigation`. Both fixes verified to fail when reverted.
- `bun run lint`, block-registry audit, all 46 audits (`check:audits`), `docs-manifest:check`, and `type-check` pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)