### PR TITLE
fix(ci): bake the CLI telemetry token into the build that bun publish ships

### DIFF
--- a/.github/workflows/publish-sim-cli.yml
+++ b/.github/workflows/publish-sim-cli.yml
@@ -15,6 +15,13 @@ concurrency:
 
 jobs:
   publish-npm:
+    # Job-level, not on the build step: `bun publish` runs `prepublishOnly`,
+    # which rebuilds `dist` a second time, and that second build is the one
+    # that ships. A build without the token reports nothing. See
+    # docs/cli/usage-data.
+    env:
+      SIM_CLI_TELEMETRY_KEY: ${{ vars.SIM_CLI_TELEMETRY_KEY }}
+      SIM_CLI_TELEMETRY_HOST: ${{ vars.SIM_CLI_TELEMETRY_HOST }}
     runs-on: ${{ (vars.CI_PROVIDER == '' || vars.CI_PROVIDER == 'blacksmith') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
@@ -63,11 +70,6 @@ jobs:
 
       - name: Build package
         working-directory: packages/sim-cli
-        env:
-          # Public PostHog project token for anonymous CLI usage reporting; a
-          # build without it reports nothing. See docs/cli/usage-data.
-          SIM_CLI_TELEMETRY_KEY: ${{ vars.SIM_CLI_TELEMETRY_KEY }}
-          SIM_CLI_TELEMETRY_HOST: ${{ vars.SIM_CLI_TELEMETRY_HOST }}
         run: bun run build
 
       - name: Resolve release channel


### PR DESCRIPTION
## Summary
- The published `sim@2.1.15` has no reporting destination: `bun publish` runs `prepublishOnly`, which rebuilds `dist` after the "Build package" step, and that second build ran without `SIM_CLI_TELEMETRY_*` because the variables were scoped to the first step
- Variables now sit at the job level so both builds see them

## Type of Change
- [x] Bug fix

## Testing
- Verified the shipped 2.1.15 tarball still contains the raw `process.env.SIM_CLI_TELEMETRY_KEY` reads and reports "no reporting destination"; the publish run log shows the second `bun build` under `bun publish`
- Locally, a build with the variable set inlines the token and reports "Usage reporting is on"

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [x] No new warnings introduced
- [x] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)