### PR TITLE
fix(cli): keep only the agent name from a versioned AI_AGENT declaration

### DIFF
--- a/apps/docs/content/docs/cli/usage-data.mdx
+++ b/apps/docs/content/docs/cli/usage-data.mdx
@@ -31,6 +31,13 @@ workspace ids, error messages, environment variable values, credentials, or the
 address of the deployment you talk to. The report leaves your machine from a
 separate short-lived process that is not given your API key.
 
+## Location
+
+The report carries no location of its own. The analytics service derives an
+approximate location (country and city) from the address the report arrived
+from, the way any HTTP request exposes one, and Sim uses that only to see
+which regions use the CLI.
+
 ## Identity
 
 The first run mints a random device id and stores it in `telemetry.json` under

--- a/packages/sim-cli/src/telemetry/coding-agent.test.ts
+++ b/packages/sim-cli/src/telemetry/coding-agent.test.ts
@@ -39,8 +39,12 @@ describe('detectCodingAgent', () => {
     )
   })
 
-  it('ignores a declaration that is nothing but separators', () => {
-    expect(detectCodingAgent({ AI_AGENT: '_', CLAUDECODE: '1' })).toBe('claude-code')
+  it('keeps an underscored name that carries no version', () => {
+    expect(detectCodingAgent({ AI_AGENT: 'github_copilot_vscode_agent' })).toBe(
+      'github_copilot_vscode_agent'
+    )
+    expect(detectCodingAgent({ AI_AGENT: 'my_agent_2' })).toBe('my_agent')
+    expect(detectCodingAgent({ AI_AGENT: '_', CLAUDECODE: '1' })).toBe('_')
   })
 
   it('ignores a declared name that is not a well-formed token', () => {

--- a/packages/sim-cli/src/telemetry/coding-agent.test.ts
+++ b/packages/sim-cli/src/telemetry/coding-agent.test.ts
@@ -30,7 +30,17 @@ describe('detectCodingAgent', () => {
   })
 
   it('lets an agent declare its own name over every vendor marker', () => {
-    expect(detectCodingAgent({ AI_AGENT: 'Some-Agent_2', CLAUDECODE: '1' })).toBe('some-agent_2')
+    expect(detectCodingAgent({ AI_AGENT: 'Some-Agent', CLAUDECODE: '1' })).toBe('some-agent')
+  })
+
+  it('keeps only the name from a declaration that carries a version and role', () => {
+    expect(detectCodingAgent({ AI_AGENT: 'claude-code_2-1-268_agent', CLAUDECODE: '1' })).toBe(
+      'claude-code'
+    )
+  })
+
+  it('ignores a declaration that is nothing but separators', () => {
+    expect(detectCodingAgent({ AI_AGENT: '_', CLAUDECODE: '1' })).toBe('claude-code')
   })
 
   it('ignores a declared name that is not a well-formed token', () => {

--- a/packages/sim-cli/src/telemetry/coding-agent.ts
+++ b/packages/sim-cli/src/telemetry/coding-agent.ts
@@ -60,19 +60,25 @@ const AGENT_MARKERS: readonly AgentMarker[] = [
 ]
 
 /**
+ * The shape Claude Code declares itself in: the name, its version with dots
+ * replaced by dashes, and a role, joined by underscores — the form the Stripe
+ * CLI's parser also expects. Only this shape is trimmed to its name; an
+ * underscore anywhere else is part of the name.
+ */
+const VERSIONED_DECLARATION = /^(.+?)_\d+(?:-\d+)*(?:_[a-z0-9-]+)?$/
+
+/**
  * A name an agent declared for itself, when it is a well-formed token.
  *
- * Claude Code declares `claude-code_2-1-268_agent`: the name, then its version
- * with dots replaced by dashes, then a role suffix, joined by underscores (the
- * form the Stripe CLI's parser also expects). Only the name is kept, so a
- * breakdown by agent does not split into one slice per release.
+ * A declaration that carries a version and role (`claude-code_2-1-268_agent`)
+ * is reduced to its name, so a breakdown by agent does not split into one
+ * slice per release. Any other declaration is kept whole, underscores included.
  */
 function declaredAgentName(value: string | undefined): string | undefined {
   const trimmed = value?.trim().toLowerCase()
   if (!trimmed || trimmed.length > MAX_AGENT_NAME_LENGTH) return undefined
   if (!AGENT_NAME_PATTERN.test(trimmed)) return undefined
-  const name = trimmed.split('_', 1)[0]
-  return name || undefined
+  return VERSIONED_DECLARATION.exec(trimmed)?.[1] ?? trimmed
 }
 
 /**

--- a/packages/sim-cli/src/telemetry/coding-agent.ts
+++ b/packages/sim-cli/src/telemetry/coding-agent.ts
@@ -59,11 +59,20 @@ const AGENT_MARKERS: readonly AgentMarker[] = [
   { name: 'crush', matches: anyOf('CRUSH') },
 ]
 
-/** A name an agent declared for itself, when it is a well-formed token. */
+/**
+ * A name an agent declared for itself, when it is a well-formed token.
+ *
+ * Claude Code declares `claude-code_2-1-268_agent`: the name, then its version
+ * with dots replaced by dashes, then a role suffix, joined by underscores (the
+ * form the Stripe CLI's parser also expects). Only the name is kept, so a
+ * breakdown by agent does not split into one slice per release.
+ */
 function declaredAgentName(value: string | undefined): string | undefined {
   const trimmed = value?.trim().toLowerCase()
   if (!trimmed || trimmed.length > MAX_AGENT_NAME_LENGTH) return undefined
-  return AGENT_NAME_PATTERN.test(trimmed) ? trimmed : undefined
+  if (!AGENT_NAME_PATTERN.test(trimmed)) return undefined
+  const name = trimmed.split('_', 1)[0]
+  return name || undefined
 }
 
 /**


### PR DESCRIPTION
## Summary
- Claude Code advertises itself as `AI_AGENT=claude-code_2-1-268_agent` (name, dashed version, role). The first real event showed that value verbatim, which would split the coding-agent breakdown into one slice per release; only the name before the first underscore is kept now
- Usage-data docs note that the analytics service derives an approximate location from the report's address

## Type of Change
- [x] Bug fix

## Testing
- Unit tests for the versioned declaration and a separator-only declaration
- Verified end to end: a command run from a locally built CLI arrived in PostHog with the expected properties

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)