### PR TITLE
fix(consent): stop asking for consent from a policy we failed to fetch

### DIFF
--- a/apps/sim/app/_shell/consent/consent-banner.test.tsx
+++ b/apps/sim/app/_shell/consent/consent-banner.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockUseConsentManager, mockUseHeadlessConsentUI } = vi.hoisted(() => ({
+  mockUseConsentManager: vi.fn(),
+  mockUseHeadlessConsentUI: vi.fn(),
+}))
+
+vi.mock('@c15t/nextjs/headless', () => ({
+  useConsentManager: mockUseConsentManager,
+  useHeadlessConsentUI: mockUseHeadlessConsentUI,
+}))
+
+vi.mock('@/app/_shell/consent/consent-preferences', () => ({
+  CONSENT_LINK_CLASS: 'link',
+  ConsentPreferences: () => <span data-testid='preferences' />,
+}))
+
+import { ConsentBanner } from '@/app/_shell/consent/consent-banner'
+
+let root: Root | null = null
+
+function render(): HTMLDivElement {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(<ConsentBanner />))
+  return container
+}
+
+function isBannerShown(container: HTMLDivElement): boolean {
+  return container.querySelector('section[aria-label="Cookie preferences"]') !== null
+}
+
+beforeEach(() => {
+  mockUseHeadlessConsentUI.mockReturnValue({
+    banner: { isVisible: true, allowedActions: ['accept', 'reject', 'customize'] },
+    dialog: { isVisible: false, allowedActions: [] },
+    openDialog: vi.fn(),
+    performAction: vi.fn(),
+    saveCustomPreferences: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  root = null
+  vi.clearAllMocks()
+})
+
+describe('ConsentBanner', () => {
+  it.each(['backend', 'backend-cache-hit', 'ssr'])(
+    'asks for consent when the policy came from %s',
+    (initDataSource) => {
+      mockUseConsentManager.mockReturnValue({ initDataSource })
+
+      expect(isBannerShown(render())).toBe(true)
+    }
+  )
+
+  it('asks nothing when the policy lookup fell back', () => {
+    // A bot challenge on the third-party `/init` makes the runtime substitute a
+    // generic opt-in policy, which would otherwise re-prompt visitors who had
+    // already consented under the real one.
+    mockUseConsentManager.mockReturnValue({ initDataSource: 'offline-fallback' })
+
+    expect(isBannerShown(render())).toBe(false)
+  })
+})

--- a/apps/sim/app/_shell/consent/consent-banner.test.tsx
+++ b/apps/sim/app/_shell/consent/consent-banner.test.tsx
@@ -63,6 +63,19 @@ describe('ConsentBanner', () => {
     }
   )
 
+  it('still renders a dialog the visitor opened, so the published control works', () => {
+    mockUseHeadlessConsentUI.mockReturnValue({
+      banner: { isVisible: false, allowedActions: [] },
+      dialog: { isVisible: true, allowedActions: ['accept', 'reject', 'customize'] },
+      openDialog: vi.fn(),
+      performAction: vi.fn(),
+      saveCustomPreferences: vi.fn(),
+    })
+    mockUseConsentManager.mockReturnValue({ initDataSource: 'offline-fallback' })
+
+    expect(isBannerShown(render())).toBe(true)
+  })
+
   it('asks nothing when the policy lookup fell back', () => {
     // A bot challenge on the third-party `/init` makes the runtime substitute a
     // generic opt-in policy, which would otherwise re-prompt visitors who had

--- a/apps/sim/app/_shell/consent/consent-banner.tsx
+++ b/apps/sim/app/_shell/consent/consent-banner.tsx
@@ -30,14 +30,20 @@ const CATEGORIES_OPEN = { height: 'auto', opacity: 1 } as const
  * themed app page where inheriting is what should happen — the card no longer
  * decides for itself.
  *
- * Nothing is asked when the policy lookup failed. `/init` answers from a
- * third-party origin, and when that origin refuses the request — a bot
+ * Nothing is asked *unprompted* when the policy lookup failed. `/init` answers
+ * from a third-party origin, and when that origin refuses the request — a bot
  * challenge returns `403` with an HTML body — the runtime substitutes a generic
- * opt-in policy rather than surfacing the failure. Prompting from it asks a
- * question the visitor's jurisdiction may not require, and asks it of people
- * who already answered, because the substituted policy's fingerprint never
- * matches the one their stored consent was recorded under. The next load that
- * reaches the real policy asks properly if it still needs to.
+ * opt-in policy rather than surfacing the failure. Volunteering a banner from
+ * it asks a question the visitor's jurisdiction may not require, and asks it of
+ * people who already answered, because the substituted policy's fingerprint
+ * never matches the one their stored consent was recorded under. The next load
+ * that reaches the real policy asks properly if it still needs to.
+ *
+ * A dialog the visitor opened themselves still renders, fallback or not: the
+ * Cookie Policy promises the choice can be changed at any time, and a control
+ * that silently does nothing breaks that promise. A choice saved during a
+ * fallback is recorded against the substituted policy and will be asked for
+ * again once the real one resolves, which is the lesser of the two failures.
  */
 export function ConsentBanner() {
   const { banner, dialog, openDialog, performAction, saveCustomPreferences } =
@@ -53,7 +59,7 @@ export function ConsentBanner() {
 
   return (
     <AnimatePresence>
-      {isPolicyResolved && (banner.isVisible || dialog.isVisible) && (
+      {((isPolicyResolved && banner.isVisible) || dialog.isVisible) && (
         <motion.section
           aria-label='Cookie preferences'
           initial={{ opacity: 0, y: enterOffset }}

--- a/apps/sim/app/_shell/consent/consent-banner.tsx
+++ b/apps/sim/app/_shell/consent/consent-banner.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useHeadlessConsentUI } from '@c15t/nextjs/headless'
+import { useConsentManager, useHeadlessConsentUI } from '@c15t/nextjs/headless'
 import { Chip } from '@sim/emcn'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import Link from 'next/link'
@@ -29,12 +29,23 @@ const CATEGORIES_OPEN = { height: 'auto', opacity: 1 } as const
  * the light layer on `<html>` through `ThemeProvider`'s forced theme, or is a
  * themed app page where inheriting is what should happen — the card no longer
  * decides for itself.
+ *
+ * Nothing is asked when the policy lookup failed. `/init` answers from a
+ * third-party origin, and when that origin refuses the request — a bot
+ * challenge returns `403` with an HTML body — the runtime substitutes a generic
+ * opt-in policy rather than surfacing the failure. Prompting from it asks a
+ * question the visitor's jurisdiction may not require, and asks it of people
+ * who already answered, because the substituted policy's fingerprint never
+ * matches the one their stored consent was recorded under. The next load that
+ * reaches the real policy asks properly if it still needs to.
  */
 export function ConsentBanner() {
   const { banner, dialog, openDialog, performAction, saveCustomPreferences } =
     useHeadlessConsentUI()
+  const { initDataSource } = useConsentManager()
   const prefersReducedMotion = useReducedMotion()
 
+  const isPolicyResolved = initDataSource !== 'offline-fallback'
   const isExpanded = dialog.isVisible
   const surfaceName = isExpanded ? 'dialog' : 'banner'
   const { allowedActions } = isExpanded ? dialog : banner
@@ -42,7 +53,7 @@ export function ConsentBanner() {
 
   return (
     <AnimatePresence>
-      {(banner.isVisible || dialog.isVisible) && (
+      {isPolicyResolved && (banner.isVisible || dialog.isVisible) && (
         <motion.section
           aria-label='Cookie preferences'
           initial={{ opacity: 0, y: enterOffset }}

--- a/apps/sim/lib/consent/constants.ts
+++ b/apps/sim/lib/consent/constants.ts
@@ -14,6 +14,19 @@
  * Sim's consent instance. Public by construction — the browser calls it
  * directly, so it is a client-visible origin like the GTM and GA container IDs
  * in the root layout, not a credential.
+ *
+ * The browser must keep calling it directly. c15t documents a same-origin
+ * rewrite (`/api/c15t/:path*`) as an optimization, and it would also sidestep
+ * the bot challenge this origin sometimes answers with — but it resolves the
+ * jurisdiction from the address the request arrives from, and proxying makes
+ * every visitor arrive from our servers. Measured against the live instance:
+ * `x-forwarded-for`, `x-real-ip`, `true-client-ip`, `cf-connecting-ip` and
+ * `x-vercel-ip-country` are all ignored, and only c15t's own `x-c15t-country`
+ * override is honored. Sim has no edge that supplies a country header for us to
+ * forward into it, so behind a proxy every visitor would resolve to our region
+ * and no one in the EU would be asked for consent at all. The same dependency
+ * rules out the SSR prefetch, which reads those headers through
+ * `extractRelevantHeaders`. Revisit only alongside an edge that provides geo.
  */
 export const CONSENT_BACKEND_URL = 'https://sim-sim.inth.app'
 


### PR DESCRIPTION
## Summary

Emir reported the cookie banner coming back "every 1/15 times" on login, for an account that had already answered it. It isn't the banner updating — it's a failure mode, and each occurrence silently destroys his recorded consent.

### What happens

The policy lookup is a cross-origin `GET /init` to the consent instance. That origin intermittently answers a bot challenge instead of the policy:

```
HTTP/2 403
x-vercel-mitigated: challenge
content-type: text/html          ← Vercel Security Checkpoint page
```

A browser `fetch()` can't solve a JS challenge, so it just gets the 403. The runtime then logs `API request failed, falling back to offline mode for consent banner` and substitutes `policyDefaults.offlineOptInBanner()` — a generic opt-in policy — and carries on as if the lookup had succeeded.

Consent records the fingerprint of the policy it was given under. The substituted policy never matches, so `updateStore` treats it as a material policy change and does this:

```js
if (storedPolicyFingerprint && storedPolicyFingerprint !== currentPolicyFingerprint) {
  deleteConsentFromStorage(...)
  set({ consents: resetConsents, consentInfo: null })
}
```

Stored consent is deleted, and with an opt-in policy and no record the banner returns — asking a question the visitor's jurisdiction may not even require.

**Reproduced against production:**

```
after consent              -> banner gone : true   c15t cookie : present
after one challenged /init -> banner back : true   c15t cookie : DELETED
console: "API request failed, falling back to offline mode for consent banner"
```

The challenge is sticky per IP for ~3 minutes, which is why it reads as occasional bursts rather than every load.

### The fix here

The banner renders only when the policy was actually resolved (`initDataSource !== 'offline-fallback'`). A load that fell back asks nothing; the next load that reaches the real policy asks if it still needs to.

### Why not the documented same-origin proxy

c15t documents a `/api/c15t/:path*` rewrite, which would also dodge the challenge. **It would break geo detection for us**, so I did not use it — and recorded why next to the constant so it isn't "optimized" in later.

The instance resolves jurisdiction from the address the request arrives from. Measured against the live instance, every forwarding header we could send is ignored:

| Header sent | Resolved |
|---|---|
| *(baseline)* | CCPA / US-CA |
| `x-forwarded-for: <EU IP>` | CCPA / US-CA |
| `x-real-ip`, `true-client-ip`, `cf-connecting-ip` | CCPA / US-CA |
| `x-vercel-ip-country: DE` | CCPA / US-CA |
| `x-c15t-country: DE` | **GDPR / europe_opt_in** |

Only c15t's own override is honored, and Sim has no edge that supplies a country header to map into it (no CloudFront/Cloudflare in front — checked). Behind a proxy every visitor would resolve to our region and **no one in the EU would be asked for consent at all** — a worse outcome than the bug. The SSR prefetch path has the same dependency via `extractRelevantHeaders`.

I also checked `offlinePolicy` (only consulted for `mode: 'offline'`, not the hosted fallback — `resolveFallbackPolicy({})` is called with an empty object) and `customFetch`/`retryConfig` (destructured as unused in the pinned 2.2.1). No config lever exists.

## Type of Change
- [x] Bug fix

## Testing

`type-check`, `lint:check`, all 46 `check:audits`, and the consent suites pass. New test covers both directions — asks on `backend`/`backend-cache-hit`/`ssr`, asks nothing on `offline-fallback` — and I verified it goes red when the guard is removed.

## Residual, and the real fix

This stops the spurious prompt. It does **not** stop the underlying lookup failure: a challenged load still clears the stored consent inside the runtime before we render, so a visitor whose jurisdiction requires consent will be asked again on their next successful load. That's fail-safe (tracking stays denied until they answer) but it is not free.

**The root cause belongs to the consent instance:** an endpoint browsers call over XHR must not be behind a JS bot challenge. That needs turning off for `/init` and `/subjects` on inth's side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tTS2kSemtRPmTq9ezGRCc
