### PR TITLE
fix(db): exclude pending-drop columns from inserts

### DIFF
--- a/apps/sim/app/api/files/uploads/finalizers.ts
+++ b/apps/sim/app/api/files/uploads/finalizers.ts
@@ -1,6 +1,7 @@
 import { AuditAction, AuditResourceType, recordAudit } from '@sim/audit'
 import { type Principal, resolvePrincipalAuditAttribution } from '@sim/auth/principal'
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import { type WorkspaceFileRow, workspaceFileColumns, workspaceFiles } from '@sim/db/schema'
 import { generateId } from '@sim/utils/id'
 import { eq, sql } from 'drizzle-orm'
@@ -354,7 +355,7 @@ async function insertOrLoadFileMetadata(
 
   const now = new Date()
   const [inserted] = await db
-    .insert(workspaceFiles)
+    .insert(withInsertColumns(workspaceFiles, workspaceFileColumns))
     .values({
       id: generateId(),
       key: input.key,

--- a/apps/sim/app/api/v1/admin/credits/route.ts
+++ b/apps/sim/app/api/v1/admin/credits/route.ts
@@ -25,7 +25,8 @@
 
 import { AuditAction, AuditResourceType, recordAudit } from '@sim/audit'
 import { db } from '@sim/db'
-import { organization, subscription, user, userStats } from '@sim/db/schema'
+import { withInsertColumns } from '@sim/db/insert-columns'
+import { organization, subscription, user, userStats, userStatsColumns } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { generateShortId } from '@sim/utils/id'
 import { normalizeEmail } from '@sim/utils/string'
@@ -155,7 +156,7 @@ export const POST = withRouteHandler(
           .limit(1)
 
         if (!existingStats) {
-          await db.insert(userStats).values({
+          await db.insert(withInsertColumns(userStats, userStatsColumns)).values({
             id: generateShortId(),
             userId: entityId,
           })

--- a/apps/sim/app/api/v1/admin/users/[id]/billing/route.ts
+++ b/apps/sim/app/api/v1/admin/users/[id]/billing/route.ts
@@ -20,6 +20,7 @@
  */
 
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   member,
   organization,
@@ -247,7 +248,7 @@ export const PATCH = withRouteHandler(
       if (existingStats) {
         await db.update(userStats).set(updateData).where(eq(userStats.userId, userId))
       } else {
-        await db.insert(userStats).values({
+        await db.insert(withInsertColumns(userStats, userStatsColumns)).values({
           id: generateShortId(),
           userId,
           ...updateData,

--- a/apps/sim/ee/workspace-forking/lib/copy/copy-files.ts
+++ b/apps/sim/ee/workspace-forking/lib/copy/copy-files.ts
@@ -1,4 +1,5 @@
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import { workspaceFileColumns, workspaceFiles } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
@@ -362,7 +363,7 @@ export async function executeForkFileBlobCopies(
         await db.transaction(async (tx) => {
           assertForkCopyActive(control)
           const [inserted] = await tx
-            .insert(workspaceFiles)
+            .insert(withInsertColumns(workspaceFiles, workspaceFileColumns))
             .values({
               id: task.targetFileId,
               key: task.targetKey,

--- a/apps/sim/lib/admin/dashboard.ts
+++ b/apps/sim/lib/admin/dashboard.ts
@@ -1,5 +1,6 @@
 import { AuditAction, AuditResourceType, recordAudit } from '@sim/audit'
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   member,
   organization,
@@ -11,6 +12,7 @@ import {
   usageLog,
   user,
   userStats,
+  userStatsColumns,
   workspace,
 } from '@sim/db/schema'
 import { generateId } from '@sim/utils/id'
@@ -1524,7 +1526,7 @@ export async function grantDashboardUserBalance(
         ? null
         : getPerUserMinimumLimit(initialSubscription).toString()
     await tx
-      .insert(userStats)
+      .insert(withInsertColumns(userStats, userStatsColumns))
       .values({
         id: generateId(),
         userId,

--- a/apps/sim/lib/auth/anonymous.ts
+++ b/apps/sim/lib/auth/anonymous.ts
@@ -1,4 +1,5 @@
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import * as schema from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
@@ -37,7 +38,7 @@ export async function ensureAnonymousUserExists(): Promise<void> {
     })
 
     if (!existingStats) {
-      await db.insert(schema.userStats).values({
+      await db.insert(withInsertColumns(schema.userStats, schema.userStatsColumns)).values({
         id: generateId(),
         userId: ANONYMOUS_USER_ID,
         currentUsageLimit: '10000000000',

--- a/apps/sim/lib/billing/core/usage.ts
+++ b/apps/sim/lib/billing/core/usage.ts
@@ -1,4 +1,5 @@
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import { member, organization, settings, user, userStats, userStatsColumns } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { isOrgAdminRole } from '@sim/platform-authz/workspace'
@@ -155,7 +156,7 @@ export async function getOrgUsageLimit(
  */
 export async function handleNewUser(userId: string): Promise<void> {
   try {
-    await db.insert(userStats).values({
+    await db.insert(withInsertColumns(userStats, userStatsColumns)).values({
       id: generateId(),
       userId: userId,
       currentUsageLimit: getFreeTierLimit().toString(),
@@ -182,7 +183,7 @@ export async function handleNewUser(userId: string): Promise<void> {
  */
 export async function ensureUserStatsExists(userId: string): Promise<void> {
   await db
-    .insert(userStats)
+    .insert(withInsertColumns(userStats, userStatsColumns))
     .values({
       id: generateId(),
       userId: userId,

--- a/apps/sim/lib/billing/enterprise-provisioning.ts
+++ b/apps/sim/lib/billing/enterprise-provisioning.ts
@@ -1,10 +1,12 @@
 import { AuditAction, AuditResourceType, recordAudit, recordAuditOnce } from '@sim/audit'
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   invitation,
   invitationWorkspaceGrant,
   member,
   organization,
+  organizationColumns,
   outboxEvent,
   permissions,
   subscription,
@@ -1638,7 +1640,7 @@ export async function issueEnterpriseProvisioning(
 
     if (organizationToCreate) {
       const now = new Date()
-      await tx.insert(organization).values({
+      await tx.insert(withInsertColumns(organization, organizationColumns)).values({
         id: organizationToCreate.id,
         name: organizationToCreate.name,
         slug: slugifyOrganizationName(organizationToCreate.name, organizationToCreate.id),

--- a/apps/sim/lib/billing/organization.ts
+++ b/apps/sim/lib/billing/organization.ts
@@ -1,5 +1,12 @@
 import { db } from '@sim/db'
-import { member, organization, subscription as subscriptionTable, user } from '@sim/db/schema'
+import { withInsertColumns } from '@sim/db/insert-columns'
+import {
+  member,
+  organization,
+  organizationColumns,
+  subscription as subscriptionTable,
+  user,
+} from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { isOrgAdminRole } from '@sim/platform-authz/workspace'
 import { generateId } from '@sim/utils/id'
@@ -442,7 +449,7 @@ export async function ensureOrganizationForTeamSubscriptionTx(
 
     organizationId = `org_${generateId()}`
     const now = new Date()
-    await tx.insert(organization).values({
+    await tx.insert(withInsertColumns(organization, organizationColumns)).values({
       id: organizationId,
       name: userData.name || `${userData.email || 'User'}'s Team`,
       slug: `${userId}-team-${generateId()}`

--- a/apps/sim/lib/billing/organizations/create-organization.ts
+++ b/apps/sim/lib/billing/organizations/create-organization.ts
@@ -1,5 +1,6 @@
 import { db } from '@sim/db'
-import { member, organization } from '@sim/db/schema'
+import { withInsertColumns } from '@sim/db/insert-columns'
+import { member, organization, organizationColumns } from '@sim/db/schema'
 import { generateId } from '@sim/utils/id'
 import { and, eq, ne } from 'drizzle-orm'
 import { acquireUserBillingIdentityLock } from '@/lib/billing/organizations/billing-identity-lock'
@@ -100,7 +101,7 @@ export async function createOrganizationWithOwnerTx(
     throw new OrganizationSlugTakenError(slug)
   }
 
-  await tx.insert(organization).values({
+  await tx.insert(withInsertColumns(organization, organizationColumns)).values({
     id: organizationId,
     name,
     slug,

--- a/apps/sim/lib/billing/organizations/membership.ts
+++ b/apps/sim/lib/billing/organizations/membership.ts
@@ -6,6 +6,7 @@
  */
 
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   account,
   credential,
@@ -18,6 +19,7 @@ import {
   subscription as subscriptionTable,
   user,
   userStats,
+  userStatsColumns,
   workspace,
   workspaceFiles,
 } from '@sim/db/schema'
@@ -1837,7 +1839,7 @@ export async function transferOrganizationOwnership(
 
       if (oldStats) {
         await tx
-          .insert(userStats)
+          .insert(withInsertColumns(userStats, userStatsColumns))
           .values({
             id: generateId(),
             userId: newOwnerUserId,

--- a/apps/sim/lib/billing/storage/tracking.ts
+++ b/apps/sim/lib/billing/storage/tracking.ts
@@ -17,7 +17,8 @@
  * writes any of them or deletes a locked row.
  */
 
-import { organization, userStats, workspace } from '@sim/db/schema'
+import { withInsertColumns } from '@sim/db/insert-columns'
+import { organization, userStats, userStatsColumns, workspace } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
 import { isRecordLike } from '@sim/utils/object'
@@ -631,7 +632,7 @@ export async function checkAndIncrementStorageUsageInTx(
 
   if (!orgScoped) {
     await tx
-      .insert(userStats)
+      .insert(withInsertColumns(userStats, userStatsColumns))
       .values({
         id: generateId(),
         userId,

--- a/apps/sim/lib/copilot/chat/fork-chat-files.ts
+++ b/apps/sim/lib/copilot/chat/fork-chat-files.ts
@@ -1,3 +1,4 @@
+import { withInsertColumns } from '@sim/db/insert-columns'
 import { type WorkspaceFileRow, workspaceFileColumns, workspaceFiles } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { getErrorMessage } from '@sim/utils/errors'
@@ -145,7 +146,7 @@ export async function planChatFileCopies(params: {
   // Ids and keys are generated client-side, so one multi-row insert suffices —
   // no per-row round trips while the fork transaction is held open.
   if (copyRows.length > 0) {
-    await tx.insert(workspaceFiles).values(copyRows)
+    await tx.insert(withInsertColumns(workspaceFiles, workspaceFileColumns)).values(copyRows)
     for (const source of rows) {
       const targetId = idMap.get(source.id)
       if (!targetId) continue

--- a/apps/sim/lib/credentials/__integration__/organization-personal-tokens.integration.ts
+++ b/apps/sim/lib/credentials/__integration__/organization-personal-tokens.integration.ts
@@ -1,11 +1,13 @@
 /** Real storage, encryption, migration, and authorization; no external GitLab calls. */
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   credential,
   credentialGroup,
   credentialGroupEnrollment,
   member,
   organization,
+  organizationColumns,
   permissions,
   resourcePolicy,
   user,
@@ -95,7 +97,7 @@ describe('organization personal tokens', () => {
         updatedAt: now,
       }))
     )
-    await db.insert(organization).values(
+    await db.insert(withInsertColumns(organization, organizationColumns)).values(
       [ids.org, ids.foreignOrg].map((id) => ({
         id,
         name: 'Token fixture organization',

--- a/apps/sim/lib/knowledge/__integration__/organization-mcp-search.integration.ts
+++ b/apps/sim/lib/knowledge/__integration__/organization-mcp-search.integration.ts
@@ -12,6 +12,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { Principal } from '@sim/auth/principal'
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   apiKey,
   document,
@@ -25,6 +26,7 @@ import {
   oauthClient,
   oauthConsent,
   organization,
+  organizationColumns,
   organizationSearchIntegration,
   rateLimitBucket,
   user,
@@ -252,7 +254,7 @@ describe('organization Search MCP with real ingestion and current access', () =>
         updatedAt: new Date(),
       }))
     )
-    await db.insert(organization).values({
+    await db.insert(withInsertColumns(organization, organizationColumns)).values({
       id: otherOrganizationId,
       name: 'Other organization MCP fixture',
       slug: otherOrganizationId,

--- a/apps/sim/lib/knowledge/__integration__/seed-source-access-fixture.ts
+++ b/apps/sim/lib/knowledge/__integration__/seed-source-access-fixture.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   credential,
   credentialGroup,
@@ -11,6 +12,7 @@ import {
   knowledgeExternalGroup,
   knowledgeExternalGroupMember,
   organization,
+  organizationColumns,
   permissions,
   user,
   workspace,
@@ -69,7 +71,7 @@ export async function seedKnowledgeAclFixture(
       updatedAt: now,
     },
   ])
-  await db.insert(organization).values({
+  await db.insert(withInsertColumns(organization, organizationColumns)).values({
     id: ids.organizationId,
     name: 'ACL integration organization',
     slug: ids.organizationId,

--- a/apps/sim/lib/knowledge/__integration__/slack-search-turns.integration.ts
+++ b/apps/sim/lib/knowledge/__integration__/slack-search-turns.integration.ts
@@ -1,10 +1,12 @@
 /** Exercises real PostgreSQL locks and constraints using only isolated, explicitly cleaned fixtures. */
 import type { OrganizationDelegatedPrincipal } from '@sim/auth/principal'
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   copilotChats,
   credential,
   organization,
+  organizationColumns,
   outboxEvent,
   slackSearchInstallation,
   slackSearchTurn,
@@ -72,7 +74,7 @@ describe('durable Slack Search turns in PostgreSQL', () => {
       }))
     )
     await db
-      .insert(organization)
+      .insert(withInsertColumns(organization, organizationColumns))
       .values({ id: organizationId, name: 'Slack queue fixture', slug: organizationId })
     await db.insert(credential).values({
       id: credentialId,

--- a/apps/sim/lib/logs/execution/logger.ts
+++ b/apps/sim/lib/logs/execution/logger.ts
@@ -1,4 +1,5 @@
 import { db, dbFor } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   organization,
   usageLog,
@@ -698,7 +699,7 @@ export class ExecutionLogger implements IExecutionLoggerService {
     const startTime = new Date()
 
     const [workflowLog] = await execDb
-      .insert(workflowExecutionLogs)
+      .insert(withInsertColumns(workflowExecutionLogs, workflowExecutionLogColumns))
       .values({
         id: generateId(),
         workflowId,

--- a/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
+++ b/apps/sim/lib/uploads/contexts/workspace/workspace-file-manager.ts
@@ -5,6 +5,7 @@
 
 import { randomBytes } from 'crypto'
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import {
   uploadSession,
   type WorkspaceFileRow,
@@ -266,7 +267,7 @@ async function insertWorkspaceFileMetadataInTx(
   metadata: WorkspaceFileMetadataInsert
 ): Promise<WorkspaceFileRow | undefined> {
   const [inserted] = await tx
-    .insert(workspaceFiles)
+    .insert(withInsertColumns(workspaceFiles, workspaceFileColumns))
     .values({
       ...omit(metadata, ['size']),
       sizeBytes: metadata.size,
@@ -1056,7 +1057,7 @@ export async function trackChatUpload(
 
       await db.transaction(async (tx) => {
         const [inserted] = await tx
-          .insert(workspaceFiles)
+          .insert(withInsertColumns(workspaceFiles, workspaceFileColumns))
           .values({
             id: fileId,
             key: s3Key,

--- a/apps/sim/lib/uploads/server/metadata.ts
+++ b/apps/sim/lib/uploads/server/metadata.ts
@@ -1,4 +1,5 @@
 import { db } from '@sim/db'
+import { withInsertColumns } from '@sim/db/insert-columns'
 import { type WorkspaceFileRow, workspaceFileColumns, workspaceFiles } from '@sim/db/schema'
 import { createLogger } from '@sim/logger'
 import { generateId } from '@sim/utils/id'
@@ -179,7 +180,7 @@ async function insertFileMetadataWithExecutor(
 
   try {
     const [inserted] = await executor
-      .insert(workspaceFiles)
+      .insert(withInsertColumns(workspaceFiles, workspaceFileColumns))
       .values({
         id: fileId,
         key,
@@ -235,7 +236,7 @@ async function insertImmutableFileMetadataWithExecutor(
   } = options
   assertFileMetadataOrganizationOwner(options)
   const [inserted] = await executor
-    .insert(workspaceFiles)
+    .insert(withInsertColumns(workspaceFiles, workspaceFileColumns))
     .values({
       id: id || generateId(),
       key,
@@ -316,7 +317,7 @@ export async function insertFileMetadataMany(
   const uniqueRows = [...uniqueRowsByKey.values()]
 
   const inserted = await db
-    .insert(workspaceFiles)
+    .insert(withInsertColumns(workspaceFiles, workspaceFileColumns))
     .values(
       uniqueRows.map((row) => ({
         id: row.id || generateId(),

--- a/packages/db/insert-columns.test.ts
+++ b/packages/db/insert-columns.test.ts
@@ -1,0 +1,145 @@
+import { withInsertColumns } from '@sim/db/insert-columns'
+import {
+  organization,
+  organizationColumns,
+  userStats,
+  userStatsColumns,
+  workflowExecutionLogColumns,
+  workflowExecutionLogs,
+  workspaceFileColumns,
+  workspaceFiles,
+} from '@sim/db/schema'
+import { getTableColumns, getTableName, sql } from 'drizzle-orm'
+import { getTableConfig, type PgTable, pgSchema, text } from 'drizzle-orm/pg-core'
+import { drizzle } from 'drizzle-orm/pg-proxy'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+const db = drizzle(async () => ({ rows: [] }))
+
+describe('withInsertColumns', () => {
+  it.each([
+    { table: userStats, columns: userStatsColumns, retired: 'total_manual_executions' },
+    { table: organization, columns: organizationColumns, retired: 'departed_member_usage' },
+    { table: workflowExecutionLogs, columns: workflowExecutionLogColumns, retired: 'cost' },
+    { table: workspaceFiles, columns: workspaceFileColumns, retired: 'size' },
+  ])('excludes every retired column from $retired inserts and RETURNING', ({ table, columns }) => {
+    const originalColumns = getTableColumns(table)
+    const originalConfig = getTableConfig(table)
+    const target = withInsertColumns(table, columns)
+    const query = db.insert(target).values({ id: 'example' }).returning().toSQL()
+    const fullQuery = db.insert(table).values({ id: 'example' }).returning().toSQL()
+
+    for (const [key, column] of Object.entries(originalColumns)) {
+      expect(fullQuery.sql).toContain(`"${column.name}"`)
+      if (key in columns) expect(query.sql).toContain(`"${column.name}"`)
+      else expect(query.sql).not.toContain(`"${column.name}"`)
+    }
+    expect(getTableName(target)).toBe(getTableName(table))
+    expect(getTableColumns(target)).toBe(columns)
+    expect(getTableColumns(table)).toBe(originalColumns)
+    expect(getTableConfig(table)).toEqual(originalConfig)
+  })
+
+  it('retains live insert types and excludes retired fields', () => {
+    const target = withInsertColumns(userStats, userStatsColumns)
+    type Insert = typeof target.$inferInsert
+    expectTypeOf<Insert['userId']>().toEqualTypeOf<string>()
+    expectTypeOf<Insert['currentUsageLimit']>().toEqualTypeOf<string | null | undefined>()
+    expectTypeOf<Insert['billingBlockedReason']>().toEqualTypeOf<
+      'payment_failed' | 'dispute' | null | undefined
+    >()
+    expectTypeOf<'totalManualExecutions'>().not.toExtend<keyof Insert>()
+    expectTypeOf<'currentPeriodCost'>().not.toExtend<keyof Insert>()
+  })
+
+  it('preserves bulk values, explicit nulls, defaults, and conflict handling', () => {
+    const target = withInsertColumns(userStats, userStatsColumns)
+    const query = db
+      .insert(target)
+      .values([
+        { id: 'stats-1', userId: 'user-1', currentUsageLimit: null },
+        { id: 'stats-2', userId: 'user-2', currentUsageLimit: '5' },
+      ])
+      .onConflictDoUpdate({
+        target: userStats.userId,
+        set: { currentUsageLimit: sql`excluded.current_usage_limit` },
+      })
+      .returning({ id: userStats.id })
+      .toSQL()
+
+    expect(query.params).toEqual(['stats-1', 'user-1', null, 'stats-2', 'user-2', '5'])
+    expect(query.sql).toContain('default')
+    expect(query.sql).toContain(
+      'on conflict ("user_id") do update set "current_usage_limit" = excluded.current_usage_limit'
+    )
+    expect(query.sql).toContain('returning "id"')
+    expect(query.sql).not.toContain('total_manual_executions')
+    expect(
+      db.insert(target).values({ id: 'stats-3', userId: 'user-3' }).onConflictDoNothing().toSQL()
+        .sql
+    ).toContain('on conflict do nothing')
+  })
+
+  it('preserves parameter encoders and RETURNING decoders', async () => {
+    const startedAt = new Date('2026-01-01T00:00:00Z')
+    const payload = { sample: true }
+    const execute = vi.fn(async () => ({
+      rows: [['2026-01-01 00:00:00', payload, '{model-a,model-b}']],
+    }))
+    const connection = drizzle(execute)
+    const rows = await connection
+      .insert(withInsertColumns(workflowExecutionLogs, workflowExecutionLogColumns))
+      .values({
+        id: 'log-1',
+        workflowId: 'workflow-1',
+        workspaceId: 'workspace-1',
+        executionId: 'execution-1',
+        stateSnapshotId: 'snapshot-1',
+        level: 'info',
+        status: 'running',
+        trigger: 'manual',
+        startedAt,
+        executionData: payload,
+        modelsUsed: ['model-a', 'model-b'],
+      })
+      .returning({
+        startedAt: workflowExecutionLogs.startedAt,
+        executionData: workflowExecutionLogs.executionData,
+        modelsUsed: workflowExecutionLogs.modelsUsed,
+      })
+
+    expect(rows).toEqual([
+      { startedAt, executionData: payload, modelsUsed: ['model-a', 'model-b'] },
+    ])
+    expect(execute).toHaveBeenCalledWith(
+      expect.not.stringContaining('"cost"'),
+      expect.arrayContaining([
+        startedAt.toISOString(),
+        JSON.stringify(payload),
+        '{"model-a","model-b"}',
+      ]),
+      'all',
+      expect.arrayContaining(['timestamp', 'json'])
+    )
+  })
+
+  it('retains schema-qualified names and runtime defaults', () => {
+    const table = pgSchema('insert_test').table('records', {
+      id: text('id').$defaultFn(() => 'generated-id'),
+      retired: text('retired'),
+    })
+    const query = db
+      .insert(withInsertColumns(table, { id: table.id }))
+      .values({})
+      .toSQL()
+    expect(query.sql).toBe('insert into "insert_test"."records" ("id") values ($1)')
+    expect(query.params).toEqual(['generated-id'])
+  })
+
+  it('rejects a column from a different table', () => {
+    const table: PgTable = userStats
+    expect(() => withInsertColumns(table, { id: organization.id })).toThrow(
+      'INSERT column id does not belong to the target table'
+    )
+  })
+})

--- a/packages/db/insert-columns.ts
+++ b/packages/db/insert-columns.ts
@@ -1,0 +1,35 @@
+import { getTableColumns } from 'drizzle-orm'
+import type { PgTable } from 'drizzle-orm/pg-core'
+
+type InsertTable<TTable extends PgTable, TKey extends keyof TTable['_']['columns']> = PgTable<{
+  name: TTable['_']['name']
+  schema: TTable['_']['schema']
+  dialect: TTable['_']['config']['dialect']
+  columns: Pick<TTable['_']['columns'], TKey>
+}>
+
+/**
+ * Restricts Drizzle's INSERT column list without changing the migration schema.
+ * Omitting a value is insufficient: Drizzle still names that column with DEFAULT.
+ * The table proxy substitutes the column map exposed by getTableColumns while
+ * retaining table metadata, column codecs, defaults, and SQL names.
+ * It is local to this insert and never mutates the shared table or its columns.
+ */
+export function withInsertColumns<
+  TTable extends PgTable,
+  TKey extends keyof TTable['_']['columns'],
+>(table: TTable, columns: Pick<TTable['_']['columns'], TKey>): InsertTable<TTable, TKey> {
+  const declaredColumns = getTableColumns(table)
+  for (const [name, column] of Object.entries(columns)) {
+    if (declaredColumns[name] !== column) {
+      throw new Error(`INSERT column ${name} does not belong to the target table`)
+    }
+  }
+
+  return new Proxy(table, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver)
+      return value === declaredColumns ? columns : value
+    },
+  }) as InsertTable<TTable, TKey>
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,10 @@
       "types": "./schema.ts",
       "default": "./schema.ts"
     },
+    "./insert-columns": {
+      "types": "./insert-columns.ts",
+      "default": "./insert-columns.ts"
+    },
     "./timestamps": {
       "types": "./timestamps.ts",
       "default": "./timestamps.ts"

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -523,12 +523,13 @@ export const workflowExecutionLogs = pgTable(
      * `materializeExecutionData`, which resolves the pointer.
      */
     executionData: jsonb('execution_data').notNull().default('{}'),
-    // contract-pending(after #7134 is fully deployed to production): DROP COLUMN
-    // cost. Same procedure and argless-read lint as the user_stats marker
-    // (scripts/check-pending-drop-tables.ts). Script migration
-    // 0009_backfill_wel_residual_cost_total projects the ~23 straggler rows
-    // whose json still held a numeric total into cost_total before the drop;
-    // the contract PR must ALSO deregister that script (it reads this column).
+    /**
+     * contract-pending(after #7134 and #7774 are fully deployed):
+     * DROP cost. Reads and inserts use workflowExecutionLogColumns. Before the
+     * drop, confirm script migration 0009_backfill_wel_residual_cost_total has
+     * projected all residual numeric totals, then deregister it in the contract
+     * PR because it reads this column.
+     */
     /** @deprecated Not written/read; cost lives in usage_log + the `cost_total` projection. */
     cost: jsonb('cost'),
     // Faithful, write-once projection of the run's usage_log ledger sum (dollars).
@@ -1247,16 +1248,16 @@ export const userStats = pgTable('user_stats', {
     .notNull()
     .references(() => user.id, { onDelete: 'cascade' })
     .unique(), // One record per user
-  // contract-pending(after #7134 is fully deployed to production): DROP COLUMN
-  // the 19 @deprecated columns in this table. Their last readers/writers were
-  // removed by the ledger cutover (#7078/#7113) and #7134; the declarations
-  // remain ONLY so the app schema keeps matching the deployed database until
-  // the drop. Argless select()/relational reads of this table are forbidden
-  // meanwhile — they would put these columns back into generated SQL and break
-  // the old task set when the contract deploy drops them mid-cutover — enforced
-  // by scripts/check-pending-drop-tables.ts. The follow-up PR deletes the
-  // @deprecated declarations plus this marker and ships the generated DROP
-  // migration in the same change.
+  /**
+   * contract-pending(after #7134 and #7774 are fully deployed):
+   * DROP the 19 deprecated columns. Usage updates were retired by #7078/#7113;
+   * #7134 removed the remaining reads. Declarations stay until the contract so
+   * generated migrations match the deployed database. Reads use userStatsColumns;
+   * inserts use withInsertColumns(userStats, userStatsColumns), because omitting
+   * values still makes Drizzle name the columns with DEFAULT. The pending-drop
+   * audit enforces both. Deploy the compatibility release to every writer before
+   * deleting these declarations and generating the DROP migration.
+   */
   /** @deprecated Retired usage counter; derive from usage_log. */
   totalManualExecutions: integer('total_manual_executions').notNull().default(0),
   /** @deprecated Retired usage counter; derive from usage_log. */
@@ -1343,8 +1344,8 @@ export const userStats = pgTable('user_stats', {
 })
 
 /**
- * Live columns of `user_stats` — the selection every read of this table goes
- * through while the contract-pending drop (see the marker inside the table) is
+ * Live columns of `user_stats` — the selection every read and withInsertColumns
+ * insert uses while the contract-pending drop (see the marker inside the table) is
  * outstanding, so generated SQL never names the doomed columns. Enforced by
  * `scripts/check-pending-drop-tables.ts`; the contract PR deletes this helper
  * together with the deprecated declarations.
@@ -1716,10 +1717,12 @@ export const organization = pgTable('organization', {
     .$type<Record<string, number>>()
     .notNull()
     .default({}),
-  // contract-pending(after #7134 is fully deployed to production): DROP COLUMN
-  // departed_member_usage. The last readers/writers (v1 admin exposure,
-  // cycle-close resets) were removed in #7134; same procedure and argless-read
-  // lint as the user_stats marker (scripts/check-pending-drop-tables.ts).
+  /**
+   * contract-pending(after #7134 and #7774 are fully deployed):
+   * DROP departed_member_usage. Reads and inserts use organizationColumns;
+   * #7134 removed the v1 admin exposure and cycle-close resets. The pending-drop
+   * audit enforces the same read and insert constraints as user_stats.
+   */
   /** @deprecated No readers or writers; a departed member's ledger rows stay stamped to the org's period, so nothing needs capturing. */
   departedMemberUsage: decimal('departed_member_usage').notNull().default('0'),
   /**
@@ -2260,7 +2263,7 @@ export const workspaceFiles = pgTable(
      */
     displayName: text('display_name'),
     contentType: text('content_type').notNull(),
-    /** contract-pending(after the cutover is fully deployed and size_bytes has no NULLs): drop size, workspace_files_sync_size_columns, and the temporary dev cutover runner — all application reads and writes use size_bytes */
+    /** contract-pending(after the cutover and #7774 are fully deployed and size_bytes has no NULLs): drop size, workspace_files_sync_size_columns, and the temporary dev cutover runner — all application reads and writes use size_bytes */
     size: integer('size').notNull().default(0),
     /** Exact byte size. The deploy migration backfills existing rows before this release serves traffic. */
     sizeBytes: bigint('size_bytes', { mode: 'number' }),

--- a/scripts/check-pending-drop-tables.test.ts
+++ b/scripts/check-pending-drop-tables.test.ts
@@ -65,6 +65,86 @@ describe('pending-drop INSERT audit', () => {
     ).toHaveLength(1)
   })
 
+  it.each([
+    'function write(userStatsColumns) { INSERT }',
+    'const write = ({ userStatsColumns }) => { INSERT }',
+    'function write(userStatsColumns = arbitrary) { INSERT }',
+    '{ const userStatsColumns = arbitrary; INSERT }',
+    'function write() { INSERT; var userStatsColumns = arbitrary }',
+    'try {} catch (userStatsColumns) { INSERT }',
+    'for (const userStatsColumns of selections) { INSERT }',
+    'const write = function userStatsColumns() { INSERT }',
+  ])('rejects a shadowed live-column map: %s', (scope) => {
+    const source = scope.replace(
+      'INSERT',
+      'db.insert(withInsertColumns(userStats, userStatsColumns)).values({});'
+    )
+    expect(
+      audit(`
+        import { userStats, userStatsColumns } from '@sim/db/schema';
+        import { withInsertColumns } from '@sim/db/insert-columns';
+        ${source}
+      `)
+    ).toEqual([
+      expect.objectContaining({ pattern: expect.stringContaining('validated live-column map') }),
+    ])
+  })
+
+  it.each([
+    `import { userStats, userStatsColumns as live } from '@sim/db/schema';
+     function write(live) { db.insert(withInsertColumns(userStats, live)).values({}) }`,
+    `import { userStats } from '@sim/db/schema';
+     import * as schema from '@sim/db/schema';
+     function write(schema) {
+       db.insert(withInsertColumns(userStats, schema.userStatsColumns)).values({})
+     }`,
+  ])('rejects shadowed renamed and namespace selections', (source) => {
+    expect(audit(`import { withInsertColumns } from '@sim/db/insert-columns'; ${source}`)).toEqual([
+      expect.objectContaining({ pattern: expect.stringContaining('validated live-column map') }),
+    ])
+  })
+
+  it.each([
+    `import { withInsertColumns } from '@sim/db/insert-columns';
+     function write(withInsertColumns) {
+       db.insert(withInsertColumns(userStats, userStatsColumns)).values({})
+     }`,
+    `import * as inserts from '@sim/db/insert-columns';
+     function write(inserts) {
+       db.insert(inserts.withInsertColumns(userStats, userStatsColumns)).values({})
+     }`,
+  ])('rejects a shadowed INSERT helper', (source) => {
+    expect(
+      audit(`import { userStats, userStatsColumns } from '@sim/db/schema'; ${source}`)
+    ).toEqual([
+      expect.objectContaining({ pattern: expect.stringContaining('imported INSERT helper') }),
+    ])
+  })
+
+  it('keeps imports valid outside the shadowing scope', () => {
+    expect(
+      audit(`
+        import { userStats, userStatsColumns } from '@sim/db/schema';
+        import { withInsertColumns } from '@sim/db/insert-columns';
+        function unrelated(userStatsColumns, withInsertColumns) {}
+        { const userStatsColumns = arbitrary }
+        function write() {
+          db.insert(withInsertColumns(userStats, userStatsColumns)).values({})
+        }
+      `)
+    ).toEqual([])
+  })
+
+  it('accepts namespace-imported INSERT helpers', () => {
+    expect(
+      audit(`
+        import * as schema from '@sim/db/schema';
+        import * as inserts from '@sim/db/insert-columns';
+        db.insert(inserts.withInsertColumns(schema.userStats, schema.userStatsColumns)).values({});
+      `)
+    ).toEqual([])
+  })
+
   it('validates namespace-imported insert helpers', () => {
     expect(
       audit(`

--- a/scripts/check-pending-drop-tables.test.ts
+++ b/scripts/check-pending-drop-tables.test.ts
@@ -1,0 +1,77 @@
+import { auditFile } from '@scripts/check-pending-drop-tables'
+import { describe, expect, it } from 'vitest'
+
+const tables = new Map([
+  ['userStats', new Set(['totalCost'])],
+  ['organization', new Set(['departedMemberUsage'])],
+])
+const columns = new Map([
+  ['userStatsColumns', 'userStats'],
+  ['organizationColumns', 'organization'],
+])
+
+function audit(source: string) {
+  return auditFile('insert-example.ts', source, tables, columns)
+}
+
+describe('pending-drop INSERT audit', () => {
+  it.each([
+    'db.insert(userStats).values({ id: "id", userId: "user" })',
+    'db.insert(userStats).values({ id: "id" }).onConflictDoNothing().returning({ id: userStats.id })',
+    'const target = userStats; tx.insert(target).values({ id: "id" })',
+    'db.insert(alias(userStats, "stats")).values({ id: "id" })',
+  ])('rejects implicit DEFAULT columns: %s', (statement) => {
+    const findings = audit(`import { userStats } from '@sim/db/schema'; ${statement}`)
+    expect(findings.some((finding) => finding.pattern.startsWith('insert()'))).toBe(true)
+  })
+
+  it.each([
+    "import { userStats as stats } from '@sim/db/schema'; db.insert(stats).values({})",
+    "import * as schema from '@sim/db/schema'; db.insert(schema.userStats).values({})",
+  ])('resolves renamed and namespace table imports', (source) => {
+    expect(audit(source)).toHaveLength(1)
+  })
+
+  it.each([
+    `import { userStats, userStatsColumns } from '@sim/db/schema';
+     import { withInsertColumns } from '@sim/db/insert-columns';
+     db.insert(withInsertColumns(userStats, userStatsColumns)).values({}).returning()`,
+    `import { userStats as stats, userStatsColumns as live } from '@sim/db/schema';
+     import { withInsertColumns as project } from '@sim/db/insert-columns';
+     db.insert(project(stats, live)).values({})`,
+    `import * as schema from '@sim/db/schema';
+     import { withInsertColumns } from '@sim/db/insert-columns';
+     db.insert(withInsertColumns(schema.userStats, schema.userStatsColumns)).values({})`,
+  ])('accepts the validated live-column map', (source) => {
+    expect(audit(source)).toEqual([])
+  })
+
+  it.each(['{}', 'organizationColumns', '{ ...userStatsColumns, totalCost: userStats.totalCost }'])(
+    'rejects an unverified or mismatched selection: %s',
+    (selection) => {
+      expect(
+        audit(`
+        import { userStats, userStatsColumns, organizationColumns } from '@sim/db/schema';
+        import { withInsertColumns } from '@sim/db/insert-columns';
+        db.insert(withInsertColumns(userStats, ${selection})).values({});
+      `)
+      ).toHaveLength(1)
+    }
+  )
+
+  it('still rejects broad reads', () => {
+    expect(
+      audit(`import { userStats } from '@sim/db/schema'; db.select().from(userStats)`)
+    ).toHaveLength(1)
+  })
+
+  it('validates namespace-imported insert helpers', () => {
+    expect(
+      audit(`
+      import { userStats } from '@sim/db/schema';
+      import * as inserts from '@sim/db/insert-columns';
+      db.insert(inserts.withInsertColumns(userStats, {})).values({});
+    `)
+    ).toHaveLength(1)
+  })
+})

--- a/scripts/check-pending-drop-tables.ts
+++ b/scripts/check-pending-drop-tables.ts
@@ -108,9 +108,8 @@ function parseSource(
     errorRecovery: true,
     plugins: [...(extname(file) === '.tsx' ? (['jsx'] as const) : []), 'typescript', 'decorators'],
   })
-  const comments = Array.isArray(syntaxTree.comments)
-    ? syntaxTree.comments.filter(isCommentNode)
-    : []
+  const detachedComments: unknown[] = syntaxTree.comments ?? []
+  const comments = detachedComments.filter(isCommentNode)
   return { program: syntaxTree.program as unknown as SyntaxNode, comments }
 }
 
@@ -247,7 +246,6 @@ function objectKeys(node: unknown): Set<string> | null {
 interface TableBindings {
   locals: Map<string, string>
   namespaces: Set<string>
-  importedNames: Map<string, string>
   insertHelpers: Set<string>
   insertHelperNamespaces: Set<string>
 }
@@ -282,16 +280,76 @@ function readLiveColumnMaps(pendingTables: Map<string, Set<string>>): Map<string
   return selections
 }
 
-function schemaExportName(node: unknown, bindings: TableBindings): string | null {
-  const unwrapped = unwrap(node)
-  if (unwrapped?.type === 'Identifier') {
-    return bindings.importedNames.get(identifierName(unwrapped) ?? '') ?? null
+interface ImportBinding {
+  module: string
+  name: string
+}
+
+/**
+ * Binds references within this file, without loading dependencies or standard
+ * libraries. Initialize lazily: only INSERT helpers need trusted import provenance.
+ * TypeScript resolves parameters, block locals, destructuring and hoisted bindings
+ * so a shadowed import cannot authorize an arbitrary column map or helper.
+ */
+function createImportResolver(file: string, source: string) {
+  let checker: ts.TypeChecker | undefined
+  const identifiers = new Map<number, ts.Identifier>()
+  const resolveIdentifier = (node: SyntaxNode): ImportBinding | null => {
+    if (!checker) {
+      const filename = resolve(file)
+      const sourceFile = ts.createSourceFile(filename, source, ts.ScriptTarget.Latest, true)
+      const host: ts.CompilerHost = {
+        getSourceFile: (name) => (name === filename ? sourceFile : undefined),
+        getDefaultLibFileName: () => 'lib.d.ts',
+        writeFile: () => {},
+        getCurrentDirectory: () => dirname(filename),
+        getDirectories: () => [],
+        fileExists: (name) => name === filename,
+        readFile: (name) => (name === filename ? source : undefined),
+        getCanonicalFileName: (name) => name,
+        useCaseSensitiveFileNames: () => true,
+        getNewLine: () => '\n',
+      }
+      checker = ts
+        .createProgram([filename], { noLib: true, noResolve: true }, host)
+        .getTypeChecker()
+      const index = (child: ts.Node) => {
+        if (ts.isIdentifier(child)) identifiers.set(child.getStart(sourceFile), child)
+        ts.forEachChild(child, index)
+      }
+      index(sourceFile)
+    }
+    const identifier = typeof node.start === 'number' ? identifiers.get(node.start) : undefined
+    const declarations = identifier
+      ? checker.getSymbolAtLocation(identifier)?.declarations
+      : undefined
+    if (declarations?.length !== 1) return null
+    const declaration = declarations[0]
+    if (!ts.isImportSpecifier(declaration) && !ts.isNamespaceImport(declaration)) return null
+    let parent: ts.Node = declaration.parent
+    while (!ts.isImportDeclaration(parent)) {
+      if (!parent.parent) return null
+      parent = parent.parent
+    }
+    if (!ts.isStringLiteral(parent.moduleSpecifier)) return null
+    return {
+      module: parent.moduleSpecifier.text,
+      name: ts.isImportSpecifier(declaration)
+        ? (declaration.propertyName ?? declaration.name).text
+        : '*',
+    }
   }
-  if (unwrapped?.type === 'MemberExpression' && !unwrapped.computed) {
-    const namespace = identifierName(unwrapped.object)
-    return namespace && bindings.namespaces.has(namespace) ? propertyName(unwrapped.property) : null
+
+  return (node: unknown): ImportBinding | null => {
+    const expression = unwrap(node)
+    if (expression?.type === 'Identifier') return resolveIdentifier(expression)
+    if (expression?.type !== 'MemberExpression' || expression.computed) return null
+    const object = unwrap(expression.object)
+    if (object?.type !== 'Identifier') return null
+    const binding = resolveIdentifier(object)
+    const member = propertyName(expression.property)
+    return binding?.name === '*' && member ? { module: binding.module, name: member } : null
   }
-  return null
 }
 
 /**
@@ -330,7 +388,12 @@ function resolveTable(
 
 /** A module that can export the schema's table objects. */
 function isSchemaModule(source: unknown): boolean {
-  const value = isSyntaxNode(source) && typeof source.value === 'string' ? source.value : null
+  const value =
+    typeof source === 'string'
+      ? source
+      : isSyntaxNode(source) && typeof source.value === 'string'
+        ? source.value
+        : null
   return value !== null && (/@sim\/db(\/|$)/.test(value) || /(^|\/)schema(\.ts)?$/.test(value))
 }
 
@@ -345,7 +408,6 @@ function collectTableBindings(
   const bindings: TableBindings = {
     locals: new Map(),
     namespaces: new Set(),
-    importedNames: new Map(),
     insertHelpers: new Set(),
     insertHelperNamespaces: new Set(),
   }
@@ -366,7 +428,6 @@ function collectTableBindings(
         }
         if (specifier.type !== 'ImportSpecifier') continue
         const imported = propertyName(specifier.imported)
-        if (imported) bindings.importedNames.set(local, imported)
         if (
           imported === 'withInsertColumns' &&
           isSyntaxNode(node.source) &&
@@ -462,6 +523,7 @@ function checkCall(
   pendingTables: Map<string, Set<string>>,
   bindings: TableBindings,
   liveColumnMaps: Map<string, string>,
+  resolveImport: ReturnType<typeof createImportResolver>,
   report: (node: SyntaxNode, table: string, pattern: string) => void
 ): void {
   const callee = isSyntaxNode(call.callee) ? call.callee : null
@@ -476,7 +538,16 @@ function checkCall(
       bindings.insertHelperNamespaces.has(identifierName(callee.object) ?? ''))
   if (isInsertHelper) {
     const table = resolveArg(args[0])
-    if (table && liveColumnMaps.get(schemaExportName(args[1], bindings) ?? '') !== table) {
+    if (!table) return
+    const helper = resolveImport(callee)
+    const columns = resolveImport(args[1])
+    if (helper?.module !== '@sim/db/insert-columns' || helper.name !== 'withInsertColumns') {
+      report(call, table, 'withInsertColumns() must resolve to the imported INSERT helper')
+    } else if (
+      !columns ||
+      !isSchemaModule(columns.module) ||
+      liveColumnMaps.get(columns.name) !== table
+    ) {
       report(call, table, "withInsertColumns() must use this table's validated live-column map")
     }
     return
@@ -596,6 +667,7 @@ export function auditFile(
   }
 
   const bindings = collectTableBindings(program, pendingTables)
+  const resolveImport = createImportResolver(file, source)
 
   const report = (node: SyntaxNode, table: string, pattern: string) => {
     violations.push({ file, line: node.loc?.start.line ?? 1, table, pattern })
@@ -603,7 +675,7 @@ export function auditFile(
 
   const visit = (node: SyntaxNode, parent: SyntaxNode | null) => {
     if (node.type === 'CallExpression') {
-      checkCall(node, parent, pendingTables, bindings, liveColumnMaps, report)
+      checkCall(node, parent, pendingTables, bindings, liveColumnMaps, resolveImport, report)
     }
     for (const child of getChildNodes(node)) visit(child, node)
   }

--- a/scripts/check-pending-drop-tables.ts
+++ b/scripts/check-pending-drop-tables.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * Fails when app code reads a pending-drop table without naming its columns.
+ * Fails when app code reads or inserts retired columns of a pending-drop table.
  *
  * A `contract-pending` marker inside a table in `packages/db/schema.ts` means the table
  * still declares columns whose physical `DROP COLUMN` is deferred until the app version
@@ -10,6 +10,8 @@
  * single argless read puts the doomed columns back into live SQL and would fail with
  * 42703 against the already-migrated database for the whole cutover window of the
  * contract deploy. Reads of these tables must name the columns they want.
+ * INSERTs must use withInsertColumns(table, liveColumns): omitted values still
+ * generate named DEFAULT columns. The supplied map must be a validated schema export.
  *
  * The audit derives everything from schema.ts itself and retires when the contract PR
  * deletes the markers:
@@ -245,6 +247,51 @@ function objectKeys(node: unknown): Set<string> | null {
 interface TableBindings {
   locals: Map<string, string>
   namespaces: Set<string>
+  importedNames: Map<string, string>
+  insertHelpers: Set<string>
+  insertHelperNamespaces: Set<string>
+}
+
+/** Live selections already validated against the pending column declarations. */
+function readLiveColumnMaps(pendingTables: Map<string, Set<string>>): Map<string, string> {
+  const { program } = parseSource(SCHEMA_PATH, readFileSync(SCHEMA_PATH, 'utf8'))
+  const selections = new Map<string, string>()
+  const visit = (node: SyntaxNode) => {
+    if (node.type === 'VariableDeclarator') {
+      const name = propertyName(node.id)
+      const init = unwrap(node.init)
+      if (name && init?.type === 'CallExpression' && identifierName(init.callee) === 'omit') {
+        const columns = unwrap(Array.isArray(init.arguments) ? init.arguments[0] : undefined)
+        if (
+          columns?.type === 'CallExpression' &&
+          identifierName(columns.callee) === 'getTableColumns'
+        ) {
+          const table = identifierName(
+            Array.isArray(columns.arguments) ? columns.arguments[0] : undefined
+          )
+          const doomed = table ? pendingTables.get(table) : undefined
+          if (table && doomed && sanctionedOmitMissing(init, doomed)?.length === 0) {
+            selections.set(name, table)
+          }
+        }
+      }
+    }
+    for (const child of getChildNodes(node)) visit(child)
+  }
+  visit(program)
+  return selections
+}
+
+function schemaExportName(node: unknown, bindings: TableBindings): string | null {
+  const unwrapped = unwrap(node)
+  if (unwrapped?.type === 'Identifier') {
+    return bindings.importedNames.get(identifierName(unwrapped) ?? '') ?? null
+  }
+  if (unwrapped?.type === 'MemberExpression' && !unwrapped.computed) {
+    const namespace = identifierName(unwrapped.object)
+    return namespace && bindings.namespaces.has(namespace) ? propertyName(unwrapped.property) : null
+  }
+  return null
 }
 
 /**
@@ -295,7 +342,13 @@ function collectTableBindings(
   program: SyntaxNode,
   pendingTables: Map<string, Set<string>>
 ): TableBindings {
-  const bindings: TableBindings = { locals: new Map(), namespaces: new Set() }
+  const bindings: TableBindings = {
+    locals: new Map(),
+    namespaces: new Set(),
+    importedNames: new Map(),
+    insertHelpers: new Set(),
+    insertHelperNamespaces: new Set(),
+  }
 
   const visitImports = (node: SyntaxNode) => {
     if (node.type === 'ImportDeclaration' && isSchemaModule(node.source)) {
@@ -306,10 +359,21 @@ function collectTableBindings(
         if (!local) continue
         if (specifier.type === 'ImportNamespaceSpecifier') {
           bindings.namespaces.add(local)
+          if (isSyntaxNode(node.source) && node.source.value === '@sim/db/insert-columns') {
+            bindings.insertHelperNamespaces.add(local)
+          }
           continue
         }
         if (specifier.type !== 'ImportSpecifier') continue
         const imported = propertyName(specifier.imported)
+        if (imported) bindings.importedNames.set(local, imported)
+        if (
+          imported === 'withInsertColumns' &&
+          isSyntaxNode(node.source) &&
+          node.source.value === '@sim/db/insert-columns'
+        ) {
+          bindings.insertHelpers.add(local)
+        }
         if (imported && imported !== local && pendingTables.has(imported)) {
           bindings.locals.set(local, imported)
         }
@@ -397,11 +461,26 @@ function checkCall(
   parent: SyntaxNode | null,
   pendingTables: Map<string, Set<string>>,
   bindings: TableBindings,
+  liveColumnMaps: Map<string, string>,
   report: (node: SyntaxNode, table: string, pattern: string) => void
 ): void {
   const callee = isSyntaxNode(call.callee) ? call.callee : null
   const args = Array.isArray(call.arguments) ? call.arguments : []
   const resolveArg = (node: unknown) => resolveTable(node, pendingTables, bindings)
+
+  const isInsertHelper =
+    bindings.insertHelpers.has(identifierName(callee) ?? '') ||
+    (callee?.type === 'MemberExpression' &&
+      !callee.computed &&
+      propertyName(callee.property) === 'withInsertColumns' &&
+      bindings.insertHelperNamespaces.has(identifierName(callee.object) ?? ''))
+  if (isInsertHelper) {
+    const table = resolveArg(args[0])
+    if (table && liveColumnMaps.get(schemaExportName(args[1], bindings) ?? '') !== table) {
+      report(call, table, "withInsertColumns() must use this table's validated live-column map")
+    }
+    return
+  }
 
   // getTableColumns(pendingTable) — spreads every declared column unless the
   // doomed ones are verifiably named away on the spot.
@@ -419,6 +498,18 @@ function checkCall(
 
   if (callee?.type !== 'MemberExpression') return
   const method = propertyName(callee.property)
+
+  if (method === 'insert') {
+    const table = resolveArg(args[0])
+    if (table) {
+      report(
+        call,
+        table,
+        'insert() names every declared column, including omitted DEFAULT values; use withInsertColumns()'
+      )
+    }
+    return
+  }
 
   // <builder>.select()/.selectDistinct() ... .from(pendingTable) with no selection.
   if (method === 'from') {
@@ -484,10 +575,11 @@ function checkCall(
   }
 }
 
-function auditFile(
+export function auditFile(
   file: string,
   source: string,
-  pendingTables: Map<string, Set<string>>
+  pendingTables: Map<string, Set<string>>,
+  liveColumnMaps: Map<string, string>
 ): Violation[] {
   const violations: Violation[] = []
   let program: SyntaxNode
@@ -511,7 +603,7 @@ function auditFile(
 
   const visit = (node: SyntaxNode, parent: SyntaxNode | null) => {
     if (node.type === 'CallExpression') {
-      checkCall(node, parent, pendingTables, bindings, report)
+      checkCall(node, parent, pendingTables, bindings, liveColumnMaps, report)
     }
     for (const child of getChildNodes(node)) visit(child, node)
   }
@@ -562,26 +654,27 @@ function main(): void {
   // must keep naming every doomed column away, including ones deprecated later.
   const skipFiles = new Set([fileURLToPath(import.meta.url)])
   const pendingTableNames = new Set(pendingTables.keys())
+  const liveColumnMaps = readLiveColumnMaps(pendingTables)
   const violations: Violation[] = []
   for (const file of SCAN_DIRS.flatMap((dir) => collectSources(dir))) {
     if (skipFiles.has(file) || /\.test\.(ts|tsx|mts|cts)$/.test(file)) continue
     const source = readFileSync(file, 'utf8')
     if (file !== SCHEMA_PATH && !mayReferencePendingTable(source, pendingTableNames)) continue
-    violations.push(...auditFile(file, source, pendingTables))
+    violations.push(...auditFile(file, source, pendingTables, liveColumnMaps))
   }
 
   if (violations.length === 0) {
     console.log(
-      `✓ No argless reads of pending-drop tables (${[...pendingTables.keys()].sort().join(', ')}).`
+      `✓ No unsafe reads or inserts of pending-drop tables (${[...pendingTables.keys()].sort().join(', ')}).`
     )
     return
   }
 
   console.error(
-    `❌ Found ${violations.length} read(s) of pending-drop tables that select every declared column.\n` +
+    `❌ Found ${violations.length} unsafe read(s) or insert(s) of pending-drop tables.\n` +
       'These tables carry a `contract-pending` marker in packages/db/schema.ts: deprecated\n' +
-      'columns are awaiting DROP, and an argless read would re-introduce them into live SQL\n' +
-      'and 42703 during the contract deploy. Name the live columns explicitly instead.\n'
+      'columns are awaiting DROP, and full-table reads or inserts re-introduce them into live SQL\n' +
+      'and 42703 during the contract deploy. Use the validated live-column maps.\n'
   )
   for (const violation of violations) {
     console.error(

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -11,6 +11,9 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
+    "paths": {
+      "@scripts/*": ["./*"]
+    },
     "jsx": "react-jsx"
   },
   "ts-node": {

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -13,6 +13,9 @@ import { defineConfig } from 'vitest/config'
  * The root is pinned so `bun run test:scripts` behaves the same from any cwd.
  */
 export default defineConfig({
+  resolve: {
+    alias: { '@scripts': fileURLToPath(new URL('.', import.meta.url)) },
+  },
   test: {
     root: fileURLToPath(new URL('..', import.meta.url)),
     environment: 'node',


### PR DESCRIPTION
## Summary
- Stop Drizzle INSERTs from naming retired columns as `DEFAULT` by applying the existing live-column maps through a shared, typed insert helper. Preserve normal defaults, conflict handling, parameter encoding, and returned-row decoding.
- Update inserts for `user_stats`, `organization`, `workflow_execution_logs`, and `workspace_files`; reject unprojected inserts and unverified column maps in the pending-drop audit.
- Keep the physical schema intact and require this compatibility release to reach every writer before a later column-drop migration.

## Type of Change
- [x] Bug fix

## Testing
- 191 focused application tests, 9 insert-helper tests, and 21 audit tests passed.
- Verified INSERT and RETURNING against disposable local PostgreSQL before and after dropping the retired columns on all four tables. The original insert form fails after the drop with `42703`.
- Lint, all 46 repository audits (including strict API boundary validation), app/database type checks, and migration safety passed. Drizzle schema generation produced no migration.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)
